### PR TITLE
[Feat] Survey UseCase 설계 및 구현

### DIFF
--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
@@ -35,4 +35,18 @@ public interface AnswerChoiceJpaRepository extends JpaRepository<AnswerChoice, L
             )
         """)
     int deleteAllByFormResponseId(@Param("formResponseId") Long formResponseId);
+
+    /**
+     * 특정 폼에 속한 모든 AnswerChoice 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM AnswerChoice ac
+            WHERE ac.answer.id IN (
+                SELECT a.id FROM Answer a
+                JOIN a.formResponse fr
+                WHERE fr.form.id = :formId
+            )
+        """)
+    int deleteByFormId(@Param("formId") Long formId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
@@ -61,4 +61,11 @@ public interface AnswerChoiceJpaRepository extends JpaRepository<AnswerChoice, L
             )
         """)
     int deleteByQuestionId(@Param("questionId") Long questionId);
+
+    /**
+     * 단일 Answer 의 모든 AnswerChoice 삭제 (deleteAnswer / updateAnswer 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM AnswerChoice ac WHERE ac.answer.id = :answerId")
+    int deleteByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceJpaRepository.java
@@ -49,4 +49,16 @@ public interface AnswerChoiceJpaRepository extends JpaRepository<AnswerChoice, L
             )
         """)
     int deleteByFormId(@Param("formId") Long formId);
+
+    /**
+     * 특정 질문에 속한 모든 AnswerChoice 삭제 (deleteQuestion cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM AnswerChoice ac
+            WHERE ac.answer.id IN (
+                SELECT a.id FROM Answer a WHERE a.question.id = :questionId
+            )
+        """)
+    int deleteByQuestionId(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerChoiceQueryRepository.java
@@ -7,12 +7,15 @@ import static com.umc.product.survey.domain.QFormResponse.formResponse;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.QQuestionOption;
 import com.umc.product.survey.domain.enums.FormResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Repository
@@ -73,5 +76,22 @@ public class AnswerChoiceQueryRepository {
                     Collectors.toList()
                 )
             ));
+    }
+
+    /**
+     * 여러 답변의 AnswerChoice 를 벌크 조회.
+     * 정렬: 선택지(questionOption) orderNo asc — 삭제된 선택지 (questionOption == null) 는 뒤로.
+     */
+    public List<AnswerChoice> findAllByAnswerIdIn(Set<Long> answerIds) {
+        if (answerIds.isEmpty()) {
+            return List.of();
+        }
+        QQuestionOption qo = QQuestionOption.questionOption;
+        return queryFactory
+            .selectFrom(answerChoice)
+            .leftJoin(answerChoice.questionOption, qo)
+            .where(answerChoice.answer.id.in(answerIds))
+            .orderBy(qo.orderNo.asc().nullsLast())
+            .fetch();
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerJpaRepository.java
@@ -29,4 +29,11 @@ public interface AnswerJpaRepository extends JpaRepository<Answer, Long> {
             )
         """)
     int deleteByFormId(@Param("formId") Long formId);
+
+    /**
+     * 특정 질문에 속한 모든 Answer 삭제 (deleteQuestion cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Answer a WHERE a.question.id = :questionId")
+    int deleteByQuestionId(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerJpaRepository.java
@@ -17,4 +17,16 @@ public interface AnswerJpaRepository extends JpaRepository<Answer, Long> {
             WHERE a.formResponse.id = :formResponseId
         """)
     int deleteAllByFormResponseId(@Param("formResponseId") Long formResponseId);
