### PR TITLE
[Feat] 커뮤니티 게시글 및 명예의 전당 관련 API 접근 권한 제한

### DIFF
--- a/src/main/java/com/umc/product/community/adapter/in/web/CommentController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/CommentController.java
@@ -5,6 +5,9 @@ import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWi
 import com.umc.product.community.adapter.in.web.dto.request.CreateCommentRequest;
 import com.umc.product.community.adapter.in.web.dto.response.CommentResponse;
 import com.umc.product.community.adapter.in.web.dto.response.LikeResponse;
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.community.application.port.in.command.comment.CreateCommentUseCase;
 import com.umc.product.community.application.port.in.command.comment.DeleteCommentUseCase;
 import com.umc.product.community.application.port.in.command.comment.ToggleCommentLikeUseCase;
@@ -51,13 +54,23 @@ public class CommentController {
 
     @GetMapping
     @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 조회합니다.")
-    public List<CommentResponse> getComments(@PathVariable Long postId) {
-        return getCommentListUseCase.getComments(postId).stream()
+    public List<CommentResponse> getComments(
+        @PathVariable Long postId,
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
+        Long challengerId = null;
+        if (memberPrincipal != null) {
+            Long memberId = memberPrincipal.getMemberId();
+            challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
+        }
+
+        return getCommentListUseCase.getComments(postId, challengerId).stream()
             .map(CommentResponse::from)
             .toList();
     }
 
     @DeleteMapping("/{commentId}")
+    @CheckAccess(resourceType = ResourceType.COMMUNITY_COMMENT, resourceId = "#commentId", permission = PermissionType.DELETE, message = "본인의 댓글만 삭제할 수 있습니다.")
     @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글을 삭제합니다.")
     public void deleteComment(
         @PathVariable Long postId,

--- a/src/main/java/com/umc/product/community/adapter/in/web/PostController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/PostController.java
@@ -73,34 +73,46 @@ public class PostController {
         return toPostResponse(createPostUseCase.createLightningPost(request.toCommand(challenger.challengerId())));
     }
 
-    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.EDIT, message = "게시글 수정 권한이 없습니다.")
+    @CheckAccess(
+        resourceType = ResourceType.COMMUNITY_POST,
+        resourceId = "#postId",
+        permission = PermissionType.EDIT,
+        message = "게시글 수정 권한이 없습니다."
+    )
     @PatchMapping("/{postId}")
     @Operation(summary = "일반 게시글 수정", description = "일반 게시글의 제목, 내용, 카테고리를 수정합니다.")
     public PostResponse updatePost(
         @PathVariable Long postId,
-        @RequestBody UpdatePostRequest request,
-        @CurrentMember MemberPrincipal memberPrincipal
+        @RequestBody UpdatePostRequest request
     ) {
         return toPostResponse(updatePostUseCase.updatePost(request.toCommand(postId)));
     }
 
-    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.EDIT, message = "번개 게시글 수정 권한이 없습니다.")
+    @CheckAccess(
+        resourceType = ResourceType.COMMUNITY_POST,
+        resourceId = "#postId",
+        permission = PermissionType.EDIT,
+        message = "번개 게시글 수정 권한이 없습니다."
+    )
     @PatchMapping("/{postId}/lightning")
     @Operation(summary = "번개글 수정", description = "번개 게시글의 제목, 내용, 모임 정보를 수정합니다.")
     public PostResponse updateLightningPost(
         @PathVariable Long postId,
-        @RequestBody UpdateLightningRequest request,
-        @CurrentMember MemberPrincipal memberPrincipal
+        @RequestBody UpdateLightningRequest request
     ) {
         return toPostResponse(updateLightningUseCase.updateLightning(request.toCommand(postId)));
     }
 
-    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.DELETE, message = "게시글 삭제 권한이 없습니다.")
+    @CheckAccess(
+        resourceType = ResourceType.COMMUNITY_POST,
+        resourceId = "#postId",
+        permission = PermissionType.DELETE,
+        message = "게시글 삭제 권한이 없습니다."
+    )
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public void deletePost(
-        @PathVariable Long postId,
-        @CurrentMember MemberPrincipal memberPrincipal
+        @PathVariable Long postId
     ) {
         deletePostUseCase.deletePost(postId);
     }

--- a/src/main/java/com/umc/product/community/adapter/in/web/PostController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/PostController.java
@@ -16,6 +16,9 @@ import com.umc.product.community.application.port.in.command.post.TogglePostLike
 import com.umc.product.community.application.port.in.command.post.ToggleScrapUseCase;
 import com.umc.product.community.application.port.in.command.post.UpdateLightningUseCase;
 import com.umc.product.community.application.port.in.command.post.UpdatePostUseCase;
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.community.application.port.in.query.dto.PostInfo;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
@@ -70,27 +73,35 @@ public class PostController {
         return toPostResponse(createPostUseCase.createLightningPost(request.toCommand(challenger.challengerId())));
     }
 
