### PR TITLE
[Fix] AccessToken을 갱신하는 API를 Public API로 수정

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
@@ -103,6 +103,7 @@ public class AuthenticationController implements AuthenticationControllerInterfa
 
     @Override
     @PostMapping("token/renew")
+    @Public
     public RenewAccessTokenResponse renewAccessToken(
             @RequestBody RenewAccessTokenRequest request
     ) {


### PR DESCRIPTION
AccessToken이 만료되어서 재발급 받으려는데 AccessToken이 필요한게 말이 안됩니다!