### PR TITLE
[Feat] Challenger ID로 출석 정보를 조회하는 API 구현

### DIFF
--- a/src/main/java/com/umc/product/schedule/adapter/in/web/AttendanceController.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/AttendanceController.java
@@ -16,6 +16,7 @@ import com.umc.product.schedule.application.port.in.command.CheckAttendanceUseCa
 import com.umc.product.schedule.application.port.in.command.SubmitReasonUseCase;
 import com.umc.product.schedule.application.port.in.query.GetAttendanceRecordUseCase;
 import com.umc.product.schedule.application.port.in.query.GetAvailableAttendancesUseCase;
+import com.umc.product.schedule.application.port.in.query.GetChallengerAttendanceHistoryUseCase;
 import com.umc.product.schedule.application.port.in.query.GetMyAttendanceHistoryUseCase;
 import com.umc.product.schedule.application.port.in.query.GetPendingAttendancesUseCase;
 import com.umc.product.schedule.domain.AttendanceRecord.AttendanceRecordId;
@@ -40,6 +41,7 @@ public class AttendanceController implements AttendanceControllerApi {
     private final GetAttendanceRecordUseCase getAttendanceRecordUseCase;
     private final GetAvailableAttendancesUseCase getAvailableAttendancesUseCase;
     private final GetMyAttendanceHistoryUseCase getMyAttendanceHistoryUseCase;
+    private final GetChallengerAttendanceHistoryUseCase getChallengerAttendanceHistoryUseCase;
     private final GetPendingAttendancesUseCase getPendingAttendancesUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
 
@@ -86,6 +88,16 @@ public class AttendanceController implements AttendanceControllerApi {
 
         return mapper.toMyAttendanceHistoryResponses(
             getMyAttendanceHistoryUseCase.getHistory(memberId, gisuId)
+        );
+    }
+
+    @Override
+    @GetMapping("/challenger/{challengerId}/history")
+    public List<MyAttendanceHistoryResponse> getChallengerAttendanceHistory(
+        @PathVariable Long challengerId
+    ) {
+        return mapper.toMyAttendanceHistoryResponses(
+            getChallengerAttendanceHistoryUseCase.getHistoryByChallengerId(challengerId)
         );
     }
 

--- a/src/main/java/com/umc/product/schedule/adapter/in/web/swagger/AttendanceControllerApi.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/swagger/AttendanceControllerApi.java
@@ -55,6 +55,26 @@ public interface AttendanceControllerApi {
         @Parameter(hidden = true) MemberPrincipal memberPrincipal
     );
 
+    @Operation(
+        summary = "챌린저 출석 이력 조회",
+        description = """
+            특정 챌린저의 출석 이력을 조회합니다.
+
+            ⚠️ 확정된 상태만 반환됩니다:
+            - PRESENT: 출석 (인정결석 승인 시 포함)
+            - LATE: 지각
+            - ABSENT: 결석 (인정결석 거부 시 포함)
+
+            제외되는 상태:
+            - PENDING: 출석 전 (아직 체크 안함)
+            - *_PENDING: 승인 대기 중 (관리자 승인 전)
+            - EXCUSED: 표시 안 됨 (승인 시 PRESENT, 거부 시 ABSENT로 처리)
+            """
+    )
+    List<MyAttendanceHistoryResponse> getChallengerAttendanceHistory(
+        @Parameter(description = "챌린저 ID") Long challengerId
+    );
+
     @Operation(summary = "출석 기록 상세 조회", description = "출석 기록을 상세 조회합니다")
     AttendanceRecordResponse getAttendanceRecord(
         @Parameter(description = "출석 기록 ID") Long recordId

--- a/src/main/java/com/umc/product/schedule/application/port/in/query/GetChallengerAttendanceHistoryUseCase.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/query/GetChallengerAttendanceHistoryUseCase.java
@@ -1,0 +1,20 @@
+package com.umc.product.schedule.application.port.in.query;
+
+import com.umc.product.schedule.application.port.in.query.dto.MyAttendanceHistoryInfo;
+import java.util.List;
+
+/**
+ * 특정 챌린저의 출석 이력을 조회하는 UseCase.
+ * challengerId를 받아 해당 챌린저의 모든 기수 출석 기록을 반환.
+ * 출석 기록 → 출석부 → 일정을 역추적하여 일정명, 일시, 출석 상태를 결합한 이력을 반환.
+ * 최신순 정렬.
+ */
+public interface GetChallengerAttendanceHistoryUseCase {
+
+    /**
+     * 챌린저 ID로 출석 이력 조회
+     * @param challengerId 챌린저 ID
+     * @return 출석 이력 목록 (최신순)
+     */
+    List<MyAttendanceHistoryInfo> getHistoryByChallengerId(Long challengerId);
+}

--- a/src/main/java/com/umc/product/schedule/application/service/query/AttendanceHistoryQueryService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/query/AttendanceHistoryQueryService.java
@@ -1,5 +1,8 @@
 package com.umc.product.schedule.application.service.query;
 
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.schedule.application.port.in.query.GetChallengerAttendanceHistoryUseCase;
 import com.umc.product.schedule.application.port.in.query.GetMyAttendanceHistoryUseCase;
 import com.umc.product.schedule.application.port.in.query.dto.MyAttendanceHistoryInfo;
 import com.umc.product.schedule.application.port.out.LoadAttendanceRecordPort;
@@ -38,7 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AttendanceHistoryQueryService implements GetMyAttendanceHistoryUseCase {
+public class AttendanceHistoryQueryService implements GetMyAttendanceHistoryUseCase, GetChallengerAttendanceHistoryUseCase {
 
     private static final Set<AttendanceStatus> CONFIRMED_STATUSES = Set.of(
         AttendanceStatus.PRESENT,
@@ -50,6 +53,7 @@ public class AttendanceHistoryQueryService implements GetMyAttendanceHistoryUseC
     private final LoadSchedulePort loadSchedulePort;
     private final LoadAttendanceSheetPort loadAttendanceSheetPort;
     private final LoadAttendanceRecordPort loadAttendanceRecordPort;
+    private final GetChallengerUseCase getChallengerUseCase;
 
     @Override
     public List<MyAttendanceHistoryInfo> getHistory(Long memberId, Long gisuId) {
@@ -104,5 +108,14 @@ public class AttendanceHistoryQueryService implements GetMyAttendanceHistoryUseC
             .filter(Objects::nonNull)
             .sorted(Comparator.comparing(MyAttendanceHistoryInfo::scheduledAt).reversed())
             .toList();
+    }
+
+    @Override
+    public List<MyAttendanceHistoryInfo> getHistoryByChallengerId(Long challengerId) {
+        // 1. 챌린저 정보 조회
+        ChallengerInfo challengerInfo = getChallengerUseCase.getChallengerPublicInfo(challengerId);
+
+        // 2. memberId와 gisuId를 이용하여 기존 메서드 재사용
+        return getHistory(challengerInfo.memberId(), challengerInfo.gisuId());
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 챌린저 ID로 출석 정보 조회 API

## 🔥 연관 이슈

- resolves #441 

## 🚀 작업 내용

1. 챌린저 ID로 출석 정보 조회 API
## 💬 리뷰 중점사항

