### PR TITLE
[Fix] 투표 응답을 삭제하는 경우에 대한 비즈니스 로직을 분리하도록 개선

### DIFF
--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -225,32 +225,38 @@ public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, Submit
 
         // 4) 선택 검증
         List<Long> optionIds = cmd.optionIds();
-        if (optionIds == null || optionIds.isEmpty()) {
-            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+        if (optionIds == null) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION,
+                "기존에 선택한 응답을 삭제하려면 null이 아닌 빈 배열을 보내야 합니다.");
         }
 
-        Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
+        if (optionIds.isEmpty()) {
+            formResponse.clearVoteResponse();
+        } else {
 
-        if (question.getType() == QuestionType.RADIO) {
-            if (uniqueOptionIds.size() > 1) {
+            Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
+
+            if (question.getType() == QuestionType.RADIO) {
+                if (uniqueOptionIds.size() != 1) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+                }
+            } else if (question.getType() == QuestionType.CHECKBOX) {
+                // pass
+            } else {
+                throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_QUESTION_TYPE);
+            }
+
+            Set<Long> allowedOptionIds = new HashSet<>();
+            for (QuestionOption opt : question.getOptions()) {
+                allowedOptionIds.add(opt.getId());
+            }
+            if (!allowedOptionIds.containsAll(uniqueOptionIds)) {
                 throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
             }
-        } else if (question.getType() == QuestionType.CHECKBOX) {
-            // pass
-        } else {
-            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_QUESTION_TYPE);
-        }
 
-        Set<Long> allowedOptionIds = new HashSet<>();
-        for (QuestionOption opt : question.getOptions()) {
-            allowedOptionIds.add(opt.getId());
+            // 5) 기존 응답 갱신
+            formResponse.updateVoteResponse(question, uniqueOptionIds.stream().toList(), now);
         }
-        if (!allowedOptionIds.containsAll(uniqueOptionIds)) {
-            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
-        }
-
-        // 5) 기존 응답 갱신
-        formResponse.updateVoteResponse(question, uniqueOptionIds.stream().toList(), now);
 
         saveFormResponsePort.save(formResponse);
     }

--- a/src/main/java/com/umc/product/survey/domain/FormResponse.java
+++ b/src/main/java/com/umc/product/survey/domain/FormResponse.java
@@ -70,19 +70,6 @@ public class FormResponse extends BaseEntity {
         return fr;
     }
 
-    public void submit(java.time.Instant submittedAt, String submittedIp) {
-        if (this.status == com.umc.product.survey.domain.enums.FormResponseStatus.SUBMITTED) {
-            return;
-        }
-        this.status = com.umc.product.survey.domain.enums.FormResponseStatus.SUBMITTED;
-        this.submittedAt = submittedAt;
-        this.submittedIp = submittedIp;
-    }
-
-    public void updateLastSavedAt(Instant now) {
-        this.lastSavedAt = now;
-    }
-
     public static FormResponse createVoteResponse(
         Form form,
         Long respondentMemberId,
@@ -106,6 +93,28 @@ public class FormResponse extends BaseEntity {
         fr.answers.add(SingleAnswer.createVoteAnswer(fr, question, selectedOptionIds));
 
         return fr;
+    }
+
+    public void submit(java.time.Instant submittedAt, String submittedIp) {
+        if (this.status == com.umc.product.survey.domain.enums.FormResponseStatus.SUBMITTED) {
+            return;
+        }
+        this.status = com.umc.product.survey.domain.enums.FormResponseStatus.SUBMITTED;
+        this.submittedAt = submittedAt;
+        this.submittedIp = submittedIp;
+    }
+
+    public void updateLastSavedAt(Instant now) {
+        this.lastSavedAt = now;
+    }
+
+    public void clearVoteResponse() {
+        Instant now = Instant.now();
+
+        this.answers.clear();
+        this.lastSavedAt = now;
+        this.submittedAt = now;
+        this.status = FormResponseStatus.SUBMITTED;
     }
 
     public void updateVoteResponse(

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyDomainException.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyDomainException.java
@@ -8,5 +8,7 @@ public class SurveyDomainException extends BusinessException {
         super(Domain.SURVEY, surveyErrorCode);
     }
 
-
+    public SurveyDomainException(SurveyErrorCode surveyErrorCode, String message) {
+        super(Domain.SURVEY, surveyErrorCode, message);
+    }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

여전히 되지 않던 버그를 수정하였습니다

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

