### PR TITLE
[Feat] 일정 목록 조회 응답에 sheetId 추가

### DIFF
--- a/src/main/java/com/umc/product/schedule/adapter/in/web/dto/response/ScheduleListResponse.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/dto/response/ScheduleListResponse.java
@@ -35,6 +35,9 @@ public record ScheduleListResponse(
     @Schema(description = "장소명", example = "강남역 스터디룸")
     String locationName,
 
+    @Schema(description = "출석부 ID (출석부가 없는 경우 null)", example = "1", nullable = true)
+    Long sheetId,
+
     @Schema(description = "전체 인원", example = "30")
     Integer totalCount,
 

--- a/src/main/java/com/umc/product/schedule/adapter/in/web/mapper/ScheduleWebMapper.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/mapper/ScheduleWebMapper.java
@@ -21,6 +21,7 @@ public class ScheduleWebMapper {
             .startTime(info.startsAt())
             .endTime(info.endsAt())
             .locationName(info.locationName())
+            .sheetId(info.sheetId())
             .totalCount(info.totalCount())
             .presentCount(info.presentCount())
             .pendingCount(info.pendingCount())

--- a/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleWithStatsInfo.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleWithStatsInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.schedule.application.port.in.query.dto;
 
+import com.umc.product.schedule.domain.AttendanceSheet;
 import com.umc.product.schedule.domain.Schedule;
 import com.umc.product.schedule.domain.vo.AttendanceStats;
 import java.time.Instant;
@@ -14,6 +15,8 @@ public record ScheduleWithStatsInfo(
     Instant startsAt,
     Instant endsAt,
     String locationName,
+    // === AttendanceSheet Info ===
+    Long sheetId,
     // === Attendance Stats ===
     Integer totalCount,
     Integer presentCount,
@@ -23,7 +26,7 @@ public record ScheduleWithStatsInfo(
     /**
      * Schedule 엔티티와 통계 수치를 받아 Info DTO 생성
      */
-    public static ScheduleWithStatsInfo of(Schedule schedule, AttendanceStats stats, Instant now) {
+    public static ScheduleWithStatsInfo of(Schedule schedule, AttendanceSheet sheet, AttendanceStats stats, Instant now) {
         return new ScheduleWithStatsInfo(
             schedule.getId(),
             schedule.getName(),
@@ -32,6 +35,7 @@ public record ScheduleWithStatsInfo(
             schedule.getStartsAt(),
             schedule.getEndsAt(),
             schedule.getLocationName(),
+            sheet != null ? sheet.getId() : null,
             stats.totalCount(),
             stats.presentCount(),
             stats.pendingCount(),

--- a/src/main/java/com/umc/product/schedule/application/service/query/ScheduleWithStatsQueryService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/query/ScheduleWithStatsQueryService.java
@@ -66,7 +66,7 @@ public class ScheduleWithStatsQueryService implements GetScheduleListUseCase {
             .map(schedule -> {
                 AttendanceSheet sheet = sheetByScheduleId.get(schedule.getId());
                 AttendanceStats stats = calculateStats(sheet, recordsBySheetId);
-                return ScheduleWithStatsInfo.of(schedule, stats, now);
+                return ScheduleWithStatsInfo.of(schedule, sheet, stats, now);
             })
             .toList();
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] ScheduleListResponse 내부에 sheetId 추가

## 🔥 연관 이슈

- resolves #579

## 🚀 작업 내용

1. ScheduleListResponse 내부에 sheetId 추가

## 💬 리뷰 중점사항
