### PR TITLE
[Feat] 타인의 회원 정보 조회 시 민감 정보는 필터링해서 보내도록 개선

### DIFF
--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
@@ -119,4 +119,36 @@ public record ChallengerInfoResponse(
             .status(memberInfo.status())
             .build();
     }
+
+    /**
+     * Public하게 공개할 목적으로 민감한 정보를 제거합니다
+     */
+    public ChallengerInfoResponse toPublic() {
+        return ChallengerInfoResponse.builder()
+            .challengerId(challengerId)
+            .memberId(memberId)
+            .gisuId(gisuId)
+            .gisu(gisu)
+            .chapterId(chapterId)
+            .chapterName(chapterName)
+            .part(part)
+            .challengerStatus(challengerStatus)
+            // 상벌점 정보는 공개하지 않음
+            .challengerPoints(List.of())
+            .points(List.of())
+            .totalPoints(totalPoints)
+            .roles(roles)
+
+            // 멤버 정보 중 일부만 공개
+            .name(name)
+            .nickname(nickname)
+            .email(null) // 이메일은 보안 상 제거하도록 함
+            .schoolId(schoolId)
+            .schoolName(schoolName)
+            .profileImageLink(profileImageLink)
+            // 회원 상태는 공개하지 않음
+            .memberStatus(null)
+            .status(null)
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java
@@ -33,13 +33,12 @@ public class MemberQueryController {
     @GetMapping("profile/{memberId}")
     @CheckAccess(
         resourceType = ResourceType.MEMBER,
-        resourceId = "#memberId",
         permission = PermissionType.READ
     )
     MemberInfoResponse getMemberProfile(
         @PathVariable Long memberId
     ) {
-        return assembler.fromMemberId(memberId);
+        return assembler.fromMemberIdToPublic(memberId);
     }
 
     @Operation(summary = "내 프로필 조회")

--- a/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
@@ -43,4 +43,8 @@ public class MemberInfoResponseAssembler {
 
         return MemberInfoResponse.from(memberInfo, memberProfileInfo, challengerInfoResponses);
     }
+
+    public MemberInfoResponse fromMemberIdToPublic(Long memberId) {
+        return fromMemberId(memberId).toPublic();
+    }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
@@ -49,7 +49,8 @@ public record MemberInfoResponse(
 
     public static MemberInfoResponse from(
         MemberInfo info, MemberProfileInfo profileInfo,
-        List<ChallengerInfoResponse> challengerRecords) {
+        List<ChallengerInfoResponse> challengerRecords
+    ) {
         return MemberInfoResponse.builder()
             .id(info.id())
             .name(info.name())
@@ -62,6 +63,22 @@ public record MemberInfoResponse(
             .roles(info.roles())
             .challengerRecords(challengerRecords)
             .profile(profileInfo)
+            .build();
+    }
+
+    public MemberInfoResponse toPublic() {
+        return MemberInfoResponse.builder()
+            .id(id)
+            .name(name)
+            .nickname(nickname)
+            .email(null)
+            .schoolId(schoolId)
+            .schoolName(schoolName)
+            .profileImageLink(profileImageLink)
+            .status(null)
+            .roles(roles)
+            .challengerRecords(challengerRecords.stream().map(ChallengerInfoResponse::toPublic).toList())
+            .profile(profile)
             .build();
     }
 }

--- a/src/main/java/com/umc/product/member/application/port/in/query/MemberInfo.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/MemberInfo.java
@@ -45,7 +45,7 @@ public record MemberInfo(
     @Deprecated
     public static MemberInfo from(Member member, String schoolName, String profileImageLink) {
         log.error("챌린저 역할 정보를 포함하지 않는 생성자를 이용하고 있습니다.");
-        
+
         return new MemberInfo(
             member.getId(),
             member.getName(),
@@ -74,6 +74,21 @@ public record MemberInfo(
             .profileImageLink(profileImageLink)
             .status(member.getStatus())
             .roles(roles)
+            .build();
+    }
+
+    public MemberInfo toPublic() {
+        return MemberInfo.builder()
+            .id(this.id)
+            .name(this.name)
+            .nickname(this.nickname)
+            .email("알 수 없음")
+            .schoolId(this.schoolId)
+            .schoolName(this.schoolName)
+            .profileImageId(this.profileImageId)
+            .profileImageLink(this.profileImageLink)
+            .status(this.status)
+            .roles(this.roles)
             .build();
     }
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberPermissionEvaluator.java
@@ -8,7 +8,6 @@ import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.common.domain.exception.CommonException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
-import com.umc.product.member.application.port.in.query.MemberInfo;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,14 +39,7 @@ public class MemberPermissionEvaluator implements ResourcePermissionEvaluator {
     // === PRIVATE METHODS ===
 
     private boolean canReadMember(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
-        if (isSelf(subjectAttributes, resourcePermission)) {
-            return true;
-        }
-
-        MemberInfo targetMemberInfo = getMemberUseCase.getMemberInfoById(resourcePermission.getResourceIdAsLong());
-
-        return isSchoolCoreOf(subjectAttributes.memberId(), targetMemberInfo.schoolId())
-            || isCentralCore(subjectAttributes.memberId());
+        return !subjectAttributes.gisuChallengerInfos().isEmpty();
     }
 
     private boolean canDeleteMember(SubjectAttributes subjectAttributes) {


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #641 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

`email`, `point` 등 null 처리

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

