### PR TITLE
[Feat] Project 조회 API 및 PM의 Draft 작성 제출 플로우 구현

### DIFF
--- a/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -1,0 +1,33 @@
+package com.umc.product.authorization.application.service.evaluator;
+
+import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
+
+    @Override
+    public ResourceType supportedResourceType() {
+        return ResourceType.PROJECT;
+    }
+
+    @Override
+    public boolean evaluate(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+        // TODO: 실제 로직 구현 필요
+        // - READ: 인증된 사용자 전체 허용 (현재 true)
+        // - WRITE: PM 챌린저(PLAN 파트)만 허용 (PROJECT-101)
+        // - EDIT: DRAFT면 작성자 PM / PENDING_REVIEW·IN_PROGRESS면 Admin (PROJECT-102)
+        // - DELETE / MANAGE: Admin(중앙운영사무국)만 (PROJECT-105, 108)
+        if (resourcePermission.permission().equals(PermissionType.READ)) {
+            return true;
+        }
+
+        // 현재는 skeleton. 임시로 중앙운영사무국 총괄만 통과.
+        return subjectAttributes.roleAttributes().stream()
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
+    }
+}

--- a/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -30,7 +30,7 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
             case READ -> true;
             case WRITE -> canWrite(subjectAttributes);
             case EDIT -> canEdit(subjectAttributes, resourcePermission);
-            case MANAGE, DELETE -> isCentralCore(subjectAttributes);
+            case DELETE -> isCentralCore(subjectAttributes);
             default -> false;
         };
     }

--- a/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -1,14 +1,23 @@
 package com.umc.product.authorization.application.service.evaluator;
 
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
-import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
+
+    private final LoadProjectPort loadProjectPort;
 
     @Override
     public ResourceType supportedResourceType() {
@@ -17,17 +26,41 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
 
     @Override
     public boolean evaluate(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
-        // TODO: 실제 로직 구현 필요
-        // - READ: 인증된 사용자 전체 허용 (현재 true)
-        // - WRITE: PM 챌린저(PLAN 파트)만 허용 (PROJECT-101)
-        // - EDIT: DRAFT면 작성자 PM / PENDING_REVIEW·IN_PROGRESS면 Admin (PROJECT-102)
-        // - DELETE / MANAGE: Admin(중앙운영사무국)만 (PROJECT-105, 108)
-        if (resourcePermission.permission().equals(PermissionType.READ)) {
-            return true;
+        return switch (resourcePermission.permission()) {
+            case READ -> true;
+            case WRITE -> canWrite(subjectAttributes);
+            case EDIT -> canEdit(subjectAttributes, resourcePermission);
+            case MANAGE, DELETE -> isCentralCore(subjectAttributes);
+            default -> false;
+        };
+    }
+
+    private boolean canWrite(SubjectAttributes subjectAttributes) {
+        return subjectAttributes.gisuChallengerInfos().stream()
+            .anyMatch(info -> info.part() == ChallengerPart.PLAN);
+    }
+
+    private boolean canEdit(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+        Long projectId = resourcePermission.getResourceIdAsLong();
+        Project project = loadProjectPort.findById(projectId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+
+        boolean isOwner = project.getProductOwnerMemberId().equals(subjectAttributes.memberId());
+
+        if (project.getStatus() == ProjectStatus.DRAFT) {
+            return isOwner;
         }
 
-        // 현재는 skeleton. 임시로 중앙운영사무국 총괄만 통과.
+        if (project.getStatus() == ProjectStatus.PENDING_REVIEW
+            || project.getStatus() == ProjectStatus.IN_PROGRESS) {
+            return isOwner || isCentralCore(subjectAttributes);
+        }
+
+        return false;
+    }
+
+    private boolean isCentralCore(SubjectAttributes subjectAttributes) {
         return subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastCentralCore());
+            .anyMatch(role -> role.roleType().isAtLeastCentralCore());
     }
 }

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -58,6 +58,9 @@ public enum ResourceType {
         Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.DELETE)),
     FCM("fcm", "FCM 알람 관련",
         Set.of(PermissionType.DELETE)),
