### PR TITLE
[Feat] 일정 수정 시, 참여자 목록에서 생성자 제외 불가하도록 로직 수정

### DIFF
--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
@@ -3,6 +3,7 @@ package com.umc.product.schedule.application.service.command;
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.schedule.application.port.in.command.CreateScheduleUseCase;
@@ -33,9 +34,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -123,6 +126,8 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
 
             // 2. 참여자 명단 동기화: participantMemberIds가 제공되었으면
             if (command.participantMemberIds() != null) {
+                // 일정 생성자는 참여자 명단에서 제외할 수 없음
+                validateAuthorNotRemoved(schedule.getAuthorChallengerId(), command.participantMemberIds());
                 syncAttendanceRecords(sheet, command.participantMemberIds());
             }
         }
@@ -155,6 +160,23 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
             schedule.getLocationName(),
             schedule.getLocation()
         );
+    }
+
+    /**
+     * 일정 생성자가 참여자 명단에서 제외되지 않았는지 검증
+     */
+    private void validateAuthorNotRemoved(Long authorChallengerId, List<Long> participantMemberIds) {
+        ChallengerInfo authorInfo = getChallengerUseCase.findByIdOrNull(authorChallengerId);
+
+        // 일정 생성자가 탈퇴/제명당한 회원일 경우 관리자가 일정을 수정할 수 있도록 검증 스킵 + 로그 남김
+        if (authorInfo == null) {
+            log.warn("[Schedule] 일정 생성자 챌린저 정보를 찾을 수 없음: authorChallengerId={}", authorChallengerId);
+            return;
+        }
+
+        if (!participantMemberIds.contains(authorInfo.memberId())) {
+            throw new ScheduleDomainException(ScheduleErrorCode.CANNOT_REMOVE_SCHEDULE_AUTHOR);
+        }
     }
 
     /**

--- a/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
@@ -40,34 +40,34 @@ public enum ScheduleErrorCode implements BaseCode {
     CANNOT_REMOVE_SCHEDULE_AUTHOR(HttpStatus.BAD_REQUEST, "SCHEDULE-0015", "일정 생성자는 참여자 명단에서 제외할 수 없습니다."),
 
     // 출석 체크 관련
-    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0015", "이미 출석 체크가 완료되었습니다"),
-    CHECK_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0016", "체크 시간은 필수입니다"),
+    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0016", "이미 출석 체크가 완료되었습니다"),
+    CHECK_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0017", "체크 시간은 필수입니다"),
 
     // 승인/거절 관련
-    NOT_PENDING_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0017", "승인 대기 상태가 아닙니다"),
+    NOT_PENDING_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0018", "승인 대기 상태가 아닙니다"),
 
     // 인정결석 관련
-    INVALID_EXCUSE_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0018", "결석 또는 지각 상태에서만 인정결석을 신청할 수 있습니다"),
-    EXCUSE_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0019", "사유는 필수입니다"),
+    INVALID_EXCUSE_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0019", "결석 또는 지각 상태에서만 인정결석을 신청할 수 있습니다"),
+    EXCUSE_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0020", "사유는 필수입니다"),
 
     // 사유 제출 관련
-    INVALID_SUBMIT_REASON_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0020", "출석 전, 지각, 결석 상태에서만 사유를 제출할 수 있습니다"),
-    SUBMIT_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0021", "제출 시각은 필수입니다"),
+    INVALID_SUBMIT_REASON_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0021", "출석 전, 지각, 결석 상태에서만 사유를 제출할 수 있습니다"),
+    SUBMIT_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0022", "제출 시각은 필수입니다"),
 
     // 상태 변경 관련
-    CANNOT_SET_PENDING_DIRECTLY(HttpStatus.BAD_REQUEST, "SCHEDULE-0022", "PENDING 상태는 직접 변경할 수 없습니다"),
-    NOT_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0023", "출석 체크가 되지 않은 기록입니다"),
+    CANNOT_SET_PENDING_DIRECTLY(HttpStatus.BAD_REQUEST, "SCHEDULE-0023", "PENDING 상태는 직접 변경할 수 없습니다"),
+    NOT_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0024", "출석 체크가 되지 않은 기록입니다"),
 
     // 출석부 상태 관련
-    ATTENDANCE_SHEET_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0024", "이미 비활성화된 출석부입니다"),
-    ATTENDANCE_SHEET_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0025", "이미 활성화된 출석부입니다"),
+    ATTENDANCE_SHEET_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0025", "이미 비활성화된 출석부입니다"),
+    ATTENDANCE_SHEET_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0026", "이미 활성화된 출석부입니다"),
 
     // 출석 시간대 관련
-    START_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0026", "시작 시간은 필수입니다"),
-    END_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0027", "종료 시간은 필수입니다"),
-    BASE_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0028", "기준 시간은 필수입니다"),
-    INVALID_BEFORE_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0029", "이전 시간은 0분 이상이어야 합니다"),
-    INVALID_AFTER_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0030", "이후 시간은 0분 이상이어야 합니다"),
+    START_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0027", "시작 시간은 필수입니다"),
+    END_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0028", "종료 시간은 필수입니다"),
+    BASE_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0029", "기준 시간은 필수입니다"),
+    INVALID_BEFORE_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0030", "이전 시간은 0분 이상이어야 합니다"),
+    INVALID_AFTER_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0031", "이후 시간은 0분 이상이어야 합니다"),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
@@ -30,10 +30,14 @@ public enum ScheduleErrorCode implements BaseCode {
 
     // 참여자 관련
     PARTICIPANT_NOT_REGISTERED(HttpStatus.FORBIDDEN, "SCHEDULE-0012", "출석 대상자 명단에 등록되지 않았습니다. 관리자에게 문의하세요."),
-    CANNOT_UPDATE_STARTED_ATTENDANCE(HttpStatus.BAD_REQUEST, "SCHEDULE-0013", "이미 출석이 시작되었습니다. 출석 시작 전에만 명단을 수정할 수 있습니다."),
+    CANNOT_UPDATE_STARTED_ATTENDANCE(HttpStatus.BAD_REQUEST, "SCHEDULE-0013",
+        "이미 출석이 시작되었습니다. 출석 시작 전에만 명단을 수정할 수 있습니다."),
 
     // 권한 관련
     NOT_STUDY_GROUP_LEADER(HttpStatus.FORBIDDEN, "SCHEDULE-0014", "스터디 그룹 리더만 일정을 생성할 수 있습니다."),
+
+    // 참여자 명단 수정 관련
+    CANNOT_REMOVE_SCHEDULE_AUTHOR(HttpStatus.BAD_REQUEST, "SCHEDULE-0015", "일정 생성자는 참여자 명단에서 제외할 수 없습니다."),
 
     // 출석 체크 관련
     ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0015", "이미 출석 체크가 완료되었습니다"),


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #704

## 🚀 작업 내용

1. 참고 discord [스레드1](https://discord.com/channels/1442030160311484416/1482666141557199010), [스레드2](https://discord.com/channels/1442030160311484416/1483351288551968829)
2. 에러 코드 추가
3. `ScheduleCommandService`에 검증 로직 추가
   - `validateAuthorNotRemoved()` 메서드 : 생성자 `memberId`가 참여자 목록에 없으면 에러, 생성자 정보를 찾을 수 없으면 경고 로그 후 스킵 (일정 생성자 탈퇴 혹은 제명 시, 서비스 운영 관리자가 일정 수정을 위해 직접 DB를 만지는 것을 방지하기 위함)
4. 스웨거 동작 확인
<img width="834" height="348" alt="image" src="https://github.com/user-attachments/assets/1e177402-6410-4e4f-9a24-fe130d973798" />

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