+
+    /**
+     * 특정 폼에 속한 모든 Answer 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM Answer a
+            WHERE a.formResponse.id IN (
+                SELECT fr.id FROM FormResponse fr WHERE fr.form.id = :formId
+            )
+        """)
+    int deleteByFormId(@Param("formId") Long formId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
@@ -80,4 +80,11 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
         answerChoiceJpaRepository.deleteByFormId(formId);
         answerJpaRepository.deleteByFormId(formId);
     }
+
+    @Override
+    public void deleteByQuestionId(Long questionId) {
+        // FK 의존성 거꾸로: AnswerChoice -> Answer 순으로 삭제
+        answerChoiceJpaRepository.deleteByQuestionId(questionId);
+        answerJpaRepository.deleteByQuestionId(questionId);
+    }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +21,22 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
     private final AnswerChoiceJpaRepository answerChoiceJpaRepository;
     private final AnswerChoiceQueryRepository answerChoiceQueryRepository;
     private final AnswerJpaRepository answerJpaRepository;
+    private final AnswerQueryRepository answerQueryRepository;
+
+    @Override
+    public Optional<Answer> findById(Long answerId) {
+        return answerJpaRepository.findById(answerId);
+    }
+
+    @Override
+    public List<Answer> listByFormResponseId(Long formResponseId) {
+        return answerQueryRepository.findAllByFormResponseId(formResponseId);
+    }
+
+    @Override
+    public List<AnswerChoice> listChoicesByAnswerIdIn(Set<Long> answerIds) {
+        return answerChoiceQueryRepository.findAllByAnswerIdIn(answerIds);
+    }
 
     @Override
     public long countTotalParticipants(Long formId) {

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
@@ -29,6 +29,11 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
     }
 
     @Override
+    public boolean existsByFormResponseIdAndQuestionId(Long formResponseId, Long questionId) {
+        return answerQueryRepository.existsByFormResponseIdAndQuestionId(formResponseId, questionId);
+    }
+
+    @Override
     public List<Answer> listByFormResponseId(Long formResponseId) {
         return answerQueryRepository.findAllByFormResponseId(formResponseId);
     }
@@ -59,6 +64,11 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
     }
 
     @Override
+    public Answer save(Answer answer) {
+        return answerJpaRepository.save(answer);
+    }
+
+    @Override
     public List<Answer> saveAll(List<Answer> answers) {
         return answerJpaRepository.saveAll(answers);
     }
@@ -86,5 +96,17 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
         // FK 의존성 거꾸로: AnswerChoice -> Answer 순으로 삭제
         answerChoiceJpaRepository.deleteByQuestionId(questionId);
         answerJpaRepository.deleteByQuestionId(questionId);
+    }
+
+    @Override
+    public void deleteByAnswerId(Long answerId) {
+        // FK 의존성 거꾸로: AnswerChoice (bulk @Query) -> Answer (단건 deleteById) 순
+        answerChoiceJpaRepository.deleteByAnswerId(answerId);
+        answerJpaRepository.deleteById(answerId);
+    }
+
+    @Override
+    public void deleteChoicesByAnswerId(Long answerId) {
+        answerChoiceJpaRepository.deleteByAnswerId(answerId);
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerPersistenceAdapter.java
@@ -55,4 +55,11 @@ public class AnswerPersistenceAdapter implements LoadAnswerPort, SaveAnswerPort 
         answerChoiceJpaRepository.deleteAllByFormResponseId(formResponseId);
         answerJpaRepository.deleteAllByFormResponseId(formResponseId);
     }
+
+    @Override
+    public void deleteByFormId(Long formId) {
+        // FK 의존성 거꾸로: AnswerChoice -> Answer 순으로 삭제
+        answerChoiceJpaRepository.deleteByFormId(formId);
+        answerJpaRepository.deleteByFormId(formId);
+    }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerQueryRepository.java
@@ -32,4 +32,20 @@ public class AnswerQueryRepository {
             .orderBy(s.orderNo.asc(), q.orderNo.asc())
             .fetch();
     }
+
+    /**
+     * 특정 FormResponse 에 특정 Question의 답변이 이미 있는지 검사 (createAnswer 중복 검증 용).
+     */
+    public boolean existsByFormResponseIdAndQuestionId(Long formResponseId, Long questionId) {
+        QAnswer a = QAnswer.answer;
+        Integer one = queryFactory
+            .selectOne()
+            .from(a)
+            .where(
+                a.formResponse.id.eq(formResponseId),
+                a.question.id.eq(questionId)
+            )
+            .fetchFirst();
+        return one != null;
+    }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/AnswerQueryRepository.java
@@ -1,0 +1,35 @@
+package com.umc.product.survey.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.QAnswer;
+import com.umc.product.survey.domain.QFormSection;
+import com.umc.product.survey.domain.QQuestion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 특정 FormResponse 의 모든 답변을 조회.
+     * 정렬: 섹션 orderNo asc -> 질문 orderNo asc (사용자가 본 화면 순서).
+     */
+    public List<Answer> findAllByFormResponseId(Long formResponseId) {
+        QAnswer a = QAnswer.answer;
+        QQuestion q = QQuestion.question;
+        QFormSection s = QFormSection.formSection;
+        return queryFactory
+            .selectFrom(a)
+            .join(a.question, q)
+            .join(q.formSection, s)
+            .where(a.formResponse.id.eq(formResponseId))
+            .orderBy(s.orderNo.asc(), q.orderNo.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponseJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponseJpaRepository.java
@@ -64,4 +64,11 @@ public interface FormResponseJpaRepository extends JpaRepository<FormResponse, L
         @Param("formId") Long formId,
         @Param("status") FormResponseStatus status
     );
+
+    /**
+     * 특정 폼의 모든 응답 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM FormResponse fr WHERE fr.form.id = :formId")
+    int deleteByFormId(@Param("formId") Long formId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -83,4 +83,10 @@ public class FormResponsePersistenceAdapter implements LoadFormResponsePort, Sav
             formId, respondentMemberId, FormResponseStatus.SUBMITTED
         );
     }
+
+    @Override
+    @Transactional
+    public void deleteByFormId(Long formId) {
+        formResponseJpaRepository.deleteByFormId(formId);
+    }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -16,10 +16,21 @@ import java.util.Optional;
 public class FormResponsePersistenceAdapter implements LoadFormResponsePort, SaveFormResponsePort {
 
     private final FormResponseJpaRepository formResponseJpaRepository;
+    private final FormResponseQueryRepository formResponseQueryRepository;
 
     @Override
     public Optional<FormResponse> findById(Long formResponseId) {
         return formResponseJpaRepository.findById(formResponseId);
+    }
+
+    @Override
+    public List<FormResponse> listByFormId(Long formId) {
+        return formResponseQueryRepository.findAllByFormId(formId);
+    }
+
+    @Override
+    public List<FormResponse> listSubmittedByFormId(Long formId) {
+        return formResponseQueryRepository.findAllSubmittedByFormId(formId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponseQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormResponseQueryRepository.java
@@ -1,0 +1,44 @@
+package com.umc.product.survey.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.QFormResponse;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FormResponseQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 폼의 모든 응답을 id 내림차순으로 조회 (DRAFT + SUBMITTED 모두 포함).
+     */
+    public List<FormResponse> findAllByFormId(Long formId) {
+        QFormResponse fr = QFormResponse.formResponse;
+        return queryFactory
+            .selectFrom(fr)
+            .where(fr.form.id.eq(formId))
+            .orderBy(fr.id.desc())
+            .fetch();
+    }
+
+    /**
+     * 폼의 SUBMITTED 응답 목록을 id 내림차순으로 조회.
+     */
+    public List<FormResponse> findAllSubmittedByFormId(Long formId) {
+        QFormResponse fr = QFormResponse.formResponse;
+        return queryFactory
+            .selectFrom(fr)
+            .where(
+                fr.form.id.eq(formId),
+                fr.status.eq(FormResponseStatus.SUBMITTED)
+            )
+            .orderBy(fr.id.desc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionJpaRepository.java
@@ -2,10 +2,20 @@ package com.umc.product.survey.adapter.out.persistence;
 
 import com.umc.product.survey.domain.FormSection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FormSectionJpaRepository extends JpaRepository<FormSection, Long> {
 
     List<FormSection> findAllByFormId(Long formId);
+
+    /**
+     * 특정 폼에 속한 모든 섹션 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM FormSection fs WHERE fs.form.id = :formId")
+    int deleteByFormId(@Param("formId") Long formId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionJpaRepository.java
@@ -6,11 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface FormSectionJpaRepository extends JpaRepository<FormSection, Long> {
-
-    List<FormSection> findAllByFormId(Long formId);
 
     /**
      * 특정 폼에 속한 모든 섹션 삭제 (deleteForm cascade 용)

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionPersistenceAdapter.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public class FormSectionPersistenceAdapter implements SaveFormSectionPort, LoadFormSectionPort {
 
     private final FormSectionJpaRepository formSectionJpaRepository;
+    private final FormSectionQueryRepository formSectionQueryRepository;
 
     @Override
     public FormSection save(FormSection formSection) {
@@ -32,7 +33,7 @@ public class FormSectionPersistenceAdapter implements SaveFormSectionPort, LoadF
 
     @Override
     public List<FormSection> listByFormId(Long formId) {
-        return formSectionJpaRepository.findAllByFormId(formId);
+        return formSectionQueryRepository.findAllByFormId(formId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionPersistenceAdapter.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -20,7 +21,27 @@ public class FormSectionPersistenceAdapter implements SaveFormSectionPort, LoadF
     }
 
     @Override
-    public List<FormSection> findAllByFormId(Long formId) {
+    public List<FormSection> saveAll(List<FormSection> sections) {
+        return formSectionJpaRepository.saveAll(sections);
+    }
+
+    @Override
+    public Optional<FormSection> findById(Long sectionId) {
+        return formSectionJpaRepository.findById(sectionId);
+    }
+
+    @Override
+    public List<FormSection> listByFormId(Long formId) {
         return formSectionJpaRepository.findAllByFormId(formId);
+    }
+
+    @Override
+    public void deleteById(Long sectionId) {
+        formSectionJpaRepository.deleteById(sectionId);
+    }
+
+    @Override
+    public void deleteByFormId(Long formId) {
+        formSectionJpaRepository.deleteByFormId(formId);
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/FormSectionQueryRepository.java
@@ -1,0 +1,28 @@
+package com.umc.product.survey.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.QFormSection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FormSectionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 폼에 속한 모든 섹션을 orderNo 오름차순으로 조회.
+     */
+    public List<FormSection> findAllByFormId(Long formId) {
+        QFormSection s = QFormSection.formSection;
+        return queryFactory
+            .selectFrom(s)
+            .where(s.form.id.eq(formId))
+            .orderBy(s.orderNo.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
@@ -61,4 +61,22 @@ public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
             """)
     List<Question> findAllByFormId(@Param("formId") Long formId);
 
+    /**
+     * 특정 폼에 속한 모든 질문 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM Question q
+            WHERE q.formSection.id IN (
+                SELECT fs.id FROM FormSection fs WHERE fs.form.id = :formId
+            )
+        """)
+    int deleteByFormId(@Param("formId") Long formId);
+
+    /**
+     * 특정 섹션에 속한 모든 질문 삭제 (deleteSection cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Question q WHERE q.formSection.id = :sectionId")
+    int deleteBySectionId(@Param("sectionId") Long sectionId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionJpaRepository.java
@@ -19,6 +19,32 @@ public interface QuestionOptionJpaRepository extends JpaRepository<QuestionOptio
     @Query("DELETE FROM QuestionOption o WHERE o.question.id = :questionId")
     int deleteAllByQuestionId(@Param("questionId") Long questionId);
 
+    /**
+     * 특정 폼에 속한 모든 선택지 삭제 (deleteForm cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM QuestionOption qo
+            WHERE qo.question.id IN (
+                SELECT q.id FROM Question q
+                JOIN q.formSection fs
+                WHERE fs.form.id = :formId
+            )
+        """)
+    int deleteByFormId(@Param("formId") Long formId);
+
+    /**
+     * 특정 섹션에 속한 모든 선택지 삭제 (deleteSection cascade 용)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM QuestionOption qo
+            WHERE qo.question.id IN (
+                SELECT q.id FROM Question q WHERE q.formSection.id = :sectionId
+            )
+        """)
+    int deleteBySectionId(@Param("sectionId") Long sectionId);
+
     boolean existsByIdAndQuestion_Id(Long optionId, Long questionId);
 
     List<QuestionOption> findAllByQuestion_IdOrderByOrderNoAsc(Long questionId);

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionJpaRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 public interface QuestionOptionJpaRepository extends JpaRepository<QuestionOption, Long> {
 
     /**
@@ -46,6 +44,4 @@ public interface QuestionOptionJpaRepository extends JpaRepository<QuestionOptio
     int deleteBySectionId(@Param("sectionId") Long sectionId);
 
     boolean existsByIdAndQuestion_Id(Long optionId, Long questionId);
-
-    List<QuestionOption> findAllByQuestion_IdOrderByOrderNoAsc(Long questionId);
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -62,5 +63,10 @@ public class QuestionOptionPersistenceAdapter implements SaveQuestionOptionPort,
     @Override
     public List<QuestionOption> listByQuestionId(Long questionId) {
         return questionOptionQueryRepository.findAllByQuestionId(questionId);
+    }
+
+    @Override
+    public List<QuestionOption> listByQuestionIdIn(Set<Long> questionIds) {
+        return questionOptionQueryRepository.findAllByQuestionIdIn(questionIds);
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public class QuestionOptionPersistenceAdapter implements SaveQuestionOptionPort, LoadQuestionOptionPort {
 
     private final QuestionOptionJpaRepository questionOptionJpaRepository;
+    private final QuestionOptionQueryRepository questionOptionQueryRepository;
 
     @Override
     public QuestionOption save(QuestionOption option) {
@@ -60,6 +61,6 @@ public class QuestionOptionPersistenceAdapter implements SaveQuestionOptionPort,
 
     @Override
     public List<QuestionOption> listByQuestionId(Long questionId) {
-        return questionOptionJpaRepository.findAllByQuestion_IdOrderByOrderNoAsc(questionId);
+        return questionOptionQueryRepository.findAllByQuestionId(questionId);
     }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionPersistenceAdapter.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -15,16 +16,13 @@ public class QuestionOptionPersistenceAdapter implements SaveQuestionOptionPort,
     private final QuestionOptionJpaRepository questionOptionJpaRepository;
 
     @Override
-    public void deleteAllByQuestionId(Long questionId) {
-        questionOptionJpaRepository.deleteAllByQuestionId(questionId);
+    public QuestionOption save(QuestionOption option) {
+        return questionOptionJpaRepository.save(option);
     }
 
     @Override
-    public boolean existsByIdAndQuestionId(Long optionId, Long questionId) {
-        if (optionId == null || questionId == null) {
-            return false;
-        }
-        return questionOptionJpaRepository.existsByIdAndQuestion_Id(optionId, questionId);
+    public List<QuestionOption> saveAll(List<QuestionOption> questionOptions) {
+        return questionOptionJpaRepository.saveAll(questionOptions);
     }
 
     @Override
@@ -33,8 +31,31 @@ public class QuestionOptionPersistenceAdapter implements SaveQuestionOptionPort,
     }
 
     @Override
-    public List<QuestionOption> saveAll(List<QuestionOption> questionOptions) {
-        return questionOptionJpaRepository.saveAll(questionOptions);
+    public void deleteAllByQuestionId(Long questionId) {
+        questionOptionJpaRepository.deleteAllByQuestionId(questionId);
+    }
+
+    @Override
+    public void deleteByFormId(Long formId) {
+        questionOptionJpaRepository.deleteByFormId(formId);
+    }
+
+    @Override
+    public void deleteBySectionId(Long sectionId) {
+        questionOptionJpaRepository.deleteBySectionId(sectionId);
+    }
+
+    @Override
+    public Optional<QuestionOption> findById(Long optionId) {
+        return questionOptionJpaRepository.findById(optionId);
+    }
+
+    @Override
+    public boolean existsByIdAndQuestionId(Long optionId, Long questionId) {
+        if (optionId == null || questionId == null) {
+            return false;
+        }
+        return questionOptionJpaRepository.existsByIdAndQuestion_Id(optionId, questionId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionQueryRepository.java
@@ -1,0 +1,28 @@
+package com.umc.product.survey.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.QQuestionOption;
+import com.umc.product.survey.domain.QuestionOption;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionOptionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 질문에 속한 모든 선택지를 orderNo 오름차순으로 조회.
+     */
+    public List<QuestionOption> findAllByQuestionId(Long questionId) {
+        QQuestionOption o = QQuestionOption.questionOption;
+        return queryFactory
+            .selectFrom(o)
+            .where(o.question.id.eq(questionId))
+            .orderBy(o.orderNo.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionOptionQueryRepository.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +23,21 @@ public class QuestionOptionQueryRepository {
         return queryFactory
             .selectFrom(o)
             .where(o.question.id.eq(questionId))
+            .orderBy(o.orderNo.asc())
+            .fetch();
+    }
+
+    /**
+     * 여러 질문의 모든 선택지를 벌크 조회. orderNo 오름차순 정렬.
+     */
+    public List<QuestionOption> findAllByQuestionIdIn(Set<Long> questionIds) {
+        if (questionIds.isEmpty()) {
+            return List.of();
+        }
+        QQuestionOption o = QQuestionOption.questionOption;
+        return queryFactory
+            .selectFrom(o)
+            .where(o.question.id.in(questionIds))
             .orderBy(o.orderNo.asc())
             .fetch();
     }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -17,6 +17,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestionPort {
     private final QuestionJpaRepository questionJpaRepository;
+    private final QuestionQueryRepository questionQueryRepository;
 
     @Override
     public void deleteByFormIdAndQuestionId(Long formId, Long questionId) {
@@ -64,6 +65,11 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
     @Override
     public List<Question> listByFormId(Long formId) {
         return questionJpaRepository.findAllByFormId(formId);
+    }
+
+    @Override
+    public List<Question> listBySectionId(Long sectionId) {
+        return questionQueryRepository.findAllBySectionId(sectionId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -73,6 +73,11 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
     }
 
     @Override
+    public List<Question> listBySectionIdIn(Set<Long> sectionIds) {
+        return questionQueryRepository.findAllBySectionIdIn(sectionIds);
+    }
+
+    @Override
     public Question save(Question question) {
         return questionJpaRepository.save(question);
     }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -42,6 +42,16 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
     }
 
     @Override
+    public void deleteByFormId(Long formId) {
+        questionJpaRepository.deleteByFormId(formId);
+    }
+
+    @Override
+    public void deleteBySectionId(Long sectionId) {
+        questionJpaRepository.deleteBySectionId(sectionId);
+    }
+
+    @Override
     public Optional<Question> findById(Long questionId) {
         return questionJpaRepository.findById(questionId);
     }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -81,4 +81,9 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
     public Question save(Question question) {
         return questionJpaRepository.save(question);
     }
+
+    @Override
+    public List<Question> saveAll(List<Question> questions) {
+        return questionJpaRepository.saveAll(questions);
+    }
 }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +23,21 @@ public class QuestionQueryRepository {
         return queryFactory
             .selectFrom(q)
             .where(q.formSection.id.eq(sectionId))
+            .orderBy(q.orderNo.asc())
+            .fetch();
+    }
+
+    /**
+     * 여러 섹션의 모든 질문을 벌크 조회. orderNo 오름차순 정렬.
+     */
+    public List<Question> findAllBySectionIdIn(Set<Long> sectionIds) {
+        if (sectionIds.isEmpty()) {
+            return List.of();
+        }
+        QQuestion q = QQuestion.question;
+        return queryFactory
+            .selectFrom(q)
+            .where(q.formSection.id.in(sectionIds))
             .orderBy(q.orderNo.asc())
             .fetch();
     }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
@@ -1,0 +1,28 @@
+package com.umc.product.survey.adapter.out.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.survey.domain.QQuestion;
+import com.umc.product.survey.domain.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 섹션에 속한 모든 질문을 orderNo 오름차순으로 조회.
+     */
+    public List<Question> findAllBySectionId(Long sectionId) {
+        QQuestion q = QQuestion.question;
+        return queryFactory
+            .selectFrom(q)
+            .where(q.formSection.id.eq(sectionId))
+            .orderBy(q.orderNo.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormResponseUseCase.java
@@ -20,14 +20,20 @@ public interface ManageFormResponseUseCase {
     /**
      * 폼에 대한 응답을 즉시 제출한다. (draft 없이 바로 SUBMITTED 상태 생성)
      * vote 같이 한 번에 제출하는 플로우에서 사용.
-     * 같은 폼에 이미 제출한 응답이 있으면 예외.
+     * <p>
+     * 결과 status 는 SUBMITTED라 제출 무결성 을 위해 형식 검증 + 필수 답변 누락 검증을 모두 수행.
+     * 같은 폼에 이미 응답 (DRAFT/SUBMITTED 무관) 이 있으면 예외.
      *
      * @return 생성된 FormResponse ID
      */
     Long submitImmediately(SubmitFormResponseCommand command);
 
     /**
-     * 기존 SUBMITTED 응답의 답변을 전체 교체한다.
+     * 기존 SUBMITTED 응답의 답변을 전체 교체한다 (재제출 의미).
+     * <p>
+     * 결과 status 는 SUBMITTED 그대로 유지되므로 제출 무결성을 위해 필수 답변 누락 검증을 수행한다 ({@link #submitImmediately} 와 동일).
+     * <p>
+     * 작성 중인 응답을 갱신하려는 경우는 {@link #updateDraft} 사용.
      * 해당 폼에 대한 기존 SUBMITTED 응답이 없으면 예외.
      */
     void updateResponse(UpdateFormResponseCommand command);
@@ -49,14 +55,23 @@ public interface ManageFormResponseUseCase {
     Long createDraft(CreateDraftFormResponseCommand command);
 
     /**
-     * 기존 draft 응답의 답변을 전체 교체한다. (임시저장)
+     * 기존 draft 응답의 답변을 전체 교체한다 (작성 중 임시저장).
+     * <p>
+     * 결과 status 는 DRAFT 그대로 유지되며, 작성 중이라는 의미상 필수 답변 누락 허용.
+     * 형식 / 옵션 소속 / OTHER 텍스트 등 형식 검증 만 수행한다.
+     * 필수 누락은 {@link #submitDraft} 시점에 검증.
+     * <p>
      * draft가 아닌 응답(SUBMITTED) 또는 존재하지 않는 응답 ID면 예외.
      */
     void updateDraft(UpdateDraftFormResponseCommand command);
 
     /**
      * draft 응답을 SUBMITTED 로 전환(최종 제출)한다.
-     * draft가 아닌 응답이면 예외. 답변 내용은 이전 updateDraft 값 그대로 유지.
+     * <p>
+     * 답변 내용은 이전 {@link #updateDraft} 로 저장된 값 그대로 유지 — status 만 DRAFT -> SUBMITTED.
+     * 결과 status 가 SUBMITTED 가 되므로 저장된 답변 기준으로 필수 답변 누락 검증을 수행.
+     * <p>
+     * draft 가 아닌 응답이면 예외.
      */
     void submitDraft(SubmitDraftFormResponseCommand command);
 

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormSectionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormSectionUseCase.java
@@ -8,8 +8,10 @@ import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionC
 /**
  * FormSection(폼 섹션) 관리 UseCase.
  * <p>
- * 섹션은 폼 안에서 질문들을 묶는 논리적 단위. 발행된 폼의 섹션 구조 변경은
- * 응답 일관성을 해칠 수 있으므로 DRAFT 상태에서만 수정/삭제/재정렬 가능.
+ * 권한 검증과 발행 상태 검증은 호출 측 (consumer 도메인) 책임. 본 UseCase 는 단순 동작만 보장.
+ * 응답 무결성은 {@code AnswerChoice.answeredAsContent} 스냅샷이 보장.
+ * <p>
+ * TODO: 발행된 폼 / 응답이 들어온 폼 의 섹션 구조 변경 차단 정책 합의 시 분기 추가.
  */
 public interface ManageFormSectionUseCase {
 
@@ -22,8 +24,8 @@ public interface ManageFormSectionUseCase {
     Long createSection(CreateFormSectionCommand command);
 
     /**
-     * 섹션의 title/description을 수정한다.
-     * 발행된 폼의 섹션은 수정 불가 — SURVEY_NOT_DRAFT 예외. TODO: 관련 로직 확정 시 수정 필요
+     * 섹션의 title/description 부분 업데이트.
+     * null 인 필드는 기존 값 유지.
      */
     void updateSection(UpdateFormSectionCommand command);
 
@@ -35,7 +37,7 @@ public interface ManageFormSectionUseCase {
     /**
      * 폼 내 섹션들의 순서를 재배치한다.
      * 입력 리스트 순서대로 orderNo가 1부터 재부여된다.
-     * 리스트에 포함되지 않은 섹션이 있으면 예외.
+     * 폼의 모든 섹션 ID 가 누락 / 중복 / 외부 ID 없이 정확히 일치해야 한다.
      */
     void reorderSections(ReorderFormSectionsCommand command);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageFormUseCase.java
@@ -11,6 +11,9 @@ import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
  * 생성 흐름: {@link #createDraft} 로 DRAFT 상태로 시작 -> {@link #updateForm}으로 임시저장 업데이트 -> {@link #publishForm} 로 PUBLISHED 전환 시 응답 수집 가능.
  * <p>
  * 삭제는 {@link #deleteForm} — 연관된 FormSection / Question / QuestionOption / FormResponse / Answer 모두 cascade 삭제.
+ * <p>
+ * 권한 검증과 발행 상태 검증은 호출 측 (consumer 도메인) 책임. 본 UseCase 는 단순 동작만 보장한다.
+ * 응답 무결성은 {@code AnswerChoice.answeredAsContent} 스냅샷이 보장.
  */
 public interface ManageFormUseCase {
 
@@ -22,9 +25,10 @@ public interface ManageFormUseCase {
     Long createDraft(CreateDraftFormCommand command);
 
     /**
-     * DRAFT 상태의 폼 메타데이터(title/description/isAnonymous)를 업데이트한다. (임시저장 용도)
-     * 발행된 폼은 수정 불가 — SURVEY_ALREADY_PUBLISHED 예외. TODO: 관련 로직 확정 시 수정
-     * 요청자가 작성자가 아니면 권한 예외.
+     * 폼 메타데이터(title/description/isAnonymous) 부분 업데이트.
+     * null 인 필드는 기존 값 유지.
+     * 발행된 폼도 수정 가능하도록 구현.
+     * TODO: 관련 정책 확정 시 수정
      */
     void updateForm(UpdateFormCommand command);
 
@@ -35,8 +39,7 @@ public interface ManageFormUseCase {
     void publishForm(PublishFormCommand command);
 
     /**
-     * 폼과 연관 구조(섹션/질문/옵션/응답/답변) 전부 삭제.
-     * 요청자가 작성자가 아니면 권한 예외.
+     * 폼과 연관 구조(섹션/질문/옵션/응답/답변) 전부 cascade 삭제.
      */
     void deleteForm(DeleteFormCommand command);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionOptionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionOptionUseCase.java
@@ -8,8 +8,12 @@ import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOpti
 /**
  * QuestionOption(질문 선택지) 관리 UseCase.
  * <p>
- * 선택지는 RADIO / CHECKBOX / DROPDOWN 타입 질문에만 유의미하며, 다른 타입 질문에는 생성하지 않는다.
- * 발행된 폼의 선택지 변경은 응답 무결성에 영향을 주므로 DRAFT 상태에서만 허용. TODO: 관련 로직 확정 시 수정
+ * 선택지는 RADIO / CHECKBOX / DROPDOWN 타입 질문에만 유의미.
+ * 타입 검증은 호출 측 책임.
+ * 권한 검증과 발행 상태 검증은 호출 측 (consumer 도메인) 책임. 본 UseCase 는 단순 동작만 보장.
+ * 응답 무결성은 {@code AnswerChoice.answeredAsContent} 스냅샷이 보장.
+ * <p>
+ * TODO: 발행된 폼 / 응답이 들어온 폼의 선택지 변경 차단 정책 합의 시 분기 추가.
  */
 public interface ManageQuestionOptionUseCase {
 
@@ -22,19 +26,20 @@ public interface ManageQuestionOptionUseCase {
     Long createOption(CreateQuestionOptionCommand command);
 
     /**
-     * 선택지의 content / isOther 속성을 업데이트한다.
-     * 발행된 폼의 선택지는 수정 불가 — SURVEY_NOT_DRAFT 예외. TODO: 관련 로직 확정 시 수정
+     * 선택지의 content / isOther 부분 업데이트.
+     * null 인 필드는 기존 값 유지.
      */
     void updateOption(UpdateQuestionOptionCommand command);
 
     /**
-     * 선택지 삭제. 연관 AnswerChoice 의 question_option_id는 ON DELETE SET NULL 로 처리됨.
+     * 선택지 삭제. 연관 AnswerChoice의 question_option_id는 ON DELETE SET NULL로 처리됨.
      */
     void deleteOption(DeleteQuestionOptionCommand command);
 
     /**
      * 질문 내 선택지들의 순서를 재배치한다.
-     * {@code orderedOptionIds} 의 순서대로 orderNo가 1부터 재부여.
+     * 입력 리스트 순서대로 orderNo가 1부터 재부여된다.
+     * 질문의 모든 선택지 ID 가 누락 / 중복 / 외부 ID 없이 정확히 일치해야 한다.
      */
     void reorderOptions(ReorderQuestionOptionsCommand command);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/AnswerCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/AnswerCommand.java
@@ -11,14 +11,17 @@ import java.util.List;
  *   <li>SHORT_TEXT / LONG_TEXT: {@code textValue} 사용</li>
  *   <li>RADIO / DROPDOWN: {@code selectedOptionIds} 에 1개</li>
  *   <li>CHECKBOX: {@code selectedOptionIds} 에 1개 이상</li>
+ *   <li>FILE: {@code fileIds} 에 1개 이상</li>
+ *   <li>PORTFOLIO: {@code textValue} (링크) 또는 {@code fileIds} — 둘 중 하나</li>
  * </ul>
  * <p>
- * SCHEDULE / FILE / PORTFOLIO 타입은 현재 미지원. (Survey UseCase 구현 시 확장 예정)
+ * SCHEDULE 타입은 현재 미지원 (후속 PR).
  */
 @Builder
 public record AnswerCommand(
     Long questionId,
     String textValue,
-    List<Long> selectedOptionIds
+    List<Long> selectedOptionIds,
+    List<String> fileIds
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateAnswerCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateAnswerCommand.java
@@ -25,7 +25,7 @@ public record CreateAnswerCommand(
     Long requesterMemberId,
     String textValue,
     List<Long> selectedOptionIds,
-    List<Long> fileIds,
+    List<String> fileIds,
     List<Instant> times
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateAnswerCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateAnswerCommand.java
@@ -16,7 +16,7 @@ public record UpdateAnswerCommand(
     Long requesterMemberId,
     String textValue,
     List<Long> selectedOptionIds,
-    List<Long> fileIds,
+    List<String> fileIds,
     List<Instant> times
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateFormCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateFormCommand.java
@@ -3,8 +3,12 @@ package com.umc.product.survey.application.port.in.command.dto;
 import lombok.Builder;
 
 /**
- * DRAFT 상태 폼의 메타데이터 업데이트 Command. (임시저장 용도)
- * {@code requesterMemberId}는 권한 검증용 — 폼 작성자 본인인지 확인.
+ * 폼 메타데이터 부분 업데이트 Command (임시저장 / 발행 후 모두 사용).
+ * <p>
+ * null 인 필드는 '변경 없음' 으로 처리 (PATCH 의미).
+ * 임시저장 상태에서는 어느 필드든 부분 변경이 가능해야 하므로 모든 필드를 nullable 로 둔다.
+ * <p>
+ * {@code requesterMemberId} 는 리뷰 협의를 통해 권한 검증을 survey 측에서 하지 않는 것이 확정되면 삭제 예정 (권한 검증은 호출 측 책임).
  */
 @Builder
 public record UpdateFormCommand(
@@ -12,6 +16,6 @@ public record UpdateFormCommand(
     Long requesterMemberId,
     String title,
     String description,
-    boolean isAnonymous
+    Boolean isAnonymous
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateQuestionCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateQuestionCommand.java
@@ -4,8 +4,9 @@ import com.umc.product.survey.domain.enums.QuestionType;
 import lombok.Builder;
 
 /**
- * 질문 속성 업데이트 Command.
- * type 변경 시 Service가 관련 QuestionOption/AnswerChoice 정리 책임.
+ * 질문 속성 부분 업데이트 Command.
+ * null 인 필드는 기존 값 유지 (PATCH semantics).
+ * type 변경 시 Service가 관련 QuestionOption / 응답 cascade 정리 책임.
  */
 @Builder
 public record UpdateQuestionCommand(
@@ -14,6 +15,6 @@ public record UpdateQuestionCommand(
     QuestionType type,
     String title,
     String description,
-    boolean isRequired
+    Boolean isRequired
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateQuestionOptionCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateQuestionOptionCommand.java
@@ -3,7 +3,8 @@ package com.umc.product.survey.application.port.in.command.dto;
 import lombok.Builder;
 
 /**
- * 선택지 속성 업데이트 Command. content 및 isOther 를 수정.
+ * 선택지 속성 업데이트 Command. content / isOther를 부분 수정.
+ * null 인 필드는 기존 값 유지.
  * 순서 변경은 {@code ReorderQuestionOptionsCommand}.
  */
 @Builder
@@ -11,6 +12,6 @@ public record UpdateQuestionOptionCommand(
     Long optionId,
     Long requesterMemberId,
     String content,
-    boolean isOther
+    Boolean isOther
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
@@ -23,15 +23,20 @@ public interface GetFormResponseUseCase {
     FormResponseInfo getById(Long formResponseId);
 
     /**
-     * 폼에 대한 모든 응답을 반환한다. (DRAFT + SUBMITTED 모두)
-     * 폼 작성자 대시보드 용도.
+     * 특정 폼의 모든 응답 (DRAFT + SUBMITTED) 을 id 내림차순으로 반환.
      */
-    List<FormResponseInfo> getAllByFormId(Long formId);
+    List<FormResponseInfo> listByFormId(Long formId);
+
+    /**
+     * 특정 폼의 SUBMITTED 응답 목록을 id 내림차순으로 반환.
+     * 폼 생성자(소유자)의 응답 관리 / 통계 화면 용도.
+     */
+    List<FormResponseInfo> listSubmittedByFormId(Long formId);
 
     /**
      * 특정 사용자의 모든 draft 응답을 반환한다. "내가 작성 중인 응답 목록" 용도.
      */
-    List<FormResponseInfo> getAllDraftByRespondentMemberId(Long respondentMemberId);
+    List<FormResponseInfo> listDraftByRespondentMemberId(Long respondentMemberId);
 
     /**
      * 특정 폼에 대한 특정 사용자의 draft 응답을 조회. 없으면 Optional.empty.

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
@@ -1,6 +1,7 @@
 package com.umc.product.survey.application.port.in.query;
 
 import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,4 +49,10 @@ public interface GetFormResponseUseCase {
      * 특정 폼에 대한 특정 사용자의 SUBMITTED 응답을 조회. 없으면 Optional.empty.
      */
     Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
+
+    /**
+     * 특정 응답의 메타 + 모든 답변을 한 번에 조회 (facade).
+     * 응답 상세 화면 (응답자 본인 / 폼 작성자) 용도. 없으면 FORM_RESPONSE_NOT_FOUND 예외.
+     */
+    FormResponseWithAnswersInfo getResponseWithAnswers(Long formResponseId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormSectionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormSectionUseCase.java
@@ -23,5 +23,5 @@ public interface GetFormSectionUseCase {
     /**
      * 폼에 속한 모든 섹션을 orderNo 오름차순으로 조회.
      */
-    List<FormSectionInfo> getAllByFormId(Long formId);
+    List<FormSectionInfo> listByFormId(Long formId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetQuestionOptionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetQuestionOptionUseCase.java
@@ -22,5 +22,5 @@ public interface GetQuestionOptionUseCase {
     /**
      * 질문에 속한 모든 선택지를 orderNo 오름차순으로 조회.
      */
-    List<QuestionOptionInfo> getAllByQuestionId(Long questionId);
+    List<QuestionOptionInfo> listByQuestionId(Long questionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetQuestionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetQuestionUseCase.java
@@ -22,5 +22,5 @@ public interface GetQuestionUseCase {
     /**
      * 섹션에 속한 모든 질문을 orderNo 오름차순으로 조회.
      */
-    List<QuestionInfo> getAllBySectionId(Long sectionId);
+    List<QuestionInfo> listBySectionId(Long sectionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/AnswerInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/AnswerInfo.java
@@ -26,7 +26,7 @@ public record AnswerInfo(
     QuestionType answeredAsType,
     String textValue,
     List<SelectedOption> selectedOptions,
-    Set<Long> fileIds,
+    Set<String> fileIds,
     Set<Instant> times,
     Instant createdAt,
     Instant updatedAt

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/AnswerInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/AnswerInfo.java
@@ -1,5 +1,8 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.enums.QuestionType;
 import lombok.Builder;
 
@@ -30,6 +33,29 @@ public record AnswerInfo(
 ) {
 
     /**
+     * Answer + 해당 답변의 AnswerChoice 리스트로부터 DTO 조립.
+     * 객관식이 아닌 답변의 경우 {@code choices} 는 빈 리스트.
+     */
+    public static AnswerInfo from(Answer answer, List<AnswerChoice> choices) {
+        List<SelectedOption> selectedOptions = choices.stream()
+            .map(SelectedOption::from)
+            .toList();
+
+        return AnswerInfo.builder()
+            .id(answer.getId())
+            .formResponseId(answer.getFormResponse().getId())
+            .questionId(answer.getQuestion().getId())
+            .answeredAsType(answer.getAnsweredAsType())
+            .textValue(answer.getTextValue())
+            .selectedOptions(selectedOptions)
+            .fileIds(answer.getFileIds())
+            .times(answer.getTimes())
+            .createdAt(answer.getCreatedAt())
+            .updatedAt(answer.getUpdatedAt())
+            .build();
+    }
+
+    /**
      * AnswerChoice 를 조회용으로 펼친 뷰.
      * {@code questionOptionId} 는 원본 선택지 ID — 선택지가 삭제됐다면 null.
      * {@code answeredAsContent} 는 응답 시점의 선택지 내용 스냅샷.
@@ -39,5 +65,14 @@ public record AnswerInfo(
         Long questionOptionId,
         String answeredAsContent
     ) {
+
+        public static SelectedOption from(AnswerChoice choice) {
+            QuestionOption option = choice.getQuestionOption();
+
+            return SelectedOption.builder()
+                .questionOptionId(option != null ? option.getId() : null)
+                .answeredAsContent(choice.getAnsweredAsContent())
+                .build();
+        }
     }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.enums.FormStatus;
 import java.time.Instant;
 import lombok.Builder;
@@ -18,4 +19,17 @@ public record FormInfo(
     Instant createdAt,
     Instant updatedAt
 ) {
+
+    public static FormInfo from(Form form) {
+        return FormInfo.builder()
+            .id(form.getId())
+            .createdMemberId(form.getCreatedMemberId())
+            .title(form.getTitle())
+            .description(form.getDescription())
+            .status(form.getStatus())
+            .isAnonymous(form.isAnonymous())
+            .createdAt(form.getCreatedAt())
+            .updatedAt(form.getUpdatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormResponseInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormResponseInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.FormResponse;
 import com.umc.product.survey.domain.enums.FormResponseStatus;
 import java.time.Instant;
 import lombok.Builder;
@@ -22,4 +23,18 @@ public record FormResponseInfo(
     Instant createdAt,
     Instant updatedAt
 ) {
+
+    public static FormResponseInfo from(FormResponse formResponse) {
+        return FormResponseInfo.builder()
+            .id(formResponse.getId())
+            .formId(formResponse.getForm().getId())
+            .respondentMemberId(formResponse.getRespondentMemberId())
+            .status(formResponse.getStatus())
+            .submittedAt(formResponse.getSubmittedAt())
+            .submittedIp(formResponse.getSubmittedIp())
+            .lastSavedAt(formResponse.getLastSavedAt())
+            .createdAt(formResponse.getCreatedAt())
+            .updatedAt(formResponse.getUpdatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormResponseWithAnswersInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormResponseWithAnswersInfo.java
@@ -1,0 +1,44 @@
+package com.umc.product.survey.application.port.in.query.dto;
+
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * FormResponse 메타 + 모든 Answer 를 합성한 facade DTO.
+ * <p>
+ * 응답 상세 화면 (응답자가 자기 응답 다시 보기 / 폼 작성자가 개별 응답 확인) 용도로
+ * 한 번의 호출로 메타 + 답변 트리를 받기 위한 합성 정보. N+1 회피 책임은 Service 가 짐.
+ */
+@Builder
+public record FormResponseWithAnswersInfo(
+    Long id,
+    Long formId,
+    Long respondentMemberId,
+    FormResponseStatus status,
+    Instant submittedAt,
+    String submittedIp,
+    Instant lastSavedAt,
+    Instant createdAt,
+    Instant updatedAt,
+    List<AnswerInfo> answers
+) {
+
+    public static FormResponseWithAnswersInfo from(FormResponse formResponse, List<AnswerInfo> answers) {
+        return FormResponseWithAnswersInfo.builder()
+            .id(formResponse.getId())
+            .formId(formResponse.getForm().getId())
+            .respondentMemberId(formResponse.getRespondentMemberId())
+            .status(formResponse.getStatus())
+            .submittedAt(formResponse.getSubmittedAt())
+            .submittedIp(formResponse.getSubmittedIp())
+            .lastSavedAt(formResponse.getLastSavedAt())
+            .createdAt(formResponse.getCreatedAt())
+            .updatedAt(formResponse.getUpdatedAt())
+            .answers(answers)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormSectionInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormSectionInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.FormSection;
 import java.time.Instant;
 import lombok.Builder;
 
@@ -16,4 +17,16 @@ public record FormSectionInfo(
     Instant createdAt,
     Instant updatedAt
 ) {
+
+    public static FormSectionInfo from(FormSection section) {
+        return FormSectionInfo.builder()
+            .sectionId(section.getId())
+            .formId(section.getForm().getId())
+            .title(section.getTitle())
+            .description(section.getDescription())
+            .orderNo(section.getOrderNo())
+            .createdAt(section.getCreatedAt())
+            .updatedAt(section.getUpdatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/QuestionInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/QuestionInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.enums.QuestionType;
 import java.time.Instant;
 import lombok.Builder;
@@ -19,4 +20,18 @@ public record QuestionInfo(
     Instant createdAt,
     Instant updatedAt
 ) {
+
+    public static QuestionInfo from(Question question) {
+        return QuestionInfo.builder()
+            .id(question.getId())
+            .sectionId(question.getFormSection().getId())
+            .type(question.getType())
+            .title(question.getTitle())
+            .description(question.getDescription())
+            .isRequired(Boolean.TRUE.equals(question.getIsRequired()))
+            .orderNo(question.getOrderNo())
+            .createdAt(question.getCreatedAt())
+            .updatedAt(question.getUpdatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/QuestionOptionInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/QuestionOptionInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import com.umc.product.survey.domain.QuestionOption;
 import java.time.Instant;
 import lombok.Builder;
 
@@ -16,4 +17,16 @@ public record QuestionOptionInfo(
     Instant createdAt,
     Instant updatedAt
 ) {
+
+    public static QuestionOptionInfo from(QuestionOption option) {
+        return QuestionOptionInfo.builder()
+            .id(option.getId())
+            .questionId(option.getQuestion().getId())
+            .content(option.getContent())
+            .orderNo(option.getOrderNo())
+            .isOther(option.isOther())
+            .createdAt(option.getCreatedAt())
+            .updatedAt(option.getUpdatedAt())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadAnswerPort.java
@@ -1,9 +1,27 @@
 package com.umc.product.survey.application.port.out;
 
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public interface LoadAnswerPort {
+
+    Optional<Answer> findById(Long answerId);
+
+    /**
+     * 특정 FormResponse 에 속한 모든 답변을 질문 orderNo 오름차순으로 반환.
+     */
+    List<Answer> listByFormResponseId(Long formResponseId);
+
+    /**
+     * 여러 답변의 AnswerChoice 를 한 번에 조회 (벌크 N+1 회피).
+     * questionOption.orderNo 오름차순으로 정렬.
+     */
+    List<AnswerChoice> listChoicesByAnswerIdIn(Set<Long> answerIds);
 
     /**
      * 특정 폼(투표)의 총 참여자 수를 반환합니다.

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadAnswerPort.java
@@ -13,6 +13,11 @@ public interface LoadAnswerPort {
     Optional<Answer> findById(Long answerId);
 
     /**
+     * 특정 FormResponse + 특정 Question 의 답변 존재 여부 (createAnswer의 중복 검증 용).
+     */
+    boolean existsByFormResponseIdAndQuestionId(Long formResponseId, Long questionId);
+
+    /**
      * 특정 FormResponse 에 속한 모든 답변을 질문 orderNo 오름차순으로 반환.
      */
     List<Answer> listByFormResponseId(Long formResponseId);

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadFormResponsePort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadFormResponsePort.java
@@ -9,6 +9,16 @@ public interface LoadFormResponsePort {
 
     Optional<FormResponse> findById(Long formResponseId);
 
+    /**
+     * 특정 폼의 모든 응답 (DRAFT + SUBMITTED) 을 id 내림차순으로 반환.
+     */
+    List<FormResponse> listByFormId(Long formId);
+
+    /**
+     * 특정 폼의 SUBMITTED 응답 목록을 id 내림차순으로 반환.
+     */
+    List<FormResponse> listSubmittedByFormId(Long formId);
+
     Optional<FormResponse> findDraftByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 
     List<FormResponse> findAllDraftByRespondentMemberId(Long respondentMemberId);

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadFormSectionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadFormSectionPort.java
@@ -2,7 +2,11 @@ package com.umc.product.survey.application.port.out;
 
 import com.umc.product.survey.domain.FormSection;
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadFormSectionPort {
-    List<FormSection> findAllByFormId(Long formId);
+
+    Optional<FormSection> findById(Long sectionId);
+
+    List<FormSection> listByFormId(Long formId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionOptionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionOptionPort.java
@@ -2,9 +2,11 @@ package com.umc.product.survey.application.port.out;
 
 import com.umc.product.survey.domain.QuestionOption;
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadQuestionOptionPort {
-    // List<QuestionOption> findAllByQuestionIdIn(Set<Long> questionIds);
+
+    Optional<QuestionOption> findById(Long optionId);
 
     boolean existsByIdAndQuestionId(Long optionId, Long questionId);
 

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionOptionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionOptionPort.java
@@ -3,6 +3,7 @@ package com.umc.product.survey.application.port.out;
 import com.umc.product.survey.domain.QuestionOption;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LoadQuestionOptionPort {
 
@@ -11,4 +12,10 @@ public interface LoadQuestionOptionPort {
     boolean existsByIdAndQuestionId(Long optionId, Long questionId);
 
     List<QuestionOption> listByQuestionId(Long questionId);
+
+    /**
+     * 여러 질문의 모든 선택지를 한 번에 조회 (벌크). orderNo 오름차순 정렬.
+     * 폼 전체 구조 조회 등 N+1 회피 용도.
+     */
+    List<QuestionOption> listByQuestionIdIn(Set<Long> questionIds);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
@@ -20,4 +20,9 @@ public interface LoadQuestionPort {
      * 필수 질문 누락 검증 등에 사용.
      */
     List<Question> listByFormId(Long formId);
+
+    /**
+     * 특정 섹션에 속한 모든 질문을 orderNo 오름차순으로 조회.
+     */
+    List<Question> listBySectionId(Long sectionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
@@ -25,4 +25,10 @@ public interface LoadQuestionPort {
      * 특정 섹션에 속한 모든 질문을 orderNo 오름차순으로 조회.
      */
     List<Question> listBySectionId(Long sectionId);
+
+    /**
+     * 여러 섹션의 모든 질문을 한 번에 조회 (벌크). orderNo 오름차순 정렬.
+     * 폼 전체 구조 조회 등 N+1 회피 용도.
+     */
+    List<Question> listBySectionIdIn(Set<Long> sectionIds);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
@@ -17,4 +17,10 @@ public interface SaveAnswerPort {
      * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
      */
     void deleteAllByFormResponseId(Long formResponseId);
+
+    /**
+     * 특정 폼에 속한 모든 Answer 와 그에 딸린 AnswerChoice 를 삭제 (deleteForm cascade 용).
+     * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
+     */
+    void deleteByFormId(Long formId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public interface SaveAnswerPort {
 
+    Answer save(Answer answer);
+
     List<Answer> saveAll(List<Answer> answers);
 
     List<AnswerChoice> saveAllChoices(List<AnswerChoice> choices);
@@ -29,4 +31,16 @@ public interface SaveAnswerPort {
      * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
      */
     void deleteByQuestionId(Long questionId);
+
+    /**
+     * 단일 Answer 와 그에 딸린 AnswerChoice를 삭제 (deleteAnswer 용).
+     * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
+     */
+    void deleteByAnswerId(Long answerId);
+
+    /**
+     * 단일 Answer의 AnswerChoice만 삭제 (updateAnswer의 객관식 갈아끼움 용).
+     * Answer 자체는 보존.
+     */
+    void deleteChoicesByAnswerId(Long answerId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveAnswerPort.java
@@ -23,4 +23,10 @@ public interface SaveAnswerPort {
      * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
      */
     void deleteByFormId(Long formId);
+
+    /**
+     * 특정 질문에 속한 모든 Answer 와 그에 딸린 AnswerChoice 를 삭제 (deleteQuestion cascade 용).
+     * AnswerChoice -> Answer 순서로 삭제하여 FK 제약을 만족시킨다.
+     */
+    void deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveFormResponsePort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveFormResponsePort.java
@@ -15,4 +15,9 @@ public interface SaveFormResponsePort {
      * @return 삭제된 row 수
      */
     int deleteByFormIdAndStatus(Long formId, FormResponseStatus status);
+
+    /**
+     * 특정 폼에 속한 모든 응답 삭제 (deleteForm cascade 용)
+     */
+    void deleteByFormId(Long formId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveFormSectionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveFormSectionPort.java
@@ -2,7 +2,18 @@ package com.umc.product.survey.application.port.out;
 
 import com.umc.product.survey.domain.FormSection;
 
+import java.util.List;
+
 public interface SaveFormSectionPort {
 
     FormSection save(FormSection formSection);
+
+    List<FormSection> saveAll(List<FormSection> sections);
+
+    void deleteById(Long sectionId);
+
+    /**
+     * 특정 폼에 속한 모든 섹션 삭제 (deleteForm cascade 용)
+     */
+    void deleteByFormId(Long formId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionOptionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionOptionPort.java
@@ -5,9 +5,22 @@ import com.umc.product.survey.domain.QuestionOption;
 import java.util.List;
 
 public interface SaveQuestionOptionPort {
-    void deleteAllByQuestionId(Long questionId);
+
+    QuestionOption save(QuestionOption option);
+
+    List<QuestionOption> saveAll(List<QuestionOption> questionOptions);
 
     void deleteById(Long optionId);
 
-    List<QuestionOption> saveAll(List<QuestionOption> questionOptions);
+    void deleteAllByQuestionId(Long questionId);
+
+    /**
+     * 특정 폼에 속한 모든 선택지 삭제 (deleteForm cascade 용)
+     */
+    void deleteByFormId(Long formId);
+
+    /**
+     * 특정 섹션에 속한 모든 선택지 삭제 (deleteSection cascade 용)
+     */
+    void deleteBySectionId(Long sectionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionPort.java
@@ -3,9 +3,20 @@ package com.umc.product.survey.application.port.out;
 import com.umc.product.survey.domain.Question;
 
 public interface SaveQuestionPort {
-    void deleteByFormIdAndQuestionId(Long formId, Long questionId);
+
+    Question save(Question question);
 
     void deleteById(Long questionId);
 
-    Question save(Question question);
+    void deleteByFormIdAndQuestionId(Long formId, Long questionId);
+
+    /**
+     * 특정 폼에 속한 모든 질문 삭제 (deleteForm cascade 용)
+     */
+    void deleteByFormId(Long formId);
+
+    /**
+     * 특정 섹션에 속한 모든 질문 삭제 (deleteSection cascade 용)
+     */
+    void deleteBySectionId(Long sectionId);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/SaveQuestionPort.java
@@ -2,9 +2,13 @@ package com.umc.product.survey.application.port.out;
 
 import com.umc.product.survey.domain.Question;
 
+import java.util.List;
+
 public interface SaveQuestionPort {
 
     Question save(Question question);
+
+    List<Question> saveAll(List<Question> questions);
 
     void deleteById(Long questionId);
 

--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -42,11 +42,13 @@ public class VoteService implements ManageVoteUseCase {
         Form savedForm = saveFormPort.save(form);
 
         // 2. 단일 섹션 생성
-        FormSection section = FormSection.builder()
-            .form(savedForm)
-            .title(command.title())
-            .orderNo(1L)
-            .build();
+        FormSection section = FormSection.create(
+            savedForm,
+            command.title(),
+            null,
+            1L
+        );
+
         FormSection savedSection = saveFormSectionPort.save(section);
 
         // 3. 단일 질문 생성

--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -1,15 +1,15 @@
 package com.umc.product.survey.application.service;
 
+import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
 import com.umc.product.survey.application.port.in.command.ManageVoteUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateVoteCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
 import com.umc.product.survey.application.port.out.*;
 import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.FormSection;
 import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.enums.QuestionType;
-import com.umc.product.survey.domain.exception.SurveyDomainException;
-import com.umc.product.survey.domain.exception.SurveyErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,10 +26,10 @@ import java.util.stream.Collectors;
 public class VoteService implements ManageVoteUseCase {
 
     private final SaveFormPort saveFormPort;
-    private final LoadFormPort loadFormPort;
     private final SaveFormSectionPort saveFormSectionPort;
     private final SaveQuestionPort saveQuestionPort;
     private final SaveQuestionOptionPort saveQuestionOptionPort;
+    private final ManageFormUseCase manageFormUseCase;
 
     @Override
     public Long createVote(CreateVoteCommand command) {
@@ -78,11 +78,10 @@ public class VoteService implements ManageVoteUseCase {
 
     @Override
     public void deleteVote(Long formId) {
-        Form form = loadFormPort.findById(formId)
-            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
-
-        // TODO: 향후 Cascade 정책 혹은 응답(FormResponse, Answer) 삭제 로직 보완 필요
-
-        saveFormPort.deleteById(form.getId());
+        manageFormUseCase.deleteForm(
+            DeleteFormCommand.builder()
+                .formId(formId)
+                .build()
+        );
     }
 }

--- a/src/main/java/com/umc/product/survey/application/service/command/AnswerCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/AnswerCommandService.java
@@ -1,0 +1,198 @@
+package com.umc.product.survey.application.service.command;
+
+import com.umc.product.survey.application.port.in.command.ManageAnswerUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateAnswerCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteAnswerCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateAnswerCommand;
+import com.umc.product.survey.application.port.out.LoadAnswerPort;
+import com.umc.product.survey.application.port.out.LoadFormResponsePort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.application.port.out.SaveAnswerPort;
+import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AnswerCommandService implements ManageAnswerUseCase {
+
+    private final LoadFormResponsePort loadFormResponsePort;
+    private final LoadQuestionPort loadQuestionPort;
+    private final LoadQuestionOptionPort loadQuestionOptionPort;
+    private final LoadAnswerPort loadAnswerPort;
+    private final SaveAnswerPort saveAnswerPort;
+    private final SaveFormResponsePort saveFormResponsePort;
+
+    @Override
+    public Long createAnswer(CreateAnswerCommand command) {
+        FormResponse draft = loadDraft(command.formResponseId());
+        Question question = loadQuestionInForm(command.questionId(), draft.getForm().getId());
+
+        // 같은 질문에 대한 답변이 이미 있으면 예외
+        if (loadAnswerPort.existsByFormResponseIdAndQuestionId(draft.getId(), question.getId())) {
+            throw new SurveyDomainException(SurveyErrorCode.ANSWER_ALREADY_EXISTS);
+        }
+
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds());
+
+        Answer answer = Answer.create(draft, question, question.getType(), command.textValue());
+        Answer saved = saveAnswerPort.save(answer);
+
+        // 객관식이면 AnswerChoice도 같이 저장
+        List<AnswerChoice> choices = buildChoices(saved, question, command.selectedOptionIds());
+        if (!choices.isEmpty()) {
+            saveAnswerPort.saveAllChoices(choices);
+        }
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+
+        return saved.getId();
+    }
+
+    @Override
+    public void updateAnswer(UpdateAnswerCommand command) {
+        Answer existing = loadAnswerPort.findById(command.answerId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.ANSWER_NOT_FOUND));
+
+        FormResponse draft = existing.getFormResponse();
+        if (draft.getStatus() != FormResponseStatus.DRAFT) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_DRAFT);
+        }
+
+        Question question = existing.getQuestion();
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds());
+
+        // 1. 기존 AnswerChoice 만 삭제 (Answer 는 PK 유지하며 update)
+        saveAnswerPort.deleteChoicesByAnswerId(existing.getId());
+
+        // 2. Answer.textValue 갱신 (도메인 메서드)
+        existing.updateTextValue(command.textValue());
+        saveAnswerPort.save(existing);
+
+        // 3. 새 AnswerChoice 저장 (객관식인 경우)
+        List<AnswerChoice> choices = buildChoices(existing, question, command.selectedOptionIds());
+        if (!choices.isEmpty()) {
+            saveAnswerPort.saveAllChoices(choices);
+        }
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
+    @Override
+    public void deleteAnswer(DeleteAnswerCommand command) {
+        Answer existing = loadAnswerPort.findById(command.answerId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.ANSWER_NOT_FOUND));
+
+        FormResponse draft = existing.getFormResponse();
+        if (draft.getStatus() != FormResponseStatus.DRAFT) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_DRAFT);
+        }
+
+        saveAnswerPort.deleteByAnswerId(existing.getId());
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
+    /**
+     * 응답 ID로 DRAFT 응답 로드. 없으면 NOT_FOUND, DRAFT가 아니면 NOT_DRAFT 예외.
+     */
+    private FormResponse loadDraft(Long formResponseId) {
+        FormResponse formResponse = loadFormResponsePort.findById(formResponseId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
+        if (formResponse.getStatus() != FormResponseStatus.DRAFT) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_DRAFT);
+        }
+        return formResponse;
+    }
+
+    /**
+     * 질문 로드 + 해당 폼 소속 검증.
+     */
+    private Question loadQuestionInForm(Long questionId, Long formId) {
+        Question question = loadQuestionPort.findById(questionId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
+        if (!question.getFormSection().getForm().getId().equals(formId)) {
+            throw new SurveyDomainException(SurveyErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+        }
+        return question;
+    }
+
+    /**
+     * 질문 type 별 답변 형식 검증.
+     */
+    private void validateAnswerContent(Question question, String textValue, List<Long> selectedOptionIds) {
+        switch (question.getType()) {
+            case SHORT_TEXT, LONG_TEXT -> {
+                if (textValue == null || textValue.isBlank()) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
+                }
+            }
+            case RADIO, DROPDOWN -> {
+                if (selectedOptionIds == null || selectedOptionIds.size() != 1) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+                }
+                validateOptionBelongsToQuestion(selectedOptionIds.get(0), question.getId());
+            }
+            case CHECKBOX -> {
+                if (selectedOptionIds == null || selectedOptionIds.isEmpty()) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_SELECTION);
+                }
+                for (Long optionId : selectedOptionIds) {
+                    validateOptionBelongsToQuestion(optionId, question.getId());
+                }
+            }
+            case SCHEDULE, FILE, PORTFOLIO ->
+                // FormResponseCommandService 와 동일 정책 — 후속 PR 에서 지원
+                throw new UnsupportedOperationException(
+                    "Question type " + question.getType() + " is not supported yet");
+        }
+    }
+
+    private void validateOptionBelongsToQuestion(Long optionId, Long questionId) {
+        if (!loadQuestionOptionPort.existsByIdAndQuestionId(optionId, questionId)) {
+            throw new SurveyDomainException(SurveyErrorCode.OPTION_NOT_IN_QUESTION);
+        }
+    }
+
+    /**
+     * 객관식 답변의 AnswerChoice 들을 빌드. 객관식이 아닌 type은 빈 리스트.
+     */
+    private List<AnswerChoice> buildChoices(Answer answer, Question question, List<Long> selectedOptionIds) {
+        if (selectedOptionIds == null || selectedOptionIds.isEmpty()) {
+            return List.of();
+        }
+        QuestionType type = question.getType();
+        if (type != QuestionType.RADIO && type != QuestionType.CHECKBOX && type != QuestionType.DROPDOWN) {
+            return List.of();
+        }
+
+        List<QuestionOption> options = loadQuestionOptionPort.listByQuestionId(question.getId());
+        List<AnswerChoice> choices = new ArrayList<>();
+        for (Long optionId : selectedOptionIds) {
+            QuestionOption option = options.stream()
+                .filter(o -> o.getId().equals(optionId))
+                .findFirst()
+                .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.OPTION_NOT_IN_QUESTION));
+            choices.add(new AnswerChoice(answer, option));
+        }
+        return choices;
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/AnswerCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/AnswerCommandService.java
@@ -10,6 +10,7 @@ import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.survey.application.port.out.LoadQuestionPort;
 import com.umc.product.survey.application.port.out.SaveAnswerPort;
 import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.survey.domain.Answer;
 import com.umc.product.survey.domain.AnswerChoice;
 import com.umc.product.survey.domain.FormResponse;
@@ -25,7 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -38,6 +41,7 @@ public class AnswerCommandService implements ManageAnswerUseCase {
     private final LoadAnswerPort loadAnswerPort;
     private final SaveAnswerPort saveAnswerPort;
     private final SaveFormResponsePort saveFormResponsePort;
+    private final GetFileUseCase getFileUseCase;
 
     @Override
     public Long createAnswer(CreateAnswerCommand command) {
@@ -49,9 +53,13 @@ public class AnswerCommandService implements ManageAnswerUseCase {
             throw new SurveyDomainException(SurveyErrorCode.ANSWER_ALREADY_EXISTS);
         }
 
-        validateAnswerContent(question, command.textValue(), command.selectedOptionIds());
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds(), command.fileIds());
 
-        Answer answer = Answer.create(draft, question, question.getType(), command.textValue());
+        Answer answer = Answer.create(
+            draft, question, question.getType(),
+            command.textValue(),
+            toFileIdSet(command.fileIds())
+        );
         Answer saved = saveAnswerPort.save(answer);
 
         // 객관식이면 AnswerChoice도 같이 저장
@@ -77,13 +85,16 @@ public class AnswerCommandService implements ManageAnswerUseCase {
         }
 
         Question question = existing.getQuestion();
-        validateAnswerContent(question, command.textValue(), command.selectedOptionIds());
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds(), command.fileIds());
 
         // 1. 기존 AnswerChoice 만 삭제 (Answer 는 PK 유지하며 update)
         saveAnswerPort.deleteChoicesByAnswerId(existing.getId());
 
-        // 2. Answer.textValue 갱신 (도메인 메서드)
-        existing.updateTextValue(command.textValue());
+        // 2. Answer 의 textValue / fileIds 갱신 (PATCH 시맨틱 — null 은 기존 값 유지)
+        Set<String> requestedFileIds = command.fileIds() == null
+            ? null  // null = keep
+            : new HashSet<>(command.fileIds());  // empty = clear, non-empty = set
+        existing.update(command.textValue(), requestedFileIds);
         saveAnswerPort.save(existing);
 
         // 3. 새 AnswerChoice 저장 (객관식인 경우)
@@ -138,7 +149,12 @@ public class AnswerCommandService implements ManageAnswerUseCase {
     /**
      * 질문 type 별 답변 형식 검증.
      */
-    private void validateAnswerContent(Question question, String textValue, List<Long> selectedOptionIds) {
+    private void validateAnswerContent(
+        Question question,
+        String textValue,
+        List<Long> selectedOptionIds,
+        List<String> fileIds
+    ) {
         switch (question.getType()) {
             case SHORT_TEXT, LONG_TEXT -> {
                 if (textValue == null || textValue.isBlank()) {
@@ -159,8 +175,28 @@ public class AnswerCommandService implements ManageAnswerUseCase {
                     validateOptionBelongsToQuestion(optionId, question.getId());
                 }
             }
-            case SCHEDULE, FILE, PORTFOLIO ->
-                // FormResponseCommandService 와 동일 정책 — 후속 PR 에서 지원
+            case FILE -> {
+                if (fileIds == null || fileIds.isEmpty()) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
+                }
+                for (String fileId : fileIds) {
+                    getFileUseCase.throwIfNotExists(fileId);
+                }
+            }
+            case PORTFOLIO -> {
+                boolean hasText = textValue != null && !textValue.isBlank();
+                boolean hasFiles = fileIds != null && !fileIds.isEmpty();
+                if (!hasText && !hasFiles) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
+                }
+                if (hasFiles) {
+                    for (String fileId : fileIds) {
+                        getFileUseCase.throwIfNotExists(fileId);
+                    }
+                }
+            }
+            case SCHEDULE ->
+                // 후속 PR 에서 지원
                 throw new UnsupportedOperationException(
                     "Question type " + question.getType() + " is not supported yet");
         }
@@ -170,6 +206,16 @@ public class AnswerCommandService implements ManageAnswerUseCase {
         if (!loadQuestionOptionPort.existsByIdAndQuestionId(optionId, questionId)) {
             throw new SurveyDomainException(SurveyErrorCode.OPTION_NOT_IN_QUESTION);
         }
+    }
+
+    /**
+     * fileIds List를 Set 으로 변환. null이면 null 반환 (Answer.fileIds 도 null 허용 컬럼).
+     */
+    private static Set<String> toFileIdSet(List<String> fileIds) {
+        if (fileIds == null || fileIds.isEmpty()) {
+            return null;
+        }
+        return new HashSet<>(fileIds);
     }
 
     /**

--- a/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class ManageFormCommandService implements ManageFormUseCase {
+public class FormCommandService implements ManageFormUseCase {
 
     private final LoadFormPort loadFormPort;
     private final SaveFormPort saveFormPort;

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.service.command;
 
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.*;
 import com.umc.product.survey.application.port.out.*;
@@ -31,6 +32,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     private final LoadAnswerPort loadAnswerPort;
     private final SaveFormResponsePort saveFormResponsePort;
     private final SaveAnswerPort saveAnswerPort;
+    private final GetFileUseCase getFileUseCase;
 
     @Override
     public Long submitImmediately(SubmitFormResponseCommand command) {
@@ -227,8 +229,31 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
                     validateOptionBelongsToQuestion(optionId, question.getId());
                 }
             }
-            case SCHEDULE, FILE, PORTFOLIO ->
-                // TODO: 다음 PR에서 Answer 엔티티에 fileIds/times setter 확장 후 구현
+            case FILE -> {
+                List<String> fileIds = answerCommand.fileIds();
+                if (fileIds == null || fileIds.isEmpty()) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
+                }
+                for (String fileId : fileIds) {
+                    getFileUseCase.throwIfNotExists(fileId);
+                }
+            }
+            case PORTFOLIO -> {
+                String text = answerCommand.textValue();
+                List<String> fileIds = answerCommand.fileIds();
+                boolean hasText = text != null && !text.isBlank();
+                boolean hasFiles = fileIds != null && !fileIds.isEmpty();
+                if (!hasText && !hasFiles) {
+                    throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
+                }
+                if (hasFiles) {
+                    for (String fileId : fileIds) {
+                        getFileUseCase.throwIfNotExists(fileId);
+                    }
+                }
+            }
+            case SCHEDULE ->
+                // 후속 PR 에서 지원
                 throw new UnsupportedOperationException(
                     "Question type " + type + " is not supported yet");
         }
@@ -250,11 +275,15 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
                 .findFirst()
                 .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
 
+            Set<String> fileIdSet = (answerCmd.fileIds() == null || answerCmd.fileIds().isEmpty())
+                ? null
+                : new HashSet<>(answerCmd.fileIds());
             Answer answer = Answer.create(
                 formResponse,
                 question,
                 question.getType(),
-                answerCmd.textValue()
+                answerCmd.textValue(),
+                fileIdSet
             );
 
             List<QuestionOption> selectedOptions = new ArrayList<>();

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -1,9 +1,10 @@
-package com.umc.product.survey.application.service;
+package com.umc.product.survey.application.service.command;
 
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.*;
 import com.umc.product.survey.application.port.out.*;
 import com.umc.product.survey.domain.*;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
 import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -26,6 +28,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     private final LoadQuestionPort loadQuestionPort;
     private final LoadQuestionOptionPort loadQuestionOptionPort;
     private final LoadFormResponsePort loadFormResponsePort;
+    private final LoadAnswerPort loadAnswerPort;
     private final SaveFormResponsePort saveFormResponsePort;
     private final SaveAnswerPort saveAnswerPort;
 
@@ -38,6 +41,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         }
 
         validateAnswers(command.formId(), command.answers());
+        validateAllRequiredAnswered(command.formId(), extractQuestionIds(command.answers()));
 
         FormResponse response = FormResponse.createDraft(form, command.respondentMemberId());
         response.submit(Instant.now(), null);
@@ -58,6 +62,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
 
         validateAnswers(command.formId(), command.answers());
+        validateAllRequiredAnswered(command.formId(), extractQuestionIds(command.answers()));
 
         saveAnswerPort.deleteAllByFormResponseId(existing.getId());
 
@@ -80,26 +85,71 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public Long createDraft(CreateDraftFormResponseCommand command) {
-        // TODO: 구현 PR 에서 실제 로직 작성 — 빈 draft 생성 + 중복 검증
-        throw new UnsupportedOperationException("Not implemented yet — Phase C 구현 PR 에서 제공");
+        Form form = loadPublishedForm(command.formId());
+
+        // 같은 폼에 같은 멤버의 응답 (DRAFT/SUBMITTED) 이 이미 있으면 예외
+        if (loadFormResponsePort.existsByFormIdAndMemberId(command.formId(), command.respondentMemberId())) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
+        }
+
+        FormResponse draft = FormResponse.createDraft(form, command.respondentMemberId());
+        return saveFormResponsePort.save(draft).getId();
     }
 
     @Override
     public void updateDraft(UpdateDraftFormResponseCommand command) {
-        // TODO: 구현 PR 에서 실제 로직 작성 — draft answers 전체 교체
-        throw new UnsupportedOperationException("Not implemented yet — Phase C 구현 PR 에서 제공");
+        FormResponse draft = loadDraft(command.formResponseId());
+
+        // 형식 검증만 수행 — 작성 중이라 필수 누락은 정상
+        validateAnswers(draft.getForm().getId(), command.answers());
+
+        // 기존 답변 전체 교체
+        saveAnswerPort.deleteAllByFormResponseId(draft.getId());
+        List<AnswerWithOptions> data = buildAnswerData(draft, command.answers());
+        saveAnswers(data);
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
     }
 
     @Override
     public void submitDraft(SubmitDraftFormResponseCommand command) {
-        // TODO: 구현 PR 에서 실제 로직 작성 — draft → SUBMITTED 전환
-        throw new UnsupportedOperationException("Not implemented yet — Phase C 구현 PR 에서 제공");
+        FormResponse draft = loadDraft(command.formResponseId());
+
+        // 저장된 답변에서 questionId 추출 -> 필수 누락 검증
+        Set<Long> answeredQuestionIds = loadAnswerPort.listByFormResponseId(draft.getId()).stream()
+            .map(answer -> answer.getQuestion().getId())
+            .collect(Collectors.toSet());
+        validateAllRequiredAnswered(draft.getForm().getId(), answeredQuestionIds);
+
+        draft.submit(Instant.now(), command.submittedIp());
+        saveFormResponsePort.save(draft);
     }
 
     @Override
     public void deleteDraft(DeleteDraftFormResponseCommand command) {
-        // TODO: 구현 PR 에서 실제 로직 작성 — draft + 연관 Answer 삭제
-        throw new UnsupportedOperationException("Not implemented yet — Phase C 구현 PR 에서 제공");
+        FormResponse draft = loadDraft(command.formResponseId());
+
+        saveAnswerPort.deleteAllByFormResponseId(draft.getId());
+        saveFormResponsePort.deleteById(draft.getId());
+    }
+
+    /**
+     * 응답 ID 로 DRAFT 응답 로드. 없으면 NOT_FOUND, DRAFT 가 아니면 NOT_DRAFT 예외.
+     */
+    private FormResponse loadDraft(Long formResponseId) {
+        FormResponse formResponse = loadFormResponsePort.findById(formResponseId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
+        if (formResponse.getStatus() != FormResponseStatus.DRAFT) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_DRAFT);
+        }
+        return formResponse;
+    }
+
+    private static Set<Long> extractQuestionIds(List<AnswerCommand> answers) {
+        return answers.stream()
+            .map(AnswerCommand::questionId)
+            .collect(Collectors.toSet());
     }
 
     private Form loadPublishedForm(Long formId) {
@@ -111,6 +161,12 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         return form;
     }
 
+    /**
+     * 답변 형식 / 질문 소속 / 옵션 소속 등 형식 검증만 수행. 필수 답변 누락 검증은 별도.
+     * <p>
+     * draft 작성 중 (updateDraft) 에는 필수 누락이 정상이라 형식만 검증.
+     * 제출 시점 (submitImmediately, updateResponse, submitDraft) 에는 별도로 {@link #validateAllRequiredAnswered} 호출 필요.
+     */
     private void validateAnswers(Long formId, List<AnswerCommand> answers) {
         if (answers == null) {
             throw new SurveyDomainException(SurveyErrorCode.INVALID_ANSWER_FORMAT);
@@ -133,7 +189,13 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
             validateAnswerAgainstQuestion(answerCommand, question);
         }
+    }
 
+    /**
+     * 폼의 모든 필수 질문이 답변에 포함됐는지 검증. 제출 시점에만 호출.
+     */
+    private void validateAllRequiredAnswered(Long formId, Set<Long> answeredQuestionIds) {
+        List<Question> formQuestions = loadQuestionPort.listByFormId(formId);
         for (Question q : formQuestions) {
             if (Boolean.TRUE.equals(q.getIsRequired()) && !answeredQuestionIds.contains(q.getId())) {
                 throw new SurveyDomainException(SurveyErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);

--- a/src/main/java/com/umc/product/survey/application/service/command/FormSectionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormSectionCommandService.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class ManageFormSectionCommandService implements ManageFormSectionUseCase {
+public class FormSectionCommandService implements ManageFormSectionUseCase {
 
     private final LoadFormPort loadFormPort;
     private final LoadFormSectionPort loadFormSectionPort;

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageFormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageFormCommandService.java
@@ -1,0 +1,76 @@
+package com.umc.product.survey.application.service.command;
+
+import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.PublishFormCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.SaveAnswerPort;
+import com.umc.product.survey.application.port.out.SaveFormPort;
+import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.survey.application.port.out.SaveFormSectionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionPort;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManageFormCommandService implements ManageFormUseCase {
+
+    private final LoadFormPort loadFormPort;
+    private final SaveFormPort saveFormPort;
+    private final SaveFormSectionPort saveFormSectionPort;
+    private final SaveQuestionPort saveQuestionPort;
+    private final SaveQuestionOptionPort saveQuestionOptionPort;
+    private final SaveFormResponsePort saveFormResponsePort;
+    private final SaveAnswerPort saveAnswerPort;
+
+    @Override
+    public Long createDraft(CreateDraftFormCommand command) {
+        Form form = Form.createDraft(command.title(), command.createdMemberId());
+
+        return saveFormPort.save(form).getId();
+    }
+
+    @Override
+    public void updateForm(UpdateFormCommand command) {
+        Form form = loadFormPort.findById(command.formId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        form.update(command.title(), command.description(), command.isAnonymous());
+        saveFormPort.save(form);
+    }
+
+    @Override
+    public void publishForm(PublishFormCommand command) {
+        Form form = loadFormPort.findById(command.formId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        form.publish();
+        saveFormPort.save(form);
+    }
+
+    @Override
+    public void deleteForm(DeleteFormCommand command) {
+        Long formId = command.formId();
+
+        // 응답 트리 (자식부터)
+        saveAnswerPort.deleteByFormId(formId);
+        saveFormResponsePort.deleteByFormId(formId);
+
+        // 폼 구조 (자식부터)
+        saveQuestionOptionPort.deleteByFormId(formId);
+        saveQuestionPort.deleteByFormId(formId);
+        saveFormSectionPort.deleteByFormId(formId);
+
+        // 폼 본체
+        saveFormPort.deleteById(formId);
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageFormSectionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageFormSectionCommandService.java
@@ -79,7 +79,10 @@ public class ManageFormSectionCommandService implements ManageFormSectionUseCase
         Set<Long> requestedIds = new HashSet<>(command.orderedSectionIds());
 
         if (!existingIds.equals(requestedIds)) {
-            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE);
+            throw new SurveyDomainException(
+                SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "재배치 요청의 섹션 ID 셋이 실제 폼의 섹션 ID 셋과 일치하지 않습니다."
+            );
         }
 
         Map<Long, FormSection> byId = sections.stream()

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageFormSectionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageFormSectionCommandService.java
@@ -1,0 +1,94 @@
+package com.umc.product.survey.application.service.command;
+
+import com.umc.product.survey.application.port.in.command.ManageFormSectionUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.application.port.out.SaveFormSectionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionPort;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManageFormSectionCommandService implements ManageFormSectionUseCase {
+
+    private final LoadFormPort loadFormPort;
+    private final LoadFormSectionPort loadFormSectionPort;
+    private final SaveFormSectionPort saveFormSectionPort;
+    private final SaveQuestionPort saveQuestionPort;
+    private final SaveQuestionOptionPort saveQuestionOptionPort;
+
+    @Override
+    public Long createSection(CreateFormSectionCommand command) {
+        Form form = loadFormPort.findById(command.formId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        long nextOrderNo = loadFormSectionPort.listByFormId(command.formId()).stream()
+            .mapToLong(FormSection::getOrderNo)
+            .max()
+            .orElse(0L) + 1L;
+
+        FormSection section = FormSection.create(form, command.title(), command.description(), nextOrderNo);
+        return saveFormSectionPort.save(section).getId();
+    }
+
+    @Override
+    public void updateSection(UpdateFormSectionCommand command) {
+        FormSection section = loadFormSectionPort.findById(command.sectionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        section.update(command.title(), command.description());
+        saveFormSectionPort.save(section);
+    }
+
+    @Override
+    public void deleteSection(DeleteFormSectionCommand command) {
+        Long sectionId = command.sectionId();
+
+        // cascade (자식부터)
+        saveQuestionOptionPort.deleteBySectionId(sectionId);
+        saveQuestionPort.deleteBySectionId(sectionId);
+        saveFormSectionPort.deleteById(sectionId);
+    }
+
+    @Override
+    public void reorderSections(ReorderFormSectionsCommand command) {
+        List<FormSection> sections = loadFormSectionPort.listByFormId(command.formId());
+
+        Set<Long> existingIds = sections.stream()
+            .map(FormSection::getId)
+            .collect(Collectors.toSet());
+        Set<Long> requestedIds = new HashSet<>(command.orderedSectionIds());
+
+        if (!existingIds.equals(requestedIds)) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE);
+        }
+
+        Map<Long, FormSection> byId = sections.stream()
+            .collect(Collectors.toMap(FormSection::getId, Function.identity()));
+
+        for (int i = 0; i < command.orderedSectionIds().size(); i++) {
+            byId.get(command.orderedSectionIds().get(i)).updateOrderNo((long) (i + 1));
+        }
+
+        saveFormSectionPort.saveAll(sections);
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionCommandService.java
@@ -1,0 +1,135 @@
+package com.umc.product.survey.application.service.command;
+
+import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
+import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.application.port.out.SaveAnswerPort;
+import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionPort;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.enums.QuestionType;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManageQuestionCommandService implements ManageQuestionUseCase {
+
+    private final LoadFormSectionPort loadFormSectionPort;
+    private final LoadQuestionPort loadQuestionPort;
+    private final SaveQuestionPort saveQuestionPort;
+    private final SaveQuestionOptionPort saveQuestionOptionPort;
+    private final SaveAnswerPort saveAnswerPort;
+
+    @Override
+    public Long createQuestion(CreateQuestionCommand command) {
+        FormSection section = loadFormSectionPort.findById(command.sectionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        long nextOrderNo = loadQuestionPort.listBySectionId(command.sectionId()).stream()
+            .mapToLong(Question::getOrderNo)
+            .max()
+            .orElse(0L) + 1L;
+
+        Question question = Question.create(
+            command.title(),
+            command.type(),
+            command.isRequired(),
+            nextOrderNo
+        );
+        question.assignTo(section);
+        return saveQuestionPort.save(question).getId();
+    }
+
+    @Override
+    public void updateQuestion(UpdateQuestionCommand command) {
+        Question question = loadQuestionPort.findById(command.questionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
+
+        // type 변경이 있으면 옵션 정리 정책 적용
+        if (command.type() != null && command.type() != question.getType()) {
+            applyTypeChange(question, command.type());
+        }
+
+        // 나머지 속성 PATCH
+        question.update(command.title(), command.description(), command.isRequired());
+
+        saveQuestionPort.save(question);
+    }
+
+    @Override
+    public void deleteQuestion(DeleteQuestionCommand command) {
+        Long questionId = command.questionId();
+
+        // FK 의존성 거꾸로: AnswerChoice/Answer -> QuestionOption -> Question
+        // (Answer cascade 는 SaveAnswerPort.deleteByQuestionId 가 내부적으로 AnswerChoice -> Answer 순으로 처리)
+        saveAnswerPort.deleteByQuestionId(questionId);
+        saveQuestionOptionPort.deleteAllByQuestionId(questionId);
+        saveQuestionPort.deleteById(questionId);
+    }
+
+    @Override
+    public void reorderQuestions(ReorderQuestionsCommand command) {
+        List<Question> questions = loadQuestionPort.listBySectionId(command.sectionId());
+
+        Set<Long> existingIds = questions.stream()
+            .map(Question::getId)
+            .collect(Collectors.toSet());
+        Set<Long> requestedIds = new HashSet<>(command.orderedQuestionIds());
+
+        if (!existingIds.equals(requestedIds)) {
+            throw new SurveyDomainException(
+                SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "재배치 요청의 질문 ID 셋이 실제 섹션의 질문 ID 셋과 일치하지 않습니다."
+            );
+        }
+
+        Map<Long, Question> byId = questions.stream()
+            .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        for (int i = 0; i < command.orderedQuestionIds().size(); i++) {
+            byId.get(command.orderedQuestionIds().get(i)).updateOrderNo(i + 1);
+        }
+
+        saveQuestionPort.saveAll(questions);
+    }
+
+    /**
+     * type 변경 시 옵션 cascade 정리.
+     * <p>
+     * 객관식 (RADIO/CHECKBOX/DROPDOWN) -> 비객관식으로 바뀌면 기존 옵션이 의미 없어지므로 삭제.
+     * 그 외 조합은 정리할 옵션 자체가 없거나 (비객관식 → *) 그대로 유지 (객관식 <-> 객관식).
+     * <p>
+     * TODO: 응답(Answer) 무효화 합의 시 분기 추가 (일단 응답 보존).
+     */
+    private void applyTypeChange(Question question, QuestionType newType) {
+        if (isObjective(question.getType()) && !isObjective(newType)) {
+            saveQuestionOptionPort.deleteAllByQuestionId(question.getId());
+        }
+        // TODO: 응답(Answer) 무효화 합의 시 분기 추가
+
+        question.changeType(newType);
+    }
+
+    private static boolean isObjective(QuestionType type) {
+        return type == QuestionType.RADIO
+            || type == QuestionType.CHECKBOX
+            || type == QuestionType.DROPDOWN;
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionOptionCommandService.java
@@ -42,8 +42,13 @@ public class ManageQuestionOptionCommandService implements ManageQuestionOptionU
             .max()
             .orElse(0L) + 1L;
 
-        QuestionOption option = QuestionOption.create(command.content(), nextOrderNo, command.isOther());
+        QuestionOption option = QuestionOption.create(
+            command.content(),
+            nextOrderNo,
+            command.isOther()
+        );
         option.assignTo(question);
+
         return saveQuestionOptionPort.save(option).getId();
     }
 
@@ -71,7 +76,10 @@ public class ManageQuestionOptionCommandService implements ManageQuestionOptionU
         Set<Long> requestedIds = new HashSet<>(command.orderedOptionIds());
 
         if (!existingIds.equals(requestedIds)) {
-            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE);
+            throw new SurveyDomainException(
+                SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "재배치 요청의 선택지 ID 셋이 실제 질문의 선택지 ID 셋과 일치하지 않습니다."
+            );
         }
 
         Map<Long, QuestionOption> byId = options.stream()

--- a/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/ManageQuestionOptionCommandService.java
@@ -1,0 +1,86 @@
+package com.umc.product.survey.application.service.command;
+
+import com.umc.product.survey.application.port.in.command.ManageQuestionOptionUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionOptionsCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionOptionCommand;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManageQuestionOptionCommandService implements ManageQuestionOptionUseCase {
+
+    private final LoadQuestionPort loadQuestionPort;
+    private final LoadQuestionOptionPort loadQuestionOptionPort;
+    private final SaveQuestionOptionPort saveQuestionOptionPort;
+
+    @Override
+    public Long createOption(CreateQuestionOptionCommand command) {
+        Question question = loadQuestionPort.findById(command.questionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        long nextOrderNo = loadQuestionOptionPort.listByQuestionId(command.questionId()).stream()
+            .mapToLong(QuestionOption::getOrderNo)
+            .max()
+            .orElse(0L) + 1L;
+
+        QuestionOption option = QuestionOption.create(command.content(), nextOrderNo, command.isOther());
+        option.assignTo(question);
+        return saveQuestionOptionPort.save(option).getId();
+    }
+
+    @Override
+    public void updateOption(UpdateQuestionOptionCommand command) {
+        QuestionOption option = loadQuestionOptionPort.findById(command.optionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        option.update(command.content(), command.isOther());
+        saveQuestionOptionPort.save(option);
+    }
+
+    @Override
+    public void deleteOption(DeleteQuestionOptionCommand command) {
+        saveQuestionOptionPort.deleteById(command.optionId());
+    }
+
+    @Override
+    public void reorderOptions(ReorderQuestionOptionsCommand command) {
+        List<QuestionOption> options = loadQuestionOptionPort.listByQuestionId(command.questionId());
+
+        Set<Long> existingIds = options.stream()
+            .map(QuestionOption::getId)
+            .collect(Collectors.toSet());
+        Set<Long> requestedIds = new HashSet<>(command.orderedOptionIds());
+
+        if (!existingIds.equals(requestedIds)) {
+            throw new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE);
+        }
+
+        Map<Long, QuestionOption> byId = options.stream()
+            .collect(Collectors.toMap(QuestionOption::getId, Function.identity()));
+
+        for (int i = 0; i < command.orderedOptionIds().size(); i++) {
+            byId.get(command.orderedOptionIds().get(i)).updateOrderNo(i + 1);
+        }
+
+        saveQuestionOptionPort.saveAll(options);
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class ManageQuestionCommandService implements ManageQuestionUseCase {
+public class QuestionCommandService implements ManageQuestionUseCase {
 
     private final LoadFormSectionPort loadFormSectionPort;
     private final LoadQuestionPort loadQuestionPort;

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionOptionCommandService.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class ManageQuestionOptionCommandService implements ManageQuestionOptionUseCase {
+public class QuestionOptionCommandService implements ManageQuestionOptionUseCase {
 
     private final LoadQuestionPort loadQuestionPort;
     private final LoadQuestionOptionPort loadQuestionOptionPort;

--- a/src/main/java/com/umc/product/survey/application/service/query/AnswerQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/AnswerQueryService.java
@@ -1,0 +1,74 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetAnswerUseCase;
+import com.umc.product.survey.application.port.in.query.dto.AnswerInfo;
+import com.umc.product.survey.application.port.out.LoadAnswerPort;
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnswerQueryService implements GetAnswerUseCase {
+
+    private final LoadAnswerPort loadAnswerPort;
+
+    @Override
+    public Optional<AnswerInfo> findById(Long answerId) {
+        return loadAnswerPort.findById(answerId)
+            .map(this::toAnswerInfo);
+    }
+
+    @Override
+    public AnswerInfo getById(Long answerId) {
+        Answer answer = loadAnswerPort.findById(answerId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.ANSWER_NOT_FOUND));
+        return toAnswerInfo(answer);
+    }
+
+    @Override
+    public List<AnswerInfo> listByFormResponseId(Long formResponseId) {
+        // 1. 답변 로드 (섹션/질문 orderNo 정렬)
+        List<Answer> answers = loadAnswerPort.listByFormResponseId(formResponseId);
+        if (answers.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 답변 ID 셋으로 AnswerChoice 벌크 로드 (N+1 회피)
+        Set<Long> answerIds = answers.stream()
+            .map(Answer::getId)
+            .collect(Collectors.toSet());
+        List<AnswerChoice> allChoices = loadAnswerPort.listChoicesByAnswerIdIn(answerIds);
+
+        // 3. answerId -> choices 그룹핑
+        Map<Long, List<AnswerChoice>> choicesByAnswer = allChoices.stream()
+            .collect(Collectors.groupingBy(c -> c.getAnswer().getId()));
+
+        // 4. DTO 조립 (answers 의 정렬 순서 보존)
+        return answers.stream()
+            .map(answer -> AnswerInfo.from(
+                answer,
+                choicesByAnswer.getOrDefault(answer.getId(), List.of())
+            ))
+            .toList();
+    }
+
+    /**
+     * 단건 Answer -> AnswerInfo. 해당 답변의 AnswerChoice 만 조회 후 조립.
+     */
+    private AnswerInfo toAnswerInfo(Answer answer) {
+        List<AnswerChoice> choices = loadAnswerPort.listChoicesByAnswerIdIn(Set.of(answer.getId()));
+        return AnswerInfo.from(answer, choices);
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
@@ -1,0 +1,135 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.Option;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FormQueryService implements GetFormUseCase {
+
+    private final LoadFormPort loadFormPort;
+    private final LoadFormSectionPort loadFormSectionPort;
+    private final LoadQuestionPort loadQuestionPort;
+    private final LoadQuestionOptionPort loadQuestionOptionPort;
+
+    @Override
+    public Optional<FormInfo> findById(Long formId) {
+        return loadFormPort.findById(formId)
+            .map(FormInfo::from);
+    }
+
+    @Override
+    public FormInfo getById(Long formId) {
+        return loadFormPort.findById(formId)
+            .map(FormInfo::from)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+    }
+
+    @Override
+    public FormWithStructureInfo getFormWithStructure(Long formId) {
+        // 1. 폼 메타 로드
+        Form form = loadFormPort.findById(formId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        // 2. 섹션 로드 (orderNo asc)
+        List<FormSection> sections = loadFormSectionPort.listByFormId(formId);
+        Set<Long> sectionIds = sections.stream()
+            .map(FormSection::getId)
+            .collect(Collectors.toSet());
+
+        // 3. 모든 섹션의 질문을 벌크 로드 (N+1 회피)
+        List<Question> questions = loadQuestionPort.listBySectionIdIn(sectionIds);
+        Set<Long> questionIds = questions.stream()
+            .map(Question::getId)
+            .collect(Collectors.toSet());
+
+        // 4. 모든 질문의 선택지를 벌크 로드
+        List<QuestionOption> options = loadQuestionOptionPort.listByQuestionIdIn(questionIds);
+
+        // 5. 메모리 grouping — sectionId -> 질문 / questionId -> 옵션
+        Map<Long, List<Question>> questionsBySection = questions.stream()
+            .collect(Collectors.groupingBy(q -> q.getFormSection().getId()));
+        Map<Long, List<QuestionOption>> optionsByQuestion = options.stream()
+            .collect(Collectors.groupingBy(o -> o.getQuestion().getId()));
+
+        // 6. 중첩 DTO 조립
+        List<SectionWithQuestions> sectionDtos = sections.stream()
+            .map(section -> SectionWithQuestions.builder()
+                .sectionId(section.getId())
+                .title(section.getTitle())
+                .description(section.getDescription())
+                .orderNo(section.getOrderNo())
+                .questions(toQuestionDtos(
+                    questionsBySection.getOrDefault(section.getId(), List.of()),
+                    optionsByQuestion
+                ))
+                .build())
+            .toList();
+
+        return FormWithStructureInfo.builder()
+            .formId(form.getId())
+            .createdMemberId(form.getCreatedMemberId())
+            .title(form.getTitle())
+            .description(form.getDescription())
+            .status(form.getStatus())
+            .isAnonymous(form.isAnonymous())
+            .createdAt(form.getCreatedAt())
+            .updatedAt(form.getUpdatedAt())
+            .sections(sectionDtos)
+            .build();
+    }
+
+    private List<QuestionWithOptions> toQuestionDtos(
+        List<Question> questions,
+        Map<Long, List<QuestionOption>> optionsByQuestion
+    ) {
+        return questions.stream()
+            .map(question -> QuestionWithOptions.builder()
+                .questionId(question.getId())
+                .title(question.getTitle())
+                .description(question.getDescription())
+                .type(question.getType())
+                .isRequired(Boolean.TRUE.equals(question.getIsRequired()))
+                .orderNo(question.getOrderNo())
+                .options(toOptionDtos(
+                    optionsByQuestion.getOrDefault(question.getId(), List.of())
+                ))
+                .build())
+            .toList();
+    }
+
+    private List<Option> toOptionDtos(List<QuestionOption> options) {
+        return options.stream()
+            .map(option -> Option.builder()
+                .optionId(option.getId())
+                .content(option.getContent())
+                .orderNo(option.getOrderNo())
+                .isOther(option.isOther())
+                .build())
+            .toList();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormResponseQueryService.java
@@ -1,8 +1,12 @@
 package com.umc.product.survey.application.service.query;
 
+import com.umc.product.survey.application.port.in.query.GetAnswerUseCase;
 import com.umc.product.survey.application.port.in.query.GetFormResponseUseCase;
+import com.umc.product.survey.application.port.in.query.dto.AnswerInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 import com.umc.product.survey.application.port.out.LoadFormResponsePort;
+import com.umc.product.survey.domain.FormResponse;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,7 @@ import java.util.Optional;
 public class FormResponseQueryService implements GetFormResponseUseCase {
 
     private final LoadFormResponsePort loadFormResponsePort;
+    private final GetAnswerUseCase getAnswerUseCase;
 
     @Override
     public Optional<FormResponseInfo> findById(Long formResponseId) {
@@ -63,5 +68,14 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
     public Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
         return loadFormResponsePort.findSubmittedByFormIdAndRespondentMemberId(formId, respondentMemberId)
             .map(FormResponseInfo::from);
+    }
+
+    @Override
+    public FormResponseWithAnswersInfo getResponseWithAnswers(Long formResponseId) {
+        FormResponse formResponse = loadFormResponsePort.findById(formResponseId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
+
+        List<AnswerInfo> answers = getAnswerUseCase.listByFormResponseId(formResponseId);
+        return FormResponseWithAnswersInfo.from(formResponse, answers);
     }
 }

--- a/src/main/java/com/umc/product/survey/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormResponseQueryService.java
@@ -1,0 +1,67 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetFormResponseUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
+import com.umc.product.survey.application.port.out.LoadFormResponsePort;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FormResponseQueryService implements GetFormResponseUseCase {
+
+    private final LoadFormResponsePort loadFormResponsePort;
+
+    @Override
+    public Optional<FormResponseInfo> findById(Long formResponseId) {
+        return loadFormResponsePort.findById(formResponseId)
+            .map(FormResponseInfo::from);
+    }
+
+    @Override
+    public FormResponseInfo getById(Long formResponseId) {
+        return loadFormResponsePort.findById(formResponseId)
+            .map(FormResponseInfo::from)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
+    }
+
+    @Override
+    public List<FormResponseInfo> listByFormId(Long formId) {
+        return loadFormResponsePort.listByFormId(formId).stream()
+            .map(FormResponseInfo::from)
+            .toList();
+    }
+
+    @Override
+    public List<FormResponseInfo> listSubmittedByFormId(Long formId) {
+        return loadFormResponsePort.listSubmittedByFormId(formId).stream()
+            .map(FormResponseInfo::from)
+            .toList();
+    }
+
+    @Override
+    public List<FormResponseInfo> listDraftByRespondentMemberId(Long respondentMemberId) {
+        return loadFormResponsePort.findAllDraftByRespondentMemberId(respondentMemberId).stream()
+            .map(FormResponseInfo::from)
+            .toList();
+    }
+
+    @Override
+    public Optional<FormResponseInfo> findDraftByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
+        return loadFormResponsePort.findDraftByFormIdAndRespondentMemberId(formId, respondentMemberId)
+            .map(FormResponseInfo::from);
+    }
+
+    @Override
+    public Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
+        return loadFormResponsePort.findSubmittedByFormIdAndRespondentMemberId(formId, respondentMemberId)
+            .map(FormResponseInfo::from);
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/FormSectionQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormSectionQueryService.java
@@ -1,0 +1,41 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetFormSectionUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormSectionInfo;
+import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FormSectionQueryService implements GetFormSectionUseCase {
+
+    private final LoadFormSectionPort loadFormSectionPort;
+
+    @Override
+    public Optional<FormSectionInfo> findById(Long sectionId) {
+        return loadFormSectionPort.findById(sectionId)
+            .map(FormSectionInfo::from);
+    }
+
+    @Override
+    public FormSectionInfo getById(Long sectionId) {
+        return loadFormSectionPort.findById(sectionId)
+            .map(FormSectionInfo::from)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+    }
+
+    @Override
+    public List<FormSectionInfo> listByFormId(Long formId) {
+        return loadFormSectionPort.listByFormId(formId).stream()
+            .map(FormSectionInfo::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/QuestionOptionQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/QuestionOptionQueryService.java
@@ -1,0 +1,41 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetQuestionOptionUseCase;
+import com.umc.product.survey.application.port.in.query.dto.QuestionOptionInfo;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuestionOptionQueryService implements GetQuestionOptionUseCase {
+
+    private final LoadQuestionOptionPort loadQuestionOptionPort;
+
+    @Override
+    public Optional<QuestionOptionInfo> findById(Long optionId) {
+        return loadQuestionOptionPort.findById(optionId)
+            .map(QuestionOptionInfo::from);
+    }
+
+    @Override
+    public QuestionOptionInfo getById(Long optionId) {
+        return loadQuestionOptionPort.findById(optionId)
+            .map(QuestionOptionInfo::from)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_OPTION_NOT_FOUND));
+    }
+
+    @Override
+    public List<QuestionOptionInfo> listByQuestionId(Long questionId) {
+        return loadQuestionOptionPort.listByQuestionId(questionId).stream()
+            .map(QuestionOptionInfo::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/QuestionQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/QuestionQueryService.java
@@ -1,0 +1,41 @@
+package com.umc.product.survey.application.service.query;
+
+import com.umc.product.survey.application.port.in.query.GetQuestionUseCase;
+import com.umc.product.survey.application.port.in.query.dto.QuestionInfo;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuestionQueryService implements GetQuestionUseCase {
+
+    private final LoadQuestionPort loadQuestionPort;
+
+    @Override
+    public Optional<QuestionInfo> findById(Long questionId) {
+        return loadQuestionPort.findById(questionId)
+            .map(QuestionInfo::from);
+    }
+
+    @Override
+    public QuestionInfo getById(Long questionId) {
+        return loadQuestionPort.findById(questionId)
+            .map(QuestionInfo::from)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
+    }
+
+    @Override
+    public List<QuestionInfo> listBySectionId(Long sectionId) {
+        return loadQuestionPort.listBySectionId(sectionId).stream()
+            .map(QuestionInfo::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/umc/product/survey/application/service/query/VoteQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/VoteQueryService.java
@@ -46,7 +46,7 @@ public class VoteQueryService implements GetVoteUseCase {
 
         // 2. 투표 구조 로드 (섹션 -> 질문 -> 옵션)
         // 공식적으로는 1섹션 1질문 구조를 전제로 하지만, 확장성을 고려하여 조회
-        FormSection section = loadFormSectionPort.findAllByFormId(formId).stream()
+        FormSection section = loadFormSectionPort.listByFormId(formId).stream()
             .findFirst()
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.INVALID_VOTE_FORM_STRUCTURE));
 

--- a/src/main/java/com/umc/product/survey/domain/Answer.java
+++ b/src/main/java/com/umc/product/survey/domain/Answer.java
@@ -81,4 +81,13 @@ public class Answer extends BaseEntity {
 
         return answer;
     }
+
+    /**
+     * 답변 내용(textValue) 갱신. 객관식 답변의 AnswerChoice 갈아끼움은 Service 책임.
+     * <p>
+     * 질문 type 변경은 {@code ManageQuestionUseCase}가 다루므로 본 메서드에서 type 변경 안 함.
+     */
+    public void updateTextValue(String textValue) {
+        this.textValue = textValue;
+    }
 }

--- a/src/main/java/com/umc/product/survey/domain/Answer.java
+++ b/src/main/java/com/umc/product/survey/domain/Answer.java
@@ -60,8 +60,8 @@ public class Answer extends BaseEntity {
     private QuestionType answeredAsType;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "file_ids", columnDefinition = "bigint[]")
-    private Set<Long> fileIds;
+    @Column(name = "file_ids", columnDefinition = "text[]")
+    private Set<String> fileIds;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "times", columnDefinition = "timestamptz[]")
@@ -71,23 +71,36 @@ public class Answer extends BaseEntity {
         FormResponse formResponse,
         Question question,
         QuestionType answeredAsType,
-        String textValue
+        String textValue,
+        Set<String> fileIds
     ) {
         Answer answer = new Answer();
         answer.formResponse = formResponse;
         answer.question = question;
         answer.answeredAsType = answeredAsType;
         answer.textValue = textValue;
+        answer.fileIds = fileIds;
 
         return answer;
     }
 
     /**
-     * 답변 내용(textValue) 갱신. 객관식 답변의 AnswerChoice 갈아끼움은 Service 책임.
+     * 답변 내용 (textValue / fileIds) 부분 갱신 (PATCH 시맨틱 — 다른 도메인 update 메서드와 일관).
+     * <ul>
+     *   <li>null -> 기존 값 유지</li>
+     *   <li>빈 문자열 / 빈 Set -> 비우기 (null 로 저장)</li>
+     *   <li>값 있음 -> 새 값으로 갱신</li>
+     * </ul>
      * <p>
+     * 객관식 답변의 AnswerChoice 갈아끼움은 Service 책임.
      * 질문 type 변경은 {@code ManageQuestionUseCase}가 다루므로 본 메서드에서 type 변경 안 함.
      */
-    public void updateTextValue(String textValue) {
-        this.textValue = textValue;
+    public void update(String textValue, Set<String> fileIds) {
+        if (textValue != null) {
+            this.textValue = textValue.isBlank() ? null : textValue;
+        }
+        if (fileIds != null) {
+            this.fileIds = fileIds.isEmpty() ? null : fileIds;
+        }
     }
 }

--- a/src/main/java/com/umc/product/survey/domain/Form.java
+++ b/src/main/java/com/umc/product/survey/domain/Form.java
@@ -80,4 +80,14 @@ public class Form extends BaseEntity {
 
         this.status = FormStatus.PUBLISHED;
     }
+
+    /**
+     * 폼 메타데이터 부분 업데이트.
+     * null 인 필드는 기존 값 유지. 임시저장 단계에서 어느 필드든 부분 변경 가능하도록 모든 파라미터 nullable.
+     */
+    public void update(String title, String description, Boolean isAnonymous) {
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+        if (isAnonymous != null) this.isAnonymous = isAnonymous;
+    }
 }

--- a/src/main/java/com/umc/product/survey/domain/FormSection.java
+++ b/src/main/java/com/umc/product/survey/domain/FormSection.java
@@ -6,8 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
-// TODO: Builder는 엔티티 단에서 정팩메에 붙여서 사용하도록 하고, 따로 엔티티 단에 붙이지 않는게 어떤지
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "form_section")
@@ -29,4 +28,30 @@ public class FormSection extends BaseEntity {
 
     @Column(name = "order_no")
     private Long orderNo;
+
+    public static FormSection create(Form form, String title, String description, Long orderNo) {
+        return FormSection.builder()
+            .form(form)
+            .title(title)
+            .description(description)
+            .orderNo(orderNo)
+            .build();
+    }
+
+    /**
+     * 섹션 메타데이터 부분 업데이트.
+     * null 인 필드는 기존 값 유지.
+     */
+    public void update(String title, String description) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
+
+    public void updateOrderNo(Long orderNo) {
+        this.orderNo = orderNo;
+    }
 }

--- a/src/main/java/com/umc/product/survey/domain/Question.java
+++ b/src/main/java/com/umc/product/survey/domain/Question.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "question")
@@ -38,40 +38,47 @@ public class Question extends BaseEntity {
     private Long orderNo;
 
     public static Question create(
-        String questionText,
+        String title,
         QuestionType type,
         boolean isRequired,
         long orderNo
     ) {
-        Question q = new Question();
-        q.title = questionText;
-        q.type = type;
-        q.isRequired = isRequired;
-        q.orderNo = orderNo;
-        return q;
+        return Question.builder()
+            .title(title)
+            .type(type)
+            .isRequired(isRequired)
+            .orderNo(orderNo)
+            .build();
     }
 
     public void assignTo(FormSection section) {
         this.formSection = section;
     }
 
-    public void changeFormSection(FormSection section) {
-        this.formSection = section;
+    /**
+     * 질문 속성 부분 업데이트 (PATCH semantics).
+     * null 인 필드는 기존 값 유지. type 변경은 별도 {@link #changeType} 사용.
+     */
+    public void update(String title, String description, Boolean isRequired) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (isRequired != null) {
+            this.isRequired = isRequired;
+        }
     }
 
-    public void changeQuestionText(String text) {
-        this.title = text;
-    }
-
+    /**
+     * 질문 타입 변경. 호출 측 Service 가 옵션 / 응답 cascade 정리 책임.
+     */
     public void changeType(QuestionType type) {
         this.type = type;
     }
 
-    public void changeRequired(boolean required) {
-        this.isRequired = required;
-    }
-
-    public void changeOrderNo(long orderNo) {
+    public void updateOrderNo(long orderNo) {
         this.orderNo = orderNo;
     }
 

--- a/src/main/java/com/umc/product/survey/domain/QuestionOption.java
+++ b/src/main/java/com/umc/product/survey/domain/QuestionOption.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "question_option")
@@ -31,23 +31,28 @@ public class QuestionOption extends BaseEntity {
     private boolean isOther;
 
     public static QuestionOption create(String content, long orderNo, boolean isOther) {
-        QuestionOption questionOption = new QuestionOption();
-        questionOption.content = content;
-        questionOption.orderNo = orderNo;
-        questionOption.isOther = isOther;
-        return questionOption;
+        return QuestionOption.builder()
+            .content(content)
+            .orderNo(orderNo)
+            .isOther(isOther)
+            .build();
     }
 
-    public void changeContent(String content) {
-        this.content = content;
+    /**
+     * 선택지 속성 부분 업데이트.
+     * null 인 필드는 기존 값 유지.
+     */
+    public void update(String content, Boolean isOther) {
+        if (content != null) {
+            this.content = content;
+        }
+        if (isOther != null) {
+            this.isOther = isOther;
+        }
     }
 
-    public void changeOrderNo(long orderNo) {
+    public void updateOrderNo(long orderNo) {
         this.orderNo = orderNo;
-    }
-
-    public void changeIsOther(boolean isOther) {
-        this.isOther = isOther;
     }
 
     public void assignTo(Question question) {

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -32,6 +32,7 @@ public enum SurveyErrorCode implements BaseCode {
     SURVEY_NOT_PUBLISHED(HttpStatus.CONFLICT, "SURVEY-0028", "발행된 폼만 응답할 수 있습니다."),
     QUESTION_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0029", "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0030", "답변을 찾을 수 없습니다."),
+    FORM_RESPONSE_NOT_DRAFT(HttpStatus.CONFLICT, "SURVEY-0031", "임시저장 상태의 응답에만 가능한 작업입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -33,6 +33,7 @@ public enum SurveyErrorCode implements BaseCode {
     QUESTION_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0029", "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0030", "답변을 찾을 수 없습니다."),
     FORM_RESPONSE_NOT_DRAFT(HttpStatus.CONFLICT, "SURVEY-0031", "임시저장 상태의 응답에만 가능한 작업입니다."),
+    ANSWER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SURVEY-0032", "이미 해당 질문에 대한 답변이 존재합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -30,6 +30,7 @@ public enum SurveyErrorCode implements BaseCode {
     // SURVEY-0026 (VOTE_RESPONSE_NOT_FOUND): notice 도메인으로 이관
     FORM_RESPONSE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SURVEY-0027", "이미 제출한 응답이 있습니다."),
     SURVEY_NOT_PUBLISHED(HttpStatus.CONFLICT, "SURVEY-0028", "발행된 폼만 응답할 수 있습니다."),
+    QUESTION_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0029", "선택지를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -31,6 +31,7 @@ public enum SurveyErrorCode implements BaseCode {
     FORM_RESPONSE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SURVEY-0027", "이미 제출한 응답이 있습니다."),
     SURVEY_NOT_PUBLISHED(HttpStatus.CONFLICT, "SURVEY-0028", "발행된 폼만 응답할 수 있습니다."),
     QUESTION_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0029", "선택지를 찾을 수 없습니다."),
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0030", "답변을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/db/migration/V2026.05.01.01.00__answer_file_ids_type_change.sql
+++ b/src/main/resources/db/migration/V2026.05.01.01.00__answer_file_ids_type_change.sql
@@ -1,0 +1,14 @@
+-- Survey 도메인 Answer.file_ids 의 컬럼 타입을 bigint[] -> text[] 로 변경.
+--
+-- 배경:
+--   다른 모든 도메인 (Project, Member, Notice, Organization, Curriculum, Challenger 등) 이 storage 도메인의 fileId 를 String 으로 사용.
+--   Survey Answer 만 Set<Long> 으로 정의돼 있어 타입 불일치 상태였음. 일관성 위해 String 으로 통일.
+--
+-- 데이터 안전성:
+--   answer 테이블 자체는 PR #748 시점에 신설됐고, V2026.04.23.02.39 마이그레이션으로 legacy single_answer 의 투표 데이터 이관.
+--   다만 이관 대상은 RADIO / DROPDOWN / CHECKBOX 객관식 답변뿐이며, 해당 INSERT 가 file_ids 컬럼을 채우지 않아 모든 row 의 file_ids 는 NULL.
+--   FILE / PORTFOLIO 답변은 본 PR 에서 처음 지원하므로 file_ids 에 실제 값이 들어간 row 는 현재 시점 0건.
+--   따라서 타입 변경 (bigint[] -> text[]) 은 NULL 값만 영향 — 데이터 손실 없이 안전.
+ALTER TABLE answer
+    ALTER COLUMN file_ids TYPE text[]
+    USING file_ids::text[];


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #773 

## 🚀 작업 내용
Survey 도메인의 UseCase들을 실제로 구현했습니다.

1. Command UseCase 구현
- `FormCommandService`
  - 폼 삭제 시 Answer -> FormResponse -> QuestionOption -> Question -> FormSection -> Form 순으로 cascade 삭제합니다.
- `FormSectionCommandService`
  - reorder 는 입력 ID 셋과 DB 의 ID 셋이 정확히 일치해야 통과합니다.
- `QuestionCommandService`
  - type 변경 시 객관식 -> 비객관식 케이스에 한해 옵션을 cascade 삭제합니다.
    - 해당 경우 응답(answer)을 무효화할 것 인지 협의가 필요합니다. 우선 질문이 수정되어도 응답은 보존한다는 합의가 있었던 것으로 기억하여, 응답 데이터는 삭제하지 않고 보존하도록 구현해두었습니다. 의견 주시기 바랍니다.
- `QuestionOptionCommandService`
  - 객관식 질문에만 옵션 추가 가능합니다.
- `FormResponseCommandService`
- `AnswerCommandService`
  - `updateAnswer`는 Answer ID 를 기반으로 기존 답변을 조회하여 `textValue` / `fileIds`를 갱신하는 방식으로, `AnswerChoice`는 전체 삭제 후 재생성하는 방식으로 구현했습니다.

2. Query UseCase 구현
- `FormQueryService` 
  - `getFormBasic` (메타만) / `getFormWithStructure` (Form + Section + Question + QuestionOption 한번에)
  - 구조 조회는 Section/Question/Option을 벌크 로드 후 조립하는 구조로 구현했습니다.                                                 
- `FormSectionQueryService`
- `QuestionQueryService`      
- `QuestionOptionQueryService`                           
- `FormResponseQueryService`
  - `listByFormId` (DRAFT+SUBMITTED), `listSubmittedByFormId` (SUBMITTED만), `getResponseWithAnswers` (FormResponse + List).
- `AnswerQueryService`
  - 객관식 답변의 경우 `AnswerChoice` 를 펼쳐 `selectedOptions` 로 제공합니다. (id + 응답 시점 content 스냅샷)

3. 도메인 엔티티 보강                                    
- `Form.update` 
  - boolean 타입이었던 isAnonymous도 Boolean으로 변경했습니다. 모든 인자를 nullable하게 설정하여, 요청 파라미터가 null로 들어오는 경우에는 갱신하지 않도록 했습니다.
- `FormSection`, `Question`, `QuestionOption`
  - `@Builder(access=PRIVATE)` + `create()` 정팩메 패턴으로 수정했습니다. 
- `Answer` 
  - fileIds 타입을 Set<Long> -> Set<String> 으로 마이그레이션 진행했습니다. 기존 경운님과 함께 엔티티 구현하면서 fileId를 Long 타입으로 뒀었는데 그 이유가 기억나지 않아 다른 도메인들과 저장 구조를 맞추어 String 형태로 수정했습니다. 이슈 있다면 말씀 부탁드립니다.

4. FILE / PORTFOLIO type 답변 구현
- `AnswerCommand` 에 `fileIds: List<String>` 필드를 추가했습니다.              
- `AnswerCommandService` / `FormResponseCommandService` 의         
`validateAnswerContent` 에 `FILE` / `PORTFOLIO` 분기를 추가했습니다.             
  - `FILE`: `fileIds` 비어있지 않은지 + 각 `fileId`를 `GetFileUseCase.throwIfNotExists` 로 검증합니다.
  - `PORTFOLIO`: `textValue`(링크) 또는 `fileIds`(PDF) 중 최소 하나가 비어있지 않으면 통과하며, `fileIds` 존재 시에는 storage를 검증합니다.
- DB 마이그레이션: ```V2026.05.01.01.00__answer_file_ids_type_change.sql``` (bigint[] -> text[])
  - 기존 row 의 `file_ids` 는 모두 NULL 이라 데이터 손실은 우려되지 않습니다.
- `SCHEDULE` type은, 현재 UI에서 해당 타입 질문을 활용하고 있지 않아 미구현 상태로 두었습니다. 요구사항이 명확해 지면 구현하는 것이 좋을 듯 합니다.

5. 조회 쿼리 QueryDSL로 재구현                       
- 본 PR 에서 새로 만드는 / 정리하는 조회 query는 QueryDSL로 작성했습니다.       
- 기존 `JpaRepository`의 method 중 본 PR 에서 사용 / 영향받는 것들은 QueryDSL로 재구현하였으며, 그 외 derived method 들은 후속 PR 에서 일괄 정리 예정입니다.

6. Vote API cascade 보강
- `VoteService.deleteVote`에 cascade 삭제 처리 로직 추가하였습니다.


## 💬 리뷰 중점사항
1. 권한 검증 위치
- Survey UseCase 안에서는 `requesterMemberId` 비교 검증을 하지 않습니다. 
- Survey는 공통 엔진으로, 권한 정책이 consumer 도메인 (`Notice` / `Project` / `Recruitment`)마다 다를 것으로 예상되어 호출 측에서 권한 검증을 통과시키고 들어오는 방향으로 생각하였습니다. 이 방향이 적절한지 의견 부탁드립니다.
- `requesterMemberId` 필드는 survey 도메인에서 권한 검증을 하지 않는 것이 협의되면 제거할 예정입니다.

2. 폼 `PUBLISHED` / 응답 `SUBMITTED` 후 수정 차단 정책 확정
- 기존 `PUBLISHED` 폼 수정 / 응답 제출 후 수정 차단 검증을 넣지 않았습니다. 정책 확정 후 분기 추가 예정입니다. 
- `PUBLISHED` 폼의 경우 수정이 제한되는지, 응답이 하나라도 달릴 시에 수정이 제한되는지 정책 확정이 필요합니다.
- `FormResponse는` `SUBMITTED` 이후 수정 차단 정책이 필요할 것으로 생각되나, 투표 응답의 경우에는 항상 `SUBMITTED`로 저장되고 투표 수정이 가능하기 때문에 UseCase 구현에 고민이 있습니다. . .

3. Question type 변경 시 기존 Answer 처리
- type 변경 시 옵션은 객관식 -> 비객관식 케이스만 cascade 삭제하도록 구현했습니다. 
- 질문이 수정되어도 응답은 보존한다는 합의가 있었던 것으로 기억하여, 응답 데이터는 삭제하지 않고 보존하도록 구현해두었습니다.                 

4. `Answer.answeredAsType` 갱신 관련
- answer create 시점의 type이 스냅샷으로 저장되는데, `Answer.update` 에서 갱신하는 로직이 필요할 지 의견 부탁드립니다. 답변 Submit 시점에 스냅샷을 갱신하는 것이 맞는 방향일 수 있겠네요.

5. 답변 저장 패턴
- `FormResponseCommandService`의 `submitImmediately` / `updateResponse` / `updateDraft` / `submitDraft` 는 답변 셋을 전체 교체하는 방식으로 구현해 두었습니다. (delete + save)
- 반면 단건 단위인 AnswerCommandService.updateAnswer 는 Answer PK 유지 + AnswerChoice 갈아끼우도록 구현했습니다,
- 변동 단위 (셋 전체 vs 단건) 가 달라 패턴을 다르게 구현했는데, 일관성 측면에서 의견 부탁드립니다.

6. fileIds 타입을 Set<Long> -> Set<String>으로 타입 변경한 건에 대해 의견 부탁드립니다.

7. `PORTFOLIO` 중 Link 답변 저장을 `textValue`에 하는 구조가 괜찮은지 확인 부탁드립니다.
- 추가적으로, Storage FileCategory.PORTFOLIO 가 200MB 인데 [UI](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=2048-31720&t=eZDKzi08AQd1OUmN-4) 상으로는 150MB 한도인 점 언급 드립니다. Survey scope 외라 본 PR에서는 수정하지 않았습니다.                    