### PR TITLE
[HotFix] Migration 파일로 인해서 DB의 PK Sequence가 일치하지 않는 문제 해결 

### DIFF
--- a/src/main/resources/db/migration/V2026.03.03.02.00__migration_sequence_fix.sql
+++ b/src/main/resources/db/migration/V2026.03.03.02.00__migration_sequence_fix.sql
@@ -1,0 +1,29 @@
+-- V2026.02.28.06.00에서 ID를 수동으로 집어넣으면서 시퀀스가 꼬이는 문제가 발생해서 이를 해결함.
+
+DO
+$$
+DECLARE
+seq_record RECORD;
+BEGIN
+    -- 현재 스키마의 모든 시퀀스를 순회
+FOR seq_record IN
+SELECT s.relname AS seq_name,
+       n.nspname AS schema_name,
+       t.relname AS table_name,
+       a.attname AS column_name
+FROM pg_class s
+         JOIN pg_namespace n ON n.oid = s.relnamespace
+         JOIN pg_depend d ON d.objid = s.oid AND d.classid = 'pg_class'::regclass
+        JOIN pg_class t
+ON t.oid = d.refobjid AND t.relkind = 'r'
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+WHERE s.relkind = 'S'
+  AND n.nspname = 'public' -- 스키마가 public인 경우만
+    LOOP
+    EXECUTE format('SELECT setval(%L, COALESCE((SELECT max(%I) FROM %I.%I), 1))'
+    , seq_record.schema_name || '.' || seq_record.seq_name
+    , seq_record.column_name
+    , seq_record.schema_name
+    , seq_record.table_name);
+END LOOP;
+END $$;


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

#245 에서 적용한 마이그레이션 파일 중 `term`, `school` 등에 적용된 INSERT 문에서 ID값을 지정하여 데이터베이스 시퀀스를 업데이트하지 않은 문제를 해결함.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

