### PR TITLE
[Feat] 공지사항 투표 결과 조회 및 응답 수정 API 추가

### DIFF
--- a/src/main/java/com/umc/product/survey/adapter/in/web/VoteController.java
+++ b/src/main/java/com/umc/product/survey/adapter/in/web/VoteController.java
@@ -19,7 +19,14 @@ import com.umc.product.survey.application.port.in.query.dto.VoteInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
 @RequestMapping("/api/v1/surveys/votes")

--- a/src/main/java/com/umc/product/survey/adapter/in/web/VoteController.java
+++ b/src/main/java/com/umc/product/survey/adapter/in/web/VoteController.java
@@ -8,22 +8,18 @@ import com.umc.product.survey.adapter.in.web.dto.response.CreateVoteResponse;
 import com.umc.product.survey.application.port.in.command.CreateVoteUseCase;
 import com.umc.product.survey.application.port.in.command.DeleteVoteUseCase;
 import com.umc.product.survey.application.port.in.command.SubmitVoteResponseUseCase;
+import com.umc.product.survey.application.port.in.command.UpdateVoteResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateVoteCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteVoteCommand;
 import com.umc.product.survey.application.port.in.command.dto.SubmitVoteResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateVoteResponseCommand;
 import com.umc.product.survey.application.port.in.query.GetVoteDetailUseCase;
 import com.umc.product.survey.application.port.in.query.dto.GetVoteDetailsQuery;
 import com.umc.product.survey.application.port.in.query.dto.VoteInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/surveys/votes")
