### PR TITLE
[Fix] 추가 모집 생성 가능 목록 조회 시 잘못된 파라미터 전달 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/recruitment/application/service/query/RecruitmentQueryService.java
+++ b/src/main/java/com/umc/product/recruitment/application/service/query/RecruitmentQueryService.java
@@ -1864,13 +1864,16 @@ public class RecruitmentQueryService implements GetActiveRecruitmentUseCase, Get
     }
 
     @Override
-    public ExtensionBaseRecruitmentsInfo getRecruitmentsForExtensionBase(Long schoolId) {
+    public ExtensionBaseRecruitmentsInfo getRecruitmentsForExtensionBase(Long memberId) {
         // 1. 현재 활성화된 기수(Active Gisu) 조회
         Long gisuId = resolveActiveGisuId();
 
+        Member member = loadMemberPort.findById(memberId)
+            .orElseThrow(() -> new BusinessException(Domain.MEMBER, MemberErrorCode.MEMBER_NOT_FOUND));
+
         // 2. 해당 학교 + Active 기수의 발행된 모집 목록 조회
         List<Recruitment> recruitments = loadRecruitmentPort.findAllPublishedBySchoolIdAndGisuId(
-            schoolId,
+            member.getSchoolId(),
             gisuId
         );
 


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #468 

## 🚀 작업 내용

추가 모집 생성 시 기반이 되는 모집 공고 목록을 조회하는 과정에서, 컨트롤러로부터 전달된 memberId를 schoolId로 잘못 참조하여 검색 결과가 나오지 않던 버그를 수정합니다.

1. 서비스 코드 수정 (`getRecruitmentsForExtensionBase()`)
- 메서드 파라미터를 schoolId에서 memberId로 변경 (컨트롤러 전달 값과 일치시킴)
- 전달받은 memberId를 통해 유저 정보를 조회한 후, 해당 유저의 실제 schoolId를 사용하여 모집 공고를 필터링하도록 로직 보완

## 💬 리뷰 중점사항

