### PR TITLE
[Hotfix] Sentry에서 Request Body를 소모해서 Controller에서 확인이 불가능하던 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,6 +227,6 @@ sentry:
   dsn: ${SENTRY_DSN}
   environment: ${spring.profiles.active}
   exception-resolver-order: -2147483647
-  max-request-body-size: always
-  send-default-pii: true
+  max-request-body-size: none
+  send-default-pii: false
   traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:1.0}


### PR DESCRIPTION
## 🚀 작업 내용

> 작업한 내용을 구체적으로 작성해주세요.
> 내용이 길어지거나 문서화해야 해서 보존해야 하는 경우 외부에 작성하고 반드시 링크 첨부해주세요.

아래와 같은 오류가 모든 API에서 발생했음.

```shell
26-01-25 00:39:07.528 INFO  [16d1] [http-nio-8080-exec-1] c.u.p.global.config.LoggingInterceptor : → POST /api/v1/auth/token/renew
2026-01-25 00:39:07.539 ERROR [16d1] [http-nio-8080-exec-1] c.u.p.g.exception.GlobalExceptionHandler : JSON 파싱 에러: Required request body is missing: public com.umc.product.authentication.adapter.in.web.dto.response.RenewAccessTokenResponse com.umc.product.authentication.adapter.in.web.AuthenticationController.renewAccessToken(com.umc.product.authentication.adapter.in.web.dto.request.RenewAccessTokenRequest)
2026-01-25 00:39:07.548 INFO  [16d1] [http-nio-8080-exec-1] c.u.p.global.config.LoggingInterceptor : ← ⚠️ 400 /api/v1/auth/token/renew 19ms
```

Request body는 요청에 포함된 상태였기에 이는 Request Body를 Filter나 Interceptor 단에서 소모하고 있다고 의심 하에 찾았으나 Aspect 또한 문제 없었음.

디버깅 중 Sentry의 설정에서 Request Body를 로깅하는 옵션이 해당 stream을 소모하고 있다는 사실을 파악하고 해당 옵션을 제거하도록 수정하였습니다.