### PR TITLE
[Fix] 하루종일 일정의 출석 가능 시간 처리 관련 버그 수정 및 지각 판정 로직 개선

### DIFF
--- a/src/main/java/com/umc/product/schedule/application/service/command/AttendanceCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/AttendanceCommandService.java
@@ -78,17 +78,16 @@ public class AttendanceCommandService implements CheckAttendanceUseCase, Approve
             throw new ScheduleDomainException(ScheduleErrorCode.OUTSIDE_ATTENDANCE_WINDOW);
         }
 
-        // 1. 출석 인정 시간 (윈도우 내)
+        // 1. 출석 인정 시간 (윈도우 내) - 출석 또는 지각
         if (sheet.isWithinTimeWindow(checkTime)) {
-            // OK - 출석 처리
+            // OK
         }
-        // 2. 지각 시간 (윈도우 종료 ~ 세션 종료)
+        // 2. 윈도우 종료 ~ 일정 종료: 일반 일정은 지각, 종일 일정은 출석
         else if (checkTime.isAfter(sheet.getWindow().getEndTime())
             && !checkTime.isAfter(schedule.getEndsAt())) {
-            // OK - 지각 처리
+            // OK
         }
-        // 3. 세션 종료 후 - 결석 처리
-        // (else 블록에서 결석으로 처리됨)
+        // 3. 일정 종료 후 - 결석 (determineAttendanceStatus에서 처리)
 
         // 기존 출석 기록 조회
         AttendanceRecord record = loadAttendanceRecordPort

--- a/src/main/java/com/umc/product/schedule/application/service/command/AttendanceCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/AttendanceCommandService.java
@@ -115,6 +115,16 @@ public class AttendanceCommandService implements CheckAttendanceUseCase, Approve
     }
 
     private AttendanceStatus determineAttendanceStatus(AttendanceSheet sheet, Schedule schedule, Instant checkTime) {
+        // 종일 일정은 지각 개념 없이 일정 종료 전까지 모두 출석 처리
+        if (schedule.isAllDay()) {
+            if (!checkTime.isAfter(schedule.getEndsAt())) {
+                return sheet.isRequiresApproval()
+                    ? AttendanceStatus.PRESENT_PENDING
+                    : AttendanceStatus.PRESENT;
+            }
+            return AttendanceStatus.ABSENT;
+        }
+
         // 출석 인정 시간
         if (sheet.isWithinTimeWindow(checkTime)) {
             return sheet.determineStatusByTime(checkTime);

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleAttendanceCommandFacadeService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleAttendanceCommandFacadeService.java
@@ -41,12 +41,12 @@ public class ScheduleAttendanceCommandFacadeService implements
         CreateScheduleCommand scheduleCommand = command.toScheduleCommand();
         Long scheduleId = createScheduleUseCase.create(scheduleCommand);
 
-        // 2. 출석부 생성 - 일정 시간 기준으로 AttendanceSheet가 Window를 조립 (지각 기준 10분 고정)
+        // 2. 출석부 생성 - 조정된 시간(scheduleCommand)을 사용해야 Schedule과 일치함
         AttendanceSheet sheet = AttendanceSheet.createWithSchedule(
             scheduleId,
             command.gisuId(),
-            command.startsAt(),
-            command.endsAt(),
+            scheduleCommand.startsAt(),
+            scheduleCommand.endsAt(),
             command.requiresApproval()
         );
         AttendanceSheet savedSheet = saveAttendanceSheetPort.save(sheet);


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #716 

## 🚀 작업 내용

1. [참고 디스코드 QA](https://discord.com/channels/1442030160311484416/1485690940055359600)
2. 종일 일정(`isAllDay=true`) 생성 시 `Schedule`과 `AttendanceSheet`의 시간이 불일치하던 버그 수정
- `ScheduleAttendanceCommandFacadeService.create()`에서 `AttendanceSheet` 생성 시 조정 전 시간(`command.startsAt()`)을 사용하던 것을 조정된 시간(`scheduleCommand.startsAt()`)으로 변경
3. 종일 일정의 출석 체크 시 지각 판정을 제거하고 일정 종료 전까지 모두 출석으로 처리
- `AttendanceCommandService.determineAttendanceStatus()`에서 `isAllDay=true`인 경우:
  - 일정 종료 시간 전 : PRESENT_PENDING
  - 일정 종료 시간 후 : ABSENT


## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

