### PR TITLE
[Fix] 기존 Form Entity의 title을 NOT NULL로 변경함에 따라 기본값 설정

### DIFF
--- a/src/main/java/com/umc/product/survey/domain/Form.java
+++ b/src/main/java/com/umc/product/survey/domain/Form.java
@@ -4,8 +4,19 @@ import com.umc.product.common.BaseEntity;
 import com.umc.product.survey.domain.enums.FormStatus;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
@@ -35,8 +46,13 @@ public class Form extends BaseEntity {
     @Column(name = "is_anonymous", nullable = false)
     private boolean isAnonymous;
 
-    public static Form createDraft(Long createdMemberId) {
+    /**
+     * Draft 생성을 위해서는 제목은 필수로 입력하여야 합니다.
+     */
+    public static Form createDraft(String title, Long createdMemberId) {
         Form form = new Form();
+
+        form.title = title;
         form.createdMemberId = createdMemberId;
         form.status = FormStatus.DRAFT;
 

--- a/src/main/resources/db/migration/V2026.04.13.01.41__form_form_section_question_question_option_edit.sql
+++ b/src/main/resources/db/migration/V2026.04.13.01.41__form_form_section_question_question_option_edit.sql
@@ -8,6 +8,11 @@
 
 -- question_option 테이블에서 orderNo를 int -> bigint
 
+UPDATE form
+SET title      = 'Untitled Form',
+    updated_at = now()
+WHERE title IS NULL;
+
 ALTER TABLE form
     ALTER COLUMN title SET NOT NULL;
 

--- a/src/main/resources/db/migration/V2026.04.27.23.37__update_null_form_title_to_default.sql
+++ b/src/main/resources/db/migration/V2026.04.27.23.37__update_null_form_title_to_default.sql
@@ -1,9 +1,0 @@
--- form.title 의 NULL 데이터에 기본값 주입
---
--- V2026.04.13.01.41 에서 form.title 에 NOT NULL 제약이 추가됐지만,
--- dev 환경에 NULL 행이 존재하여 운영 정합성 회복을 위해 정리합니다.
-
-UPDATE form
-SET title = '폼 제목',
-    updated_at = now()
-WHERE title IS NULL;

--- a/src/main/resources/db/migration/V2026.04.27.23.37__update_null_form_title_to_default.sql
+++ b/src/main/resources/db/migration/V2026.04.27.23.37__update_null_form_title_to_default.sql
@@ -1,0 +1,9 @@
+-- form.title 의 NULL 데이터에 기본값 주입
+--
+-- V2026.04.13.01.41 에서 form.title 에 NOT NULL 제약이 추가됐지만,
+-- dev 환경에 NULL 행이 존재하여 운영 정합성 회복을 위해 정리합니다.
+
+UPDATE form
+SET title = '폼 제목',
+    updated_at = now()
+WHERE title IS NULL;


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #771 

## 🚀 작업 내용

dev 환경 점검 중 `form` 테이블에 `title`이 `NULL`인 행이 존재하여, Flyway 마이그레이션 1개로 기본값을 주입합니다.

  `V2026.04.13.01.41` 에서 `form.title` 에 `NOT NULL` 제약이 추가됐지만 그 이전에 `NULL`로 들어간 행이 정리되지 않은 상태였습니다. 본 마이그레이션으로 NULL 행에 `'폼 제목'`을 채우고 `updated_at` 도 갱신합니다.

## 💬 리뷰 중점사항

- 기본값 텍스트 ('폼 제목') 가 적절한지 확인 부탁드립니다.