@@ -34,6 +30,7 @@ public class VoteController {
     private final CreateVoteUseCase createVoteUseCase;
     private final DeleteVoteUseCase deleteVoteUseCase;
     private final SubmitVoteResponseUseCase submitVoteResponseUseCase;
+    private final UpdateVoteResponseUseCase updateVoteResponseUseCase;
     private final GetVoteDetailUseCase getVoteDetailUseCase;
 
     @PostMapping
@@ -102,6 +99,29 @@ public class VoteController {
     ) {
         SubmitVoteResponseCommand command = request.toCommand(voteId, memberPrincipal.getMemberId());
         submitVoteResponseUseCase.submit(command);
+    }
+
+    @PutMapping("/{voteId}/responses")
+    @Operation(
+        summary = "투표 응답 수정",
+        description = """
+        특정 투표에 대해 사용자의 기존 응답을 수정합니다.
+
+        - 투표 기간 내(OPEN 상태)에서만 수정 가능합니다.
+        - 기존에 제출한 응답이 있어야 수정 가능합니다.
+        - 단일 선택(RADIO)의 경우 1개만 선택해야 합니다.
+        - 복수 선택(CHECKBOX)의 경우 여러 개 선택 가능합니다.
+        - 선택한 optionId는 해당 투표의 옵션에 포함되어 있어야 합니다.
+        """
+    )
+    public void update(
+        @PathVariable Long voteId,
+        @RequestBody SubmitVoteResponseRequest request,
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
+        UpdateVoteResponseCommand command =
+            request.toUpdateCommand(voteId, memberPrincipal.getMemberId());
+        updateVoteResponseUseCase.update(command);
     }
 
     @Deprecated

--- a/src/main/java/com/umc/product/survey/adapter/in/web/dto/request/SubmitVoteResponseRequest.java
+++ b/src/main/java/com/umc/product/survey/adapter/in/web/dto/request/SubmitVoteResponseRequest.java
@@ -1,6 +1,8 @@
 package com.umc.product.survey.adapter.in.web.dto.request;
 
 import com.umc.product.survey.application.port.in.command.dto.SubmitVoteResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateVoteResponseCommand;
+
 import java.util.List;
 
 public record SubmitVoteResponseRequest(
@@ -8,5 +10,9 @@ public record SubmitVoteResponseRequest(
 ) {
     public SubmitVoteResponseCommand toCommand(Long voteId, Long memberId) {
         return new SubmitVoteResponseCommand(voteId, memberId, optionIds);
+    }
+
+    public UpdateVoteResponseCommand toUpdateCommand(Long voteId, Long memberId) {
+        return new UpdateVoteResponseCommand(voteId, memberId, optionIds);
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -138,6 +138,13 @@ public class FormResponsePersistenceAdapter implements LoadFormResponsePort, Sav
         return List.of();
     }
 
+    @Override
+    public Optional<FormResponse> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
+        return formResponseJpaRepository.findFirstByForm_IdAndRespondentMemberIdAndStatusOrderByIdDesc(
+            formId, respondentMemberId, FormResponseStatus.SUBMITTED
+        );
+    }
+
     private Long toLong(Object o) {
         if (o instanceof Long l) {
             return l;

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/SingleAnswerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/SingleAnswerPersistenceAdapter.java
@@ -2,11 +2,17 @@ package com.umc.product.survey.adapter.out.persistence;
 
 import com.umc.product.survey.application.port.out.LoadSingleAnswerPort;
 import com.umc.product.survey.application.port.out.SaveSingleAnswerPort;
+
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.umc.product.survey.application.port.out.dto.VoteAnswerRow;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static com.umc.product.survey.domain.enums.QuestionType.CHECKBOX;
 
 @Component
 @RequiredArgsConstructor
@@ -39,5 +45,52 @@ public class SingleAnswerPersistenceAdapter implements SaveSingleAnswerPort, Loa
             result.put(optionId, cnt);
         }
         return result;
+    }
+
+    @Override
+    public Map<Long, List<Long>> findSelectedMemberIdsByOptionId(Long voteId) {
+        List<VoteAnswerRow> rows = singleAnswerQueryRepository.findVoteAnswerRows(voteId);
+
+        Map<Long, List<Long>> result = new LinkedHashMap<>();
+
+        for (VoteAnswerRow row : rows) {
+            Long memberId = row.respondentMemberId();
+            Map<String, Object> value = row.value();
+
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
+
+            switch (row.answeredAsType()) {
+                case RADIO, DROPDOWN -> {
+                    Long optionId = toLong(value.get("selectedOptionId"));
+                    if (optionId != null) {
+                        result.computeIfAbsent(optionId, k -> new ArrayList<>()).add(memberId);
+                    }
+                }
+                case CHECKBOX -> {
+                    Object raw = value.get("selectedOptionIds");
+                    if (raw instanceof List<?> ids) {
+                        for (Object id : ids) {
+                            Long optionId = toLong(id);
+                            if (optionId != null) {
+                                result.computeIfAbsent(optionId, k -> new ArrayList<>()).add(memberId);
+                            }
+                        }
+                    }
+                }
+                default -> {
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number n) return n.longValue();
+        if (value instanceof String s && !s.isBlank()) return Long.parseLong(s);
+        return null;
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/SingleAnswerQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/SingleAnswerQueryRepository.java
@@ -1,10 +1,14 @@
 package com.umc.product.survey.adapter.out.persistence;
 
+import static com.umc.product.survey.domain.QFormResponse.formResponse;
 import static com.umc.product.survey.domain.QQuestion.question;
 import static com.umc.product.survey.domain.QSingleAnswer.singleAnswer;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.application.port.out.dto.VoteAnswerRow;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
 import com.umc.product.survey.domain.enums.QuestionType;
 import java.util.HashMap;
 import java.util.List;
@@ -46,5 +50,22 @@ public class SingleAnswerQueryRepository {
             }
         }
         return result;
+    }
+
+    public List<VoteAnswerRow> findVoteAnswerRows(Long voteId) {
+        return queryFactory
+            .select(Projections.constructor(
+                VoteAnswerRow.class,
+                formResponse.respondentMemberId,
+                singleAnswer.answeredAsType,
+                singleAnswer.value
+            ))
+            .from(singleAnswer)
+            .join(singleAnswer.formResponse, formResponse)
+            .where(
+                formResponse.form.id.eq(voteId),
+                formResponse.status.eq(FormResponseStatus.SUBMITTED)
+            )
+            .fetch();
     }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/UpdateVoteResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/UpdateVoteResponseUseCase.java
@@ -1,0 +1,7 @@
+package com.umc.product.survey.application.port.in.command;
+
+import com.umc.product.survey.application.port.in.command.dto.UpdateVoteResponseCommand;
+
+public interface UpdateVoteResponseUseCase {
+    void update(UpdateVoteResponseCommand command);
+}

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateVoteResponseCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateVoteResponseCommand.java
@@ -1,0 +1,10 @@
+package com.umc.product.survey.application.port.in.command.dto;
+
+import java.util.List;
+
+public record UpdateVoteResponseCommand(
+    Long voteId,
+    Long memberId,
+    List<Long> optionIds
+) {
+}

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/VoteInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/VoteInfo.java
@@ -24,7 +24,8 @@ public record VoteInfo(
         Long optionId,
         String content,
         int voteCount,
-        BigDecimal voteRate
+        BigDecimal voteRate,
+        List<Long> selectedMemberIds
     ) {
     }
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadFormResponsePort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadFormResponsePort.java
@@ -22,4 +22,6 @@ public interface LoadFormResponsePort {
     int countSubmittedByFormId(Long formId);
 
     List<Long> findMySelectedOptionIds(Long formId, Long memberId);
+
+    Optional<FormResponse> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadSingleAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadSingleAnswerPort.java
@@ -9,5 +9,6 @@ public interface LoadSingleAnswerPort {
     Map<Long, Map<String, Object>> findScheduleValuesByFormResponseIds(List<Long> formResponseIds);
 
     Map<Long, Integer> countVotesByOptionId(Long formId);
-    
+
+    Map<Long, List<Long>> findSelectedMemberIdsByOptionId(Long voteId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/dto/VoteAnswerRow.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/dto/VoteAnswerRow.java
@@ -1,0 +1,11 @@
+package com.umc.product.survey.application.port.out.dto;
+
+import com.umc.product.survey.domain.enums.QuestionType;
+
+import java.util.Map;
+
+public record VoteAnswerRow(
+    Long respondentMemberId,
+    QuestionType answeredAsType,
+    Map<String, Object> value
+) {}

--- a/src/main/java/com/umc/product/survey/application/service/VoteQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteQueryService.java
@@ -68,6 +68,11 @@ public class VoteQueryService implements GetVoteDetailUseCase {
         // 2) 옵션별 득표수 (optionId -> count)
         Map<Long, Integer> optionCounts = loadSingleAnswerPort.countVotesByOptionId(voteId);
 
+        Map<Long, List<Long>> selectedMemberIdsByOptionId =
+            form.isAnonymous()
+                ? Map.of()
+                : loadSingleAnswerPort.findSelectedMemberIdsByOptionId(voteId);
+
         // 3) 옵션 DTO 구성 (옵션 순서 유지)
         List<VoteInfo.VoteOptionInfo> options = new ArrayList<>();
         for (QuestionOption opt : question.getOptions()) {
@@ -76,11 +81,16 @@ public class VoteQueryService implements GetVoteDetailUseCase {
 
             BigDecimal voteRate = calcRate(voteCount, totalParticipants);
 
+            List<Long> selectedMemberIds = form.isAnonymous()
+                ? List.of()
+                : selectedMemberIdsByOptionId.getOrDefault(optionId, List.of());
+
             options.add(new VoteOptionInfo(
                 optionId,
                 opt.getContent(),
                 voteCount,
-                voteRate
+                voteRate,
+                selectedMemberIds
             ));
         }
 

--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -3,9 +3,11 @@ package com.umc.product.survey.application.service;
 import com.umc.product.survey.application.port.in.command.CreateVoteUseCase;
 import com.umc.product.survey.application.port.in.command.DeleteVoteUseCase;
 import com.umc.product.survey.application.port.in.command.SubmitVoteResponseUseCase;
+import com.umc.product.survey.application.port.in.command.UpdateVoteResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateVoteCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteVoteCommand;
 import com.umc.product.survey.application.port.in.command.dto.SubmitVoteResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateVoteResponseCommand;
 import com.umc.product.survey.application.port.out.LoadFormPort;
 import com.umc.product.survey.application.port.out.LoadFormResponsePort;
 import com.umc.product.survey.application.port.out.SaveFormPort;
@@ -37,7 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Transactional
 @RequiredArgsConstructor
-public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, SubmitVoteResponseUseCase {
+public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, SubmitVoteResponseUseCase, UpdateVoteResponseUseCase {
 
     private final SaveFormPort saveFormPort;
     private final LoadFormPort loadFormPort;
@@ -192,6 +194,62 @@ public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, Submit
             uniqueOptionIds.stream().toList(),
             now
         );
+
+        saveFormResponsePort.save(formResponse);
+    }
+
+    @Override
+    public void update(UpdateVoteResponseCommand cmd) {
+        Instant now = Instant.now();
+
+        Form form = loadFormPort.findById(cmd.voteId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        // 1) 기간 체크
+        FormOpenStatus openStatus = form.getOpenStatus(now);
+        if (openStatus == FormOpenStatus.NOT_STARTED) {
+            throw new SurveyDomainException(SurveyErrorCode.VOTE_NOT_STARTED);
+        }
+        if (openStatus == FormOpenStatus.CLOSED) {
+            throw new SurveyDomainException(SurveyErrorCode.VOTE_CLOSED);
+        }
+
+        // 2) 기존 응답 조회
+        FormResponse formResponse = loadFormResponsePort
+            .findSubmittedByFormIdAndRespondentMemberId(form.getId(), cmd.memberId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.VOTE_RESPONSE_NOT_FOUND));
+
+        // 3) 투표 구조에서 Question 1개 꺼내기
+        Question question = extractSingleQuestion(form);
+
+        // 4) 선택 검증
+        List<Long> optionIds = cmd.optionIds();
+        if (optionIds == null || optionIds.isEmpty()) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+        }
+
+        Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
+
+        if (question.getType() == QuestionType.RADIO) {
+            if (uniqueOptionIds.size() != 1) {
+                throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+            }
+        } else if (question.getType() == QuestionType.CHECKBOX) {
+            // pass
+        } else {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_QUESTION_TYPE);
+        }
+
+        Set<Long> allowedOptionIds = new HashSet<>();
+        for (QuestionOption opt : question.getOptions()) {
+            allowedOptionIds.add(opt.getId());
+        }
+        if (!allowedOptionIds.containsAll(uniqueOptionIds)) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+        }
+
+        // 5) 기존 응답 갱신
+        formResponse.updateVoteResponse(question, uniqueOptionIds.stream().toList(), now);
 
         saveFormResponsePort.save(formResponse);
     }

--- a/src/main/java/com/umc/product/survey/domain/FormResponse.java
+++ b/src/main/java/com/umc/product/survey/domain/FormResponse.java
@@ -108,4 +108,16 @@ public class FormResponse extends BaseEntity {
         return fr;
     }
 
+    public void updateVoteResponse(
+        Question question,
+        List<Long> selectedOptionIds,
+        Instant now
+    ) {
+        this.answers.clear();
+        this.answers.add(SingleAnswer.createVoteAnswer(this, question, selectedOptionIds));
+        this.lastSavedAt = now;
+        this.submittedAt = now;
+        this.status = FormResponseStatus.SUBMITTED;
+    }
+
 }

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -32,7 +32,9 @@ public enum SurveyErrorCode implements BaseCode {
     VOTE_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "SURVEY-0022", "이미 답변한 투표입니다."),
     INVALID_VOTE_SELECTION(HttpStatus.BAD_REQUEST, "SURVEY-0023", "선택이 올바르지 않습니다."),
     INVALID_VOTE_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "SURVEY-0024", "투표의 질문 타입이 올바르지 않습니다."),
-    INVALID_VOTE_FORM_STRUCTURE(HttpStatus.BAD_REQUEST, "SURVEY-0025", "투표의 질문 형식이 올바르지 않습니다.");
+    INVALID_VOTE_FORM_STRUCTURE(HttpStatus.BAD_REQUEST, "SURVEY-0025", "투표의 질문 형식이 올바르지 않습니다."),
+    VOTE_RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0026", "투표 응답을 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- closes #680 

## 🚀 작업 내용

공지사항에 연동된 투표 기능과 관련하여 아래 두 가지를 반영했습니다.

1. 공지사항 상세 조회 시 비익명 투표 결과에 옵션별 선택 멤버 ID 목록을 포함하도록 수정
   - 기존에는 공지사항 상세 조회 시 투표의 기본 정보, 옵션별 득표 수/비율, 내 선택 정보만 응답했습니다.
   - 비익명 투표의 경우, 옵션별로 어떤 멤버가 선택했는지 확인할 수 있어야 한다는 요구사항이 있어 `selectedMemberIds` 필드를 추가했습니다.
   - 익명 투표의 경우에는 동일 필드를 내려주되, 빈 배열(`[]`)로 응답하도록 처리했습니다.
   - `SingleAnswer`에 저장된 투표 응답값을 조회 전용 DTO(`VoteAnswerRow`)로 projection하여 option별 memberId 목록으로 가공하는 방식으로 구현했습니다.

2. 투표 응답 수정 API 추가
   - 기존에는 투표 응답 최초 제출만 가능했고, 이미 제출한 사용자의 응답을 수정할 수 있는 API가 없었습니다.
   - 이에 따라 `PUT /api/v1/surveys/votes/{voteId}/responses` API를 추가했습니다.
   - 수정 API는 다음 정책을 따릅니다.
     - 투표 기간 내(`OPEN`)에서만 수정 가능
     - 기존 제출 응답이 있어야 수정 가능
     - 단일 선택(RADIO)은 1개만 허용
     - 복수 선택(CHECKBOX)은 다중 선택 허용
     - 선택한 optionId가 해당 투표 옵션에 포함되어 있어야 함
   - 기존 `FormResponse`를 조회한 뒤, 응답(answer)을 새 선택값으로 교체하는 방식으로 반영했습니다.

## 💬 리뷰 중점사항
`SingleAnswer`의 JSON value를 projection 조회 후 애플리케이션에서 파싱하여 option별 memberId 목록으로 가공하는 방식으로 구현했습니다.