### PR TITLE
[Fix] 일정 위치 좌표 필드에 대한 검증을 NotNull로 변경

### DIFF
--- a/src/main/java/com/umc/product/schedule/adapter/in/web/dto/request/UpdateScheduleLocationRequest.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/dto/request/UpdateScheduleLocationRequest.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "일정 출석체크 위치 변경")
 public record UpdateScheduleLocationRequest(
@@ -16,13 +17,13 @@ public record UpdateScheduleLocationRequest(
     @Schema(description = "위도 (Latitude)", example = "37.498095")
     @Min(value = -90, message = "위도는 -90 이상이어야 합니다")
     @Max(value = 90, message = "위도는 90 이하여야 합니다")
-    @NotBlank
+    @NotNull
     Double latitude,
 
     @Schema(description = "경도 (Longitude)", example = "127.027610")
     @Min(value = -180, message = "경도는 -180 이상이어야 합니다")
     @Max(value = 180, message = "경도는 180 이하여야 합니다")
-    @NotBlank
+    @NotNull
     Double longitude
 ) {
     public UpdateScheduleLocationCommand toCommand(Long scheduleId) {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #388 

## 🚀 작업 내용

일정 위치 관련 좌표 필드(`longitude`, `latitude`)의 Validation 어노테이션을 수정했습니다.
### 변경 이유
@NotBlank는 String 타입 전용 어노테이션인데, Double 타입 필드에 적용되어 있어 런타임 에러가 발생했습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

