### PR TITLE
[Refactor] 출석부 도메인 내 예외 처리 커스텀 예외로 변경

### DIFF
--- a/src/main/java/com/umc/product/schedule/domain/AttendanceRecord.java
+++ b/src/main/java/com/umc/product/schedule/domain/AttendanceRecord.java
@@ -120,7 +120,8 @@ public class AttendanceRecord extends BaseEntity {
             case PRESENT_PENDING -> AttendanceStatus.PRESENT;
             case LATE_PENDING -> AttendanceStatus.LATE;
             case EXCUSED_PENDING -> AttendanceStatus.PRESENT;  // ✅ 인정 시 출석으로 처리
-            default -> throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS);
+            default ->
+                throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS, "승인 가능한 상태가 아닙니다: " + status);
         };
         this.confirmedBy = confirmerId;
         this.confirmedAt = Instant.now();
@@ -129,9 +130,8 @@ public class AttendanceRecord extends BaseEntity {
     /**
      * 관리자가 PENDING 상태의 출석을 거절함. 상태는 무조건 ABSENT로 바뀜
      * <p>
-     * 재시도 정책:
-     * - PRESENT_PENDING, LATE_PENDING (일반 출석): 거절 후 재시도 가능 (checkedAt 초기화)
-     * - EXCUSED_PENDING (사유 제출): 거절 후 재시도 불가 (checkedAt 유지)
+     * 재시도 정책: - PRESENT_PENDING, LATE_PENDING (일반 출석): 거절 후 재시도 가능 (checkedAt 초기화) - EXCUSED_PENDING (사유 제출): 거절 후 재시도
+     * 불가 (checkedAt 유지)
      */
     public void reject(Long confirmerId) {
         validatePendingStatus();
@@ -139,7 +139,7 @@ public class AttendanceRecord extends BaseEntity {
 
         // 일반 출석 체크는 재시도 허용 (단순 오류 가능성)
         boolean isRegularAttendance = (status == AttendanceStatus.PRESENT_PENDING
-                                    || status == AttendanceStatus.LATE_PENDING);
+            || status == AttendanceStatus.LATE_PENDING);
 
         this.status = AttendanceStatus.ABSENT;
         this.confirmedBy = confirmerId;
@@ -161,7 +161,8 @@ public class AttendanceRecord extends BaseEntity {
      */
     public void requestExcuse(String memo) {
         if (status != AttendanceStatus.ABSENT && status != AttendanceStatus.LATE) {
-            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_EXCUSE_STATUS);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_EXCUSE_STATUS,
+                "결석 또는 지각 상태에서만 인정결석을 신청할 수 있습니다. 현재 상태: " + status);
         }
         if (memo == null || memo.isBlank()) {
             throw new ScheduleDomainException(ScheduleErrorCode.EXCUSE_REASON_REQUIRED);
@@ -172,8 +173,7 @@ public class AttendanceRecord extends BaseEntity {
     }
 
     /**
-     * 출석 체크 전에 사유를 제출하는 메서드 (사유 작성 출석)
-     * 위치 인증은 실패로 간주됨
+     * 출석 체크 전에 사유를 제출하는 메서드 (사유 작성 출석) 위치 인증은 실패로 간주됨
      * <p>
      * PENDING, LATE, ABSENT 상태에서 가능
      */
@@ -182,7 +182,8 @@ public class AttendanceRecord extends BaseEntity {
         if (this.status != AttendanceStatus.PENDING &&
             this.status != AttendanceStatus.LATE &&
             this.status != AttendanceStatus.ABSENT) {
-            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_SUBMIT_REASON_STATUS);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_SUBMIT_REASON_STATUS,
+                "출석 전, 지각, 결석 상태에서만 사유를 제출할 수 있습니다. 현재 상태: " + this.status);
         }
         if (reason == null || reason.isBlank()) {
             throw new ScheduleDomainException(ScheduleErrorCode.EXCUSE_REASON_REQUIRED);
@@ -238,7 +239,7 @@ public class AttendanceRecord extends BaseEntity {
 
     private void validatePendingStatus() {
         if (!isPending()) {
-            throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS);
+            throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS, "승인 대기 상태가 아닙니다: " + status);
         }
     }
 

--- a/src/main/java/com/umc/product/schedule/domain/AttendanceRecord.java
+++ b/src/main/java/com/umc/product/schedule/domain/AttendanceRecord.java
@@ -2,6 +2,8 @@ package com.umc.product.schedule.domain;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import com.umc.product.schedule.domain.exception.ScheduleDomainException;
+import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -90,13 +92,13 @@ public class AttendanceRecord extends BaseEntity {
         boolean locationVerified
     ) {
         if (this.checkedAt != null) {
-            throw new IllegalStateException("이미 출석 체크가 완료되었습니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.ALREADY_CHECKED_IN);
         }
         if (newStatus == null) {
-            throw new IllegalArgumentException("출석 상태는 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_ATTENDANCE_STATUS);
         }
         if (checkedAt == null) {
-            throw new IllegalArgumentException("체크 시간은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.CHECK_TIME_REQUIRED);
         }
 
         this.status = newStatus;
@@ -118,7 +120,7 @@ public class AttendanceRecord extends BaseEntity {
             case PRESENT_PENDING -> AttendanceStatus.PRESENT;
             case LATE_PENDING -> AttendanceStatus.LATE;
             case EXCUSED_PENDING -> AttendanceStatus.PRESENT;  // ✅ 인정 시 출석으로 처리
-            default -> throw new IllegalStateException("승인 가능한 상태가 아닙니다: " + status);
+            default -> throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS);
         };
         this.confirmedBy = confirmerId;
         this.confirmedAt = Instant.now();
@@ -159,10 +161,10 @@ public class AttendanceRecord extends BaseEntity {
      */
     public void requestExcuse(String memo) {
         if (status != AttendanceStatus.ABSENT && status != AttendanceStatus.LATE) {
-            throw new IllegalStateException("결석 또는 지각 상태에서만 인정결석을 신청할 수 있습니다. 현재 상태: " + status);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_EXCUSE_STATUS);
         }
         if (memo == null || memo.isBlank()) {
-            throw new IllegalArgumentException("사유는 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.EXCUSE_REASON_REQUIRED);
         }
 
         this.status = AttendanceStatus.EXCUSED_PENDING;
@@ -180,14 +182,13 @@ public class AttendanceRecord extends BaseEntity {
         if (this.status != AttendanceStatus.PENDING &&
             this.status != AttendanceStatus.LATE &&
             this.status != AttendanceStatus.ABSENT) {
-            throw new IllegalStateException(
-                "출석 전, 지각, 결석 상태에서만 사유를 제출할 수 있습니다. 현재 상태: " + this.status);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_SUBMIT_REASON_STATUS);
         }
         if (reason == null || reason.isBlank()) {
-            throw new IllegalArgumentException("사유는 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.EXCUSE_REASON_REQUIRED);
         }
         if (submittedAt == null) {
-            throw new IllegalArgumentException("제출 시각은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.SUBMIT_TIME_REQUIRED);
         }
 
         // 상태 변경
@@ -214,7 +215,7 @@ public class AttendanceRecord extends BaseEntity {
 
         // PENDING 상태는 approve/reject 메서드로만 변경 가능
         if (newStatus.name().endsWith("_PENDING")) {
-            throw new IllegalArgumentException("PENDING 상태는 직접 변경할 수 없습니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.CANNOT_SET_PENDING_DIRECTLY);
         }
 
         this.status = newStatus;
@@ -222,7 +223,7 @@ public class AttendanceRecord extends BaseEntity {
 
     public void updateCheckInfo(Instant checkedAt) {
         if (this.checkedAt == null) {
-            throw new IllegalStateException("출석 체크가 되지 않은 기록입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.NOT_CHECKED_IN);
         }
         this.checkedAt = checkedAt;
     }
@@ -237,7 +238,7 @@ public class AttendanceRecord extends BaseEntity {
 
     private void validatePendingStatus() {
         if (!isPending()) {
-            throw new IllegalStateException("승인 대기 상태가 아닙니다: " + status);
+            throw new ScheduleDomainException(ScheduleErrorCode.NOT_PENDING_STATUS);
         }
     }
 
@@ -255,7 +256,7 @@ public class AttendanceRecord extends BaseEntity {
 
     private void validateStatus(AttendanceStatus status) {
         if (status == null) {
-            throw new IllegalArgumentException("출석 상태는 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_ATTENDANCE_STATUS);
         }
     }
 

--- a/src/main/java/com/umc/product/schedule/domain/AttendanceSheet.java
+++ b/src/main/java/com/umc/product/schedule/domain/AttendanceSheet.java
@@ -2,6 +2,8 @@ package com.umc.product.schedule.domain;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import com.umc.product.schedule.domain.exception.ScheduleDomainException;
+import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
 import com.umc.product.schedule.domain.vo.AttendanceWindow;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -143,7 +145,7 @@ public class AttendanceSheet extends BaseEntity {
      */
     public void deactivate() {
         if (!active) {
-            throw new IllegalStateException("이미 비활성화된 출석부입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.ATTENDANCE_SHEET_ALREADY_INACTIVE);
         }
         this.active = false;
     }
@@ -153,7 +155,7 @@ public class AttendanceSheet extends BaseEntity {
      */
     public void activate() {
         if (active) {
-            throw new IllegalStateException("이미 활성화된 출석부입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.ATTENDANCE_SHEET_ALREADY_ACTIVE);
         }
         this.active = true;
     }

--- a/src/main/java/com/umc/product/schedule/domain/exception/ScheduleDomainException.java
+++ b/src/main/java/com/umc/product/schedule/domain/exception/ScheduleDomainException.java
@@ -8,4 +8,8 @@ public class ScheduleDomainException extends BusinessException {
     public ScheduleDomainException(ScheduleErrorCode errorCode) {
         super(Domain.SCHEDULE, errorCode);
     }
+
+    public ScheduleDomainException(ScheduleErrorCode errorCode, String message) {
+        super(Domain.SCHEDULE, errorCode, message);
+    }
 }

--- a/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
@@ -34,8 +34,37 @@ public enum ScheduleErrorCode implements BaseCode {
 
     // 권한 관련
     NOT_STUDY_GROUP_LEADER(HttpStatus.FORBIDDEN, "SCHEDULE-0014", "스터디 그룹 리더만 일정을 생성할 수 있습니다."),
+
+    // 출석 체크 관련
+    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0015", "이미 출석 체크가 완료되었습니다"),
+    CHECK_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0016", "체크 시간은 필수입니다"),
+
+    // 승인/거절 관련
+    NOT_PENDING_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0017", "승인 대기 상태가 아닙니다"),
+
+    // 인정결석 관련
+    INVALID_EXCUSE_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0018", "결석 또는 지각 상태에서만 인정결석을 신청할 수 있습니다"),
+    EXCUSE_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0019", "사유는 필수입니다"),
+
+    // 사유 제출 관련
+    INVALID_SUBMIT_REASON_STATUS(HttpStatus.BAD_REQUEST, "SCHEDULE-0020", "출석 전, 지각, 결석 상태에서만 사유를 제출할 수 있습니다"),
+    SUBMIT_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0021", "제출 시각은 필수입니다"),
+
+    // 상태 변경 관련
+    CANNOT_SET_PENDING_DIRECTLY(HttpStatus.BAD_REQUEST, "SCHEDULE-0022", "PENDING 상태는 직접 변경할 수 없습니다"),
+    NOT_CHECKED_IN(HttpStatus.BAD_REQUEST, "SCHEDULE-0023", "출석 체크가 되지 않은 기록입니다"),
+
+    // 출석부 상태 관련
+    ATTENDANCE_SHEET_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0024", "이미 비활성화된 출석부입니다"),
+    ATTENDANCE_SHEET_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "SCHEDULE-0025", "이미 활성화된 출석부입니다"),
+
+    // 출석 시간대 관련
+    START_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0026", "시작 시간은 필수입니다"),
+    END_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0027", "종료 시간은 필수입니다"),
+    BASE_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE-0028", "기준 시간은 필수입니다"),
+    INVALID_BEFORE_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0029", "이전 시간은 0분 이상이어야 합니다"),
+    INVALID_AFTER_MINUTES(HttpStatus.BAD_REQUEST, "SCHEDULE-0030", "이후 시간은 0분 이상이어야 합니다"),
     ;
-    //별도 추가 예정
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/umc/product/schedule/domain/vo/AttendanceWindow.java
+++ b/src/main/java/com/umc/product/schedule/domain/vo/AttendanceWindow.java
@@ -45,10 +45,10 @@ public class AttendanceWindow {
             throw new ScheduleDomainException(ScheduleErrorCode.INVALID_TIME_RANGE);
         }
         if (lateThresholdMinutes < 0) {
-            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD, "지각 인정 시간은 0분 이상이어야 합니다");
         }
         if (lateThresholdMinutes > 120) {
-            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD);
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD, "지각 인정 시간은 120분을 초과할 수 없습니다");
             //스터디를 보통 2시간 정도 하는 것같아서 세운 기준
         }
         this.startTime = startTime;

--- a/src/main/java/com/umc/product/schedule/domain/vo/AttendanceWindow.java
+++ b/src/main/java/com/umc/product/schedule/domain/vo/AttendanceWindow.java
@@ -1,6 +1,8 @@
 package com.umc.product.schedule.domain.vo;
 
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import com.umc.product.schedule.domain.exception.ScheduleDomainException;
+import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.Duration;
@@ -34,19 +36,19 @@ public class AttendanceWindow {
 
     private AttendanceWindow(Instant startTime, Instant endTime, int lateThresholdMinutes) {
         if (startTime == null) {
-            throw new IllegalArgumentException("시작 시간은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.START_TIME_REQUIRED);
         }
         if (endTime == null) {
-            throw new IllegalArgumentException("종료 시간은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.END_TIME_REQUIRED);
         }
         if (startTime.isAfter(endTime)) {
-            throw new IllegalArgumentException("시작 시간은 종료 시간보다 이전이어야 합니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_TIME_RANGE);
         }
         if (lateThresholdMinutes < 0) {
-            throw new IllegalArgumentException("지각 인정 시간은 0분 이상이어야 합니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD);
         }
         if (lateThresholdMinutes > 120) {
-            throw new IllegalArgumentException("지각 인정 시간은 120분을 초과할 수 없습니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_LATE_THRESHOLD);
             //스터디를 보통 2시간 정도 하는 것같아서 세운 기준
         }
         this.startTime = startTime;
@@ -69,13 +71,13 @@ public class AttendanceWindow {
         int lateThresholdMinutes
     ) {
         if (baseTime == null) {
-            throw new IllegalArgumentException("기준 시간은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.BASE_TIME_REQUIRED);
         }
         if (beforeMinutes < 0) {
-            throw new IllegalArgumentException("이전 시간은 0분 이상이어야 합니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_BEFORE_MINUTES);
         }
         if (afterMinutes < 0) {
-            throw new IllegalArgumentException("이후 시간은 0분 이상이어야 합니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.INVALID_AFTER_MINUTES);
         }
 
         Instant start = baseTime.minus(beforeMinutes, ChronoUnit.MINUTES);
@@ -125,7 +127,7 @@ public class AttendanceWindow {
      */
     public AttendanceStatus determineStatus(Instant checkTime, boolean requiresApproval) {
         if (checkTime == null) {
-            throw new IllegalArgumentException("체크 시간은 필수입니다");
+            throw new ScheduleDomainException(ScheduleErrorCode.CHECK_TIME_REQUIRED);
         }
 
         // 시간대 밖


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] ScheduleErrorCode 커스텀 에러 코드 추가
- [ ] 기존 공통 예외 -> 커스텀으로 변경 

## 🔥 연관 이슈

- resolves #706 

## 🚀 작업 내용

IllegalArgumentException, IllegalStateException 등 표준 예외로 처리되던 에러를 세분화된 커스텀 예외로 전부 수정하였습니다.

1. ScheduleErrorCode 에러 코드 추가

2. 기존 IllegalArgumentException, IllegalStateException을 각각 ScheduleErrorCode의 에러코드로 매핑 변경

3. 검증 로직에서 발생하는 예외를 ScheduleErrorCode으로 변경

## 💬 리뷰 중점사항