+    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.EDIT, message = "게시글 수정 권한이 없습니다.")
     @PatchMapping("/{postId}")
     @Operation(summary = "일반 게시글 수정", description = "일반 게시글의 제목, 내용, 카테고리를 수정합니다.")
     public PostResponse updatePost(
         @PathVariable Long postId,
-        @RequestBody UpdatePostRequest request
+        @RequestBody UpdatePostRequest request,
+        @CurrentMember MemberPrincipal memberPrincipal
     ) {
         return toPostResponse(updatePostUseCase.updatePost(request.toCommand(postId)));
     }
 
+    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.EDIT, message = "번개 게시글 수정 권한이 없습니다.")
     @PatchMapping("/{postId}/lightning")
     @Operation(summary = "번개글 수정", description = "번개 게시글의 제목, 내용, 모임 정보를 수정합니다.")
     public PostResponse updateLightningPost(
         @PathVariable Long postId,
-        @RequestBody UpdateLightningRequest request
+        @RequestBody UpdateLightningRequest request,
+        @CurrentMember MemberPrincipal memberPrincipal
     ) {
         return toPostResponse(updateLightningUseCase.updateLightning(request.toCommand(postId)));
     }
 
+    @CheckAccess(resourceType = ResourceType.COMMUNITY_POST, resourceId = "#postId", permission = PermissionType.DELETE, message = "게시글 삭제 권한이 없습니다.")
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    public void deletePost(@PathVariable Long postId) {
+    public void deletePost(
+        @PathVariable Long postId,
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
         deletePostUseCase.deletePost(postId);
     }
 

--- a/src/main/java/com/umc/product/community/adapter/in/web/PostQueryController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/PostQueryController.java
@@ -58,15 +58,18 @@ public class PostQueryController {
         return PostResponse.from(postInfo, memberInfo, challengerInfo);
     }
 
+    private Long resolveChallengerId(MemberPrincipal memberPrincipal) {
+        return getChallengerUseCase.getLatestActiveChallengerByMemberId(memberPrincipal.getMemberId()).challengerId();
+    }
+
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보를 조회합니다. (댓글 수, 좋아요/스크랩 여부 포함)")
     public PostDetailResponse getPostDetail(
         @PathVariable Long postId,
         @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        Long memberId = memberPrincipal.getMemberId();
-        ChallengerInfoWithStatus challenger = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId);
-        return PostDetailResponse.from(getPostDetailUseCase.getPostDetail(postId, challenger.challengerId()));
+        Long challengerId = resolveChallengerId(memberPrincipal);
+        return PostDetailResponse.from(getPostDetailUseCase.getPostDetail(postId, challengerId));
     }
 
     @GetMapping
@@ -80,16 +83,11 @@ public class PostQueryController {
         Pageable pageable,
         @CurrentMember MemberPrincipal memberPrincipal
     ) {
-        Long challengerId = null;
-        if (memberPrincipal != null) {
-            Long memberId = memberPrincipal.getMemberId();
-            challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
-        }
-
+        Long memberId = memberPrincipal != null ? memberPrincipal.getMemberId() : null;
         PostSearchQuery query = new PostSearchQuery(category);
 
         return PageResponse.of(
-            getPostListUseCase.getPostList(query, challengerId, pageable),
+            getPostListUseCase.getPostList(query, memberId, pageable),
             this::toPostResponse
         );
     }
@@ -112,7 +110,7 @@ public class PostQueryController {
     }
 
     @GetMapping("/my")
-    @Operation(summary = "내가 쓴 글 조회", description = "챌린저가 작성한 게시글 목록을 조회합니다. (최신순 정렬)")
+    @Operation(summary = "내가 쓴 글 조회", description = "멤버가 작성한 게시글 목록을 조회합니다. (전 기수 포함, 최신순 정렬)")
     public PageResponse<PostResponse> getMyPosts(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PageableDefault(size = 20)
@@ -120,13 +118,12 @@ public class PostQueryController {
         Pageable pageable
     ) {
         Long memberId = memberPrincipal.getMemberId();
-        ChallengerInfoWithStatus challenger = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId);
-        Page<PostInfo> posts = getMyPostsUseCase.getMyPosts(challenger.challengerId(), pageable);
+        Page<PostInfo> posts = getMyPostsUseCase.getMyPosts(memberId, pageable);
         return PageResponse.of(posts, PostResponse::from);
     }
 
     @GetMapping("/commented")
