### PR TITLE
[Feat] ChallengerRole 기반 공지사항 조회 권한 평가 로직 및 직책 유형 확인 메소드명 변경

### DIFF
--- a/src/main/java/com/umc/product/authorization/application/service/evaluator/ChallengerRolePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/authorization/application/service/evaluator/ChallengerRolePermissionEvaluator.java
@@ -25,6 +25,6 @@ public class ChallengerRolePermissionEvaluator implements ResourcePermissionEval
         // 조회를 제외한 생성/수정/삭제는 중앙운영사무국 총괄만 가능하도록 설정함. 추후 개선
         // TODO: 중앙운영사무국 측과 협의할 것
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isCentralCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
     }
 }

--- a/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
@@ -113,7 +113,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
 
         return roles.stream()
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isCentralCore);
+            .anyMatch(ChallengerRoleType::isAtLeastCentralCore);
     }
 
     @Override
@@ -122,7 +122,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
 
         return roles.stream()
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isCentralMember);
+            .anyMatch(ChallengerRoleType::isAtLeastCentralMember);
     }
 
     @Override
@@ -138,7 +138,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
             .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
             .filter(role -> role.getOrganizationId().equals(schoolId))
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isSchoolCore);
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolCore);
     }
 
     @Override
@@ -154,7 +154,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
             .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
             .filter(role -> role.getOrganizationId().equals(schoolId))
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isSchoolAdmin);
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolAdmin);
     }
 
     @Override
@@ -286,7 +286,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
 
         return roles.stream()
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isCentralCore);
+            .anyMatch(ChallengerRoleType::isAtLeastCentralCore);
     }
 
     @Override
@@ -321,7 +321,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
 
         return roles.stream()
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isCentralMember);
+            .anyMatch(ChallengerRoleType::isAtLeastCentralMember);
     }
 
     @Override
@@ -341,7 +341,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
             .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
             .filter(role -> role.getOrganizationId().equals(schoolId))
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isSchoolCore);
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolCore);
     }
 
     @Override
@@ -361,7 +361,7 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
             .filter(role -> role.getOrganizationType() == OrganizationType.SCHOOL)
             .filter(role -> role.getOrganizationId().equals(schoolId))
             .map(ChallengerRole::getChallengerRoleType)
-            .anyMatch(ChallengerRoleType::isSchoolAdmin);
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolAdmin);
     }
 
     @Override

--- a/src/main/java/com/umc/product/authorization/domain/RoleAttribute.java
+++ b/src/main/java/com/umc/product/authorization/domain/RoleAttribute.java
@@ -14,14 +14,16 @@ public record RoleAttribute(
     OrganizationType organizationType,
     // CENTRAL이면 null, CHAPTER이면 chapterId, SCHOOL이면 schoolId
     Long organizationId,
-    ChallengerPart responsiblePart
+    ChallengerPart responsiblePart,
+    Long gisuId
 ) {
     public static RoleAttribute from(ChallengerRole challengerRole) {
         return new RoleAttribute(
             challengerRole.getChallengerRoleType(),
             challengerRole.getOrganizationType(),
             challengerRole.getOrganizationId(),
-            challengerRole.getResponsiblePart()
+            challengerRole.getResponsiblePart(),
+            challengerRole.getGisuId()
         );
     }
 }

--- a/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerPermissionEvaluator.java
@@ -29,18 +29,18 @@ public class ChallengerPermissionEvaluator implements ResourcePermissionEvaluato
     private boolean canCreateChallenger(SubjectAttributes subjectAttributes) {
         // 교내 회장/부회장 이상만 가능함
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isSchoolCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastSchoolCore());
     }
 
     private boolean canUpdateChallenger(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
         // 중앙운영사무국 총괄단만 가능
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isCentralCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
     }
 
     private boolean canDeleteChallenger(SubjectAttributes subjectAttributes) {
         // 중앙운영사무국 총괄단만 가능함
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isCentralCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
     }
 }

