### PR TITLE
[Fix] Google Client ID 검증으로 인해 Google OAuth 로그인이 되지 않던 문제 해결

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
@@ -4,6 +4,7 @@ import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +31,8 @@ public class GoogleTokenVerifier {
 
     private final RestClient restClient;
 
-    @Value("${spring.security.oauth2.client.registration.google.client-id}")
-    private String googleClientId;
+    @Value("${app.oauth2.google.client-id-list}")
+    private List<String> googleClientIdList;
 
     /**
      * Google ID 토큰을 검증하고 OAuth2Attributes로 변환합니다.
@@ -60,8 +61,8 @@ public class GoogleTokenVerifier {
             }
 
             // audience(aud) 검증 - 우리 앱의 client ID와 일치해야 함
-            if (!googleClientId.equals(response.aud())) {
-                log.error("Google ID 토큰 audience 불일치: expected={}, actual={}", googleClientId, response.aud());
+            if (!googleClientIdList.contains(response.aud())) {
+                log.error("Google ID 토큰 audience 불일치: expected={}, actual={}", googleClientIdList, response.aud());
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
@@ -103,8 +104,8 @@ public class GoogleTokenVerifier {
             }
 
             // audience(aud) 검증 - 우리 앱의 client ID와 일치해야 함
-            if (!googleClientId.equals(response.aud())) {
-                log.error("Google ID 토큰 audience 불일치: expected={}, actual={}", googleClientId, response.aud());
+            if (!googleClientIdList.contains(response.aud())) {
+                log.error("Google ID 토큰 audience 불일치: expected={}, actual={}", googleClientIdList, response.aud());
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
@@ -129,7 +130,8 @@ public class GoogleTokenVerifier {
      * Google OAuth 토큰을 revoke합니다.
      *
      * @param token revoke할 토큰 (access token 또는 refresh token)
-     * @see <a href="https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke">Google Token Revoke</a>
+     * @see <a href="https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke">Google Token
+     * Revoke</a>
      */
     public void revokeToken(String token) {
         log.info("Google token revoke 시작");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -163,7 +163,7 @@ logging:
     root: INFO
 
     # 애플리케이션 기본값
-    com.umc.product: ${LOGGING_APP_LEVEL:-INFO}
+    com.umc.product: ${LOGGING_APP_LEVEL:INFO}
 
     # Spring Framework
     org.springframework.web: INFO
@@ -266,6 +266,8 @@ app:
     password: ${SWAGGER_AUTH_PASSWORD:password}
 
   oauth2:
+    google:
+      client-id-list: ${GOOGLE_CLIENT_ID_LIST:}
     apple:
       client-id: ${APPLE_CLIENT_ID}
       team-id: ${APPLE_TEAM_ID}


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

AccessToken에서 Google Client ID를 검증하던 로직을 수정하였음 (클라이언트가 여러개임)

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

