### PR TITLE
[Fix] Persistence Context로 인해 공지사항 삭제 시 발생하던 오류 해결

### DIFF
--- a/src/main/java/com/umc/product/notice/adapter/in/web/NoticeController.java
+++ b/src/main/java/com/umc/product/notice/adapter/in/web/NoticeController.java
@@ -70,6 +70,11 @@ public class NoticeController implements NoticeApi {
      * 공지사항 수정
      */
     @PatchMapping("/{noticeId}")
+    @CheckAccess(
+        resourceType = ResourceType.NOTICE,
+        resourceId = "#noticeId",
+        permission = PermissionType.EDIT
+    )
     public void updateNotice(
         @PathVariable Long noticeId,
         @RequestBody @Valid UpdateNoticeRequest request,

--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeImageJpaRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeImageJpaRepository.java
@@ -15,7 +15,7 @@ public interface NoticeImageJpaRepository extends JpaRepository<NoticeImage, Lon
 
     int countByNotice_Id(Long noticeId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM NoticeImage ni WHERE ni.notice.id = :noticeId")
     void deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 

--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeLinkJpaRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeLinkJpaRepository.java
@@ -14,7 +14,7 @@ public interface NoticeLinkJpaRepository extends JpaRepository<NoticeLink, Long>
 
     int countByNotice_Id(Long noticeId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM NoticeLink nl WHERE nl.notice.id = :noticeId")
     void deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeReadJpaRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeReadJpaRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 public interface NoticeReadJpaRepository extends JpaRepository<NoticeRead, Long> {
     List<NoticeRead> findAllByNoticeId(Long noticeId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM NoticeRead nr WHERE nr.notice.id = :noticeId")
     void deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 

--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeVoteJpaRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeVoteJpaRepository.java
@@ -14,7 +14,7 @@ public interface NoticeVoteJpaRepository extends JpaRepository<NoticeVote, Long>
 
     boolean existsByNoticeId(Long noticeId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM NoticeVote nv WHERE nv.notice.id = :noticeId")
     void deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -11,8 +11,10 @@ import com.umc.product.authorization.domain.exception.AuthorizationDomainExcepti
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.notice.application.port.in.query.GetNoticeTargetUseCase;
-import com.umc.product.notice.application.port.in.query.GetNoticeUseCase;
-import com.umc.product.notice.application.port.in.query.dto.NoticeInfo;
+import com.umc.product.notice.application.port.out.LoadNoticePort;
+import com.umc.product.notice.domain.Notice;
+import com.umc.product.notice.domain.exception.NoticeDomainException;
+import com.umc.product.notice.domain.exception.NoticeErrorCode;
 import com.umc.product.notice.dto.NoticeTargetInfo;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,7 @@ import org.springframework.stereotype.Component;
 public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
 
     private final GetNoticeTargetUseCase getNoticeTargetUseCase;
-    private final GetNoticeUseCase getNoticeUseCase;
+    private final LoadNoticePort loadNoticePort;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @Override
@@ -112,10 +114,10 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
             return true;
         }
 
-        NoticeInfo noticeInfo = getNoticeUseCase.getNoticeDetail(resourcePermission.getResourceIdAsLong(),
-            subjectAttributes.memberId());
+        Notice notice = loadNoticePort.findNoticeById(resourcePermission.getResourceIdAsLong())
+            .orElseThrow(() -> new NoticeDomainException(NoticeErrorCode.NOTICE_NOT_FOUND));
 
-        return Objects.equals(subjectAttributes.memberId(), noticeInfo.authorMemberId());
+        return Objects.equals(subjectAttributes.memberId(), notice.getAuthorMemberId());
     }
 
     /**

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -53,7 +53,7 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
 
         return switch (resourcePermission.permission()) {
             case READ -> canReadNotice(subjectAttributes, targetInfo);
-            case EDIT, DELETE -> canDeleteNotice(subjectAttributes, resourcePermission);
+            case EDIT, DELETE -> canDeleteOrEditNotice(subjectAttributes, resourcePermission);
             // TODO: Check는 임시로 Manage랑 동일하게 적용, 하나야 수정해줘!
             case MANAGE, CHECK -> canManageNotice(subjectAttributes.memberId(), targetInfo);
             default -> throw new AuthorizationDomainException(AuthorizationErrorCode.PERMISSION_TYPE_NOT_IMPLEMENTED,
@@ -107,7 +107,7 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
     }
 
 
-    private boolean canDeleteNotice(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+    private boolean canDeleteOrEditNotice(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
         if (subjectAttributes.roleAttributes().stream().anyMatch(r -> r.roleType().isSuperAdmin())) {
             return true;
         }

--- a/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
+++ b/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
@@ -112,7 +112,6 @@ public class NoticeService implements ManageNoticeUseCase {
     @Override
     public void updateNoticeTitleOrContent(UpdateNoticeCommand command) {
         Notice notice = findNoticeById(command.noticeId());
-        notice.validateAuthorMember(command.memberId());
 
         /**
          * 제목/내용만 수정
@@ -127,7 +126,6 @@ public class NoticeService implements ManageNoticeUseCase {
     @Override
     public void deleteNotice(DeleteNoticeCommand command) {
         Notice notice = findNoticeById(command.noticeId());
-        notice.validateAuthorMember(command.memberId());
 
         // 관련 이미지, 투표, 링크 등도 모두 삭제
         manageNoticeContentUseCase.removeContentsByNoticeId(notice.getId(), command.memberId());


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #711 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

- 영속성 컨텍스트에 공지가 남아있어서 생긴 오류였음. 어노테이션으로 이를 해결
- edit의 경우도 어노테이션으로 권한관리를 할 수 있도록 변경
- edit, delete의 비즈니스로직 속 검증 로직 삭제

<img width="1452" height="895" alt="image" src="https://github.com/user-attachments/assets/92e24f76-5688-4580-8830-770bf5c3dcb3" />

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

