### PR TITLE
[Feat] 일정 상세 조회 응답에 참석자 ID를 포함하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/schedule/adapter/in/web/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/dto/response/ScheduleDetailResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.umc.product.schedule.application.port.in.query.dto.ScheduleDetailInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,7 +48,10 @@ public record ScheduleDetailResponse(
     long dDay,
 
     @Schema(description = "출석 승인 필요 여부", example = "true")
-    boolean requiresAttendanceApproval
+    boolean requiresAttendanceApproval,
+
+    @Schema(description = "참여자 Member ID 목록")
+    List<Long> participantMemberIds
 ) {
 
     public static ScheduleDetailResponse from(ScheduleDetailInfo info) {
@@ -68,7 +72,8 @@ public record ScheduleDetailResponse(
             info.longitude(),
             info.status(),
             info.dDay(),
-            info.requiresAttendanceApproval()
+            info.requiresAttendanceApproval(),
+            info.participantMemberIds()
         );
     }
 }

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/AttendanceRecordPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/AttendanceRecordPersistenceAdapter.java
@@ -93,6 +93,11 @@ public class AttendanceRecordPersistenceAdapter implements SaveAttendanceRecordP
         return recordQueryRepository.findPermissionContext(recordId);
     }
 
+    @Override
+    public List<Long> findMemberIdsByAttendanceSheetId(Long sheetId) {
+        return recordQueryRepository.findMemberIdsByAttendanceSheetId(sheetId);
+    }
+
     // ========== DeleteAttendanceRecordPort ==========
 
     @Override

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/AttendanceRecordQueryRepository.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/AttendanceRecordQueryRepository.java
@@ -101,4 +101,15 @@ public class AttendanceRecordQueryRepository {
 
         return Optional.ofNullable(result);
     }
+
+    /**
+     * 출석부 ID로 참여자 Member ID 목록만 조회 (성능 최적화)
+     */
+    public List<Long> findMemberIdsByAttendanceSheetId(Long sheetId) {
+        return queryFactory
+            .select(attendanceRecord.memberId)
+            .from(attendanceRecord)
+            .where(attendanceRecord.attendanceSheetId.eq(sheetId))
+            .fetch();
+    }
 }

--- a/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleDetailInfo.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/query/dto/ScheduleDetailInfo.java
@@ -5,6 +5,7 @@ import com.umc.product.schedule.domain.ScheduleConstants;
 import com.umc.product.schedule.domain.enums.ScheduleTag;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Set;
 
 public record ScheduleDetailInfo(
@@ -20,10 +21,16 @@ public record ScheduleDetailInfo(
     Double longitude,
     String status,
     long dDay,
-    boolean requiresAttendanceApproval
+    boolean requiresAttendanceApproval,
+    List<Long> participantMemberIds
 ) {
 
-    public static ScheduleDetailInfo from(Schedule schedule, Instant now, boolean requiresAttendanceApproval) {
+    public static ScheduleDetailInfo from(
+        Schedule schedule,
+        Instant now,
+        boolean requiresAttendanceApproval,
+        List<Long> participantMemberIds
+    ) {
         Double lat = schedule.getLocation() != null ? schedule.getLocation().getY() : null;
         Double lng = schedule.getLocation() != null ? schedule.getLocation().getX() : null;
         long dDay = ChronoUnit.DAYS.between(
@@ -44,7 +51,8 @@ public record ScheduleDetailInfo(
             lng,
             schedule.resolveStatus(now),
             dDay,
-            requiresAttendanceApproval
+            requiresAttendanceApproval,
+            participantMemberIds
         );
     }
 }

--- a/src/main/java/com/umc/product/schedule/application/port/out/LoadAttendanceRecordPort.java
+++ b/src/main/java/com/umc/product/schedule/application/port/out/LoadAttendanceRecordPort.java
@@ -90,4 +90,12 @@ public interface LoadAttendanceRecordPort {
      * @return 권한 평가 컨텍스트
      */
     Optional<AttendanceRecordPermissionContext> findPermissionContext(Long recordId);
+
+    /**
+     * 출석부 ID로 참여자 Member ID 목록만 조회 (성능 최적화)
+     *
+     * @param sheetId 출석부 ID
+     * @return Member ID 목록
+     */
+    List<Long> findMemberIdsByAttendanceSheetId(Long sheetId);
 }

--- a/src/main/java/com/umc/product/schedule/application/service/query/ScheduleQueryService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/query/ScheduleQueryService.java
@@ -7,7 +7,6 @@ import com.umc.product.schedule.application.port.in.query.dto.ScheduleDetailInfo
 import com.umc.product.schedule.application.port.out.LoadAttendanceRecordPort;
 import com.umc.product.schedule.application.port.out.LoadAttendanceSheetPort;
 import com.umc.product.schedule.application.port.out.LoadSchedulePort;
-import com.umc.product.schedule.domain.AttendanceRecord;
 import com.umc.product.schedule.domain.AttendanceSheet;
 import com.umc.product.schedule.domain.Schedule;
 import com.umc.product.schedule.domain.ScheduleConstants;
@@ -65,10 +64,7 @@ public class ScheduleQueryService implements
             .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.ATTENDANCE_SHEET_NOT_FOUND));
 
         List<Long> participantMemberIds = loadAttendanceRecordPort
-            .findByAttendanceSheetId(attendanceSheet.getId())
-            .stream()
-            .map(AttendanceRecord::getMemberId)
-            .toList();
+            .findMemberIdsByAttendanceSheetId(attendanceSheet.getId());
 
         return ScheduleDetailInfo.from(schedule, now, attendanceSheet.isRequiresApproval(), participantMemberIds);
     }

