### PR TITLE
[Feat] 교내 파트 공지 작성 권한 변경

### DIFF
--- a/src/main/java/com/umc/product/authorization/application/port/in/query/GetChallengerRoleUseCase.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/query/GetChallengerRoleUseCase.java
@@ -172,6 +172,36 @@ public interface GetChallengerRoleUseCase {
     boolean isCentralMemberInGisu(Long memberId, Long gisuId);
 
     /**
+     * 특정 기수에서 특정 학교의 회장단 여부 (회장, 부회장)
+     *
+     * @param memberId 사용자 ID
+     * @param gisuId   기수 ID
+     * @param schoolId 학교 ID
+     * @return 해당 기수에서 해당 학교 회장단이면 true
+     */
+    boolean isSchoolCoreInGisu(Long memberId, Long gisuId, Long schoolId);
+
+    /**
+     * 특정 기수에서 특정 학교의 관리자 여부 (회장단, 파트장, 기타 운영진)
+     *
+     * @param memberId 사용자 ID
+     * @param gisuId   기수 ID
+     * @param schoolId 학교 ID
+     * @return 해당 기수에서 해당 학교 관리자면 true
+     */
+    boolean isSchoolAdminInGisu(Long memberId, Long gisuId, Long schoolId);
+
+    /**
+     * 특정 기수에서 특정 지부의 지부장 여부
+     *
+     * @param memberId  사용자 ID
+     * @param gisuId    기수 ID
+     * @param chapterId 지부 ID
+     * @return 해당 기수에서 해당 지부 지부장이면 true
+     */
+    boolean isChapterPresidentInGisu(Long memberId, Long gisuId, Long chapterId);
+
+    /**
      * 여러 챌린저의 역할 타입을 일괄 조회
      *
      * @param challengerIds 챌린저 ID 목록

--- a/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
@@ -323,4 +323,64 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
             .map(ChallengerRole::getChallengerRoleType)
             .anyMatch(ChallengerRoleType::isCentralMember);
     }
+
+    @Override
+    public boolean isSchoolCoreInGisu(Long memberId, Long gisuId, Long schoolId) {
+        if (gisuId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "gisuId는 null일 수 없습니다.");
+        }
+        if (schoolId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "schoolId는 null일 수 없습니다.");
+        }
+
+        List<ChallengerRole> roles = loadChallengerRolePort.findRolesByMemberIdAndGisuId(memberId, gisuId);
+
+        return roles.stream()
+            .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
+            .filter(role -> role.getOrganizationId().equals(schoolId))
+            .map(ChallengerRole::getChallengerRoleType)
+            .anyMatch(ChallengerRoleType::isSchoolCore);
+    }
+
+    @Override
+    public boolean isSchoolAdminInGisu(Long memberId, Long gisuId, Long schoolId) {
+        if (gisuId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "gisuId는 null일 수 없습니다.");
+        }
+        if (schoolId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "schoolId는 null일 수 없습니다.");
+        }
+
+        List<ChallengerRole> roles = loadChallengerRolePort.findRolesByMemberIdAndGisuId(memberId, gisuId);
+
+        return roles.stream()
+            .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
+            .filter(role -> role.getOrganizationId().equals(schoolId))
+            .map(ChallengerRole::getChallengerRoleType)
+            .anyMatch(ChallengerRoleType::isSchoolAdmin);
+    }
+
+    @Override
+    public boolean isChapterPresidentInGisu(Long memberId, Long gisuId, Long chapterId) {
+        if (gisuId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "gisuId는 null일 수 없습니다.");
+        }
+        if (chapterId == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "chapterId는 null일 수 없습니다.");
+        }
+
+        List<ChallengerRole> roles = loadChallengerRolePort.findRolesByMemberIdAndGisuId(memberId, gisuId);
+
+        return roles.stream()
+            .filter(role -> role.getOrganizationType() == OrganizationType.CHAPTER)
+            .filter(role -> role.getOrganizationId().equals(chapterId))
+            .map(ChallengerRole::getChallengerRoleType)
+            .anyMatch(roleType -> roleType == ChallengerRoleType.CHAPTER_PRESIDENT);
+    }
 }

--- a/src/main/java/com/umc/product/notice/dto/NoticeTargetPattern.java
+++ b/src/main/java/com/umc/product/notice/dto/NoticeTargetPattern.java
@@ -63,7 +63,8 @@ public enum NoticeTargetPattern {
     SPECIFIC_GISU_SPECIFIC_PART(true, false, false, true) {
         @Override
         public boolean validatePermission(NoticeTargetInfo info, Long memberId, GetChallengerRoleUseCase useCase) {
-            return useCase.hasRole(memberId, ChallengerRoleType.CENTRAL_EDUCATION_TEAM_MEMBER);
+            return useCase.hasRoleInGisu(memberId, info.targetGisuId(),
+                ChallengerRoleType.CENTRAL_EDUCATION_TEAM_MEMBER);
         }
     },
 
@@ -71,7 +72,7 @@ public enum NoticeTargetPattern {
     SPECIFIC_GISU_SPECIFIC_SCHOOL(true, false, true, false) {
         @Override
         public boolean validatePermission(NoticeTargetInfo info, Long memberId, GetChallengerRoleUseCase useCase) {
-            return useCase.isSchoolCore(memberId, info.targetSchoolId());
+            return useCase.isSchoolCoreInGisu(memberId, info.targetGisuId(), info.targetSchoolId());
         }
     },
 
@@ -79,7 +80,7 @@ public enum NoticeTargetPattern {
     SPECIFIC_GISU_SPECIFIC_SCHOOL_WITH_PART(true, false, true, true) {
         @Override
         public boolean validatePermission(NoticeTargetInfo info, Long memberId, GetChallengerRoleUseCase useCase) {
-            return useCase.isSchoolAdmin(memberId, info.targetSchoolId());
+            return useCase.isSchoolAdminInGisu(memberId, info.targetGisuId(), info.targetSchoolId());
         }
     },
 
@@ -87,7 +88,7 @@ public enum NoticeTargetPattern {
     SPECIFIC_GISU_SPECIFIC_CHAPTER(true, true, false, false) {
         @Override
         public boolean validatePermission(NoticeTargetInfo info, Long memberId, GetChallengerRoleUseCase useCase) {
-            return useCase.isChapterPresident(memberId, info.targetChapterId());
+            return useCase.isChapterPresidentInGisu(memberId, info.targetGisuId(), info.targetChapterId());
         }
     },
 
@@ -95,7 +96,7 @@ public enum NoticeTargetPattern {
     SPECIFIC_GISU_SPECIFIC_CHAPTER_WITH_PART(true, true, false, true) {
         @Override
         public boolean validatePermission(NoticeTargetInfo info, Long memberId, GetChallengerRoleUseCase useCase) {
-            return useCase.isChapterPresident(memberId, info.targetChapterId());
+            return useCase.isChapterPresidentInGisu(memberId, info.targetGisuId(), info.targetChapterId());
         }
     },
 


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #592 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

- 공지 작성 권한 중, 교내 파트 공지에 대한 권한을 schoolCore -> schoolAdmin으로 수정합니다.

- **특정 기수**에 대한 실질적인 검증을 하지 않고 있어 기수를 포함해 검증하는 메서드를 구현해 사용하도록 합니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

