### PR TITLE
[Fix] ChallengerWorkbook 엔티티의 scheduleId 컬럼을 nullable로 수정

### DIFF
--- a/src/main/java/com/umc/product/curriculum/domain/ChallengerWorkbook.java
+++ b/src/main/java/com/umc/product/curriculum/domain/ChallengerWorkbook.java
@@ -44,7 +44,7 @@ public class ChallengerWorkbook extends BaseEntity {
     @Column(nullable = false)
     private WorkbookStatus status;
 
-    @Column(nullable = false)
+    @Column
     private Long scheduleId;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/resources/db/migration/V2026.03.13.00.00__nullable_schedule_id_in_challenger_workbook.sql
+++ b/src/main/resources/db/migration/V2026.03.13.00.00__nullable_schedule_id_in_challenger_workbook.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenger_workbook
+    ALTER COLUMN schedule_id DROP NOT NULL;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

## 🚀 작업 내용

1. Challengerorkbook 엔티티의 scheduleId 컬럼 nullable로 수정

## 💬 리뷰 중점사항
