### PR TITLE
[Fix] Redirect 방식 OAuth 로그인 시 RefreshToken을 제공하지 않던 오류 해결

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -48,6 +48,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             .queryParam("success", oAuth2ResultCode.isSuccess())
             .queryParam("code", oAuth2ResultCode.getCode())
             .queryParam("accessToken", accessToken)
+            .queryParam("refreshToken", refreshToken)
             .build().toUriString();
 
         log.info("Redirecting to: {}", targetUrl);

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
-@Tag(name = "Member | 회원 Command", description = "")
+@Tag(name = "Member | 회원 Command", description = "회원가입, 정보 수정, 탈퇴 등")
 public class MemberCommandController {
 
     private final MemberInfoResponseAssembler assembler;


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

<img width="925" height="351" alt="image" src="https://github.com/user-attachments/assets/89dde6bf-3704-40c2-a726-b3856f147a24" />

레전드 누락 현상을 해결하였습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

