### PR TITLE
[Refactor] Organization 도메인의 School 관련 비즈니스 로직 및 DTO 구조 개선

### DIFF
--- a/src/main/java/com/umc/product/organization/adapter/in/web/AdminSchoolController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/AdminSchoolController.java
@@ -31,7 +31,7 @@ public class AdminSchoolController implements AdminSchoolControllerApi {
     @Override
     @PostMapping
     public void createSchool(@RequestBody @Valid CreateSchoolRequest request) {
-        manageSchoolUseCase.register(request.toCommand());
+        manageSchoolUseCase.create(request.toCommand());
     }
 
     @CheckAccess(resourceType = ResourceType.SCHOOL, permission = PermissionType.EDIT)

--- a/src/main/java/com/umc/product/organization/adapter/in/web/AdminSchoolQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/AdminSchoolQueryController.java
@@ -11,7 +11,6 @@ import com.umc.product.organization.adapter.in.web.dto.response.UnassignedSchool
 import com.umc.product.organization.adapter.in.web.swagger.AdminSchoolQueryControllerApi;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
-import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSchoolQueryController implements AdminSchoolQueryControllerApi {
 
     private final GetSchoolUseCase getSchoolUseCase;
-    private final GetFileUseCase getFileUseCase;
 
     @Override
     @GetMapping

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.adapter.out.persistence;
 
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.domain.School;
 import java.util.List;
@@ -28,6 +29,9 @@ public interface SchoolJpaRepository extends Repository<School, Long> {
 
     @Query("SELECT new com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo(s.id, s.name) FROM School s ORDER BY s.name ASC")
     List<SchoolNameInfo> findAllNameInfoOrderByNameAsc();
+
+    @Query("SELECT new com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo$SchoolLinkItem(sl.title, sl.type, sl.url) FROM SchoolLink sl WHERE sl.school.id = :schoolId")
+    List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(@Param("schoolId") Long schoolId);
 
     List<School> findAllByIdIn(List<Long> ids);
 

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
@@ -1,7 +1,5 @@
 package com.umc.product.organization.adapter.out.persistence;
 
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
-import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.domain.School;
 import java.util.List;
 import java.util.Optional;
@@ -27,12 +25,6 @@ public interface SchoolJpaRepository extends Repository<School, Long> {
             "WHERE s.id = :schoolId")
     Optional<School> findByIdWithDetails(@Param("schoolId") Long schoolId);
 
-    @Query("SELECT new com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo(s.id, s.name) FROM School s ORDER BY s.name ASC")
-    List<SchoolNameInfo> findAllNameInfoOrderByNameAsc();
-
-    @Query("SELECT new com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo$SchoolLinkItem(sl.title, sl.type, sl.url) FROM SchoolLink sl WHERE sl.school.id = :schoolId")
-    List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(@Param("schoolId") Long schoolId);
-
     List<School> findAllByIdIn(List<Long> ids);
 
     @Query("SELECT s FROM School s " +
@@ -41,13 +33,6 @@ public interface SchoolJpaRepository extends Repository<School, Long> {
             "    WHERE cs.chapter.gisu.id = :gisuId" +
             ")")
     List<School> findUnassignedByGisuId(@Param("gisuId") Long gisuId);
-
-    @Query("SELECT DISTINCT s FROM School s " +
-            "JOIN FETCH s.chapterSchools cs " +
-            "JOIN FETCH cs.chapter c " +
-            "JOIN FETCH c.gisu " +
-            "WHERE c.gisu.id = :gisuId")
-    List<School> findSchoolsByGisuId(@Param("gisuId") Long gisuId);
 
     boolean existsById(Long schoolId);
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
@@ -42,5 +42,12 @@ public interface SchoolJpaRepository extends Repository<School, Long> {
             ")")
     List<School> findUnassignedByGisuId(@Param("gisuId") Long gisuId);
 
+    @Query("SELECT DISTINCT s FROM School s " +
+            "JOIN FETCH s.chapterSchools cs " +
+            "JOIN FETCH cs.chapter c " +
+            "JOIN FETCH c.gisu " +
+            "WHERE c.gisu.id = :gisuId")
+    List<School> findSchoolsByGisuId(@Param("gisuId") Long gisuId);
+
     boolean existsById(Long schoolId);
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolJpaRepository.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.adapter.out.persistence;
 
+import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.domain.School;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +26,8 @@ public interface SchoolJpaRepository extends Repository<School, Long> {
             "WHERE s.id = :schoolId")
     Optional<School> findByIdWithDetails(@Param("schoolId") Long schoolId);
 
-    List<School> findAllByOrderByNameAsc();
+    @Query("SELECT new com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo(s.id, s.name) FROM School s ORDER BY s.name ASC")
+    List<SchoolNameInfo> findAllNameInfoOrderByNameAsc();
 
     List<School> findAllByIdIn(List<Long> ids);
 

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.umc.product.organization.adapter.out.persistence;
 
 
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
@@ -83,11 +84,16 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
     }
 
     @Override
-    public SchoolDetailInfo.SchoolInfo findSchoolDetailByIdWithActiveChapter(Long schoolId) {
-        SchoolDetailInfo.SchoolInfo schoolInfo = schoolQueryRepository.getSchoolDetail(schoolId);
-        if (schoolInfo == null) {
+    public SchoolInfoWithoutSchoolLinkItem findSchoolDetailByIdWithActiveChapter(Long schoolId) {
+        SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = schoolQueryRepository.getSchoolDetail(schoolId);
+        if (schoolInfoWithoutSchoolLinkItem == null) {
             throw new OrganizationDomainException(OrganizationErrorCode.SCHOOL_NOT_FOUND);
         }
-        return schoolInfo;
+        return schoolInfoWithoutSchoolLinkItem;
+    }
+
+    @Override
+    public List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(Long schoolId) {
+        return schoolJpaRepository.findLinksBySchoolId(schoolId);
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
@@ -48,7 +48,7 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
 
     @Override
     public List<SchoolNameInfo> findAllNames() {
-        return schoolJpaRepository.findAllNameInfoOrderByNameAsc();
+        return schoolQueryRepository.findAllNames();
     }
 
     @Override
@@ -105,6 +105,6 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
 
     @Override
     public List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(Long schoolId) {
-        return schoolJpaRepository.findLinksBySchoolId(schoolId);
+        return schoolQueryRepository.findLinksBySchoolId(schoolId);
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
@@ -84,6 +84,11 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
     }
 
     @Override
+    public List<School> findSchoolsByGisuId(Long gisuId) {
+        return schoolJpaRepository.findSchoolsByGisuId(gisuId);
+    }
+
+    @Override
     public SchoolInfoWithoutSchoolLinkItem findSchoolDetailByIdWithActiveChapter(Long schoolId) {
         SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = schoolQueryRepository.getSchoolDetail(schoolId);
         if (schoolInfoWithoutSchoolLinkItem == null) {

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
@@ -1,8 +1,8 @@
 package com.umc.product.organization.adapter.out.persistence;
 
 
+import com.umc.product.organization.application.port.in.query.dto.SchoolChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
@@ -12,6 +12,7 @@ import com.umc.product.organization.domain.School;
 import com.umc.product.organization.exception.OrganizationDomainException;
 import com.umc.product.organization.exception.OrganizationErrorCode;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -84,13 +85,18 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
     }
 
     @Override
-    public List<School> findSchoolsByGisuId(Long gisuId) {
-        return schoolJpaRepository.findSchoolsByGisuId(gisuId);
+    public List<SchoolChapterInfo> findSchoolDetailsByGisuId(Long gisuId) {
+        return schoolQueryRepository.getSchoolDetailsByGisuId(gisuId);
     }
 
     @Override
-    public SchoolInfoWithoutSchoolLinkItem findSchoolDetailByIdWithActiveChapter(Long schoolId) {
-        SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = schoolQueryRepository.getSchoolDetail(schoolId);
+    public Map<Long, List<SchoolDetailInfo.SchoolLinkItem>> findLinksBySchoolIds(List<Long> schoolIds) {
+        return schoolQueryRepository.findLinksBySchoolIds(schoolIds);
+    }
+
+    @Override
+    public SchoolChapterInfo findSchoolDetailByIdWithActiveChapter(Long schoolId) {
+        SchoolChapterInfo schoolInfoWithoutSchoolLinkItem = schoolQueryRepository.getSchoolDetail(schoolId);
         if (schoolInfoWithoutSchoolLinkItem == null) {
             throw new OrganizationDomainException(OrganizationErrorCode.SCHOOL_NOT_FOUND);
         }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.umc.product.organization.adapter.out.persistence;
 
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import com.umc.product.organization.application.port.out.command.ManageSchoolPort;
 import com.umc.product.organization.application.port.out.query.LoadSchoolPort;
@@ -44,8 +45,8 @@ public class SchoolPersistenceAdapter implements ManageSchoolPort, LoadSchoolPor
     }
 
     @Override
-    public List<School> findAll() {
-        return schoolJpaRepository.findAllByOrderByNameAsc();
+    public List<SchoolNameInfo> findAllNames() {
+        return schoolJpaRepository.findAllNameInfoOrderByNameAsc();
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
@@ -115,7 +115,5 @@ public class SchoolQueryRepository {
             .leftJoin(chapterSchool.chapter, chapter)
             .where(school.id.eq(schoolId))
             .fetchFirst();
-        // TODO: fetchFirst로 임시로 해결은 해두었으나, 같은 기수 (활성 기수) 내에 학교가 중복된 지부에 속하는 경우 오류가 발생함.
-        // 해당 경우를 고려해서 학교를 지부에 배정할 때 검증하는 로직을 추가할 필요성이 있음.
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
@@ -14,8 +14,10 @@ import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.organization.application.port.in.query.dto.SchoolChapterInfo;
+import com.umc.product.organization.domain.School;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import java.util.List;
 import java.util.Map;
@@ -140,6 +142,40 @@ public class SchoolQueryRepository {
             .join(chapterSchool.chapter, chapter)
             .join(chapter.gisu, gisu)
             .where(gisu.id.eq(gisuId))
+            .fetch();
+    }
+
+    public List<School> findSchoolsByGisuId(Long gisuId) {
+        return queryFactory
+            .selectDistinct(school)
+            .from(school)
+            .join(school.chapterSchools, chapterSchool).fetchJoin()
+            .join(chapterSchool.chapter, chapter).fetchJoin()
+            .join(chapter.gisu, gisu).fetchJoin()
+            .where(gisu.id.eq(gisuId))
+            .fetch();
+    }
+
+    public List<SchoolNameInfo> findAllNames() {
+        return queryFactory
+            .select(Projections.constructor(SchoolNameInfo.class,
+                school.id,
+                school.name
+            ))
+            .from(school)
+            .orderBy(school.name.asc())
+            .fetch();
+    }
+
+    public List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(Long schoolId) {
+        return queryFactory
+            .select(Projections.constructor(SchoolDetailInfo.SchoolLinkItem.class,
+                schoolLink.title,
+                schoolLink.type,
+                schoolLink.url
+            ))
+            .from(schoolLink)
+            .where(schoolLink.school.id.eq(schoolId))
             .fetch();
     }
 

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
@@ -11,7 +11,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import java.util.List;
@@ -92,11 +92,11 @@ public class SchoolQueryRepository {
     /**
      * 학교 상세 정보를 반환합니다.
      */
-    public SchoolDetailInfo.SchoolInfo getSchoolDetail(Long schoolId) {
+    public SchoolInfoWithoutSchoolLinkItem getSchoolDetail(Long schoolId) {
         JPQLQuery<Long> activeChapterIds = activeChapterIdSubQuery();
 
         return queryFactory
-            .select(Projections.constructor(SchoolDetailInfo.SchoolInfo.class,
+            .select(Projections.constructor(SchoolInfoWithoutSchoolLinkItem.class,
                 chapter.id,
                 chapter.name,
                 school.name,

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/SchoolQueryRepository.java
@@ -4,17 +4,22 @@ import static com.umc.product.organization.domain.QChapter.chapter;
 import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
 import static com.umc.product.organization.domain.QGisu.gisu;
 import static com.umc.product.organization.domain.QSchool.school;
+import static com.umc.product.organization.domain.QSchoolLink.schoolLink;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
+import com.umc.product.organization.application.port.in.query.dto.SchoolChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -92,11 +97,11 @@ public class SchoolQueryRepository {
     /**
      * 학교 상세 정보를 반환합니다.
      */
-    public SchoolInfoWithoutSchoolLinkItem getSchoolDetail(Long schoolId) {
+    public SchoolChapterInfo getSchoolDetail(Long schoolId) {
         JPQLQuery<Long> activeChapterIds = activeChapterIdSubQuery();
 
         return queryFactory
-            .select(Projections.constructor(SchoolInfoWithoutSchoolLinkItem.class,
+            .select(Projections.constructor(SchoolChapterInfo.class,
                 chapter.id,
                 chapter.name,
                 school.name,
@@ -115,5 +120,49 @@ public class SchoolQueryRepository {
             .leftJoin(chapterSchool.chapter, chapter)
             .where(school.id.eq(schoolId))
             .fetchFirst();
+    }
+
+    public List<SchoolChapterInfo> getSchoolDetailsByGisuId(Long gisuId) {
+        return queryFactory
+            .select(Projections.constructor(SchoolChapterInfo.class,
+                chapter.id,
+                chapter.name,
+                school.name,
+                school.id,
+                school.remark,
+                school.logoImageId,
+                gisu.isActive,
+                school.createdAt,
+                school.updatedAt
+            ))
+            .from(school)
+            .join(chapterSchool).on(chapterSchool.school.eq(school))
+            .join(chapterSchool.chapter, chapter)
+            .join(chapter.gisu, gisu)
+            .where(gisu.id.eq(gisuId))
+            .fetch();
+    }
+
+    public Map<Long, List<SchoolDetailInfo.SchoolLinkItem>> findLinksBySchoolIds(List<Long> schoolIds) {
+        if (schoolIds.isEmpty()) return Map.of();
+
+        List<Tuple> tuples = queryFactory
+            .select(schoolLink.school.id, schoolLink.title, schoolLink.type, schoolLink.url)
+            .from(schoolLink)
+            .where(schoolLink.school.id.in(schoolIds))
+            .fetch();
+
+        return tuples.stream()
+            .collect(Collectors.groupingBy(
+                t -> t.get(schoolLink.school.id),
+                Collectors.mapping(
+                    t -> new SchoolDetailInfo.SchoolLinkItem(
+                        t.get(schoolLink.title),
+                        t.get(schoolLink.type),
+                        t.get(schoolLink.url)
+                    ),
+                    Collectors.toList()
+                )
+            ));
     }
 }

--- a/src/main/java/com/umc/product/organization/application/port/in/command/ManageSchoolUseCase.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/command/ManageSchoolUseCase.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ManageSchoolUseCase {
 
-    Long register(CreateSchoolCommand command);
+    Long create(CreateSchoolCommand command);
 
     void updateSchool(Long schoolId, UpdateSchoolCommand command);
 

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolChapterInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolChapterInfo.java
@@ -1,0 +1,16 @@
+package com.umc.product.organization.application.port.in.query.dto;
+
+import java.time.Instant;
+
+public record SchoolChapterInfo(
+    Long chapterId,
+    String chapterName,
+    String schoolName,
+    Long schoolId,
+    String remark,
+    String logoImageId, // 아직 파일 URL이 아닌 ID
+    boolean isActive,
+    Instant createdAt,
+    Instant updatedAt
+) {
+}

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolDetailInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolDetailInfo.java
@@ -23,7 +23,7 @@ public record SchoolDetailInfo(
     ) {
     }
 
-    public record SchoolInfo(
+    public record SchoolInfoWithoutSchoolLinkItem (
         Long chapterId,
         String chapterName,
         String schoolName,

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolDetailInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/SchoolDetailInfo.java
@@ -4,6 +4,7 @@ import com.umc.product.organization.domain.enums.SchoolLinkType;
 import java.time.Instant;
 import java.util.List;
 
+
 public record SchoolDetailInfo(
     Long chapterId,
     String chapterName,
@@ -23,30 +24,4 @@ public record SchoolDetailInfo(
     ) {
     }
 
-    public record SchoolInfoWithoutSchoolLinkItem (
-        Long chapterId,
-        String chapterName,
-        String schoolName,
-        Long schoolId,
-        String remark,
-        String logoImageId,
-        boolean isActive,
-        Instant createdAt,
-        Instant updatedAt
-    ) {
-        public SchoolDetailInfo toDetailInfo(String logoImageUrl, List<SchoolLinkItem> links) {
-            return new SchoolDetailInfo(
-                chapterId,
-                chapterName,
-                schoolName,
-                schoolId,
-                remark,
-                logoImageUrl,
-                links,
-                isActive,
-                createdAt,
-                updatedAt
-            );
-        }
-    }
 }

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
@@ -2,6 +2,7 @@ package com.umc.product.organization.application.port.out.query;
 
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import com.umc.product.organization.domain.School;
 import java.util.List;
@@ -12,7 +13,7 @@ public interface LoadSchoolPort {
 
     Page<SchoolListItemInfo> findSchools(SchoolSearchCondition condition, Pageable pageable);
 
-    List<School> findAll();
+    List<SchoolNameInfo> findAllNames();
 
     School findSchoolDetailById(Long schoolId);
 

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
@@ -28,6 +28,8 @@ public interface LoadSchoolPort {
 
     List<School> findUnassignedByGisuId(Long gisuId);
 
+    List<School> findSchoolsByGisuId(Long gisuId);
+
     boolean existsById(Long schoolId);
 
     void throwIfNotExists(Long schoolId);

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
@@ -1,12 +1,13 @@
 package com.umc.product.organization.application.port.out.query;
 
+import com.umc.product.organization.application.port.in.query.dto.SchoolChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import com.umc.product.organization.domain.School;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,15 +21,17 @@ public interface LoadSchoolPort {
 
     School findById(Long schoolId);
 
-    SchoolInfoWithoutSchoolLinkItem findSchoolDetailByIdWithActiveChapter(Long schoolId);
+    SchoolChapterInfo findSchoolDetailByIdWithActiveChapter(Long schoolId);
 
     List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(Long schoolId);
+
+    Map<Long, List<SchoolDetailInfo.SchoolLinkItem>> findLinksBySchoolIds(List<Long> schoolIds);
+
+    List<SchoolChapterInfo> findSchoolDetailsByGisuId(Long gisuId);
 
     List<School> findAllByIds(List<Long> schoolIds);
 
     List<School> findUnassignedByGisuId(Long gisuId);
-
-    List<School> findSchoolsByGisuId(Long gisuId);
 
     boolean existsById(Long schoolId);
 

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadSchoolPort.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.application.port.out.query;
 
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
@@ -19,7 +20,9 @@ public interface LoadSchoolPort {
 
     School findById(Long schoolId);
 
-    SchoolDetailInfo.SchoolInfo findSchoolDetailByIdWithActiveChapter(Long schoolId);
+    SchoolInfoWithoutSchoolLinkItem findSchoolDetailByIdWithActiveChapter(Long schoolId);
+
+    List<SchoolDetailInfo.SchoolLinkItem> findLinksBySchoolId(Long schoolId);
 
     List<School> findAllByIds(List<Long> schoolIds);
 

--- a/src/main/java/com/umc/product/organization/application/port/service/command/SchoolService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/command/SchoolService.java
@@ -28,7 +28,7 @@ public class SchoolService implements ManageSchoolUseCase {
     private final ManageChapterSchoolPort manageChapterSchoolPort;
 
     @Override
-    public Long register(CreateSchoolCommand command) {
+    public Long create(CreateSchoolCommand command) {
 
         School newSchool = School.create(command.schoolName(), command.remark());
         newSchool.updateLogoImageId(command.logoImageId());

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolAccessContextService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolAccessContextService.java
@@ -1,7 +1,6 @@
 package com.umc.product.organization.application.port.service.query;
 
-import com.umc.product.authorization.application.port.out.LoadChallengerRolePort;
-import com.umc.product.authorization.domain.RoleAttribute;
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.MemberInfo;
@@ -10,7 +9,6 @@ import com.umc.product.organization.application.port.in.query.GetSchoolAccessCon
 import com.umc.product.organization.application.port.in.query.dto.SchoolAccessContext;
 import com.umc.product.organization.exception.OrganizationDomainException;
 import com.umc.product.organization.exception.OrganizationErrorCode;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +20,7 @@ public class SchoolAccessContextService implements GetSchoolAccessContextUseCase
 
     private final GetMemberUseCase getMemberUseCase;
     private final GetGisuUseCase getGisuUseCase;
-    private final LoadChallengerRolePort loadChallengerRolePort; // TODO: usecase에 의존하도록 수정되어야 한다.
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @Override
     public SchoolAccessContext getContext(Long memberId) {
@@ -33,25 +31,18 @@ public class SchoolAccessContextService implements GetSchoolAccessContextUseCase
         // 2. 현재 활성 기수 조회
         Long activeGisuId = getGisuUseCase.getActiveGisuId();
 
-        // 3. 해당 기수에서의 역할 조회 (권한 체크는 @CheckAccess에서 처리됨)
-        List<RoleAttribute> roles = loadChallengerRolePort
-            .findRolesByMemberIdAndGisuId(memberId, activeGisuId)
-            .stream()
-            .map(RoleAttribute::from)
-            .toList();
-
-        // 학교 운영진 역할 찾기 (학교 운영진이 아니면 접근 불가)
-        RoleAttribute schoolAdminRole = roles.stream()
-            .filter(role -> role.roleType().isSchoolAdmin())
-            .findFirst()
-            .orElseThrow(() -> new OrganizationDomainException(OrganizationErrorCode.STUDY_GROUP_ACCESS_DENIED));
+        // 3. 학교 운영진 여부 확인 (학교 운영진이 아니면 접근 불가)
+        if (!getChallengerRoleUseCase.isSchoolAdminInGisu(memberId, activeGisuId, schoolId)) {
+            throw new OrganizationDomainException(OrganizationErrorCode.STUDY_GROUP_ACCESS_DENIED);
+        }
 
         // 4. 파트 제한 적용
         // 회장/부회장(isSchoolCore): 모든 파트 조회 가능 (part = null)
         // 파트장/기타 운영진: 본인 담당 파트만 조회 가능
-        ChallengerPart part = schoolAdminRole.roleType().isSchoolCore()
+        ChallengerPart part = getChallengerRoleUseCase.isSchoolCoreInGisu(memberId, activeGisuId, schoolId)
             ? null
-            : schoolAdminRole.responsiblePart();
+            : getChallengerRoleUseCase.getResponsiblePartsByMemberAndGisu(memberId, activeGisuId)
+                .stream().findFirst().orElse(null);
 
         return new SchoolAccessContext(schoolId, part);
     }

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
@@ -2,6 +2,7 @@ package com.umc.product.organization.application.port.service.query;
 
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
+import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolLinkInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
@@ -66,20 +67,17 @@ public class SchoolQueryService implements GetSchoolUseCase {
     @Override
     public SchoolDetailInfo getSchoolDetail(Long schoolId) {
 
-        SchoolDetailInfo.SchoolInfo schoolInfo = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(schoolId);
+        SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(schoolId);
 
         String logoImageUrl = null;
-        if (schoolInfo.logoImageId() != null) {
-            FileInfo fileInfo = getFileUseCase.getById(schoolInfo.logoImageId());
+        if (schoolInfoWithoutSchoolLinkItem.logoImageId() != null) {
+            FileInfo fileInfo = getFileUseCase.getById(schoolInfoWithoutSchoolLinkItem.logoImageId());
             logoImageUrl = fileInfo.fileLink();
         }
 
-        School school = loadSchoolPort.findById(schoolId);
-        List<SchoolDetailInfo.SchoolLinkItem> links = school.getSchoolLinks().stream()
-            .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
-            .toList();
+        List<SchoolDetailInfo.SchoolLinkItem> links = loadSchoolPort.findLinksBySchoolId(schoolId);
 
-        return schoolInfo.toDetailInfo(logoImageUrl, links);
+        return schoolInfoWithoutSchoolLinkItem.toDetailInfo(logoImageUrl, links);
 
     }
 
@@ -110,20 +108,20 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
         return schools.stream()
             .map(school -> {
-                SchoolDetailInfo.SchoolInfo schoolInfo = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(
+                SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(
                     school.getId());
-
-                String logoImageUrl = null;
-                if (schoolInfo.logoImageId() != null) {
-                    FileInfo fileInfo = getFileUseCase.getById(schoolInfo.logoImageId());
-                    logoImageUrl = fileInfo.fileLink();
-                }
 
                 List<SchoolDetailInfo.SchoolLinkItem> links = school.getSchoolLinks().stream()
                     .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
                     .toList();
 
-                return schoolInfo.toDetailInfo(logoImageUrl, links);
+                String logoImageUrl = null;
+                if (schoolInfoWithoutSchoolLinkItem.logoImageId() != null) {
+                    FileInfo fileInfo = getFileUseCase.getById(schoolInfoWithoutSchoolLinkItem.logoImageId());
+                    logoImageUrl = fileInfo.fileLink();
+                }
+
+                return schoolInfoWithoutSchoolLinkItem.toDetailInfo(logoImageUrl, links);
             }).toList();
     }
 }

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
@@ -1,15 +1,14 @@
 package com.umc.product.organization.application.port.service.query;
 
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.SchoolChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo;
-import com.umc.product.organization.application.port.in.query.dto.SchoolDetailInfo.SchoolInfoWithoutSchoolLinkItem;
 import com.umc.product.organization.application.port.in.query.dto.SchoolLinkInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolListItemInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import com.umc.product.organization.application.port.in.query.dto.UnassignedSchoolInfo;
 import com.umc.product.organization.application.port.out.query.LoadSchoolPort;
-import com.umc.product.organization.domain.ChapterSchool;
 import com.umc.product.organization.domain.School;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.storage.application.port.in.query.dto.FileInfo;
@@ -64,7 +63,7 @@ public class SchoolQueryService implements GetSchoolUseCase {
     @Override
     public SchoolDetailInfo getSchoolDetail(Long schoolId) {
 
-        SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(schoolId);
+        SchoolChapterInfo schoolInfoWithoutSchoolLinkItem = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(schoolId);
 
         String logoImageUrl = null;
         if (schoolInfoWithoutSchoolLinkItem.logoImageId() != null) {
@@ -74,7 +73,7 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
         List<SchoolDetailInfo.SchoolLinkItem> links = loadSchoolPort.findLinksBySchoolId(schoolId);
 
-        return schoolInfoWithoutSchoolLinkItem.toDetailInfo(logoImageUrl, links);
+        return toSchoolDetailInfo(schoolInfoWithoutSchoolLinkItem, logoImageUrl, links);
 
     }
 
@@ -96,10 +95,16 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
     @Override
     public List<SchoolDetailInfo> getSchoolListByGisuId(Long gisuId) {
-        List<School> schools = loadSchoolPort.findSchoolsByGisuId(gisuId);
+
+        List<SchoolChapterInfo> schools = loadSchoolPort.findSchoolDetailsByGisuId(gisuId);
+        if (schools.isEmpty()) return List.of();
+
+        List<Long> schoolIds = schools.stream().map(SchoolChapterInfo::schoolId).toList();
+
+        Map<Long, List<SchoolDetailInfo.SchoolLinkItem>> linksMap = loadSchoolPort.findLinksBySchoolIds(schoolIds);
 
         List<String> logoImageIds = schools.stream()
-            .map(School::getLogoImageId)
+            .map(SchoolChapterInfo::logoImageId)
             .filter(Objects::nonNull)
             .toList();
 
@@ -108,31 +113,26 @@ public class SchoolQueryService implements GetSchoolUseCase {
             : getFileUseCase.getFileLinks(logoImageIds);
 
         return schools.stream()
-            .map(school -> toSchoolDetailInfo(school, gisuId, logoImageUrls.get(school.getLogoImageId())))
+            .map(school -> toSchoolDetailInfo(
+                school,
+                logoImageUrls.get(school.logoImageId()),
+                linksMap.getOrDefault(school.schoolId(), List.of())
+            ))
             .toList();
     }
 
-    private SchoolDetailInfo toSchoolDetailInfo(School school, Long gisuId, String logoImageUrl) {
-        ChapterSchool cs = school.getChapterSchools().stream()
-            .filter(c -> c.getChapter().getGisu().getId().equals(gisuId))
-            .findFirst()
-            .orElse(null);
-
-        List<SchoolDetailInfo.SchoolLinkItem> links = school.getSchoolLinks().stream()
-            .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
-            .toList();
-
+    private SchoolDetailInfo toSchoolDetailInfo(SchoolChapterInfo info, String logoImageUrl, List<SchoolDetailInfo.SchoolLinkItem> links) {
         return new SchoolDetailInfo(
-            cs != null ? cs.getChapter().getId() : null,
-            cs != null ? cs.getChapter().getName() : null,
-            school.getName(),
-            school.getId(),
-            school.getRemark(),
+            info.chapterId(),
+            info.chapterName(),
+            info.schoolName(),
+            info.schoolId(),
+            info.remark(),
             logoImageUrl,
             links,
-            cs != null && cs.getChapter().getGisu().isActive(),
-            school.getCreatedAt(),
-            school.getUpdatedAt()
+            info.isActive(),
+            info.createdAt(),
+            info.updatedAt()
         );
     }
 }

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
@@ -60,9 +60,7 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
     @Override
     public List<SchoolNameInfo> getAllSchoolNames() {
-        return loadSchoolPort.findAll().stream()
-            .map(SchoolNameInfo::from)
-            .toList();
+        return loadSchoolPort.findAllNames();
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/SchoolQueryService.java
@@ -8,7 +8,6 @@ import com.umc.product.organization.application.port.in.query.dto.SchoolListItem
 import com.umc.product.organization.application.port.in.query.dto.SchoolNameInfo;
 import com.umc.product.organization.application.port.in.query.dto.SchoolSearchCondition;
 import com.umc.product.organization.application.port.in.query.dto.UnassignedSchoolInfo;
-import com.umc.product.organization.application.port.out.query.LoadChapterSchoolPort;
 import com.umc.product.organization.application.port.out.query.LoadSchoolPort;
 import com.umc.product.organization.domain.ChapterSchool;
 import com.umc.product.organization.domain.School;
@@ -17,8 +16,6 @@ import com.umc.product.storage.application.port.in.query.dto.FileInfo;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,11 +29,11 @@ public class SchoolQueryService implements GetSchoolUseCase {
 
 
     private final LoadSchoolPort loadSchoolPort;
-    private final LoadChapterSchoolPort loadChapterSchoolPort;
     private final GetFileUseCase getFileUseCase;
 
 
     @Override
+    @Deprecated
     public Page<SchoolListItemInfo> getSchools(SchoolSearchCondition condition, Pageable pageable) {
         Page<SchoolListItemInfo> page = loadSchoolPort.findSchools(condition, pageable);
 
@@ -97,31 +94,45 @@ public class SchoolQueryService implements GetSchoolUseCase {
             .toList();
     }
 
-    // TODO: 여기는 심각하게 리팩토링이 필요해보인다
-
     @Override
     public List<SchoolDetailInfo> getSchoolListByGisuId(Long gisuId) {
-        Set<School> schools = loadChapterSchoolPort.findByGisuId(gisuId)
-            .stream()
-            .map(ChapterSchool::getSchool)
-            .collect(Collectors.toSet());
+        List<School> schools = loadSchoolPort.findSchoolsByGisuId(gisuId);
+
+        List<String> logoImageIds = schools.stream()
+            .map(School::getLogoImageId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        Map<String, String> logoImageUrls = logoImageIds.isEmpty()
+            ? Map.of()
+            : getFileUseCase.getFileLinks(logoImageIds);
 
         return schools.stream()
-            .map(school -> {
-                SchoolInfoWithoutSchoolLinkItem schoolInfoWithoutSchoolLinkItem = loadSchoolPort.findSchoolDetailByIdWithActiveChapter(
-                    school.getId());
+            .map(school -> toSchoolDetailInfo(school, gisuId, logoImageUrls.get(school.getLogoImageId())))
+            .toList();
+    }
 
-                List<SchoolDetailInfo.SchoolLinkItem> links = school.getSchoolLinks().stream()
-                    .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
-                    .toList();
+    private SchoolDetailInfo toSchoolDetailInfo(School school, Long gisuId, String logoImageUrl) {
+        ChapterSchool cs = school.getChapterSchools().stream()
+            .filter(c -> c.getChapter().getGisu().getId().equals(gisuId))
+            .findFirst()
+            .orElse(null);
 
-                String logoImageUrl = null;
-                if (schoolInfoWithoutSchoolLinkItem.logoImageId() != null) {
-                    FileInfo fileInfo = getFileUseCase.getById(schoolInfoWithoutSchoolLinkItem.logoImageId());
-                    logoImageUrl = fileInfo.fileLink();
-                }
+        List<SchoolDetailInfo.SchoolLinkItem> links = school.getSchoolLinks().stream()
+            .map(link -> new SchoolDetailInfo.SchoolLinkItem(link.getTitle(), link.getType(), link.getUrl()))
+            .toList();
 
-                return schoolInfoWithoutSchoolLinkItem.toDetailInfo(logoImageUrl, links);
-            }).toList();
+        return new SchoolDetailInfo(
+            cs != null ? cs.getChapter().getId() : null,
+            cs != null ? cs.getChapter().getName() : null,
+            school.getName(),
+            school.getId(),
+            school.getRemark(),
+            logoImageUrl,
+            links,
+            cs != null && cs.getChapter().getGisu().isActive(),
+            school.getCreatedAt(),
+            school.getUpdatedAt()
+        );
     }
 }

--- a/src/main/java/com/umc/product/organization/domain/School.java
+++ b/src/main/java/com/umc/product/organization/domain/School.java
@@ -4,6 +4,7 @@ import com.umc.product.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,7 +29,7 @@ public class School extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "school", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "school", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     List<ChapterSchool> chapterSchools;
 
     @Column(nullable = false)

--- a/src/test/java/com/umc/product/organization/application/port/in/command/ManageSchoolUseCaseTest.java
+++ b/src/test/java/com/umc/product/organization/application/port/in/command/ManageSchoolUseCaseTest.java
@@ -51,7 +51,7 @@ class ManageSchoolUseCaseTest extends UseCaseTestSupport {
         CreateSchoolCommand command = new CreateSchoolCommand("한성대", "비고", null, List.of());
 
         // when
-        Long schoolId = manageSchoolUseCase.register(command);
+        Long schoolId = manageSchoolUseCase.create(command);
 
         // then
         School savedSchool = loadSchoolPort.findSchoolDetailById(schoolId);
@@ -71,7 +71,7 @@ class ManageSchoolUseCaseTest extends UseCaseTestSupport {
         CreateSchoolCommand command = new CreateSchoolCommand("한성대", "비고", null, links);
 
         // when
-        Long schoolId = manageSchoolUseCase.register(command);
+        Long schoolId = manageSchoolUseCase.create(command);
 
         // then
         School savedSchool = loadSchoolPort.findSchoolDetailById(schoolId);
@@ -93,7 +93,7 @@ class ManageSchoolUseCaseTest extends UseCaseTestSupport {
         CreateSchoolCommand command = new CreateSchoolCommand("한성대", "비고", null, links);
 
         // when
-        Long schoolId = manageSchoolUseCase.register(command);
+        Long schoolId = manageSchoolUseCase.create(command);
 
         // then
         School savedSchool = loadSchoolPort.findSchoolDetailById(schoolId);
@@ -115,7 +115,7 @@ class ManageSchoolUseCaseTest extends UseCaseTestSupport {
             new CreateSchoolCommand.SchoolLinkCommand("서브 인스타", SchoolLinkType.INSTAGRAM, "https://instagram.com/sub")
         );
         CreateSchoolCommand createCommand = new CreateSchoolCommand("한성대", "비고", null, initialLinks);
-        Long schoolId = manageSchoolUseCase.register(createCommand);
+        Long schoolId = manageSchoolUseCase.create(createCommand);
 
         // when - 같은 타입 링크를 다른 URL로 교체
         List<CreateSchoolCommand.SchoolLinkCommand> updatedLinks = List.of(


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #563 
- resolves #564 

## 🚀 작업 내용

1. SchoolLink만 가져올 수 있는 port추가
2. 코드 가독성 개선
3. SchoolAccessContextService Port의존에서 usecase의존으로 개선

## 💬 리뷰 중점사항

School, Chapter는 생명주기가 다르기 때문에 SchoolChapter 테이블에서 schoolId, chapterId만 이용해서 매칭 테이블을 만드는게 좋을 듯
장점 : 영속성 컨텍스트 분리 가능, 의도치 않은 N + 1 구조적 차단,
단점 : 조회 시 join을 직접 관리
