### PR TITLE
[Feat] 챌린저 검색 시 이름과 닉네임을 AND 조건으로 변경

### DIFF
--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java
@@ -45,7 +45,7 @@ public class ChallengerSearchController {
         @ParameterObject SearchChallengerRequest searchRequest
     ) {
         return SearchChallengerResponse.from(
-            searchChallengerUseCase.search(
+            searchChallengerUseCase.offsetSearch(
                 searchRequest.toQuery(),
                 pageable
             )

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
@@ -39,9 +39,12 @@ public class ChallengerQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 페이지네이션 검색 구현
+     */
     public Page<Challenger> pagingSearch(SearchChallengerQuery query, Pageable pageable) {
 
-        BooleanBuilder condition = buildOffsetSearchCondition(query, challenger, member);
+        BooleanBuilder condition = buildBaseCondition(query, challenger, member);
 
         List<Challenger> content = queryFactory
             .selectFrom(challenger)
@@ -62,10 +65,14 @@ public class ChallengerQueryRepository {
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
+    /**
+     * 커서 기반 검색 구현
+     */
     public List<Challenger> cursorSearch(SearchChallengerQuery query, Long cursor, int size) {
 
-        BooleanBuilder condition = buildOffsetSearchCondition(query, challenger, member);
+        BooleanBuilder condition = buildBaseCondition(query, challenger, member);
 
+        // 커서가 주어졌다면 커서 기반 검색 조건을 추가함
         if (cursor != null) {
             condition.and(buildCursorSearchCondition(cursor, challenger, member));
         }
@@ -80,11 +87,11 @@ public class ChallengerQueryRepository {
     }
 
     /**
-     * 파트별 챌린저 수
+     * Search Query에 해당하는 전체 조회 결과의 파트별 챌린저 수
      */
     public Map<ChallengerPart, Long> countByPart(SearchChallengerQuery query) {
 
-        BooleanBuilder condition = buildOffsetSearchCondition(query, challenger, member);
+        BooleanBuilder condition = buildBaseCondition(query, challenger, member);
 
         List<Tuple> tuples = queryFactory
             .select(challenger.part, challenger.count())
@@ -152,7 +159,7 @@ public class ChallengerQueryRepository {
             .fetch();
     }
 
-    // ========== private methods ==========
+    // ========== PRIVATE METHODS ==========
 
     private NumberExpression<Double> pointValueExpression(QChallengerPoint point) {
         CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
@@ -172,6 +179,9 @@ public class ChallengerQueryRepository {
         return caseBuilder.otherwise(0.0);
     }
 
+    /**
+     * 파트별 정렬 순서 결정
+     */
     private NumberExpression<Integer> partOrder(QChallenger challenger) {
         return new CaseBuilder()
             .when(challenger.part.eq(ChallengerPart.PLAN)).then(ChallengerPart.PLAN.getSortOrder())
@@ -184,7 +194,12 @@ public class ChallengerQueryRepository {
             .otherwise(999);
     }
 
-    private BooleanBuilder buildOffsetSearchCondition(
+    /**
+     * Challenger와 Member를 기준으로 공통 검색 조건을 생성함
+     * <p>
+     * 페이지네이션 방식과 관계없이 공통으로 쓰이는 조건
+     */
+    private BooleanBuilder buildBaseCondition(
         SearchChallengerQuery query,
         QChallenger challenger,
         QMember member
@@ -195,96 +210,150 @@ public class ChallengerQueryRepository {
 
         // keyword가 있으면 name/nickname 무시하고 keyword로 검색, 없으면 각각 검색
         if (query.keyword() != null && !query.keyword().isBlank()) {
-            builder.and(keywordContains(query.keyword(), member));
+            builder.and(containsKeyword(query.keyword(), member));
         } else {
-            builder.and(nicknameOrNameContains(query.nickname(), query.name(), member));
+            // JavaDoc 읽을 것, 둘 다 주어지면 AND 조건, 하나만 주어지면 해당 조건으로, 없으면 적용 X
+            builder.and(containsNicknameAndName(query.nickname(), query.name(), member));
         }
 
-        builder.and(schoolIdEq(query.schoolId(), member));
-        builder.and(chapterIdExists(query.chapterId(), member));
-        builder.and(partEq(query.part(), challenger));
-        builder.and(gisuIdEq(query.gisuId(), challenger));
-        builder.and(statusIn(query.statuses(), challenger));
+        builder.and(schoolIdEq(query.schoolId(), member)); // 학교 ID가 있다면 일치해야함
+        builder.and(chapterIdExists(query.chapterId(), member)); // 지부 ID가 있다면 챌린저의 학교가 해당 지부에 속해야함
+        builder.and(partEq(query.part(), challenger)); // 파트값이 주어졌다면 일치하여야 함
+        builder.and(gisuIdEq(query.gisuId(), challenger)); // 기수 값이 주어졌다면 일치하여야 함
+        builder.and(statusIn(query.statuses(), challenger)); // 챌린저 상태값이 주어졌다면 일치하여야 함
 
         return builder;
     }
 
+    /**
+     * 커서 기반 검색 조건을 추가함
+     */
     private BooleanExpression buildCursorSearchCondition(Long cursorId, QChallenger challenger, QMember member) {
+        // 메인 쿼리에서 이미 QChallenger와 QMember의 alias를 사용하고 있어서 새로운 alias 생성
         QChallenger c = new QChallenger("cursorC");
         QMember m = new QMember("cursorM");
 
         // 커서 챌린저의 정렬 키 값 조회
         Tuple cursorRow = queryFactory
             .select(partOrder(c), c.gisuId, m.name, c.id)
+            // 챌린저 테이블에 회원 테이블을 조인함
             .from(c)
             .join(m).on(c.memberId.eq(m.id))
+            // 커서 ID (챌린저 ID)가 일치하는 행을 가져옴
             .where(c.id.eq(cursorId))
             .fetchOne();
 
+        // 커서 ID가 유효하지 않은 경우 예외 처리
         if (cursorRow == null) {
             throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CURSOR_ID);
         }
 
+        // 가져온 Cursor Row를 기반으로 각 키 값을
         Integer cursorPartOrder = cursorRow.get(partOrder(c));
         Long cursorGisuId = cursorRow.get(c.gisuId);
         String cursorName = cursorRow.get(m.name);
         Long cursorIdVal = cursorRow.get(c.id);
 
-        NumberExpression<Integer> currentPartOrder = partOrder(challenger);
+        NumberExpression<Integer> currentPartOrder = partOrder(challenger); // 해당 챌린저 행의 파트 키 값
 
         // keyset pagination: 정렬 순서(partOrder ASC, gisuId DESC, name ASC, id ASC) 기반
-        return currentPartOrder.gt(cursorPartOrder)
-            .or(currentPartOrder.eq(cursorPartOrder)
-                .and(challenger.gisuId.lt(cursorGisuId)))
-            .or(currentPartOrder.eq(cursorPartOrder)
-                .and(challenger.gisuId.eq(cursorGisuId))
-                .and(member.name.gt(cursorName)))
-            .or(currentPartOrder.eq(cursorPartOrder)
-                .and(challenger.gisuId.eq(cursorGisuId))
-                .and(member.name.eq(cursorName))
-                .and(challenger.id.gt(cursorIdVal)));
+        return currentPartOrder.gt(cursorPartOrder) // 가장 먼저 정렬되는 키: 파트 순서가 더 크거나
+            .or(
+                currentPartOrder.eq(cursorPartOrder)
+                    .and(challenger.gisuId.lt(cursorGisuId)) // 두 번째: 파트 순서가 같고, 기수 ID가 더 크거나
+            )
+            .or(
+                currentPartOrder.eq(cursorPartOrder)
+                    .and(challenger.gisuId.eq(cursorGisuId))
+                    .and(member.name.gt(cursorName)) // 세 번째: 기수 ID까지 같고, 이름값이 사전순으로 더 크거나
+            )
+            .or(
+                currentPartOrder.eq(cursorPartOrder)
+                    .and(challenger.gisuId.eq(cursorGisuId))
+                    .and(member.name.eq(cursorName))
+                    .and(challenger.id.gt(cursorIdVal)) // 네 번째: 이름까지 같으면 챌린저 ID가 큰 것을 기준으로
+            );
     }
 
-    private BooleanExpression challengerIdEq(Long challengerId, QChallenger challenger) {
-        return challengerId != null ? challenger.id.eq(challengerId) : null;
-    }
-
-    private BooleanExpression gisuIdEq(Long gisuId, QChallenger challenger) {
-        return gisuId != null ? challenger.gisuId.eq(gisuId) : null;
-    }
-
-    private BooleanExpression partEq(ChallengerPart part, QChallenger challenger) {
-        return part != null ? challenger.part.eq(part) : null;
-    }
-
-    private BooleanExpression keywordContains(String keyword, QMember member) {
+    /**
+     * 키워드 검색, 이름 또는 닉네임이 포함하는지
+     */
+    private BooleanExpression containsKeyword(String keyword, QMember member) {
         return member.nickname.containsIgnoreCase(keyword)
             .or(member.name.containsIgnoreCase(keyword));
     }
 
-    private BooleanExpression nicknameOrNameContains(String nickname, String name, QMember member) {
-        BooleanExpression nicknameCondition = (nickname != null && !nickname.isBlank())
-            ? member.nickname.containsIgnoreCase(nickname) : null;
-        BooleanExpression nameCondition = (name != null && !name.isBlank())
-            ? member.name.containsIgnoreCase(name) : null;
+    /**
+     * 이름과 닉네임을 포함하는지 검색
+     * <p>
+     * 둘 다 주어진 경우 AND로 검색함. 둘 중 하나만 주어진 경우에는 해당 조건으로 검색함
+     */
+    private BooleanExpression containsNicknameAndName(String nickname, String name, QMember member) {
+        // 닉네임 관련 조건, 닉네임이 비어있지 않다면 조건 생성
+        BooleanExpression nicknameCondition =
+            (nickname != null && !nickname.isBlank())
+                ? member.nickname.containsIgnoreCase(nickname)
+                : null;
 
+        // 이름 관련 조건, 이름이 비어있지 않다면 조건 생성
+        BooleanExpression nameCondition =
+            (name != null && !name.isBlank())
+                ? member.name.containsIgnoreCase(name)
+                : null;
+
+        // 닉네임 및 이름 조건이 모두 존재하는 경우 (둘 다 주어진 경우) AND 조건으로 결합
         if (nicknameCondition != null && nameCondition != null) {
-            return nicknameCondition.or(nameCondition);
+            return nicknameCondition.and(nameCondition);
         }
+
+        // 닉네임 조건이 존재하는 경우 반환
         if (nicknameCondition != null) {
             return nicknameCondition;
         }
+
         return nameCondition;
     }
 
+    /**
+     * 챌린저 ID가 일치하는지
+     */
+    private BooleanExpression challengerIdEq(Long challengerId, QChallenger challenger) {
+        return challengerId != null ? challenger.id.eq(challengerId) : null;
+    }
+
+    /**
+     * 기수 ID가 일치하는지
+     */
+    private BooleanExpression gisuIdEq(Long gisuId, QChallenger challenger) {
+        return gisuId != null ? challenger.gisuId.eq(gisuId) : null;
+    }
+
+    /**
+     * 파트가 일치하는지
+     */
+    private BooleanExpression partEq(ChallengerPart part, QChallenger challenger) {
+        return part != null ? challenger.part.eq(part) : null;
+    }
+
+    /**
+     * 학교 ID가 일치하는지
+     */
     private BooleanExpression schoolIdEq(Long schoolId, QMember member) {
         return schoolId != null ? member.schoolId.eq(schoolId) : null;
     }
 
+    /**
+     * 챌린저 상태값이 일치하는지
+     */
     private BooleanExpression statusIn(List<ChallengerStatus> statuses, QChallenger challenger) {
         return (statuses != null && !statuses.isEmpty()) ? challenger.status.in(statuses) : null;
     }
 
+    /**
+     * 회원이 속한 학교가 속했던 지부 ID들이 검색 조건의 지부 ID와 일치하는지
+     * <p>
+     * TODO: 이거 이렇게 제한하면 안 될 것 같아요 - 경운
+     */
     private BooleanExpression chapterIdExists(Long chapterId, QMember member) {
         if (chapterId == null) {
             return null;
@@ -292,7 +361,8 @@ public class ChallengerQueryRepository {
 
         return JPAExpressions
             .selectOne()
-            .from(chapterSchool)
+            .from(chapterSchool) // 지부-학교 매핑 테이블에서
+            // WHERE 회원 학교 = 매핑된 학교 AND 매핑된 지부 = 검색 조건의 지부
             .where(
                 chapterSchool.school.id.eq(member.schoolId),
                 chapterSchool.chapter.id.eq(chapterId)

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/SearchChallengerUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/SearchChallengerUseCase.java
@@ -13,7 +13,7 @@ public interface SearchChallengerUseCase {
     /**
      * 조건에 맞는 챌린저 목록을 조회합니다. (Offset 기반)
      */
-    SearchChallengerResult search(SearchChallengerQuery query, Pageable pageable);
+    SearchChallengerResult offsetSearch(SearchChallengerQuery query, Pageable pageable);
 
     /**
      * 조건에 맞는 챌린저 목록을 조회합니다. (Cursor 기반)

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerSearchService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerSearchService.java
@@ -44,11 +44,8 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
 
     private final GetChallengerPointUseCase getChallengerPointUseCase;
 
-    /**
-     * 현재는 사용하고 있지 않는 것으로 보입니다.
-     */
     @Override
-    public SearchChallengerResult search(SearchChallengerQuery query, Pageable pageable) {
+    public SearchChallengerResult offsetSearch(SearchChallengerQuery query, Pageable pageable) {
         // 페이지네이션을 적용해서 조건에 따라 챌린저 검색
         Page<Challenger> challengers = searchChallengerPort.search(query, pageable);
 
@@ -60,9 +57,10 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
         Map<Long, MemberInfo> memberProfiles = loadMemberProfiles(challengers);
         // 챌린저별 역할 조회
         Map<Long, List<ChallengerRoleType>> roleTypes = loadRoleTypes(challengers.getContent());
-        //
+        // 챌린저별 기수 정보 조회
         Map<Long, Long> gisuGenerationMap = loadGisuGenerationMap(challengers.getContent());
 
+        // Page Item으로 변환
         Page<SearchChallengerItemInfo> items = challengers.map(challenger ->
             toItemInfo(challenger, memberProfiles, pointSums, roleTypes, gisuGenerationMap)
         );
@@ -72,13 +70,16 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
 
     @Override
     public SearchChallengerCursorResult cursorSearch(SearchChallengerQuery query, Long cursor, int size) {
+        // 조건에 맞는 챌린저 결과 및 파트별 인원 수 조회
         List<Challenger> challengers = searchChallengerPort.cursorSearch(query, cursor, size);
         Map<ChallengerPart, Long> partCounts = buildPartCounts(query);
 
+        // cursor 기반 페이지네이션 처리
+        // 조회된 결과가 요청한 size보다 많으면 다음 페이지가 존재하는 것으로 간주 및 마지막 값 자르기
         boolean hasNext = challengers.size() > size;
         List<Challenger> result = hasNext ? challengers.subList(0, size) : challengers;
 
-        Map<Long, Double> pointSums = buildPointSums(result);
+        Map<Long, Double> pointSums = buildPointSums(result); // 챌린저별 상벌점 합계 계산
         Map<Long, MemberInfo> memberProfiles = loadMemberProfiles(result);
         Map<Long, List<ChallengerRoleType>> roleTypes = loadRoleTypes(result);
         Map<Long, Long> gisuGenerationMap = loadGisuGenerationMap(result);
@@ -87,11 +88,14 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
             .map(challenger -> toItemInfo(challenger, memberProfiles, pointSums, roleTypes, gisuGenerationMap))
             .toList();
 
+        // 커서 페이지네이션: 다음 커서 ID값 제공
         Long nextCursor = hasNext ? result.get(result.size() - 1).getId() : null;
 
         return new SearchChallengerCursorResult(items, nextCursor, hasNext, partCounts);
     }
 
+    // global API에서 사용하는 해당 메소드는 deprecate 예정입니다. (중복)
+    @Deprecated(since = "v1.3.0", forRemoval = true)
     @Override
     public GlobalSearchChallengerCursorResult globalCursorSearch(SearchChallengerQuery query, Long cursor, int size) {
         List<Challenger> challengers = searchChallengerPort.cursorSearch(query, cursor, size);
@@ -110,6 +114,8 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
 
         return new GlobalSearchChallengerCursorResult(items, nextCursor, hasNext);
     }
+
+    // TODO: 아래 V2 메소드들은 왜 사용되고 있지 않은지 파악 필요 - 경운
 
     @Override
     public Page<ChallengerInfo> searchV2(SearchChallengerQuery query, Pageable pageable) {
@@ -144,11 +150,15 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
      * 조회된 챌린저의 파트별 인원 수를 계산
      */
     private Map<ChallengerPart, Long> buildPartCounts(SearchChallengerQuery query) {
+        // 빈 Map 생성 후, 모든 ChallengerPart에 대해 0으로 초기화
         Map<ChallengerPart, Long> counts = new EnumMap<>(ChallengerPart.class);
         for (ChallengerPart part : ChallengerPart.values()) {
             counts.put(part, 0L);
         }
+
+        // 검색 조건에 맞는 결과값을 파트에 따라 나누어서 제공함.
         counts.putAll(searchChallengerPort.countByPart(query));
+
         return counts;
     }
 
@@ -183,6 +193,9 @@ public class ChallengerSearchService implements SearchChallengerUseCase {
         return loadMemberProfiles(challengers.getContent());
     }
 
+    /**
+     * 챌린저 목록에 있는 모든 회원의 프로필 정보를 조회함
+     */
     private Map<Long, MemberInfo> loadMemberProfiles(List<Challenger> challengers) {
         Set<Long> memberIds = challengers.stream()
             .map(Challenger::getMemberId)


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #594

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

1. 챌린저 검색 API에서 `name`과 `nickname`이 OR 조건으로 검색을 하게 되어 있어 이를 `keyword` 필드로 대체하고, 본래 조건은 AND로 걸리도록 변경하였음.
2. Query Repository 코드에 하나도 존재하지 않던 주석을 추가함.
3. 코드 가독성 향상

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

