### PR TITLE
[Fix] 공지 전체 조회 시 파트 필터에서 발생하는 QueryDSL 오류 해결

### DIFF
--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeQueryRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeQueryRepository.java
@@ -234,16 +234,20 @@ public class NoticeQueryRepository {
                 .and(target.targetSchoolId.isNull());
 
             // 특정 기수 + 특정 지부 + 특정 파트
-            scopeCondition.or(
-                target.targetChapterId.eq(chapterId)
-                    .and(target.targetSchoolId.isNull())
-            );
+            if (chapterId != null) {
+                scopeCondition = scopeCondition.or(
+                    target.targetChapterId.eq(chapterId)
+                        .and(target.targetSchoolId.isNull())
+                );
+            }
 
             // 특정 기수 + 특정 학교 + 특정 파트
-            scopeCondition.or(
-                target.targetChapterId.isNull()
-                    .and(target.targetSchoolId.eq(schoolId))
-            );
+            if (schoolId != null) {
+                scopeCondition = scopeCondition.or(
+                    target.targetChapterId.isNull()
+                        .and(target.targetSchoolId.eq(schoolId))
+                );
+            }
 
             return gisuAndPartMatch.and(scopeCondition);
         }

--- a/src/main/java/com/umc/product/notice/application/service/query/NoticeQueryService.java
+++ b/src/main/java/com/umc/product/notice/application/service/query/NoticeQueryService.java
@@ -276,8 +276,10 @@ public class NoticeQueryService implements GetNoticeUseCase {
         }
 
         // 클라이언트가 요청한 필터 종류는 유지하되, 실제 값은 사용자 프로필에서만 가져옴
-        Long filteredChapterId = classification.chapterId() != null ? chapterId : null;
-        Long filteredSchoolId = classification.schoolId() != null ? schoolId : null;
+        // 파트 필터일 때는 chapterId/schoolId가 없어도 실제 유저 값으로 채움
+        boolean hasPart = classification.part() != null;
+        Long filteredChapterId = (classification.chapterId() != null || hasPart) ? chapterId : null;
+        Long filteredSchoolId = (classification.schoolId() != null || hasPart) ? schoolId : null;
 
         return new NoticeClassification(gisuId, filteredChapterId, filteredSchoolId, classification.part());
     }


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #597 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

어제 작업 중 파트필터에 있던 지부, 학교id null체크 분기를 제거해서 파트필터에서 eq() null 오류 발생
-> 파트필터시 지부id, 기수id를  repository단 접근 전에 실제 유저의 정보를 기반으로 채워서 넘기도록 수정합니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

