### PR TITLE
[Fix] 커뮤니티 내 번개글 시간 검증 로직 개선

### DIFF
--- a/src/main/java/com/umc/product/community/application/service/PostCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/PostCommandService.java
@@ -18,6 +18,7 @@ import com.umc.product.community.domain.Post.LightningInfo;
 import com.umc.product.community.domain.exception.CommunityErrorCode;
 import com.umc.product.global.exception.BusinessException;
 import com.umc.product.global.exception.constant.Domain;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +55,9 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
                 command.maxParticipants(),
                 command.openChatUrl()
         );
+
+        // Service 레이어에서 시간 검증 (테스트 용이성)
+        lightningInfo.validateMeetAtIsFuture(LocalDateTime.now());
 
         Post post = Post.createLightning(
                 command.title(),
@@ -97,6 +101,9 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
                 command.maxParticipants(),
                 command.openChatUrl()
         );
+
+        // Service 레이어에서 시간 검증 (테스트 용이성)
+        lightningInfo.validateMeetAtIsFuture(LocalDateTime.now());
 
         post.updateLightning(
                 command.title(),

--- a/src/main/java/com/umc/product/community/domain/Post.java
+++ b/src/main/java/com/umc/product/community/domain/Post.java
@@ -54,7 +54,7 @@ public class Post {
         }
         validateCommonFields(title, content);
         validateAuthorChallengerId(authorChallengerId);
-        info.validateMeetAtIsFuture(); // 생성 시에만 미래 시간 검증
+        // 시간 검증은 Service 레이어에서 수행
         return new Post(null, title, content, Category.LIGHTNING, authorChallengerId, info, 0, false, null);
     }
 
@@ -118,7 +118,7 @@ public class Post {
         if (newLightningInfo == null) {
             throw new IllegalArgumentException("번개 정보는 필수입니다.");
         }
-        newLightningInfo.validateMeetAtIsFuture(); // 수정 시에만 미래 시간 검증
+        // 시간 검증은 Service 레이어에서 수행
 
         this.title = title;
         this.content = content;
@@ -156,10 +156,13 @@ public class Post {
         }
 
         /**
-         * 모임 시간이 현재 이후인지 검증 (생성/수정 시에만 호출)
+         * 모임 시간이 현재 이후인지 검증 (Service 레이어에서 호출)
+         *
+         * @param now 비교할 현재 시간 (테스트 용이성을 위해 외부에서 주입)
+         * @throws IllegalArgumentException 모임 시간이 현재 이전인 경우
          */
-        public void validateMeetAtIsFuture() {
-            if (meetAt.isBefore(LocalDateTime.now())) {
+        public void validateMeetAtIsFuture(LocalDateTime now) {
+            if (meetAt.isBefore(now)) {
                 throw new IllegalArgumentException("모임 시간은 현재 이후여야 합니다.");
             }
         }


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 번개글 조회 시 시간 검증 로직 수정
- [ ] 생성/수정 시 시간 검증 분리

## 🔥 연관 이슈

- resolves #431

## 🚀 작업 내용

1.  해당 시간 검증 별도 분리
2. 생성, 수정에서 호출
3. 조회에서는 제외

## 💬 리뷰 중점사항