--- a/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerPointPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerPointPermissionEvaluator.java
@@ -104,6 +104,6 @@ public class ChallengerPointPermissionEvaluator implements ResourcePermissionEva
     private boolean canDelete(SubjectAttributes subjectAttributes) {
         // 중앙운영사무국 총괄단만 가능함
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isCentralCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
     }
 }

--- a/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerRecordPermissionController.java
+++ b/src/main/java/com/umc/product/challenger/application/service/evaluator/ChallengerRecordPermissionController.java
@@ -28,12 +28,12 @@ public class ChallengerRecordPermissionController implements ResourcePermissionE
     private boolean canRead(SubjectAttributes subjectAttributes) {
         // 교내 회장/부회장 이상만 가능함
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isSchoolCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastSchoolCore());
     }
 
     private boolean canWriteOrDelete(SubjectAttributes subjectAttributes) {
         // 중앙운영사무국 총괄단만 가능함
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isCentralCore());
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
     }
 }

--- a/src/main/java/com/umc/product/common/domain/enums/ChallengerRoleType.java
+++ b/src/main/java/com/umc/product/common/domain/enums/ChallengerRoleType.java
@@ -59,7 +59,7 @@ public enum ChallengerRoleType {
     /**
      * 중앙운영사무국 총괄단 여부를 확인합니다. 총괄, 부총괄이 해당됩니다.
      */
-    public boolean isCentralCore() {
+    public boolean isAtLeastCentralCore() {
         return
             isSuperAdmin() ||
                 this == CENTRAL_PRESIDENT || this == CENTRAL_VICE_PRESIDENT;
@@ -68,8 +68,8 @@ public enum ChallengerRoleType {
     /**
      * 중앙운영사무국 멤버 여부를 확인합니다. 총괄단, 운영국원, 교육국원이 해당됩니다.
      */
-    public boolean isCentralMember() {
-        return isCentralCore()
+    public boolean isAtLeastCentralMember() {
+        return isAtLeastCentralCore()
             || this == CENTRAL_OPERATING_TEAM_MEMBER
             || this == CENTRAL_EDUCATION_TEAM_MEMBER;
     }
@@ -77,7 +77,7 @@ public enum ChallengerRoleType {
     /**
      * 학교 회장단 여부를 확인합니다. 회장, 부회장이 해당됩니다.
      */
-    public boolean isSchoolCore() {
+    public boolean isAtLeastSchoolCore() {
         return isSuperAdmin() ||
             this == SCHOOL_PRESIDENT || this == SCHOOL_VICE_PRESIDENT;
     }
@@ -85,8 +85,8 @@ public enum ChallengerRoleType {
     /**
      * 학교 관리자 여부를 확인합니다. 회장단, 파트장, 기타 운영진이 해당됩니다.
      */
-    public boolean isSchoolAdmin() {
-        return isSchoolCore()
+    public boolean isAtLeastSchoolAdmin() {
+        return isAtLeastSchoolCore()
             || this == SCHOOL_PART_LEADER
             || this == SCHOOL_ETC_ADMIN;
     }
@@ -95,7 +95,7 @@ public enum ChallengerRoleType {
      * 해당 역할이 속하는 조직 타입을 반환합니다.
      */
     public OrganizationType organizationType() {
-        if (isCentralMember()) {
+        if (isAtLeastCentralMember()) {
             return OrganizationType.CENTRAL;
         }
 
@@ -105,7 +105,7 @@ public enum ChallengerRoleType {
         }
 
         // 교내 운영진은 학교 단위 반환
-        else if (isSchoolAdmin()) {
+        else if (isAtLeastSchoolAdmin()) {
             return OrganizationType.SCHOOL;
         }
 

--- a/src/main/java/com/umc/product/curriculum/application/service/evaluator/OriginalWorkbookPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/evaluator/OriginalWorkbookPermissionEvaluator.java
@@ -24,7 +24,7 @@ public class OriginalWorkbookPermissionEvaluator implements ResourcePermissionEv
                 // 중앙운영사무국 멤버만 가능
                 // TODO: 중앙 파트장으로 좁힐 필요 있음
                 subjectAttributes.roleAttributes().stream()
-                    .anyMatch(role -> role.roleType().isCentralMember());
+                    .anyMatch(role -> role.roleType().isAtLeastCentralMember());
             default -> throw new CommonException(CommonErrorCode.PERMISSION_TYPE_NOT_IMPLEMENTED);
         };
     }

--- a/src/main/java/com/umc/product/curriculum/application/service/evaluator/WorkbookSubmissionPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/evaluator/WorkbookSubmissionPermissionEvaluator.java
@@ -26,7 +26,7 @@ public class WorkbookSubmissionPermissionEvaluator implements ResourcePermission
         if (resourcePermission.permission() == PermissionType.READ) {
             // 학교 운영진(회장, 부회장, 파트장, 기타 운영진)만 READ 권한
             return subjectAttributes.roleAttributes().stream()
-                .anyMatch(role -> role.roleType().isSchoolAdmin());
+                .anyMatch(role -> role.roleType().isAtLeastSchoolAdmin());
         }
 
         throw new CommonException(CommonErrorCode.PERMISSION_TYPE_NOT_IMPLEMENTED,

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -4,10 +4,12 @@ import com.umc.product.authorization.application.port.in.query.GetChallengerRole
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
 import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.authorization.domain.SubjectAttributes.GisuChallengerInfo;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.notice.application.port.in.query.GetNoticeTargetUseCase;
 import com.umc.product.notice.application.port.in.query.GetNoticeUseCase;
 import com.umc.product.notice.application.port.in.query.dto.NoticeInfo;
@@ -61,6 +63,12 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
     }
 
     private boolean canReadNotice(SubjectAttributes subjectAttributes, NoticeTargetInfo targetInfo) {
+        // 총괄/부총괄: 모든 공지 읽기 가능
+        if (subjectAttributes.roleAttributes().stream().anyMatch(r -> r.roleType().isCentralCore())) {
+            return true;
+        }
+
+        // 기본 챌린저 권한 체크 (본인의 part, gisu, chapter 기반)
         for (GisuChallengerInfo gisuChallengerInfo : subjectAttributes.gisuChallengerInfos()) {
             if (targetInfo.isTarget(
                 gisuChallengerInfo.gisuId(),
@@ -72,8 +80,34 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
             }
         }
 
+        // 역할 기반 추가 권한 체크
+        for (RoleAttribute role : subjectAttributes.roleAttributes()) {
+            if (canReadByRole(role, targetInfo, subjectAttributes)) {
+                return true;
+            }
+        }
+
         return false;
     }
+
+    /**
+     * 역할에 따른 추가 읽기 권한 평가
+     * <p>
+     * 기본 챌린저 체크(part 기반)를 통과하지 못한 경우에만 호출되도록 구현
+     */
+    private boolean canReadByRole(RoleAttribute role, NoticeTargetInfo targetInfo, SubjectAttributes subject) {
+        return switch (role.roleType()) {
+            // 중앙운영진(운영국원, 교육국원): 본인 기수 범위의 모든 공지를 파트 무관하게 읽기 가능
+            case CENTRAL_OPERATING_TEAM_MEMBER, CENTRAL_EDUCATION_TEAM_MEMBER -> subject.gisuChallengerInfos().stream()
+                .anyMatch(info -> role.gisuId().equals(info.gisuId())
+                    && (targetInfo.targetGisuId() == null || targetInfo.targetGisuId().equals(info.gisuId())));
+            case CHAPTER_PRESIDENT -> chapterPresidentCanRead(role, targetInfo, subject);
+            case SCHOOL_PRESIDENT, SCHOOL_VICE_PRESIDENT -> schoolCoreCanRead(role, targetInfo, subject);
+            case SCHOOL_PART_LEADER -> schoolPartLeaderCanRead(role, targetInfo, subject);
+            default -> false;
+        };
+    }
+
 
     private boolean canDeleteNotice(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
         NoticeInfo noticeInfo = getNoticeUseCase.getNoticeDetail(resourcePermission.getResourceIdAsLong(),
@@ -104,4 +138,76 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
         // Gisu 레벨 공지 (전체): 중앙 멤버
         return getChallengerRoleUseCase.isCentralMember(memberId);
     }
+
+    /**
+     * Role별 Read권한 검증
+     */
+    // 지부장: 본인 지부 또는 본인 학교 대상 공지를 파트 무관하게 읽기 가능
+    private boolean chapterPresidentCanRead(RoleAttribute role, NoticeTargetInfo targetInfo,
+                                            SubjectAttributes subject) {
+        Long myChapterId = role.organizationId();
+        if (myChapterId == null) {
+            return false;
+        }
+        // 지부가 명시된 경우 본인 지부이어야 함
+        if (targetInfo.targetChapterId() != null && !myChapterId.equals(targetInfo.targetChapterId())) {
+            return false;
+        }
+        // 학교가 명시된 경우 본인 학교이어야 함
+        if (targetInfo.targetSchoolId() != null
+            && (subject.schoolId() == null || !subject.schoolId().equals(targetInfo.targetSchoolId()))) {
+            return false;
+        }
+        // 지부·학교가 모두 미지정인 기수 범위 공지는 기본 체크에서 처리
+        if (targetInfo.targetChapterId() == null && targetInfo.targetSchoolId() == null) {
+            return false;
+        }
+        return subject.gisuChallengerInfos().stream()
+            .filter(info -> myChapterId.equals(info.chapterId()))
+            .filter(info -> role.gisuId().equals(info.gisuId()))
+            .anyMatch(info -> targetInfo.targetGisuId() == null
+                || targetInfo.targetGisuId().equals(info.gisuId()));
+    }
+
+    // 학교 회장단: 본인 학교 대상 공지를 파트 무관하게 읽기 가능
+    private boolean schoolCoreCanRead(RoleAttribute role, NoticeTargetInfo targetInfo, SubjectAttributes subject) {
+        Long mySchoolId = role.organizationId();
+        if (mySchoolId == null) {
+            return false;
+        }
+        if (!mySchoolId.equals(targetInfo.targetSchoolId())) {
+            return false;
+        }
+        return subject.gisuChallengerInfos().stream()
+            .filter(info -> role.gisuId().equals(info.gisuId()))
+            .anyMatch(info ->
+                (targetInfo.targetGisuId() == null || targetInfo.targetGisuId().equals(info.gisuId()))
+                    && (targetInfo.targetChapterId() == null || targetInfo.targetChapterId().equals(info.chapterId())));
+    }
+
+    // 교내 파트장: 담당 파트 공지를 본인 학교 범위 내에서 읽기 가능
+    private boolean schoolPartLeaderCanRead(RoleAttribute role, NoticeTargetInfo targetInfo,
+                                            SubjectAttributes subject) {
+        ChallengerPart responsiblePart = role.responsiblePart();
+        if (responsiblePart == null) {
+            return false;
+        }
+        Long mySchoolId = role.organizationId();
+        if (mySchoolId == null) {
+            return false;
+        }
+        if (targetInfo.targetSchoolId() != null && !mySchoolId.equals(targetInfo.targetSchoolId())) {
+            return false;
+        }
+        if (targetInfo.targetParts() == null || targetInfo.targetParts().isEmpty()
+            || !targetInfo.targetParts().contains(responsiblePart)) {
+            return false;
+        }
+        return subject.gisuChallengerInfos().stream()
+            .filter(info -> role.gisuId().equals(info.gisuId()))
+            .anyMatch(info ->
+                (targetInfo.targetGisuId() == null || targetInfo.targetGisuId().equals(info.gisuId()))
+                    && (targetInfo.targetChapterId() == null || targetInfo.targetChapterId().equals(info.chapterId())));
+    }
+
 }

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -108,6 +108,10 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
 
 
     private boolean canDeleteNotice(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+        if (subjectAttributes.roleAttributes().stream().anyMatch(r -> r.roleType().isSuperAdmin())) {
+            return true;
+        }
+
         NoticeInfo noticeInfo = getNoticeUseCase.getNoticeDetail(resourcePermission.getResourceIdAsLong(),
             subjectAttributes.memberId());
 

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -64,7 +64,7 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
 
     private boolean canReadNotice(SubjectAttributes subjectAttributes, NoticeTargetInfo targetInfo) {
         // 총괄/부총괄: 모든 공지 읽기 가능
-        if (subjectAttributes.roleAttributes().stream().anyMatch(r -> r.roleType().isCentralCore())) {
+        if (subjectAttributes.roleAttributes().stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
             return true;
         }
 

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -176,11 +176,7 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
         if (!mySchoolId.equals(targetInfo.targetSchoolId())) {
             return false;
         }
-        return subject.gisuChallengerInfos().stream()
-            .filter(info -> role.gisuId().equals(info.gisuId()))
-            .anyMatch(info ->
-                (targetInfo.targetGisuId() == null || targetInfo.targetGisuId().equals(info.gisuId()))
-                    && (targetInfo.targetChapterId() == null || targetInfo.targetChapterId().equals(info.chapterId())));
+        return isInGisuAndChapter(role, targetInfo, subject);
     }
 
     // 교내 파트장: 담당 파트 공지를 본인 학교 범위 내에서 읽기 가능
@@ -201,6 +197,10 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
             || !targetInfo.targetParts().contains(responsiblePart)) {
             return false;
         }
+        return isInGisuAndChapter(role, targetInfo, subject);
+    }
+
+    private boolean isInGisuAndChapter(RoleAttribute role, NoticeTargetInfo targetInfo, SubjectAttributes subject) {
         return subject.gisuChallengerInfos().stream()
             .filter(info -> role.gisuId().equals(info.gisuId()))
             .anyMatch(info ->

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -81,10 +81,9 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
         }
 
         // 역할 기반 추가 권한 체크
-        for (RoleAttribute role : subjectAttributes.roleAttributes()) {
-            if (canReadByRole(role, targetInfo, subjectAttributes)) {
-                return true;
-            }
+        if (subjectAttributes.roleAttributes().stream()
+            .anyMatch(role -> canReadByRole(role, targetInfo, subjectAttributes))) {
+            return true;
         }
 
         return false;
@@ -98,9 +97,8 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
     private boolean canReadByRole(RoleAttribute role, NoticeTargetInfo targetInfo, SubjectAttributes subject) {
         return switch (role.roleType()) {
             // 중앙운영진(운영국원, 교육국원): 본인 기수 범위의 모든 공지를 파트 무관하게 읽기 가능
-            case CENTRAL_OPERATING_TEAM_MEMBER, CENTRAL_EDUCATION_TEAM_MEMBER -> subject.gisuChallengerInfos().stream()
-                .anyMatch(info -> role.gisuId().equals(info.gisuId())
-                    && (targetInfo.targetGisuId() == null || targetInfo.targetGisuId().equals(info.gisuId())));
+            case CENTRAL_OPERATING_TEAM_MEMBER, CENTRAL_EDUCATION_TEAM_MEMBER -> targetInfo.targetGisuId() == null ||
+                targetInfo.targetGisuId().equals(role.gisuId());
             case CHAPTER_PRESIDENT -> chapterPresidentCanRead(role, targetInfo, subject);
             case SCHOOL_PRESIDENT, SCHOOL_VICE_PRESIDENT -> schoolCoreCanRead(role, targetInfo, subject);
             case SCHOOL_PART_LEADER -> schoolPartLeaderCanRead(role, targetInfo, subject);


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #663 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

- 기본적으로 본인의 소속을 통한 검증을 먼저 진행 후, 권한이 없을 시 Role기반 검증을 진행합니다.
- 총괄단, 중앙의 경우, "조회"권한은 모든 공지에 대해 부여했습니다.
- 지부장과 학교 회장단의 경우,. "조회"권한은 전체공지, 지부공지, 학교공지에 대해 어떤 파트던 상관없이 조회 가능하게 했습니다. 단, 본인이 속한 지부와 학교에 적용됩니다.
- 교내 파트장의 경우, "조회"권한은 본인이 속한 파트와 본인이 맡은 파트에 대한 공지에 부여했습니다.


추가로 특정 기수에 대한 권한을 검증하기 위해 RoleAttribute에 기수에 관한 필드를 추가했습니다. 

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

