### PR TITLE
[Feat] 학교 상세 조회 API에서 이미지 필드명 통일

### DIFF
--- a/src/main/java/com/umc/product/organization/adapter/in/web/dto/response/SchoolDetailResponse.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/dto/response/SchoolDetailResponse.java
@@ -24,7 +24,7 @@ public record SchoolDetailResponse(
         String remark,
 
         @Schema(description = "로고 이미지 URL")
-        String logoImageLink,
+        String logoImageUrl,
 
         @Schema(description = "학교 링크 목록")
         List<SchoolLinkItem> links,

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
@@ -63,10 +63,10 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
         SchoolDetailInfo.SchoolInfo schoolInfo = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(schoolId);
 
-        String logoImageLink = null;
+        String logoImageUrl = null;
         if (schoolInfo.logoImageId() != null) {
             FileInfo fileInfo = getFileUseCase.getById(schoolInfo.logoImageId());
-            logoImageLink = fileInfo.fileLink();
+            logoImageUrl = fileInfo.fileLink();
         }
 
         School school = loadSchoolPort.findById(schoolId);
@@ -74,7 +74,7 @@ public class SchoolQueryService implements GetSchoolUseCase {
                 .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
                 .toList();
 
-        return schoolInfo.toDetailInfo(logoImageLink, links);
+        return schoolInfo.toDetailInfo(logoImageUrl, links);
 
     }
 

--- a/src/test/java/com/umc/product/organization/adapter/in/web/AdminSchoolQueryControllerTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/in/web/AdminSchoolQueryControllerTest.java
@@ -130,7 +130,7 @@ class AdminSchoolQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("result.schoolId").type(JsonFieldType.STRING).description("학교 ID"),
                                 fieldWithPath("result.isActive").type(JsonFieldType.BOOLEAN).description("학교 활성상태"),
                                 fieldWithPath("result.remark").type(JsonFieldType.STRING).description("비고"),
-                                fieldWithPath("result.logoImageLink").type(JsonFieldType.STRING).description("로고 이미지 URL").optional(),
+                                fieldWithPath("result.logoImageUrl").type(JsonFieldType.STRING).description("로고 이미지 URL").optional(),
                                 fieldWithPath("result.links").type(JsonFieldType.ARRAY).description("학교 링크 목록"),
                                 fieldWithPath("result.links[].title").type(JsonFieldType.STRING).description("링크 제목"),
                                 fieldWithPath("result.links[].type").type(JsonFieldType.STRING).description("링크 타입 (KAKAO, INSTAGRAM, YOUTUBE)"),


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #408 

## 🚀 작업 내용

학교 상세 조회에서 logoImageLink -> logoImageUrl 로 변수명 변경


