### PR TITLE
[Feat] 주차별 워크북 자동 배포 기능 구현

### DIFF
--- a/src/main/java/com/umc/product/curriculum/adapter/in/scheduler/WorkbookAutoReleaseScheduler.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/scheduler/WorkbookAutoReleaseScheduler.java
@@ -1,0 +1,44 @@
+package com.umc.product.curriculum.adapter.in.scheduler;
+
+import com.umc.product.curriculum.application.port.in.command.AutoReleaseWorkbookUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 워크북 자동 배포 스케줄러
+ * <p>
+ * 매일 자정(KST)에 실행되어 배포 조건을 만족하는 워크북을 자동 배포합니다.
+ * <p>
+ * 배포 조건:
+ * <ul>
+ *   <li>startDate가 현재 시간보다 과거</li>
+ *   <li>아직 배포되지 않음 (releasedAt == null)</li>
+ *   <li>직전 주차(weekNo - 1)가 배포됨 (1주차는 직전 주차 없으므로 스킵)</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WorkbookAutoReleaseScheduler {
+
+    private final AutoReleaseWorkbookUseCase autoReleaseWorkbookUseCase;
+
+    /**
+     * 매일 자정(KST)에 실행
+     * <p>
+     * - 크론 표현식 : 초 분 시 일 월 요일 "0 0 0 * * *" = 매일 00:00:00 - 테스트용 표현식 : "0 * * * * *" = 매 1분마다 실행
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void releaseDueWorkbooks() {
+        log.info("[WorkbookAutoRelease] 자동 배포 스케줄 시작");
+
+        try {
+            int releasedCount = autoReleaseWorkbookUseCase.releaseAllDue();
+            log.info("[WorkbookAutoRelease] 자동 배포 스케줄 완료: {}건 배포", releasedCount);
+        } catch (Exception e) {
+            log.error("[WorkbookAutoRelease] 자동 배포 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumQueryRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumQueryRepository.java
@@ -165,4 +165,23 @@ public class CurriculumQueryRepository {
     private BooleanExpression partCondition(ChallengerPart part) {
         return part != null ? curriculum.part.eq(part) : null;
     }
+
+    /**
+     * 미배포 상태이면서 시작일이 지난 워크북 목록 조회 (자동 배포 대상)
+     * <p>
+     * 조건 : - releasedAt IS NULL (미배포) - startDate < now (시작일이 지남)
+     *
+     * @param now 현재 시간
+     * @return 자동 배포 후보 워크북 목록
+     */
+    public List<Long> findUnreleasedWorkbookIdsWithStartDateBefore(Instant now) {
+        return queryFactory
+            .select(originalWorkbook.id)
+            .from(originalWorkbook)
+            .where(
+                originalWorkbook.releasedAt.isNull(),
+                originalWorkbook.startDate.before(now)
+            )
+            .fetch();
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumQueryRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumQueryRepository.java
@@ -14,6 +14,7 @@ import com.umc.product.curriculum.application.port.in.query.dto.CurriculumProgre
 import com.umc.product.curriculum.application.port.in.query.dto.CurriculumProgressInfo.WorkbookProgressInfo;
 import com.umc.product.curriculum.application.port.in.query.dto.CurriculumWeekInfo;
 import com.umc.product.curriculum.domain.Curriculum;
+import com.umc.product.curriculum.domain.OriginalWorkbook;
 import com.umc.product.curriculum.domain.enums.WorkbookStatus;
 import java.time.Instant;
 import java.util.List;
@@ -174,10 +175,10 @@ public class CurriculumQueryRepository {
      * @param now 현재 시간
      * @return 자동 배포 후보 워크북 목록
      */
-    public List<Long> findUnreleasedWorkbookIdsWithStartDateBefore(Instant now) {
+    public List<OriginalWorkbook> findUnreleasedWorkbookIdsWithStartDateBefore(Instant now) {
         return queryFactory
-            .select(originalWorkbook.id)
-            .from(originalWorkbook)
+            .selectFrom(originalWorkbook)
+            .join(originalWorkbook.curriculum, curriculum).fetchJoin()
             .where(
                 originalWorkbook.releasedAt.isNull(),
                 originalWorkbook.startDate.before(now)

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookJpaRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookJpaRepository.java
@@ -2,6 +2,7 @@ package com.umc.product.curriculum.adapter.out.persistence;
 
 import com.umc.product.curriculum.domain.OriginalWorkbook;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +12,8 @@ public interface OriginalWorkbookJpaRepository extends JpaRepository<OriginalWor
     List<OriginalWorkbook> findByCurriculumId(Long curriculumId);
 
     List<OriginalWorkbook> findByCurriculumIdOrderByWeekNoAsc(Long curriculumId);
+
+    Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo);
 
     @Query("SELECT DISTINCT o.weekNo FROM OriginalWorkbook o " +
             "WHERE o.curriculum.gisuId = :gisuId ORDER BY o.weekNo")

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookJpaRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookJpaRepository.java
@@ -2,7 +2,6 @@ package com.umc.product.curriculum.adapter.out.persistence;
 
 import com.umc.product.curriculum.domain.OriginalWorkbook;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,9 +12,9 @@ public interface OriginalWorkbookJpaRepository extends JpaRepository<OriginalWor
 
     List<OriginalWorkbook> findByCurriculumIdOrderByWeekNoAsc(Long curriculumId);
 
-    Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo);
+    List<OriginalWorkbook> findByCurriculumIdIn(List<Long> curriculumIds);
 
     @Query("SELECT DISTINCT o.weekNo FROM OriginalWorkbook o " +
-            "WHERE o.curriculum.gisuId = :gisuId ORDER BY o.weekNo")
+        "WHERE o.curriculum.gisuId = :gisuId ORDER BY o.weekNo")
     List<Integer> findDistinctWeekNoByGisuId(@Param("gisuId") Long gisuId);
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookPersistenceAdapter.java
@@ -7,7 +7,9 @@ import com.umc.product.curriculum.application.port.out.SaveOriginalWorkbookPort;
 import com.umc.product.curriculum.domain.OriginalWorkbook;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -52,5 +54,19 @@ public class OriginalWorkbookPersistenceAdapter implements LoadOriginalWorkbookP
     @Override
     public OriginalWorkbook save(OriginalWorkbook workbook) {
         return originalWorkbookJpaRepository.save(workbook);
+    }
+
+    @Override
+    public List<OriginalWorkbook> findUnreleasedWithStartDateBefore(Instant now) {
+        List<Long> workbookIds = curriculumQueryRepository.findUnreleasedWorkbookIdsWithStartDateBefore(now);
+        if (workbookIds.isEmpty()) {
+            return List.of();
+        }
+        return originalWorkbookJpaRepository.findAllById(workbookIds);
+    }
+
+    @Override
+    public Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo) {
+        return originalWorkbookJpaRepository.findByCurriculumIdAndWeekNo(curriculumId, weekNo);
     }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/OriginalWorkbookPersistenceAdapter.java
@@ -9,7 +9,6 @@ import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -58,15 +57,14 @@ public class OriginalWorkbookPersistenceAdapter implements LoadOriginalWorkbookP
 
     @Override
     public List<OriginalWorkbook> findUnreleasedWithStartDateBefore(Instant now) {
-        List<Long> workbookIds = curriculumQueryRepository.findUnreleasedWorkbookIdsWithStartDateBefore(now);
-        if (workbookIds.isEmpty()) {
-            return List.of();
-        }
-        return originalWorkbookJpaRepository.findAllById(workbookIds);
+        return curriculumQueryRepository.findUnreleasedWorkbookIdsWithStartDateBefore(now);
     }
 
     @Override
-    public Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo) {
-        return originalWorkbookJpaRepository.findByCurriculumIdAndWeekNo(curriculumId, weekNo);
+    public List<OriginalWorkbook> findByCurriculumIdIn(List<Long> curriculumIds) {
+        if (curriculumIds == null || curriculumIds.isEmpty()) {
+            return List.of();
+        }
+        return originalWorkbookJpaRepository.findByCurriculumIdIn(curriculumIds);
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/in/command/AutoReleaseWorkbookUseCase.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/command/AutoReleaseWorkbookUseCase.java
@@ -1,0 +1,25 @@
+package com.umc.product.curriculum.application.port.in.command;
+
+/**
+ * 워크북 자동 배포 UseCase
+ * <p>
+ * 스케줄러에서 호출되어 배포 조건을 만족하는 워크북들을 일괄 배포합니다.
+ * <p>
+ * 배포 조건:
+ * <ul>
+ *   <li>startDate가 현재 시간보다 과거</li>
+ *   <li>아직 배포되지 않음 (releasedAt == null)</li>
+ *   <li>직전 주차(weekNo - 1)가 배포됨 (1주차는 직전 주차 없으므로 스킵)</li>
+ * </ul>
+ */
+public interface AutoReleaseWorkbookUseCase {
+
+    /**
+     * 배포 조건을 만족하는 모든 워크북을 일괄 배포합니다.
+     * <p>
+     * 연쇄 배포 방지를 위해 조회를 먼저 완료한 후 배포를 수행합니다.
+     *
+     * @return 배포된 워크북 수
+     */
+    int releaseAllDue();
+}

--- a/src/main/java/com/umc/product/curriculum/application/port/out/LoadOriginalWorkbookPort.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/out/LoadOriginalWorkbookPort.java
@@ -5,7 +5,6 @@ import com.umc.product.curriculum.application.port.in.query.dto.CurriculumWeekIn
 import com.umc.product.curriculum.domain.OriginalWorkbook;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 public interface LoadOriginalWorkbookPort {
 
@@ -42,11 +41,10 @@ public interface LoadOriginalWorkbookPort {
     List<OriginalWorkbook> findUnreleasedWithStartDateBefore(Instant now);
 
     /**
-     * 커리큘럼 ID와 주차 번호로 워크북 조회
+     * 여러 커리큘럼의 워크북 일괄 조회 (N+1 방지용)
      *
-     * @param curriculumId 커리큘럼 ID
-     * @param weekNo       주차 번호
-     * @return 워크북 (없으면 empty)
+     * @param curriculumIds 커리큘럼 ID 목록
+     * @return 해당 커리큘럼들의 모든 워크북
      */
-    Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo);
+    List<OriginalWorkbook> findByCurriculumIdIn(List<Long> curriculumIds);
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/out/LoadOriginalWorkbookPort.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/out/LoadOriginalWorkbookPort.java
@@ -3,7 +3,9 @@ package com.umc.product.curriculum.application.port.out;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.curriculum.application.port.in.query.dto.CurriculumWeekInfo;
 import com.umc.product.curriculum.domain.OriginalWorkbook;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadOriginalWorkbookPort {
 
@@ -30,4 +32,21 @@ public interface LoadOriginalWorkbookPort {
      * @return 배포된 주차 번호 목록 (오름차순)
      */
     List<Integer> findReleasedWeekNos(ChallengerPart part);
+
+    /**
+     * 미배포 상태이면서 시작일이 지난 워크북 목록 조회 (자동 배포 대상)
+     *
+     * @param now 현재 시간
+     * @return 자동 배포 후보 워크북 목록
+     */
+    List<OriginalWorkbook> findUnreleasedWithStartDateBefore(Instant now);
+
+    /**
+     * 커리큘럼 ID와 주차 번호로 워크북 조회
+     *
+     * @param curriculumId 커리큘럼 ID
+     * @param weekNo       주차 번호
+     * @return 워크북 (없으면 empty)
+     */
+    Optional<OriginalWorkbook> findByCurriculumIdAndWeekNo(Long curriculumId, Integer weekNo);
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/command/WorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/WorkbookCommandService.java
@@ -1,5 +1,6 @@
 package com.umc.product.curriculum.application.service.command;
 
+import com.umc.product.curriculum.application.port.in.command.AutoReleaseWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.command.ManageWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.command.ReviewWorkbookCommand;
 import com.umc.product.curriculum.application.port.in.command.SelectBestWorkbookCommand;
@@ -13,15 +14,19 @@ import com.umc.product.curriculum.domain.enums.MissionType;
 import com.umc.product.curriculum.domain.enums.WorkbookStatus;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
+import java.time.Instant;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class WorkbookCommandService implements ManageWorkbookUseCase {
+public class WorkbookCommandService implements ManageWorkbookUseCase, AutoReleaseWorkbookUseCase {
 
     private final LoadChallengerWorkbookPort loadChallengerWorkbookPort;
     private final LoadOriginalWorkbookPort loadOriginalWorkbookPort;
@@ -83,5 +88,60 @@ public class WorkbookCommandService implements ManageWorkbookUseCase {
         workbook.selectBest(command.bestReason());
 
         saveChallengerWorkbookPort.save(workbook);
+    }
+
+    /**
+     * 배포 조건을 만족하는 모든 워크북을 일괄 배포합니다.
+     * <p>
+     * 연쇄 배포 방지: 조회를 먼저 완료한 후 배포를 수행합니다.
+     */
+    @Override
+    public int releaseAllDue() {
+        Instant now = Instant.now();
+
+        // 1. 미배포 & 시작일 지난 워크북 전부 조회 (연쇄 배포 방지)
+        List<OriginalWorkbook> candidates = loadOriginalWorkbookPort.findUnreleasedWithStartDateBefore(now);
+
+        if (candidates.isEmpty()) {
+            log.info("[WorkbookAutoRelease] 배포 대상 워크북 없음");
+            return 0;
+        }
+
+        // 2. 직전 주차 배포 여부 확인하여 필터링
+        List<OriginalWorkbook> toRelease = candidates.stream()
+            .filter(this::isPreviousWeekReleased)
+            .toList();
+
+        if (toRelease.isEmpty()) {
+            log.info("[WorkbookAutoRelease] 직전 주차 미배포로 배포 대상 없음 (후보: {}건)", candidates.size());
+            return 0;
+        }
+
+        // 3. 한 번에 배포
+        for (OriginalWorkbook workbook : toRelease) {
+            workbook.release();
+            log.info("[WorkbookAutoRelease] 워크북 배포 완료: id={}, weekNo={}, title={}",
+                workbook.getId(), workbook.getWeekNo(), workbook.getTitle());
+        }
+
+        log.info("[WorkbookAutoRelease] 총 {}건 배포 완료", toRelease.size());
+        return toRelease.size();
+    }
+
+    /**
+     * 직전 주차가 배포되었는지 확인합니다. 1주차는 직전 주차가 없으므로 true를 반환합니다.
+     */
+    private boolean isPreviousWeekReleased(OriginalWorkbook workbook) {
+        if (workbook.getWeekNo() == 1) {
+            return true;
+        }
+
+        return loadOriginalWorkbookPort
+            .findByCurriculumIdAndWeekNo(
+                workbook.getCurriculum().getId(),
+                workbook.getWeekNo() - 1
+            )
+            .map(OriginalWorkbook::isReleased)
+            .orElse(false);
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/command/WorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/WorkbookCommandService.java
@@ -16,6 +16,9 @@ import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -107,9 +110,31 @@ public class WorkbookCommandService implements ManageWorkbookUseCase, AutoReleas
             return 0;
         }
 
-        // 2. 직전 주차 배포 여부 확인하여 필터링
+        // 2. 커리큘럼별 배포된 주차 Set 조회 (N+1 방지)
+        List<Long> curriculumIds = candidates.stream()
+            .map(w -> w.getCurriculum().getId())
+            .distinct()
+            .toList();
+
+        Map<Long, Set<Integer>> releasedWeeksByCurriculum = loadOriginalWorkbookPort
+            .findByCurriculumIdIn(curriculumIds)
+            .stream()
+            .filter(OriginalWorkbook::isReleased)
+            .collect(Collectors.groupingBy(
+                w -> w.getCurriculum().getId(),
+                Collectors.mapping(OriginalWorkbook::getWeekNo, Collectors.toSet())
+            ));
+
+        // 3. 직전 주차 배포 여부 확인하여 필터링
         List<OriginalWorkbook> toRelease = candidates.stream()
-            .filter(this::isPreviousWeekReleased)
+            .filter(candidate -> {
+                if (candidate.getWeekNo() == 1) {
+                    return true;
+                }
+                Set<Integer> releasedWeeks = releasedWeeksByCurriculum
+                    .getOrDefault(candidate.getCurriculum().getId(), Set.of());
+                return releasedWeeks.contains(candidate.getWeekNo() - 1);
+            })
             .toList();
 
         if (toRelease.isEmpty()) {
@@ -117,7 +142,7 @@ public class WorkbookCommandService implements ManageWorkbookUseCase, AutoReleas
             return 0;
         }
 
-        // 3. 한 번에 배포
+        // 4. 한 번에 배포
         for (OriginalWorkbook workbook : toRelease) {
             workbook.release();
             log.info("[WorkbookAutoRelease] 워크북 배포 완료: id={}, weekNo={}, title={}",
@@ -126,22 +151,5 @@ public class WorkbookCommandService implements ManageWorkbookUseCase, AutoReleas
 
         log.info("[WorkbookAutoRelease] 총 {}건 배포 완료", toRelease.size());
         return toRelease.size();
-    }
-
-    /**
-     * 직전 주차가 배포되었는지 확인합니다. 1주차는 직전 주차가 없으므로 true를 반환합니다.
-     */
-    private boolean isPreviousWeekReleased(OriginalWorkbook workbook) {
-        if (workbook.getWeekNo() == 1) {
-            return true;
-        }
-
-        return loadOriginalWorkbookPort
-            .findByCurriculumIdAndWeekNo(
-                workbook.getCurriculum().getId(),
-                workbook.getWeekNo() - 1
-            )
-            .map(OriginalWorkbook::isReleased)
-            .orElse(false);
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #692 

## 🚀 작업 내용

1. 경운이가 저에게 주차별 워크북 자동 배포 기능 구현 업무를 주었습니다. ([참고 discord 스레드](https://discord.com/channels/1442030160311484416/1482899598929432799))
2. 스케쥴러 주기 : 매일 자정 하루에 한 번
3. 배포 조건 : 현재 시간이 워크북의 startAt 시간 이후 & 미배포 상태 & 직전 주차 워크북은 배포된 상태 (1주차 배포는 이 조건 스킵)
4. 연쇄 배포를 방지하기 위해, 먼저 3번 조건을 만족하는 워크북 목록을 모두 조회 -> 그 후에 한꺼번에 배포
5. 로그 및 db에서 테스트 완료
<img width="2834" height="654" alt="image" src="https://github.com/user-attachments/assets/75fce0a9-a8b5-4cc2-808d-19ade47b2d88" />
<img width="1522" height="392" alt="image" src="https://github.com/user-attachments/assets/1bd9b7cb-e5b8-4de1-a524-72c4b7622a19" />

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

