### PR TITLE
[Fix] 게시글 목록 조회 시 댓글 수를 반환하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostResponse.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostResponse.java
@@ -83,7 +83,7 @@ public record PostResponse(
             .authorProfileImage(profileImageLink)
             .authorPart(part)
             .createdAt(postInfo.createdAt())
-            .commentCount(0) // TODO: 리팩토링 후에 다시 하자 ...
+            .commentCount(postInfo.commentCount())
             .likeCount(postInfo.likeCount())
             .isLiked(false) // 검색 결과에서는 좋아요 여부를 알 수 없으므로 false로 설정
             .isAuthor(false) // 검색 결과에서는 본인 작성 여부를 알 수 없으므로 false로 설정


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 게시글 목록 조회시 postInfo.commentCount()를 사용하도록 변경
## 🔥 연관 이슈

- resolves #657 

## 🚀 작업 내용

1. commentCount(0)으로 하드코딩 되어있던 파트를 postInfo.commentCount()로 변경함으로써 정상 댓글수 반환 로직 수정

## 💬 리뷰 중점사항