-    @Operation(summary = "댓글 단 글 조회", description = "챌린저가 댓글을 단 게시글 목록을 조회합니다. (최신 댓글 순)")
+    @Operation(summary = "댓글 단 글 조회", description = "멤버가 댓글을 단 게시글 목록을 조회합니다. (전 기수 포함, 최신 댓글 순)")
     public PageResponse<PostResponse> getCommentedPosts(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PageableDefault(size = 20)
@@ -134,13 +131,12 @@ public class PostQueryController {
         Pageable pageable
     ) {
         Long memberId = memberPrincipal.getMemberId();
-        ChallengerInfoWithStatus challenger = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId);
-        Page<PostInfo> posts = getCommentedPostsUseCase.getCommentedPosts(challenger.challengerId(), pageable);
+        Page<PostInfo> posts = getCommentedPostsUseCase.getCommentedPosts(memberId, pageable);
         return PageResponse.of(posts, PostResponse::from);
     }
 
     @GetMapping("/scrapped")
-    @Operation(summary = "스크랩한 글 조회", description = "챌린저가 스크랩한 게시글 목록을 조회합니다. (최신 스크랩 순)")
+    @Operation(summary = "스크랩한 글 조회", description = "멤버가 스크랩한 게시글 목록을 조회합니다. (전 기수 포함, 최신 스크랩 순)")
     public PageResponse<PostResponse> getScrappedPosts(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PageableDefault(size = 20)
@@ -148,8 +144,7 @@ public class PostQueryController {
         Pageable pageable
     ) {
         Long memberId = memberPrincipal.getMemberId();
-        ChallengerInfoWithStatus challenger = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId);
-        Page<PostInfo> posts = getScrappedPostsUseCase.getScrappedPosts(challenger.challengerId(), pageable);
+        Page<PostInfo> posts = getScrappedPostsUseCase.getScrappedPosts(memberId, pageable);
         return PageResponse.of(posts, PostResponse::from);
     }
 }

