### PR TITLE
[Fix] OAuth 계정 연동 제약으로 인해 회원 탈퇴가 불가능하던 문제 해결

### DIFF
--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/UnlinkOAuthCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/UnlinkOAuthCommand.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record UnlinkOAuthCommand(
     Long memberId,
-    Long memberOAuthId
+    Long memberOAuthId,
+    boolean bypassValidation // OAuth 계정이 최소 하나는 있어야 한다는 원칙을 bypass (탈퇴용)
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -157,10 +157,13 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
 
         memberOAuth.throwIfNotValidMember(command.memberId());
 
-        // 회원에 연결된 OAuth 계정이 최소한 한 개는 있어야 함
-        List<MemberOAuth> linkedOAuth = loadMemberOAuthPort.findAllByMemberId(command.memberId());
-        if (linkedOAuth.size() <= 1) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_CANNOT_UNLINK_LAST_PROVIDER);
+        if (!command.bypassValidation()) {
+            // 회원에 연결된 OAuth 계정이 최소한 한 개는 있어야 함
+            List<MemberOAuth> linkedOAuth = loadMemberOAuthPort.findAllByMemberId(command.memberId());
+
+            if (linkedOAuth.size() <= 1) {
+                throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_CANNOT_UNLINK_LAST_PROVIDER);
+            }
         }
 
         saveMemberOAuthPort.delete(memberOAuth);


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- related to #430

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

1. (이 글을 지우고 작성해주세요)

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

