### PR TITLE
[Chore] 이메일 인증 발송 시 제목에 인증코드를 포함하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
+++ b/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
@@ -38,7 +38,7 @@ public class SendEmailService implements SendEmailUseCase {
             // fromAddress는 바꿔도 SMTP 설정대로 전송됨
             helper.setFrom(fromAddress, "University MakeUs Challenge");
             helper.setTo(command.to());
-            helper.setSubject("University MakeUs Challenge: 이메일 인증 코드");
+            helper.setSubject("이메일 인증 코드: " + command.verificationCode());
 
             // Thymeleaf 템플릿 렌더링
             Context context = new Context();


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

다른 기업들도 그렇게 많이 처리하고, 테스트하면서 너무 불편하기도 해서 변경하였습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

