### PR TITLE
[Fix] 출석 가능한 일정 조회 API 지연 로딩 에러 해결

### DIFF
--- a/src/main/java/com/umc/product/schedule/application/port/in/query/dto/AvailableAttendanceInfo.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/query/dto/AvailableAttendanceInfo.java
@@ -31,7 +31,7 @@ public record AvailableAttendanceInfo(
         return new AvailableAttendanceInfo(
             schedule.getId(),
             schedule.getName(),
-            schedule.getTags(),
+            Set.copyOf(schedule.getTags()),
             schedule.getStartsAt().toLocalTime(),
             schedule.getEndsAt().toLocalTime(),
             sheet.getId(),
@@ -48,7 +48,7 @@ public record AvailableAttendanceInfo(
         return new AvailableAttendanceInfo(
             schedule.getId(),
             schedule.getName(),
-            schedule.getTags(),
+            Set.copyOf(schedule.getTags()),
             schedule.getStartsAt().toLocalTime(),
             schedule.getEndsAt().toLocalTime(),
             sheet.getId(),

--- a/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleDetailInfo.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleDetailInfo.java
@@ -31,7 +31,7 @@ public record ScheduleDetailInfo(
             schedule.getId(),
             schedule.getName(),
             schedule.getDescription(),
-            schedule.getTags(),
+            Set.copyOf(schedule.getTags()),
             schedule.getStartsAt(),
             schedule.getEndsAt(),
             schedule.isAllDay(),


### PR DESCRIPTION
## ✅ 체크리스트


## 🔥 연관 이슈
- resolves #307 

## 🚀 작업 내용

1. Set.copyOf()를 통한 지연 로딩 에러 해결 
-> AvailableAttendanceInfo 및 ScheduleDetailInfo 변환 시 Set.copyOf() 적용

## 💬 리뷰 중점사항

