### PR TITLE
[Fix] 예정된 일정도 출석 관리 화면에서 조회되도록 로직 수정

### DIFF
--- a/src/main/java/com/umc/product/schedule/application/service/query/ScheduleWithStatsQueryService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/query/ScheduleWithStatsQueryService.java
@@ -80,10 +80,9 @@ public class ScheduleWithStatsQueryService implements GetScheduleListUseCase {
             })
             .toList();
 
-        // 7. "예정" 상태 제외 및 정렬: 진행 중 → 종료됨 (종료됨은 최근 것부터)
+        // 7. 정렬: 진행 중 → 예정 → 종료됨
         //    같은 상태 내에서는 활성 출석부가 있는 일정 우선
         return result.stream()
-            .filter(info -> !"예정".equals(info.status()))
             .sorted(scheduleComparator())
             .toList();
     }
@@ -214,7 +213,7 @@ public class ScheduleWithStatsQueryService implements GetScheduleListUseCase {
                 return a.sheetActive() ? -1 : 1;
             }
 
-            // 진행 중은 시작 시간 오름차순, 종료됨은 종료 시간 내림차순
+            // 예정, 진행 중은 시작 시간 오름차순, 종료됨은 종료 시간 내림차순
             if ("종료됨".equals(a.status())) {
                 return b.endsAt().compareTo(a.endsAt());
             }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #718

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

1. [참고 디스코드 QA](https://discord.com/channels/1442030160311484416/1486304580386951228)
2. 예정된 상태의 일정을 filter 하는 부분을 삭제
3. 일정 정렬 순위 : 진행 중 -> 예정 -> 종료
4. 스웨거 동작 확인
<img width="1706" height="699" alt="image" src="https://github.com/user-attachments/assets/e845379f-a9bf-4674-84ee-a961cc6d8f45" />


## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