+    PROJECT("project", "프로젝트",
+        Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
+            PermissionType.DELETE, PermissionType.MANAGE)),
     ;
 
     private final String code;

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -60,7 +60,7 @@ public enum ResourceType {
         Set.of(PermissionType.DELETE)),
     PROJECT("project", "프로젝트",
         Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
-            PermissionType.DELETE, PermissionType.MANAGE)),
+            PermissionType.DELETE)),
     ;
 
     private final String code;

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -14,8 +14,6 @@ import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
-import com.umc.product.project.application.port.in.query.GetProjectUseCase;
-import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,7 +36,6 @@ public class ProjectCommandController {
     private final UpdateProjectUseCase updateProjectUseCase;
     private final SubmitProjectUseCase submitProjectUseCase;
     private final TransferProjectOwnershipUseCase transferProjectOwnershipUseCase;
-    private final GetProjectUseCase getProjectUseCase;
 
     @PostMapping
     @Operation(
@@ -75,9 +72,9 @@ public class ProjectCommandController {
         @PathVariable Long projectId,
         @Valid @RequestBody UpdateProjectRequest request
     ) {
-        updateProjectUseCase.update(request.toCommand(projectId, memberPrincipal.getMemberId()));
-        ProjectInfo info = getProjectUseCase.getById(projectId);
-        return ProjectStatusResponse.from(info);
+        ProjectStatus status = updateProjectUseCase.update(
+            request.toCommand(projectId, memberPrincipal.getMemberId()));
+        return ProjectStatusResponse.of(projectId, status);
     }
 
     @PostMapping("/{projectId}/submit")
@@ -118,9 +115,8 @@ public class ProjectCommandController {
         @PathVariable Long projectId,
         @Valid @RequestBody TransferProjectOwnershipRequest request
     ) {
-        transferProjectOwnershipUseCase.transfer(
+        ProjectStatus status = transferProjectOwnershipUseCase.transfer(
             request.toCommand(projectId, memberPrincipal.getMemberId()));
-        ProjectInfo info = getProjectUseCase.getById(projectId);
-        return ProjectStatusResponse.from(info);
+        return ProjectStatusResponse.of(projectId, status);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -39,7 +39,7 @@ public class ProjectCommandController {
 
     @PostMapping
     @Operation(
-        summary = "프로젝트 Draft 생성 (PROJECT-101)",
+        summary = "[PROJECT-101] 프로젝트 Draft 생성",
         description = "PM(PLAN 파트 챌린저)이 빈 DRAFT 상태의 프로젝트를 생성합니다. 페이지 진입 시 GET /me/draft로 사전 확인 후 호출 권장. 동일 PM·동일 기수 중복 생성 시 409."
     )
     @CheckAccess(
@@ -58,7 +58,7 @@ public class ProjectCommandController {
 
     @PatchMapping("/{projectId}")
     @Operation(
-        summary = "프로젝트 기본정보 수정 (PROJECT-102)",
+        summary = "[PROJECT-102] 프로젝트 기본정보 수정",
         description = "프로젝트 기본정보를 부분 업데이트합니다. DRAFT/PENDING_REVIEW/IN_PROGRESS 모두 허용, 종료 상태(COMPLETED/ABORTED)는 수정 불가. 소유권 양도는 별도 엔드포인트."
     )
     @CheckAccess(
@@ -79,7 +79,7 @@ public class ProjectCommandController {
 
     @PostMapping("/{projectId}/submit")
     @Operation(
-        summary = "프로젝트 제출 (PROJECT-107)",
+        summary = "[PROJECT-107] 프로젝트 제출",
         description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다. 작성자 PM만 호출 가능."
     )
     @CheckAccess(
@@ -101,7 +101,7 @@ public class ProjectCommandController {
 
     @PostMapping("/{projectId}/transfer-ownership")
     @Operation(
-        summary = "프로젝트 소유권 양도",
+        summary = "[PROJECT-104] 프로젝트 소유권 양도",
         description = "메인 PM을 다른 PLAN 파트 챌린저에게 양도합니다. 현재 PM만 호출 가능. 종료 상태에서는 호출 불가."
     )
     @CheckAccess(

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -6,10 +6,12 @@ import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.dto.request.CreateDraftProjectRequest;
+import com.umc.product.project.adapter.in.web.dto.request.TransferProjectOwnershipRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdateProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectStatusResponse;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
 import com.umc.product.project.application.port.in.query.GetProjectUseCase;
@@ -35,12 +37,13 @@ public class ProjectCommandController {
     private final CreateDraftProjectUseCase createDraftProjectUseCase;
     private final UpdateProjectUseCase updateProjectUseCase;
     private final SubmitProjectUseCase submitProjectUseCase;
+    private final TransferProjectOwnershipUseCase transferProjectOwnershipUseCase;
     private final GetProjectUseCase getProjectUseCase;
 
     @PostMapping
     @Operation(
         summary = "프로젝트 Draft 생성 (PROJECT-101)",
-        description = "PM(PLAN 파트 챌린저)이 DRAFT 상태의 프로젝트를 생성합니다. 이미 같은 기수에 프로젝트가 있으면 409를 반환합니다."
+        description = "PM(PLAN 파트 챌린저)이 빈 DRAFT 상태의 프로젝트를 생성합니다. 페이지 진입 시 GET /me/draft로 사전 확인 후 호출 권장. 동일 PM·동일 기수 중복 생성 시 409."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -59,7 +62,7 @@ public class ProjectCommandController {
     @PatchMapping("/{projectId}")
     @Operation(
         summary = "프로젝트 기본정보 수정 (PROJECT-102)",
-        description = "프로젝트 기본정보를 부분 업데이트합니다. null 필드는 수정하지 않습니다."
+        description = "프로젝트 기본정보를 부분 업데이트합니다. DRAFT/PENDING_REVIEW/IN_PROGRESS 모두 허용, 종료 상태(COMPLETED/ABORTED)는 수정 불가. 소유권 양도는 별도 엔드포인트."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -80,7 +83,7 @@ public class ProjectCommandController {
     @PostMapping("/{projectId}/submit")
     @Operation(
         summary = "프로젝트 제출 (PROJECT-107)",
-        description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다."
+        description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다. 작성자 PM만 호출 가능."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -97,5 +100,27 @@ public class ProjectCommandController {
             .requesterMemberId(memberPrincipal.getMemberId())
             .build());
         return ProjectStatusResponse.of(projectId, ProjectStatus.PENDING_REVIEW);
+    }
+
+    @PostMapping("/{projectId}/transfer-ownership")
+    @Operation(
+        summary = "프로젝트 소유권 양도",
+        description = "메인 PM을 다른 PLAN 파트 챌린저에게 양도합니다. 현재 PM만 호출 가능. 종료 상태에서는 호출 불가."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.EDIT,
+        message = "프로젝트 소유권 양도 권한이 없습니다."
+    )
+    public ProjectStatusResponse transferOwnership(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @Valid @RequestBody TransferProjectOwnershipRequest request
+    ) {
+        transferProjectOwnershipUseCase.transfer(
+            request.toCommand(projectId, memberPrincipal.getMemberId()));
+        ProjectInfo info = getProjectUseCase.getById(projectId);
+        return ProjectStatusResponse.from(info);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -1,7 +1,28 @@
 package com.umc.product.project.adapter.in.web;
 
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.dto.request.CreateDraftProjectRequest;
+import com.umc.product.project.adapter.in.web.dto.request.UpdateProjectRequest;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectStatusResponse;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,5 +32,70 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Project | 프로젝트 Command", description = "프로젝트 및 참여자 관련 생성, 수정, 삭제 등")
 public class ProjectCommandController {
 
+    private final CreateDraftProjectUseCase createDraftProjectUseCase;
+    private final UpdateProjectUseCase updateProjectUseCase;
+    private final SubmitProjectUseCase submitProjectUseCase;
+    private final GetProjectUseCase getProjectUseCase;
 
+    @PostMapping
+    @Operation(
+        summary = "프로젝트 Draft 생성 (PROJECT-101)",
+        description = "PM(PLAN 파트 챌린저)이 DRAFT 상태의 프로젝트를 생성합니다. 이미 같은 기수에 프로젝트가 있으면 409를 반환합니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        permission = PermissionType.WRITE,
+        message = "프로젝트 생성 권한이 없습니다."
+    )
+    public ProjectStatusResponse createDraft(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @Valid @RequestBody CreateDraftProjectRequest request
+    ) {
+        Long projectId = createDraftProjectUseCase.create(
+            request.toCommand(memberPrincipal.getMemberId()));
+        return ProjectStatusResponse.of(projectId, ProjectStatus.DRAFT);
+    }
+
+    @PatchMapping("/{projectId}")
+    @Operation(
+        summary = "프로젝트 기본정보 수정 (PROJECT-102)",
+        description = "프로젝트 기본정보를 부분 업데이트합니다. null 필드는 수정하지 않습니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.EDIT,
+        message = "프로젝트 수정 권한이 없습니다."
+    )
+    public ProjectStatusResponse update(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @Valid @RequestBody UpdateProjectRequest request
+    ) {
+        updateProjectUseCase.update(request.toCommand(projectId, memberPrincipal.getMemberId()));
+        ProjectInfo info = getProjectUseCase.getById(projectId);
+        return ProjectStatusResponse.from(info);
+    }
+
+    @PostMapping("/{projectId}/submit")
+    @Operation(
+        summary = "프로젝트 제출 (PROJECT-107)",
+        description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.EDIT,
+        message = "프로젝트 제출 권한이 없습니다."
+    )
+    public ProjectStatusResponse submit(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        submitProjectUseCase.submit(SubmitProjectCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(memberPrincipal.getMemberId())
+            .build());
+        return ProjectStatusResponse.of(projectId, ProjectStatus.PENDING_REVIEW);
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -1,8 +1,29 @@
 package com.umc.product.project.adapter.in.web;
 
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
+import com.umc.product.project.adapter.in.web.dto.request.SearchProjectRequest;
+import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -11,4 +32,58 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Project | 프로젝트 Query", description = "프로젝트 및 관련 정보 조회")
 public class ProjectQueryController {
 
+    private final ProjectResponseAssembler assembler;
+
+    @GetMapping
+    @Operation(
+        summary = "프로젝트 목록 조회 (PROJECT-001)",
+        description = "기수/지부/파트 등으로 필터링된 프로젝트 목록을 페이지 조회합니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        permission = PermissionType.READ,
+        message = "프로젝트 조회 권한이 없습니다."
+    )
+    public PageResponse<ProjectSummaryResponse> searchProjects(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject @Valid SearchProjectRequest request,
+        @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        // TODO: 실제 Admin 권한 체크 로직 구현 (GetChallengerRoleUseCase 연동)
+        boolean isAdmin = false;
+        SearchProjectQuery query = request.toQuery(isAdmin, pageable);
+        return assembler.searchFor(query, isAdmin);
+    }
+
+    @GetMapping("/{projectId}")
+    @Operation(
+        summary = "프로젝트 상세 조회 (PROJECT-002)",
+        description = "단건 프로젝트 상세 정보를 조회합니다. 권한에 따라 실명 정보가 마스킹됩니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.READ,
+        message = "프로젝트 조회 권한이 없습니다."
+    )
+    public ProjectDetailResponse getDetail(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        // TODO: 실제 마스킹 정책 체크 (PM/Admin/팀원 여부)
+        boolean canSeeFullInfo = false;
+        return assembler.detailFor(projectId, canSeeFullInfo);
+    }
+
+    @GetMapping("/me/draft")
+    @Operation(
+        summary = "내 Draft 조회 (PROJECT-103)",
+        description = "요청자(PM)가 작성 중인 Draft 프로젝트를 조회합니다. 없으면 null."
+    )
+    public DraftProjectResponse getMyDraft(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @RequestParam Long gisuId
+    ) {
+        return assembler.draftFor(memberPrincipal.getMemberId(), gisuId);
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -36,7 +36,7 @@ public class ProjectQueryController {
 
     @GetMapping
     @Operation(
-        summary = "프로젝트 목록 조회 (PROJECT-001)",
+        summary = "[PROJECT-001] 프로젝트 목록 조회",
         description = "기수/지부/파트 등으로 필터링된 프로젝트 목록을 페이지 조회합니다."
     )
     @CheckAccess(
@@ -57,7 +57,7 @@ public class ProjectQueryController {
 
     @GetMapping("/{projectId}")
     @Operation(
-        summary = "프로젝트 상세 조회 (PROJECT-002)",
+        summary = "[PROJECT-002] 프로젝트 상세 조회",
         description = "단건 프로젝트 상세 정보를 조회합니다. 권한에 따라 실명 정보가 마스킹됩니다."
     )
     @CheckAccess(
@@ -77,7 +77,7 @@ public class ProjectQueryController {
 
     @GetMapping("/me/draft")
     @Operation(
-        summary = "내 Draft 조회 (PROJECT-103)",
+        summary = "[PROJECT-103] 내 Draft 조회",
         description = "요청자(PM)가 작성 중인 Draft 프로젝트를 조회합니다. 없으면 null."
     )
     public DraftProjectResponse getMyDraft(

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -1,0 +1,109 @@
+package com.umc.product.project.adapter.in.web.assembler;
+
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionItem;
+import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
+import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+/**
+ * Project Response 조립기. Controller에서 여러 UseCase를 조합하는 로직을 캡슐화합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ProjectResponseAssembler {
+
+    private final GetProjectUseCase getProjectUseCase;
+    private final SearchProjectUseCase searchProjectUseCase;
+    private final GetMemberUseCase getMemberUseCase;
+
+    /**
+     * PROJECT-001 프로젝트 목록 조회.
+     */
+    public PageResponse<ProjectSummaryResponse> searchFor(
+        SearchProjectQuery query,
+        boolean canSeeFullInfo
+    ) {
+        Page<ProjectInfo> page = searchProjectUseCase.search(query);
+
+        Set<Long> ownerIds = page.getContent().stream()
+            .map(ProjectInfo::productOwnerMemberId)
+            .collect(Collectors.toSet());
+        Map<Long, MemberInfo> memberMap = ownerIds.isEmpty()
+            ? Map.of()
+            : getMemberUseCase.findAllByIds(ownerIds);
+
+        return PageResponse.of(page, info -> {
+            MemberBrief owner = toBrief(memberMap.get(info.productOwnerMemberId()));
+            ProjectSummaryResponse response = ProjectSummaryResponse.from(info, owner);
+            return canSeeFullInfo ? response : response.toPublic();
+        });
+    }
+
+    /**
+     * PROJECT-002 프로젝트 상세 조회.
+     */
+    public ProjectDetailResponse detailFor(Long projectId, boolean canSeeFullInfo) {
+        ProjectInfo info = getProjectUseCase.getById(projectId);
+
+        Map<Long, MemberInfo> memberMap = loadMembers(info);
+
+        MemberBrief owner = toBrief(memberMap.get(info.productOwnerMemberId()));
+        List<MemberBrief> coOwners = info.coProductOwnerMemberIds().stream()
+            .map(id -> toBrief(memberMap.get(id)))
+            .toList();
+
+        ProjectDetailResponse response = ProjectDetailResponse.from(info, owner, coOwners);
+        return canSeeFullInfo ? response : response.toPublic();
+    }
+
+    /**
+     * PROJECT-103 PM의 내 Draft 조회. Draft가 없으면 {@code null} 반환.
+     */
+    public DraftProjectResponse draftFor(Long memberId, Long gisuId) {
+        Optional<ProjectInfo> maybe = getProjectUseCase.findDraftByOwnerAndGisu(memberId, gisuId);
+        if (maybe.isEmpty()) {
+            return null;
+        }
+        ProjectInfo info = maybe.get();
+
+        Map<Long, MemberInfo> memberMap = loadMembers(info);
+
+        MemberBrief owner = toBrief(memberMap.get(info.productOwnerMemberId()));
+        List<MemberBrief> coOwners = info.coProductOwnerMemberIds().stream()
+            .map(id -> toBrief(memberMap.get(id)))
+            .toList();
+
+        // TODO: 지원 문항(questions)은 Survey 도메인 GetFormDefinitionUseCase 연동 필요
+        List<ApplicationQuestionItem> questions = List.of();
+
+        return DraftProjectResponse.from(info, owner, coOwners, questions);
+    }
+
+    private Map<Long, MemberInfo> loadMembers(ProjectInfo info) {
+        Set<Long> ids = new HashSet<>();
+        ids.add(info.productOwnerMemberId());
+        ids.addAll(info.coProductOwnerMemberIds());
+        return ids.isEmpty() ? Map.of() : getMemberUseCase.findAllByIds(ids);
+    }
+
+    private MemberBrief toBrief(MemberInfo info) {
+        return info == null ? null : MemberBrief.from(info);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
@@ -1,0 +1,17 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 지원 문항 한 개. DraftProjectResponse와 UpsertApplicationFormRequest 양쪽에서 재사용됩니다.
+ */
+@Builder
+public record ApplicationQuestionItem(
+    int order,
+    QuestionType type,
+    String title,
+    boolean required,
+    List<String> options
+) { }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
@@ -9,7 +9,7 @@ import lombok.Builder;
  */
 @Builder
 public record ApplicationQuestionItem(
-    int order,
+    long order,
     QuestionType type,
     String title,
     boolean required,

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/MemberBrief.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/MemberBrief.java
@@ -1,0 +1,30 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import lombok.Builder;
+
+/**
+ * 멤버 간략 정보. 여러 Response에 embedded되는 공용 값 객체.
+ * <p>
+ * {@link #toPublic()} 호출 시 실명({@code name})은 {@code null}로 마스킹됩니다.
+ */
+@Builder
+public record MemberBrief(
+    Long memberId,
+    String nickname,
+    String name,
+    String schoolName
+) {
+    public MemberBrief toPublic() {
+        return new MemberBrief(memberId, nickname, null, schoolName);
+    }
+
+    public static MemberBrief from(MemberInfo info) {
+        return MemberBrief.builder()
+            .memberId(info.id())
+            .nickname(info.nickname())
+            .name(info.name())
+            .schoolName(info.schoolName())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/PartQuotaInfo.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/PartQuotaInfo.java
@@ -1,0 +1,28 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.query.dto.ProjectPartQuotaInfo;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import lombok.Builder;
+
+/**
+ * 파트별 TO 정보 Web VO. Summary/Detail Response에 embedded.
+ * <p>
+ * Application layer의 {@link ProjectPartQuotaInfo}에 계산값 {@code status}를 추가한 형태.
+ */
+@Builder
+public record PartQuotaInfo(
+    ChallengerPart part,
+    int currentCount,
+    int quota,
+    PartQuotaStatus status
+) {
+    public static PartQuotaInfo from(ProjectPartQuotaInfo info) {
+        return PartQuotaInfo.builder()
+            .part(info.part())
+            .currentCount(info.currentCount())
+            .quota(info.quota())
+            .status(info.computeStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/PartQuotaInfo.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/PartQuotaInfo.java
@@ -13,8 +13,8 @@ import lombok.Builder;
 @Builder
 public record PartQuotaInfo(
     ChallengerPart part,
-    int currentCount,
-    int quota,
+    long currentCount,
+    long quota,
     PartQuotaStatus status
 ) {
     public static PartQuotaInfo from(ProjectPartQuotaInfo info) {
@@ -22,7 +22,7 @@ public record PartQuotaInfo(
             .part(info.part())
             .currentCount(info.currentCount())
             .quota(info.quota())
-            .status(info.computeStatus())
+            .status(info.status())
             .build();
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CreateDraftProjectRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CreateDraftProjectRequest.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DRAFT 상태의 프로젝트 생성 요청 (PROJECT-101).
+ */
+public record CreateDraftProjectRequest(
+    @NotNull(message = "기수 ID는 필수입니다")
+    Long gisuId
+) {
+    public CreateDraftProjectCommand toCommand(Long requesterMemberId) {
+        return CreateDraftProjectCommand.builder()
+            .gisuId(gisuId)
+            .productOwnerMemberId(requesterMemberId)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/SearchProjectRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/SearchProjectRequest.java
@@ -1,0 +1,42 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 프로젝트 목록 검색 요청 (PROJECT-001).
+ * <p>
+ * {@link #toQuery(boolean, Pageable)}에서 요청자 권한(Admin 여부)에 따라
+ * {@link SearchProjectQuery#forChallenger} 또는 {@link SearchProjectQuery#forAdmin}을 선택합니다.
+ */
+public record SearchProjectRequest(
+    @NotNull(message = "기수 ID는 필수입니다")
+    Long gisuId,
+
+    String keyword,
+
+    Long chapterId,
+
+    List<Long> schoolIds,
+
+    List<ChallengerPart> parts,
+
+    PartQuotaStatus partQuotaStatus,
+
+    List<ProjectStatus> statuses
+) {
+    public SearchProjectQuery toQuery(boolean isAdmin, Pageable pageable) {
+        return isAdmin
+            ? SearchProjectQuery.forAdmin(
+                gisuId, keyword, chapterId, schoolIds,
+                parts, partQuotaStatus, statuses, pageable)
+            : SearchProjectQuery.forChallenger(
+                gisuId, keyword, chapterId, schoolIds,
+                parts, partQuotaStatus, pageable);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/TransferProjectOwnershipRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/TransferProjectOwnershipRequest.java
@@ -1,0 +1,25 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로젝트 소유권 양도 요청.
+ */
+public record TransferProjectOwnershipRequest(
+    @NotNull(message = "새 PM의 memberId는 필수입니다")
+    Long newOwnerMemberId,
+
+    @Size(max = 200, message = "사유는 200자 이하여야 합니다")
+    String reason
+) {
+    public TransferProjectOwnershipCommand toCommand(Long projectId, Long requesterMemberId) {
+        return TransferProjectOwnershipCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(requesterMemberId)
+            .newOwnerMemberId(newOwnerMemberId)
+            .reason(reason)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateProjectRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateProjectRequest.java
@@ -4,7 +4,7 @@ import com.umc.product.project.application.port.in.command.dto.UpdateProjectComm
 import jakarta.validation.constraints.Size;
 
 /**
- * 프로젝트 기본 정보 수정 요청 (PROJECT-102). 모든 필드가 nullable인 부분 업데이트.
+ * 프로젝트 기본 정보 수정 요청 (PROJECT-102). 모든 필드 nullable 부분 갱신.
  */
 public record UpdateProjectRequest(
     @Size(max = 100, message = "프로젝트명은 100자 이하여야 합니다")
@@ -18,9 +18,7 @@ public record UpdateProjectRequest(
 
     String thumbnailFileId,
 
-    String logoFileId,
-
-    Long productOwnerMemberId
+    String logoFileId
 ) {
     public UpdateProjectCommand toCommand(Long projectId, Long requesterMemberId) {
         return UpdateProjectCommand.builder()
@@ -31,7 +29,6 @@ public record UpdateProjectRequest(
             .externalLink(externalLink)
             .thumbnailFileId(thumbnailFileId)
             .logoFileId(logoFileId)
-            .productOwnerMemberId(productOwnerMemberId)
             .build();
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateProjectRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateProjectRequest.java
@@ -1,0 +1,37 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로젝트 기본 정보 수정 요청 (PROJECT-102). 모든 필드가 nullable인 부분 업데이트.
+ */
+public record UpdateProjectRequest(
+    @Size(max = 100, message = "프로젝트명은 100자 이하여야 합니다")
+    String name,
+
+    @Size(max = 200, message = "설명은 200자 이하여야 합니다")
+    String description,
+
+    @Size(max = 300, message = "외부 링크는 300자 이하여야 합니다")
+    String externalLink,
+
+    String thumbnailFileId,
+
+    String logoFileId,
+
+    Long productOwnerMemberId
+) {
+    public UpdateProjectCommand toCommand(Long projectId, Long requesterMemberId) {
+        return UpdateProjectCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(requesterMemberId)
+            .name(name)
+            .description(description)
+            .externalLink(externalLink)
+            .thumbnailFileId(thumbnailFileId)
+            .logoFileId(logoFileId)
+            .productOwnerMemberId(productOwnerMemberId)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
@@ -1,0 +1,54 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionItem;
+import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * PM이 자신의 Draft를 복원하기 위한 응답 (PROJECT-103).
+ * <p>
+ * 편집 재개용이라 {@code thumbnailFileId}/{@code logoFileId}(UUID)도 함께 내려줍니다.
+ * 작성자 PM만 조회하므로 {@code toPublic()} 마스킹 불필요.
+ */
+@Builder
+public record DraftProjectResponse(
+    Long id,
+    ProjectStatus status,
+    String name,
+    String description,
+    String thumbnailFileId,
+    String thumbnailImageUrl,
+    String logoFileId,
+    String logoImageUrl,
+    String externalLink,
+    MemberBrief productOwner,
+    List<MemberBrief> coProductOwners,
+    Long applicationFormId,
+    List<ApplicationQuestionItem> questions
+) {
+    public static DraftProjectResponse from(
+        ProjectInfo info,
+        MemberBrief productOwner,
+        List<MemberBrief> coProductOwners,
+        List<ApplicationQuestionItem> questions
+    ) {
+        return DraftProjectResponse.builder()
+            .id(info.id())
+            .status(info.status())
+            .name(info.name())
+            .description(info.description())
+            .thumbnailFileId(info.thumbnailFileId())
+            .thumbnailImageUrl(info.thumbnailImageUrl())
+            .logoFileId(info.logoFileId())
+            .logoImageUrl(info.logoImageUrl())
+            .externalLink(info.externalLink())
+            .productOwner(productOwner)
+            .coProductOwners(coProductOwners)
+            .applicationFormId(info.applicationFormId())
+            .questions(questions)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
@@ -25,7 +25,6 @@ public record DraftProjectResponse(
     String externalLink,
     MemberBrief productOwner,
     List<MemberBrief> coProductOwners,
-    Long applicationFormId,
     List<ApplicationQuestionItem> questions
 ) {
     public static DraftProjectResponse from(
@@ -44,7 +43,6 @@ public record DraftProjectResponse(
             .externalLink(info.externalLink())
             .productOwner(productOwner)
             .coProductOwners(coProductOwners)
-            .applicationFormId(info.applicationFormId())
             .questions(questions)
             .build();
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
@@ -10,8 +10,9 @@ import lombok.Builder;
 /**
  * PM이 자신의 Draft를 복원하기 위한 응답 (PROJECT-103).
  * <p>
- * 편집 재개용이라 {@code thumbnailFileId}/{@code logoFileId}(UUID)도 함께 내려줍니다.
- * 작성자 PM만 조회하므로 {@code toPublic()} 마스킹 불필요.
+ * 작성자 PM만 조회하므로 {@code toPublic()} 마스킹 불필요. 이미지는 storage 도메인 컨벤션에 따라
+ * end-user에 fileId를 노출하지 않고 access URL({@code thumbnailImageUrl}/{@code logoImageUrl})만 제공합니다.
+ * 사진 미변경은 PATCH에서 해당 fileId 필드를 null로 보내 표현합니다.
  */
 @Builder
 public record DraftProjectResponse(
@@ -19,9 +20,7 @@ public record DraftProjectResponse(
     ProjectStatus status,
     String name,
     String description,
-    String thumbnailFileId,
     String thumbnailImageUrl,
-    String logoFileId,
     String logoImageUrl,
     String externalLink,
     MemberBrief productOwner,
@@ -40,9 +39,7 @@ public record DraftProjectResponse(
             .status(info.status())
             .name(info.name())
             .description(info.description())
-            .thumbnailFileId(info.thumbnailFileId())
             .thumbnailImageUrl(info.thumbnailImageUrl())
-            .logoFileId(info.logoFileId())
             .logoImageUrl(info.logoImageUrl())
             .externalLink(info.externalLink())
             .productOwner(productOwner)

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
@@ -1,0 +1,72 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
+import com.umc.product.project.adapter.in.web.dto.common.PartQuotaInfo;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 프로젝트 상세 응답 (PROJECT-002).
+ */
+@Builder
+public record ProjectDetailResponse(
+    Long id,
+    String name,
+    String description,
+    String thumbnailImageUrl,
+    String logoImageUrl,
+    String externalLink,
+    MemberBrief productOwner,
+    List<MemberBrief> coProductOwners,
+    List<PartQuotaInfo> partQuotas,
+    PartQuotaStatus partQuotaStatus,
+    Long applicationFormId
+) {
+    public static ProjectDetailResponse from(
+        ProjectInfo info,
+        MemberBrief productOwner,
+        List<MemberBrief> coProductOwners
+    ) {
+        List<PartQuotaInfo> quotas = info.partQuotas().stream()
+            .map(PartQuotaInfo::from)
+            .toList();
+        return ProjectDetailResponse.builder()
+            .id(info.id())
+            .name(info.name())
+            .description(info.description())
+            .thumbnailImageUrl(info.thumbnailImageUrl())
+            .logoImageUrl(info.logoImageUrl())
+            .externalLink(info.externalLink())
+            .productOwner(productOwner)
+            .coProductOwners(coProductOwners)
+            .partQuotas(quotas)
+            .partQuotaStatus(aggregateStatus(quotas))
+            .applicationFormId(info.applicationFormId())
+            .build();
+    }
+
+    public ProjectDetailResponse toPublic() {
+        return ProjectDetailResponse.builder()
+            .id(id)
+            .name(name)
+            .description(description)
+            .thumbnailImageUrl(thumbnailImageUrl)
+            .logoImageUrl(logoImageUrl)
+            .externalLink(externalLink)
+            .productOwner(productOwner.toPublic())
+            .coProductOwners(coProductOwners.stream().map(MemberBrief::toPublic).toList())
+            .partQuotas(partQuotas)
+            .partQuotaStatus(partQuotaStatus)
+            .applicationFormId(applicationFormId)
+            .build();
+    }
+
+    private static PartQuotaStatus aggregateStatus(List<PartQuotaInfo> quotas) {
+        if (quotas.isEmpty()) return null;
+        boolean anyRecruiting = quotas.stream()
+            .anyMatch(q -> q.status() == PartQuotaStatus.RECRUITING);
+        return anyRecruiting ? PartQuotaStatus.RECRUITING : PartQuotaStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
@@ -21,8 +21,7 @@ public record ProjectDetailResponse(
     MemberBrief productOwner,
     List<MemberBrief> coProductOwners,
     List<PartQuotaInfo> partQuotas,
-    PartQuotaStatus partQuotaStatus,
-    Long applicationFormId
+    PartQuotaStatus partQuotaStatus
 ) {
     public static ProjectDetailResponse from(
         ProjectInfo info,
@@ -43,7 +42,6 @@ public record ProjectDetailResponse(
             .coProductOwners(coProductOwners)
             .partQuotas(quotas)
             .partQuotaStatus(aggregateStatus(quotas))
-            .applicationFormId(info.applicationFormId())
             .build();
     }
 
@@ -59,7 +57,6 @@ public record ProjectDetailResponse(
             .coProductOwners(coProductOwners.stream().map(MemberBrief::toPublic).toList())
             .partQuotas(partQuotas)
             .partQuotaStatus(partQuotaStatus)
-            .applicationFormId(applicationFormId)
             .build();
     }
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectStatusResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectStatusResponse.java
@@ -1,0 +1,24 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import lombok.Builder;
+
+/**
+ * 상태 변경을 수반하는 API들의 통일 응답 (PROJECT-101, 102, 107, 105, 108).
+ * <p>
+ * "이 호출 이후의 현재 상태"를 알려주는 최소 응답입니다. 마스킹 대상 필드 없음.
+ */
+@Builder
+public record ProjectStatusResponse(
+    Long projectId,
+    ProjectStatus status
+) {
+    public static ProjectStatusResponse of(Long projectId, ProjectStatus status) {
+        return new ProjectStatusResponse(projectId, status);
+    }
+
+    public static ProjectStatusResponse from(ProjectInfo info) {
+        return new ProjectStatusResponse(info.id(), info.status());
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectSummaryResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectSummaryResponse.java
@@ -1,0 +1,56 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
+import com.umc.product.project.adapter.in.web.dto.common.PartQuotaInfo;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 프로젝트 목록 아이템 응답 (PROJECT-001).
+ */
+@Builder
+public record ProjectSummaryResponse(
+    Long id,
+    String name,
+    String description,
+    String thumbnailImageUrl,
+    MemberBrief productOwner,
+    List<PartQuotaInfo> partQuotas,
+    PartQuotaStatus partQuotaStatus
+) {
+    public static ProjectSummaryResponse from(ProjectInfo info, MemberBrief productOwner) {
+        List<PartQuotaInfo> quotas = info.partQuotas().stream()
+            .map(PartQuotaInfo::from)
+            .toList();
+        return ProjectSummaryResponse.builder()
+            .id(info.id())
+            .name(info.name())
+            .description(info.description())
+            .thumbnailImageUrl(info.thumbnailImageUrl())
+            .productOwner(productOwner)
+            .partQuotas(quotas)
+            .partQuotaStatus(aggregateStatus(quotas))
+            .build();
+    }
+
+    public ProjectSummaryResponse toPublic() {
+        return ProjectSummaryResponse.builder()
+            .id(id)
+            .name(name)
+            .description(description)
+            .thumbnailImageUrl(thumbnailImageUrl)
+            .productOwner(productOwner.toPublic())
+            .partQuotas(partQuotas)
+            .partQuotaStatus(partQuotaStatus)
+            .build();
+    }
+
+    private static PartQuotaStatus aggregateStatus(List<PartQuotaInfo> quotas) {
+        if (quotas.isEmpty()) return null;
+        boolean anyRecruiting = quotas.stream()
+            .anyMatch(q -> q.status() == PartQuotaStatus.RECRUITING);
+        return anyRecruiting ? PartQuotaStatus.RECRUITING : PartQuotaStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
@@ -1,0 +1,9 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.domain.ProjectApplicationForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectApplicationFormJpaRepository extends JpaRepository<ProjectApplicationForm, Long> {
+
+    boolean existsByProjectId(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
@@ -1,0 +1,17 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectApplicationFormPersistenceAdapter implements LoadProjectApplicationFormPort {
+
+    private final ProjectApplicationFormJpaRepository repository;
+
+    @Override
+    public boolean existsByProjectId(Long projectId) {
+        return repository.existsByProjectId(projectId);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -1,0 +1,12 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.domain.Project;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
+
+    Optional<Project> findByProductOwnerMemberIdAndGisuId(Long productOwnerMemberId, Long gisuId);
+
+    boolean existsByProductOwnerMemberIdAndGisuId(Long productOwnerMemberId, Long gisuId);
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+// TODO: 프로젝트 전반의 QueryDSL 일관성을 위해 ProjectMemberQueryRepository로 마이그레이션 필요.
 public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember, Long> {
 
     List<ProjectMember> findByProjectIdAndPartAndStatus(Long projectId, ChallengerPart part, ProjectMemberStatus status);

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember, Long> {
+
+    List<ProjectMember> findByProjectIdAndPartAndStatus(Long projectId, ChallengerPart part, ProjectMemberStatus status);
+
+    @Query("SELECT pm.part, COUNT(pm) FROM ProjectMember pm "
+        + "WHERE pm.project.id = :projectId AND pm.status = :status "
+        + "GROUP BY pm.part")
+    List<Object[]> countByProjectIdGroupByPartRaw(@Param("projectId") Long projectId, @Param("status") ProjectMemberStatus status);
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -1,0 +1,34 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort {
+
+    private final ProjectMemberJpaRepository repository;
+
+    @Override
+    public List<ProjectMember> listByProjectIdAndPart(Long projectId, ChallengerPart part) {
+        return repository.findByProjectIdAndPartAndStatus(projectId, part, ProjectMemberStatus.ACTIVE);
+    }
+
+    @Override
+    public Map<ChallengerPart, Long> countByProjectIdGroupByPart(Long projectId) {
+        List<Object[]> rows = repository.countByProjectIdGroupByPartRaw(projectId, ProjectMemberStatus.ACTIVE);
+
+        Map<ChallengerPart, Long> result = new EnumMap<>(ChallengerPart.class);
+        for (Object[] row : rows) {
+            result.put((ChallengerPart) row[0], (Long) row[1]);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
@@ -1,0 +1,10 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.domain.ProjectPartQuota;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectPartQuotaJpaRepository extends JpaRepository<ProjectPartQuota, Long> {
+
+    List<ProjectPartQuota> findByProjectId(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.domain.ProjectPartQuota;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectPartQuotaPersistenceAdapter implements LoadProjectPartQuotaPort {
+
+    private final ProjectPartQuotaJpaRepository repository;
+
+    @Override
+    public List<ProjectPartQuota> listByProjectId(Long projectId) {
+        return repository.findByProjectId(projectId);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -1,0 +1,62 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectPersistenceAdapter implements LoadProjectPort, SaveProjectPort {
+
+    private final ProjectJpaRepository jpaRepository;
+    private final ProjectQueryRepository queryRepository;
+
+    @Override
+    public Optional<Project> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Project getById(Long id) {
+        return jpaRepository.findById(id)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<Project> findByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
+        return jpaRepository.findByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
+    }
+
+    @Override
+    public boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
+        return jpaRepository.existsByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
+    }
+
+    @Override
+    public Page<Project> search(SearchProjectQuery query) {
+        return queryRepository.search(query);
+    }
+
+    @Override
+    public Project save(Project project) {
+        return jpaRepository.save(project);
+    }
+
+    @Override
+    public List<Project> saveAll(List<Project> projects) {
+        return jpaRepository.saveAll(projects);
+    }
+
+    @Override
+    public void delete(Project project) {
+        jpaRepository.delete(project);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -7,6 +7,7 @@ import static com.umc.product.project.domain.QProjectPartQuota.projectPartQuota;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
@@ -60,8 +61,7 @@ public class ProjectQueryRepository {
             .and(keywordContains(query.keyword()))
             .and(chapterIdEq(query.chapterId()))
             .and(schoolIdsIn(query.schoolIds()))
-            .and(partsIn(query.parts()))
-            .and(partQuotaStatusEq(query.partQuotaStatus()))
+            .and(partAndQuotaFilter(query.parts(), query.partQuotaStatus()))
             .and(statusIn(query.statuses()));
 
         return builder;
@@ -96,46 +96,51 @@ public class ProjectQueryRepository {
     }
 
     /**
-     * 지정된 파트 중 <b>RECRUITING 상태</b>(정원 미달)인 파트가 있는 프로젝트만 필터링합니다.
-     * api-design.md 사양: "해당 파트의 RECRUITING 상태인 프로젝트만 반환".
+     * 파트 목록과 모집 상태를 <b>상관(correlated)</b>으로 결합해 필터링합니다.
+     * <ul>
+     *   <li>{@code parts} 있고 {@code status} 있음 → 선택한 각 파트가 존재하며 해당 파트가 지정 상태 (AND)</li>
+     *   <li>{@code parts} 있고 {@code status} 없음 → 선택한 각 파트가 존재 (AND, 상태 무관)</li>
+     *   <li>{@code parts} 없고 {@code status} 있음 → 프로젝트 전체 기준 (아무 파트 하나라도 모집중 / 모든 파트 완료)</li>
+     *   <li>둘 다 없음 → 필터 미적용</li>
+     * </ul>
      */
-    private BooleanExpression partsIn(List<ChallengerPart> parts) {
-        if (parts == null || parts.isEmpty()) {
+    private BooleanExpression partAndQuotaFilter(List<ChallengerPart> parts, PartQuotaStatus status) {
+        boolean hasParts = parts != null && !parts.isEmpty();
+        if (!hasParts && status == null) {
             return null;
         }
-        return JPAExpressions
-            .selectOne()
-            .from(projectPartQuota)
-            .where(
-                projectPartQuota.project.eq(project),
-                projectPartQuota.part.in(parts),
-                projectPartQuota.quota.gt(
-                    JPAExpressions
-                        .select(projectMember.count())
-                        .from(projectMember)
-                        .where(
-                            projectMember.project.eq(project),
-                            projectMember.part.eq(projectPartQuota.part),
-                            projectMember.status.eq(ProjectMemberStatus.ACTIVE)
-                        )
-                )
-            )
-            .exists();
+        if (!hasParts) {
+            return projectWideQuotaStatus(status);
+        }
+        BooleanExpression combined = null;
+        for (ChallengerPart part : parts) {
+            BooleanExpression perPart = partExistsWithStatus(part, status);
+            combined = (combined == null) ? perPart : combined.and(perPart);
+        }
+        return combined;
     }
 
     /**
-     * 파트별 모집 상태로 필터링합니다.
-     * <ul>
-     *   <li>RECRUITING — 정원 미달 파트가 하나라도 있는 프로젝트</li>
-     *   <li>COMPLETED — 모든 파트가 정원 이상인 프로젝트</li>
-     * </ul>
+     * 특정 파트가 프로젝트에 존재하는지 + (지정 시) 해당 파트가 모집중/완료 상태인지 체크.
      */
-    private BooleanExpression partQuotaStatusEq(PartQuotaStatus partQuotaStatus) {
-        if (partQuotaStatus == null) {
-            return null;
+    private BooleanExpression partExistsWithStatus(ChallengerPart part, PartQuotaStatus status) {
+        BooleanBuilder where = new BooleanBuilder()
+            .and(projectPartQuota.project.eq(project))
+            .and(projectPartQuota.part.eq(part));
+
+        if (status != null) {
+            BooleanExpression recruiting = projectPartQuota.quota.gt(activeMemberCountForPart(part));
+            where.and(status == PartQuotaStatus.RECRUITING ? recruiting : recruiting.not());
         }
 
-        // 정원 미달인 파트가 존재하는지 서브쿼리
+        return JPAExpressions.selectOne().from(projectPartQuota).where(where).exists();
+    }
+
+    /**
+     * 프로젝트 전체 기준 모집 상태.
+     * RECRUITING = 모집중 파트가 하나라도 있음, COMPLETED = 모든 파트가 정원 이상.
+     */
+    private BooleanExpression projectWideQuotaStatus(PartQuotaStatus status) {
         BooleanExpression hasRecruitingPart = JPAExpressions
             .selectOne()
             .from(projectPartQuota)
@@ -154,9 +159,20 @@ public class ProjectQueryRepository {
             )
             .exists();
 
-        return partQuotaStatus == PartQuotaStatus.RECRUITING
+        return status == PartQuotaStatus.RECRUITING
             ? hasRecruitingPart
             : hasRecruitingPart.not();
+    }
+
+    private JPQLQuery<Long> activeMemberCountForPart(ChallengerPart part) {
+        return JPAExpressions
+            .select(projectMember.count())
+            .from(projectMember)
+            .where(
+                projectMember.project.eq(project),
+                projectMember.part.eq(part),
+                projectMember.status.eq(ProjectMemberStatus.ACTIVE)
+            );
     }
 
     private BooleanExpression statusIn(List<ProjectStatus> statuses) {

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -5,7 +5,10 @@ import static com.umc.product.project.domain.QProjectMember.projectMember;
 import static com.umc.product.project.domain.QProjectPartQuota.projectPartQuota;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -15,10 +18,12 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.PartQuotaStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -39,7 +44,7 @@ public class ProjectQueryRepository {
         List<Project> content = queryFactory
             .selectFrom(project)
             .where(condition)
-            .orderBy(project.createdAt.desc())
+            .orderBy(toOrderSpecifiers(query.pageable().getSort()))
             .offset(query.pageable().getOffset())
             .limit(query.pageable().getPageSize())
             .fetch();
@@ -180,5 +185,22 @@ public class ProjectQueryRepository {
         return (statuses != null && !statuses.isEmpty())
             ? project.status.in(statuses)
             : null;
+    }
+
+    /**
+     * Pageable의 Sort를 QueryDSL OrderSpecifier 배열로 변환합니다.
+     * 정렬 조건이 없으면 createdAt 내림차순을 기본으로 사용합니다.
+     */
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return new OrderSpecifier<?>[]{project.createdAt.desc()};
+        }
+        PathBuilder<Project> path = new PathBuilder<>(Project.class, project.getMetadata());
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+        for (Sort.Order order : sort) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            specifiers.add(new OrderSpecifier<>(direction, path.getComparable(order.getProperty(), Comparable.class)));
+        }
+        return specifiers.toArray(new OrderSpecifier<?>[0]);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -85,14 +85,9 @@ public class ProjectQueryRepository {
         if (schoolIds == null || schoolIds.isEmpty()) {
             return null;
         }
-        // TODO: api-design.md 사양 — "학교 필터는 PM 학교만" 적용 필요.
-        //  Project에는 PM의 schoolId가 없고 productOwnerMemberId만 있음 (member 도메인에 school 소속).
-        //  구현 방향:
-        //   (a) member 도메인 호출로 memberId→schoolId 매핑을 미리 조회 후 in-memory 필터
-        //   (b) DB view / denormalize: project.owner_school_id 컬럼 추가 (schema 변경 필요)
-        //   (c) GetMemberUseCase.findAllSchoolIdsByIds() batch 조회 후 Service 단에서 필터
-        //  헥사고날 규칙상 member Entity는 직접 JOIN 불가 → Service 레벨에서 처리 권장.
-        return null;
+        // TODO: member 도메인에 memberId→schoolId 배치 조회 API 추가 후 Service 레벨에서 필터 적용.
+        throw new UnsupportedOperationException(
+            "schoolIds 필터는 아직 지원되지 않습니다. (member 도메인 연동 대기)");
     }
 
     /**
@@ -138,9 +133,15 @@ public class ProjectQueryRepository {
 
     /**
      * 프로젝트 전체 기준 모집 상태.
-     * RECRUITING = 모집중 파트가 하나라도 있음, COMPLETED = 모든 파트가 정원 이상.
+     * RECRUITING = 모집중 파트가 하나라도 있음, COMPLETED = 파트가 존재하면서 모두 정원 이상.
      */
     private BooleanExpression projectWideQuotaStatus(PartQuotaStatus status) {
+        BooleanExpression hasAnyPart = JPAExpressions
+            .selectOne()
+            .from(projectPartQuota)
+            .where(projectPartQuota.project.eq(project))
+            .exists();
+
         BooleanExpression hasRecruitingPart = JPAExpressions
             .selectOne()
             .from(projectPartQuota)
@@ -161,7 +162,7 @@ public class ProjectQueryRepository {
 
         return status == PartQuotaStatus.RECRUITING
             ? hasRecruitingPart
-            : hasRecruitingPart.not();
+            : hasAnyPart.and(hasRecruitingPart.not());
     }
 
     private JPQLQuery<Long> activeMemberCountForPart(ChallengerPart part) {

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -1,0 +1,28 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.domain.Project;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Project QueryDSL 동적 검색 구현 (PROJECT-001).
+ */
+@Repository
+@RequiredArgsConstructor
+public class ProjectQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<Project> search(SearchProjectQuery query) {
+        // TODO: QueryDSL로 동적 조건 구현
+        //  - gisuId (필수), keyword (name LIKE), chapterId, schoolIds (IN),
+        //    parts (IN, project_part_quota join), partQuotaStatus (집계 서브쿼리),
+        //    statuses (IN)
+        //  - 정렬: createdAt DESC 기본
+        //  - count 쿼리 분리 필요
+        throw new UnsupportedOperationException("TODO: ProjectQueryRepository.search 구현 필요");
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -1,10 +1,23 @@
 package com.umc.product.project.adapter.out.persistence;
 
+import static com.umc.product.project.domain.QProject.project;
+import static com.umc.product.project.domain.QProjectMember.projectMember;
+import static com.umc.product.project.domain.QProjectPartQuota.projectPartQuota;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -16,13 +29,124 @@ public class ProjectQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 동적 조건으로 프로젝트 목록을 페이지 조회합니다.
+     */
     public Page<Project> search(SearchProjectQuery query) {
-        // TODO: QueryDSL로 동적 조건 구현
-        //  - gisuId (필수), keyword (name LIKE), chapterId, schoolIds (IN),
-        //    parts (IN, project_part_quota join), partQuotaStatus (집계 서브쿼리),
-        //    statuses (IN)
-        //  - 정렬: createdAt DESC 기본
-        //  - count 쿼리 분리 필요
-        throw new UnsupportedOperationException("TODO: ProjectQueryRepository.search 구현 필요");
+        BooleanBuilder condition = buildCondition(query);
+
+        List<Project> content = queryFactory
+            .selectFrom(project)
+            .where(condition)
+            .orderBy(project.createdAt.desc())
+            .offset(query.pageable().getOffset())
+            .limit(query.pageable().getPageSize())
+            .fetch();
+
+        Long total = queryFactory
+            .select(project.count())
+            .from(project)
+            .where(condition)
+            .fetchOne();
+
+        return new PageImpl<>(content, query.pageable(), total != null ? total : 0L);
+    }
+
+    private BooleanBuilder buildCondition(SearchProjectQuery query) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder
+            .and(gisuIdEq(query.gisuId()))
+            .and(keywordContains(query.keyword()))
+            .and(chapterIdEq(query.chapterId()))
+            .and(schoolIdsIn(query.schoolIds()))
+            .and(partsIn(query.parts()))
+            .and(partQuotaStatusEq(query.partQuotaStatus()))
+            .and(statusIn(query.statuses()));
+
+        return builder;
+    }
+
+    private BooleanExpression gisuIdEq(Long gisuId) {
+        return project.gisuId.eq(gisuId);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return (keyword != null && !keyword.isBlank())
+            ? project.name.containsIgnoreCase(keyword)
+            : null;
+    }
+
+    private BooleanExpression chapterIdEq(Long chapterId) {
+        return chapterId != null ? project.chapterId.eq(chapterId) : null;
+    }
+
+    private BooleanExpression schoolIdsIn(List<Long> schoolIds) {
+        if (schoolIds == null || schoolIds.isEmpty()) {
+            return null;
+        }
+        // project_member 중 해당 학교 소속 멤버가 있는 프로젝트
+        // 단, schoolIds는 PM이 속한 학교 기준이 아니라 chapterId 하위 학교 필터이므로
+        // project.chapterId 기반으로 이미 필터됨. 추가 필터가 필요한 경우 확장.
+        return null;
+    }
+
+    /**
+     * 특정 파트의 TO가 설정된 프로젝트만 필터링합니다.
+     */
+    private BooleanExpression partsIn(List<ChallengerPart> parts) {
+        if (parts == null || parts.isEmpty()) {
+            return null;
+        }
+        return JPAExpressions
+            .selectOne()
+            .from(projectPartQuota)
+            .where(
+                projectPartQuota.project.eq(project),
+                projectPartQuota.part.in(parts)
+            )
+            .exists();
+    }
+
+    /**
+     * 파트별 모집 상태로 필터링합니다.
+     * <ul>
+     *   <li>RECRUITING — 정원 미달 파트가 하나라도 있는 프로젝트</li>
+     *   <li>COMPLETED — 모든 파트가 정원 이상인 프로젝트</li>
+     * </ul>
+     */
+    private BooleanExpression partQuotaStatusEq(PartQuotaStatus partQuotaStatus) {
+        if (partQuotaStatus == null) {
+            return null;
+        }
+
+        // 정원 미달인 파트가 존재하는지 서브쿼리
+        BooleanExpression hasRecruitingPart = JPAExpressions
+            .selectOne()
+            .from(projectPartQuota)
+            .where(
+                projectPartQuota.project.eq(project),
+                projectPartQuota.quota.gt(
+                    JPAExpressions
+                        .select(projectMember.count())
+                        .from(projectMember)
+                        .where(
+                            projectMember.project.eq(project),
+                            projectMember.part.eq(projectPartQuota.part),
+                            projectMember.status.eq(ProjectMemberStatus.ACTIVE)
+                        )
+                )
+            )
+            .exists();
+
+        return partQuotaStatus == PartQuotaStatus.RECRUITING
+            ? hasRecruitingPart
+            : hasRecruitingPart.not();
+    }
+
+    private BooleanExpression statusIn(List<ProjectStatus> statuses) {
+        return (statuses != null && !statuses.isEmpty())
+            ? project.status.in(statuses)
+            : null;
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -85,14 +85,19 @@ public class ProjectQueryRepository {
         if (schoolIds == null || schoolIds.isEmpty()) {
             return null;
         }
-        // project_member 중 해당 학교 소속 멤버가 있는 프로젝트
-        // 단, schoolIds는 PM이 속한 학교 기준이 아니라 chapterId 하위 학교 필터이므로
-        // project.chapterId 기반으로 이미 필터됨. 추가 필터가 필요한 경우 확장.
+        // TODO: api-design.md 사양 — "학교 필터는 PM 학교만" 적용 필요.
+        //  Project에는 PM의 schoolId가 없고 productOwnerMemberId만 있음 (member 도메인에 school 소속).
+        //  구현 방향:
+        //   (a) member 도메인 호출로 memberId→schoolId 매핑을 미리 조회 후 in-memory 필터
+        //   (b) DB view / denormalize: project.owner_school_id 컬럼 추가 (schema 변경 필요)
+        //   (c) GetMemberUseCase.findAllSchoolIdsByIds() batch 조회 후 Service 단에서 필터
+        //  헥사고날 규칙상 member Entity는 직접 JOIN 불가 → Service 레벨에서 처리 권장.
         return null;
     }
 
     /**
-     * 특정 파트의 TO가 설정된 프로젝트만 필터링합니다.
+     * 지정된 파트 중 <b>RECRUITING 상태</b>(정원 미달)인 파트가 있는 프로젝트만 필터링합니다.
+     * api-design.md 사양: "해당 파트의 RECRUITING 상태인 프로젝트만 반환".
      */
     private BooleanExpression partsIn(List<ChallengerPart> parts) {
         if (parts == null || parts.isEmpty()) {
@@ -103,7 +108,17 @@ public class ProjectQueryRepository {
             .from(projectPartQuota)
             .where(
                 projectPartQuota.project.eq(project),
-                projectPartQuota.part.in(parts)
+                projectPartQuota.part.in(parts),
+                projectPartQuota.quota.gt(
+                    JPAExpressions
+                        .select(projectMember.count())
+                        .from(projectMember)
+                        .where(
+                            projectMember.project.eq(project),
+                            projectMember.part.eq(projectPartQuota.part),
+                            projectMember.status.eq(ProjectMemberStatus.ACTIVE)
+                        )
+                )
             )
             .exists();
     }

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
@@ -3,17 +3,16 @@ package com.umc.product.project.application.port.in.command;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 
 /**
- * 프로젝트 생성 UseCase (PROJECT-101).
+ * 프로젝트 Draft 생성 UseCase (PROJECT-101).
  * <p>
- * 생성은 항상 {@code DRAFT} 상태로 시작합니다. 이후 상태 전이는
- * {@link SubmitProjectUseCase}(PM 제출) 및 후속 Publish/Complete/Abort UseCase에서 담당합니다.
+ * 한 PM이 한 기수에 가질 수 있는 프로젝트는 1개. 이미 존재하면 {@code PROJECT_DUPLICATE_IN_GISU}.
+ * 프론트는 {@code GET /projects/me/draft?gisuId=X}로 사전 확인 후 호출하는 것을 권장.
  */
 public interface CreateDraftProjectUseCase {
 
     /**
-     * DRAFT 상태의 프로젝트를 생성합니다.
+     * 빈 DRAFT 프로젝트를 생성합니다.
      *
-     * @param command 생성 Command
      * @return 생성된 프로젝트 ID
      */
     Long create(CreateDraftProjectCommand command);

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
@@ -1,6 +1,6 @@
 package com.umc.product.project.application.port.in.command;
 
-import com.umc.product.project.application.port.in.command.dto.CreateProjectDraftCommand;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 
 /**
  * 프로젝트 생성 UseCase (PROJECT-101).
@@ -8,7 +8,7 @@ import com.umc.product.project.application.port.in.command.dto.CreateProjectDraf
  * 생성은 항상 {@code DRAFT} 상태로 시작합니다. 이후 상태 전이는
  * {@link SubmitProjectUseCase}(PM 제출) 및 후속 Publish/Complete/Abort UseCase에서 담당합니다.
  */
-public interface CreateProjectUseCase {
+public interface CreateDraftProjectUseCase {
 
     /**
      * DRAFT 상태의 프로젝트를 생성합니다.
@@ -16,5 +16,5 @@ public interface CreateProjectUseCase {
      * @param command 생성 Command
      * @return 생성된 프로젝트 ID
      */
-    Long create(CreateProjectDraftCommand command);
+    Long create(CreateDraftProjectCommand command);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateProjectUseCase.java
@@ -1,0 +1,20 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.CreateProjectDraftCommand;
+
+/**
+ * 프로젝트 생성 UseCase (PROJECT-101).
+ * <p>
+ * 생성은 항상 {@code DRAFT} 상태로 시작합니다. 이후 상태 전이는
+ * {@link SubmitProjectUseCase}(PM 제출) 및 후속 Publish/Complete/Abort UseCase에서 담당합니다.
+ */
+public interface CreateProjectUseCase {
+
+    /**
+     * DRAFT 상태의 프로젝트를 생성합니다.
+     *
+     * @param command 생성 Command
+     * @return 생성된 프로젝트 ID
+     */
+    Long create(CreateProjectDraftCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectUseCase.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+
+/**
+ * 프로젝트 제출 UseCase (PROJECT-107).
+ * <p>
+ * PM이 작성한 Draft를 제출하여 {@code PENDING_REVIEW} 상태로 전이시킵니다.
+ * 이후 Admin이 파트/TO 할당(PROJECT-105)과 공개(PROJECT-108) 단계를 수행합니다.
+ */
+public interface SubmitProjectUseCase {
+
+    /**
+     * DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다.
+     *
+     * @param command 제출 Command
+     */
+    void submit(SubmitProjectCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/TransferProjectOwnershipUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/TransferProjectOwnershipUseCase.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.application.port.in.command;
 
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
+import com.umc.product.project.domain.enums.ProjectStatus;
 
 /**
  * 프로젝트 소유권(메인 PM) 양도 UseCase.
@@ -12,6 +13,8 @@ public interface TransferProjectOwnershipUseCase {
 
     /**
      * 프로젝트 소유권을 새 PM에게 양도합니다.
+     *
+     * @return 양도 후 프로젝트 상태
      */
-    void transfer(TransferProjectOwnershipCommand command);
+    ProjectStatus transfer(TransferProjectOwnershipCommand command);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/TransferProjectOwnershipUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/TransferProjectOwnershipUseCase.java
@@ -1,0 +1,17 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
+
+/**
+ * 프로젝트 소유권(메인 PM) 양도 UseCase.
+ * <p>
+ * 양도는 권한 이동(EDIT/SUBMIT 권한)을 동반하는 의도된 액션이므로 일반 PATCH가 아닌
+ * 별도 엔드포인트로 분리합니다.
+ */
+public interface TransferProjectOwnershipUseCase {
+
+    /**
+     * 프로젝트 소유권을 새 PM에게 양도합니다.
+     */
+    void transfer(TransferProjectOwnershipCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectUseCase.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+
+/**
+ * 프로젝트 기본 정보 수정 UseCase (PROJECT-102).
+ * <p>
+ * {@code DRAFT} 상태에서는 전체 필드 수정 가능하며,
+ * 공개 이후 상태에서의 제한 정책은 구현 단에서 별도 확인합니다.
+ */
+public interface UpdateProjectUseCase {
+
+    /**
+     * 프로젝트 기본 정보를 부분 업데이트합니다.
+     *
+     * @param command 수정 Command ({@code null} 필드는 수정 제외)
+     */
+    void update(UpdateProjectCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectUseCase.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.application.port.in.command;
 
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.domain.enums.ProjectStatus;
 
 /**
  * 프로젝트 기본 정보 수정 UseCase (PROJECT-102).
@@ -14,6 +15,7 @@ public interface UpdateProjectUseCase {
      * 프로젝트 기본 정보를 부분 업데이트합니다.
      *
      * @param command 수정 Command ({@code null} 필드는 수정 제외)
+     * @return 갱신 후 프로젝트 상태
      */
-    void update(UpdateProjectCommand command);
+    ProjectStatus update(UpdateProjectCommand command);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectCommand.java
@@ -4,11 +4,8 @@ import java.util.Objects;
 import lombok.Builder;
 
 /**
- * 프로젝트 Draft 생성 Command.
- * <p>
- * PROJECT-101 요청이 {@code toCommand(memberId)}로 변환되어 전달됩니다.
- * 최초 생성 시점에는 기수와 작성자만 확정하며, 나머지 정보는
- * {@code UpdateProjectCommand}를 통해 단계적으로 저장됩니다.
+ * 프로젝트 Draft 생성 Command. 최초 생성 시점엔 기수와 작성자만 확정하고,
+ * 이후 정보는 {@link UpdateProjectCommand}로 갱신합니다.
  */
 @Builder
 public record CreateDraftProjectCommand(

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectCommand.java
@@ -11,11 +11,11 @@ import lombok.Builder;
  * {@code UpdateProjectCommand}를 통해 단계적으로 저장됩니다.
  */
 @Builder
-public record CreateProjectDraftCommand(
+public record CreateDraftProjectCommand(
     Long gisuId,
     Long productOwnerMemberId
 ) {
-    public CreateProjectDraftCommand {
+    public CreateDraftProjectCommand {
         Objects.requireNonNull(gisuId, "gisuId must not be null");
         Objects.requireNonNull(productOwnerMemberId, "productOwnerMemberId must not be null");
     }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateProjectDraftCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateProjectDraftCommand.java
@@ -1,0 +1,22 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 Draft 생성 Command.
+ * <p>
+ * PROJECT-101 요청이 {@code toCommand(memberId)}로 변환되어 전달됩니다.
+ * 최초 생성 시점에는 기수와 작성자만 확정하며, 나머지 정보는
+ * {@code UpdateProjectCommand}를 통해 단계적으로 저장됩니다.
+ */
+@Builder
+public record CreateProjectDraftCommand(
+    Long gisuId,
+    Long productOwnerMemberId
+) {
+    public CreateProjectDraftCommand {
+        Objects.requireNonNull(gisuId, "gisuId must not be null");
+        Objects.requireNonNull(productOwnerMemberId, "productOwnerMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectCommand.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 제출 Command (PROJECT-107).
+ * <p>
+ * DRAFT 상태의 프로젝트를 PENDING_REVIEW로 상태 전이합니다.
+ * 상태 전이 시 필수 필드(name, applicationFormId 등) 완비 검증이 동반됩니다.
+ */
+@Builder
+public record SubmitProjectCommand(
+    Long projectId,
+    Long requesterMemberId
+) {
+    public SubmitProjectCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/TransferProjectOwnershipCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/TransferProjectOwnershipCommand.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 소유권 양도 Command.
+ */
+@Builder
+public record TransferProjectOwnershipCommand(
+    Long projectId,
+    Long requesterMemberId,
+    Long newOwnerMemberId,
+    String reason
+) {
+    public TransferProjectOwnershipCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+        Objects.requireNonNull(newOwnerMemberId, "newOwnerMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectCommand.java
@@ -1,0 +1,29 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 기본 정보 부분 업데이트 Command (PROJECT-102).
+ * <p>
+ * {@code projectId}와 {@code requesterMemberId}를 제외한 필드는 모두 nullable이며,
+ * {@code null}이면 해당 필드는 <b>수정하지 않음</b>(부분 업데이트 의미)입니다.
+ * <p>
+ * 보조 PM 목록은 이 Command로 관리하지 않습니다. 별도 팀원 관리 API로 처리됩니다.
+ */
+@Builder
+public record UpdateProjectCommand(
+    Long projectId,
+    Long requesterMemberId,
+    String name,
+    String description,
+    String externalLink,
+    String thumbnailFileId,
+    String logoFileId,
+    Long productOwnerMemberId
+) {
+    public UpdateProjectCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectCommand.java
@@ -7,9 +7,9 @@ import lombok.Builder;
  * 프로젝트 기본 정보 부분 업데이트 Command (PROJECT-102).
  * <p>
  * {@code projectId}와 {@code requesterMemberId}를 제외한 필드는 모두 nullable이며,
- * {@code null}이면 해당 필드는 <b>수정하지 않음</b>(부분 업데이트 의미)입니다.
+ * {@code null}이면 해당 필드는 변경하지 않습니다.
  * <p>
- * 보조 PM 목록은 이 Command로 관리하지 않습니다. 별도 팀원 관리 API로 처리됩니다.
+ * 소유권 변경은 별도 {@link TransferProjectOwnershipCommand} 사용.
  */
 @Builder
 public record UpdateProjectCommand(
@@ -19,8 +19,7 @@ public record UpdateProjectCommand(
     String description,
     String externalLink,
     String thumbnailFileId,
-    String logoFileId,
-    Long productOwnerMemberId
+    String logoFileId
 ) {
     public UpdateProjectCommand {
         Objects.requireNonNull(projectId, "projectId must not be null");

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectUseCase.java
@@ -1,0 +1,34 @@
+package com.umc.product.project.application.port.in.query;
+
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import java.util.Optional;
+
+/**
+ * 단건 프로젝트 조회 UseCase.
+ * <ul>
+ *   <li>{@link #getById(Long)} — 프로젝트 상세 조회 (PROJECT-002). 반드시 존재해야 하며, 없으면 예외.</li>
+ *   <li>{@link #findDraftByOwnerAndGisu(Long, Long)} — PM의 내 Draft 조회 (PROJECT-103). 없으면 {@link Optional#empty()}.</li>
+ * </ul>
+ * <p>
+ * 목록/검색 조회는 {@link SearchProjectUseCase}를 참고하세요.
+ */
+public interface GetProjectUseCase {
+
+    /**
+     * 프로젝트 ID로 단건 조회합니다. 해당 ID의 프로젝트가 없으면 도메인 예외를 던집니다.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 프로젝트 Info
+     */
+    ProjectInfo getById(Long projectId);
+
+    /**
+     * 특정 PM이 특정 기수에 작성한 Draft 프로젝트를 조회합니다.
+     * PM이 아직 만들지 않았거나 상태가 DRAFT가 아닌 경우 {@link Optional#empty()}.
+     *
+     * @param productOwnerMemberId PO(작성자) Member ID
+     * @param gisuId               기수 ID
+     * @return Draft Info, 없으면 empty
+     */
+    Optional<ProjectInfo> findDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/SearchProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/SearchProjectUseCase.java
@@ -1,0 +1,22 @@
+package com.umc.product.project.application.port.in.query;
+
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import org.springframework.data.domain.Page;
+
+/**
+ * 프로젝트 목록 검색 UseCase (PROJECT-001).
+ * <p>
+ * 동적 필터와 페이지네이션을 지원합니다. 상태 필터는 {@link SearchProjectQuery}의
+ * {@code forChallenger}/{@code forAdmin} 팩토리에서 권한에 따라 자동 조립됩니다.
+ */
+public interface SearchProjectUseCase {
+
+    /**
+     * 조건에 맞는 프로젝트 목록을 페이징하여 반환합니다.
+     *
+     * @param query 검색 조건 ({@code Pageable} 포함)
+     * @return ProjectInfo 페이지
+     */
+    Page<ProjectInfo> search(SearchProjectQuery query);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
@@ -9,8 +9,11 @@ import lombok.Builder;
 /**
  * 프로젝트 도메인 전반의 조회 UseCase가 공유하는 Info DTO (도메인 공유 DTO).
  * <p>
- * Entity + 부가 정보(파일 URL, 파트 TO, 보조 PM IDs 등)를 조합해 생성합니다.
- * Controller/Assembler가 다시 Web Response DTO로 변환합니다.
+ * Entity + 부가 정보를 조합해 생성합니다. Controller/Assembler가 다시 Web Response DTO로 변환합니다.
+ * <ul>
+ *   <li>{@code thumbnailImageUrl}/{@code logoImageUrl} — storage 도메인에서 resolve해 Service가 주입</li>
+ *   <li>{@code coProductOwnerMemberIds} — {@code project_member} 중 PLAN 파트(메인 PM 제외)로부터 추출</li>
+ * </ul>
  */
 @Builder
 public record ProjectInfo(
@@ -19,14 +22,14 @@ public record ProjectInfo(
     String name,
     String description,
     String thumbnailFileId,
-    String thumbnailImageUrl,          // storage 도메인에서 resolve한 CDN/Pre-signed URL
+    String thumbnailImageUrl,
     String logoFileId,
-    String logoImageUrl,                // 동일
+    String logoImageUrl,
     String externalLink,
     Long gisuId,
     Long chapterId,
     Long productOwnerMemberId,
-    List<Long> coProductOwnerMemberIds, // project_member WHERE part=PLAN AND member_id != productOwnerMemberId
+    List<Long> coProductOwnerMemberIds,
     List<ProjectPartQuotaInfo> partQuotas,
     Long applicationFormId,
     Instant createdAt,

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
@@ -31,7 +31,6 @@ public record ProjectInfo(
     Long productOwnerMemberId,
     List<Long> coProductOwnerMemberIds,
     List<ProjectPartQuotaInfo> partQuotas,
-    Long applicationFormId,
     Instant createdAt,
     Instant updatedAt
 ) {
@@ -66,7 +65,6 @@ public record ProjectInfo(
             .productOwnerMemberId(project.getProductOwnerMemberId())
             .coProductOwnerMemberIds(coProductOwnerMemberIds)
             .partQuotas(partQuotas)
-            .applicationFormId(project.getApplicationFormId())
             .createdAt(project.getCreatedAt())
             .updatedAt(project.getUpdatedAt())
             .build();

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectInfo.java
@@ -1,0 +1,71 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 프로젝트 도메인 전반의 조회 UseCase가 공유하는 Info DTO (도메인 공유 DTO).
+ * <p>
+ * Entity + 부가 정보(파일 URL, 파트 TO, 보조 PM IDs 등)를 조합해 생성합니다.
+ * Controller/Assembler가 다시 Web Response DTO로 변환합니다.
+ */
+@Builder
+public record ProjectInfo(
+    Long id,
+    ProjectStatus status,
+    String name,
+    String description,
+    String thumbnailFileId,
+    String thumbnailImageUrl,          // storage 도메인에서 resolve한 CDN/Pre-signed URL
+    String logoFileId,
+    String logoImageUrl,                // 동일
+    String externalLink,
+    Long gisuId,
+    Long chapterId,
+    Long productOwnerMemberId,
+    List<Long> coProductOwnerMemberIds, // project_member WHERE part=PLAN AND member_id != productOwnerMemberId
+    List<ProjectPartQuotaInfo> partQuotas,
+    Long applicationFormId,
+    Instant createdAt,
+    Instant updatedAt
+) {
+    /**
+     * Project 엔티티와 부가 조회 결과를 조립해 ProjectInfo를 만듭니다.
+     *
+     * @param project                    Project 엔티티
+     * @param coProductOwnerMemberIds    보조 PM Member ID 목록 (없으면 {@code List.of()})
+     * @param partQuotas                 파트별 TO 정보 목록 (DRAFT 상태면 비어있음)
+     * @param thumbnailImageUrl          썸네일 CDN URL (없으면 null)
+     * @param logoImageUrl               로고 CDN URL (없으면 null)
+     */
+    public static ProjectInfo from(
+        Project project,
+        List<Long> coProductOwnerMemberIds,
+        List<ProjectPartQuotaInfo> partQuotas,
+        String thumbnailImageUrl,
+        String logoImageUrl
+    ) {
+        return ProjectInfo.builder()
+            .id(project.getId())
+            .status(project.getStatus())
+            .name(project.getName())
+            .description(project.getDescription())
+            .thumbnailFileId(project.getThumbnailFileId())
+            .thumbnailImageUrl(thumbnailImageUrl)
+            .logoFileId(project.getLogoFileId())
+            .logoImageUrl(logoImageUrl)
+            .externalLink(project.getExternalLink())
+            .gisuId(project.getGisuId())
+            .chapterId(project.getChapterId())
+            .productOwnerMemberId(project.getProductOwnerMemberId())
+            .coProductOwnerMemberIds(coProductOwnerMemberIds)
+            .partQuotas(partQuotas)
+            .applicationFormId(project.getApplicationFormId())
+            .createdAt(project.getCreatedAt())
+            .updatedAt(project.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectMemberInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectMemberInfo.java
@@ -1,0 +1,38 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import java.time.Instant;
+import lombok.Builder;
+
+/**
+ * 프로젝트 멤버 정보를 담는 Info DTO.
+ * <p>
+ * Controller는 이 목록을 받아 Member 도메인의 {@code MemberInfo}를 추가 조회하여
+ * Web 레이어의 {@code MemberBrief}/{@code ProjectMemberItem}으로 조립합니다.
+ */
+@Builder
+public record ProjectMemberInfo(
+    Long projectMemberId,
+    Long projectId,
+    Long memberId,
+    ChallengerPart part,
+    boolean isLeader,
+    String description,
+    Instant decidedAt,
+    ProjectMemberStatus status
+) {
+    public static ProjectMemberInfo from(ProjectMember entity) {
+        return ProjectMemberInfo.builder()
+            .projectMemberId(entity.getId())
+            .projectId(entity.getProject().getId())
+            .memberId(entity.getMemberId())
+            .part(entity.getPart())
+            .isLeader(entity.isLeader())
+            .description(entity.getDescription())
+            .decidedAt(entity.getDecidedAt())
+            .status(entity.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
@@ -1,0 +1,32 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import lombok.Builder;
+
+/**
+ * 프로젝트 파트별 TO 정보를 담는 Info DTO.
+ * <p>
+ * Web 레이어의 PartQuotaInfo와는 분리되어 있습니다.
+ * <ul>
+ *   <li><b>Info (Application)</b>: raw 데이터 — part, quota, currentCount</li>
+ *   <li><b>PartQuotaInfo (Web)</b>: 계산값 포함 — 위 필드 + {@link PartQuotaStatus status}</li>
+ * </ul>
+ */
+@Builder
+public record ProjectPartQuotaInfo(
+    ChallengerPart part,
+    int quota,        // 어드민이 PROJECT-105로 기록한 정원 (NOT NULL, 항상 ≥ 1)
+    int currentCount  // 현재 등록된 활성 멤버 수 (실시간 조회)
+) {
+    /**
+     * 현재 카운트와 정원을 비교해 모집 상태를 계산합니다.
+     *
+     * @return {@link PartQuotaStatus#RECRUITING} 혹은 {@link PartQuotaStatus#COMPLETED}
+     */
+    public PartQuotaStatus computeStatus() {
+        return currentCount < quota
+            ? PartQuotaStatus.RECRUITING
+            : PartQuotaStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
@@ -2,31 +2,21 @@ package com.umc.product.project.application.port.in.query.dto;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.domain.enums.PartQuotaStatus;
-import lombok.Builder;
 
 /**
- * 프로젝트 파트별 TO 정보를 담는 Info DTO.
- * <p>
- * Web 레이어의 PartQuotaInfo와는 분리되어 있습니다.
- * <ul>
- *   <li><b>Info (Application)</b>: raw 데이터 — part, quota, currentCount</li>
- *   <li><b>PartQuotaInfo (Web)</b>: 계산값 포함 — 위 필드 + {@link PartQuotaStatus status}</li>
- * </ul>
+ * 프로젝트 파트별 TO 정보를 담는 Info DTO. {@code status}는 {@code quota}/{@code currentCount}로부터
+ * 결정되는 파생값으로, 정적 팩토리 {@link #of}에서 자동 채워집니다.
  */
-@Builder
 public record ProjectPartQuotaInfo(
     ChallengerPart part,
-    int quota,        // 어드민이 PROJECT-105로 할당
-    int currentCount  // 활성 멤버 수
+    long quota,
+    long currentCount,
+    PartQuotaStatus status
 ) {
-    /**
-     * 현재 카운트와 정원을 비교해 모집 상태를 계산합니다.
-     *
-     * @return {@link PartQuotaStatus#RECRUITING} 혹은 {@link PartQuotaStatus#COMPLETED}
-     */
-    public PartQuotaStatus computeStatus() {
-        return currentCount < quota
+    public static ProjectPartQuotaInfo of(ChallengerPart part, long quota, long currentCount) {
+        PartQuotaStatus status = currentCount < quota
             ? PartQuotaStatus.RECRUITING
             : PartQuotaStatus.COMPLETED;
+        return new ProjectPartQuotaInfo(part, quota, currentCount, status);
     }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectPartQuotaInfo.java
@@ -16,8 +16,8 @@ import lombok.Builder;
 @Builder
 public record ProjectPartQuotaInfo(
     ChallengerPart part,
-    int quota,        // 어드민이 PROJECT-105로 기록한 정원 (NOT NULL, 항상 ≥ 1)
-    int currentCount  // 현재 등록된 활성 멤버 수 (실시간 조회)
+    int quota,        // 어드민이 PROJECT-105로 할당
+    int currentCount  // 활성 멤버 수
 ) {
     /**
      * 현재 카운트와 정원을 비교해 모집 상태를 계산합니다.

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
@@ -23,7 +23,7 @@ public record SearchProjectQuery(
     List<Long> schoolIds,
     List<ChallengerPart> parts,
     PartQuotaStatus partQuotaStatus,
-    List<ProjectStatus> statuses,   // 서비스 내부 필터 — 절대 null이 아니며, 비어있지 않음
+    List<ProjectStatus> statuses,
     Pageable pageable
 ) {
     public SearchProjectQuery {

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
@@ -1,0 +1,90 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 프로젝트 목록 검색 Query (PROJECT-001).
+ * <p>
+ * 권한(챌린저 vs Admin)에 따라 노출되는 상태 범위가 다릅니다.
+ * 직접 {@code builder()}/생성자로 만들지 말고 {@link #forChallenger} 또는 {@link #forAdmin}을 사용하세요.
+ * Controller는 분기 로직을 가지지 않고, Request DTO의 {@code toQuery(isAdmin, pageable)}에서 팩토리를 선택합니다.
+ */
+@Builder
+public record SearchProjectQuery(
+    Long gisuId,
+    String keyword,
+    Long chapterId,
+    List<Long> schoolIds,
+    List<ChallengerPart> parts,
+    PartQuotaStatus partQuotaStatus,
+    List<ProjectStatus> statuses,   // 서비스 내부 필터 — 절대 null이 아니며, 비어있지 않음
+    Pageable pageable
+) {
+    public SearchProjectQuery {
+        Objects.requireNonNull(gisuId, "gisuId must not be null");
+        Objects.requireNonNull(pageable, "pageable must not be null");
+        if (statuses == null || statuses.isEmpty()) {
+            throw new IllegalArgumentException("statuses must contain at least one ProjectStatus");
+        }
+    }
+
+    /**
+     * 일반 챌린저용 — {@code statuses}를 {@code [IN_PROGRESS]}로 강제합니다.
+     * 챌린저 요청에서 넘어온 {@code statuses} 값은 무시됩니다.
+     */
+    public static SearchProjectQuery forChallenger(
+        Long gisuId,
+        String keyword,
+        Long chapterId,
+        List<Long> schoolIds,
+        List<ChallengerPart> parts,
+        PartQuotaStatus partQuotaStatus,
+        Pageable pageable
+    ) {
+        return SearchProjectQuery.builder()
+            .gisuId(gisuId)
+            .keyword(keyword)
+            .chapterId(chapterId)
+            .schoolIds(schoolIds)
+            .parts(parts)
+            .partQuotaStatus(partQuotaStatus)
+            .statuses(List.of(ProjectStatus.IN_PROGRESS))
+            .pageable(pageable)
+            .build();
+    }
+
+    /**
+     * Admin용 — {@code statuses}를 자유 지정합니다.
+     * null/빈 리스트면 {@code [IN_PROGRESS]}로 default 처리합니다.
+     */
+    public static SearchProjectQuery forAdmin(
+        Long gisuId,
+        String keyword,
+        Long chapterId,
+        List<Long> schoolIds,
+        List<ChallengerPart> parts,
+        PartQuotaStatus partQuotaStatus,
+        List<ProjectStatus> statuses,
+        Pageable pageable
+    ) {
+        List<ProjectStatus> effectiveStatuses = (statuses == null || statuses.isEmpty())
+            ? List.of(ProjectStatus.IN_PROGRESS)
+            : statuses;
+        return SearchProjectQuery.builder()
+            .gisuId(gisuId)
+            .keyword(keyword)
+            .chapterId(chapterId)
+            .schoolIds(schoolIds)
+            .parts(parts)
+            .partQuotaStatus(partQuotaStatus)
+            .statuses(effectiveStatuses)
+            .pageable(pageable)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPort.java
@@ -1,0 +1,13 @@
+package com.umc.product.project.application.port.out;
+
+/**
+ * ProjectApplicationForm 조회 Port (Driven / Port Out).
+ */
+public interface LoadProjectApplicationFormPort {
+
+    /**
+     * 특정 프로젝트에 연결된 지원 폼이 하나라도 존재하는지 확인합니다.
+     * PROJECT-107 submit 검증에 사용됩니다.
+     */
+    boolean existsByProjectId(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -1,0 +1,29 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectMember;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ProjectMember 조회 Port (Driven / Port Out).
+ * <p>
+ * Phase 1 범위: 보조 PM 추출(PROJECT-002/103), 파트별 인원 집계(PROJECT-001).
+ * Save 성격의 팀원 CRUD는 Phase 2 이후 ManageProjectMember UseCase에서 다룹니다.
+ */
+public interface LoadProjectMemberPort {
+
+    /**
+     * 특정 프로젝트의 특정 파트에 속한 멤버 목록을 조회합니다.
+     * PLAN 파트 조회 시 보조 PM(coPM) 추출에 사용됩니다.
+     */
+    List<ProjectMember> listByProjectIdAndPart(Long projectId, ChallengerPart part);
+
+    /**
+     * 특정 프로젝트의 파트별 활성 멤버 수를 집계합니다.
+     * {@code PartQuotaInfo.currentCount} 계산에 사용됩니다.
+     *
+     * @return 파트 → 인원수 맵. 활성 멤버가 없는 파트는 0 또는 엔트리 없음
+     */
+    Map<ChallengerPart, Long> countByProjectIdGroupByPart(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -7,10 +7,8 @@ import java.util.Map;
 
 /**
  * ProjectMember 조회 Port (Driven / Port Out).
- * <p>
- * Phase 1 범위: 보조 PM 추출(PROJECT-002/103), 파트별 인원 집계(PROJECT-001).
- * Save 성격의 팀원 CRUD는 Phase 2 이후 ManageProjectMember UseCase에서 다룹니다.
  */
+// TODO: ManageProjectMember 구현 시 SaveProjectMemberPort 추가
 public interface LoadProjectMemberPort {
 
     /**

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
@@ -5,10 +5,8 @@ import java.util.List;
 
 /**
  * ProjectPartQuota 조회 Port (Driven / Port Out).
- * <p>
- * Phase 1 범위: 단건 프로젝트의 파트 TO 목록 조회.
- * 파트 TO 생성/수정은 Phase 2의 PROJECT-105 UpdatePartQuotas에서 다룹니다.
  */
+// TODO: PROJECT-105 UpdatePartQuotas 구현 시 SaveProjectPartQuotaPort 추가
 public interface LoadProjectPartQuotaPort {
 
     List<ProjectPartQuota> listByProjectId(Long projectId);

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
@@ -1,0 +1,15 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectPartQuota;
+import java.util.List;
+
+/**
+ * ProjectPartQuota 조회 Port (Driven / Port Out).
+ * <p>
+ * Phase 1 범위: 단건 프로젝트의 파트 TO 목록 조회.
+ * 파트 TO 생성/수정은 Phase 2의 PROJECT-105 UpdatePartQuotas에서 다룹니다.
+ */
+public interface LoadProjectPartQuotaPort {
+
+    List<ProjectPartQuota> listByProjectId(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
@@ -1,0 +1,44 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.domain.Project;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+
+/**
+ * Project 조회 Port (Driven / Port Out).
+ * <p>
+ * 메서드 prefix 규칙:
+ * <ul>
+ *   <li>{@code findBy*} — 없어도 정상 ({@link Optional})</li>
+ *   <li>{@code getBy*} — 반드시 있어야 하며 없으면 {@code ProjectDomainException} (PROJECT_NOT_FOUND)</li>
+ *   <li>{@code existsBy*} — 존재 여부만 반환</li>
+ *   <li>{@code search} — 동적 조건 페이지 검색</li>
+ * </ul>
+ */
+public interface LoadProjectPort {
+
+    Optional<Project> findById(Long id);
+
+    /**
+     * ID로 Project를 조회합니다. 존재하지 않으면 도메인 예외를 던집니다.
+     */
+    Project getById(Long id);
+
+    /**
+     * 특정 PM이 특정 기수에 등록한 프로젝트를 조회합니다. 상태 필터 없이 단건 반환
+     * (한 PM당 한 기수 1개 UNIQUE 제약).
+     */
+    Optional<Project> findByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+
+    /**
+     * 특정 PM이 특정 기수에 이미 프로젝트를 보유하고 있는지 확인합니다.
+     * 중복 생성 방지(PROJECT-101)용 빠른 체크.
+     */
+    boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+
+    /**
+     * 동적 조건으로 프로젝트 목록을 페이지 조회합니다.
+     */
+    Page<Project> search(SearchProjectQuery query);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectPort.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.Project;
+import java.util.List;
+
+/**
+ * Project 쓰기 Port (Driven / Port Out).
+ * <p>
+ * 코드베이스 컨벤션: {@code save}, {@code saveAll}, {@code delete}는
+ * 현재 사용 여부와 무관하게 함께 선언합니다.
+ */
+public interface SaveProjectPort {
+
+    Project save(Project project);
+
+    List<Project> saveAll(List<Project> projects);
+
+    void delete(Project project);
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -10,9 +10,11 @@ import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.ChapterInfo;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
@@ -29,7 +31,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectCommandService implements
     CreateDraftProjectUseCase,
     UpdateProjectUseCase,
-    SubmitProjectUseCase {
+    SubmitProjectUseCase,
+    TransferProjectOwnershipUseCase {
 
     private final LoadProjectPort loadProjectPort;
     private final SaveProjectPort saveProjectPort;
@@ -42,10 +45,8 @@ public class ProjectCommandService implements
 
     @Override
     public Long create(CreateDraftProjectCommand command) {
-        // 1. 기수 존재 확인
         getGisuUseCase.getById(command.gisuId());
 
-        // 2. 요청자의 챌린저 조회 → PLAN 파트인지 확인
         ChallengerInfo challenger = getChallengerUseCase.getByMemberIdAndGisuId(
             command.productOwnerMemberId(), command.gisuId()
         );
@@ -53,16 +54,13 @@ public class ProjectCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
         }
 
-        // 3. 중복 프로젝트 체크
         if (loadProjectPort.existsByOwnerAndGisu(command.productOwnerMemberId(), command.gisuId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
         }
 
-        // 4. 멤버의 학교 → 지부 조회
         MemberInfo member = getMemberUseCase.getById(command.productOwnerMemberId());
         ChapterInfo chapter = getChapterUseCase.byGisuAndSchool(command.gisuId(), member.schoolId());
 
-        // 5. 프로젝트 생성 및 저장
         Project project = Project.createDraft(command.gisuId(), chapter.id(), command.productOwnerMemberId());
         return saveProjectPort.save(project).getId();
     }
@@ -70,16 +68,12 @@ public class ProjectCommandService implements
     @Override
     public void update(UpdateProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
-
-        validateOwner(project, command.requesterMemberId());
-
         project.updateBasicInfo(
             command.name(),
             command.description(),
             command.externalLink(),
             command.thumbnailFileId(),
-            command.logoFileId(),
-            command.productOwnerMemberId()
+            command.logoFileId()
         );
     }
 
@@ -87,14 +81,32 @@ public class ProjectCommandService implements
     public void submit(SubmitProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
 
-        validateOwner(project, command.requesterMemberId());
+        if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+        }
 
         project.submit();
     }
 
-    private void validateOwner(Project project, Long memberId) {
-        if (!project.getProductOwnerMemberId().equals(memberId)) {
+    @Override
+    public void transfer(TransferProjectOwnershipCommand command) {
+        Project project = loadProjectPort.getById(command.projectId());
+
+        if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
+
+        ChallengerInfo newOwner = getChallengerUseCase.getByMemberIdAndGisuId(
+            command.newOwnerMemberId(), project.getGisuId()
+        );
+        if (newOwner.part() != ChallengerPart.PLAN) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
+        }
+
+        if (loadProjectPort.existsByOwnerAndGisu(command.newOwnerMemberId(), project.getGisuId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+        }
+
+        project.transferOwnership(command.newOwnerMemberId());
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -19,6 +19,7 @@ import com.umc.product.project.application.port.in.command.dto.UpdateProjectComm
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -66,7 +67,7 @@ public class ProjectCommandService implements
     }
 
     @Override
-    public void update(UpdateProjectCommand command) {
+    public ProjectStatus update(UpdateProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
         project.updateBasicInfo(
             command.name(),
@@ -75,6 +76,7 @@ public class ProjectCommandService implements
             command.thumbnailFileId(),
             command.logoFileId()
         );
+        return project.getStatus();
     }
 
     @Override
@@ -89,7 +91,7 @@ public class ProjectCommandService implements
     }
 
     @Override
-    public void transfer(TransferProjectOwnershipCommand command) {
+    public ProjectStatus transfer(TransferProjectOwnershipCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
 
         if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
@@ -108,5 +110,6 @@ public class ProjectCommandService implements
         }
 
         project.transferOwnership(command.newOwnerMemberId());
+        return project.getStatus();
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -94,7 +94,7 @@ public class ProjectCommandService implements
 
     private void validateOwner(Project project, Long memberId) {
         if (!project.getProductOwnerMemberId().equals(memberId)) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -1,0 +1,48 @@
+package com.umc.product.project.application.service.command;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectCommandService implements
+    CreateDraftProjectUseCase,
+    UpdateProjectUseCase,
+    SubmitProjectUseCase {
+
+    private final LoadProjectPort loadProjectPort;
+    private final SaveProjectPort saveProjectPort;
+
+    // Cross-domain UseCases
+    private final GetMemberUseCase getMemberUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetGisuUseCase getGisuUseCase;
+
+    @Override
+    public Long create(CreateDraftProjectCommand command) {
+        throw new UnsupportedOperationException("TODO: CreateDraftProjectUseCase.create 구현 필요");
+    }
+
+    @Override
+    public void update(UpdateProjectCommand command) {
+        throw new UnsupportedOperationException("TODO: UpdateProjectUseCase.update 구현 필요");
+    }
+
+    @Override
+    public void submit(SubmitProjectCommand command) {
+        throw new UnsupportedOperationException("TODO: SubmitProjectUseCase.submit 구현 필요");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -1,8 +1,13 @@
 package com.umc.product.project.application.service.command;
 
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.ChapterInfo;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
@@ -11,6 +16,9 @@ import com.umc.product.project.application.port.in.command.dto.SubmitProjectComm
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,19 +38,63 @@ public class ProjectCommandService implements
     private final GetMemberUseCase getMemberUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetGisuUseCase getGisuUseCase;
+    private final GetChapterUseCase getChapterUseCase;
 
     @Override
     public Long create(CreateDraftProjectCommand command) {
-        throw new UnsupportedOperationException("TODO: CreateDraftProjectUseCase.create 구현 필요");
+        // 1. 기수 존재 확인
+        getGisuUseCase.getById(command.gisuId());
+
+        // 2. 요청자의 챌린저 조회 → PLAN 파트인지 확인
+        ChallengerInfo challenger = getChallengerUseCase.getByMemberIdAndGisuId(
+            command.productOwnerMemberId(), command.gisuId()
+        );
+        if (challenger.part() != ChallengerPart.PLAN) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
+        }
+
+        // 3. 중복 프로젝트 체크
+        if (loadProjectPort.existsByOwnerAndGisu(command.productOwnerMemberId(), command.gisuId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+        }
+
+        // 4. 멤버의 학교 → 지부 조회
+        MemberInfo member = getMemberUseCase.getById(command.productOwnerMemberId());
+        ChapterInfo chapter = getChapterUseCase.byGisuAndSchool(command.gisuId(), member.schoolId());
+
+        // 5. 프로젝트 생성 및 저장
+        Project project = Project.createDraft(command.gisuId(), chapter.id(), command.productOwnerMemberId());
+        return saveProjectPort.save(project).getId();
     }
 
     @Override
     public void update(UpdateProjectCommand command) {
-        throw new UnsupportedOperationException("TODO: UpdateProjectUseCase.update 구현 필요");
+        Project project = loadProjectPort.getById(command.projectId());
+
+        validateOwner(project, command.requesterMemberId());
+
+        project.updateBasicInfo(
+            command.name(),
+            command.description(),
+            command.externalLink(),
+            command.thumbnailFileId(),
+            command.logoFileId(),
+            command.productOwnerMemberId()
+        );
     }
 
     @Override
     public void submit(SubmitProjectCommand command) {
-        throw new UnsupportedOperationException("TODO: SubmitProjectUseCase.submit 구현 필요");
+        Project project = loadProjectPort.getById(command.projectId());
+
+        validateOwner(project, command.requesterMemberId());
+
+        project.submit();
+    }
+
+    private void validateOwner(Project project, Long memberId) {
+        if (!project.getProductOwnerMemberId().equals(memberId)) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -16,6 +16,7 @@ import com.umc.product.project.application.port.in.command.dto.CreateDraftProjec
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
@@ -37,6 +38,7 @@ public class ProjectCommandService implements
 
     private final LoadProjectPort loadProjectPort;
     private final SaveProjectPort saveProjectPort;
+    private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
 
     // Cross-domain UseCases
     private final GetMemberUseCase getMemberUseCase;
@@ -85,6 +87,10 @@ public class ProjectCommandService implements
 
         if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+        }
+
+        if (!loadProjectApplicationFormPort.existsByProjectId(project.getId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
         }
 
         project.submit();

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -1,13 +1,23 @@
 package com.umc.product.project.application.service.query;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.query.GetProjectUseCase;
 import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
 import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.in.query.dto.ProjectPartQuotaInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,16 +40,91 @@ public class ProjectQueryService implements
 
     @Override
     public ProjectInfo getById(Long projectId) {
-        throw new UnsupportedOperationException("TODO: GetProjectUseCase.getById 구현 필요");
+        Project project = loadProjectPort.getById(projectId);
+        return toProjectInfo(project);
     }
 
     @Override
     public Optional<ProjectInfo> findDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
-        throw new UnsupportedOperationException("TODO: GetProjectUseCase.findDraftByOwnerAndGisu 구현 필요");
+        return loadProjectPort.findByOwnerAndGisu(productOwnerMemberId, gisuId)
+            .filter(project -> project.getStatus() == ProjectStatus.DRAFT)
+            .map(this::toProjectInfo);
     }
 
     @Override
     public Page<ProjectInfo> search(SearchProjectQuery query) {
-        throw new UnsupportedOperationException("TODO: SearchProjectUseCase.search 구현 필요");
+        return loadProjectPort.search(query)
+            .map(this::toProjectInfo);
+    }
+
+    /**
+     * Project 엔티티를 ProjectInfo로 조립합니다.
+     * coPM 목록, 파트별 TO, 파일 URL을 함께 조회합니다.
+     */
+    private ProjectInfo toProjectInfo(Project project) {
+        List<Long> coPmMemberIds = extractCoPmMemberIds(project);
+        List<ProjectPartQuotaInfo> partQuotas = buildPartQuotas(project.getId());
+        Map<String, String> fileLinks = resolveFileLinks(project);
+
+        return ProjectInfo.from(
+            project,
+            coPmMemberIds,
+            partQuotas,
+            fileLinks.get(project.getThumbnailFileId()),
+            fileLinks.get(project.getLogoFileId())
+        );
+    }
+
+    /**
+     * PLAN 파트 멤버 중 메인 PO를 제외한 보조 PM Member ID 목록을 추출합니다.
+     */
+    private List<Long> extractCoPmMemberIds(Project project) {
+        List<ProjectMember> planMembers = loadProjectMemberPort
+            .listByProjectIdAndPart(project.getId(), ChallengerPart.PLAN);
+
+        return planMembers.stream()
+            .map(ProjectMember::getMemberId)
+            .filter(memberId -> !memberId.equals(project.getProductOwnerMemberId()))
+            .toList();
+    }
+
+    /**
+     * 파트별 TO 정보를 조립합니다 (quota + 현재 활성 멤버 수).
+     */
+    private List<ProjectPartQuotaInfo> buildPartQuotas(Long projectId) {
+        List<ProjectPartQuota> quotas = loadProjectPartQuotaPort.listByProjectId(projectId);
+        if (quotas.isEmpty()) {
+            return List.of();
+        }
+
+        Map<ChallengerPart, Long> currentCounts = loadProjectMemberPort
+            .countByProjectIdGroupByPart(projectId);
+
+        return quotas.stream()
+            .map(q -> ProjectPartQuotaInfo.builder()
+                .part(q.getPart())
+                .quota(q.getQuota().intValue())
+                .currentCount(currentCounts.getOrDefault(q.getPart(), 0L).intValue())
+                .build())
+            .toList();
+    }
+
+    /**
+     * 썸네일/로고 파일 ID → CDN URL을 일괄 조회합니다.
+     */
+    private Map<String, String> resolveFileLinks(Project project) {
+        List<String> fileIds = new ArrayList<>();
+        if (project.getThumbnailFileId() != null) {
+            fileIds.add(project.getThumbnailFileId());
+        }
+        if (project.getLogoFileId() != null) {
+            fileIds.add(project.getLogoFileId());
+        }
+
+        if (fileIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return getFileUseCase.getFileLinks(fileIds);
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -53,6 +53,8 @@ public class ProjectQueryService implements
 
     @Override
     public Page<ProjectInfo> search(SearchProjectQuery query) {
+        // TODO: N+1 — 각 Project마다 toProjectInfo가 4개 쿼리 발생 (coPM, quotas, count, file).
+        //  search 경로는 batch 조회(LoadProjectMemberPort.batchListByProjectIds 등)로 전환 필요.
         return loadProjectPort.search(query)
             .map(this::toProjectInfo);
     }
@@ -70,9 +72,13 @@ public class ProjectQueryService implements
             project,
             coPmMemberIds,
             partQuotas,
-            fileLinks.get(project.getThumbnailFileId()),
-            fileLinks.get(project.getLogoFileId())
+            resolveLink(fileLinks, project.getThumbnailFileId()),
+            resolveLink(fileLinks, project.getLogoFileId())
         );
+    }
+
+    private String resolveLink(Map<String, String> fileLinks, String fileId) {
+        return fileId == null ? null : fileLinks.get(fileId);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -53,8 +53,10 @@ public class ProjectQueryService implements
 
     @Override
     public Page<ProjectInfo> search(SearchProjectQuery query) {
-        // TODO: N+1 — 각 Project마다 toProjectInfo가 4개 쿼리 발생 (coPM, quotas, count, file).
-        //  search 경로는 batch 조회(LoadProjectMemberPort.batchListByProjectIds 등)로 전환 필요.
+        // TODO: N+1 — 페이지당 (3 × size + 1) 쿼리. batch 메서드 추가 필요:
+        //  LoadProjectMemberPort.listByProjectIdsAndPart(Set<Long>, ChallengerPart)
+        //  LoadProjectMemberPort.countByProjectIdsGroupByPart(Set<Long>)
+        //  LoadProjectPartQuotaPort.listByProjectIds(Set<Long>)
         return loadProjectPort.search(query)
             .map(this::toProjectInfo);
     }

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -1,0 +1,45 @@
+package com.umc.product.project.application.service.query;
+
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectQueryService implements
+    GetProjectUseCase,
+    SearchProjectUseCase {
+
+    private final LoadProjectPort loadProjectPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+
+    // Cross-domain
+    private final GetFileUseCase getFileUseCase;
+
+    @Override
+    public ProjectInfo getById(Long projectId) {
+        throw new UnsupportedOperationException("TODO: GetProjectUseCase.getById 구현 필요");
+    }
+
+    @Override
+    public Optional<ProjectInfo> findDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
+        throw new UnsupportedOperationException("TODO: GetProjectUseCase.findDraftByOwnerAndGisu 구현 필요");
+    }
+
+    @Override
+    public Page<ProjectInfo> search(SearchProjectQuery query) {
+        throw new UnsupportedOperationException("TODO: SearchProjectUseCase.search 구현 필요");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -17,7 +17,6 @@ import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -109,11 +108,11 @@ public class ProjectQueryService implements
             .countByProjectIdGroupByPart(projectId);
 
         return quotas.stream()
-            .map(q -> ProjectPartQuotaInfo.builder()
-                .part(q.getPart())
-                .quota(q.getQuota().intValue())
-                .currentCount(currentCounts.getOrDefault(q.getPart(), 0L).intValue())
-                .build())
+            .map(q -> ProjectPartQuotaInfo.of(
+                q.getPart(),
+                q.getQuota(),
+                currentCounts.getOrDefault(q.getPart(), 0L)
+            ))
             .toList();
     }
 

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -2,6 +2,8 @@ package com.umc.product.project.domain;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -109,7 +111,12 @@ public class Project extends BaseEntity {
         Long chapterId,
         Long productOwnerMemberId
     ) {
-        throw new UnsupportedOperationException("TODO: createDraft 구현 필요");
+        return Project.builder()
+            .gisuId(gisuId)
+            .chapterId(chapterId)
+            .productOwnerMemberId(productOwnerMemberId)
+            .status(ProjectStatus.DRAFT)
+            .build();
     }
 
     /**
@@ -131,7 +138,24 @@ public class Project extends BaseEntity {
         String logoFileId,
         Long productOwnerMemberId
     ) {
-        throw new UnsupportedOperationException("TODO: updateBasicInfo 구현 필요");
+        if (name != null) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (externalLink != null) {
+            this.externalLink = externalLink;
+        }
+        if (thumbnailFileId != null) {
+            this.thumbnailFileId = thumbnailFileId;
+        }
+        if (logoFileId != null) {
+            this.logoFileId = logoFileId;
+        }
+        if (productOwnerMemberId != null) {
+            this.productOwnerMemberId = productOwnerMemberId;
+        }
     }
 
     /**
@@ -140,7 +164,9 @@ public class Project extends BaseEntity {
      * - 필수 필드(name, applicationFormId) 미입력 시 {@code PROJECT_SUBMIT_VALIDATION_FAILED}.
      */
     public void submit() {
-        throw new UnsupportedOperationException("TODO: submit 구현 필요");
+        validateStatus(ProjectStatus.DRAFT);
+        validateSubmitRequiredFields();
+        this.status = ProjectStatus.PENDING_REVIEW;
     }
 
     /**
@@ -149,14 +175,15 @@ public class Project extends BaseEntity {
      * @param applicationFormId survey 도메인의 Form ID
      */
     public void attachApplicationForm(Long applicationFormId) {
-        throw new UnsupportedOperationException("TODO: attachApplicationForm 구현 필요");
+        this.applicationFormId = applicationFormId;
     }
 
     /**
      * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다.
      */
     public void complete() {
-        throw new UnsupportedOperationException("TODO: complete 구현 필요");
+        validateStatus(ProjectStatus.IN_PROGRESS);
+        this.status = ProjectStatus.COMPLETED;
     }
 
     /**
@@ -166,7 +193,24 @@ public class Project extends BaseEntity {
      * @param decidedByMemberId 해당 사항을 결정한 운영진 Member ID
      */
     public void abort(String reason, Long decidedByMemberId) {
-        throw new UnsupportedOperationException("TODO: abort 구현 필요");
+        if (this.status == ProjectStatus.COMPLETED || this.status == ProjectStatus.ABORTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ABORT_UNAVAILABLE);
+        }
+        this.status = ProjectStatus.ABORTED;
+        this.statusChangedReason = reason;
+        this.statusChangedByMemberId = decidedByMemberId;
+    }
+
+    private void validateStatus(ProjectStatus expected) {
+        if (this.status != expected) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    private void validateSubmitRequiredFields() {
+        if (this.name == null || this.name.isBlank() || this.applicationFormId == null) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
+        }
     }
 
 }

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -153,14 +153,14 @@ public class Project extends BaseEntity {
     }
 
     /**
-     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다. (Phase 2 이후 구현)
+     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다.
      */
     public void complete() {
         throw new UnsupportedOperationException("TODO: complete 구현 필요");
     }
 
     /**
-     * 프로젝트가 중간에 와해되었을 때 사용합니다. 사유를 반드시 제공하여야 합니다. (Phase 2 이후 구현)
+     * 프로젝트가 중간에 와해되었을 때 사용합니다. 사유를 반드시 제공하여야 합니다.
      *
      * @param reason            와해 사유
      * @param decidedByMemberId 해당 사항을 결정한 운영진 Member ID

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -120,24 +120,17 @@ public class Project extends BaseEntity {
     }
 
     /**
-     * 프로젝트 기본 정보를 부분 업데이트합니다. null 필드는 무시(= 변경하지 않음).
-     * DRAFT 상태에서는 전체 필드 수정 가능하며, 공개 이후(IN_PROGRESS)의 제한 정책은 별도 확인 필요.
-     *
-     * @param name                 프로젝트명 (null이면 무시)
-     * @param description          설명 (null이면 무시)
-     * @param externalLink         외부 링크 (null이면 무시)
-     * @param thumbnailFileId      썸네일 파일 ID UUID (null이면 무시)
-     * @param logoFileId           로고 파일 ID UUID (null이면 무시)
-     * @param productOwnerMemberId 새 PO Member ID (null이면 무시, PLAN 파트여야 함)
+     * 프로젝트 기본 정보를 부분 업데이트합니다. null 필드는 변경하지 않습니다.
+     * 소유권(productOwnerMemberId)은 별도 액션({@link #transferOwnership})으로 처리합니다.
      */
     public void updateBasicInfo(
         String name,
         String description,
         String externalLink,
         String thumbnailFileId,
-        String logoFileId,
-        Long productOwnerMemberId
+        String logoFileId
     ) {
+        validateMutable();
         if (name != null) {
             this.name = name;
         }
@@ -153,8 +146,22 @@ public class Project extends BaseEntity {
         if (logoFileId != null) {
             this.logoFileId = logoFileId;
         }
-        if (productOwnerMemberId != null) {
-            this.productOwnerMemberId = productOwnerMemberId;
+    }
+
+    /**
+     * 메인 PM(소유권)을 새 멤버에게 양도합니다. 종료 상태에서는 호출 불가.
+     * <p>
+     * 새 owner가 PLAN 파트인지, 동일 기수 내 다른 프로젝트가 없는지 등의 검증은
+     * Service 레벨에서 수행합니다 (도메인은 다른 도메인 정보를 알 수 없음).
+     */
+    public void transferOwnership(Long newOwnerMemberId) {
+        validateMutable();
+        this.productOwnerMemberId = newOwnerMemberId;
+    }
+
+    private void validateMutable() {
+        if (this.status == ProjectStatus.COMPLETED || this.status == ProjectStatus.ABORTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
         }
     }
 

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -61,9 +61,6 @@ public class Project extends BaseEntity {
     private Long statusChangedByMemberId; // 프로젝트 상태를 변경한 멤버의 ID입니다. (예: ABORTED로 변경한 멤버)
     private String statusChangedReason; // 프로젝트 상태를 변경한 이유입니다. (예: ABORTED로 변경한 이유)
 
-    // 연결된 지원 폼(Survey) ID. PM이 PROJECT-106으로 지원 문항을 저장할 때 연결됩니다.
-    private Long applicationFormId;
-
     // 프로젝트 지원 폼은, 파트별로 섹션을 나누어서 가지고 있어야 합니다.
     // Design, FE, BE 각각 섹션을 나누어서 가지고 있으며, 지원자의 파트에 따라서 자동으로 해당 섹션으로 렌더링해서 제공하여야 합니다.
     // 기존에는 ElementCollection, CollectionTable을 통해서 저장했으나, FormSection마다 조회 및 작성 가능한 파트를 제한하여야 하고,
@@ -168,21 +165,15 @@ public class Project extends BaseEntity {
     /**
      * DRAFT 상태에서 PENDING_REVIEW 상태로 전이합니다. PM 제출 액션.
      * - 현재 상태가 DRAFT가 아니면 {@code PROJECT_INVALID_STATE}.
-     * - 필수 필드(name, applicationFormId) 미입력 시 {@code PROJECT_SUBMIT_VALIDATION_FAILED}.
+     * - {@code name} 미입력 시 {@code PROJECT_SUBMIT_VALIDATION_FAILED}.
+     * <p>
+     * 지원 폼({@link ProjectApplicationForm}) 연결 여부는 다른 도메인 lookup이 필요하므로
+     * Service 레이어에서 {@code submit()} 호출 전 검증합니다.
      */
     public void submit() {
         validateStatus(ProjectStatus.DRAFT);
         validateSubmitRequiredFields();
         this.status = ProjectStatus.PENDING_REVIEW;
-    }
-
-    /**
-     * Survey 도메인의 지원 폼 ID를 연결합니다. PROJECT-106에서 Service가 호출합니다.
-     *
-     * @param applicationFormId survey 도메인의 Form ID
-     */
-    public void attachApplicationForm(Long applicationFormId) {
-        this.applicationFormId = applicationFormId;
     }
 
     /**
@@ -215,7 +206,7 @@ public class Project extends BaseEntity {
     }
 
     private void validateSubmitRequiredFields() {
-        if (this.name == null || this.name.isBlank() || this.applicationFormId == null) {
+        if (this.name == null || this.name.isBlank()) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,14 +36,16 @@ public class Project extends BaseEntity {
     private ProjectStatus status;
     // ABORTED로 status를 변경하고자 하는 경우 반드시 ProjectMember 또한 변경하여야 합니다.
 
-    @Column(length = 100, nullable = false)
+    // DRAFT 단계에서는 미입력 상태가 허용되므로 nullable.
+    @Column(length = 100)
     private String name; // 프로젝트명
 
     @Column(length = 200)
     private String description; // 프로젝트 설명
 
-    private Long logoFileId; // 로고 ID
-    private Long thumbnailFileId; // 프로젝트 썸네일 이미지 파일 ID
+    // storage 도메인 file_metadata.id는 UUID(VARCHAR)라 String으로 저장합니다.
+    private String logoFileId; // 로고 파일 ID (UUID)
+    private String thumbnailFileId; // 프로젝트 썸네일 이미지 파일 ID (UUID)
 
 
     @Column(length = 300)
@@ -56,6 +59,9 @@ public class Project extends BaseEntity {
     private Long statusChangedByMemberId; // 프로젝트 상태를 변경한 멤버의 ID입니다. (예: ABORTED로 변경한 멤버)
     private String statusChangedReason; // 프로젝트 상태를 변경한 이유입니다. (예: ABORTED로 변경한 이유)
 
+    // 연결된 지원 폼(Survey) ID. PM이 PROJECT-106으로 지원 문항을 저장할 때 연결됩니다.
+    private Long applicationFormId;
+
     // 프로젝트 지원 폼은, 파트별로 섹션을 나누어서 가지고 있어야 합니다.
     // Design, FE, BE 각각 섹션을 나누어서 가지고 있으며, 지원자의 파트에 따라서 자동으로 해당 섹션으로 렌더링해서 제공하여야 합니다.
     // 기존에는 ElementCollection, CollectionTable을 통해서 저장했으나, FormSection마다 조회 및 작성 가능한 파트를 제한하여야 하고,
@@ -66,62 +72,101 @@ public class Project extends BaseEntity {
     // 추후 확장성을 고려하여 분리하는 방향으로 결정하였습니다.
     // (다음 기수부터 Web-Server 통합 가능성 고려)
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private Project(
+        Long gisuId,
+        Long chapterId,
+        ProjectStatus status,
+        String name,
+        String description,
+        String externalLink,
+        String logoFileId,
+        String thumbnailFileId,
+        Long productOwnerMemberId
+    ) {
+        this.gisuId = gisuId;
+        this.chapterId = chapterId;
+        this.status = status;
+        this.name = name;
+        this.description = description;
+        this.externalLink = externalLink;
+        this.logoFileId = logoFileId;
+        this.thumbnailFileId = thumbnailFileId;
+        this.productOwnerMemberId = productOwnerMemberId;
+    }
+
     /**
-     * 프로젝트를 생성하는 정팩메 입니다.
+     * DRAFT 상태로 프로젝트를 생성합니다. 최초 생성 시 기수/지부/PO만 확정하고,
+     * 나머지 정보(name, description 등)는 이후 updateBasicInfo로 단계별 저장합니다.
      *
      * @param gisuId               프로젝트가 속한 기수 ID
-     * @param name                 프로젝트명 (100자 이내)
-     * @param description          프로젝트 설명 (200자 이내)
-     * @param productOwnerMemberId PO Member ID
-     * @return 생성된 프로젝트를 반환합니다.
+     * @param chapterId            프로젝트가 속한 지부 ID (PO의 소속 지부에서 결정)
+     * @param productOwnerMemberId PO Member ID (PLAN 파트 챌린저여야 함)
+     * @return DRAFT 상태의 프로젝트
      */
-    public static Project create(
-        Long gisuId, String name, String description, String externalLink,
-        Long productOwnerMemberId,
-        Long statusChangedByMemberId, String statusChangedReason
+    public static Project createDraft(
+        Long gisuId,
+        Long chapterId,
+        Long productOwnerMemberId
     ) {
-        // 로그로 생성 이력 남겨주세요
-
-        return null;
+        throw new UnsupportedOperationException("TODO: createDraft 구현 필요");
     }
 
     /**
-     * 프로젝트명을 변경합니다.
+     * 프로젝트 기본 정보를 부분 업데이트합니다. null 필드는 무시(= 변경하지 않음).
+     * DRAFT 상태에서는 전체 필드 수정 가능하며, 공개 이후(IN_PROGRESS)의 제한 정책은 별도 확인 필요.
      *
-     * @param name 변경하고자 하는 이름
+     * @param name                 프로젝트명 (null이면 무시)
+     * @param description          설명 (null이면 무시)
+     * @param externalLink         외부 링크 (null이면 무시)
+     * @param thumbnailFileId      썸네일 파일 ID UUID (null이면 무시)
+     * @param logoFileId           로고 파일 ID UUID (null이면 무시)
+     * @param productOwnerMemberId 새 PO Member ID (null이면 무시, PLAN 파트여야 함)
      */
-    public void rename(String name) {
+    public void updateBasicInfo(
+        String name,
+        String description,
+        String externalLink,
+        String thumbnailFileId,
+        String logoFileId,
+        Long productOwnerMemberId
+    ) {
+        throw new UnsupportedOperationException("TODO: updateBasicInfo 구현 필요");
     }
 
     /**
-     * 프로젝트 설명을 변경합니다. null을 제공하면 삭제합니다.
+     * DRAFT 상태에서 PENDING_REVIEW 상태로 전이합니다. PM 제출 액션.
+     * - 현재 상태가 DRAFT가 아니면 {@code PROJECT_INVALID_STATE}.
+     * - 필수 필드(name, applicationFormId) 미입력 시 {@code PROJECT_SUBMIT_VALIDATION_FAILED}.
+     */
+    public void submit() {
+        throw new UnsupportedOperationException("TODO: submit 구현 필요");
+    }
+
+    /**
+     * Survey 도메인의 지원 폼 ID를 연결합니다. PROJECT-106에서 Service가 호출합니다.
      *
-     * @param description 변경하고자 하는 프로젝트 설명
+     * @param applicationFormId survey 도메인의 Form ID
      */
-    public void updateDescription(String description) {
+    public void attachApplicationForm(Long applicationFormId) {
+        throw new UnsupportedOperationException("TODO: attachApplicationForm 구현 필요");
     }
 
     /**
-     * 프로젝트 PO를 변경합니다.
-     *
-     * @param newOwnerMemberId 새로운 PO ID
-     */
-    public void changeProductOwner(Long newOwnerMemberId) {
-    }
-
-    /**
-     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다.
+     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다. (Phase 2 이후 구현)
      */
     public void complete() {
+        throw new UnsupportedOperationException("TODO: complete 구현 필요");
     }
 
     /**
-     * 프로젝트가 중간에 와해되었을 때 사용합니다. 사유를 반드시 제공하여야 합니다.
+     * 프로젝트가 중간에 와해되었을 때 사용합니다. 사유를 반드시 제공하여야 합니다. (Phase 2 이후 구현)
      *
      * @param reason            와해 사유
      * @param decidedByMemberId 해당 사항을 결정한 운영진 Member ID
      */
     public void abort(String reason, Long decidedByMemberId) {
+        throw new UnsupportedOperationException("TODO: abort 구현 필요");
     }
 
 }

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.domain;
 
 import com.umc.product.common.BaseEntity;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -60,6 +61,11 @@ public class ProjectMember extends BaseEntity {
 
     @Column(nullable = false)
     private Long memberId;
+
+    // 해당 멤버가 어느 파트로 프로젝트에 참여하는지를 나타냅니다. 보조 PM은 PLAN으로 저장됩니다.
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChallengerPart part;
 
     // 리더 여부를 나타냅니다. 추후 리더에 대해서 특정 권한을 부여하거나, 뱃지 등을 필요로 할 때 활용될 수 있습니다.
     @Column(nullable = false)

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -62,7 +62,7 @@ public class ProjectMember extends BaseEntity {
     @Column(nullable = false)
     private Long memberId;
 
-    // 해당 멤버가 어느 파트로 프로젝트에 참여하는지를 나타냅니다. 보조 PM은 PLAN으로 저장됩니다.
+    // 보조 PM은 PLAN 파트로 저장됩니다.
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ChallengerPart part;

--- a/src/main/java/com/umc/product/project/domain/enums/PartQuotaStatus.java
+++ b/src/main/java/com/umc/product/project/domain/enums/PartQuotaStatus.java
@@ -1,0 +1,12 @@
+package com.umc.product.project.domain.enums;
+
+/**
+ * 프로젝트의 파트별 TO 상태를 나타냅니다.
+ * <p>
+ * DB에 저장되지 않는 <b>실시간 계산값</b>입니다.
+ * {@code currentCount}와 {@code quota}를 비교하여 서비스 단에서 산출합니다.
+ */
+public enum PartQuotaStatus {
+    RECRUITING, // currentCount < quota — 아직 모집 중 (자리 있음)
+    COMPLETED,  // currentCount >= quota — 다 찼음 (모집 완료)
+}

--- a/src/main/java/com/umc/product/project/domain/enums/ProjectStatus.java
+++ b/src/main/java/com/umc/product/project/domain/enums/ProjectStatus.java
@@ -1,6 +1,8 @@
 package com.umc.product.project.domain.enums;
 
 public enum ProjectStatus {
+    DRAFT, // PM 작성 중 (임시저장)
+    PENDING_REVIEW, // PM 제출 완료, Admin 리뷰 + TO 입력 대기
     IN_PROGRESS, // 기수와 무관하게, 프로젝트가 계속 진행 중인 경우
     COMPLETED, // 기수 종료에 따라서 프로젝트를 정상적으로 완료한 경우
     ABORTED, // 프로젝트가 기수 종료 시까지 정상적으로 운영되지 못하고 데모데이 불참 등으로 와해된 경우

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -27,6 +27,7 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_INVALID_STATE(HttpStatus.BAD_REQUEST, "PROJECT-0009", "현재 상태에서 수행할 수 없는 작업입니다."),
     PROJECT_OWNER_NOT_PLAN_CHALLENGER(HttpStatus.BAD_REQUEST, "PROJECT-0010", "프로젝트 PO는 PLAN 파트 챌린저여야 합니다."),
     PROJECT_SUBMIT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "PROJECT-0011", "제출에 필요한 필수 정보가 누락되었습니다."),
+    PROJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PROJECT-0012", "해당 프로젝트에 대한 접근 권한이 없습니다."),
 
     ;
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -22,6 +22,12 @@ public enum ProjectErrorCode implements BaseCode {
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0006", "프로젝트에서 해당 지원용 폼을 찾을 수 없습니다."),
     APPLICATION_FORM_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0007", "요청하신 지원용 폼 섹션에 접근 권한이 없습니다."),
 
+    // Project Draft flow (PROJECT-101, 102, 107)
+    PROJECT_DUPLICATE_IN_GISU(HttpStatus.CONFLICT, "PROJECT-0008", "이미 해당 기수에 등록한 프로젝트가 있습니다."),
+    PROJECT_INVALID_STATE(HttpStatus.BAD_REQUEST, "PROJECT-0009", "현재 상태에서 수행할 수 없는 작업입니다."),
+    PROJECT_OWNER_NOT_PLAN_CHALLENGER(HttpStatus.BAD_REQUEST, "PROJECT-0010", "프로젝트 PO는 PLAN 파트 챌린저여야 합니다."),
+    PROJECT_SUBMIT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "PROJECT-0011", "제출에 필요한 필수 정보가 누락되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/storage/domain/enums/FileCategory.java
+++ b/src/main/java/com/umc/product/storage/domain/enums/FileCategory.java
@@ -51,6 +51,16 @@ public enum FileCategory {
     PORTFOLIO("private/portfolio", 200 * 1024 * 1024, new String[]{"pdf"}),
 
     /**
+     * 프로젝트 썸네일 이미지 (S-CHL-01 카드용 540x286)
+     */
+    PROJECT_THUMBNAIL("public/project-thumbnail", 10 * 1024 * 1024, new String[]{"jpg", "jpeg", "png"}),
+
+    /**
+     * 프로젝트 로고 이미지 (정사각형)
+     */
+    PROJECT_LOGO("public/project-logo", 10 * 1024 * 1024, new String[]{"jpg", "jpeg", "png", "svg"}),
+
+    /**
      * 기타
      */
     ETC("public/etc", 10 * 1024 * 1024, new String[]{});

--- a/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
+++ b/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
@@ -20,3 +20,8 @@ ALTER TABLE project
 --    enum 추가마다 migration 동반 비용 회피
 ALTER TABLE file_metadata
     DROP CONSTRAINT file_metadata_category_check;
+
+-- 5) project_member.part 컬럼 추가 — 엔티티에는 정의되어 있으나 V2026.04.13 마이그레이션에서 누락됨.
+--    Challenger.part 스냅샷(반정규화) 의도로 ProjectMember에 직접 보관한다.
+ALTER TABLE project_member
+    ADD COLUMN part VARCHAR(255) NOT NULL;

--- a/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
+++ b/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
@@ -1,0 +1,37 @@
+-- Project 도메인 Phase 1 — DRAFT 플로우 + storage 도메인 정렬을 위한 schema 보정.
+-- V2026.04.13.12.23__create_project_domain.sql 위에서 누락된 부분을 보강한다.
+
+-- 1) DRAFT 단계의 빈 name 허용
+ALTER TABLE project
+    ALTER COLUMN name DROP NOT NULL;
+
+-- 2) file_id 컬럼을 storage 도메인의 UUID 문자열과 정렬 (BIGINT → VARCHAR)
+ALTER TABLE project
+    ALTER COLUMN logo_file_id TYPE VARCHAR(36) USING logo_file_id::TEXT;
+
+ALTER TABLE project
+    ALTER COLUMN thumbnail_file_id TYPE VARCHAR(36) USING thumbnail_file_id::TEXT;
+
+-- 3) "한 PM당 한 기수 1개" 정책 (상태 무관)
+ALTER TABLE project
+    ADD CONSTRAINT uk_project_owner_gisu UNIQUE (product_owner_member_id, gisu_id);
+
+-- 4) FileCategory CHECK 확장 — PROJECT_THUMBNAIL / PROJECT_LOGO 허용
+ALTER TABLE file_metadata
+    DROP CONSTRAINT file_metadata_category_check;
+
+ALTER TABLE file_metadata
+    ADD CONSTRAINT file_metadata_category_check CHECK (
+        (category)::text = ANY (ARRAY[
+            'PROFILE_IMAGE'::character varying,
+            'POST_IMAGE'::character varying,
+            'POST_ATTACHMENT'::character varying,
+            'NOTICE_ATTACHMENT'::character varying,
+            'WORKBOOK_SUBMISSION'::character varying,
+            'SCHOOL_LOGO'::character varying,
+            'PORTFOLIO'::character varying,
+            'ETC'::character varying,
+            'PROJECT_THUMBNAIL'::character varying,
+            'PROJECT_LOGO'::character varying
+        ]::text[])
+    );

--- a/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
+++ b/src/main/resources/db/migration/V2026.04.25.11.00__alter_project_for_draft_flow.sql
@@ -16,22 +16,7 @@ ALTER TABLE project
 ALTER TABLE project
     ADD CONSTRAINT uk_project_owner_gisu UNIQUE (product_owner_member_id, gisu_id);
 
--- 4) FileCategory CHECK 확장 — PROJECT_THUMBNAIL / PROJECT_LOGO 허용
+-- 4) FileCategory CHECK 제거 — Java enum @Enumerated(EnumType.STRING)이 이미 가드,
+--    enum 추가마다 migration 동반 비용 회피
 ALTER TABLE file_metadata
     DROP CONSTRAINT file_metadata_category_check;
-
-ALTER TABLE file_metadata
-    ADD CONSTRAINT file_metadata_category_check CHECK (
-        (category)::text = ANY (ARRAY[
-            'PROFILE_IMAGE'::character varying,
-            'POST_IMAGE'::character varying,
-            'POST_ATTACHMENT'::character varying,
-            'NOTICE_ATTACHMENT'::character varying,
-            'WORKBOOK_SUBMISSION'::character varying,
-            'SCHOOL_LOGO'::character varying,
-            'PORTFOLIO'::character varying,
-            'ETC'::character varying,
-            'PROJECT_THUMBNAIL'::character varying,
-            'PROJECT_LOGO'::character varying
-        ]::text[])
-    );

--- a/src/test/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -1,0 +1,279 @@
+package com.umc.product.authorization.application.service.evaluator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.authorization.domain.SubjectAttributes.GisuChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectPermissionEvaluatorTest {
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+
+    @InjectMocks
+    ProjectPermissionEvaluator sut;
+
+    @Test
+    void supportedResourceType은_PROJECT를_반환한다() {
+        assertThat(sut.supportedResourceType()).isEqualTo(ResourceType.PROJECT);
+    }
+
+    // --- READ ---
+
+    @Test
+    void READ는_모든_인증된_사용자_허용() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    // --- WRITE ---
+
+    @Test
+    void WRITE는_PLAN_파트_챌린저_허용() {
+        SubjectAttributes subject = subjectWith(1L,
+            List.of(gisuInfo(1L, 1L, ChallengerPart.PLAN, 1L)),
+            List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.WRITE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void WRITE는_비PLAN_파트_거부() {
+        SubjectAttributes subject = subjectWith(1L,
+            List.of(gisuInfo(1L, 1L, ChallengerPart.SPRINGBOOT, 1L)),
+            List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.WRITE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void WRITE는_챌린저_정보_없으면_거부() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.WRITE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    // --- EDIT ---
+
+    @Test
+    void EDIT은_DRAFT에서_작성자만_허용() {
+        Long memberId = 10L;
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, memberId, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(memberId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void EDIT은_DRAFT에서_작성자가_아니면_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_DRAFT에서_중앙총괄이라도_작성자가_아니면_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_PENDING_REVIEW에서_작성자_허용() {
+        Long memberId = 10L;
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, memberId, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(memberId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void EDIT은_PENDING_REVIEW에서_중앙총괄_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void EDIT은_IN_PROGRESS에서_중앙총괄_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.IN_PROGRESS)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void EDIT은_COMPLETED_상태에서_거부() {
+        Long memberId = 10L;
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, memberId, ProjectStatus.COMPLETED)));
+
+        SubjectAttributes subject = subjectWith(memberId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_ABORTED_상태에서_거부() {
+        Long memberId = 10L;
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, memberId, ProjectStatus.ABORTED)));
+
+        SubjectAttributes subject = subjectWith(memberId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_프로젝트가_없으면_예외() {
+        Long projectId = 999L;
+        given(loadProjectPort.findById(projectId)).willReturn(Optional.empty());
+
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThatThrownBy(() -> sut.evaluate(subject, permission))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    // --- MANAGE ---
+
+    @Test
+    void MANAGE는_중앙총괄만_허용() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void MANAGE는_일반_사용자_거부() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    // --- DELETE ---
+
+    @Test
+    void DELETE는_중앙총괄만_허용() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void DELETE는_일반_사용자_거부() {
+        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    // --- helpers ---
+
+    private SubjectAttributes subjectWith(Long memberId,
+                                          List<GisuChallengerInfo> gisuInfos,
+                                          List<RoleAttribute> roles) {
+        return SubjectAttributes.builder()
+            .memberId(memberId)
+            .schoolId(1L)
+            .gisuChallengerInfos(gisuInfos)
+            .roleAttributes(roles)
+            .build();
+    }
+
+    private GisuChallengerInfo gisuInfo(Long gisuId, Long chapterId,
+                                        ChallengerPart part, Long challengerId) {
+        return GisuChallengerInfo.builder()
+            .gisuId(gisuId)
+            .chapterId(chapterId)
+            .part(part)
+            .challengerId(challengerId)
+            .build();
+    }
+
+    private RoleAttribute centralCoreRole() {
+        return new RoleAttribute(
+            ChallengerRoleType.CENTRAL_PRESIDENT,
+            OrganizationType.CENTRAL,
+            null, null, 1L
+        );
+    }
+
+    private Project project(Long id, Long ownerMemberId, ProjectStatus status) {
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Project project = constructor.newInstance();
+            ReflectionTestUtils.setField(project, "id", id);
+            ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "status", status);
+            ReflectionTestUtils.setField(project, "gisuId", 1L);
+            ReflectionTestUtils.setField(project, "chapterId", 1L);
+            return project;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -194,24 +194,6 @@ class ProjectPermissionEvaluatorTest {
             .isInstanceOf(ProjectDomainException.class);
     }
 
-    // --- MANAGE ---
-
-    @Test
-    void MANAGE는_중앙총괄만_허용() {
-        SubjectAttributes subject = subjectWith(1L, List.of(), List.of(centralCoreRole()));
-        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
-
-        assertThat(sut.evaluate(subject, permission)).isTrue();
-    }
-
-    @Test
-    void MANAGE는_일반_사용자_거부() {
-        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
-        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
-
-        assertThat(sut.evaluate(subject, permission)).isFalse();
-    }
-
     // --- DELETE ---
 
     @Test

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -1,0 +1,187 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.TestContainersConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class, TestContainersConfig.class})
+class ProjectQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectQueryRepository sut;
+
+    private Long gisuId;
+
+    @BeforeEach
+    void setUp() {
+        gisuId = 1L;
+
+        persistProject("프로젝트 알파", ProjectStatus.IN_PROGRESS, gisuId, 1L, 10L);
+        persistProject("프로젝트 베타", ProjectStatus.IN_PROGRESS, gisuId, 1L, 11L);
+        persistProject("프로젝트 감마", ProjectStatus.DRAFT, gisuId, 1L, 12L);
+        persistProject("프로젝트 델타", ProjectStatus.IN_PROGRESS, gisuId, 2L, 13L);
+        persistProject("다른기수 프로젝트", ProjectStatus.IN_PROGRESS, 2L, 1L, 14L);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void 기수_필터로_조회() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then — gisuId=1 + IN_PROGRESS만
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent())
+            .allMatch(p -> p.getGisuId().equals(gisuId))
+            .allMatch(p -> p.getStatus() == ProjectStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void 이름_키워드_검색() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, "알파", null, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("프로젝트 알파");
+    }
+
+    @Test
+    void 지부_필터() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, 2L, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then — chapterId=2인 프로젝트만
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("프로젝트 델타");
+    }
+
+    @Test
+    void 상태_필터_Admin용() {
+        // given — DRAFT 포함 조회
+        SearchProjectQuery query = SearchProjectQuery.forAdmin(
+            gisuId, null, null, null, null, null,
+            List.of(ProjectStatus.DRAFT), PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo(ProjectStatus.DRAFT);
+    }
+
+    @Test
+    void 조합_필터_키워드와_지부() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, "프로젝트", 1L, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then — chapterId=1 + name contains "프로젝트" + IN_PROGRESS
+        assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    void 페이지네이션() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null, null, PageRequest.of(0, 2));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    void 정렬_createdAt_DESC() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then — createdAt 내림차순
+        List<Project> content = result.getContent();
+        for (int i = 0; i < content.size() - 1; i++) {
+            assertThat(content.get(i).getCreatedAt())
+                .isAfterOrEqualTo(content.get(i + 1).getCreatedAt());
+        }
+    }
+
+    @Test
+    void 빈_결과() {
+        // given
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            999L, null, null, null, null, null, PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    // ========== Helper ==========
+
+    private void persistProject(String name, ProjectStatus status, Long gisuId, Long chapterId, Long ownerId) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "gisuId", gisuId);
+        ReflectionTestUtils.setField(project, "chapterId", chapterId);
+        ReflectionTestUtils.setField(project, "status", status);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
+        em.persist(project);
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.umc.product.project.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JpaConfig;
 import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.Project;
@@ -22,7 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({QueryDslConfig.class, TestContainersConfig.class})
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, ProjectQueryRepository.class})
 class ProjectQueryRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -1,12 +1,17 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.config.JpaConfig;
 import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.support.TestContainersConfig;
 import java.util.List;
@@ -33,15 +38,19 @@ class ProjectQueryRepositoryTest {
     ProjectQueryRepository sut;
 
     private Long gisuId;
+    private Long alphaId;
+    private Long betaId;
+    private Long gammaId;
+    private Long deltaId;
 
     @BeforeEach
     void setUp() {
         gisuId = 1L;
 
-        persistProject("프로젝트 알파", ProjectStatus.IN_PROGRESS, gisuId, 1L, 10L);
-        persistProject("프로젝트 베타", ProjectStatus.IN_PROGRESS, gisuId, 1L, 11L);
-        persistProject("프로젝트 감마", ProjectStatus.DRAFT, gisuId, 1L, 12L);
-        persistProject("프로젝트 델타", ProjectStatus.IN_PROGRESS, gisuId, 2L, 13L);
+        alphaId = persistProject("프로젝트 알파", ProjectStatus.IN_PROGRESS, gisuId, 1L, 10L).getId();
+        betaId = persistProject("프로젝트 베타", ProjectStatus.IN_PROGRESS, gisuId, 1L, 11L).getId();
+        gammaId = persistProject("프로젝트 감마", ProjectStatus.DRAFT, gisuId, 1L, 12L).getId();
+        deltaId = persistProject("프로젝트 델타", ProjectStatus.IN_PROGRESS, gisuId, 2L, 13L).getId();
         persistProject("다른기수 프로젝트", ProjectStatus.IN_PROGRESS, 2L, 1L, 14L);
 
         em.flush();
@@ -50,14 +59,11 @@ class ProjectQueryRepositoryTest {
 
     @Test
     void 기수_필터로_조회() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, null, null, null, null, null, PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then — gisuId=1 + IN_PROGRESS만
         assertThat(result.getContent()).hasSize(3);
         assertThat(result.getContent())
             .allMatch(p -> p.getGisuId().equals(gisuId))
@@ -66,70 +72,55 @@ class ProjectQueryRepositoryTest {
 
     @Test
     void 이름_키워드_검색() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, "알파", null, null, null, null, PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getName()).isEqualTo("프로젝트 알파");
     }
 
     @Test
     void 지부_필터() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, null, 2L, null, null, null, PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then — chapterId=2인 프로젝트만
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getName()).isEqualTo("프로젝트 델타");
     }
 
     @Test
     void 상태_필터_Admin용() {
-        // given — DRAFT 포함 조회
         SearchProjectQuery query = SearchProjectQuery.forAdmin(
             gisuId, null, null, null, null, null,
             List.of(ProjectStatus.DRAFT), PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getStatus()).isEqualTo(ProjectStatus.DRAFT);
     }
 
     @Test
     void 조합_필터_키워드와_지부() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, "프로젝트", 1L, null, null, null, PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then — chapterId=1 + name contains "프로젝트" + IN_PROGRESS
         assertThat(result.getContent()).hasSize(2);
     }
 
     @Test
     void 페이지네이션() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, null, null, null, null, null, PageRequest.of(0, 2));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
@@ -138,14 +129,11 @@ class ProjectQueryRepositoryTest {
 
     @Test
     void 정렬_createdAt_DESC() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, null, null, null, null, null, PageRequest.of(0, 20));
 
-        // when
         Page<Project> result = sut.search(query);
 
-        // then — createdAt 내림차순
         List<Project> content = result.getContent();
         for (int i = 0; i < content.size() - 1; i++) {
             assertThat(content.get(i).getCreatedAt())
@@ -155,21 +143,251 @@ class ProjectQueryRepositoryTest {
 
     @Test
     void 빈_결과() {
-        // given
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             999L, null, null, null, null, null, PageRequest.of(0, 20));
+
+        Page<Project> result = sut.search(query);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    // ========== parts / partQuotaStatus 상관 필터 ==========
+
+    @Test
+    void 파트_단일_선택_해당_파트_있는_프로젝트만() {
+        // given — 알파에만 WEB quota
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, List.of(ChallengerPart.WEB), null, PageRequest.of(0, 20));
 
         // when
         Page<Project> result = sut.search(query);
 
         // then
-        assertThat(result.getContent()).isEmpty();
-        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 알파");
+    }
+
+    @Test
+    void 파트_여러개_AND로_모두_포함하는_프로젝트만() {
+        // given — 알파: WEB만 / 베타: WEB+SPRINGBOOT / 델타: WEB만
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.SPRINGBOOT, 1);
+        persistQuota(deltaId, ChallengerPart.WEB, 2);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null,
+            List.of(ChallengerPart.WEB, ChallengerPart.SPRINGBOOT), null,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 베타");
+    }
+
+    @Test
+    void 파트_RECRUITING_해당_파트가_아직_정원_미달() {
+        // given — 알파 WEB 2/0 (recruiting), 베타 WEB 2/2 (full)
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.WEB, 2);
+        persistMember(betaId, ChallengerPart.WEB, 200L);
+        persistMember(betaId, ChallengerPart.WEB, 201L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null,
+            List.of(ChallengerPart.WEB), PartQuotaStatus.RECRUITING,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 알파");
+    }
+
+    @Test
+    void 파트_COMPLETED_해당_파트가_정원_달성() {
+        // given
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.WEB, 2);
+        persistMember(betaId, ChallengerPart.WEB, 200L);
+        persistMember(betaId, ChallengerPart.WEB, 201L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null,
+            List.of(ChallengerPart.WEB), PartQuotaStatus.COMPLETED,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 베타");
+    }
+
+    @Test
+    void 파트_여러개_RECRUITING_선택한_파트_모두_모집중() {
+        // given — 베타: WEB+SPRINGBOOT 둘 다 미달 / 델타: WEB만 미달, SPRINGBOOT 정원 달성
+        persistQuota(betaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.SPRINGBOOT, 1);
+        persistQuota(deltaId, ChallengerPart.WEB, 2);
+        persistQuota(deltaId, ChallengerPart.SPRINGBOOT, 1);
+        persistMember(deltaId, ChallengerPart.SPRINGBOOT, 300L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null,
+            List.of(ChallengerPart.WEB, ChallengerPart.SPRINGBOOT),
+            PartQuotaStatus.RECRUITING,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 베타");
+    }
+
+    @Test
+    void 파트_여러개_COMPLETED_선택한_파트_모두_정원_달성() {
+        // given — 베타: WEB+SPRINGBOOT 둘 다 풀 / 델타: WEB 풀, SPRINGBOOT 미달
+        persistQuota(betaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.SPRINGBOOT, 1);
+        persistMember(betaId, ChallengerPart.WEB, 200L);
+        persistMember(betaId, ChallengerPart.WEB, 201L);
+        persistMember(betaId, ChallengerPart.SPRINGBOOT, 202L);
+        persistQuota(deltaId, ChallengerPart.WEB, 2);
+        persistQuota(deltaId, ChallengerPart.SPRINGBOOT, 3);
+        persistMember(deltaId, ChallengerPart.WEB, 300L);
+        persistMember(deltaId, ChallengerPart.WEB, 301L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null,
+            List.of(ChallengerPart.WEB, ChallengerPart.SPRINGBOOT),
+            PartQuotaStatus.COMPLETED,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 베타");
+    }
+
+    @Test
+    void 파트_없이_RECRUITING_아무_파트라도_모집중이면_포함() {
+        // given — 알파: 모집중 파트 있음 / 베타: 모든 파트 풀 / 델타: 일부 풀, 일부 모집중
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.WEB, 1);
+        persistMember(betaId, ChallengerPart.WEB, 200L);
+        persistQuota(deltaId, ChallengerPart.WEB, 1);
+        persistQuota(deltaId, ChallengerPart.SPRINGBOOT, 2);
+        persistMember(deltaId, ChallengerPart.WEB, 300L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null,
+            PartQuotaStatus.RECRUITING,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactlyInAnyOrder("프로젝트 알파", "프로젝트 델타");
+    }
+
+    @Test
+    void 파트_없이_COMPLETED_모든_파트가_정원_달성이면_포함() {
+        // given — 알파: 모집중 / 베타: 모두 풀 / 델타: 일부 모집중
+        persistQuota(alphaId, ChallengerPart.WEB, 2);
+        persistQuota(betaId, ChallengerPart.WEB, 1);
+        persistMember(betaId, ChallengerPart.WEB, 200L);
+        persistQuota(deltaId, ChallengerPart.WEB, 1);
+        persistQuota(deltaId, ChallengerPart.SPRINGBOOT, 2);
+        persistMember(deltaId, ChallengerPart.WEB, 300L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null,
+            PartQuotaStatus.COMPLETED,
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 베타");
+    }
+
+    @Test
+    void COMPLETED_quota가_없는_프로젝트는_제외된다() {
+        // given — Admin 뷰로 DRAFT 포함. 감마는 DRAFT + quota row 없음 → 잘못된 COMPLETED 분류 회피
+        persistQuota(alphaId, ChallengerPart.WEB, 1);
+        persistMember(alphaId, ChallengerPart.WEB, 100L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forAdmin(
+            gisuId, null, null, null, null,
+            PartQuotaStatus.COMPLETED,
+            List.of(ProjectStatus.IN_PROGRESS, ProjectStatus.DRAFT),
+            PageRequest.of(0, 20));
+
+        // when
+        Page<Project> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("프로젝트 알파");
+    }
+
+    @Test
+    void schoolIds_필터는_아직_지원되지_않음() {
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, List.of(1L), null, null, PageRequest.of(0, 20));
+
+        assertThatThrownBy(() -> sut.search(query))
+            .isInstanceOf(UnsupportedOperationException.class);
     }
 
     // ========== Helper ==========
 
-    private void persistProject(String name, ProjectStatus status, Long gisuId, Long chapterId, Long ownerId) {
+    private Project persistProject(String name, ProjectStatus status, Long gisuId, Long chapterId, Long ownerId) {
         Project project;
         try {
             var constructor = Project.class.getDeclaredConstructor();
@@ -184,5 +402,39 @@ class ProjectQueryRepositoryTest {
         ReflectionTestUtils.setField(project, "name", name);
         ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
         em.persist(project);
+        return project;
+    }
+
+    private void persistQuota(Long projectId, ChallengerPart part, long quota) {
+        Project project = em.find(Project.class, projectId);
+        ProjectPartQuota pq;
+        try {
+            var constructor = ProjectPartQuota.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            pq = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(pq, "project", project);
+        ReflectionTestUtils.setField(pq, "part", part);
+        ReflectionTestUtils.setField(pq, "quota", quota);
+        em.persist(pq);
+    }
+
+    private void persistMember(Long projectId, ChallengerPart part, Long memberId) {
+        Project project = em.find(Project.class, projectId);
+        ProjectMember pm;
+        try {
+            var constructor = ProjectMember.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            pm = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(pm, "project", project);
+        ReflectionTestUtils.setField(pm, "memberId", memberId);
+        ReflectionTestUtils.setField(pm, "part", part);
+        ReflectionTestUtils.setField(pm, "status", ProjectMemberStatus.ACTIVE);
+        em.persist(pm);
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -19,6 +19,7 @@ import com.umc.product.project.application.port.in.command.dto.CreateDraftProjec
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
@@ -38,6 +39,7 @@ class ProjectCommandServiceTest {
 
     @Mock LoadProjectPort loadProjectPort;
     @Mock SaveProjectPort saveProjectPort;
+    @Mock LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     @Mock GetMemberUseCase getMemberUseCase;
     @Mock GetChallengerUseCase getChallengerUseCase;
     @Mock GetGisuUseCase getGisuUseCase;
@@ -180,8 +182,8 @@ class ProjectCommandServiceTest {
         void 프로젝트_제출_성공() {
             Project project = createProject(ProjectStatus.DRAFT);
             project.updateBasicInfo("프로젝트명", null, null, null, null);
-            project.attachApplicationForm(10L);
             given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectApplicationFormPort.existsByProjectId(1L)).willReturn(true);
 
             sut.submit(SubmitProjectCommand.builder()
                 .projectId(1L)
@@ -203,6 +205,22 @@ class ProjectCommandServiceTest {
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+        }
+
+        @Test
+        void 지원폼_미연결이면_SUBMIT_VALIDATION_FAILED() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            project.updateBasicInfo("프로젝트명", null, null, null, null);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectApplicationFormPort.existsByProjectId(1L)).willReturn(false);
+
+            assertThatThrownBy(() -> sut.submit(SubmitProjectCommand.builder()
+                    .projectId(1L)
+                    .requesterMemberId(100L)
+                    .build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
         }
     }
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -152,7 +152,7 @@ class ProjectCommandServiceTest {
             assertThatThrownBy(() -> sut.update(command))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
     }
 
@@ -195,7 +195,7 @@ class ProjectCommandServiceTest {
             assertThatThrownBy(() -> sut.submit(command))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
     }
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -17,10 +17,12 @@ import com.umc.product.organization.application.port.in.query.dto.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.GisuInfo;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import org.junit.jupiter.api.Nested;
@@ -48,7 +50,6 @@ class ProjectCommandServiceTest {
 
         @Test
         void 프로젝트_생성_성공() {
-            // given
             var command = CreateDraftProjectCommand.builder()
                 .gisuId(1L)
                 .productOwnerMemberId(100L)
@@ -56,7 +57,7 @@ class ProjectCommandServiceTest {
 
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
-                .willReturn(challengerInfo(ChallengerPart.PLAN));
+                .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
             given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
@@ -66,17 +67,14 @@ class ProjectCommandServiceTest {
                 return p;
             });
 
-            // when
             Long result = sut.create(command);
 
-            // then
             assertThat(result).isEqualTo(99L);
             then(saveProjectPort).should().save(any(Project.class));
         }
 
         @Test
         void PLAN_파트가_아니면_예외() {
-            // given
             var command = CreateDraftProjectCommand.builder()
                 .gisuId(1L)
                 .productOwnerMemberId(100L)
@@ -84,9 +82,8 @@ class ProjectCommandServiceTest {
 
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
-                .willReturn(challengerInfo(ChallengerPart.SPRINGBOOT));
+                .willReturn(challengerInfo(100L, ChallengerPart.SPRINGBOOT));
 
-            // when & then
             assertThatThrownBy(() -> sut.create(command))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -95,7 +92,6 @@ class ProjectCommandServiceTest {
 
         @Test
         void 중복_프로젝트면_예외() {
-            // given
             var command = CreateDraftProjectCommand.builder()
                 .gisuId(1L)
                 .productOwnerMemberId(100L)
@@ -103,10 +99,9 @@ class ProjectCommandServiceTest {
 
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
-                .willReturn(challengerInfo(ChallengerPart.PLAN));
+                .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
             given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(true);
 
-            // when & then
             assertThatThrownBy(() -> sut.create(command))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -118,41 +113,63 @@ class ProjectCommandServiceTest {
     class update {
 
         @Test
-        void 프로젝트_수정_성공() {
-            // given
-            Project project = createDraftProject(1L, 100L);
+        void DRAFT_상태_수정_성공() {
+            Project project = createProject(ProjectStatus.DRAFT);
             given(loadProjectPort.getById(1L)).willReturn(project);
 
-            var command = UpdateProjectCommand.builder()
-                .projectId(1L)
-                .requesterMemberId(100L)
-                .name("새이름")
-                .build();
+            sut.update(updateCommand("새이름"));
 
-            // when
-            sut.update(command);
-
-            // then
             assertThat(project.getName()).isEqualTo("새이름");
         }
 
         @Test
-        void 작성자가_아니면_예외() {
-            // given
-            Project project = createDraftProject(1L, 100L);
+        void PENDING_REVIEW_상태_수정_성공() {
+            Project project = createProject(ProjectStatus.PENDING_REVIEW);
             given(loadProjectPort.getById(1L)).willReturn(project);
 
-            var command = UpdateProjectCommand.builder()
-                .projectId(1L)
-                .requesterMemberId(999L)
-                .name("새이름")
-                .build();
+            sut.update(updateCommand("새이름"));
 
-            // when & then
-            assertThatThrownBy(() -> sut.update(command))
+            assertThat(project.getName()).isEqualTo("새이름");
+        }
+
+        @Test
+        void IN_PROGRESS_상태_수정_성공() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            sut.update(updateCommand("새이름"));
+
+            assertThat(project.getName()).isEqualTo("새이름");
+        }
+
+        @Test
+        void COMPLETED_상태는_수정_불가() {
+            Project project = createProject(ProjectStatus.COMPLETED);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.update(updateCommand("새이름")))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void ABORTED_상태는_수정_불가() {
+            Project project = createProject(ProjectStatus.ABORTED);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.update(updateCommand("새이름")))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        private UpdateProjectCommand updateCommand(String name) {
+            return UpdateProjectCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(100L)
+                .name(name)
+                .build();
         }
     }
 
@@ -161,56 +178,124 @@ class ProjectCommandServiceTest {
 
         @Test
         void 프로젝트_제출_성공() {
-            // given
-            Project project = createDraftProject(1L, 100L);
-            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            Project project = createProject(ProjectStatus.DRAFT);
+            project.updateBasicInfo("프로젝트명", null, null, null, null);
             project.attachApplicationForm(10L);
             given(loadProjectPort.getById(1L)).willReturn(project);
 
-            var command = SubmitProjectCommand.builder()
+            sut.submit(SubmitProjectCommand.builder()
                 .projectId(1L)
                 .requesterMemberId(100L)
-                .build();
+                .build());
 
-            // when
-            sut.submit(command);
-
-            // then
-            assertThat(project.getStatus())
-                .isEqualTo(com.umc.product.project.domain.enums.ProjectStatus.PENDING_REVIEW);
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.PENDING_REVIEW);
         }
 
         @Test
         void 작성자가_아니면_예외() {
-            // given
-            Project project = createDraftProject(1L, 100L);
+            Project project = createProject(ProjectStatus.DRAFT);
             given(loadProjectPort.getById(1L)).willReturn(project);
 
-            var command = SubmitProjectCommand.builder()
-                .projectId(1L)
-                .requesterMemberId(999L)
-                .build();
-
-            // when & then
-            assertThatThrownBy(() -> sut.submit(command))
+            assertThatThrownBy(() -> sut.submit(SubmitProjectCommand.builder()
+                    .projectId(1L)
+                    .requesterMemberId(999L)
+                    .build()))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
     }
 
+    @Nested
+    class transferOwnership {
+
+        @Test
+        void 양도_성공() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
+                .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(false);
+
+            sut.transfer(transferCommand(100L, 200L));
+
+            assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
+        }
+
+        @Test
+        void 현재_PM이_아니면_예외() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.transfer(transferCommand(999L, 200L)))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+        }
+
+        @Test
+        void 새_PM이_PLAN이_아니면_예외() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
+                .willReturn(challengerInfo(200L, ChallengerPart.WEB));
+
+            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
+        }
+
+        @Test
+        void 새_PM이_같은_기수에_이미_프로젝트_있으면_예외() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
+                .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(true);
+
+            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+        }
+
+        @Test
+        void COMPLETED_상태는_양도_불가() {
+            Project project = createProject(ProjectStatus.COMPLETED);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
+                .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(false);
+
+            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        private TransferProjectOwnershipCommand transferCommand(Long requester, Long newOwner) {
+            return TransferProjectOwnershipCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(requester)
+                .newOwnerMemberId(newOwner)
+                .build();
+        }
+    }
+
     // --- helpers ---
 
-    private Project createDraftProject(Long projectId, Long ownerMemberId) {
-        Project project = Project.createDraft(1L, 2L, ownerMemberId);
-        ReflectionTestUtils.setField(project, "id", projectId);
+    private Project createProject(ProjectStatus status) {
+        Project project = Project.createDraft(1L, 2L, 100L);
+        ReflectionTestUtils.setField(project, "id", 1L);
+        ReflectionTestUtils.setField(project, "status", status);
         return project;
     }
 
-    private ChallengerInfo challengerInfo(ChallengerPart part) {
+    private ChallengerInfo challengerInfo(Long memberId, ChallengerPart part) {
         return ChallengerInfo.builder()
             .challengerId(1L)
-            .memberId(100L)
+            .memberId(memberId)
             .gisuId(1L)
             .part(part)
             .build();

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -1,0 +1,229 @@
+package com.umc.product.project.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.ChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.GisuInfo;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectCommandServiceTest {
+
+    @Mock LoadProjectPort loadProjectPort;
+    @Mock SaveProjectPort saveProjectPort;
+    @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetChallengerUseCase getChallengerUseCase;
+    @Mock GetGisuUseCase getGisuUseCase;
+    @Mock GetChapterUseCase getChapterUseCase;
+
+    @InjectMocks ProjectCommandService sut;
+
+    @Nested
+    class create {
+
+        @Test
+        void 프로젝트_생성_성공() {
+            // given
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(ChallengerPart.PLAN));
+            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
+            given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
+            given(saveProjectPort.save(any())).willAnswer(inv -> {
+                Project p = inv.getArgument(0);
+                ReflectionTestUtils.setField(p, "id", 99L);
+                return p;
+            });
+
+            // when
+            Long result = sut.create(command);
+
+            // then
+            assertThat(result).isEqualTo(99L);
+            then(saveProjectPort).should().save(any(Project.class));
+        }
+
+        @Test
+        void PLAN_파트가_아니면_예외() {
+            // given
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(ChallengerPart.SPRINGBOOT));
+
+            // when & then
+            assertThatThrownBy(() -> sut.create(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
+        }
+
+        @Test
+        void 중복_프로젝트면_예외() {
+            // given
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(ChallengerPart.PLAN));
+            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> sut.create(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+        }
+    }
+
+    @Nested
+    class update {
+
+        @Test
+        void 프로젝트_수정_성공() {
+            // given
+            Project project = createDraftProject(1L, 100L);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            var command = UpdateProjectCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(100L)
+                .name("새이름")
+                .build();
+
+            // when
+            sut.update(command);
+
+            // then
+            assertThat(project.getName()).isEqualTo("새이름");
+        }
+
+        @Test
+        void 작성자가_아니면_예외() {
+            // given
+            Project project = createDraftProject(1L, 100L);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            var command = UpdateProjectCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(999L)
+                .name("새이름")
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> sut.update(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    @Nested
+    class submit {
+
+        @Test
+        void 프로젝트_제출_성공() {
+            // given
+            Project project = createDraftProject(1L, 100L);
+            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.attachApplicationForm(10L);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            var command = SubmitProjectCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(100L)
+                .build();
+
+            // when
+            sut.submit(command);
+
+            // then
+            assertThat(project.getStatus())
+                .isEqualTo(com.umc.product.project.domain.enums.ProjectStatus.PENDING_REVIEW);
+        }
+
+        @Test
+        void 작성자가_아니면_예외() {
+            // given
+            Project project = createDraftProject(1L, 100L);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            var command = SubmitProjectCommand.builder()
+                .projectId(1L)
+                .requesterMemberId(999L)
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> sut.submit(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    // --- helpers ---
+
+    private Project createDraftProject(Long projectId, Long ownerMemberId) {
+        Project project = Project.createDraft(1L, 2L, ownerMemberId);
+        ReflectionTestUtils.setField(project, "id", projectId);
+        return project;
+    }
+
+    private ChallengerInfo challengerInfo(ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(1L)
+            .memberId(100L)
+            .gisuId(1L)
+            .part(part)
+            .build();
+    }
+
+    private MemberInfo memberInfo(Long schoolId) {
+        return MemberInfo.builder()
+            .id(100L)
+            .schoolId(schoolId)
+            .build();
+    }
+
+    private GisuInfo gisuInfo() {
+        return new GisuInfo(1L, 9L, null, null, true);
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -1,0 +1,247 @@
+package com.umc.product.project.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectQueryServiceTest {
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
+    LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @InjectMocks
+    ProjectQueryService sut;
+
+    @Test
+    void getById_프로젝트_상세_조회_성공() {
+        // given
+        Project project = createProject(1L, ProjectStatus.IN_PROGRESS);
+        given(loadProjectPort.getById(1L)).willReturn(project);
+        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
+            .willReturn(List.of());
+        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of());
+        given(getFileUseCase.getFileLinks(List.of("thumb-1")))
+            .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
+
+        // when
+        ProjectInfo result = sut.getById(1L);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.name()).isEqualTo("테스트 프로젝트");
+        assertThat(result.thumbnailImageUrl()).isEqualTo("https://cdn.example.com/thumb-1");
+        assertThat(result.coProductOwnerMemberIds()).isEmpty();
+    }
+
+    @Test
+    void getById_존재하지_않으면_예외() {
+        // given
+        given(loadProjectPort.getById(999L))
+            .willThrow(new ProjectDomainException(
+                com.umc.product.project.domain.exception.ProjectErrorCode.PROJECT_NOT_FOUND));
+
+        // when & then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> sut.getById(999L))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    @Test
+    void getById_coPM과_partQuota_포함_조회() {
+        // given
+        Project project = createProject(1L, ProjectStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", 10L);
+
+        given(loadProjectPort.getById(1L)).willReturn(project);
+
+        var coPm = createProjectMember(20L);
+        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
+            .willReturn(List.of(coPm));
+
+        var quota = createPartQuota(1L, ChallengerPart.WEB, 3);
+        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of(quota));
+        given(loadProjectMemberPort.countByProjectIdGroupByPart(1L))
+            .willReturn(Map.of(ChallengerPart.WEB, 2L));
+        given(getFileUseCase.getFileLinks(List.of("thumb-1")))
+            .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
+
+        // when
+        ProjectInfo result = sut.getById(1L);
+
+        // then
+        assertThat(result.coProductOwnerMemberIds()).containsExactly(20L);
+        assertThat(result.partQuotas()).hasSize(1);
+        assertThat(result.partQuotas().get(0).part()).isEqualTo(ChallengerPart.WEB);
+        assertThat(result.partQuotas().get(0).quota()).isEqualTo(3);
+        assertThat(result.partQuotas().get(0).currentCount()).isEqualTo(2);
+    }
+
+    @Test
+    void findDraftByOwnerAndGisu_DRAFT_프로젝트_반환() {
+        // given
+        Project project = createProject(1L, ProjectStatus.DRAFT);
+        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
+            .willReturn(Optional.of(project));
+        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
+            .willReturn(List.of());
+        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of());
+        given(getFileUseCase.getFileLinks(List.of("thumb-1")))
+            .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
+
+        // when
+        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().status()).isEqualTo(ProjectStatus.DRAFT);
+    }
+
+    @Test
+    void findDraftByOwnerAndGisu_DRAFT가_아니면_empty() {
+        // given
+        Project project = createProject(1L, ProjectStatus.IN_PROGRESS);
+        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
+            .willReturn(Optional.of(project));
+
+        // when
+        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findDraftByOwnerAndGisu_프로젝트_없으면_empty() {
+        // given
+        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
+            .willReturn(Optional.empty());
+
+        // when
+        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void search_페이지_결과_변환() {
+        // given
+        Project project = createProject(1L, ProjectStatus.IN_PROGRESS);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            1L, null, null, null, null, null, pageable);
+
+        given(loadProjectPort.search(query))
+            .willReturn(new PageImpl<>(List.of(project), pageable, 1));
+        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
+            .willReturn(List.of());
+        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of());
+        given(getFileUseCase.getFileLinks(List.of("thumb-1")))
+            .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
+
+        // when
+        Page<ProjectInfo> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).id()).isEqualTo(1L);
+    }
+
+    @Test
+    void search_빈_결과() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            1L, null, null, null, null, null, pageable);
+
+        given(loadProjectPort.search(query))
+            .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        // when
+        Page<ProjectInfo> result = sut.search(query);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    // ========== Helper Methods ==========
+
+    private Project createProject(Long id, ProjectStatus status) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "id", id);
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", status);
+        ReflectionTestUtils.setField(project, "name", "테스트 프로젝트");
+        ReflectionTestUtils.setField(project, "description", "테스트 설명");
+        ReflectionTestUtils.setField(project, "thumbnailFileId", "thumb-1");
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", 10L);
+        return project;
+    }
+
+    private com.umc.product.project.domain.ProjectMember createProjectMember(Long memberId) {
+        com.umc.product.project.domain.ProjectMember pm;
+        try {
+            var constructor = com.umc.product.project.domain.ProjectMember.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            pm = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(pm, "memberId", memberId);
+        ReflectionTestUtils.setField(pm, "part", ChallengerPart.PLAN);
+        return pm;
+    }
+
+    private ProjectPartQuota createPartQuota(Long projectId, ChallengerPart part, int quota) {
+        ProjectPartQuota pq;
+        try {
+            var constructor = ProjectPartQuota.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            pq = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(pq, "part", part);
+        ReflectionTestUtils.setField(pq, "quota", (long) quota);
+        return pq;
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -1,0 +1,252 @@
+package com.umc.product.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProjectTest {
+
+    Project project;
+
+    @BeforeEach
+    void setUp() {
+        project = Project.createDraft(1L, 2L, 100L);
+    }
+
+    @Nested
+    class createDraft {
+
+        @Test
+        void DRAFT_상태로_생성된다() {
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.DRAFT);
+        }
+
+        @Test
+        void 기수_지부_PO가_설정된다() {
+            assertThat(project.getGisuId()).isEqualTo(1L);
+            assertThat(project.getChapterId()).isEqualTo(2L);
+            assertThat(project.getProductOwnerMemberId()).isEqualTo(100L);
+        }
+
+        @Test
+        void name과_description은_null이다() {
+            assertThat(project.getName()).isNull();
+            assertThat(project.getDescription()).isNull();
+        }
+    }
+
+    @Nested
+    class updateBasicInfo {
+
+        @Test
+        void null이_아닌_필드만_업데이트된다() {
+            // when
+            project.updateBasicInfo("프로젝트A", null, null, null, null, null);
+
+            // then
+            assertThat(project.getName()).isEqualTo("프로젝트A");
+            assertThat(project.getDescription()).isNull();
+        }
+
+        @Test
+        void 모든_필드를_업데이트할_수_있다() {
+            // when
+            project.updateBasicInfo("이름", "설명", "https://link.com", "thumb-uuid", "logo-uuid", 200L);
+
+            // then
+            assertThat(project.getName()).isEqualTo("이름");
+            assertThat(project.getDescription()).isEqualTo("설명");
+            assertThat(project.getExternalLink()).isEqualTo("https://link.com");
+            assertThat(project.getThumbnailFileId()).isEqualTo("thumb-uuid");
+            assertThat(project.getLogoFileId()).isEqualTo("logo-uuid");
+            assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
+        }
+
+        @Test
+        void 전부_null이면_아무것도_변경되지_않는다() {
+            // given
+            project.updateBasicInfo("원래이름", null, null, null, null, null);
+
+            // when
+            project.updateBasicInfo(null, null, null, null, null, null);
+
+            // then
+            assertThat(project.getName()).isEqualTo("원래이름");
+        }
+    }
+
+    @Nested
+    class submit {
+
+        @Test
+        void DRAFT에서_PENDING_REVIEW로_전이된다() {
+            // given
+            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.attachApplicationForm(10L);
+
+            // when
+            project.submit();
+
+            // then
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.PENDING_REVIEW);
+        }
+
+        @Test
+        void DRAFT가_아니면_PROJECT_INVALID_STATE() {
+            // given
+            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.attachApplicationForm(10L);
+            project.submit();
+
+            // when & then
+            assertThatThrownBy(() -> project.submit())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void name이_null이면_SUBMIT_VALIDATION_FAILED() {
+            // given
+            project.attachApplicationForm(10L);
+
+            // when & then
+            assertThatThrownBy(() -> project.submit())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
+        }
+
+        @Test
+        void name이_빈문자열이면_SUBMIT_VALIDATION_FAILED() {
+            // given
+            project.updateBasicInfo("  ", null, null, null, null, null);
+            project.attachApplicationForm(10L);
+
+            // when & then
+            assertThatThrownBy(() -> project.submit())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
+        }
+
+        @Test
+        void applicationFormId가_null이면_SUBMIT_VALIDATION_FAILED() {
+            // given
+            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+
+            // when & then
+            assertThatThrownBy(() -> project.submit())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
+        }
+    }
+
+    @Nested
+    class attachApplicationForm {
+
+        @Test
+        void applicationFormId가_설정된다() {
+            // when
+            project.attachApplicationForm(42L);
+
+            // then
+            assertThat(project.getApplicationFormId()).isEqualTo(42L);
+        }
+    }
+
+    @Nested
+    class complete {
+
+        @Test
+        void IN_PROGRESS에서_COMPLETED로_전이된다() {
+            // given
+            setStatus(project, ProjectStatus.IN_PROGRESS);
+
+            // when
+            project.complete();
+
+            // then
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
+        }
+
+        @Test
+        void IN_PROGRESS가_아니면_PROJECT_INVALID_STATE() {
+            // when & then (DRAFT 상태)
+            assertThatThrownBy(() -> project.complete())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    @Nested
+    class abort {
+
+        @Test
+        void DRAFT에서_ABORTED로_전이된다() {
+            // when
+            project.abort("사유", 999L);
+
+            // then
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.ABORTED);
+            assertThat(project.getStatusChangedReason()).isEqualTo("사유");
+            assertThat(project.getStatusChangedByMemberId()).isEqualTo(999L);
+        }
+
+        @Test
+        void PENDING_REVIEW에서_ABORTED로_전이된다() {
+            // given
+            project.updateBasicInfo("이름", null, null, null, null, null);
+            project.attachApplicationForm(10L);
+            project.submit();
+
+            // when
+            project.abort("사유", 999L);
+
+            // then
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.ABORTED);
+        }
+
+        @Test
+        void COMPLETED_상태에서는_abort_불가() {
+            // given
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            // when & then
+            assertThatThrownBy(() -> project.abort("사유", 999L))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_ABORT_UNAVAILABLE);
+        }
+
+        @Test
+        void ABORTED_상태에서는_abort_불가() {
+            // given
+            project.abort("첫번째 사유", 999L);
+
+            // when & then
+            assertThatThrownBy(() -> project.abort("두번째 사유", 888L))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_ABORT_UNAVAILABLE);
+        }
+    }
+
+    private void setStatus(Project project, ProjectStatus status) {
+        try {
+            var field = Project.class.getDeclaredField("status");
+            field.setAccessible(true);
+            field.set(project, status);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -130,7 +130,6 @@ class ProjectTest {
         @Test
         void DRAFT에서_PENDING_REVIEW로_전이된다() {
             project.updateBasicInfo("프로젝트명", null, null, null, null);
-            project.attachApplicationForm(10L);
 
             project.submit();
 
@@ -140,7 +139,6 @@ class ProjectTest {
         @Test
         void DRAFT가_아니면_PROJECT_INVALID_STATE() {
             project.updateBasicInfo("프로젝트명", null, null, null, null);
-            project.attachApplicationForm(10L);
             project.submit();
 
             assertThatThrownBy(() -> project.submit())
@@ -151,8 +149,6 @@ class ProjectTest {
 
         @Test
         void name이_null이면_SUBMIT_VALIDATION_FAILED() {
-            project.attachApplicationForm(10L);
-
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -162,33 +158,11 @@ class ProjectTest {
         @Test
         void name이_빈문자열이면_SUBMIT_VALIDATION_FAILED() {
             project.updateBasicInfo("  ", null, null, null, null);
-            project.attachApplicationForm(10L);
 
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
-        }
-
-        @Test
-        void applicationFormId가_null이면_SUBMIT_VALIDATION_FAILED() {
-            project.updateBasicInfo("프로젝트명", null, null, null, null);
-
-            assertThatThrownBy(() -> project.submit())
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
-        }
-    }
-
-    @Nested
-    class attachApplicationForm {
-
-        @Test
-        void applicationFormId가_설정된다() {
-            project.attachApplicationForm(42L);
-
-            assertThat(project.getApplicationFormId()).isEqualTo(42L);
         }
     }
 
@@ -228,7 +202,6 @@ class ProjectTest {
         @Test
         void PENDING_REVIEW에서_ABORTED로_전이된다() {
             project.updateBasicInfo("이름", null, null, null, null);
-            project.attachApplicationForm(10L);
             project.submit();
 
             project.abort("사유", 999L);

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -46,38 +46,81 @@ class ProjectTest {
 
         @Test
         void null이_아닌_필드만_업데이트된다() {
-            // when
-            project.updateBasicInfo("프로젝트A", null, null, null, null, null);
+            project.updateBasicInfo("프로젝트A", null, null, null, null);
 
-            // then
             assertThat(project.getName()).isEqualTo("프로젝트A");
             assertThat(project.getDescription()).isNull();
         }
 
         @Test
-        void 모든_필드를_업데이트할_수_있다() {
-            // when
-            project.updateBasicInfo("이름", "설명", "https://link.com", "thumb-uuid", "logo-uuid", 200L);
+        void 모든_기본정보_필드를_업데이트할_수_있다() {
+            project.updateBasicInfo("이름", "설명", "https://link.com", "thumb-uuid", "logo-uuid");
 
-            // then
             assertThat(project.getName()).isEqualTo("이름");
             assertThat(project.getDescription()).isEqualTo("설명");
             assertThat(project.getExternalLink()).isEqualTo("https://link.com");
             assertThat(project.getThumbnailFileId()).isEqualTo("thumb-uuid");
             assertThat(project.getLogoFileId()).isEqualTo("logo-uuid");
-            assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
         }
 
         @Test
         void 전부_null이면_아무것도_변경되지_않는다() {
-            // given
-            project.updateBasicInfo("원래이름", null, null, null, null, null);
+            project.updateBasicInfo("원래이름", null, null, null, null);
 
-            // when
-            project.updateBasicInfo(null, null, null, null, null, null);
+            project.updateBasicInfo(null, null, null, null, null);
 
-            // then
             assertThat(project.getName()).isEqualTo("원래이름");
+        }
+
+        @Test
+        void COMPLETED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            assertThatThrownBy(() -> project.updateBasicInfo("새이름", null, null, null, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void ABORTED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.ABORTED);
+
+            assertThatThrownBy(() -> project.updateBasicInfo("새이름", null, null, null, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    @Nested
+    class transferOwnership {
+
+        @Test
+        void 새_PM에게_양도된다() {
+            project.transferOwnership(200L);
+
+            assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
+        }
+
+        @Test
+        void COMPLETED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            assertThatThrownBy(() -> project.transferOwnership(200L))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void ABORTED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.ABORTED);
+
+            assertThatThrownBy(() -> project.transferOwnership(200L))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
         }
     }
 
@@ -86,25 +129,20 @@ class ProjectTest {
 
         @Test
         void DRAFT에서_PENDING_REVIEW로_전이된다() {
-            // given
-            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.updateBasicInfo("프로젝트명", null, null, null, null);
             project.attachApplicationForm(10L);
 
-            // when
             project.submit();
 
-            // then
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.PENDING_REVIEW);
         }
 
         @Test
         void DRAFT가_아니면_PROJECT_INVALID_STATE() {
-            // given
-            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.updateBasicInfo("프로젝트명", null, null, null, null);
             project.attachApplicationForm(10L);
             project.submit();
 
-            // when & then
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -113,10 +151,8 @@ class ProjectTest {
 
         @Test
         void name이_null이면_SUBMIT_VALIDATION_FAILED() {
-            // given
             project.attachApplicationForm(10L);
 
-            // when & then
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -125,11 +161,9 @@ class ProjectTest {
 
         @Test
         void name이_빈문자열이면_SUBMIT_VALIDATION_FAILED() {
-            // given
-            project.updateBasicInfo("  ", null, null, null, null, null);
+            project.updateBasicInfo("  ", null, null, null, null);
             project.attachApplicationForm(10L);
 
-            // when & then
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -138,10 +172,8 @@ class ProjectTest {
 
         @Test
         void applicationFormId가_null이면_SUBMIT_VALIDATION_FAILED() {
-            // given
-            project.updateBasicInfo("프로젝트명", null, null, null, null, null);
+            project.updateBasicInfo("프로젝트명", null, null, null, null);
 
-            // when & then
             assertThatThrownBy(() -> project.submit())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -154,10 +186,8 @@ class ProjectTest {
 
         @Test
         void applicationFormId가_설정된다() {
-            // when
             project.attachApplicationForm(42L);
 
-            // then
             assertThat(project.getApplicationFormId()).isEqualTo(42L);
         }
     }
@@ -167,19 +197,15 @@ class ProjectTest {
 
         @Test
         void IN_PROGRESS에서_COMPLETED로_전이된다() {
-            // given
             setStatus(project, ProjectStatus.IN_PROGRESS);
 
-            // when
             project.complete();
 
-            // then
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
         }
 
         @Test
         void IN_PROGRESS가_아니면_PROJECT_INVALID_STATE() {
-            // when & then (DRAFT 상태)
             assertThatThrownBy(() -> project.complete())
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -192,10 +218,8 @@ class ProjectTest {
 
         @Test
         void DRAFT에서_ABORTED로_전이된다() {
-            // when
             project.abort("사유", 999L);
 
-            // then
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.ABORTED);
             assertThat(project.getStatusChangedReason()).isEqualTo("사유");
             assertThat(project.getStatusChangedByMemberId()).isEqualTo(999L);
@@ -203,24 +227,19 @@ class ProjectTest {
 
         @Test
         void PENDING_REVIEW에서_ABORTED로_전이된다() {
-            // given
-            project.updateBasicInfo("이름", null, null, null, null, null);
+            project.updateBasicInfo("이름", null, null, null, null);
             project.attachApplicationForm(10L);
             project.submit();
 
-            // when
             project.abort("사유", 999L);
 
-            // then
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.ABORTED);
         }
 
         @Test
         void COMPLETED_상태에서는_abort_불가() {
-            // given
             setStatus(project, ProjectStatus.COMPLETED);
 
-            // when & then
             assertThatThrownBy(() -> project.abort("사유", 999L))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -229,10 +248,8 @@ class ProjectTest {
 
         @Test
         void ABORTED_상태에서는_abort_불가() {
-            // given
             project.abort("첫번째 사유", 999L);
 
-            // when & then
             assertThatThrownBy(() -> project.abort("두번째 사유", 888L))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치 확인 (`develop`)
- [x] PR 제목 컨벤션 확인

## 🔥 연관 이슈

related to #747 — Project 기본 CRUD 이슈의 1차 범위. 후속 PR 머지 후 close 예정.
기본 CRUD가 아니라 복잡한 CRUD flow가 프로젝트의 전부인 것 같아서 이슈 내용은 수정할 예정이에요.
전체적은 흐름을 구현하는 이슈라고 우선 봐주시면 좋을 것 같습니다.

## 🚀 작업 내용

### 포함된 API

| ID | Method | Path | 설명 |
|---|---|---|---|
| PROJECT-001 | GET | `/api/v1/projects` | 목록 조회 |
| PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 상세 조회 |
| PROJECT-101 | POST | `/api/v1/projects` | Draft 생성 |
| PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 기본정보 수정 |
| PROJECT-103 | GET | `/api/v1/projects/me/draft?gisuId=` | 내 Draft 조회 |
| PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 소유권 양도 |
| PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 제출 (DRAFT → PENDING_REVIEW) |

### 주요 결정

- PATCH는 DRAFT/PENDING_REVIEW/IN_PROGRESS 허용, 종료상태 차단. 권한은 `@CheckAccess` 위임.
- 소유권 양도는 별도 엔드포인트로 분리 (PATCH 본문에서 `productOwnerMemberId` 제거).
- `schoolIds` 필터는 `UnsupportedOperationException` (member 도메인 batch 조회 대기).

### 스키마 (`V2026.04.25.11.00__alter_project_for_draft_flow.sql`)

PR #741 마이그레이션은 건드리지 않고 신규 ALTER 마이그레이션으로 처리.

- `project.name` nullable
- `logo_file_id` / `thumbnail_file_id` BIGINT → VARCHAR(36)
- `UNIQUE(product_owner_member_id, gisu_id)` 추가
- `file_metadata_category_check`에 `PROJECT_THUMBNAIL`, `PROJECT_LOGO` 허용

## 리뷰 중점사항

큰 PR이라 commit 그룹 단위로 봐주세요.

1. **도메인 + 권한** — `Project` 상태 전이 메서드, `ProjectPermissionEvaluator` 매트릭스
2. **조회** — 파트 × 모집상태 상관 필터(선택 파트 모두 모집중 vs 한 파트라도 모집중), COMPLETED 분류 시 quota row 0개 제외
3. **Command + Controller** — 양도 분리, PATCH 상태별 정책
4. **마이그레이션** — 타입 변경 안전성, FileCategory CHECK 재생성

## 후속 PR 계획

- **PR2** PROJECT-003 팀원 조회
- **PR3** auth 하드코딩 풀기 + N+1 batch + `schoolIds` 필터
- **PR4** PROJECT-105/108 Admin 흐름 + 팀원 관리
- **PR5** (별도 이슈) PROJECT-106 지원 문항 (Survey 도메인 선행 필요)
