### PR TITLE
[Fix] 챌린저 기록을 중복으로 등록할 수 있는 문제 수정

### DIFF
--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
@@ -12,7 +12,6 @@ import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallen
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
-import com.umc.product.notification.application.port.in.annotation.WebhookAlarm;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -42,10 +41,10 @@ public class ChallengerRecordController {
             각 코드는 1회만 생성 가능하며, 어떤 계정에, 언제 사용되었는지 기록됩니다.
             """)
     @PostMapping("member")
-    @WebhookAlarm(
-        title = "'챌린저 기록이 추가되었어요!'",
-        content = "'회원 ID: ' + #memberPrincipal.getMemberId() + '\n챌린저 코드: ' + #request.code"
-    )
+//    @WebhookAlarm(
+//        title = "'챌린저 기록이 추가되었어요!'",
+//        content = "'회원 ID: ' + #memberPrincipal.getMemberId() + '\n챌린저 코드: ' + #request.code"
+//    )
     public void addChallengerRecordToMember(
         @CurrentMember MemberPrincipal memberPrincipal,
         @RequestBody AddChallengerRecordToMemberRequest request) {

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -15,6 +15,9 @@ import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.MemberInfo;
+import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
+import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmCommand;
+import com.umc.product.notification.domain.WebhookPlatform;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.ChapterInfo;
 import jakarta.transaction.Transactional;
@@ -38,6 +41,8 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
     private final GetChapterUseCase getChapterUseCase;
     private final GetMemberUseCase getMemberUseCase;
     private final ManageChallengerRoleUseCase manageChallengerRoleUseCase;
+
+    private final SendWebhookAlarmUseCase sendWebhookAlarmUseCase;
 
     @Override
     public Long create(CreateChallengerRecordCommand command) {
@@ -80,6 +85,8 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
                 .orElseThrow(() -> new ChallengerDomainException(ChallengerErrorCode.NO_CHALLENGER_IN_MEMBER_GISU))
                 .getId();
 
+            MemberInfo memberInfo = getMemberUseCase.getMemberInfoById(memberId);
+
             manageChallengerRoleUseCase.createChallengerRole(
                 CreateChallengerRoleCommand.builder()
                     .challengerId(challengerId)
@@ -89,6 +96,20 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
                     .gisuId(record.getGisuId())
                     .build()
             );
+
+            String roleType =
+                record.getChallengerRoleType() != null ? record.getChallengerRoleType().name() : "역할없음";
+            String responsiblePart = record.getPart() != null ? record.getPart().name() : "파트없음";
+
+            sendWebhookAlarmUseCase.sendBuffered(
+                SendWebhookAlarmCommand.builder()
+                    .title("운영진 권한이 추가되었습니다.")
+                    .content(
+                        memberInfo.schoolName() + " " + memberInfo.nickname() + "/" + memberInfo.name() + " 님이 gisuId"
+                            + record.getGisuId() + "에" + roleType + "/" + responsiblePart + " 권한을 가진 코드를 등록하였습니다.")
+                    .platforms(List.of(WebhookPlatform.TELEGRAM, WebhookPlatform.DISCORD))
+                    .build()
+            );
         }
 
         // 챌린저 기록 추가하기
@@ -96,11 +117,28 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
             MemberInfo memberInfo = getMemberUseCase.getMemberInfoById(memberId);
             record.validateMember(memberInfo.name(), memberInfo.schoolId());
 
+            // 해당 기수에 챌린저 기록이 없는지 확인
+            loadChallengerPort.findByMemberIdAndGisuId(memberId, record.getGisuId())
+                .ifPresent(challenger -> {
+                    throw new ChallengerDomainException(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS,
+                        "해당 기수에 이미 챌린저 기록이 존재합니다.");
+                });
+
             saveChallengerPort.save(
                 Challenger.builder()
                     .memberId(memberId)
                     .part(record.getPart())
                     .gisuId(record.getGisuId())
+                    .build()
+            );
+
+            sendWebhookAlarmUseCase.sendBuffered(
+                SendWebhookAlarmCommand.builder()
+                    .title("챌린저 기록이 추가되었습니다.")
+                    .content(
+                        memberInfo.schoolName() + " " + memberInfo.nickname() + "/" + memberInfo.name() + " 님이 gisuId"
+                            + record.getGisuId() + "에" + record.getPart() + " 파트 챌린저 코드를 등록하였습니다.")
+                    .platforms(List.of(WebhookPlatform.TELEGRAM, WebhookPlatform.DISCORD))
                     .build()
             );
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ spring:
     enabled: true
     baseline-version: 2026.02.25.01.30
     baseline-on-migrate: ${FLYWAY_BASELINE_ON_MIGRATE:false}
+    out-of-order: ${FLYWAY_OUT_OF_ORDER:false}
 
   jpa:
     # database-platform은 SpringBoot가 hibernate-spatial 의존성을 기반으로 자동으로 선택함


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- closes #671 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

이슈 참고

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

