### PR TITLE
[Fix] 투표 취소 시 다시 투표를 할 수 없던 버그 수정

### DIFF
--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -231,33 +231,31 @@ public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, Submit
         }
 
         if (optionIds.isEmpty()) {
-            formResponse.clearVoteResponse();
-        } else {
-
-            Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
-
-            if (question.getType() == QuestionType.RADIO) {
-                if (uniqueOptionIds.size() != 1) {
-                    throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
-                }
-            } else if (question.getType() == QuestionType.CHECKBOX) {
-                // pass
-            } else {
-                throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_QUESTION_TYPE);
-            }
-
-            Set<Long> allowedOptionIds = new HashSet<>();
-            for (QuestionOption opt : question.getOptions()) {
-                allowedOptionIds.add(opt.getId());
-            }
-            if (!allowedOptionIds.containsAll(uniqueOptionIds)) {
-                throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
-            }
-
-            // 5) 기존 응답 갱신
-            formResponse.updateVoteResponse(question, uniqueOptionIds.stream().toList(), now);
+            cancelVoteResponse(formResponse);
+            return;
         }
 
+        Set<Long> uniqueOptionIds = new LinkedHashSet<>(optionIds);
+
+        if (question.getType() == QuestionType.RADIO) {
+            if (uniqueOptionIds.size() != 1) {
+                throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+            }
+        } else if (question.getType() == QuestionType.CHECKBOX) {
+            // pass
+        } else {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_QUESTION_TYPE);
+        }
+
+        Set<Long> allowedOptionIds = new HashSet<>();
+        for (QuestionOption opt : question.getOptions()) {
+            allowedOptionIds.add(opt.getId());
+        }
+        if (!allowedOptionIds.containsAll(uniqueOptionIds)) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+        }
+
+        formResponse.updateVoteResponse(question, uniqueOptionIds.stream().toList(), now);
         saveFormResponsePort.save(formResponse);
     }
 
@@ -271,5 +269,10 @@ public class VoteService implements CreateVoteUseCase, DeleteVoteUseCase, Submit
             throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE);
         }
         return section.getQuestions().iterator().next();
+    }
+
+    private void cancelVoteResponse(FormResponse formResponse) {
+        saveSingleAnswerPort.deleteAllByFormResponseIds(List.of(formResponse.getId()));
+        saveFormResponsePort.deleteById(formResponse.getId());
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- closes #700 

## 🚀 작업 내용
투표 수정 API에 빈 파라미터를 보내 투표를 취소한 뒤, 다시 투표(`POST /surveys/votes`)를 시도하면 "이미 답변한 투표입니다" 예외가 발생하는 버그가 있었습니다.
기존 로직에서 투표 취소 시 응답 내용만 비워지고 기존 `FormResponse` 데이터가 남아있던 것이 원인이었습니다.

1. 투표 취소 시 `FormResponse` 및 관련 답변을 DB에서 완전히 삭제하는 `cancelVoteResponse()` 로직을 추가하여, 이후 재투표가 정상적으로 진행되도록 수정했습니다.
## 💬 리뷰 중점사항
