### PR TITLE
[Feat] Project 지원 폼 저장/조회 API 및 Survey 도메인 연동

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/config/SurveyBootstrapConfig.java
+++ b/src/main/java/com/umc/product/project/adapter/config/SurveyBootstrapConfig.java
@@ -1,0 +1,177 @@
+package com.umc.product.project.adapter.config;
+
+import com.umc.product.survey.application.port.in.command.ManageFormSectionUseCase;
+import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionOptionUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.PublishFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionOptionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Survey 도메인 5종 UseCase 의 임시 stub 빈 등록.
+ * <p>
+ * 본 PR2 는 Survey 인터페이스에만 의존하지만, Survey 구현체가 develop 에 머지되기 전엔
+ * Spring 컨텍스트가 빈을 못 찾아 부팅이 실패한다. Survey 구현 PR 이 머지될 때까지
+ * 부팅만 가능하도록 임시로 빈을 등록한다.
+ * <p>
+ * {@link ConditionalOnMissingBean} 덕분에 Survey 구현체가 등록되면 자동으로 진짜 빈이 우선되고
+ * 본 stub 은 무시된다. Survey 구현 PR 머지 후 본 클래스 전체를 삭제하면 된다.
+ *
+ * <h2>호출 시 동작</h2>
+ * stub 메서드를 실제로 호출하면 {@link UnsupportedOperationException} 을 던져 즉시 실패한다.
+ * PROJECT-106 / 106-GET 엔드포인트는 호출 시 모두 Survey 메서드를 거치므로 동작 안 함 —
+ * 부팅만 가능한 상태일 뿐이다.
+ */
+// TODO: Survey 구현 PR (ManageFormService / ManageFormSectionService 등) 머지되면 본 클래스 삭제
+@Configuration
+public class SurveyBootstrapConfig {
+
+    private static final String NOT_IMPLEMENTED_MSG =
+        "Survey 도메인 구현 미머지 상태입니다. 실제 호출 전에 Survey 구현 PR 을 먼저 머지해주세요.";
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ManageFormUseCase manageFormUseCaseStub() {
+        return new ManageFormUseCase() {
+            @Override
+            public Long createDraft(CreateDraftFormCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void updateForm(UpdateFormCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void publishForm(PublishFormCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void deleteForm(DeleteFormCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ManageFormSectionUseCase manageFormSectionUseCaseStub() {
+        return new ManageFormSectionUseCase() {
+            @Override
+            public Long createSection(CreateFormSectionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void updateSection(UpdateFormSectionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void deleteSection(DeleteFormSectionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void reorderSections(ReorderFormSectionsCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ManageQuestionUseCase manageQuestionUseCaseStub() {
+        return new ManageQuestionUseCase() {
+            @Override
+            public Long createQuestion(CreateQuestionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void updateQuestion(UpdateQuestionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void deleteQuestion(DeleteQuestionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void reorderQuestions(ReorderQuestionsCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ManageQuestionOptionUseCase manageQuestionOptionUseCaseStub() {
+        return new ManageQuestionOptionUseCase() {
+            @Override
+            public Long createOption(CreateQuestionOptionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void updateOption(UpdateQuestionOptionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void deleteOption(DeleteQuestionOptionCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public void reorderOptions(ReorderQuestionOptionsCommand command) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GetFormUseCase getFormUseCaseStub() {
+        return new GetFormUseCase() {
+            @Override
+            public Optional<FormInfo> findById(Long formId) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public FormInfo getById(Long formId) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+
+            @Override
+            public FormWithStructureInfo getFormWithStructure(Long formId) {
+                throw new UnsupportedOperationException(NOT_IMPLEMENTED_MSG);
+            }
+        };
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java
@@ -1,0 +1,75 @@
+package com.umc.product.project.adapter.in.web;
+
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.dto.request.UpsertApplicationFormRequest;
+import com.umc.product.project.adapter.in.web.dto.response.GetApplicationFormResponse;
+import com.umc.product.project.adapter.in.web.dto.response.UpsertApplicationFormResponse;
+import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+@Tag(name = "Project | 프로젝트 지원 폼", description = "프로젝트 지원 폼 저장 / 조회 (PROJECT-106)")
+public class ProjectApplicationFormController {
+
+    private final UpsertProjectApplicationFormUseCase upsertProjectApplicationFormUseCase;
+    private final GetProjectApplicationFormUseCase getProjectApplicationFormUseCase;
+
+    @PutMapping("/{projectId}/application-form")
+    @Operation(
+        summary = "[PROJECT-106] 지원 폼 저장",
+        description = "본문이 곧 폼의 새 상태가 된다 (PUT 시멘틱). 폼이 없으면 생성하고, 있으면 섹션/질문/옵션을 본문 구조와 일치하도록 동기화한다. DRAFT/PENDING_REVIEW 상태에서만 호출 가능."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.EDIT,
+        message = "지원 폼 저장 권한이 없습니다."
+    )
+    public UpsertApplicationFormResponse upsert(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @Valid @RequestBody UpsertApplicationFormRequest request
+    ) {
+        ApplicationFormInfo info = upsertProjectApplicationFormUseCase.upsert(
+            request.toCommand(projectId, memberPrincipal.getMemberId()));
+        return UpsertApplicationFormResponse.from(info);
+    }
+
+    // TODO: 챌린저 호출 시 본인 파트 + COMMON 섹션 마스킹 적용 (response.forApplicant(applicantPart))
+    @GetMapping("/{projectId}/application-form")
+    @Operation(
+        summary = "[PROJECT-106-GET] 지원 폼 조회",
+        description = "프로젝트의 지원 폼 전체 구조를 조회한다. 폼이 없으면 ApiResponse.result = null."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.READ,
+        message = "지원 폼 조회 권한이 없습니다."
+    )
+    public GetApplicationFormResponse get(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        return getProjectApplicationFormUseCase.findByProjectId(projectId)
+            .map(GetApplicationFormResponse::from)
+            .orElse(null);
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -3,7 +3,6 @@ package com.umc.product.project.adapter.in.web.assembler;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
-import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionItem;
 import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
 import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
@@ -69,7 +68,8 @@ public class ProjectResponseAssembler {
             .map(id -> toBrief(memberMap.get(id)))
             .toList();
 
-        ProjectDetailResponse response = ProjectDetailResponse.from(info, owner, coOwners);
+        // TODO: applicationFormId hydrate from LoadProjectApplicationFormPort.findByProjectId
+        ProjectDetailResponse response = ProjectDetailResponse.from(info, owner, coOwners, null);
         return canSeeFullInfo ? response : response.toPublic();
     }
 
@@ -90,10 +90,8 @@ public class ProjectResponseAssembler {
             .map(id -> toBrief(memberMap.get(id)))
             .toList();
 
-        // TODO: 지원 문항(questions)은 Survey 도메인 GetFormDefinitionUseCase 연동 필요
-        List<ApplicationQuestionItem> questions = List.of();
-
-        return DraftProjectResponse.from(info, owner, coOwners, questions);
+        // TODO: applicationFormId hydrate from LoadProjectApplicationFormPort.findByProjectId
+        return DraftProjectResponse.from(info, owner, coOwners, null);
     }
 
     private Map<Long, MemberInfo> loadMembers(ProjectInfo info) {

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -11,6 +11,8 @@ import com.umc.product.project.application.port.in.query.GetProjectUseCase;
 import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
 import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.domain.ProjectApplicationForm;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,7 @@ public class ProjectResponseAssembler {
     private final GetProjectUseCase getProjectUseCase;
     private final SearchProjectUseCase searchProjectUseCase;
     private final GetMemberUseCase getMemberUseCase;
+    private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
 
     /**
      * PROJECT-001 프로젝트 목록 조회.
@@ -68,8 +71,8 @@ public class ProjectResponseAssembler {
             .map(id -> toBrief(memberMap.get(id)))
             .toList();
 
-        // TODO: applicationFormId hydrate from LoadProjectApplicationFormPort.findByProjectId
-        ProjectDetailResponse response = ProjectDetailResponse.from(info, owner, coOwners, null);
+        ProjectDetailResponse response =
+            ProjectDetailResponse.from(info, owner, coOwners, resolveApplicationFormId(projectId));
         return canSeeFullInfo ? response : response.toPublic();
     }
 
@@ -90,8 +93,13 @@ public class ProjectResponseAssembler {
             .map(id -> toBrief(memberMap.get(id)))
             .toList();
 
-        // TODO: applicationFormId hydrate from LoadProjectApplicationFormPort.findByProjectId
-        return DraftProjectResponse.from(info, owner, coOwners, null);
+        return DraftProjectResponse.from(info, owner, coOwners, resolveApplicationFormId(info.id()));
+    }
+
+    private Long resolveApplicationFormId(Long projectId) {
+        return loadProjectApplicationFormPort.findByProjectId(projectId)
+            .map(ProjectApplicationForm::getId)
+            .orElse(null);
     }
 
     private Map<Long, MemberInfo> loadMembers(ProjectInfo info) {

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationFormSection.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationFormSection.java
@@ -1,0 +1,66 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationFormSectionEntry;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.domain.enums.FormSectionType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+import java.util.Set;
+import lombok.Builder;
+
+/**
+ * 지원 폼 섹션. {@code sectionId} 가 null 이면 신규 추가, 있으면 기존 수정/이동.
+ * <p>
+ * {@link FormSectionType#COMMON} 은 모든 파트에게 노출되며 {@code allowedParts} 가 무시된다.
+ * {@link FormSectionType#PART} 는 {@code allowedParts} 가 1개 이상이어야 한다 (Service 레벨에서 검증).
+ */
+@Builder
+public record ApplicationFormSection(
+    Long sectionId,
+
+    @NotNull(message = "섹션 타입은 필수입니다")
+    FormSectionType type,
+
+    Set<ChallengerPart> allowedParts,
+
+    @NotBlank(message = "섹션 제목은 필수입니다")
+    String title,
+
+    String description,
+
+    @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
+    int orderNo,
+
+    @NotNull(message = "질문 리스트는 null 일 수 없습니다 (빈 리스트는 허용)")
+    @Valid
+    List<ApplicationQuestionItem> questions
+) {
+
+    public ApplicationFormSectionEntry toEntry() {
+        return ApplicationFormSectionEntry.builder()
+            .sectionId(sectionId)
+            .type(type)
+            .allowedParts(allowedParts == null ? Set.of() : allowedParts)
+            .title(title)
+            .description(description)
+            .orderNo(orderNo)
+            .questions(questions.stream().map(ApplicationQuestionItem::toEntry).toList())
+            .build();
+    }
+
+    public static ApplicationFormSection from(ApplicationFormInfo.SectionInfo info) {
+        return ApplicationFormSection.builder()
+            .sectionId(info.sectionId())
+            .type(info.type())
+            .allowedParts(info.allowedParts())
+            .title(info.title())
+            .description(info.description())
+            .orderNo((int) info.orderNo())
+            .questions(info.questions().stream().map(ApplicationQuestionItem::from).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationFormSection.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationFormSection.java
@@ -33,7 +33,7 @@ public record ApplicationFormSection(
     String description,
 
     @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
-    int orderNo,
+    long orderNo,
 
     @NotNull(message = "질문 리스트는 null 일 수 없습니다 (빈 리스트는 허용)")
     @Valid
@@ -59,7 +59,7 @@ public record ApplicationFormSection(
             .allowedParts(info.allowedParts())
             .title(info.title())
             .description(info.description())
-            .orderNo((int) info.orderNo())
+            .orderNo(info.orderNo())
             .questions(info.questions().stream().map(ApplicationQuestionItem::from).toList())
             .build();
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
@@ -31,7 +31,7 @@ public record ApplicationQuestionItem(
     boolean isRequired,
 
     @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
-    int orderNo,
+    long orderNo,
 
     @NotNull(message = "옵션 리스트는 null 일 수 없습니다 (빈 리스트는 허용)")
     @Valid
@@ -57,7 +57,7 @@ public record ApplicationQuestionItem(
             .title(info.title())
             .description(info.description())
             .isRequired(info.isRequired())
-            .orderNo((int) info.orderNo())
+            .orderNo(info.orderNo())
             .options(info.options().stream().map(ApplicationQuestionOptionItem::from).toList())
             .build();
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionItem.java
@@ -1,17 +1,64 @@
 package com.umc.product.project.adapter.in.web.dto.common;
 
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionEntry;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.survey.domain.enums.QuestionType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.Builder;
 
 /**
- * 지원 문항 한 개. DraftProjectResponse와 UpsertApplicationFormRequest 양쪽에서 재사용됩니다.
+ * 지원 문항 한 개. {@code questionId} 가 null 이면 신규 추가, 있으면 기존 수정/이동.
+ * <p>
+ * 옵션은 RADIO / CHECKBOX / DROPDOWN 타입에서만 의미가 있으며, 그 외 타입은 빈 리스트여야 한다
+ * (Service 레벨에서 거부됨).
  */
 @Builder
 public record ApplicationQuestionItem(
-    long order,
+    Long questionId,
+
+    @NotNull(message = "질문 타입은 필수입니다")
     QuestionType type,
+
+    @NotBlank(message = "질문 제목은 필수입니다")
     String title,
-    boolean required,
-    List<String> options
-) { }
+
+    String description,
+
+    boolean isRequired,
+
+    @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
+    int orderNo,
+
+    @NotNull(message = "옵션 리스트는 null 일 수 없습니다 (빈 리스트는 허용)")
+    @Valid
+    List<ApplicationQuestionOptionItem> options
+) {
+
+    public ApplicationQuestionEntry toEntry() {
+        return ApplicationQuestionEntry.builder()
+            .questionId(questionId)
+            .type(type)
+            .title(title)
+            .description(description)
+            .isRequired(isRequired)
+            .orderNo(orderNo)
+            .options(options.stream().map(ApplicationQuestionOptionItem::toEntry).toList())
+            .build();
+    }
+
+    public static ApplicationQuestionItem from(ApplicationFormInfo.QuestionInfo info) {
+        return ApplicationQuestionItem.builder()
+            .questionId(info.questionId())
+            .type(info.type())
+            .title(info.title())
+            .description(info.description())
+            .isRequired(info.isRequired())
+            .orderNo((int) info.orderNo())
+            .options(info.options().stream().map(ApplicationQuestionOptionItem::from).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionOptionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionOptionItem.java
@@ -1,0 +1,44 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionOptionEntry;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+
+/**
+ * 지원 문항 선택지 (RADIO / CHECKBOX / DROPDOWN 타입에서만 의미 있음).
+ * <p>
+ * Request 와 Response 양쪽에서 재사용된다. {@code optionId} 가 null 이면 신규 추가, 있으면 기존 수정/이동.
+ */
+@Builder
+public record ApplicationQuestionOptionItem(
+    Long optionId,
+
+    @NotBlank(message = "선택지 내용은 필수입니다")
+    String content,
+
+    @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
+    int orderNo,
+
+    boolean isOther
+) {
+
+    public ApplicationQuestionOptionEntry toEntry() {
+        return ApplicationQuestionOptionEntry.builder()
+            .optionId(optionId)
+            .content(content)
+            .orderNo(orderNo)
+            .isOther(isOther)
+            .build();
+    }
+
+    public static ApplicationQuestionOptionItem from(ApplicationFormInfo.OptionInfo info) {
+        return ApplicationQuestionOptionItem.builder()
+            .optionId(info.optionId())
+            .content(info.content())
+            .orderNo((int) info.orderNo())
+            .isOther(info.isOther())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionOptionItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationQuestionOptionItem.java
@@ -19,7 +19,7 @@ public record ApplicationQuestionOptionItem(
     String content,
 
     @PositiveOrZero(message = "orderNo는 0 이상이어야 합니다")
-    int orderNo,
+    long orderNo,
 
     boolean isOther
 ) {
@@ -37,7 +37,7 @@ public record ApplicationQuestionOptionItem(
         return ApplicationQuestionOptionItem.builder()
             .optionId(info.optionId())
             .content(info.content())
-            .orderNo((int) info.orderNo())
+            .orderNo(info.orderNo())
             .isOther(info.isOther())
             .build();
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpsertApplicationFormRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpsertApplicationFormRequest.java
@@ -1,0 +1,43 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationFormSection;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * 지원 폼 저장 요청 (PROJECT-106 PUT).
+ * <p>
+ * 본문이 곧 폼의 새 상태가 된다 (PUT 시멘틱). 빠진 섹션/질문/옵션은 삭제됨.
+ * <p>
+ * 필드 fallback:
+ * <ul>
+ *   <li>{@code title} 이 null 이면 Service 가 {@code Project.name} → {@code "프로젝트 지원서"} 순으로 폴백</li>
+ *   <li>{@code sections} 가 빈 리스트면 모든 섹션 삭제</li>
+ * </ul>
+ */
+public record UpsertApplicationFormRequest(
+
+    @Size(max = 200, message = "폼 제목은 200자 이하여야 합니다")
+    String title,
+
+    @Size(max = 500, message = "폼 설명은 500자 이하여야 합니다")
+    String description,
+
+    @NotNull(message = "sections 필드는 필수입니다 (빈 리스트는 허용)")
+    @Valid
+    List<ApplicationFormSection> sections
+) {
+
+    public UpsertApplicationFormCommand toCommand(Long projectId, Long requesterMemberId) {
+        return UpsertApplicationFormCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(requesterMemberId)
+            .title(title)
+            .description(description)
+            .sections(sections.stream().map(ApplicationFormSection::toEntry).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/DraftProjectResponse.java
@@ -1,6 +1,5 @@
 package com.umc.product.project.adapter.in.web.dto.response;
 
-import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionItem;
 import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
 import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.domain.enums.ProjectStatus;
@@ -13,6 +12,9 @@ import lombok.Builder;
  * 작성자 PM만 조회하므로 {@code toPublic()} 마스킹 불필요. 이미지는 storage 도메인 컨벤션에 따라
  * end-user에 fileId를 노출하지 않고 access URL({@code thumbnailImageUrl}/{@code logoImageUrl})만 제공합니다.
  * 사진 미변경은 PATCH에서 해당 fileId 필드를 null로 보내 표현합니다.
+ * <p>
+ * {@code applicationFormId} 가 null 이 아니면 PM이 PROJECT-106 으로 폼을 1회 이상 작성한 상태이며,
+ * 폼 전체 구조는 별도 PROJECT-106-GET 호출로 조회한다 (등록 1단계 응답을 슬림하게 유지).
  */
 @Builder
 public record DraftProjectResponse(
@@ -25,13 +27,13 @@ public record DraftProjectResponse(
     String externalLink,
     MemberBrief productOwner,
     List<MemberBrief> coProductOwners,
-    List<ApplicationQuestionItem> questions
+    Long applicationFormId
 ) {
     public static DraftProjectResponse from(
         ProjectInfo info,
         MemberBrief productOwner,
         List<MemberBrief> coProductOwners,
-        List<ApplicationQuestionItem> questions
+        Long applicationFormId
     ) {
         return DraftProjectResponse.builder()
             .id(info.id())
@@ -43,7 +45,7 @@ public record DraftProjectResponse(
             .externalLink(info.externalLink())
             .productOwner(productOwner)
             .coProductOwners(coProductOwners)
-            .questions(questions)
+            .applicationFormId(applicationFormId)
             .build();
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/GetApplicationFormResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/GetApplicationFormResponse.java
@@ -1,0 +1,32 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationFormSection;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 지원 폼 조회 응답 (PROJECT-106-GET).
+ * <p>
+ * 폼이 존재하지 않으면 Controller 가 {@code ApiResponse.result = null} 로 반환한다.
+ */
+// TODO: 챌린저 호출 시 본인 파트 + COMMON 섹션만 노출하는 forApplicant(part) 마스킹 메서드 추가
+@Builder
+public record GetApplicationFormResponse(
+    Long projectId,
+    Long applicationFormId,
+    String title,
+    String description,
+    List<ApplicationFormSection> sections
+) {
+
+    public static GetApplicationFormResponse from(ApplicationFormInfo info) {
+        return GetApplicationFormResponse.builder()
+            .projectId(info.projectId())
+            .applicationFormId(info.applicationFormId())
+            .title(info.title())
+            .description(info.description())
+            .sections(info.sections().stream().map(ApplicationFormSection::from).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectDetailResponse.java
@@ -9,6 +9,9 @@ import lombok.Builder;
 
 /**
  * 프로젝트 상세 응답 (PROJECT-002).
+ * <p>
+ * {@code applicationFormId} 가 null 이 아니면 PM이 PROJECT-106 으로 폼을 1회 이상 작성한 상태.
+ * 폼 전체 구조는 별도 PROJECT-106-GET 호출로 조회한다.
  */
 @Builder
 public record ProjectDetailResponse(
@@ -21,12 +24,14 @@ public record ProjectDetailResponse(
     MemberBrief productOwner,
     List<MemberBrief> coProductOwners,
     List<PartQuotaInfo> partQuotas,
-    PartQuotaStatus partQuotaStatus
+    PartQuotaStatus partQuotaStatus,
+    Long applicationFormId
 ) {
     public static ProjectDetailResponse from(
         ProjectInfo info,
         MemberBrief productOwner,
-        List<MemberBrief> coProductOwners
+        List<MemberBrief> coProductOwners,
+        Long applicationFormId
     ) {
         List<PartQuotaInfo> quotas = info.partQuotas().stream()
             .map(PartQuotaInfo::from)
@@ -42,6 +47,7 @@ public record ProjectDetailResponse(
             .coProductOwners(coProductOwners)
             .partQuotas(quotas)
             .partQuotaStatus(aggregateStatus(quotas))
+            .applicationFormId(applicationFormId)
             .build();
     }
 
@@ -57,6 +63,7 @@ public record ProjectDetailResponse(
             .coProductOwners(coProductOwners.stream().map(MemberBrief::toPublic).toList())
             .partQuotas(partQuotas)
             .partQuotaStatus(partQuotaStatus)
+            .applicationFormId(applicationFormId)
             .build();
     }
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/UpsertApplicationFormResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/UpsertApplicationFormResponse.java
@@ -1,0 +1,31 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationFormSection;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 지원 폼 저장 응답 (PROJECT-106 PUT).
+ * <p>
+ * 저장 후 폼의 전체 구조를 반환한다. PM 편집 화면이 즉시 갱신된 결과를 그릴 수 있도록 함.
+ */
+@Builder
+public record UpsertApplicationFormResponse(
+    Long projectId,
+    Long applicationFormId,
+    String title,
+    String description,
+    List<ApplicationFormSection> sections
+) {
+
+    public static UpsertApplicationFormResponse from(ApplicationFormInfo info) {
+        return UpsertApplicationFormResponse.builder()
+            .projectId(info.projectId())
+            .applicationFormId(info.applicationFormId())
+            .title(info.title())
+            .description(info.description())
+            .sections(info.sections().stream().map(ApplicationFormSection::from).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
@@ -1,9 +1,12 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.domain.ProjectApplicationForm;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectApplicationFormJpaRepository extends JpaRepository<ProjectApplicationForm, Long> {
 
     boolean existsByProjectId(Long projectId);
+
+    Optional<ProjectApplicationForm> findFirstByProjectIdOrderByIdAsc(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
@@ -1,17 +1,42 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ProjectApplicationFormPersistenceAdapter implements LoadProjectApplicationFormPort {
+public class ProjectApplicationFormPersistenceAdapter
+    implements LoadProjectApplicationFormPort, SaveProjectApplicationFormPort {
 
     private final ProjectApplicationFormJpaRepository repository;
 
     @Override
     public boolean existsByProjectId(Long projectId) {
         return repository.existsByProjectId(projectId);
+    }
+
+    @Override
+    public Optional<ProjectApplicationForm> findByProjectId(Long projectId) {
+        return repository.findFirstByProjectIdOrderByIdAsc(projectId);
+    }
+
+    @Override
+    public ProjectApplicationForm save(ProjectApplicationForm form) {
+        return repository.save(form);
+    }
+
+    @Override
+    public List<ProjectApplicationForm> saveAll(List<ProjectApplicationForm> forms) {
+        return repository.saveAll(forms);
+    }
+
+    @Override
+    public void delete(ProjectApplicationForm form) {
+        repository.delete(form);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyJpaRepository.java
@@ -1,0 +1,13 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectApplicationFormPolicyJpaRepository
+    extends JpaRepository<ProjectApplicationFormPolicy, Long> {
+
+    List<ProjectApplicationFormPolicy> findAllByApplicationFormId(Long applicationFormId);
+
+    void deleteByFormSectionId(Long formSectionId);
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectApplicationFormPolicyPersistenceAdapter
+    implements LoadProjectApplicationFormPolicyPort, SaveProjectApplicationFormPolicyPort {
+
+    private final ProjectApplicationFormPolicyJpaRepository repository;
+
+    @Override
+    public List<ProjectApplicationFormPolicy> listByApplicationFormId(Long applicationFormId) {
+        return repository.findAllByApplicationFormId(applicationFormId);
+    }
+
+    @Override
+    public ProjectApplicationFormPolicy save(ProjectApplicationFormPolicy policy) {
+        return repository.save(policy);
+    }
+
+    @Override
+    public List<ProjectApplicationFormPolicy> saveAll(List<ProjectApplicationFormPolicy> policies) {
+        return repository.saveAll(policies);
+    }
+
+    @Override
+    public void delete(ProjectApplicationFormPolicy policy) {
+        repository.delete(policy);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByFormSectionId(Long formSectionId) {
+        repository.deleteByFormSectionId(formSectionId);
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/UpsertProjectApplicationFormUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/UpsertProjectApplicationFormUseCase.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+
+/**
+ * 프로젝트 지원 폼 저장 UseCase (PROJECT-106).
+ * <p>
+ * PUT 시멘틱: 폼이 없으면 생성하고, 있으면 본문 구조와 일치하도록 섹션/질문/옵션을 동기화한다.
+ * Survey 도메인의 {@link com.umc.product.survey.application.port.in.command.ManageFormUseCase} 등 5종 UseCase를
+ * orchestration 으로 호출하며, 정책({@link com.umc.product.project.domain.ProjectApplicationFormPolicy}) 도 함께 갱신한다.
+ */
+public interface UpsertProjectApplicationFormUseCase {
+
+    /**
+     * 본문 구조와 일치하도록 폼을 생성/갱신한다.
+     *
+     * @return 갱신 후 폼의 전체 구조
+     */
+    ApplicationFormInfo upsert(UpsertApplicationFormCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpsertApplicationFormCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpsertApplicationFormCommand.java
@@ -50,7 +50,7 @@ public record UpsertApplicationFormCommand(
         Set<ChallengerPart> allowedParts,
         String title,
         String description,
-        int orderNo,
+        long orderNo,
         List<ApplicationQuestionEntry> questions
     ) {
         public ApplicationFormSectionEntry {
@@ -71,7 +71,7 @@ public record UpsertApplicationFormCommand(
         String title,
         String description,
         boolean isRequired,
-        int orderNo,
+        long orderNo,
         List<ApplicationQuestionOptionEntry> options
     ) {
         public ApplicationQuestionEntry {
@@ -88,7 +88,7 @@ public record UpsertApplicationFormCommand(
     public record ApplicationQuestionOptionEntry(
         Long optionId,
         String content,
-        int orderNo,
+        long orderNo,
         boolean isOther
     ) {
         public ApplicationQuestionOptionEntry {

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpsertApplicationFormCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpsertApplicationFormCommand.java
@@ -1,0 +1,98 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.Builder;
+
+/**
+ * 지원 폼 upsert Command (PROJECT-106).
+ * <p>
+ * 본문이 곧 폼의 새 상태가 된다 (PUT 시멘틱 — full replace).
+ * <ul>
+ *   <li>{@code sectionId == null} → 신규 섹션 추가</li>
+ *   <li>본문에 있고 기존에도 있음 → 수정 / 순서 갱신</li>
+ *   <li>본문에 없고 기존에는 있음 → 삭제 (cascade)</li>
+ * </ul>
+ * 질문/옵션도 동일 패턴 (각 entry 의 ID 기준 diff).
+ * <p>
+ * 섹션 타입 검증:
+ * <ul>
+ *   <li>{@code type == PART} 인데 {@code allowedParts} 가 비어있으면 도메인 예외</li>
+ *   <li>{@code type == COMMON} 의 {@code allowedParts} 는 무시되고 빈 리스트로 저장</li>
+ * </ul>
+ */
+@Builder
+public record UpsertApplicationFormCommand(
+    Long projectId,
+    Long requesterMemberId,
+    String title,
+    String description,
+    List<ApplicationFormSectionEntry> sections
+) {
+
+    public UpsertApplicationFormCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+        Objects.requireNonNull(sections, "sections must not be null");
+    }
+
+    /**
+     * 섹션 entry. {@code sectionId} 가 null 이면 신규 추가.
+     */
+    @Builder
+    public record ApplicationFormSectionEntry(
+        Long sectionId,
+        FormSectionType type,
+        Set<ChallengerPart> allowedParts,
+        String title,
+        String description,
+        int orderNo,
+        List<ApplicationQuestionEntry> questions
+    ) {
+        public ApplicationFormSectionEntry {
+            Objects.requireNonNull(type, "section type must not be null");
+            Objects.requireNonNull(title, "section title must not be null");
+            Objects.requireNonNull(questions, "section questions must not be null");
+        }
+    }
+
+    /**
+     * 질문 entry. {@code questionId} 가 null 이면 신규 추가.
+     * 옵션은 RADIO / CHECKBOX / DROPDOWN 타입에서만 의미가 있다.
+     */
+    @Builder
+    public record ApplicationQuestionEntry(
+        Long questionId,
+        QuestionType type,
+        String title,
+        String description,
+        boolean isRequired,
+        int orderNo,
+        List<ApplicationQuestionOptionEntry> options
+    ) {
+        public ApplicationQuestionEntry {
+            Objects.requireNonNull(type, "question type must not be null");
+            Objects.requireNonNull(title, "question title must not be null");
+            Objects.requireNonNull(options, "question options must not be null");
+        }
+    }
+
+    /**
+     * 옵션 entry. {@code optionId} 가 null 이면 신규 추가.
+     */
+    @Builder
+    public record ApplicationQuestionOptionEntry(
+        Long optionId,
+        String content,
+        int orderNo,
+        boolean isOther
+    ) {
+        public ApplicationQuestionOptionEntry {
+            Objects.requireNonNull(content, "option content must not be null");
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectApplicationFormUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectApplicationFormUseCase.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.application.port.in.query;
+
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import java.util.Optional;
+
+/**
+ * 프로젝트 지원 폼 조회 UseCase (PROJECT-106-GET).
+ * <p>
+ * 폼이 없으면 {@link Optional#empty()} 를 반환하며, Controller 단에서 {@code ApiResponse.result = null} 로 매핑된다.
+ * 챌린저 호출 시 본인 파트 + 공통 섹션만 노출하는 마스킹 로직은 PR3b 에서 도입 예정이며,
+ * 본 UseCase 는 raw 정보를 그대로 반환한다.
+ */
+public interface GetProjectApplicationFormUseCase {
+
+    /**
+     * 특정 프로젝트의 지원 폼 전체 구조를 조회합니다.
+     *
+     * @return 폼이 있으면 {@link ApplicationFormInfo}, 없으면 {@link Optional#empty()}
+     */
+    Optional<ApplicationFormInfo> findByProjectId(Long projectId);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ApplicationFormInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ApplicationFormInfo.java
@@ -1,0 +1,137 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+/**
+ * 지원 폼 전체 구조 (폼 메타 + 섹션 → 질문 → 옵션) Info DTO.
+ * <p>
+ * Survey 도메인의 {@link FormWithStructureInfo} 와 Project 도메인의 정책({@link ProjectApplicationFormPolicy})
+ * 을 합성하여 단일 응답 구조를 만든다.
+ */
+@Builder
+public record ApplicationFormInfo(
+    Long projectId,
+    Long applicationFormId,
+    String title,
+    String description,
+    List<SectionInfo> sections
+) {
+
+    /**
+     * 어댑터/서비스에서 모은 데이터들을 합성하여 Info DTO 를 조립한다.
+     */
+    public static ApplicationFormInfo of(
+        ProjectApplicationForm applicationForm,
+        FormWithStructureInfo formStructure,
+        List<ProjectApplicationFormPolicy> policies
+    ) {
+        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId = policies.stream()
+            .collect(Collectors.toMap(ProjectApplicationFormPolicy::getFormSectionId, Function.identity()));
+
+        List<SectionInfo> sections = formStructure.sections().stream()
+            .map(section -> SectionInfo.of(section, policyByFormSectionId.get(section.sectionId())))
+            .toList();
+
+        return ApplicationFormInfo.builder()
+            .projectId(applicationForm.getProject().getId())
+            .applicationFormId(applicationForm.getId())
+            .title(formStructure.title())
+            .description(formStructure.description())
+            .sections(sections)
+            .build();
+    }
+
+    /**
+     * 섹션 정보. 정책이 없는 섹션(보통은 발생하지 않지만 데이터 정합 깨질 경우)은 PART + 빈 parts 로 폴백한다.
+     */
+    @Builder
+    public record SectionInfo(
+        Long sectionId,
+        FormSectionType type,
+        Set<ChallengerPart> allowedParts,
+        String title,
+        String description,
+        long orderNo,
+        List<QuestionInfo> questions
+    ) {
+        public static SectionInfo of(
+            FormWithStructureInfo.SectionWithQuestions section,
+            ProjectApplicationFormPolicy policy
+        ) {
+            FormSectionType type = (policy != null) ? policy.getType() : FormSectionType.PART;
+            Set<ChallengerPart> allowedParts = (policy != null)
+                ? new HashSet<>(policy.getAllowedParts())
+                : Set.of();
+
+            List<QuestionInfo> questions = section.questions().stream()
+                .map(QuestionInfo::from)
+                .toList();
+
+            return SectionInfo.builder()
+                .sectionId(section.sectionId())
+                .type(type)
+                .allowedParts(allowedParts)
+                .title(section.title())
+                .description(section.description())
+                .orderNo(section.orderNo())
+                .questions(questions)
+                .build();
+        }
+    }
+
+    @Builder
+    public record QuestionInfo(
+        Long questionId,
+        QuestionType type,
+        String title,
+        String description,
+        boolean isRequired,
+        long orderNo,
+        List<OptionInfo> options
+    ) {
+        public static QuestionInfo from(FormWithStructureInfo.QuestionWithOptions question) {
+            List<OptionInfo> options = question.options().stream()
+                .map(OptionInfo::from)
+                .toList();
+
+            return QuestionInfo.builder()
+                .questionId(question.questionId())
+                .type(question.type())
+                .title(question.title())
+                .description(question.description())
+                .isRequired(question.isRequired())
+                .orderNo(question.orderNo())
+                .options(options)
+                .build();
+        }
+    }
+
+    @Builder
+    public record OptionInfo(
+        Long optionId,
+        String content,
+        long orderNo,
+        boolean isOther
+    ) {
+        public static OptionInfo from(FormWithStructureInfo.Option option) {
+            return OptionInfo.builder()
+                .optionId(option.optionId())
+                .content(option.content())
+                .orderNo(option.orderNo())
+                .isOther(option.isOther())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPolicyPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPolicyPort.java
@@ -1,0 +1,15 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import java.util.List;
+
+/**
+ * ProjectApplicationFormPolicy 조회 Port (Driven / Port Out).
+ */
+public interface LoadProjectApplicationFormPolicyPort {
+
+    /**
+     * 특정 지원 폼에 속한 모든 섹션 정책을 조회합니다.
+     */
+    List<ProjectApplicationFormPolicy> listByApplicationFormId(Long applicationFormId);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationFormPort.java
@@ -1,5 +1,8 @@
 package com.umc.product.project.application.port.out;
 
+import com.umc.product.project.domain.ProjectApplicationForm;
+import java.util.Optional;
+
 /**
  * ProjectApplicationForm 조회 Port (Driven / Port Out).
  */
@@ -10,4 +13,11 @@ public interface LoadProjectApplicationFormPort {
      * PROJECT-107 submit 검증에 사용됩니다.
      */
     boolean existsByProjectId(Long projectId);
+
+    /**
+     * 특정 프로젝트에 연결된 지원 폼을 조회합니다.
+     * <p>
+     * 운영상 프로젝트당 폼 1개로 사용하지만 스키마는 1:N 을 허용하므로 가장 먼저 생성된 row 를 반환합니다.
+     */
+    Optional<ProjectApplicationForm> findByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPolicyPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPolicyPort.java
@@ -1,0 +1,26 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import java.util.List;
+
+/**
+ * ProjectApplicationFormPolicy 쓰기 Port (Driven / Port Out).
+ * <p>
+ * 코드베이스 컨벤션: {@code save}, {@code saveAll}, {@code delete}는
+ * 현재 사용 여부와 무관하게 함께 선언합니다.
+ */
+public interface SaveProjectApplicationFormPolicyPort {
+
+    ProjectApplicationFormPolicy save(ProjectApplicationFormPolicy policy);
+
+    List<ProjectApplicationFormPolicy> saveAll(List<ProjectApplicationFormPolicy> policies);
+
+    void delete(ProjectApplicationFormPolicy policy);
+
+    /**
+     * 특정 FormSection 에 매핑된 정책 row 를 삭제합니다.
+     * <p>
+     * Survey 단의 {@code deleteSection} 호출 후 이 메서드로 매핑 row 를 정리합니다.
+     */
+    void deleteByFormSectionId(Long formSectionId);
+}

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPort.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectApplicationForm;
+import java.util.List;
+
+/**
+ * ProjectApplicationForm 쓰기 Port (Driven / Port Out).
+ * <p>
+ * 코드베이스 컨벤션: {@code save}, {@code saveAll}, {@code delete}는
+ * 현재 사용 여부와 무관하게 함께 선언합니다.
+ */
+public interface SaveProjectApplicationFormPort {
+
+    ProjectApplicationForm save(ProjectApplicationForm form);
+
+    List<ProjectApplicationForm> saveAll(List<ProjectApplicationForm> forms);
+
+    void delete(ProjectApplicationForm form);
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -36,7 +36,6 @@ import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionC
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
-import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.Option;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
@@ -90,16 +89,31 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         Project project = loadProjectPort.getById(command.projectId());
         project.validateApplicationFormEditable();
 
-        ProjectApplicationForm applicationForm = loadApplicationFormPort.findByProjectId(command.projectId())
-            .map(existing -> {
-                syncFormMetaIfChanged(existing, project, command);
-                return existing;
-            })
-            .orElseGet(() -> createApplicationForm(project, command));
+        ProjectApplicationForm applicationForm;
+        FormWithStructureInfo existingStructure;
 
-        applyDiff(applicationForm, command);
+        var maybeExisting = loadApplicationFormPort.findByProjectId(command.projectId());
+        if (maybeExisting.isPresent()) {
+            applicationForm = maybeExisting.get();
+            // 메타 + 구조를 한 번에 가져와 syncFormMetaIfChanged / applyDiff 둘 다 재사용 (cross-domain 호출 1회 절감)
+            existingStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+            syncFormMetaIfChanged(applicationForm, existingStructure, project, command);
+        } else {
+            applicationForm = createApplicationForm(project, command);
+            // 신규 폼은 비어있는 구조 — 호출 없이 직접 생성
+            existingStructure = emptyStructureFor(applicationForm.getFormId());
+        }
+
+        applyDiff(applicationForm, existingStructure, command);
 
         return assembleResponse(applicationForm);
+    }
+
+    private FormWithStructureInfo emptyStructureFor(Long formId) {
+        return FormWithStructureInfo.builder()
+            .formId(formId)
+            .sections(List.of())
+            .build();
     }
 
     /* =====================================================
@@ -120,10 +134,10 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
 
     private void syncFormMetaIfChanged(
         ProjectApplicationForm applicationForm,
+        FormWithStructureInfo existing,
         Project project,
         UpsertApplicationFormCommand command
     ) {
-        FormInfo existing = getFormUseCase.getById(applicationForm.getFormId());
         String resolvedTitle = resolveTitle(project, command);
 
         if (Objects.equals(existing.title(), resolvedTitle)
@@ -156,8 +170,11 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
      * 2) 3계층 diff (section -> question -> option)
      * ===================================================== */
 
-    private void applyDiff(ProjectApplicationForm applicationForm, UpsertApplicationFormCommand command) {
-        FormWithStructureInfo existing = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+    private void applyDiff(
+        ProjectApplicationForm applicationForm,
+        FormWithStructureInfo existing,
+        UpsertApplicationFormCommand command
+    ) {
         Map<Long, SectionWithQuestions> existingSectionById = existing.sections().stream()
             .collect(Collectors.toMap(SectionWithQuestions::sectionId, Function.identity()));
         Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId =

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -1,0 +1,123 @@
+package com.umc.product.project.application.service.command;
+
+import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 지원 폼 upsert 서비스 (PROJECT-106).
+ * <p>
+ * 본 커밋(C6)은 폼 라이프사이클(부재 시 생성 / 메타 sync) 까지만 다룬다.
+ * 섹션 / 질문 / 옵션 diff orchestration 은 후속 커밋(C7)에서 추가된다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectApplicationFormCommandService implements UpsertProjectApplicationFormUseCase {
+
+    /**
+     * 본문 title 도 null, Project.name 도 null 인 DRAFT 단계에서 사용할 기본 폼 제목.
+     * Survey 단의 {@code Form.title} 이 NOT NULL 이라 어떤 값이든 채워야 한다.
+     */
+    private static final String DEFAULT_FORM_TITLE = "프로젝트 지원서";
+
+    private final LoadProjectPort loadProjectPort;
+    private final LoadProjectApplicationFormPort loadApplicationFormPort;
+    private final SaveProjectApplicationFormPort saveApplicationFormPort;
+    private final LoadProjectApplicationFormPolicyPort loadPolicyPort;
+
+    // Cross-domain
+    private final ManageFormUseCase manageFormUseCase;
+    private final GetFormUseCase getFormUseCase;
+
+    @Override
+    public ApplicationFormInfo upsert(UpsertApplicationFormCommand command) {
+        Project project = loadProjectPort.getById(command.projectId());
+        project.validateApplicationFormEditable();
+
+        ProjectApplicationForm applicationForm = loadApplicationFormPort.findByProjectId(command.projectId())
+            .map(existing -> {
+                syncFormMetaIfChanged(existing, project, command);
+                return existing;
+            })
+            .orElseGet(() -> createApplicationForm(project, command));
+
+        // TODO (C7): 섹션 / 질문 / 옵션 diff orchestration
+
+        return assembleResponse(applicationForm);
+    }
+
+    private ProjectApplicationForm createApplicationForm(Project project, UpsertApplicationFormCommand command) {
+        Long formId = manageFormUseCase.createDraft(
+            CreateDraftFormCommand.builder()
+                .createdMemberId(command.requesterMemberId())
+                .title(resolveTitle(project, command))
+                .description(command.description())
+                .isAnonymous(false)
+                .build()
+        );
+        return saveApplicationFormPort.save(ProjectApplicationForm.create(project, formId));
+    }
+
+    private void syncFormMetaIfChanged(
+        ProjectApplicationForm applicationForm,
+        Project project,
+        UpsertApplicationFormCommand command
+    ) {
+        FormInfo existing = getFormUseCase.getById(applicationForm.getFormId());
+        String resolvedTitle = resolveTitle(project, command);
+
+        if (Objects.equals(existing.title(), resolvedTitle)
+            && Objects.equals(existing.description(), command.description())) {
+            return;
+        }
+
+        manageFormUseCase.updateForm(
+            UpdateFormCommand.builder()
+                .formId(applicationForm.getFormId())
+                .requesterMemberId(command.requesterMemberId())
+                .title(resolvedTitle)
+                .description(command.description())
+                .isAnonymous(existing.isAnonymous())
+                .build()
+        );
+    }
+
+    /**
+     * 폼 제목 fallback: 본문 title → {@code Project.name} → "프로젝트 지원서".
+     */
+    private String resolveTitle(Project project, UpsertApplicationFormCommand command) {
+        if (command.title() != null) {
+            return command.title();
+        }
+        if (project.getName() != null) {
+            return project.getName();
+        }
+        return DEFAULT_FORM_TITLE;
+    }
+
+    private ApplicationFormInfo assembleResponse(ProjectApplicationForm applicationForm) {
+        FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+        List<ProjectApplicationFormPolicy> policies =
+            loadPolicyPort.listByApplicationFormId(applicationForm.getId());
+        return ApplicationFormInfo.of(applicationForm, formStructure, policies);
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -2,22 +2,54 @@ package com.umc.product.project.application.service.command;
 
 import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
 import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationFormSectionEntry;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionEntry;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionOptionEntry;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.survey.application.port.in.command.ManageFormSectionUseCase;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionOptionUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionOptionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.Option;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,31 +57,36 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 지원 폼 upsert 서비스 (PROJECT-106).
  * <p>
- * 본 커밋(C6)은 폼 라이프사이클(부재 시 생성 / 메타 sync) 까지만 다룬다.
- * 섹션 / 질문 / 옵션 diff orchestration 은 후속 커밋(C7)에서 추가된다.
+ * 본문이 곧 폼의 새 상태가 되도록 (PUT 시멘틱) 섹션/질문/옵션을 3계층 diff 로 동기화한다.
+ * Survey 도메인의 5종 UseCase 와 Project 도메인의 정책({@link ProjectApplicationFormPolicy})
+ * 을 합쳐 단일 트랜잭션으로 처리한다.
  */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ProjectApplicationFormCommandService implements UpsertProjectApplicationFormUseCase {
 
-    /**
-     * 본문 title 도 null, Project.name 도 null 인 DRAFT 단계에서 사용할 기본 폼 제목.
-     * Survey 단의 {@code Form.title} 이 NOT NULL 이라 어떤 값이든 채워야 한다.
-     */
     private static final String DEFAULT_FORM_TITLE = "프로젝트 지원서";
+    private static final Set<QuestionType> CHOICE_QUESTION_TYPES =
+        Set.of(QuestionType.RADIO, QuestionType.CHECKBOX, QuestionType.DROPDOWN);
 
     private final LoadProjectPort loadProjectPort;
     private final LoadProjectApplicationFormPort loadApplicationFormPort;
     private final SaveProjectApplicationFormPort saveApplicationFormPort;
     private final LoadProjectApplicationFormPolicyPort loadPolicyPort;
+    private final SaveProjectApplicationFormPolicyPort savePolicyPort;
 
     // Cross-domain
     private final ManageFormUseCase manageFormUseCase;
+    private final ManageFormSectionUseCase manageFormSectionUseCase;
+    private final ManageQuestionUseCase manageQuestionUseCase;
+    private final ManageQuestionOptionUseCase manageQuestionOptionUseCase;
     private final GetFormUseCase getFormUseCase;
 
     @Override
     public ApplicationFormInfo upsert(UpsertApplicationFormCommand command) {
+        validateOptionTypeRules(command.sections());
+
         Project project = loadProjectPort.getById(command.projectId());
         project.validateApplicationFormEditable();
 
@@ -60,10 +97,14 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
             })
             .orElseGet(() -> createApplicationForm(project, command));
 
-        // TODO (C7): 섹션 / 질문 / 옵션 diff orchestration
+        applyDiff(applicationForm, command);
 
         return assembleResponse(applicationForm);
     }
+
+    /* =====================================================
+     * 1) 폼 라이프사이클 (생성 / 메타 sync)
+     * ===================================================== */
 
     private ProjectApplicationForm createApplicationForm(Project project, UpsertApplicationFormCommand command) {
         Long formId = manageFormUseCase.createDraft(
@@ -101,9 +142,6 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         );
     }
 
-    /**
-     * 폼 제목 fallback: 본문 title → {@code Project.name} → "프로젝트 지원서".
-     */
     private String resolveTitle(Project project, UpsertApplicationFormCommand command) {
         if (command.title() != null) {
             return command.title();
@@ -113,6 +151,447 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         }
         return DEFAULT_FORM_TITLE;
     }
+
+    /* =====================================================
+     * 2) 3계층 diff (section -> question -> option)
+     * ===================================================== */
+
+    private void applyDiff(ProjectApplicationForm applicationForm, UpsertApplicationFormCommand command) {
+        FormWithStructureInfo existing = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+        Map<Long, SectionWithQuestions> existingSectionById = existing.sections().stream()
+            .collect(Collectors.toMap(SectionWithQuestions::sectionId, Function.identity()));
+        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId =
+            loadPolicyPort.listByApplicationFormId(applicationForm.getId()).stream()
+                .collect(Collectors.toMap(ProjectApplicationFormPolicy::getFormSectionId, Function.identity()));
+
+        validateSectionIds(command.sections(), existingSectionById.keySet());
+        validateQuestionAndOptionIds(command.sections(), existingSectionById);
+
+        List<Long> orderedSectionIds = applySectionDiff(
+            applicationForm, command, existingSectionById, policyByFormSectionId
+        );
+
+        deleteRemovedSections(command.sections(), existing.sections(), command.requesterMemberId());
+
+        if (!orderedSectionIds.isEmpty()) {
+            manageFormSectionUseCase.reorderSections(
+                ReorderFormSectionsCommand.builder()
+                    .formId(applicationForm.getFormId())
+                    .requesterMemberId(command.requesterMemberId())
+                    .orderedSectionIds(orderedSectionIds)
+                    .build()
+            );
+        }
+    }
+
+    private List<Long> applySectionDiff(
+        ProjectApplicationForm applicationForm,
+        UpsertApplicationFormCommand command,
+        Map<Long, SectionWithQuestions> existingSectionById,
+        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId
+    ) {
+        List<Long> orderedSectionIds = new ArrayList<>();
+        for (ApplicationFormSectionEntry entry : command.sections()) {
+            Long sectionId = (entry.sectionId() == null)
+                ? createNewSection(applicationForm, entry, command.requesterMemberId())
+                : updateExistingSection(
+                    entry,
+                    existingSectionById.get(entry.sectionId()),
+                    policyByFormSectionId.get(entry.sectionId()),
+                    command.requesterMemberId()
+                );
+            orderedSectionIds.add(sectionId);
+        }
+        return orderedSectionIds;
+    }
+
+    private Long createNewSection(
+        ProjectApplicationForm applicationForm,
+        ApplicationFormSectionEntry entry,
+        Long requesterMemberId
+    ) {
+        Long sectionId = manageFormSectionUseCase.createSection(
+            CreateFormSectionCommand.builder()
+                .formId(applicationForm.getFormId())
+                .requesterMemberId(requesterMemberId)
+                .title(entry.title())
+                .description(entry.description())
+                .build()
+        );
+
+        savePolicyPort.save(buildPolicy(applicationForm, sectionId, entry));
+
+        for (ApplicationQuestionEntry questionEntry : entry.questions()) {
+            createNewQuestion(sectionId, questionEntry, requesterMemberId);
+        }
+
+        return sectionId;
+    }
+
+    private Long updateExistingSection(
+        ApplicationFormSectionEntry entry,
+        SectionWithQuestions existingSection,
+        ProjectApplicationFormPolicy existingPolicy,
+        Long requesterMemberId
+    ) {
+        if (sectionMetaChanged(existingSection, entry)) {
+            manageFormSectionUseCase.updateSection(
+                UpdateFormSectionCommand.builder()
+                    .sectionId(entry.sectionId())
+                    .requesterMemberId(requesterMemberId)
+                    .title(entry.title())
+                    .description(entry.description())
+                    .build()
+            );
+        }
+
+        if (policyChanged(existingPolicy, entry)) {
+            existingPolicy.updatePolicy(entry.type(), nullSafeAllowedParts(entry));
+            savePolicyPort.save(existingPolicy);
+        }
+
+        applyQuestionDiff(entry, existingSection, requesterMemberId);
+        return entry.sectionId();
+    }
+
+    private void deleteRemovedSections(
+        List<ApplicationFormSectionEntry> requestSections,
+        List<SectionWithQuestions> existingSections,
+        Long requesterMemberId
+    ) {
+        Set<Long> requestedExistingIds = requestSections.stream()
+            .map(ApplicationFormSectionEntry::sectionId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        for (SectionWithQuestions existing : existingSections) {
+            if (requestedExistingIds.contains(existing.sectionId())) {
+                continue;
+            }
+            manageFormSectionUseCase.deleteSection(
+                DeleteFormSectionCommand.builder()
+                    .sectionId(existing.sectionId())
+                    .requesterMemberId(requesterMemberId)
+                    .build()
+            );
+            savePolicyPort.deleteByFormSectionId(existing.sectionId());
+        }
+    }
+
+    private void applyQuestionDiff(
+        ApplicationFormSectionEntry sectionEntry,
+        SectionWithQuestions existingSection,
+        Long requesterMemberId
+    ) {
+        Map<Long, QuestionWithOptions> existingQuestionById = existingSection.questions().stream()
+            .collect(Collectors.toMap(QuestionWithOptions::questionId, Function.identity()));
+
+        List<Long> orderedQuestionIds = new ArrayList<>();
+        for (ApplicationQuestionEntry questionEntry : sectionEntry.questions()) {
+            Long questionId = (questionEntry.questionId() == null)
+                ? createNewQuestion(sectionEntry.sectionId(), questionEntry, requesterMemberId)
+                : updateExistingQuestion(
+                    questionEntry,
+                    existingQuestionById.get(questionEntry.questionId()),
+                    requesterMemberId
+                );
+            orderedQuestionIds.add(questionId);
+        }
+
+        deleteRemovedQuestions(sectionEntry.questions(), existingSection.questions(), requesterMemberId);
+
+        if (!orderedQuestionIds.isEmpty()) {
+            manageQuestionUseCase.reorderQuestions(
+                ReorderQuestionsCommand.builder()
+                    .sectionId(sectionEntry.sectionId())
+                    .requesterMemberId(requesterMemberId)
+                    .orderedQuestionIds(orderedQuestionIds)
+                    .build()
+            );
+        }
+    }
+
+    private Long createNewQuestion(Long sectionId, ApplicationQuestionEntry entry, Long requesterMemberId) {
+        Long questionId = manageQuestionUseCase.createQuestion(
+            CreateQuestionCommand.builder()
+                .sectionId(sectionId)
+                .requesterMemberId(requesterMemberId)
+                .type(entry.type())
+                .title(entry.title())
+                .description(entry.description())
+                .isRequired(entry.isRequired())
+                .build()
+        );
+
+        for (ApplicationQuestionOptionEntry optionEntry : entry.options()) {
+            createNewOption(questionId, optionEntry, requesterMemberId);
+        }
+
+        return questionId;
+    }
+
+    private Long updateExistingQuestion(
+        ApplicationQuestionEntry entry,
+        QuestionWithOptions existingQuestion,
+        Long requesterMemberId
+    ) {
+        if (questionMetaChanged(existingQuestion, entry)) {
+            manageQuestionUseCase.updateQuestion(
+                UpdateQuestionCommand.builder()
+                    .questionId(entry.questionId())
+                    .requesterMemberId(requesterMemberId)
+                    .type(entry.type())
+                    .title(entry.title())
+                    .description(entry.description())
+                    .isRequired(entry.isRequired())
+                    .build()
+            );
+        }
+
+        applyOptionDiff(entry, existingQuestion, requesterMemberId);
+        return entry.questionId();
+    }
+
+    private void deleteRemovedQuestions(
+        List<ApplicationQuestionEntry> requestQuestions,
+        List<QuestionWithOptions> existingQuestions,
+        Long requesterMemberId
+    ) {
+        Set<Long> requestedExistingIds = requestQuestions.stream()
+            .map(ApplicationQuestionEntry::questionId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        for (QuestionWithOptions existing : existingQuestions) {
+            if (requestedExistingIds.contains(existing.questionId())) {
+                continue;
+            }
+            manageQuestionUseCase.deleteQuestion(
+                DeleteQuestionCommand.builder()
+                    .questionId(existing.questionId())
+                    .requesterMemberId(requesterMemberId)
+                    .build()
+            );
+        }
+    }
+
+    private void applyOptionDiff(
+        ApplicationQuestionEntry questionEntry,
+        QuestionWithOptions existingQuestion,
+        Long requesterMemberId
+    ) {
+        Map<Long, Option> existingOptionById = existingQuestion.options().stream()
+            .collect(Collectors.toMap(Option::optionId, Function.identity()));
+
+        List<Long> orderedOptionIds = new ArrayList<>();
+        for (ApplicationQuestionOptionEntry optionEntry : questionEntry.options()) {
+            Long optionId = (optionEntry.optionId() == null)
+                ? createNewOption(questionEntry.questionId(), optionEntry, requesterMemberId)
+                : updateExistingOption(
+                    optionEntry,
+                    existingOptionById.get(optionEntry.optionId()),
+                    requesterMemberId
+                );
+            orderedOptionIds.add(optionId);
+        }
+
+        deleteRemovedOptions(questionEntry.options(), existingQuestion.options(), requesterMemberId);
+
+        if (!orderedOptionIds.isEmpty()) {
+            manageQuestionOptionUseCase.reorderOptions(
+                ReorderQuestionOptionsCommand.builder()
+                    .questionId(questionEntry.questionId())
+                    .requesterMemberId(requesterMemberId)
+                    .orderedOptionIds(orderedOptionIds)
+                    .build()
+            );
+        }
+    }
+
+    private Long createNewOption(Long questionId, ApplicationQuestionOptionEntry entry, Long requesterMemberId) {
+        return manageQuestionOptionUseCase.createOption(
+            CreateQuestionOptionCommand.builder()
+                .questionId(questionId)
+                .requesterMemberId(requesterMemberId)
+                .content(entry.content())
+                .isOther(entry.isOther())
+                .build()
+        );
+    }
+
+    private Long updateExistingOption(
+        ApplicationQuestionOptionEntry entry,
+        Option existingOption,
+        Long requesterMemberId
+    ) {
+        if (optionMetaChanged(existingOption, entry)) {
+            manageQuestionOptionUseCase.updateOption(
+                UpdateQuestionOptionCommand.builder()
+                    .optionId(entry.optionId())
+                    .requesterMemberId(requesterMemberId)
+                    .content(entry.content())
+                    .isOther(entry.isOther())
+                    .build()
+            );
+        }
+        return entry.optionId();
+    }
+
+    private void deleteRemovedOptions(
+        List<ApplicationQuestionOptionEntry> requestOptions,
+        List<Option> existingOptions,
+        Long requesterMemberId
+    ) {
+        Set<Long> requestedExistingIds = requestOptions.stream()
+            .map(ApplicationQuestionOptionEntry::optionId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        for (Option existing : existingOptions) {
+            if (requestedExistingIds.contains(existing.optionId())) {
+                continue;
+            }
+            manageQuestionOptionUseCase.deleteOption(
+                DeleteQuestionOptionCommand.builder()
+                    .optionId(existing.optionId())
+                    .requesterMemberId(requesterMemberId)
+                    .build()
+            );
+        }
+    }
+
+    /* =====================================================
+     * 3) 검증
+     * ===================================================== */
+
+    private void validateOptionTypeRules(List<ApplicationFormSectionEntry> sections) {
+        for (ApplicationFormSectionEntry section : sections) {
+            for (ApplicationQuestionEntry question : section.questions()) {
+                boolean isChoice = CHOICE_QUESTION_TYPES.contains(question.type());
+                boolean hasOptions = !question.options().isEmpty();
+
+                if (!isChoice && hasOptions) {
+                    throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_OPTIONS_NOT_ALLOWED);
+                }
+                if (isChoice && !hasOptions) {
+                    throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_OPTIONS_REQUIRED);
+                }
+            }
+        }
+    }
+
+    private void validateSectionIds(List<ApplicationFormSectionEntry> sections, Set<Long> existingSectionIds) {
+        for (ApplicationFormSectionEntry section : sections) {
+            if (section.sectionId() != null && !existingSectionIds.contains(section.sectionId())) {
+                throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_SECTION_ID);
+            }
+        }
+    }
+
+    private void validateQuestionAndOptionIds(
+        List<ApplicationFormSectionEntry> sections,
+        Map<Long, SectionWithQuestions> existingSectionById
+    ) {
+        for (ApplicationFormSectionEntry sectionEntry : sections) {
+            if (sectionEntry.sectionId() == null) {
+                // 신규 섹션은 비교 대상이 없음 — 모든 questionId/optionId 가 null 이어야 함
+                ensureAllQuestionIdsNull(sectionEntry.questions());
+                continue;
+            }
+            SectionWithQuestions existingSection = existingSectionById.get(sectionEntry.sectionId());
+            Map<Long, QuestionWithOptions> existingQuestionById = existingSection.questions().stream()
+                .collect(Collectors.toMap(QuestionWithOptions::questionId, Function.identity()));
+
+            for (ApplicationQuestionEntry questionEntry : sectionEntry.questions()) {
+                if (questionEntry.questionId() != null
+                    && !existingQuestionById.containsKey(questionEntry.questionId())) {
+                    throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+                }
+
+                if (questionEntry.questionId() == null) {
+                    ensureAllOptionIdsNull(questionEntry.options());
+                    continue;
+                }
+                Set<Long> existingOptionIds = existingQuestionById.get(questionEntry.questionId()).options()
+                    .stream().map(Option::optionId).collect(Collectors.toSet());
+                for (ApplicationQuestionOptionEntry optionEntry : questionEntry.options()) {
+                    if (optionEntry.optionId() != null
+                        && !existingOptionIds.contains(optionEntry.optionId())) {
+                        throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_OPTION_ID);
+                    }
+                }
+            }
+        }
+    }
+
+    private void ensureAllQuestionIdsNull(List<ApplicationQuestionEntry> questions) {
+        for (ApplicationQuestionEntry question : questions) {
+            if (question.questionId() != null) {
+                throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+            }
+            ensureAllOptionIdsNull(question.options());
+        }
+    }
+
+    private void ensureAllOptionIdsNull(List<ApplicationQuestionOptionEntry> options) {
+        for (ApplicationQuestionOptionEntry option : options) {
+            if (option.optionId() != null) {
+                throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_OPTION_ID);
+            }
+        }
+    }
+
+    /* =====================================================
+     * 4) Diff 비교 / 정책 빌드 헬퍼
+     * ===================================================== */
+
+    private boolean sectionMetaChanged(SectionWithQuestions existing, ApplicationFormSectionEntry entry) {
+        return !Objects.equals(existing.title(), entry.title())
+            || !Objects.equals(existing.description(), entry.description());
+    }
+
+    private boolean policyChanged(ProjectApplicationFormPolicy existing, ApplicationFormSectionEntry entry) {
+        if (existing.getType() != entry.type()) {
+            return true;
+        }
+        if (entry.type() == FormSectionType.COMMON) {
+            return !existing.getAllowedParts().isEmpty();
+        }
+        return !new HashSet<>(existing.getAllowedParts()).equals(nullSafeAllowedParts(entry));
+    }
+
+    private boolean questionMetaChanged(QuestionWithOptions existing, ApplicationQuestionEntry entry) {
+        return existing.type() != entry.type()
+            || !Objects.equals(existing.title(), entry.title())
+            || !Objects.equals(existing.description(), entry.description())
+            || existing.isRequired() != entry.isRequired();
+    }
+
+    private boolean optionMetaChanged(Option existing, ApplicationQuestionOptionEntry entry) {
+        return !Objects.equals(existing.content(), entry.content())
+            || existing.isOther() != entry.isOther();
+    }
+
+    private ProjectApplicationFormPolicy buildPolicy(
+        ProjectApplicationForm applicationForm,
+        Long sectionId,
+        ApplicationFormSectionEntry entry
+    ) {
+        if (entry.type() == FormSectionType.COMMON) {
+            return ProjectApplicationFormPolicy.createCommon(applicationForm, sectionId);
+        }
+        return ProjectApplicationFormPolicy.createForParts(applicationForm, sectionId, nullSafeAllowedParts(entry));
+    }
+
+    private Set<com.umc.product.common.domain.enums.ChallengerPart> nullSafeAllowedParts(
+        ApplicationFormSectionEntry entry
+    ) {
+        return entry.allowedParts() == null ? Set.of() : entry.allowedParts();
+    }
+
+    /* =====================================================
+     * 5) 응답 조립
+     * ===================================================== */
 
     private ApplicationFormInfo assembleResponse(ProjectApplicationForm applicationForm) {
         FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -351,8 +351,19 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
                 .build()
         );
 
+        // 본문 순서대로 reorder 명시 호출 — Survey 단의 자동 orderNo 부여 정책에 의존하지 않음
+        List<Long> newOptionIds = new ArrayList<>();
         for (ApplicationQuestionOptionEntry optionEntry : entry.options()) {
-            createNewOption(questionId, optionEntry, requesterMemberId);
+            newOptionIds.add(createNewOption(questionId, optionEntry, requesterMemberId));
+        }
+        if (!newOptionIds.isEmpty()) {
+            manageQuestionOptionUseCase.reorderOptions(
+                ReorderQuestionOptionsCommand.builder()
+                    .questionId(questionId)
+                    .requesterMemberId(requesterMemberId)
+                    .orderedOptionIds(newOptionIds)
+                    .build()
+            );
         }
 
         return questionId;

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -238,8 +238,19 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
 
         savePolicyPort.save(buildPolicy(applicationForm, sectionId, entry));
 
+        // 본문 순서대로 reorder 명시 호출 — Survey 단의 자동 orderNo 부여 정책에 의존하지 않음
+        List<Long> newQuestionIds = new ArrayList<>();
         for (ApplicationQuestionEntry questionEntry : entry.questions()) {
-            createNewQuestion(sectionId, questionEntry, requesterMemberId);
+            newQuestionIds.add(createNewQuestion(sectionId, questionEntry, requesterMemberId));
+        }
+        if (!newQuestionIds.isEmpty()) {
+            manageQuestionUseCase.reorderQuestions(
+                ReorderQuestionsCommand.builder()
+                    .sectionId(sectionId)
+                    .requesterMemberId(requesterMemberId)
+                    .orderedQuestionIds(newQuestionIds)
+                    .build()
+            );
         }
 
         return sectionId;

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
@@ -1,0 +1,45 @@
+package com.umc.product.project.application.service.query;
+
+import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 지원 폼 조회 서비스 (PROJECT-106-GET).
+ * <p>
+ * 폼 메타와 섹션→질문→옵션 nested 구조는 Survey 도메인에 위임하며, Project 도메인의 정책({@link ProjectApplicationFormPolicy})
+ * 을 합성해 단일 응답을 만든다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectApplicationFormQueryService implements GetProjectApplicationFormUseCase {
+
+    private final LoadProjectApplicationFormPort loadApplicationFormPort;
+    private final LoadProjectApplicationFormPolicyPort loadPolicyPort;
+
+    // Cross-domain
+    private final GetFormUseCase getFormUseCase;
+
+    @Override
+    public Optional<ApplicationFormInfo> findByProjectId(Long projectId) {
+        return loadApplicationFormPort.findByProjectId(projectId)
+            .map(this::assemble);
+    }
+
+    private ApplicationFormInfo assemble(ProjectApplicationForm applicationForm) {
+        FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+        List<ProjectApplicationFormPolicy> policies = loadPolicyPort.listByApplicationFormId(applicationForm.getId());
+        return ApplicationFormInfo.of(applicationForm, formStructure, policies);
+    }
+}

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -156,8 +156,25 @@ public class Project extends BaseEntity {
         this.productOwnerMemberId = newOwnerMemberId;
     }
 
-    private void validateMutable() {
+    /**
+     * 프로젝트 본체(이름·소개·소유권 등)를 변경 가능한 상태인지 검증한다.
+     * 종료 상태({@code COMPLETED}, {@code ABORTED})에서는 변경 불가.
+     */
+    public void validateMutable() {
         if (this.status == ProjectStatus.COMPLETED || this.status == ProjectStatus.ABORTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    /**
+     * 지원 폼을 편집 가능한 상태인지 검증한다.
+     * <p>
+     * Form 은 Project 가 IN_PROGRESS 로 전이되는 시점(PROJECT-108)에 PUBLISHED 로 같이 전이되므로,
+     * 편집은 {@code DRAFT} / {@code PENDING_REVIEW} 단계에서만 허용된다.
+     * Survey 단의 {@code SURVEY_ALREADY_PUBLISHED} 가드와 2단 방어 관계.
+     */
+    public void validateApplicationFormEditable() {
+        if (this.status != ProjectStatus.DRAFT && this.status != ProjectStatus.PENDING_REVIEW) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
         }
     }

--- a/src/main/java/com/umc/product/project/domain/ProjectApplicationForm.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplicationForm.java
@@ -61,9 +61,9 @@ public class ProjectApplicationForm extends BaseEntity {
     }
 
     /**
-     * TODO: 특정 프로젝트에 속한 지원용 폼인지 검증하는 메소드입니다.
+     * 본 지원 폼이 인자로 전달된 프로젝트에 속하는지 검증한다.
      */
     public boolean belongsTo(Project project) {
-        return false;
+        return this.project.getId().equals(project.getId());
     }
 }

--- a/src/main/java/com/umc/product/project/domain/ProjectApplicationFormPolicy.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplicationFormPolicy.java
@@ -2,6 +2,7 @@ package com.umc.product.project.domain;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.FormSectionType;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import jakarta.persistence.Column;
@@ -26,13 +27,15 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 /**
- * 프로젝트에 지원하기 위한 폼 내에 포함된 특정 섹션이 어떤 파트에 의해서 접근이 가능한지를 나타내는 엔티티입니다.
+ * 지원 폼 내 특정 섹션의 가시성 정책.
  * <p>
- * 프로젝트 지원용 폼 조회 시, 본 엔티티를 반드시 거쳐서 접근 권한이 있는 사용자에게만 노출되도록 하여야 하며,
- * <p>
- * Form 내에 있는 FormSection 중에서 본 Policy가 명시되지 않은 Section은 어떠한 파트에게도 노출되지 않습니다.
- * <p>
- * 단, 운영진이나 프로젝트 Plan은 반드시 해당 사항을 조회할 수 있어야 합니다.
+ * 각 섹션은 {@link FormSectionType#COMMON COMMON} 또는 {@link FormSectionType#PART PART} 중 하나로 분류되며,
+ * 챌린저가 폼을 조회할 때 본인 파트가 해당 섹션을 볼 수 있는지 결정한다.
+ * <ul>
+ *   <li>{@code COMMON} — 모든 파트 노출, {@code allowedParts} 무시</li>
+ *   <li>{@code PART} — {@code allowedParts} 명시 1개 이상</li>
+ * </ul>
+ * 운영진이나 프로젝트 PM 은 본 정책을 우회하고 전체 섹션을 조회한다.
  */
 @Entity
 @Table(name = "project_application_form_policy")
@@ -49,54 +52,95 @@ public class ProjectApplicationFormPolicy extends BaseEntity {
     private ProjectApplicationForm applicationForm;
 
     @Column(nullable = false)
-    private Long formSectionId; // 접근 권한 제한을 받을 FormSection의 ID
+    private Long formSectionId;
 
-    @Enumerated(EnumType.STRING) // Enum 값이므로 String으로 저장
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FormSectionType type;
+
+    @Enumerated(EnumType.STRING)
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "allowed_parts", columnDefinition = "text[]", nullable = false)
+    @Column(name = "allowed_parts", columnDefinition = "text[]")
     private List<ChallengerPart> allowedParts = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private ProjectApplicationFormPolicy(
         ProjectApplicationForm applicationForm,
         Long formSectionId,
-        Set<ChallengerPart> allowedParts
+        FormSectionType type,
+        List<ChallengerPart> allowedParts
     ) {
         this.applicationForm = applicationForm;
         this.formSectionId = formSectionId;
-        this.allowedParts = allowedParts.stream().toList();
+        this.type = type;
+        this.allowedParts = allowedParts;
     }
 
-    public static ProjectApplicationFormPolicy create(
-        ProjectApplicationForm form, Long formSectionId,
-        Set<ChallengerPart> allowedParts
+    /**
+     * 모든 파트에게 노출되는 공통 섹션 정책을 생성한다.
+     */
+    public static ProjectApplicationFormPolicy createCommon(
+        ProjectApplicationForm form, Long formSectionId
     ) {
         return ProjectApplicationFormPolicy.builder()
             .applicationForm(form)
             .formSectionId(formSectionId)
-            .allowedParts(allowedParts)
+            .type(FormSectionType.COMMON)
+            .allowedParts(new ArrayList<>())
             .build();
     }
 
     /**
-     * FormSection에 접근 가능한 파트를 설정합니다.
+     * 특정 파트에게만 노출되는 섹션 정책을 생성한다.
+     * {@code allowedParts} 는 1개 이상이어야 한다.
      */
-    public void upsertAllowedParts(Set<ChallengerPart> parts) {
-        this.allowedParts = parts.stream().toList();
+    public static ProjectApplicationFormPolicy createForParts(
+        ProjectApplicationForm form, Long formSectionId, Set<ChallengerPart> allowedParts
+    ) {
+        if (allowedParts == null || allowedParts.isEmpty()) {
+            throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_POLICY_PARTS_EMPTY);
+        }
+        return ProjectApplicationFormPolicy.builder()
+            .applicationForm(form)
+            .formSectionId(formSectionId)
+            .type(FormSectionType.PART)
+            .allowedParts(new ArrayList<>(allowedParts))
+            .build();
     }
 
     /**
-     * 특정 파트가 FormSection에 접근이 가능한지를 판단합니다.
+     * 정책 타입과 노출 파트 목록을 갱신한다.
+     * <p>
+     * {@code COMMON} 으로 변경하면 {@code allowedParts} 는 비워진다.
+     * {@code PART} 로 변경 시 {@code allowedParts} 가 비어있으면 도메인 예외를 던진다.
+     */
+    public void updatePolicy(FormSectionType type, Set<ChallengerPart> allowedParts) {
+        if (type == FormSectionType.PART && (allowedParts == null || allowedParts.isEmpty())) {
+            throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_POLICY_PARTS_EMPTY);
+        }
+        this.type = type;
+        this.allowedParts = (type == FormSectionType.COMMON)
+            ? new ArrayList<>()
+            : new ArrayList<>(allowedParts);
+    }
+
+    /**
+     * 특정 파트가 본 섹션을 조회할 수 있는지 판단한다.
+     * <p>
+     * {@code COMMON} 이면 항상 true (ChallengerPart enum 추가에도 안전).
+     * {@code PART} 이면 {@code allowedParts} 매칭.
      */
     public boolean canAccess(ChallengerPart part) {
-        return this.allowedParts.contains(part);
+        if (type == FormSectionType.COMMON) {
+            return true;
+        }
+        return allowedParts.contains(part);
     }
 
     public void validateSectionAccessPermission(ChallengerPart part) {
         if (canAccess(part)) {
             return;
         }
-
         throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED);
     }
 }

--- a/src/main/java/com/umc/product/project/domain/enums/FormSectionType.java
+++ b/src/main/java/com/umc/product/project/domain/enums/FormSectionType.java
@@ -1,0 +1,12 @@
+package com.umc.product.project.domain.enums;
+
+/**
+ * 지원 폼 섹션의 가시성 타입.
+ * <p>
+ * {@link #COMMON} 은 모든 파트 챌린저에게 노출되며 {@code allowed_parts} 가 무시된다.
+ * {@link #PART} 는 {@code allowed_parts} 에 명시된 챌린저 파트만 해당 섹션을 볼 수 있다.
+ */
+public enum FormSectionType {
+    COMMON,
+    PART,
+}

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -21,6 +21,7 @@ public enum ProjectErrorCode implements BaseCode {
     // ProjectApplicationForm
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0006", "프로젝트에서 해당 지원용 폼을 찾을 수 없습니다."),
     APPLICATION_FORM_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0007", "요청하신 지원용 폼 섹션에 접근 권한이 없습니다."),
+    APPLICATION_FORM_POLICY_PARTS_EMPTY(HttpStatus.BAD_REQUEST, "PROJECT-0013", "PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다."),
 
     // Project Draft flow (PROJECT-101, 102, 107)
     PROJECT_DUPLICATE_IN_GISU(HttpStatus.CONFLICT, "PROJECT-0008", "이미 해당 기수에 등록한 프로젝트가 있습니다."),

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -22,6 +22,11 @@ public enum ProjectErrorCode implements BaseCode {
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0006", "프로젝트에서 해당 지원용 폼을 찾을 수 없습니다."),
     APPLICATION_FORM_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0007", "요청하신 지원용 폼 섹션에 접근 권한이 없습니다."),
     APPLICATION_FORM_POLICY_PARTS_EMPTY(HttpStatus.BAD_REQUEST, "PROJECT-0013", "PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다."),
+    APPLICATION_FORM_INVALID_SECTION_ID(HttpStatus.BAD_REQUEST, "PROJECT-0014", "현재 폼에 존재하지 않는 sectionId 입니다."),
+    APPLICATION_FORM_INVALID_QUESTION_ID(HttpStatus.BAD_REQUEST, "PROJECT-0015", "해당 섹션에 속하지 않는 questionId 입니다."),
+    APPLICATION_FORM_INVALID_OPTION_ID(HttpStatus.BAD_REQUEST, "PROJECT-0016", "해당 질문에 속하지 않는 optionId 입니다."),
+    APPLICATION_FORM_OPTIONS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PROJECT-0017", "선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다."),
+    APPLICATION_FORM_OPTIONS_REQUIRED(HttpStatus.BAD_REQUEST, "PROJECT-0018", "선택지 타입 질문에는 1개 이상의 옵션이 필요합니다."),
 
     // Project Draft flow (PROJECT-101, 102, 107)
     PROJECT_DUPLICATE_IN_GISU(HttpStatus.CONFLICT, "PROJECT-0008", "이미 해당 기수에 등록한 프로젝트가 있습니다."),

--- a/src/main/resources/db/migration/V2026.04.29.10.00__add_application_form_policy_type.sql
+++ b/src/main/resources/db/migration/V2026.04.29.10.00__add_application_form_policy_type.sql
@@ -1,0 +1,32 @@
+-- Project 도메인 PR2 — 지원 폼 섹션 타입 도입.
+-- 섹션을 COMMON(전체 파트 노출) | PART(allowed_parts 명시) 두 종으로 구분하여
+-- ChallengerPart enum 변경에도 의도가 보존되도록 한다.
+
+-- 1) type 컬럼 추가 — 기존 row는 모두 part 한정 의도였으므로 'PART'로 백필
+ALTER TABLE project_application_form_policy
+    ADD COLUMN type VARCHAR(255);
+
+UPDATE project_application_form_policy
+SET type = 'PART'
+WHERE type IS NULL;
+
+ALTER TABLE project_application_form_policy
+    ALTER COLUMN type SET NOT NULL;
+
+-- 2) allowed_parts 를 nullable 로 완화 (COMMON 일 때는 의미 없음)
+ALTER TABLE project_application_form_policy
+    ALTER COLUMN allowed_parts DROP NOT NULL;
+
+-- 3) type 값 도메인 제약
+ALTER TABLE project_application_form_policy
+    ADD CONSTRAINT chk_policy_type_value CHECK (type IN ('COMMON', 'PART'));
+
+-- 4) type 과 allowed_parts 의 일관성 제약
+--    COMMON  → allowed_parts 비어있거나 NULL
+--    PART    → allowed_parts 1개 이상
+ALTER TABLE project_application_form_policy
+    ADD CONSTRAINT chk_policy_part_consistency CHECK (
+        (type = 'COMMON' AND (allowed_parts IS NULL OR cardinality(allowed_parts) = 0))
+        OR
+        (type = 'PART' AND cardinality(allowed_parts) >= 1)
+    );

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormControllerTest.java
@@ -1,0 +1,162 @@
+package com.umc.product.project.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationFormSection;
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionItem;
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationQuestionOptionItem;
+import com.umc.product.project.adapter.in.web.dto.request.UpsertApplicationFormRequest;
+import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ProjectApplicationFormController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProjectApplicationFormControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    UpsertProjectApplicationFormUseCase upsertProjectApplicationFormUseCase;
+
+    @MockitoBean
+    GetProjectApplicationFormUseCase getProjectApplicationFormUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    void PUT_지원_폼_저장() throws Exception {
+        UpsertApplicationFormRequest request = new UpsertApplicationFormRequest(
+            "Triple 지원서", "팀 소개",
+            List.of(
+                ApplicationFormSection.builder()
+                    .sectionId(null).type(FormSectionType.PART)
+                    .allowedParts(Set.of(ChallengerPart.WEB))
+                    .title("프론트엔드").description(null).orderNo(1)
+                    .questions(List.of(
+                        ApplicationQuestionItem.builder()
+                            .questionId(null).type(QuestionType.RADIO).title("선호 프레임워크")
+                            .description(null).isRequired(true).orderNo(1)
+                            .options(List.of(
+                                ApplicationQuestionOptionItem.builder()
+                                    .optionId(null).content("React").orderNo(1).isOther(false).build()
+                            ))
+                            .build()
+                    ))
+                    .build()
+            )
+        );
+
+        given(upsertProjectApplicationFormUseCase.upsert(any())).willReturn(
+            ApplicationFormInfo.builder()
+                .projectId(42L).applicationFormId(100L)
+                .title("Triple 지원서").description("팀 소개")
+                .sections(List.of())
+                .build()
+        );
+
+        mockMvc.perform(put("/api/v1/projects/42/application-form")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.projectId").value(42))
+            .andExpect(jsonPath("$.result.applicationFormId").value(100));
+    }
+
+    @Test
+    void PUT_sections_필드_누락시_400() throws Exception {
+        String body = """
+            { "title": "Triple 지원서" }
+            """;
+
+        mockMvc.perform(put("/api/v1/projects/42/application-form")
+                .content(body).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void PUT_section_title이_빈_문자열이면_400() throws Exception {
+        UpsertApplicationFormRequest request = new UpsertApplicationFormRequest(
+            null, null,
+            List.of(
+                ApplicationFormSection.builder()
+                    .sectionId(null).type(FormSectionType.COMMON).allowedParts(Set.of())
+                    .title("").description(null).orderNo(1).questions(List.of())
+                    .build()
+            )
+        );
+
+        mockMvc.perform(put("/api/v1/projects/42/application-form")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void GET_폼이_있으면_구조_반환() throws Exception {
+        given(getProjectApplicationFormUseCase.findByProjectId(42L)).willReturn(Optional.of(
+            ApplicationFormInfo.builder()
+                .projectId(42L).applicationFormId(100L)
+                .title("Triple 지원서").description(null)
+                .sections(List.of())
+                .build()
+        ));
+
+        mockMvc.perform(get("/api/v1/projects/42/application-form"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.applicationFormId").value(100));
+    }
+
+    @Test
+    void GET_폼이_없으면_result_null() throws Exception {
+        given(getProjectApplicationFormUseCase.findByProjectId(42L)).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/projects/42/application-form"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result").doesNotExist());
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
@@ -1,0 +1,137 @@
+package com.umc.product.project.adapter.in.web.assembler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectResponseAssemblerTest {
+
+    @Mock
+    GetProjectUseCase getProjectUseCase;
+    @Mock
+    SearchProjectUseCase searchProjectUseCase;
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+    @Mock
+    LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+
+    @InjectMocks
+    ProjectResponseAssembler sut;
+
+    @Test
+    void detailFor_폼이_있으면_applicationFormId가_채워진다() {
+        ProjectInfo info = projectInfo(42L);
+        given(getProjectUseCase.getById(42L)).willReturn(info);
+        given(getMemberUseCase.findAllByIds(java.util.Set.of(99L)))
+            .willReturn(Map.of(99L, memberInfo(99L)));
+
+        Project project = project(42L);
+        ProjectApplicationForm form = applicationForm(project, 100L, 500L);
+        given(loadProjectApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+
+        ProjectDetailResponse response = sut.detailFor(42L, true);
+
+        assertThat(response.applicationFormId()).isEqualTo(100L);
+    }
+
+    @Test
+    void detailFor_폼이_없으면_applicationFormId가_null() {
+        ProjectInfo info = projectInfo(42L);
+        given(getProjectUseCase.getById(42L)).willReturn(info);
+        given(getMemberUseCase.findAllByIds(java.util.Set.of(99L)))
+            .willReturn(Map.of(99L, memberInfo(99L)));
+        given(loadProjectApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+
+        ProjectDetailResponse response = sut.detailFor(42L, true);
+
+        assertThat(response.applicationFormId()).isNull();
+    }
+
+    @Test
+    void draftFor_Draft가_있으면_applicationFormId_hydrate() {
+        ProjectInfo info = projectInfo(42L);
+        given(getProjectUseCase.findDraftByOwnerAndGisu(99L, 1L)).willReturn(Optional.of(info));
+        given(getMemberUseCase.findAllByIds(java.util.Set.of(99L)))
+            .willReturn(Map.of(99L, memberInfo(99L)));
+
+        Project project = project(42L);
+        ProjectApplicationForm form = applicationForm(project, 100L, 500L);
+        given(loadProjectApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+
+        DraftProjectResponse response = sut.draftFor(99L, 1L);
+
+        assertThat(response.applicationFormId()).isEqualTo(100L);
+    }
+
+    @Test
+    void draftFor_Draft가_없으면_null_반환() {
+        given(getProjectUseCase.findDraftByOwnerAndGisu(99L, 1L)).willReturn(Optional.empty());
+
+        DraftProjectResponse response = sut.draftFor(99L, 1L);
+
+        assertThat(response).isNull();
+    }
+
+    private ProjectInfo projectInfo(Long projectId) {
+        return ProjectInfo.builder()
+            .id(projectId)
+            .status(ProjectStatus.DRAFT)
+            .name("Triple")
+            .description(null)
+            .gisuId(1L)
+            .chapterId(1L)
+            .productOwnerMemberId(99L)
+            .coProductOwnerMemberIds(List.of())
+            .partQuotas(List.of())
+            .build();
+    }
+
+    private MemberInfo memberInfo(Long memberId) {
+        return MemberInfo.builder()
+            .id(memberId)
+            .nickname("이방토")
+            .name("이예원")
+            .schoolName("한양대 ERICA")
+            .build();
+    }
+
+    private Project project(Long id) {
+        Project p;
+        try {
+            var c = Project.class.getDeclaredConstructor();
+            c.setAccessible(true);
+            p = c.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(p, "id", id);
+        return p;
+    }
+
+    private ProjectApplicationForm applicationForm(Project project, Long id, Long formId) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, formId);
+        ReflectionTestUtils.setField(form, "id", id);
+        return form;
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
@@ -1,0 +1,111 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.TestContainersConfig;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+    ProjectApplicationFormPersistenceAdapter.class})
+class ProjectApplicationFormPersistenceAdapterTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectApplicationFormPersistenceAdapter sut;
+
+    private Long projectId;
+    private Long otherProjectId;
+
+    @BeforeEach
+    void setUp() {
+        projectId = persistProject("프로젝트 알파", 10L).getId();
+        otherProjectId = persistProject("프로젝트 베타", 11L).getId();
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void existsByProjectId_폼이_없으면_false() {
+        assertThat(sut.existsByProjectId(projectId)).isFalse();
+    }
+
+    @Test
+    void existsByProjectId_폼이_하나라도_있으면_true() {
+        Project project = em.find(Project.class, projectId);
+        em.persist(ProjectApplicationForm.create(project, 999L));
+        em.flush();
+        em.clear();
+
+        assertThat(sut.existsByProjectId(projectId)).isTrue();
+        assertThat(sut.existsByProjectId(otherProjectId)).isFalse();
+    }
+
+    @Test
+    void findByProjectId_폼이_없으면_empty() {
+        assertThat(sut.findByProjectId(projectId)).isEmpty();
+    }
+
+    @Test
+    void findByProjectId_여러_폼_중_가장_먼저_생성된_것을_반환() {
+        Project project = em.find(Project.class, projectId);
+        Long firstId = em.persistAndGetId(ProjectApplicationForm.create(project, 100L), Long.class);
+        em.persist(ProjectApplicationForm.create(project, 200L));
+        em.flush();
+        em.clear();
+
+        Optional<ProjectApplicationForm> found = sut.findByProjectId(projectId);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(firstId);
+        assertThat(found.get().getFormId()).isEqualTo(100L);
+    }
+
+    @Test
+    void save_새_폼이_영속화된다() {
+        Project project = em.find(Project.class, projectId);
+
+        ProjectApplicationForm saved = sut.save(ProjectApplicationForm.create(project, 500L));
+        em.flush();
+        em.clear();
+
+        assertThat(saved.getId()).isNotNull();
+        ProjectApplicationForm reloaded = em.find(ProjectApplicationForm.class, saved.getId());
+        assertThat(reloaded.getFormId()).isEqualTo(500L);
+        assertThat(reloaded.getProject().getId()).isEqualTo(projectId);
+    }
+
+    private Project persistProject(String name, Long ownerId) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.DRAFT);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
+        em.persist(project);
+        return project;
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
@@ -1,0 +1,137 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.TestContainersConfig;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+    ProjectApplicationFormPolicyPersistenceAdapter.class})
+class ProjectApplicationFormPolicyPersistenceAdapterTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectApplicationFormPolicyPersistenceAdapter sut;
+
+    private ProjectApplicationForm form;
+    private ProjectApplicationForm otherForm;
+
+    @BeforeEach
+    void setUp() {
+        Project project = persistProject("프로젝트 알파", 10L);
+        Project otherProject = persistProject("프로젝트 베타", 11L);
+        form = em.persist(ProjectApplicationForm.create(project, 100L));
+        otherForm = em.persist(ProjectApplicationForm.create(otherProject, 200L));
+        em.flush();
+    }
+
+    @Test
+    void save_COMMON_정책_저장_후_조회() {
+        ProjectApplicationFormPolicy saved = sut.save(
+            ProjectApplicationFormPolicy.createCommon(form, 500L)
+        );
+        em.flush();
+        em.clear();
+
+        ProjectApplicationFormPolicy reloaded =
+            em.find(ProjectApplicationFormPolicy.class, saved.getId());
+        assertThat(reloaded.getType()).isEqualTo(FormSectionType.COMMON);
+        assertThat(reloaded.getAllowedParts()).isEmpty();
+        assertThat(reloaded.getFormSectionId()).isEqualTo(500L);
+    }
+
+    @Test
+    void save_PART_정책_저장_후_조회() {
+        ProjectApplicationFormPolicy saved = sut.save(
+            ProjectApplicationFormPolicy.createForParts(
+                form, 501L, Set.of(ChallengerPart.WEB, ChallengerPart.IOS)
+            )
+        );
+        em.flush();
+        em.clear();
+
+        ProjectApplicationFormPolicy reloaded =
+            em.find(ProjectApplicationFormPolicy.class, saved.getId());
+        assertThat(reloaded.getType()).isEqualTo(FormSectionType.PART);
+        assertThat(reloaded.getAllowedParts())
+            .containsExactlyInAnyOrder(ChallengerPart.WEB, ChallengerPart.IOS);
+    }
+
+    @Test
+    void listByApplicationFormId_해당_폼의_정책만_반환() {
+        sut.save(ProjectApplicationFormPolicy.createCommon(form, 510L));
+        sut.save(ProjectApplicationFormPolicy.createForParts(form, 511L, Set.of(ChallengerPart.DESIGN)));
+        sut.save(ProjectApplicationFormPolicy.createCommon(otherForm, 520L));
+        em.flush();
+        em.clear();
+
+        List<ProjectApplicationFormPolicy> result = sut.listByApplicationFormId(form.getId());
+
+        assertThat(result).hasSize(2);
+        assertThat(result)
+            .extracting(ProjectApplicationFormPolicy::getFormSectionId)
+            .containsExactlyInAnyOrder(510L, 511L);
+    }
+
+    @Test
+    void deleteByFormSectionId_매칭되는_row_제거() {
+        sut.save(ProjectApplicationFormPolicy.createCommon(form, 530L));
+        sut.save(ProjectApplicationFormPolicy.createCommon(form, 531L));
+        em.flush();
+        em.clear();
+
+        sut.deleteByFormSectionId(530L);
+        em.flush();
+        em.clear();
+
+        List<ProjectApplicationFormPolicy> remaining = sut.listByApplicationFormId(form.getId());
+        assertThat(remaining)
+            .extracting(ProjectApplicationFormPolicy::getFormSectionId)
+            .containsExactly(531L);
+    }
+
+    // CHECK 제약(`chk_policy_part_consistency`, `chk_policy_type_value`) 검증은
+    // Flyway 마이그레이션이 적용된 환경에서만 가능하다. 본 테스트는 ddl-auto=create-drop 으로
+    // 스키마를 생성하므로 CHECK 가 만들어지지 않아 직접 검증할 수 없다. 마이그레이션 SQL 자체는
+    // dev/staging 의 실 PostgreSQL 에서 1차 검증되며, 향후 Flyway 기반 통합 테스트가 추가되면
+    // 그곳에서 다시 검증한다.
+
+    private Project persistProject(String name, Long ownerId) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.DRAFT);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
+        em.persist(project);
+        return project;
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -44,7 +44,6 @@ import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
-import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.Option;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
@@ -211,7 +210,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
             given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
             given(manageFormSectionUseCase.createSection(any())).willReturn(1000L);
@@ -256,7 +254,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
 
             // 기존: 섹션 1 (COMMON) — title="공통"
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
@@ -285,7 +282,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "예전 이름", null, 1L, List.of())
             )));
@@ -313,7 +309,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "공통", null, 1L, List.of())
             )));
@@ -337,7 +332,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "공통", null, 1L, List.of()),
                 existingSection(1001L, "지울 섹션", null, 2L, List.of())
@@ -371,7 +365,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "공통", null, 1L, List.of(
                     existingQuestion(2000L, QuestionType.SHORT_TEXT, "남길 질문", null, true, 1L, List.of()),
@@ -402,7 +395,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "공통", null, 1L, List.of(
                     existingQuestion(2000L, QuestionType.RADIO, "선호도", null, true, 1L, List.of(
@@ -435,7 +427,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "공통", null, 1L, List.of(
                     existingQuestion(2000L, QuestionType.RADIO, "선호도", null, true, 1L, List.of(
@@ -511,7 +502,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
             given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
 
@@ -532,7 +522,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
             given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
 
@@ -555,7 +544,6 @@ class ProjectApplicationFormCommandServiceTest {
 
             given(loadProjectPort.getById(42L)).willReturn(project);
             given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
             given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
                 existingSection(1000L, "A", null, 1L, List.of(
                     existingQuestion(2000L, QuestionType.SHORT_TEXT, "Q1", null, true, 1L, List.of())
@@ -594,8 +582,7 @@ class ProjectApplicationFormCommandServiceTest {
 
         given(loadProjectPort.getById(42L)).willReturn(project);
         given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
-        given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
-        // service 가 두 번 호출 — 1) applyDiff 시점, 2) assembleResponse 시점
+        // service 가 두 번 호출 — 1) syncFormMetaIfChanged + applyDiff 시점, 2) assembleResponse 시점
         given(getFormUseCase.getFormWithStructure(eq(500L)))
             .willReturn(emptyStructure())
             .willReturn(structure(List.of(existingSection(1000L, "공통", null, 1L, List.of()))));
@@ -665,13 +652,6 @@ class ProjectApplicationFormCommandServiceTest {
             .build();
     }
 
-    private FormInfo formInfo(String title, String description) {
-        return FormInfo.builder()
-            .id(500L).createdMemberId(99L).title(title).description(description)
-            .status(FormStatus.DRAFT).isAnonymous(false)
-            .build();
-    }
-
     private FormWithStructureInfo emptyStructure() {
         return structure(List.of());
     }
@@ -717,9 +697,19 @@ class ProjectApplicationFormCommandServiceTest {
 
         given(loadProjectPort.getById(projectId)).willReturn(project);
         given(loadApplicationFormPort.findByProjectId(projectId)).willReturn(Optional.of(form));
-        given(getFormUseCase.getById(surveyFormId)).willReturn(formInfo(formTitle, formDescription));
-        given(getFormUseCase.getFormWithStructure(surveyFormId)).willReturn(emptyStructure());
+        given(getFormUseCase.getFormWithStructure(surveyFormId))
+            .willReturn(structureWithMeta(surveyFormId, formTitle, formDescription, List.of()));
         given(loadPolicyPort.listByApplicationFormId(formRowId)).willReturn(List.of());
+    }
+
+    private FormWithStructureInfo structureWithMeta(
+        Long formId, String title, String description, List<SectionWithQuestions> sections
+    ) {
+        return FormWithStructureInfo.builder()
+            .formId(formId).title(title).description(description)
+            .status(FormStatus.DRAFT).isAnonymous(false)
+            .sections(sections)
+            .build();
     }
 
     private Project createProject(Long id, ProjectStatus status, String name) {

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -3,30 +3,58 @@ package com.umc.product.project.application.service.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationFormSectionEntry;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionEntry;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionOptionEntry;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.enums.FormSectionType;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.survey.application.port.in.command.ManageFormSectionUseCase;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionOptionUseCase;
+import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.Option;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
 import com.umc.product.survey.domain.enums.FormStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -47,220 +75,652 @@ class ProjectApplicationFormCommandServiceTest {
     @Mock
     LoadProjectApplicationFormPolicyPort loadPolicyPort;
     @Mock
+    SaveProjectApplicationFormPolicyPort savePolicyPort;
+    @Mock
     ManageFormUseCase manageFormUseCase;
+    @Mock
+    ManageFormSectionUseCase manageFormSectionUseCase;
+    @Mock
+    ManageQuestionUseCase manageQuestionUseCase;
+    @Mock
+    ManageQuestionOptionUseCase manageQuestionOptionUseCase;
     @Mock
     GetFormUseCase getFormUseCase;
 
     @InjectMocks
     ProjectApplicationFormCommandService sut;
 
+    /* =====================================================
+     * 폼 라이프사이클 (C6 회귀 보장)
+     * ===================================================== */
+
+    @Nested
+    class formLifecycle {
+
+        @Test
+        void 폼이_없으면_createDraft_호출_후_save() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+            given(manageFormUseCase.createDraft(any())).willReturn(500L);
+
+            ProjectApplicationForm savedForm = createApplicationForm(project, 100L, 500L);
+            given(saveApplicationFormPort.save(any())).willReturn(savedForm);
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+            sut.upsert(emptyCommand(42L));
+
+            ArgumentCaptor<CreateDraftFormCommand> captor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
+            then(manageFormUseCase).should().createDraft(captor.capture());
+            assertThat(captor.getValue().title()).isEqualTo("Triple");
+            then(manageFormUseCase).should(never()).updateForm(any());
+        }
+
+        @Test
+        void 본문_title이_null이고_Project_name도_null이면_default_title_사용() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, null);
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+            given(manageFormUseCase.createDraft(any())).willReturn(500L);
+            given(saveApplicationFormPort.save(any())).willReturn(createApplicationForm(project, 100L, 500L));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+            sut.upsert(emptyCommand(42L));
+
+            ArgumentCaptor<CreateDraftFormCommand> captor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
+            then(manageFormUseCase).should().createDraft(captor.capture());
+            assertThat(captor.getValue().title()).isEqualTo("프로젝트 지원서");
+        }
+
+        @Test
+        void 폼이_있고_meta가_같으면_updateForm_호출_안_함() {
+            stubExistingFormWithEmptyStructure(42L, 100L, 500L, "Triple", "팀 소개");
+
+            UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
+                .projectId(42L).requesterMemberId(99L)
+                .title("Triple").description("팀 소개")
+                .sections(List.of())
+                .build();
+
+            sut.upsert(cmd);
+
+            then(manageFormUseCase).should(never()).updateForm(any());
+        }
+
+        @Test
+        void 폼이_있고_title이_바뀌면_updateForm_호출() {
+            stubExistingFormWithEmptyStructure(42L, 100L, 500L, "예전 제목", null);
+
+            UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
+                .projectId(42L).requesterMemberId(99L)
+                .title("새 제목").description(null)
+                .sections(List.of())
+                .build();
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<UpdateFormCommand> captor = ArgumentCaptor.forClass(UpdateFormCommand.class);
+            then(manageFormUseCase).should().updateForm(captor.capture());
+            assertThat(captor.getValue().title()).isEqualTo("새 제목");
+        }
+    }
+
+    /* =====================================================
+     * 상태 가드
+     * ===================================================== */
+
+    @Nested
+    class stateGuards {
+
+        @Test
+        void Project가_COMPLETED면_PROJECT_INVALID_STATE() {
+            Project project = createProject(42L, ProjectStatus.COMPLETED, "Triple");
+            given(loadProjectPort.getById(42L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.upsert(emptyCommand(42L)))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void Project가_IN_PROGRESS면_PROJECT_INVALID_STATE() {
+            Project project = createProject(42L, ProjectStatus.IN_PROGRESS, "Triple");
+            given(loadProjectPort.getById(42L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.upsert(emptyCommand(42L)))
+                .isInstanceOf(ProjectDomainException.class);
+
+            then(manageFormUseCase).should(never()).createDraft(any());
+        }
+    }
+
+    /* =====================================================
+     * 섹션 / 질문 / 옵션 diff
+     * ===================================================== */
+
+    @Nested
+    class sectionDiff {
+
+        @Test
+        void 신규_섹션_생성시_createSection_정책_저장_질문_생성_reorder_호출() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+            given(manageFormSectionUseCase.createSection(any())).willReturn(1000L);
+            given(manageQuestionUseCase.createQuestion(any())).willReturn(2000L);
+            given(manageQuestionOptionUseCase.createOption(any())).willReturn(3000L, 3001L);
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(null, FormSectionType.PART, Set.of(ChallengerPart.WEB), "프론트엔드", 1, List.of(
+                    radioQuestion(null, "선호 프레임워크", List.of(
+                        option(null, "React"),
+                        option(null, "Vue")
+                    ))
+                ))
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<CreateFormSectionCommand> sectionCaptor = ArgumentCaptor.forClass(CreateFormSectionCommand.class);
+            then(manageFormSectionUseCase).should().createSection(sectionCaptor.capture());
+            assertThat(sectionCaptor.getValue().title()).isEqualTo("프론트엔드");
+
+            ArgumentCaptor<ProjectApplicationFormPolicy> policyCaptor =
+                ArgumentCaptor.forClass(ProjectApplicationFormPolicy.class);
+            then(savePolicyPort).should().save(policyCaptor.capture());
+            assertThat(policyCaptor.getValue().getType()).isEqualTo(FormSectionType.PART);
+            assertThat(policyCaptor.getValue().getAllowedParts()).containsExactly(ChallengerPart.WEB);
+
+            then(manageQuestionUseCase).should().createQuestion(any(CreateQuestionCommand.class));
+            then(manageQuestionOptionUseCase).should(times(2))
+                .createOption(any(CreateQuestionOptionCommand.class));
+
+            ArgumentCaptor<ReorderFormSectionsCommand> reorderCaptor =
+                ArgumentCaptor.forClass(ReorderFormSectionsCommand.class);
+            then(manageFormSectionUseCase).should().reorderSections(reorderCaptor.capture());
+            assertThat(reorderCaptor.getValue().orderedSectionIds()).containsExactly(1000L);
+        }
+
+        @Test
+        void 기존_섹션_meta_변경_없으면_updateSection_호출_안_함_idempotent() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+
+            // 기존: 섹션 1 (COMMON) — title="공통"
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of())
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L)
+            ));
+
+            // 본문 동일
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of())
+            ));
+
+            sut.upsert(cmd);
+
+            then(manageFormSectionUseCase).should(never()).updateSection(any());
+            then(savePolicyPort).should(never()).save(any());
+            then(manageFormSectionUseCase).should(never()).deleteSection(any());
+        }
+
+        @Test
+        void 기존_섹션_title_변경시_updateSection_호출() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "예전 이름", null, 1L, List.of())
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L)
+            ));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "새 이름", 1, List.of())
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<UpdateFormSectionCommand> captor = ArgumentCaptor.forClass(UpdateFormSectionCommand.class);
+            then(manageFormSectionUseCase).should().updateSection(captor.capture());
+            assertThat(captor.getValue().title()).isEqualTo("새 이름");
+        }
+
+        @Test
+        void 정책_타입이_바뀌면_savePolicy_호출_COMMON_to_PART() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+            ProjectApplicationFormPolicy existingPolicy =
+                ProjectApplicationFormPolicy.createCommon(form, 1000L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of())
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(existingPolicy));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.PART, Set.of(ChallengerPart.WEB), "공통", 1, List.of())
+            ));
+
+            sut.upsert(cmd);
+
+            then(savePolicyPort).should().save(existingPolicy);
+            assertThat(existingPolicy.getType()).isEqualTo(FormSectionType.PART);
+            assertThat(existingPolicy.getAllowedParts()).containsExactly(ChallengerPart.WEB);
+        }
+
+        @Test
+        void 본문에서_빠진_섹션은_deleteSection_및_정책_삭제() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of()),
+                existingSection(1001L, "지울 섹션", null, 2L, List.of())
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L),
+                ProjectApplicationFormPolicy.createCommon(form, 1001L)
+            ));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of())
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<DeleteFormSectionCommand> deleteCaptor =
+                ArgumentCaptor.forClass(DeleteFormSectionCommand.class);
+            then(manageFormSectionUseCase).should().deleteSection(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue().sectionId()).isEqualTo(1001L);
+            then(savePolicyPort).should().deleteByFormSectionId(1001L);
+        }
+    }
+
+    @Nested
+    class questionAndOptionDiff {
+
+        @Test
+        void 기존_질문_삭제시_deleteQuestion_호출() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of(
+                    existingQuestion(2000L, QuestionType.SHORT_TEXT, "남길 질문", null, true, 1L, List.of()),
+                    existingQuestion(2001L, QuestionType.SHORT_TEXT, "지울 질문", null, false, 2L, List.of())
+                ))
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L)
+            ));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of(
+                    shortTextQuestion(2000L, "남길 질문", true)
+                ))
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<DeleteQuestionCommand> captor = ArgumentCaptor.forClass(DeleteQuestionCommand.class);
+            then(manageQuestionUseCase).should().deleteQuestion(captor.capture());
+            assertThat(captor.getValue().questionId()).isEqualTo(2001L);
+        }
+
+        @Test
+        void 기존_옵션_content_변경시_updateOption_호출() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of(
+                    existingQuestion(2000L, QuestionType.RADIO, "선호도", null, true, 1L, List.of(
+                        existingOption(3000L, "예전 답안", 1L, false)
+                    ))
+                ))
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L)
+            ));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of(
+                    radioQuestion(2000L, "선호도", List.of(option(3000L, "새 답안")))
+                ))
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<UpdateQuestionOptionCommand> captor =
+                ArgumentCaptor.forClass(UpdateQuestionOptionCommand.class);
+            then(manageQuestionOptionUseCase).should().updateOption(captor.capture());
+            assertThat(captor.getValue().content()).isEqualTo("새 답안");
+        }
+
+        @Test
+        void 옵션_삭제시_deleteOption_호출() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "공통", null, 1L, List.of(
+                    existingQuestion(2000L, QuestionType.RADIO, "선호도", null, true, 1L, List.of(
+                        existingOption(3000L, "남길 옵션", 1L, false),
+                        existingOption(3001L, "지울 옵션", 2L, false)
+                    ))
+                ))
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L)
+            ));
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of(
+                    radioQuestion(2000L, "선호도", List.of(option(3000L, "남길 옵션")))
+                ))
+            ));
+
+            sut.upsert(cmd);
+
+            ArgumentCaptor<DeleteQuestionOptionCommand> captor =
+                ArgumentCaptor.forClass(DeleteQuestionOptionCommand.class);
+            then(manageQuestionOptionUseCase).should().deleteOption(captor.capture());
+            assertThat(captor.getValue().optionId()).isEqualTo(3001L);
+        }
+    }
+
+    /* =====================================================
+     * 검증
+     * ===================================================== */
+
+    @Nested
+    class validation {
+
+        @Test
+        void choice_타입에_옵션_0개면_OPTIONS_REQUIRED() {
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(null, FormSectionType.COMMON, Set.of(), "섹션", 1, List.of(
+                    radioQuestion(null, "선택지 없음", List.of())
+                ))
+            ));
+
+            assertThatThrownBy(() -> sut.upsert(cmd))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_OPTIONS_REQUIRED);
+
+            then(loadProjectPort).should(never()).getById(anyLong());
+        }
+
+        @Test
+        void non_choice_타입에_옵션_있으면_OPTIONS_NOT_ALLOWED() {
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(null, FormSectionType.COMMON, Set.of(), "섹션", 1, List.of(
+                    ApplicationQuestionEntry.builder()
+                        .questionId(null).type(QuestionType.SHORT_TEXT).title("주관식")
+                        .description(null).isRequired(true).orderNo(1)
+                        .options(List.of(option(null, "있을 수 없는 옵션")))
+                        .build()
+                ))
+            ));
+
+            assertThatThrownBy(() -> sut.upsert(cmd))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_OPTIONS_NOT_ALLOWED);
+        }
+
+        @Test
+        void 존재하지_않는_sectionId면_INVALID_SECTION_ID() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(9999L, FormSectionType.COMMON, Set.of(), "잘못된 섹션", 1, List.of())
+            ));
+
+            assertThatThrownBy(() -> sut.upsert(cmd))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_INVALID_SECTION_ID);
+        }
+
+        @Test
+        void 신규_섹션에_questionId가_있으면_INVALID_QUESTION_ID() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyStructure());
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(null, FormSectionType.COMMON, Set.of(), "섹션", 1, List.of(
+                    shortTextQuestion(9999L, "이상한 질문", true)
+                ))
+            ));
+
+            assertThatThrownBy(() -> sut.upsert(cmd))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+        }
+
+        @Test
+        void 다른_섹션의_questionId면_INVALID_QUESTION_ID() {
+            Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+            given(getFormUseCase.getFormWithStructure(500L)).willReturn(structure(List.of(
+                existingSection(1000L, "A", null, 1L, List.of(
+                    existingQuestion(2000L, QuestionType.SHORT_TEXT, "Q1", null, true, 1L, List.of())
+                )),
+                existingSection(1001L, "B", null, 2L, List.of(
+                    existingQuestion(2001L, QuestionType.SHORT_TEXT, "Q2", null, true, 1L, List.of())
+                ))
+            )));
+            given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, 1000L),
+                ProjectApplicationFormPolicy.createCommon(form, 1001L)
+            ));
+
+            // 1000 섹션에 1001 섹션의 질문 ID(2001)를 끼워넣음
+            UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "A", 1, List.of(
+                    shortTextQuestion(2001L, "잘못된 질문", true)
+                ))
+            ));
+
+            assertThatThrownBy(() -> sut.upsert(cmd))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+        }
+    }
+
+    /* =====================================================
+     * 응답 조립
+     * ===================================================== */
+
+    @SuppressWarnings("unchecked")
     @Test
-    void upsert_폼이_없으면_createDraft_호출_후_save() {
-        // given
+    void upsert_후_응답에_업데이트된_구조가_담겨야() {
         Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+        ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
         given(loadProjectPort.getById(42L)).willReturn(project);
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+        given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
+        given(getFormUseCase.getFormWithStructure(eq(500L))).willReturn(emptyStructure(), structure(List.of(
+            existingSection(1000L, "공통", null, 1L, List.of())
+        )));
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(
+            List.<ProjectApplicationFormPolicy>of(),
+            List.of(ProjectApplicationFormPolicy.createCommon(form, 1000L))
+        );
+        given(manageFormSectionUseCase.createSection(any())).willReturn(1000L);
 
-        given(manageFormUseCase.createDraft(any(CreateDraftFormCommand.class))).willReturn(500L);
+        UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(
+            section(null, FormSectionType.COMMON, Set.of(), "공통", 1, List.of())
+        ));
 
-        ProjectApplicationForm savedForm = createApplicationForm(project, 100L, 500L);
-        given(saveApplicationFormPort.save(any(ProjectApplicationForm.class))).willReturn(savedForm);
-
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
-
-        UpsertApplicationFormCommand cmd = baseCommand(42L);
-
-        // when
         ApplicationFormInfo result = sut.upsert(cmd);
 
-        // then — createDraft 가 한 번 호출되고, getById/updateForm 은 호출되지 않음 (신규 생성이므로)
-        ArgumentCaptor<CreateDraftFormCommand> createCaptor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
-        then(manageFormUseCase).should().createDraft(createCaptor.capture());
-        assertThat(createCaptor.getValue().title()).isEqualTo("Triple");
-        assertThat(createCaptor.getValue().createdMemberId()).isEqualTo(99L);
-        assertThat(createCaptor.getValue().isAnonymous()).isFalse();
-
-        then(getFormUseCase).should(never()).getById(any());
-        then(manageFormUseCase).should(never()).updateForm(any());
-
         assertThat(result.applicationFormId()).isEqualTo(100L);
-        assertThat(result.projectId()).isEqualTo(42L);
+        assertThat(result.sections()).hasSize(1);
+        assertThat(result.sections().get(0).type()).isEqualTo(FormSectionType.COMMON);
     }
 
-    @Test
-    void upsert_본문_title이_null이고_Project_name도_null이면_default_title_사용() {
-        // given
-        Project project = createProject(42L, ProjectStatus.DRAFT, null);
-        given(loadProjectPort.getById(42L)).willReturn(project);
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
-        given(manageFormUseCase.createDraft(any())).willReturn(500L);
-        given(saveApplicationFormPort.save(any())).willReturn(createApplicationForm(project, 100L, 500L));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+    /* =====================================================
+     * Helpers
+     * ===================================================== */
 
-        UpsertApplicationFormCommand cmd = baseCommand(42L);
-
-        // when
-        sut.upsert(cmd);
-
-        // then
-        ArgumentCaptor<CreateDraftFormCommand> captor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
-        then(manageFormUseCase).should().createDraft(captor.capture());
-        assertThat(captor.getValue().title()).isEqualTo("프로젝트 지원서");
-    }
-
-    @Test
-    void upsert_폼이_있고_meta가_같으면_updateForm_호출_안_함() {
-        // given
-        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
-        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
-
-        given(loadProjectPort.getById(42L)).willReturn(project);
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
-        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "Triple", "팀 소개"));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
-
-        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
-            .projectId(42L).requesterMemberId(99L)
-            .title("Triple").description("팀 소개")
-            .sections(List.of())
-            .build();
-
-        // when
-        sut.upsert(cmd);
-
-        // then
-        then(manageFormUseCase).should(never()).createDraft(any());
-        then(manageFormUseCase).should(never()).updateForm(any());
-    }
-
-    @Test
-    void upsert_폼이_있고_title이_바뀌면_updateForm_호출() {
-        // given
-        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
-        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
-
-        given(loadProjectPort.getById(42L)).willReturn(project);
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
-        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "예전 제목", null));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
-
-        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
-            .projectId(42L).requesterMemberId(99L)
-            .title("새 제목").description(null)
-            .sections(List.of())
-            .build();
-
-        // when
-        sut.upsert(cmd);
-
-        // then
-        ArgumentCaptor<UpdateFormCommand> captor = ArgumentCaptor.forClass(UpdateFormCommand.class);
-        then(manageFormUseCase).should().updateForm(captor.capture());
-        assertThat(captor.getValue().formId()).isEqualTo(500L);
-        assertThat(captor.getValue().title()).isEqualTo("새 제목");
-        assertThat(captor.getValue().description()).isNull();
-    }
-
-    @Test
-    void upsert_폼이_있고_description이_바뀌면_updateForm_호출() {
-        // given
-        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
-        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
-
-        given(loadProjectPort.getById(42L)).willReturn(project);
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
-        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "Triple", null));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
-
-        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
-            .projectId(42L).requesterMemberId(99L)
-            .title("Triple").description("새 설명")
-            .sections(List.of())
-            .build();
-
-        // when
-        sut.upsert(cmd);
-
-        // then
-        then(manageFormUseCase).should().updateForm(any(UpdateFormCommand.class));
-    }
-
-    @Test
-    void upsert_Project가_COMPLETED면_PROJECT_INVALID_STATE() {
-        Project project = createProject(42L, ProjectStatus.COMPLETED, "Triple");
-        given(loadProjectPort.getById(42L)).willReturn(project);
-
-        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
-            .isInstanceOf(ProjectDomainException.class)
-            .extracting("baseCode")
-            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
-
-        then(loadApplicationFormPort).should(never()).findByProjectId(any());
-        then(manageFormUseCase).should(never()).createDraft(any());
-    }
-
-    @Test
-    void upsert_Project가_ABORTED면_PROJECT_INVALID_STATE() {
-        Project project = createProject(42L, ProjectStatus.ABORTED, "Triple");
-        given(loadProjectPort.getById(42L)).willReturn(project);
-
-        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
-            .isInstanceOf(ProjectDomainException.class)
-            .extracting("baseCode")
-            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
-    }
-
-    @Test
-    void upsert_Project가_IN_PROGRESS면_PROJECT_INVALID_STATE() {
-        // Form 이 PUBLISHED 라 Survey 단에서도 차단되지만, Project 단에서 먼저 빠르게 실패한다.
-        Project project = createProject(42L, ProjectStatus.IN_PROGRESS, "Triple");
-        given(loadProjectPort.getById(42L)).willReturn(project);
-
-        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
-            .isInstanceOf(ProjectDomainException.class)
-            .extracting("baseCode")
-            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
-
-        // Survey 호출까지 가지 않음
-        then(manageFormUseCase).should(never()).createDraft(any());
-        then(manageFormUseCase).should(never()).updateForm(any());
-    }
-
-    private UpsertApplicationFormCommand baseCommand(Long projectId) {
+    private UpsertApplicationFormCommand emptyCommand(Long projectId) {
         return UpsertApplicationFormCommand.builder()
-            .projectId(projectId)
-            .requesterMemberId(99L)
-            .title(null)
-            .description(null)
+            .projectId(projectId).requesterMemberId(99L)
+            .title(null).description(null)
             .sections(List.of())
             .build();
     }
 
-    private FormInfo formInfo(Long id, String title, String description) {
+    private UpsertApplicationFormCommand commandWithSections(Long projectId, List<ApplicationFormSectionEntry> sections) {
+        return UpsertApplicationFormCommand.builder()
+            .projectId(projectId).requesterMemberId(99L)
+            .title("Triple").description(null)
+            .sections(sections)
+            .build();
+    }
+
+    private ApplicationFormSectionEntry section(
+        Long sectionId, FormSectionType type, Set<ChallengerPart> allowedParts,
+        String title, int orderNo, List<ApplicationQuestionEntry> questions
+    ) {
+        return ApplicationFormSectionEntry.builder()
+            .sectionId(sectionId).type(type).allowedParts(allowedParts)
+            .title(title).description(null).orderNo(orderNo).questions(questions)
+            .build();
+    }
+
+    private ApplicationQuestionEntry radioQuestion(Long id, String title, List<ApplicationQuestionOptionEntry> opts) {
+        return ApplicationQuestionEntry.builder()
+            .questionId(id).type(QuestionType.RADIO).title(title)
+            .description(null).isRequired(true).orderNo(1).options(opts)
+            .build();
+    }
+
+    private ApplicationQuestionEntry shortTextQuestion(Long id, String title, boolean required) {
+        return ApplicationQuestionEntry.builder()
+            .questionId(id).type(QuestionType.SHORT_TEXT).title(title)
+            .description(null).isRequired(required).orderNo(1).options(List.of())
+            .build();
+    }
+
+    private ApplicationQuestionOptionEntry option(Long id, String content) {
+        return ApplicationQuestionOptionEntry.builder()
+            .optionId(id).content(content).orderNo(1).isOther(false)
+            .build();
+    }
+
+    private FormInfo formInfo(String title, String description) {
         return FormInfo.builder()
-            .id(id)
-            .createdMemberId(99L)
-            .title(title)
-            .description(description)
-            .status(FormStatus.DRAFT)
-            .isAnonymous(false)
+            .id(500L).createdMemberId(99L).title(title).description(description)
+            .status(FormStatus.DRAFT).isAnonymous(false)
             .build();
     }
 
-    private FormWithStructureInfo emptyFormStructure() {
+    private FormWithStructureInfo emptyStructure() {
+        return structure(List.of());
+    }
+
+    private FormWithStructureInfo structure(List<SectionWithQuestions> sections) {
         return FormWithStructureInfo.builder()
-            .formId(500L)
-            .title("Triple")
-            .description(null)
-            .status(FormStatus.DRAFT)
-            .isAnonymous(false)
-            .sections(List.of())
+            .formId(500L).title("Triple").description(null)
+            .status(FormStatus.DRAFT).isAnonymous(false)
+            .sections(sections)
             .build();
+    }
+
+    private SectionWithQuestions existingSection(
+        Long id, String title, String description, Long orderNo, List<QuestionWithOptions> questions
+    ) {
+        return SectionWithQuestions.builder()
+            .sectionId(id).title(title).description(description).orderNo(orderNo)
+            .questions(questions)
+            .build();
+    }
+
+    private QuestionWithOptions existingQuestion(
+        Long id, QuestionType type, String title, String description,
+        boolean isRequired, Long orderNo, List<Option> options
+    ) {
+        return QuestionWithOptions.builder()
+            .questionId(id).type(type).title(title).description(description)
+            .isRequired(isRequired).orderNo(orderNo).options(options)
+            .build();
+    }
+
+    private Option existingOption(Long id, String content, Long orderNo, boolean isOther) {
+        return Option.builder()
+            .optionId(id).content(content).orderNo(orderNo).isOther(isOther)
+            .build();
+    }
+
+    private void stubExistingFormWithEmptyStructure(
+        Long projectId, Long formRowId, Long surveyFormId, String formTitle, String formDescription
+    ) {
+        Project project = createProject(projectId, ProjectStatus.DRAFT, "Triple");
+        ProjectApplicationForm form = createApplicationForm(project, formRowId, surveyFormId);
+
+        given(loadProjectPort.getById(projectId)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(projectId)).willReturn(Optional.of(form));
+        given(getFormUseCase.getById(surveyFormId)).willReturn(formInfo(formTitle, formDescription));
+        given(getFormUseCase.getFormWithStructure(surveyFormId)).willReturn(emptyStructure());
+        given(loadPolicyPort.listByApplicationFormId(formRowId)).willReturn(List.of());
     }
 
     private Project createProject(Long id, ProjectStatus status, String name) {

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -1,0 +1,289 @@
+package com.umc.product.project.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.domain.enums.FormStatus;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicationFormCommandServiceTest {
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+    @Mock
+    LoadProjectApplicationFormPort loadApplicationFormPort;
+    @Mock
+    SaveProjectApplicationFormPort saveApplicationFormPort;
+    @Mock
+    LoadProjectApplicationFormPolicyPort loadPolicyPort;
+    @Mock
+    ManageFormUseCase manageFormUseCase;
+    @Mock
+    GetFormUseCase getFormUseCase;
+
+    @InjectMocks
+    ProjectApplicationFormCommandService sut;
+
+    @Test
+    void upsert_폼이_없으면_createDraft_호출_후_save() {
+        // given
+        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+        given(loadProjectPort.getById(42L)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+
+        given(manageFormUseCase.createDraft(any(CreateDraftFormCommand.class))).willReturn(500L);
+
+        ProjectApplicationForm savedForm = createApplicationForm(project, 100L, 500L);
+        given(saveApplicationFormPort.save(any(ProjectApplicationForm.class))).willReturn(savedForm);
+
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+        UpsertApplicationFormCommand cmd = baseCommand(42L);
+
+        // when
+        ApplicationFormInfo result = sut.upsert(cmd);
+
+        // then — createDraft 가 한 번 호출되고, getById/updateForm 은 호출되지 않음 (신규 생성이므로)
+        ArgumentCaptor<CreateDraftFormCommand> createCaptor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
+        then(manageFormUseCase).should().createDraft(createCaptor.capture());
+        assertThat(createCaptor.getValue().title()).isEqualTo("Triple");
+        assertThat(createCaptor.getValue().createdMemberId()).isEqualTo(99L);
+        assertThat(createCaptor.getValue().isAnonymous()).isFalse();
+
+        then(getFormUseCase).should(never()).getById(any());
+        then(manageFormUseCase).should(never()).updateForm(any());
+
+        assertThat(result.applicationFormId()).isEqualTo(100L);
+        assertThat(result.projectId()).isEqualTo(42L);
+    }
+
+    @Test
+    void upsert_본문_title이_null이고_Project_name도_null이면_default_title_사용() {
+        // given
+        Project project = createProject(42L, ProjectStatus.DRAFT, null);
+        given(loadProjectPort.getById(42L)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+        given(manageFormUseCase.createDraft(any())).willReturn(500L);
+        given(saveApplicationFormPort.save(any())).willReturn(createApplicationForm(project, 100L, 500L));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+        UpsertApplicationFormCommand cmd = baseCommand(42L);
+
+        // when
+        sut.upsert(cmd);
+
+        // then
+        ArgumentCaptor<CreateDraftFormCommand> captor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
+        then(manageFormUseCase).should().createDraft(captor.capture());
+        assertThat(captor.getValue().title()).isEqualTo("프로젝트 지원서");
+    }
+
+    @Test
+    void upsert_폼이_있고_meta가_같으면_updateForm_호출_안_함() {
+        // given
+        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
+
+        given(loadProjectPort.getById(42L)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
+        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "Triple", "팀 소개"));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
+            .projectId(42L).requesterMemberId(99L)
+            .title("Triple").description("팀 소개")
+            .sections(List.of())
+            .build();
+
+        // when
+        sut.upsert(cmd);
+
+        // then
+        then(manageFormUseCase).should(never()).createDraft(any());
+        then(manageFormUseCase).should(never()).updateForm(any());
+    }
+
+    @Test
+    void upsert_폼이_있고_title이_바뀌면_updateForm_호출() {
+        // given
+        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
+
+        given(loadProjectPort.getById(42L)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
+        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "예전 제목", null));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
+            .projectId(42L).requesterMemberId(99L)
+            .title("새 제목").description(null)
+            .sections(List.of())
+            .build();
+
+        // when
+        sut.upsert(cmd);
+
+        // then
+        ArgumentCaptor<UpdateFormCommand> captor = ArgumentCaptor.forClass(UpdateFormCommand.class);
+        then(manageFormUseCase).should().updateForm(captor.capture());
+        assertThat(captor.getValue().formId()).isEqualTo(500L);
+        assertThat(captor.getValue().title()).isEqualTo("새 제목");
+        assertThat(captor.getValue().description()).isNull();
+    }
+
+    @Test
+    void upsert_폼이_있고_description이_바뀌면_updateForm_호출() {
+        // given
+        Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
+        ProjectApplicationForm existing = createApplicationForm(project, 100L, 500L);
+
+        given(loadProjectPort.getById(42L)).willReturn(project);
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(existing));
+        given(getFormUseCase.getById(500L)).willReturn(formInfo(500L, "Triple", null));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(emptyFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of());
+
+        UpsertApplicationFormCommand cmd = UpsertApplicationFormCommand.builder()
+            .projectId(42L).requesterMemberId(99L)
+            .title("Triple").description("새 설명")
+            .sections(List.of())
+            .build();
+
+        // when
+        sut.upsert(cmd);
+
+        // then
+        then(manageFormUseCase).should().updateForm(any(UpdateFormCommand.class));
+    }
+
+    @Test
+    void upsert_Project가_COMPLETED면_PROJECT_INVALID_STATE() {
+        Project project = createProject(42L, ProjectStatus.COMPLETED, "Triple");
+        given(loadProjectPort.getById(42L)).willReturn(project);
+
+        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+
+        then(loadApplicationFormPort).should(never()).findByProjectId(any());
+        then(manageFormUseCase).should(never()).createDraft(any());
+    }
+
+    @Test
+    void upsert_Project가_ABORTED면_PROJECT_INVALID_STATE() {
+        Project project = createProject(42L, ProjectStatus.ABORTED, "Triple");
+        given(loadProjectPort.getById(42L)).willReturn(project);
+
+        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+    }
+
+    @Test
+    void upsert_Project가_IN_PROGRESS면_PROJECT_INVALID_STATE() {
+        // Form 이 PUBLISHED 라 Survey 단에서도 차단되지만, Project 단에서 먼저 빠르게 실패한다.
+        Project project = createProject(42L, ProjectStatus.IN_PROGRESS, "Triple");
+        given(loadProjectPort.getById(42L)).willReturn(project);
+
+        assertThatThrownBy(() -> sut.upsert(baseCommand(42L)))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+
+        // Survey 호출까지 가지 않음
+        then(manageFormUseCase).should(never()).createDraft(any());
+        then(manageFormUseCase).should(never()).updateForm(any());
+    }
+
+    private UpsertApplicationFormCommand baseCommand(Long projectId) {
+        return UpsertApplicationFormCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(99L)
+            .title(null)
+            .description(null)
+            .sections(List.of())
+            .build();
+    }
+
+    private FormInfo formInfo(Long id, String title, String description) {
+        return FormInfo.builder()
+            .id(id)
+            .createdMemberId(99L)
+            .title(title)
+            .description(description)
+            .status(FormStatus.DRAFT)
+            .isAnonymous(false)
+            .build();
+    }
+
+    private FormWithStructureInfo emptyFormStructure() {
+        return FormWithStructureInfo.builder()
+            .formId(500L)
+            .title("Triple")
+            .description(null)
+            .status(FormStatus.DRAFT)
+            .isAnonymous(false)
+            .sections(List.of())
+            .build();
+    }
+
+    private Project createProject(Long id, ProjectStatus status, String name) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "id", id);
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", status);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", 99L);
+        return project;
+    }
+
+    private ProjectApplicationForm createApplicationForm(Project project, Long id, Long formId) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, formId);
+        ReflectionTestUtils.setField(form, "id", id);
+        return form;
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -587,7 +587,6 @@ class ProjectApplicationFormCommandServiceTest {
      * 응답 조립
      * ===================================================== */
 
-    @SuppressWarnings("unchecked")
     @Test
     void upsert_후_응답에_업데이트된_구조가_담겨야() {
         Project project = createProject(42L, ProjectStatus.DRAFT, "Triple");
@@ -596,13 +595,13 @@ class ProjectApplicationFormCommandServiceTest {
         given(loadProjectPort.getById(42L)).willReturn(project);
         given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
         given(getFormUseCase.getById(500L)).willReturn(formInfo("Triple", null));
-        given(getFormUseCase.getFormWithStructure(eq(500L))).willReturn(emptyStructure(), structure(List.of(
-            existingSection(1000L, "공통", null, 1L, List.of())
-        )));
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(
-            List.<ProjectApplicationFormPolicy>of(),
-            List.of(ProjectApplicationFormPolicy.createCommon(form, 1000L))
-        );
+        // service 가 두 번 호출 — 1) applyDiff 시점, 2) assembleResponse 시점
+        given(getFormUseCase.getFormWithStructure(eq(500L)))
+            .willReturn(emptyStructure())
+            .willReturn(structure(List.of(existingSection(1000L, "공통", null, 1L, List.of()))));
+        given(loadPolicyPort.listByApplicationFormId(100L))
+            .willReturn(List.of())
+            .willReturn(List.of(ProjectApplicationFormPolicy.createCommon(form, 1000L)));
         given(manageFormSectionUseCase.createSection(any())).willReturn(1000L);
 
         UpsertApplicationFormCommand cmd = commandWithSections(42L, List.of(

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
@@ -1,0 +1,201 @@
+package com.umc.product.project.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.domain.enums.FormStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicationFormQueryServiceTest {
+
+    @Mock
+    LoadProjectApplicationFormPort loadApplicationFormPort;
+    @Mock
+    LoadProjectApplicationFormPolicyPort loadPolicyPort;
+    @Mock
+    GetFormUseCase getFormUseCase;
+
+    @InjectMocks
+    ProjectApplicationFormQueryService sut;
+
+    @Test
+    void findByProjectId_폼이_없으면_empty_반환() {
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+
+        Optional<ApplicationFormInfo> result = sut.findByProjectId(42L);
+
+        assertThat(result).isEmpty();
+        then(getFormUseCase).should(never()).getFormWithStructure(any());
+        then(loadPolicyPort).should(never()).listByApplicationFormId(any());
+    }
+
+    @Test
+    void findByProjectId_폼이_있으면_FormWithStructure와_정책을_합성() {
+        // given
+        Project project = createProject(42L);
+        ProjectApplicationForm applicationForm = createApplicationForm(project, 100L, 500L);
+
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, 1000L),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, 1001L,
+                Set.of(ChallengerPart.WEB, ChallengerPart.IOS))
+        ));
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(42L).orElseThrow();
+
+        // then
+        assertThat(result.projectId()).isEqualTo(42L);
+        assertThat(result.applicationFormId()).isEqualTo(100L);
+        assertThat(result.title()).isEqualTo("Triple 지원서");
+        assertThat(result.sections()).hasSize(2);
+
+        var commonSection = result.sections().get(0);
+        assertThat(commonSection.sectionId()).isEqualTo(1000L);
+        assertThat(commonSection.type()).isEqualTo(FormSectionType.COMMON);
+        assertThat(commonSection.allowedParts()).isEmpty();
+        assertThat(commonSection.questions()).hasSize(1);
+
+        var partSection = result.sections().get(1);
+        assertThat(partSection.sectionId()).isEqualTo(1001L);
+        assertThat(partSection.type()).isEqualTo(FormSectionType.PART);
+        assertThat(partSection.allowedParts())
+            .containsExactlyInAnyOrder(ChallengerPart.WEB, ChallengerPart.IOS);
+        assertThat(partSection.questions()).hasSize(1);
+        assertThat(partSection.questions().get(0).options()).hasSize(2);
+    }
+
+    @Test
+    void findByProjectId_정책이_누락된_섹션은_PART와_빈_parts로_폴백() {
+        // given — Survey 단엔 섹션 2개 있지만 Project 정책은 1개만 (데이터 정합 깨진 시나리오)
+        Project project = createProject(42L);
+        ProjectApplicationForm applicationForm = createApplicationForm(project, 100L, 500L);
+
+        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, 1000L)
+            // 1001L 정책 누락
+        ));
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(42L).orElseThrow();
+
+        // then
+        var orphanSection = result.sections().get(1);
+        assertThat(orphanSection.type()).isEqualTo(FormSectionType.PART);
+        assertThat(orphanSection.allowedParts()).isEmpty();
+    }
+
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+
+    private Project createProject(Long id) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "id", id);
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.DRAFT);
+        ReflectionTestUtils.setField(project, "name", "Triple");
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", 10L);
+        return project;
+    }
+
+    private ProjectApplicationForm createApplicationForm(Project project, Long id, Long formId) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, formId);
+        ReflectionTestUtils.setField(form, "id", id);
+        return form;
+    }
+
+    private FormWithStructureInfo buildFormStructure() {
+        return FormWithStructureInfo.builder()
+            .formId(500L)
+            .title("Triple 지원서")
+            .description(null)
+            .status(FormStatus.DRAFT)
+            .isAnonymous(false)
+            .sections(List.of(
+                FormWithStructureInfo.SectionWithQuestions.builder()
+                    .sectionId(1000L)
+                    .title("공통 문항")
+                    .description(null)
+                    .orderNo(1L)
+                    .questions(List.of(
+                        FormWithStructureInfo.QuestionWithOptions.builder()
+                            .questionId(2000L)
+                            .title("자기소개")
+                            .description(null)
+                            .type(QuestionType.LONG_TEXT)
+                            .isRequired(true)
+                            .orderNo(1L)
+                            .options(List.of())
+                            .build()
+                    ))
+                    .build(),
+                FormWithStructureInfo.SectionWithQuestions.builder()
+                    .sectionId(1001L)
+                    .title("프론트엔드")
+                    .description(null)
+                    .orderNo(2L)
+                    .questions(List.of(
+                        FormWithStructureInfo.QuestionWithOptions.builder()
+                            .questionId(2001L)
+                            .title("선호 프레임워크")
+                            .description(null)
+                            .type(QuestionType.RADIO)
+                            .isRequired(true)
+                            .orderNo(1L)
+                            .options(List.of(
+                                FormWithStructureInfo.Option.builder()
+                                    .optionId(3000L)
+                                    .content("React")
+                                    .orderNo(1L)
+                                    .isOther(false)
+                                    .build(),
+                                FormWithStructureInfo.Option.builder()
+                                    .optionId(3001L)
+                                    .content("Vue")
+                                    .orderNo(2L)
+                                    .isOther(false)
+                                    .build()
+                            ))
+                            .build()
+                    ))
+                    .build()
+            ))
+            .build();
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectApplicationFormPolicyTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectApplicationFormPolicyTest.java
@@ -1,0 +1,150 @@
+package com.umc.product.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProjectApplicationFormPolicyTest {
+
+    @Nested
+    class createCommon {
+
+        @Test
+        void COMMON_타입으로_생성되며_allowedParts는_빈_리스트다() {
+            ProjectApplicationFormPolicy policy =
+                ProjectApplicationFormPolicy.createCommon(null, 100L);
+
+            assertThat(policy.getType()).isEqualTo(FormSectionType.COMMON);
+            assertThat(policy.getFormSectionId()).isEqualTo(100L);
+            assertThat(policy.getAllowedParts()).isEmpty();
+        }
+    }
+
+    @Nested
+    class createForParts {
+
+        @Test
+        void PART_타입으로_생성된다() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createForParts(
+                null, 100L, Set.of(ChallengerPart.WEB, ChallengerPart.IOS)
+            );
+
+            assertThat(policy.getType()).isEqualTo(FormSectionType.PART);
+            assertThat(policy.getAllowedParts())
+                .containsExactlyInAnyOrder(ChallengerPart.WEB, ChallengerPart.IOS);
+        }
+
+        @Test
+        void allowedParts가_비어있으면_PROJECT_0013_예외() {
+            assertThatThrownBy(() ->
+                ProjectApplicationFormPolicy.createForParts(null, 100L, Set.of())
+            )
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_POLICY_PARTS_EMPTY);
+        }
+
+        @Test
+        void allowedParts가_null이면_PROJECT_0013_예외() {
+            assertThatThrownBy(() ->
+                ProjectApplicationFormPolicy.createForParts(null, 100L, null)
+            )
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_POLICY_PARTS_EMPTY);
+        }
+    }
+
+    @Nested
+    class updatePolicy {
+
+        @Test
+        void COMMON으로_변경하면_allowedParts가_비워진다() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createForParts(
+                null, 100L, Set.of(ChallengerPart.WEB)
+            );
+
+            policy.updatePolicy(FormSectionType.COMMON, Set.of(ChallengerPart.IOS));
+
+            assertThat(policy.getType()).isEqualTo(FormSectionType.COMMON);
+            assertThat(policy.getAllowedParts()).isEmpty();
+        }
+
+        @Test
+        void PART로_변경하면_allowedParts가_갱신된다() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createCommon(null, 100L);
+
+            policy.updatePolicy(FormSectionType.PART, Set.of(ChallengerPart.SPRINGBOOT));
+
+            assertThat(policy.getType()).isEqualTo(FormSectionType.PART);
+            assertThat(policy.getAllowedParts()).containsExactly(ChallengerPart.SPRINGBOOT);
+        }
+
+        @Test
+        void PART로_변경하면서_allowedParts가_비면_PROJECT_0013_예외() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createCommon(null, 100L);
+
+            assertThatThrownBy(() -> policy.updatePolicy(FormSectionType.PART, Set.of()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_POLICY_PARTS_EMPTY);
+        }
+    }
+
+    @Nested
+    class canAccess {
+
+        @Test
+        void COMMON은_모든_파트에_대해_true() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createCommon(null, 100L);
+
+            for (ChallengerPart part : ChallengerPart.values()) {
+                assertThat(policy.canAccess(part)).isTrue();
+            }
+        }
+
+        @Test
+        void PART는_allowedParts에_포함된_경우만_true() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createForParts(
+                null, 100L, Set.of(ChallengerPart.WEB, ChallengerPart.IOS)
+            );
+
+            assertThat(policy.canAccess(ChallengerPart.WEB)).isTrue();
+            assertThat(policy.canAccess(ChallengerPart.IOS)).isTrue();
+            assertThat(policy.canAccess(ChallengerPart.DESIGN)).isFalse();
+            assertThat(policy.canAccess(ChallengerPart.PLAN)).isFalse();
+        }
+    }
+
+    @Nested
+    class validateSectionAccessPermission {
+
+        @Test
+        void 접근_불가_파트면_PROJECT_0007_예외() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createForParts(
+                null, 100L, Set.of(ChallengerPart.WEB)
+            );
+
+            assertThatThrownBy(() -> policy.validateSectionAccessPermission(ChallengerPart.DESIGN))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED);
+        }
+
+        @Test
+        void 접근_가능_파트면_예외_없음() {
+            ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createForParts(
+                null, 100L, Set.of(ChallengerPart.WEB)
+            );
+
+            policy.validateSectionAccessPermission(ChallengerPart.WEB);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -230,6 +230,53 @@ class ProjectTest {
         }
     }
 
+    @Nested
+    class validateApplicationFormEditable {
+
+        @Test
+        void DRAFT_상태에서는_통과() {
+            // setUp 의 project 가 DRAFT
+            project.validateApplicationFormEditable();
+        }
+
+        @Test
+        void PENDING_REVIEW_상태에서는_통과() {
+            setStatus(project, ProjectStatus.PENDING_REVIEW);
+
+            project.validateApplicationFormEditable();
+        }
+
+        @Test
+        void IN_PROGRESS_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.IN_PROGRESS);
+
+            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void COMPLETED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void ABORTED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.ABORTED);
+
+            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
     private void setStatus(Project project, ProjectStatus status) {
         try {
             var field = Project.class.getDeclaredField("status");


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #781

## 🚀 작업 내용

PR1([#761](https://github.com/UMC-PRODUCT/umc-product-server/pull/761))에서 PM Draft 라이프사이클은 만들어졌으나, 지원 문항을 작성할 수단이 없어 PROJECT-107(최종 제출)이 의도된 가드로 항상 실패하던 상태였어요. 해당 PR로 지원 폼 저장/조회 API를 추가해 PM이 빈 프로젝트부터 PENDING_REVIEW까지 끝까지 진행 가능하게 만듭니다.

### 신규 API

| ID | Method | Path | 설명 |
|---|---|---|---|
| **PROJECT-106** | `PUT` | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 (PUT 시멘틱: 본문이 곧 새 상태) |
| **PROJECT-106-GET** | `GET` | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 |

### 핵심 동작

- **PUT 시멘틱**: 본문에 따라 섹션/질문/옵션을 통째로 동기화 (없으면 생성, 있으면 수정, 빠지면 삭제, 순서 다르면 reorder). `*Id` 가 `null`이면 신규, 있으면 기존 매칭. 같은 본문 재호출 시 멱등.
- **Survey 도메인 5종 UseCase 활용** ([PR #748](https://github.com/UMC-PRODUCT/umc-product-server/pull/748)에서 정의된 인터페이스). Project 도메인이 호출자, Survey는 인터페이스만 의존.
- **섹션 가시성** — `FormSectionType` enum (`COMMON` / `PART`) + `ProjectApplicationFormPolicy.allowedParts`. ChallengerPart enum 추가에 안전 (`COMMON`은 type만 보고 통과).

### 머지 후 가능한 누적 흐름 (PR1 + PR2)

PM이 빈 페이지부터 PENDING_REVIEW까지 끝까지:

1. `GET /me/draft` → Draft 확인
2. `POST /projects` → DRAFT 생성
3. `PATCH /projects/{id}` → 기본정보 작성
4. **`PUT /application-form`** ← 본 PR 효과
5. **`POST /submit`** → DRAFT → PENDING_REVIEW 정상 동작 ← PR2로 가드 풀림

여전히 막혀 있는 것: Admin 흐름(파트 할당/publish), 보조 PM 추가/제거, 챌린저 마스킹 등은 후속 PR.

## 💬 리뷰 중점사항

Survey 도메인 구현체 의존 — `SurveyBootstrapConfig` 임시 stub

해당 PR은 Survey 5종 UseCase **인터페이스**만 의존합니다. Survey 구현체가 develop에 없으면 Spring 부팅 자체가 실패하므로, 단독 부팅용 임시 stub config (`project/adapter/config/SurveyBootstrapConfig.java`)를 추가했습니다.

- 메서드 호출 시 `UnsupportedOperationException` — 부팅만 가능하게 할 뿐
- **Survey 구현 PR 머지 후 본 클래스는 별도 cleanup PR로 삭제 필요**
