### PR TITLE
[Fix] 객관식 응답 삭제가 불가능한 현상 해결

### DIFF
--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -39,11 +39,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Transactional
 @RequiredArgsConstructor
-public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, SubmitVoteResponseUseCase, UpdateVoteResponseUseCase {
+public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, SubmitVoteResponseUseCase,
+    UpdateVoteResponseUseCase {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private final SaveFormPort saveFormPort;
     private final LoadFormPort loadFormPort;
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private final LoadFormResponsePort loadFormResponsePort;
     private final SaveFormResponsePort saveFormResponsePort;
     private final SaveSingleAnswerPort saveSingleAnswerPort;
@@ -231,7 +232,7 @@ public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, Submit
         Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
 
         if (question.getType() == QuestionType.RADIO) {
-            if (uniqueOptionIds.size() != 1) {
+            if (uniqueOptionIds.size() > 1) {
                 throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
             }
         } else if (question.getType() == QuestionType.CHECKBOX) {


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

객관식인 경우 1개가 아닐 때 오류를 던지는거에서 1개 초과일 때 오류 던지도록 수정

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

