### PR TITLE
[Feat] 커리큘럼 조회 및 진행상황 조회를 기수별로 할 수 있도록 변경

### DIFF
--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/CurriculumQueryController.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/CurriculumQueryController.java
@@ -36,6 +36,7 @@ public class CurriculumQueryController implements CurriculumQueryControllerApi {
         return CurriculumResponse.from(getCurriculumUseCase.getByActiveGisuAndPart(part));
     }
 
+    @Deprecated
     @Override
     @GetMapping("/challengers/me/progress")
     public CurriculumProgressResponse getMyProgress(@CurrentMember MemberPrincipal memberPrincipal) {

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/CurriculumQueryControllerV2.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/CurriculumQueryControllerV2.java
@@ -1,0 +1,33 @@
+package com.umc.product.curriculum.adapter.in.web;
+
+import com.umc.product.curriculum.adapter.in.web.dto.response.CurriculumProgressResponse;
+import com.umc.product.curriculum.adapter.in.web.swagger.CurriculumQueryControllerV2Api;
+import com.umc.product.curriculum.application.port.in.query.GetCurriculumProgressUseCase;
+import com.umc.product.curriculum.application.port.in.query.dto.CurriculumProgressInfo;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/curriculums")
+@RequiredArgsConstructor
+public class CurriculumQueryControllerV2 implements CurriculumQueryControllerV2Api {
+
+    private final GetCurriculumProgressUseCase getCurriculumProgressUseCase;
+
+    @Override
+    @GetMapping("/challengers/me/progress")
+    public CurriculumProgressResponse getMyProgress(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @RequestParam Long gisuId
+    ) {
+        CurriculumProgressInfo info = getCurriculumProgressUseCase.getMyProgressByGisu(
+            memberPrincipal.getMemberId(), gisuId
+        );
+        return CurriculumProgressResponse.from(info);
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/dto/response/CurriculumResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/dto/response/CurriculumResponse.java
@@ -23,10 +23,6 @@ public record CurriculumResponse(
     List<WorkbookResponse> workbooks
 ) {
     public static CurriculumResponse from(CurriculumInfo info) {
-        if (info == null) {
-            return null;
-        }
-
         List<WorkbookResponse> workbookResponses = info.workbooks().stream()
             .map(WorkbookResponse::from)
             .toList();

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/swagger/CurriculumQueryControllerApi.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/swagger/CurriculumQueryControllerApi.java
@@ -28,10 +28,13 @@ public interface CurriculumQueryControllerApi {
     );
 
     @Operation(
-        summary = "내 커리큘럼 진행 상황 조회",
+        summary = "내 커리큘럼 진행 상황 조회 (Deprecated)",
         description = "챌린저의 커리큘럼 진행 상황을 조회합니다. " +
-            "각 주차별 워크북의 상태(기본/진행중/제출완료/통과/실패)를 반환합니다."
+            "각 주차별 워크북의 상태(기본/진행중/제출완료/통과/실패)를 반환합니다.\n\n" +
+            "**Deprecated**: 현재 활성 기수 기준으로만 조회되어 이전 기수 사용자는 조회가 불가합니다. " +
+            "`GET /api/v2/curriculums/challengers/me/progress?gisuId={gisuId}` 사용을 권장합니다."
     )
+    @Deprecated
     CurriculumProgressResponse getMyProgress(MemberPrincipal memberPrincipal);
 
     @Operation(

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/swagger/CurriculumQueryControllerV2Api.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/swagger/CurriculumQueryControllerV2Api.java
@@ -1,0 +1,21 @@
+package com.umc.product.curriculum.adapter.in.web.swagger;
+
+import com.umc.product.curriculum.adapter.in.web.dto.response.CurriculumProgressResponse;
+import com.umc.product.global.security.MemberPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Curriculum | 커리큘럼 Query V2", description = "커리큘럼 조회 V2")
+public interface CurriculumQueryControllerV2Api {
+
+    @Operation(
+        summary = "내 커리큘럼 진행 상황 조회 (기수 지정)",
+        description = "기수 ID를 지정하여 해당 기수의 커리큘럼 진행 상황을 조회합니다. " +
+            "이전 기수였던 사용자도 gisuId를 전달하면 해당 기수의 진행 상황을 조회할 수 있습니다."
+    )
+    CurriculumProgressResponse getMyProgress(
+        MemberPrincipal memberPrincipal,
+        @Parameter(description = "기수 ID", required = true) Long gisuId
+    );
+}

--- a/src/main/java/com/umc/product/curriculum/application/port/in/query/GetCurriculumProgressUseCase.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/query/GetCurriculumProgressUseCase.java
@@ -13,6 +13,11 @@ public interface GetCurriculumProgressUseCase {
     CurriculumProgressInfo getMyProgress(Long memberId);
 
     /**
+     * 내 커리큘럼 진행 상황 조회 - 지정한 기수의 챌린저 기반으로 워크북 목록 + 제출 현황
+     */
+    CurriculumProgressInfo getMyProgressByGisu(Long memberId, Long gisuId);
+
+    /**
      * 파트별 커리큘럼 주차 목록 조회 - 활성 기수의 해당 파트 워크북 주차/제목 목록
      */
     List<CurriculumWeekInfo> getWeeksByPart(ChallengerPart part);

--- a/src/main/java/com/umc/product/curriculum/application/service/query/CurriculumQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/CurriculumQueryService.java
@@ -11,6 +11,8 @@ import com.umc.product.curriculum.application.port.in.query.dto.CurriculumWeekIn
 import com.umc.product.curriculum.application.port.out.LoadCurriculumPort;
 import com.umc.product.curriculum.application.port.out.LoadCurriculumProgressPort;
 import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookPort;
+import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
+import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +34,7 @@ public class CurriculumQueryService implements GetCurriculumProgressUseCase, Get
     public CurriculumInfo getByActiveGisuAndPart(ChallengerPart part) {
         return loadCurriculumPort.findByActiveGisuAndPart(part)
             .map(CurriculumInfo::from)
-            .orElse(null);
+            .orElseThrow(() -> new CurriculumDomainException(CurriculumErrorCode.CURRICULUM_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/umc/product/curriculum/application/service/query/CurriculumQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/CurriculumQueryService.java
@@ -44,6 +44,13 @@ public class CurriculumQueryService implements GetCurriculumProgressUseCase, Get
     }
 
     @Override
+    public CurriculumProgressInfo getMyProgressByGisu(Long memberId, Long gisuId) {
+        ChallengerInfo challengerInfo = getChallengerUseCase.getByMemberIdAndGisuId(memberId, gisuId);
+
+        return loadCurriculumProgressPort.findCurriculumProgress(challengerInfo.challengerId(), challengerInfo.part());
+    }
+
+    @Override
     public List<CurriculumWeekInfo> getWeeksByPart(ChallengerPart part) {
         return loadOriginalWorkbookPort.findWeekInfoByActiveGisuAndPart(part);
     }

--- a/src/test/java/com/umc/product/curriculum/application/port/in/query/GetCurriculumUseCaseTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/port/in/query/GetCurriculumUseCaseTest.java
@@ -141,41 +141,5 @@ class GetCurriculumUseCaseTest extends UseCaseTestSupport {
         assertThat(workbookInfo.releasedAt()).isNotNull();
     }
 
-    @Test
-    void 커리큘럼이_없으면_null을_반환한다() {
-        // given - 커리큘럼 없음
 
-        // when
-        CurriculumInfo result = getCurriculumUseCase.getByActiveGisuAndPart(ChallengerPart.SPRINGBOOT);
-
-        // then
-        assertThat(result).isNull();
-    }
-
-    @Test
-    void 다른_파트의_커리큘럼은_조회되지_않는다() {
-        // given
-        Curriculum webCurriculum = Curriculum.create(activeGisu.getId(), ChallengerPart.WEB, "9기 WEB");
-        saveCurriculumPort.save(webCurriculum);
-
-        // when
-        CurriculumInfo result = getCurriculumUseCase.getByActiveGisuAndPart(ChallengerPart.SPRINGBOOT);
-
-        // then
-        assertThat(result).isNull();
-    }
-
-    @Test
-    void 비활성_기수의_커리큘럼은_조회되지_않는다() {
-        // given
-        Gisu inactiveGisu = gisuFixture.비활성_기수(8L);
-        Curriculum curriculum = Curriculum.create(inactiveGisu.getId(), ChallengerPart.SPRINGBOOT, "8기 Springboot");
-        saveCurriculumPort.save(curriculum);
-
-        // when
-        CurriculumInfo result = getCurriculumUseCase.getByActiveGisuAndPart(ChallengerPart.SPRINGBOOT);
-
-        // then
-        assertThat(result).isNull();
-    }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #580 
- resolves #418 

## 🚀 작업 내용

1. 커리큘럼 조회 시 조회된 데이터가 없는 경우 result 자체가 오지 않는 현상
2. 커리큘럼 조회 시 현재 기수가 아니면 에러나는 문제를 해결하기 위해 V2 API 생성

## 💬 리뷰 중점사항