--- a/src/main/java/com/umc/product/community/adapter/in/web/PostQueryController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/PostQueryController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
-@Tag(name = "Community | 게시글 Query", description = "")
+@Tag(name = "Community | 게시글 Query", description = "게시글 조회 API")
 public class PostQueryController {
 
     private final GetPostDetailUseCase getPostDetailUseCase;
@@ -77,12 +77,19 @@ public class PostQueryController {
         Category category,
         @PageableDefault(size = 20)
         @ParameterObject
-        Pageable pageable
+        Pageable pageable,
+        @CurrentMember MemberPrincipal memberPrincipal
     ) {
+        Long challengerId = null;
+        if (memberPrincipal != null) {
+            Long memberId = memberPrincipal.getMemberId();
+            challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
+        }
+
         PostSearchQuery query = new PostSearchQuery(category);
 
         return PageResponse.of(
-            getPostListUseCase.getPostList(query, pageable),
+            getPostListUseCase.getPostList(query, challengerId, pageable),
             this::toPostResponse
         );
     }

--- a/src/main/java/com/umc/product/community/adapter/in/web/TrophyController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/TrophyController.java
@@ -1,8 +1,12 @@
 package com.umc.product.community.adapter.in.web;
 
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import com.umc.product.community.adapter.in.web.dto.request.CreateTrophyRequest;
 import com.umc.product.community.adapter.in.web.dto.response.TrophyResponse;
 import com.umc.product.community.application.port.in.command.trophy.CreateTrophyUseCase;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trophies")
 @RequiredArgsConstructor
-@Tag(name = "Community | 명예의 전당 Command", description = "")
+@Tag(name = "Community | 명예의 전당 Command", description = "명예의 전당 생성/수정/삭제 API")
 public class TrophyController {
 
     private final CreateTrophyUseCase createTrophyUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
 
     @PostMapping
     @Operation(summary = "상장 생성", description = "주차별 상장을 생성합니다.")
-    public TrophyResponse createTrophy(@RequestBody CreateTrophyRequest request) {
-        return TrophyResponse.from(createTrophyUseCase.createTrophy(request.toCommand()));
+    public TrophyResponse createTrophy(
+        @RequestBody CreateTrophyRequest request,
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
+        Long memberId = memberPrincipal.getMemberId();
+        ChallengerInfoWithStatus challenger = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId);
+        return TrophyResponse.from(createTrophyUseCase.createTrophy(request.toCommand(challenger.challengerId())));
     }
 }

--- a/src/main/java/com/umc/product/community/adapter/in/web/TrophyController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/TrophyController.java
@@ -25,7 +25,7 @@ public class TrophyController {
     private final GetChallengerUseCase getChallengerUseCase;
 
     @PostMapping
-    @Operation(summary = "상장 생성", description = "주차별 상장을 생성합니다.")
+    @Operation(summary = "베스트 워크북 생성", description = "주차별 베스트 워크북을 생성합니다.")
     public TrophyResponse createTrophy(
         @RequestBody CreateTrophyRequest request,
         @CurrentMember MemberPrincipal memberPrincipal

--- a/src/main/java/com/umc/product/community/adapter/in/web/TrophyQueryController.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/TrophyQueryController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trophies")
 @RequiredArgsConstructor
-@Tag(name = "Community | 명예의 전당 Query", description = "")
+@Tag(name = "Community | 명예의 전당 Query", description = "명예의 전당 조회 API")
 public class TrophyQueryController {
 
     private final GetTrophyListUseCase getTrophyListUseCase;

--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/request/CreateTrophyRequest.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/request/CreateTrophyRequest.java
@@ -34,4 +34,8 @@ public record CreateTrophyRequest(
     public CreateTrophyCommand toCommand() {
         return new CreateTrophyCommand(challengerId, week, title, content, url);
     }
+
+    public CreateTrophyCommand toCommand(Long challengerId) {
+        return new CreateTrophyCommand(challengerId, week, title, content, url);
+    }
 }

--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/request/CreateTrophyRequest.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/request/CreateTrophyRequest.java
@@ -4,14 +4,12 @@ import com.umc.product.community.application.port.in.command.trophy.dto.CreateTr
 import java.util.Objects;
 
 public record CreateTrophyRequest(
-    Long challengerId,
     Integer week,
     String title,
     String content,
     String url
 ) {
     public CreateTrophyRequest {
-        Objects.requireNonNull(challengerId, "챌린저 ID는 필수입니다");
         Objects.requireNonNull(week, "주차는 필수입니다");
         Objects.requireNonNull(title, "제목은 필수입니다");
         Objects.requireNonNull(content, "내용은 필수입니다");
@@ -31,11 +29,13 @@ public record CreateTrophyRequest(
         }
     }
 
-    public CreateTrophyCommand toCommand() {
-        return new CreateTrophyCommand(challengerId, week, title, content, url);
-    }
-
     public CreateTrophyCommand toCommand(Long challengerId) {
-        return new CreateTrophyCommand(challengerId, week, title, content, url);
+        return CreateTrophyCommand.builder()
+            .challengerId(challengerId)
+            .week(week)
+            .title(title)
+            .content(content)
+            .url(url)
+            .build();
     }
 }

--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostDetailResponse.java
@@ -53,9 +53,6 @@ public record PostDetailResponse(
     @Schema(description = "좋아요 클릭 여부", example = "true")
     boolean isLiked,
 
-    @Schema(description = "본인 작성 글 여부", example = "true")
-    boolean isAuthor,
-
     @Schema(description = "스크랩 수", example = "3")
     int scrapCount,
 
@@ -91,7 +88,6 @@ public record PostDetailResponse(
             .writeTime(info.createdAt())
             .likeCount(info.likeCount())
             .isLiked(info.isLiked())
-            .isAuthor(info.isAuthor())
             .scrapCount(info.scrapCount())
             .isScrapped(info.isScrapped())
             .build();

--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostResponse.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/response/PostResponse.java
@@ -56,9 +56,6 @@ public record PostResponse(
     @Schema(description = "좋아요 여부", example = "true")
     boolean isLiked,
 
-    @Schema(description = "본인 작성 글 여부", example = "true")
-    boolean isAuthor,
-
     @Schema(description = "번개 정보 (번개글인 경우)")
     LightningInfoResponse lightningInfo
 ) {
@@ -86,7 +83,6 @@ public record PostResponse(
             .commentCount(postInfo.commentCount())
             .likeCount(postInfo.likeCount())
             .isLiked(false) // 검색 결과에서는 좋아요 여부를 알 수 없으므로 false로 설정
-            .isAuthor(false) // 검색 결과에서는 본인 작성 여부를 알 수 없으므로 false로 설정
             .lightningInfo(null) // 검색 결과에서는 번개 정보가 없으므로 null로 설정
             .build();
     }
@@ -123,7 +119,6 @@ public record PostResponse(
             .commentCount(info.commentCount())
             .likeCount(info.likeCount())
             .isLiked(info.isLiked())
-            .isAuthor(info.isAuthor())
             .lightningInfo(lightningInfoResponse)
             .build();
     }

--- a/src/main/java/com/umc/product/community/adapter/out/persistence/PostQueryRepository.java
+++ b/src/main/java/com/umc/product/community/adapter/out/persistence/PostQueryRepository.java
@@ -181,7 +181,6 @@ public class PostQueryRepository {
      * 챌린저가 댓글을 단 게시글 목록 조회 (중복 제거, 최신 댓글 순)
      */
     public Page<Post> findCommentedPostsByChallengerId(Long challengerId, Pageable pageable) {
-        // 1. JOIN과 GROUP BY를 사용하여 단일 쿼리로 조회 (DB에서 정렬)
         List<PostJpaEntity> results = queryFactory
             .selectFrom(postJpaEntity)
             .innerJoin(commentJpaEntity)
@@ -197,7 +196,6 @@ public class PostQueryRepository {
             return Page.empty(pageable);
         }
 
-        // 2. 전체 개수 조회
         Long totalCount = queryFactory
             .select(commentJpaEntity.postId.countDistinct())
             .from(commentJpaEntity)
@@ -215,7 +213,6 @@ public class PostQueryRepository {
      * 챌린저가 스크랩한 게시글 목록 조회 (최신 스크랩 순)
      */
     public Page<Post> findScrappedPostsByChallengerId(Long challengerId, Pageable pageable) {
-        // 1. JOIN을 사용하여 단일 쿼리로 조회 (DB에서 정렬)
         List<PostJpaEntity> results = queryFactory
             .selectFrom(postJpaEntity)
             .innerJoin(scrapJpaEntity)
@@ -230,7 +227,6 @@ public class PostQueryRepository {
             return Page.empty(pageable);
         }
 
-        // 2. 전체 개수 조회
         Long totalCount = queryFactory
             .select(scrapJpaEntity.count())
             .from(scrapJpaEntity)

--- a/src/main/java/com/umc/product/community/application/port/in/command/trophy/dto/CreateTrophyCommand.java
+++ b/src/main/java/com/umc/product/community/application/port/in/command/trophy/dto/CreateTrophyCommand.java
@@ -1,5 +1,8 @@
 package com.umc.product.community.application.port.in.command.trophy.dto;
 
+import lombok.Builder;
+
+@Builder
 public record CreateTrophyCommand(
     Long challengerId,
     Integer week,

--- a/src/main/java/com/umc/product/community/application/port/in/query/GetCommentedPostsUseCase.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/GetCommentedPostsUseCase.java
@@ -9,11 +9,11 @@ import org.springframework.data.domain.Pageable;
  */
 public interface GetCommentedPostsUseCase {
     /**
-     * 챌린저가 댓글을 단 게시글 목록 조회
+     * 멤버가 댓글을 단 게시글 목록 조회
      *
-     * @param challengerId 챌린저 ID
-     * @param pageable     페이지네이션
+     * @param memberId 멤버 ID
+     * @param pageable 페이지네이션
      * @return 게시글 목록
      */
-    Page<PostInfo> getCommentedPosts(Long challengerId, Pageable pageable);
+    Page<PostInfo> getCommentedPosts(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/community/application/port/in/query/GetMyPostsUseCase.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/GetMyPostsUseCase.java
@@ -9,11 +9,11 @@ import org.springframework.data.domain.Pageable;
  */
 public interface GetMyPostsUseCase {
     /**
-     * 챌린저가 작성한 게시글 목록 조회
+     * 멤버가 작성한 게시글 목록 조회
      *
-     * @param challengerId 챌린저 ID
-     * @param pageable     페이지네이션
+     * @param memberId 멤버 ID
+     * @param pageable 페이지네이션
      * @return 게시글 목록
      */
-    Page<PostInfo> getMyPosts(Long challengerId, Pageable pageable);
+    Page<PostInfo> getMyPosts(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/community/application/port/in/query/GetPostListUseCase.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/GetPostListUseCase.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface GetPostListUseCase {
-    Page<PostInfo> getPostList(PostSearchQuery query, Long challengerId, Pageable pageable);
+    Page<PostInfo> getPostList(PostSearchQuery query, Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/community/application/port/in/query/GetPostListUseCase.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/GetPostListUseCase.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface GetPostListUseCase {
-    Page<PostInfo> getPostList(PostSearchQuery query, Pageable pageable);
+    Page<PostInfo> getPostList(PostSearchQuery query, Long challengerId, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/community/application/port/in/query/GetScrappedPostsUseCase.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/GetScrappedPostsUseCase.java
@@ -9,11 +9,11 @@ import org.springframework.data.domain.Pageable;
  */
 public interface GetScrappedPostsUseCase {
     /**
-     * 챌린저가 스크랩한 게시글 목록 조회
+     * 멤버가 스크랩한 게시글 목록 조회
      *
-     * @param challengerId 챌린저 ID
-     * @param pageable     페이지네이션
+     * @param memberId 멤버 ID
+     * @param pageable 페이지네이션
      * @return 게시글 목록
      */
-    Page<PostInfo> getScrappedPosts(Long challengerId, Pageable pageable);
+    Page<PostInfo> getScrappedPosts(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/community/application/port/in/query/dto/PostDetailInfo.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/dto/PostDetailInfo.java
@@ -26,7 +26,6 @@ public record PostDetailInfo(
     Instant createdAt,
     int likeCount,
     boolean isLiked,
-    boolean isAuthor,
     boolean isScrapped,
     int scrapCount
 ) {
@@ -54,7 +53,6 @@ public record PostDetailInfo(
             .createdAt(postInfo.createdAt())
             .likeCount(postInfo.likeCount())
             .isLiked(postInfo.isLiked())
-            .isAuthor(postInfo.isAuthor())
             .isScrapped(isScrapped)
             .scrapCount(scrapCount)
             .build();

--- a/src/main/java/com/umc/product/community/application/port/in/query/dto/PostInfo.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/dto/PostInfo.java
@@ -27,8 +27,7 @@ public record PostInfo(
     Instant createdAt,
     int commentCount,
     int likeCount,
-    boolean isLiked, // Deprecated
-    boolean isAuthor // Deprecated
+    boolean isLiked
 ) {
 
     public static PostInfo from(Post post, MemberInfo memberInfo, ChallengerInfo challengerInfo) {
@@ -66,7 +65,6 @@ public record PostInfo(
             .createdAt(post.getCreatedAt())
             .likeCount(post.getLikeCount())
             .isLiked(post.isLiked())
-            .isAuthor(false) // TODO: deprecate 예정
             .build();
     }
 
@@ -76,22 +74,7 @@ public record PostInfo(
 
     @Deprecated
     public static PostInfo from(Post post, Long authorId, String authorName) {
-
-        return from(post, authorId, authorName, null, null, 0, false);
-    }
-
-    @Deprecated
-    public static PostInfo from(Post post, Long authorId, String authorName, int commentCount) {
-
-        return from(post, authorId, authorName, null, null, commentCount, false);
-    }
-
-    @Deprecated
-    public static PostInfo from(
-        Post post, Long authorId, String authorName,
-        String authorProfileImage, int commentCount) {
-
-        return from(post, authorId, authorName, authorProfileImage, null, commentCount, false);
+        return from(post, authorId, authorName, null, null, 0);
     }
 
     @Deprecated
@@ -99,42 +82,8 @@ public record PostInfo(
         Post post, Long authorId, String authorName, String authorProfileImage,
         ChallengerPart authorPart, int commentCount) {
 
-        return from(post, authorId, authorName, authorProfileImage, authorPart, commentCount, false);
-    }
-
-    @Deprecated
-    public static PostInfo from(
-        Post post, Long authorId, String authorName, String authorProfileImage,
-        ChallengerPart authorPart, int commentCount, boolean isAuthor) {
-
         Long postId = post.getPostId() != null ? post.getPostId().id() : null;
-
-        // 번개글인 경우
-        if (post.isLightning()) {
-            Post.LightningInfo info = post.getLightningInfoOrThrow();
-            return PostInfo.builder()
-                .postId(postId)
-                .title(post.getTitle())
-                .content(post.getContent())
-                .category(post.getCategory())
-                .authorChallengerId(authorId)
-                .authorName(authorName)
-                .authorProfileImage(authorProfileImage)
-                .authorPart(authorPart)
-                .meetAt(info.meetAt())
-                .location(info.location())
-                .maxParticipants(info.maxParticipants())
-                .openChatUrl(info.openChatUrl())
-                .createdAt(post.getCreatedAt())
-                .commentCount(commentCount)
-                .likeCount(post.getLikeCount())
-                .isLiked(post.isLiked())
-                .isAuthor(isAuthor)
-                .build();
-        }
-
-        // 일반 게시글
-        return PostInfo.builder()
+        PostInfoBuilder builder = PostInfo.builder()
             .postId(postId)
             .title(post.getTitle())
             .content(post.getContent())
@@ -146,8 +95,16 @@ public record PostInfo(
             .createdAt(post.getCreatedAt())
             .commentCount(commentCount)
             .likeCount(post.getLikeCount())
-            .isLiked(post.isLiked())
-            .isAuthor(isAuthor)
-            .build();
+            .isLiked(post.isLiked());
+
+        if (post.isLightning()) {
+            Post.LightningInfo info = post.getLightningInfoOrThrow();
+            builder.meetAt(info.meetAt())
+                .location(info.location())
+                .maxParticipants(info.maxParticipants())
+                .openChatUrl(info.openChatUrl());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/umc/product/community/application/service/query/PostQueryService.java
+++ b/src/main/java/com/umc/product/community/application/service/query/PostQueryService.java
@@ -88,9 +88,9 @@ public class PostQueryService implements GetPostDetailUseCase, GetPostListUseCas
     }
 
     @Override
-    public Page<PostInfo> getPostList(PostSearchQuery query, Pageable pageable) {
+    public Page<PostInfo> getPostList(PostSearchQuery query, Long challengerId, Pageable pageable) {
         Page<Post> posts = loadPostPort.findAllByQuery(query, pageable);
-        return convertToPostInfoPage(posts, null, pageable);
+        return convertToPostInfoPage(posts, challengerId, pageable);
     }
 
     @Override

--- a/src/main/java/com/umc/product/community/application/service/query/PostQueryService.java
+++ b/src/main/java/com/umc/product/community/application/service/query/PostQueryService.java
@@ -88,9 +88,9 @@ public class PostQueryService implements GetPostDetailUseCase, GetPostListUseCas
     }
 
     @Override
-    public Page<PostInfo> getPostList(PostSearchQuery query, Long challengerId, Pageable pageable) {
+    public Page<PostInfo> getPostList(PostSearchQuery query, Long memberId, Pageable pageable) {
         Page<Post> posts = loadPostPort.findAllByQuery(query, pageable);
-        return convertToPostInfoPage(posts, challengerId, pageable);
+        return convertToPostInfoPage(posts, pageable);
     }
 
     @Override
@@ -108,55 +108,33 @@ public class PostQueryService implements GetPostDetailUseCase, GetPostListUseCas
                 );
             }
         );
-
-//        return searchDataPage.map(PostSearchData::toResult);
     }
 
     @Override
-    public Page<PostInfo> getMyPosts(Long challengerId, Pageable pageable) {
+    public Page<PostInfo> getMyPosts(Long memberId, Pageable pageable) {
+        Long challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
         Page<Post> posts = loadPostPort.findByAuthorChallengerId(challengerId, pageable);
-
-        // 게시글이 없으면 빈 페이지 반환
-        if (posts.isEmpty()) {
-            return Page.empty(pageable);
-        }
-
-        // 작성자 챌린저 정보 조회 (한 번만)
-        ChallengerInfo challengerInfo = getChallengerUseCase.getChallengerPublicInfo(challengerId);
-
-        // 작성자 멤버 프로필 조회 (이름과 프로필 이미지, 한 번만)
-        MemberInfo memberProfile = getMemberUseCase.getMemberInfoById(challengerInfo.memberId());
-        String authorName = memberProfile.name();
-        String authorProfileImage = memberProfile.profileImageLink();
-
-        // PostInfo로 변환 (모든 게시글이 본인 글이므로 isAuthor = true)
-        return posts.map(
-            post -> PostInfo.from(post, challengerId, authorName, authorProfileImage, challengerInfo.part(), 0,
-                true));
+        return convertToPostInfoPage(posts, pageable);
     }
 
     @Override
-    public Page<PostInfo> getCommentedPosts(Long challengerId, Pageable pageable) {
+    public Page<PostInfo> getCommentedPosts(Long memberId, Pageable pageable) {
+        Long challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
         Page<Post> posts = loadPostPort.findCommentedPostsByChallengerId(challengerId, pageable);
-
-        return convertToPostInfoPage(posts, challengerId, pageable);
+        return convertToPostInfoPage(posts, pageable);
     }
 
     @Override
-    public Page<PostInfo> getScrappedPosts(Long challengerId, Pageable pageable) {
+    public Page<PostInfo> getScrappedPosts(Long memberId, Pageable pageable) {
+        Long challengerId = getChallengerUseCase.getLatestActiveChallengerByMemberId(memberId).challengerId();
         Page<Post> posts = loadPostPort.findScrappedPostsByChallengerId(challengerId, pageable);
-
-        return convertToPostInfoPage(posts, challengerId, pageable);
+        return convertToPostInfoPage(posts, pageable);
     }
 
     /**
      * Post 페이지를 PostInfo 페이지로 변환 (작성자 정보 포함)
-     *
-     * @param posts               게시글 페이지
-     * @param currentChallengerId 현재 로그인한 사용자의 challengerId (비로그인 시 null)
-     * @param pageable            페이지 정보
      */
-    private Page<PostInfo> convertToPostInfoPage(Page<Post> posts, Long currentChallengerId, Pageable pageable) {
+    private Page<PostInfo> convertToPostInfoPage(Page<Post> posts, Pageable pageable) {
         // 게시글이 없으면 빈 페이지 반환
         if (posts.isEmpty()) {
             return Page.empty(pageable);
@@ -184,7 +162,7 @@ public class PostQueryService implements GetPostDetailUseCase, GetPostListUseCas
         // 6. 멤버 ID -> 멤버 프로필 매핑 (1 query, 일괄 조회로 N+1 해결)
         Map<Long, MemberInfo> memberProfileMap = getMemberUseCase.getProfiles(memberIds);
 
-        // 7. 챌린저 ID -> 작성자 정보 매핑 (이름 + 프로필 이미지 + 파트, 한 번의 스트림 처리)
+        // 7. 챌린저 ID -> 작성자 정보 매핑 (이름 + 프로필 이미지 + 파트)
         Map<Long, AuthorDetails> authorDetailsMap = challengerInfoMap.entrySet().stream()
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
@@ -203,21 +181,16 @@ public class PostQueryService implements GetPostDetailUseCase, GetPostListUseCas
         // 9. PostInfo로 변환
         return posts.map(post -> {
             Long postId = post.getPostId().id();
-            Long authorId = postIdToAuthorId.get(postId);
-            AuthorDetails authorDetails = authorId != null ? authorDetailsMap.get(authorId) : null;
+            Long authorChallengerId = postIdToAuthorId.get(postId);
+            AuthorDetails authorDetails = authorChallengerId != null ? authorDetailsMap.get(authorChallengerId) : null;
             String authorName = authorDetails != null ? authorDetails.name() : "알 수 없음";
             String authorProfileImage = authorDetails != null ? authorDetails.profileImage() : null;
-            var authorPart = authorDetails != null ? authorDetails.part() : null;
+            ChallengerPart authorPart = authorDetails != null ? authorDetails.part() : null;
             int commentCount = commentCountMap.getOrDefault(postId, 0);
-            // 본인 작성 글 여부 확인
-            boolean isAuthor = authorId != null && authorId.equals(currentChallengerId);
-            return PostInfo.from(post, authorId, authorName, authorProfileImage, authorPart, commentCount, isAuthor);
+            return PostInfo.from(post, authorChallengerId, authorName, authorProfileImage, authorPart, commentCount);
         });
     }
 
-    /**
-     * 작성자 정보를 담는 내부 record
-     */
     private record AuthorDetails(
         String name,
         String profileImage,


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 게시글 삭제 API에 @CheckAccess + @CurrentMember 추가
- [x] 게시글 수정 API에 @CheckAccess + @CurrentMember 추가
- [x] 번개 게시글 수정 API에 @CheckAccess + @CurrentMember 추가
- [x] 트로피 생성 API에 @CurrentMember 인증 추가
- [x] 게시글 목록 조회 API에 @CurrentMember 추가
- [x] 댓글 목록 조회 API에 @CurrentMember 추가
- [x] Swagger Tag description 보완

## 🔥 연관 이슈

- resolves #701

## 🚀 작업 내용

 1. 게시글 삭제/수정 API 권한 설정
- `DELETE /api/v1/posts/{postId}`
- `PATCH /api/v1/posts/{postId}`
- `PATCH /api/v1/posts/{postId}/lightning`
위 세개 api에 @CheckAccess를 추가하여 CommunityPostPermissionEvaluator를 통해 권한을 체크하도록 변경했습니다.

  - EDIT: 게시글 작성자 본인만 가능
  - DELETE: 게시글 작성자 본인 또는 총괄단 가능

 2. 트로피 생성 API 인증 추가
- `POST /api/v1/trophies`에 @CurrentMember를 추가하고, 인증 정보에서 challengerId를 추출하도록 변경했습니다.

3. 게시글 목록/댓글 조회 API에 @CurrentMember 추가
- `GET /api/v1/posts`
- `GET /api/v1/posts/{postId}/comments`에 추가
->  `isLiked`, `isAuthor`가 항상 `false`로 응답되던 문제 해결 

 4. Swagger Tag description 보완
- `PostQueryController`, `TrophyController`, `TrophyQueryController`에 비어있던 Swagger Tag description 추가 작성


## 💬 리뷰 중점사항

PostInfo Deprecated 팩토리 메서드 정리로 인하여 PostQueryController파트를 중점으로 봐주셨음 합니다