### PR TITLE
[HotFix] CI에 필요한 권한을 CD에서 제공하지 않아 Nested Call이 불가능한 오류 수정

### DIFF
--- a/.github/workflows/cd-ecr.yml
+++ b/.github/workflows/cd-ecr.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
+      issues: write
       packages: write
       statuses: write
       deployments: write


### PR DESCRIPTION
`issue: write` 양측에 모두 부여