### PR TITLE
[Refactor] 커뮤니티 도메인의 표준 예외 처리를 커스텀 예외로 변경

### DIFF
--- a/src/main/java/com/umc/product/community/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/community/adapter/out/persistence/PostPersistenceAdapter.java
@@ -8,6 +8,8 @@ import com.umc.product.community.application.port.out.post.LoadPostPort;
 import com.umc.product.community.application.port.out.post.SavePostPort;
 import com.umc.product.community.domain.Post;
 import com.umc.product.community.domain.enums.Category;
+import com.umc.product.community.domain.exception.CommunityDomainException;
+import com.umc.product.community.domain.exception.CommunityErrorCode;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,7 +33,7 @@ public class PostPersistenceAdapter implements LoadPostPort, SavePostPort {
         // UPDATE용 (authorChallengerId 필요 없음)
         if (post.getPostId() != null) {
             PostJpaEntity entity = postRepository.findById(post.getPostId().id())
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.POST_NOT_FOUND));
             if (post.isLightning() && post.getLightningInfo() != null) {
                 Post.LightningInfo info = post.getLightningInfo();
                 entity.updateLightning(
@@ -48,14 +50,14 @@ public class PostPersistenceAdapter implements LoadPostPort, SavePostPort {
             return entity.toDomain();
         }
 
-        throw new IllegalArgumentException("새 게시글 생성 시에는 save(Post post, Long authorChallengerId)를 사용하세요.");
+        throw new CommunityDomainException(CommunityErrorCode.POST_SAVE_REQUIRES_AUTHOR);
     }
 
     @Override
     public Post save(Post post, Long authorChallengerId) {
         // CREATE용 (authorChallengerId 포함)
         if (post.getPostId() != null) {
-            throw new IllegalArgumentException("이미 ID가 있는 게시글은 save(Post post)를 사용하세요.");
+            throw new CommunityDomainException(CommunityErrorCode.POST_UPDATE_INVALID_CALL);
         }
 
         PostJpaEntity entity = PostJpaEntity.from(post, authorChallengerId);
@@ -125,7 +127,7 @@ public class PostPersistenceAdapter implements LoadPostPort, SavePostPort {
     @Override
     public LikeResult toggleLike(Long postId, Long challengerId) {
         PostJpaEntity entity = postRepository.findById(postId)
-            .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+            .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.POST_NOT_FOUND));
         boolean liked = entity.toggleLike(challengerId);
         return new LikeResult(liked, entity.getLikeCount());
     }
@@ -139,7 +141,7 @@ public class PostPersistenceAdapter implements LoadPostPort, SavePostPort {
     public Long findAuthorIdByPostId(Long postId) {
         return postRepository.findById(postId)
             .map(PostJpaEntity::getAuthorChallengerId)
-            .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+            .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.POST_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/umc/product/community/domain/Comment.java
+++ b/src/main/java/com/umc/product/community/domain/Comment.java
@@ -1,5 +1,7 @@
 package com.umc.product.community.domain;
 
+import com.umc.product.community.domain.exception.CommunityDomainException;
+import com.umc.product.community.domain.exception.CommunityErrorCode;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -52,19 +54,19 @@ public class Comment {
 
     private static void validateRequired(Long postId, Long challengerId, String content) {
         if (postId == null || postId <= 0) {
-            throw new IllegalArgumentException("게시글 ID는 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_COMMENT_POST_ID);
         }
         if (challengerId == null || challengerId <= 0) {
-            throw new IllegalArgumentException("챌린저 ID는 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_COMMENT_CHALLENGER_ID);
         }
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("내용은 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_COMMENT_CONTENT);
         }
     }
 
     public void updateContent(String content) {
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("내용은 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_COMMENT_CONTENT);
         }
         this.content = content;
     }
@@ -72,7 +74,7 @@ public class Comment {
     public record CommentId(Long id) {
         public CommentId {
             if (id <= 0) {
-                throw new IllegalArgumentException("ID는 양수여야 합니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_ID);
             }
         }
     }

--- a/src/main/java/com/umc/product/community/domain/Post.java
+++ b/src/main/java/com/umc/product/community/domain/Post.java
@@ -1,6 +1,8 @@
 package com.umc.product.community.domain;
 
 import com.umc.product.community.domain.enums.Category;
+import com.umc.product.community.domain.exception.CommunityDomainException;
+import com.umc.product.community.domain.exception.CommunityErrorCode;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -42,7 +44,7 @@ public class Post {
 
     public static Post createPost(String title, String content, Category category, Long authorChallengerId) {
         if (category.isLightning()) {
-            throw new IllegalArgumentException("번개 게시글은 createLightning()을 사용하세요");
+            throw new CommunityDomainException(CommunityErrorCode.USE_LIGHTNING_API);
         }
         validateCommonFields(title, content);
         validateAuthorChallengerId(authorChallengerId);
@@ -51,7 +53,7 @@ public class Post {
 
     public static Post createLightning(String title, String content, LightningInfo info, Long authorChallengerId) {
         if (info == null) {
-            throw new IllegalArgumentException("번개 게시글은 추가 정보가 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.LIGHTNING_INFO_REQUIRED);
         }
 
         validateCommonFields(title, content);
@@ -75,38 +77,38 @@ public class Post {
 
     public LightningInfo getLightningInfoOrThrow() {
         if (!isLightning() || lightningInfo == null) {
-            throw new IllegalStateException("번개 게시글이 아닙니다.");
+            throw new CommunityDomainException(CommunityErrorCode.NOT_LIGHTNING_POST);
         }
         return lightningInfo;
     }
 
     private static void validateCommonFields(String title, String content) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_POST_TITLE);
         }
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("내용은 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_POST_CONTENT);
         }
     }
 
     private static void validateAuthorChallengerId(Long authorChallengerId) {
         if (authorChallengerId == null) {
-            throw new IllegalArgumentException("작성자 ID는 필수입니다");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_POST_AUTHOR);
         }
     }
 
     public void update(String title, String content, Category category) {
         validateCommonFields(title, content);
         if (category == null) {
-            throw new IllegalArgumentException("카테고리는 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.INVALID_POST_CATEGORY);
         }
         // 번개 게시글로 카테고리 변경 불가
         if (category == Category.LIGHTNING && this.category != Category.LIGHTNING) {
-            throw new IllegalArgumentException("일반 게시글을 번개 게시글로 변경할 수 없습니다.");
+            throw new CommunityDomainException(CommunityErrorCode.CANNOT_CHANGE_TO_LIGHTNING);
         }
         // 번개 게시글에서 일반 게시글로 변경 불가
         if (this.category == Category.LIGHTNING && category != Category.LIGHTNING) {
-            throw new IllegalArgumentException("번개 게시글을 일반 게시글로 변경할 수 없습니다.");
+            throw new CommunityDomainException(CommunityErrorCode.CANNOT_CHANGE_FROM_LIGHTNING);
         }
 
         this.title = title;
@@ -116,11 +118,11 @@ public class Post {
 
     public void updateLightning(String title, String content, LightningInfo newLightningInfo) {
         if (!isLightning()) {
-            throw new IllegalStateException("번개 게시글이 아닙니다.");
+            throw new CommunityDomainException(CommunityErrorCode.NOT_LIGHTNING_POST);
         }
         validateCommonFields(title, content);
         if (newLightningInfo == null) {
-            throw new IllegalArgumentException("번개 정보는 필수입니다.");
+            throw new CommunityDomainException(CommunityErrorCode.LIGHTNING_INFO_REQUIRED);
         }
         // 시간 검증은 Service 레이어에서 수행
 
@@ -133,7 +135,7 @@ public class Post {
     public record PostId(Long id) {
         public PostId {
             if (id <= 0) {
-                throw new IllegalArgumentException("ID는 양수여야 합니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_ID);
             }
         }
     }
@@ -150,19 +152,19 @@ public class Post {
             // 비즈니스 로직 검증은 Request DTO에서 수행
             // 필수 필드만 검증
             if (meetAt == null) {
-                throw new IllegalArgumentException("모임 시간은 필수입니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_MEET_AT);
             }
             if (location == null || location.isBlank()) {
-                throw new IllegalArgumentException("모임 장소는 필수입니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_LOCATION);
             }
             if (maxParticipants == null || maxParticipants <= 0) {
-                throw new IllegalArgumentException("최대 참가자는 1명 이상이어야 합니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_MAX_PARTICIPANTS);
             }
             if (openChatUrl == null || openChatUrl.isBlank()) {
-                throw new IllegalArgumentException("오픈 채팅 링크는 필수입니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_OPEN_CHAT_URL);
             }
             if (!openChatUrl.startsWith("https://") && !openChatUrl.startsWith("http://")) {
-                throw new IllegalArgumentException("오픈 채팅 링크는 http:// 또는 https://로 시작해야 합니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_OPEN_CHAT_URL_FORMAT);
             }
         }
 
@@ -170,11 +172,11 @@ public class Post {
          * 모임 시간이 현재 이후인지 검증 (Service 레이어에서 호출)
          *
          * @param now 비교할 현재 시간 (테스트 용이성을 위해 외부에서 주입)
-         * @throws IllegalArgumentException 모임 시간이 현재 이전인 경우
+         * @throws CommunityDomainException 모임 시간이 현재 이전인 경우
          */
         public void validateMeetAtIsFuture(Instant now) {
             if (meetAt.isBefore(now)) {
-                throw new IllegalArgumentException("모임 시간은 현재 이후여야 합니다.");
+                throw new CommunityDomainException(CommunityErrorCode.INVALID_LIGHTNING_MEET_AT_PAST);
             }
         }
     }

--- a/src/main/java/com/umc/product/community/domain/exception/CommunityErrorCode.java
+++ b/src/main/java/com/umc/product/community/domain/exception/CommunityErrorCode.java
@@ -28,7 +28,33 @@ public enum CommunityErrorCode implements BaseCode {
     INVALID_TROPHY_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0303", "상장 내용이 유효하지 않습니다."),
     INVALID_TROPHY_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0304", "상장 URL이 유효하지 않습니다."),
 
-    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "COMMUNITY-0401", "이미 신고한 게시글/댓글입니다.");
+    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "COMMUNITY-0401", "이미 신고한 게시글/댓글입니다."),
+
+    // === Post 검증 ===
+    INVALID_POST_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0107", "작성자 ID는 필수입니다."),
+    NOT_LIGHTNING_POST(HttpStatus.BAD_REQUEST, "COMMUNITY-0108", "번개 게시글이 아닙니다."),
+    USE_LIGHTNING_API(HttpStatus.BAD_REQUEST, "COMMUNITY-0109", "번개 게시글은 번개 전용 API를 사용하세요."),
+    LIGHTNING_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "COMMUNITY-0110", "번개 게시글은 추가 정보가 필수입니다."),
+    POST_NOT_OWNED(HttpStatus.FORBIDDEN, "COMMUNITY-0111", "본인의 게시글만 수정/삭제할 수 있습니다."),
+
+    // === Lightning 검증 ===
+    INVALID_LIGHTNING_MEET_AT(HttpStatus.BAD_REQUEST, "COMMUNITY-0151", "모임 시간은 필수입니다."),
+    INVALID_LIGHTNING_LOCATION(HttpStatus.BAD_REQUEST, "COMMUNITY-0152", "모임 장소는 필수입니다."),
+    INVALID_LIGHTNING_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "COMMUNITY-0153", "최대 참가자는 1명 이상이어야 합니다."),
+    INVALID_LIGHTNING_OPEN_CHAT_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0154", "오픈 채팅 링크는 필수입니다."),
+    INVALID_LIGHTNING_OPEN_CHAT_URL_FORMAT(HttpStatus.BAD_REQUEST, "COMMUNITY-0155", "오픈 채팅 링크는 http:// 또는 https://로 시작해야 합니다."),
+    INVALID_LIGHTNING_MEET_AT_PAST(HttpStatus.BAD_REQUEST, "COMMUNITY-0156", "모임 시간은 현재 이후여야 합니다."),
+
+    // === Comment 검증 ===
+    INVALID_COMMENT_POST_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0203", "게시글 ID는 필수입니다."),
+    INVALID_COMMENT_CHALLENGER_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0204", "챌린저 ID는 필수입니다."),
+
+    // === 공통 ID 검증 ===
+    INVALID_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0901", "ID는 양수여야 합니다."),
+
+    // === Adapter 검증 ===
+    POST_SAVE_REQUIRES_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0902", "새 게시글 생성 시에는 작성자 정보가 필요합니다."),
+    POST_UPDATE_INVALID_CALL(HttpStatus.BAD_REQUEST, "COMMUNITY-0903", "이미 ID가 있는 게시글은 update용 save를 사용하세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/product/community/domain/exception/CommunityErrorCode.java
+++ b/src/main/java/com/umc/product/community/domain/exception/CommunityErrorCode.java
@@ -13,48 +13,48 @@ public enum CommunityErrorCode implements BaseCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY-0002", "댓글을 찾을 수 없습니다."),
     TROPHY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY-0003", "상장을 찾을 수 없습니다."),
 
-    INVALID_POST_TITLE(HttpStatus.BAD_REQUEST, "COMMUNITY-0101", "게시글 제목이 유효하지 않습니다."),
-    INVALID_POST_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0102", "게시글 내용이 유효하지 않습니다."),
-    INVALID_POST_CATEGORY(HttpStatus.BAD_REQUEST, "COMMUNITY-0103", "게시글 카테고리가 유효하지 않습니다."),
-    INVALID_POST_REGION(HttpStatus.BAD_REQUEST, "COMMUNITY-0104", "게시글 지역이 유효하지 않습니다."),
-    CANNOT_CHANGE_TO_LIGHTNING(HttpStatus.BAD_REQUEST, "COMMUNITY-0105", "일반 게시글을 번개 게시글로 변경할 수 없습니다."),
-    CANNOT_CHANGE_FROM_LIGHTNING(HttpStatus.BAD_REQUEST, "COMMUNITY-0106", "번개 게시글을 일반 게시글로 변경할 수 없습니다."),
+    INVALID_POST_TITLE(HttpStatus.BAD_REQUEST, "COMMUNITY-0004", "게시글 제목이 유효하지 않습니다."),
+    INVALID_POST_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0005", "게시글 내용이 유효하지 않습니다."),
+    INVALID_POST_CATEGORY(HttpStatus.BAD_REQUEST, "COMMUNITY-0006", "게시글 카테고리가 유효하지 않습니다."),
+    INVALID_POST_REGION(HttpStatus.BAD_REQUEST, "COMMUNITY-0007", "게시글 지역이 유효하지 않습니다."),
+    CANNOT_CHANGE_TO_LIGHTNING(HttpStatus.BAD_REQUEST, "COMMUNITY-0008", "일반 게시글을 번개 게시글로 변경할 수 없습니다."),
+    CANNOT_CHANGE_FROM_LIGHTNING(HttpStatus.BAD_REQUEST, "COMMUNITY-0009", "번개 게시글을 일반 게시글로 변경할 수 없습니다."),
 
-    INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0201", "댓글 내용이 유효하지 않습니다."),
-    COMMENT_NOT_OWNED(HttpStatus.FORBIDDEN, "COMMUNITY-0202", "본인의 댓글만 삭제할 수 있습니다."),
+    INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0010", "댓글 내용이 유효하지 않습니다."),
+    COMMENT_NOT_OWNED(HttpStatus.FORBIDDEN, "COMMUNITY-0011", "본인의 댓글만 삭제할 수 있습니다."),
 
-    INVALID_TROPHY_WEEK(HttpStatus.BAD_REQUEST, "COMMUNITY-0301", "상장 주차가 유효하지 않습니다."),
-    INVALID_TROPHY_TITLE(HttpStatus.BAD_REQUEST, "COMMUNITY-0302", "상장 제목이 유효하지 않습니다."),
-    INVALID_TROPHY_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0303", "상장 내용이 유효하지 않습니다."),
-    INVALID_TROPHY_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0304", "상장 URL이 유효하지 않습니다."),
+    INVALID_TROPHY_WEEK(HttpStatus.BAD_REQUEST, "COMMUNITY-0012", "상장 주차가 유효하지 않습니다."),
+    INVALID_TROPHY_TITLE(HttpStatus.BAD_REQUEST, "COMMUNITY-0013", "상장 제목이 유효하지 않습니다."),
+    INVALID_TROPHY_CONTENT(HttpStatus.BAD_REQUEST, "COMMUNITY-0014", "상장 내용이 유효하지 않습니다."),
+    INVALID_TROPHY_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0015", "상장 URL이 유효하지 않습니다."),
 
-    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "COMMUNITY-0401", "이미 신고한 게시글/댓글입니다."),
+    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "COMMUNITY-0016", "이미 신고한 게시글/댓글입니다."),
 
     // === Post 검증 ===
-    INVALID_POST_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0107", "작성자 ID는 필수입니다."),
-    NOT_LIGHTNING_POST(HttpStatus.BAD_REQUEST, "COMMUNITY-0108", "번개 게시글이 아닙니다."),
-    USE_LIGHTNING_API(HttpStatus.BAD_REQUEST, "COMMUNITY-0109", "번개 게시글은 번개 전용 API를 사용하세요."),
-    LIGHTNING_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "COMMUNITY-0110", "번개 게시글은 추가 정보가 필수입니다."),
-    POST_NOT_OWNED(HttpStatus.FORBIDDEN, "COMMUNITY-0111", "본인의 게시글만 수정/삭제할 수 있습니다."),
+    INVALID_POST_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0017", "작성자 ID는 필수입니다."),
+    NOT_LIGHTNING_POST(HttpStatus.BAD_REQUEST, "COMMUNITY-0018", "번개 게시글이 아닙니다."),
+    USE_LIGHTNING_API(HttpStatus.BAD_REQUEST, "COMMUNITY-0019", "번개 게시글은 번개 전용 API를 사용하세요."),
+    LIGHTNING_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "COMMUNITY-0020", "번개 게시글은 추가 정보가 필수입니다."),
+    POST_NOT_OWNED(HttpStatus.FORBIDDEN, "COMMUNITY-0021", "본인의 게시글만 수정/삭제할 수 있습니다."),
 
     // === Lightning 검증 ===
-    INVALID_LIGHTNING_MEET_AT(HttpStatus.BAD_REQUEST, "COMMUNITY-0151", "모임 시간은 필수입니다."),
-    INVALID_LIGHTNING_LOCATION(HttpStatus.BAD_REQUEST, "COMMUNITY-0152", "모임 장소는 필수입니다."),
-    INVALID_LIGHTNING_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "COMMUNITY-0153", "최대 참가자는 1명 이상이어야 합니다."),
-    INVALID_LIGHTNING_OPEN_CHAT_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0154", "오픈 채팅 링크는 필수입니다."),
-    INVALID_LIGHTNING_OPEN_CHAT_URL_FORMAT(HttpStatus.BAD_REQUEST, "COMMUNITY-0155", "오픈 채팅 링크는 http:// 또는 https://로 시작해야 합니다."),
-    INVALID_LIGHTNING_MEET_AT_PAST(HttpStatus.BAD_REQUEST, "COMMUNITY-0156", "모임 시간은 현재 이후여야 합니다."),
+    INVALID_LIGHTNING_MEET_AT(HttpStatus.BAD_REQUEST, "COMMUNITY-0022", "모임 시간은 필수입니다."),
+    INVALID_LIGHTNING_LOCATION(HttpStatus.BAD_REQUEST, "COMMUNITY-0023", "모임 장소는 필수입니다."),
+    INVALID_LIGHTNING_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "COMMUNITY-0024", "최대 참가자는 1명 이상이어야 합니다."),
+    INVALID_LIGHTNING_OPEN_CHAT_URL(HttpStatus.BAD_REQUEST, "COMMUNITY-0025", "오픈 채팅 링크는 필수입니다."),
+    INVALID_LIGHTNING_OPEN_CHAT_URL_FORMAT(HttpStatus.BAD_REQUEST, "COMMUNITY-0026", "오픈 채팅 링크는 http:// 또는 https://로 시작해야 합니다."),
+    INVALID_LIGHTNING_MEET_AT_PAST(HttpStatus.BAD_REQUEST, "COMMUNITY-0027", "모임 시간은 현재 이후여야 합니다."),
 
     // === Comment 검증 ===
-    INVALID_COMMENT_POST_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0203", "게시글 ID는 필수입니다."),
-    INVALID_COMMENT_CHALLENGER_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0204", "챌린저 ID는 필수입니다."),
+    INVALID_COMMENT_POST_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0028", "게시글 ID는 필수입니다."),
+    INVALID_COMMENT_CHALLENGER_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0029", "챌린저 ID는 필수입니다."),
 
     // === 공통 ID 검증 ===
-    INVALID_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0901", "ID는 양수여야 합니다."),
+    INVALID_ID(HttpStatus.BAD_REQUEST, "COMMUNITY-0030", "ID는 양수여야 합니다."),
 
     // === Adapter 검증 ===
-    POST_SAVE_REQUIRES_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0902", "새 게시글 생성 시에는 작성자 정보가 필요합니다."),
-    POST_UPDATE_INVALID_CALL(HttpStatus.BAD_REQUEST, "COMMUNITY-0903", "이미 ID가 있는 게시글은 update용 save를 사용하세요.");
+    POST_SAVE_REQUIRES_AUTHOR(HttpStatus.BAD_REQUEST, "COMMUNITY-0031", "새 게시글 생성 시에는 작성자 정보가 필요합니다."),
+    POST_UPDATE_INVALID_CALL(HttpStatus.BAD_REQUEST, "COMMUNITY-0032", "이미 ID가 있는 게시글은 update용 save를 사용하세요.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  CommunityErrorCode 에러 코드 추가
- [x] 매핑 적용

## 🔥 연관 이슈

- resolves #697

## 🚀 작업 내용

IllegalArgumentException, IllegalStateException 등 표준 예외로 처리되던 에러를 세분화된 커스텀 예외(CommunityDomainException)로 전부 수정하였습니다.

1. CommunityErrorCode 에러 코드
Post 검증, Lightning(번개) 게시글 검증, Comment 검증, 공통 ID 검증, Adapter 검증 등 각 커스텀 에러 추가

2. 기존 IllegalArgumentException, IllegalStateException을 각각  CommunityErrorCode의 에러코드로 매핑 변경

3. 검증 로직에서 발생하는 예외를 CommunityDomainException으로 변경

## 💬 리뷰 중점사항