--- a/src/main/java/com/umc/product/schedule/application/service/query/ScheduleQueryService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/query/ScheduleQueryService.java
@@ -4,13 +4,15 @@ import com.umc.product.schedule.application.port.in.query.GetMyScheduleUseCase;
 import com.umc.product.schedule.application.port.in.query.GetScheduleDetailUseCase;
 import com.umc.product.schedule.application.port.in.query.dto.MyScheduleInfo;
 import com.umc.product.schedule.application.port.in.query.dto.ScheduleDetailInfo;
+import com.umc.product.schedule.application.port.out.LoadAttendanceRecordPort;
 import com.umc.product.schedule.application.port.out.LoadAttendanceSheetPort;
 import com.umc.product.schedule.application.port.out.LoadSchedulePort;
+import com.umc.product.schedule.domain.AttendanceRecord;
 import com.umc.product.schedule.domain.AttendanceSheet;
 import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.ScheduleConstants;
 import com.umc.product.schedule.domain.exception.ScheduleDomainException;
 import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
-import com.umc.product.schedule.domain.ScheduleConstants;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.util.List;
@@ -27,6 +29,7 @@ public class ScheduleQueryService implements
 
     private final LoadSchedulePort loadSchedulePort;
     private final LoadAttendanceSheetPort loadAttendanceSheetPort;
+    private final LoadAttendanceRecordPort loadAttendanceRecordPort;
 
     // 캘린더 나의 일정 조회하기
     @Override
@@ -61,6 +64,12 @@ public class ScheduleQueryService implements
         AttendanceSheet attendanceSheet = loadAttendanceSheetPort.findByScheduleId(scheduleId)
             .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.ATTENDANCE_SHEET_NOT_FOUND));
 
-        return ScheduleDetailInfo.from(schedule, now, attendanceSheet.isRequiresApproval());
+        List<Long> participantMemberIds = loadAttendanceRecordPort
+            .findByAttendanceSheetId(attendanceSheet.getId())
+            .stream()
+            .map(AttendanceRecord::getMemberId)
+            .toList();
+
+        return ScheduleDetailInfo.from(schedule, now, attendanceSheet.isRequiresApproval(), participantMemberIds);
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #678 

## 🚀 작업 내용

1. 디스코드 [해당 프로덕트팀-qa](https://discord.com/channels/1442030160311484416/1482666141557199010) 에서 논의한 대로, 일정 상세 조회 시 응답에 참여자의 memberId `participantMemberIds` 필드를 추가했습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

