### PR TITLE
[Feat] 프로젝트 지원용 폼 조회 시 챌린저 파트에 따라 조회되는 섹션 필터링 구현

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java
@@ -52,11 +52,14 @@ public class ProjectApplicationFormController {
         return UpsertApplicationFormResponse.from(info);
     }
 
-    // TODO: 챌린저 호출 시 본인 파트 + COMMON 섹션 마스킹 적용 (response.forApplicant(applicantPart))
     @GetMapping("/{projectId}/application-form")
     @Operation(
         summary = "[PROJECT-106-GET] 지원 폼 조회",
-        description = "프로젝트의 지원 폼 전체 구조를 조회한다. 폼이 없으면 ApiResponse.result = null."
+        description = """
+            프로젝트의 지원 폼 구조를 조회한다.
+            호출자가 PM/총괄단/프로젝트 지부의 지부장이면 전체 섹션, 일반 챌린저이면 본인 파트가 매칭된 PART 섹션과 COMMON 섹션만 노출된다.
+            프로젝트 기수에 챌린저 레코드가 없는 외부 사용자는 403. 폼이 없으면 ApiResponse.result = null.
+            """
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -68,7 +71,8 @@ public class ProjectApplicationFormController {
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId
     ) {
-        return getProjectApplicationFormUseCase.findByProjectId(projectId)
+        return getProjectApplicationFormUseCase
+            .findByProjectId(projectId, memberPrincipal.getMemberId())
             .map(GetApplicationFormResponse::from)
             .orElse(null);
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/GetApplicationFormResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/GetApplicationFormResponse.java
@@ -9,8 +9,8 @@ import lombok.Builder;
  * 지원 폼 조회 응답 (PROJECT-106-GET).
  * <p>
  * 폼이 존재하지 않으면 Controller 가 {@code ApiResponse.result = null} 로 반환한다.
+ * 마스킹(파트별 섹션 가시성)은 Service 단의 {@code ApplicationFormInfo.forApplicant} 에서 이미 적용된 상태로 전달된다.
  */
-// TODO: 챌린저 호출 시 본인 파트 + COMMON 섹션만 노출하는 forApplicant(part) 마스킹 메서드 추가
 @Builder
 public record GetApplicationFormResponse(
     Long projectId,

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectApplicationFormUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectApplicationFormUseCase.java
@@ -7,14 +7,22 @@ import java.util.Optional;
  * 프로젝트 지원 폼 조회 UseCase (PROJECT-106-GET).
  * <p>
  * 폼이 없으면 {@link Optional#empty()} 를 반환하며, Controller 단에서 {@code ApiResponse.result = null} 로 매핑된다.
+ * <p>
+ * 호출자 역할에 따라 응답이 다음과 같이 차등 적용된다.
+ * <ul>
+ *   <li>프로젝트 PM(owner) / Central Core / 프로젝트 지부의 지부장 → 전체 섹션 노출</li>
+ *   <li>그 외 챌린저(지원자, 프로젝트 기수 소속) → 본인 파트가 매칭된 {@code PART} 섹션 + 모든 {@code COMMON} 섹션만 노출</li>
+ *   <li>해당 기수에 챌린저 레코드가 없는 외부 사용자 → 도메인 예외(403) 로 차단</li>
+ * </ul>
  */
-// TODO: 챌린저 호출 시 본인 파트 + 공통 섹션만 노출하는 마스킹 로직 추가
 public interface GetProjectApplicationFormUseCase {
 
     /**
-     * 특정 프로젝트의 지원 폼 전체 구조를 조회합니다.
+     * 특정 프로젝트의 지원 폼 구조를 조회합니다.
      *
-     * @return 폼이 있으면 {@link ApplicationFormInfo}, 없으면 {@link Optional#empty()}
+     * @param projectId         조회 대상 프로젝트 ID
+     * @param requesterMemberId 호출자 Member ID. 마스킹/접근 판단 기준
+     * @return 폼이 있으면 호출자 역할에 따라 (마스킹된) {@link ApplicationFormInfo}, 없으면 {@link Optional#empty()}
      */
-    Optional<ApplicationFormInfo> findByProjectId(Long projectId);
+    Optional<ApplicationFormInfo> findByProjectId(Long projectId, Long requesterMemberId);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ApplicationFormInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ApplicationFormInfo.java
@@ -15,10 +15,14 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 
 /**
- * 지원 폼 전체 구조 (폼 메타 + 섹션 → 질문 → 옵션) Info DTO.
+ * 지원 폼 구조 (폼 메타 + 섹션 → 질문 → 옵션) Info DTO.
  * <p>
- * Survey 도메인의 {@link FormWithStructureInfo} 와 Project 도메인의 정책({@link ProjectApplicationFormPolicy})
- * 을 합성하여 단일 응답 구조를 만든다.
+ * Survey 도메인의 {@link FormWithStructureInfo} 와 Project 도메인의 정책({@link ProjectApplicationFormPolicy}) 을 합성하여 단일 응답 구조를
+ * 만든다.
+ * <ul>
+ *   <li>{@link #of} — PM/운영진 시점의 마스킹 없는 전체 섹션 노출</li>
+ *   <li>{@link #forApplicant} — 일반 챌린저 시점의 파트 기반 마스킹 (COMMON + 본인 파트 PART 만)</li>
+ * </ul>
  */
 @Builder
 public record ApplicationFormInfo(
@@ -30,7 +34,7 @@ public record ApplicationFormInfo(
 ) {
 
     /**
-     * 어댑터/서비스에서 모은 데이터들을 합성하여 Info DTO 를 조립한다.
+     * 어댑터/서비스에서 모은 데이터들을 합성하여 Info DTO 를 조립한다. 마스킹 없이 전체 섹션을 노출한다.
      */
     public static ApplicationFormInfo of(
         ProjectApplicationForm applicationForm,
@@ -51,6 +55,50 @@ public record ApplicationFormInfo(
             .description(formStructure.description())
             .sections(sections)
             .build();
+    }
+
+    /**
+     * 일반 챌린저(지원자) 시점의 마스킹된 Info 를 조립한다.
+     * <p>
+     * {@link FormSectionType#COMMON COMMON} 섹션은 모두 노출, {@link FormSectionType#PART PART} 섹션은 {@code applicantPart} 가
+     * 정책의 {@code allowedParts} 에 포함될 때만 노출한다. 정책이 누락된 섹션은 안전을 위해 차단한다.
+     * <p>
+     * 외부 사용자(프로젝트 기수에 챌린저 레코드가 없는 호출자)는 Service 단에서 사전에 차단되어야 하며, 본 메서드는 호출자가 해당 기수의 챌린저임이 확인된 상태로 진입한다.
+     */
+    public static ApplicationFormInfo forApplicant(
+        ProjectApplicationForm applicationForm,
+        FormWithStructureInfo formStructure,
+        List<ProjectApplicationFormPolicy> policies,
+        ChallengerPart applicantPart
+    ) {
+        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId = policies.stream()
+            .collect(Collectors.toMap(ProjectApplicationFormPolicy::getFormSectionId, Function.identity()));
+
+        List<SectionInfo> sections = formStructure.sections().stream()
+            .filter(section -> isVisibleToApplicant(
+                policyByFormSectionId.get(section.sectionId()), applicantPart))
+            .map(section -> SectionInfo.of(section, policyByFormSectionId.get(section.sectionId())))
+            .toList();
+
+        return ApplicationFormInfo.builder()
+            .projectId(applicationForm.getProject().getId())
+            .applicationFormId(applicationForm.getId())
+            .title(formStructure.title())
+            .description(formStructure.description())
+            .sections(sections)
+            .build();
+    }
+
+    private static boolean isVisibleToApplicant(
+        ProjectApplicationFormPolicy policy, ChallengerPart applicantPart
+    ) {
+        if (policy == null) {
+            return false;
+        }
+        if (policy.getType() == FormSectionType.COMMON) {
+            return true;
+        }
+        return policy.getAllowedParts().contains(applicantPart);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
@@ -48,20 +48,26 @@ public class ProjectApplicationFormQueryService implements GetProjectApplication
 
     private ApplicationFormInfo assemble(ProjectApplicationForm applicationForm, Long requesterMemberId) {
         Project project = applicationForm.getProject();
+
+        // 권한 체크를 먼저 수행하여 불필요한 데이터 조회를 방지
+        boolean isFullViewAllowed = canViewFullForm(project, requesterMemberId);
+        ChallengerPart applicantPart = null;
+
+        if (!isFullViewAllowed) {
+            applicantPart = getChallengerUseCase
+                .findByMemberIdAndGisuId(requesterMemberId, project.getGisuId())
+                .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED))
+                .part();
+        }
+
+        // 권한 확인이 완료된 경우에만 데이터 조회
         FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
         List<ProjectApplicationFormPolicy> policies =
             loadPolicyPort.listByApplicationFormId(applicationForm.getId());
 
-        if (canViewFullForm(project, requesterMemberId)) {
-            return ApplicationFormInfo.of(applicationForm, formStructure, policies);
-        }
-
-        ChallengerPart applicantPart = getChallengerUseCase
-            .findByMemberIdAndGisuId(requesterMemberId, project.getGisuId())
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED))
-            .part();
-
-        return ApplicationFormInfo.forApplicant(applicationForm, formStructure, policies, applicantPart);
+        return isFullViewAllowed
+            ? ApplicationFormInfo.of(applicationForm, formStructure, policies)
+            : ApplicationFormInfo.forApplicant(applicationForm, formStructure, policies, applicantPart);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryService.java
@@ -1,14 +1,21 @@
 package com.umc.product.project.application.service.query;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,8 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 지원 폼 조회 서비스 (PROJECT-106-GET).
  * <p>
- * 폼 메타와 섹션→질문→옵션 nested 구조는 Survey 도메인에 위임하며, Project 도메인의 정책({@link ProjectApplicationFormPolicy})
- * 을 합성해 단일 응답을 만든다.
+ * 폼 메타와 섹션→질문→옵션 nested 구조는 Survey 도메인에 위임하며, Project 도메인의 정책({@link ProjectApplicationFormPolicy}) 을 합성해 단일 응답을 만든다.
+ * 호출자 역할에 따라 전체/마스킹된 섹션을 차등 노출한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -30,16 +37,45 @@ public class ProjectApplicationFormQueryService implements GetProjectApplication
 
     // Cross-domain
     private final GetFormUseCase getFormUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @Override
-    public Optional<ApplicationFormInfo> findByProjectId(Long projectId) {
+    public Optional<ApplicationFormInfo> findByProjectId(Long projectId, Long requesterMemberId) {
         return loadApplicationFormPort.findByProjectId(projectId)
-            .map(this::assemble);
+            .map(applicationForm -> assemble(applicationForm, requesterMemberId));
     }
 
-    private ApplicationFormInfo assemble(ProjectApplicationForm applicationForm) {
+    private ApplicationFormInfo assemble(ProjectApplicationForm applicationForm, Long requesterMemberId) {
+        Project project = applicationForm.getProject();
         FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
-        List<ProjectApplicationFormPolicy> policies = loadPolicyPort.listByApplicationFormId(applicationForm.getId());
-        return ApplicationFormInfo.of(applicationForm, formStructure, policies);
+        List<ProjectApplicationFormPolicy> policies =
+            loadPolicyPort.listByApplicationFormId(applicationForm.getId());
+
+        if (canViewFullForm(project, requesterMemberId)) {
+            return ApplicationFormInfo.of(applicationForm, formStructure, policies);
+        }
+
+        ChallengerPart applicantPart = getChallengerUseCase
+            .findByMemberIdAndGisuId(requesterMemberId, project.getGisuId())
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED))
+            .part();
+
+        return ApplicationFormInfo.forApplicant(applicationForm, formStructure, policies, applicantPart);
+    }
+
+    /**
+     * 정책 우회 가능 여부. PM(owner) / Central Core / 프로젝트 지부의 지부장 만 전체 섹션을 본다. {@code ProjectPermissionEvaluator#canEdit} 의 외부
+     * 운영진 정의와 정합을 맞춘다.
+     */
+    private boolean canViewFullForm(Project project, Long requesterMemberId) {
+        if (Objects.equals(requesterMemberId, project.getProductOwnerMemberId())) {
+            return true;
+        }
+        if (getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, project.getGisuId())) {
+            return true;
+        }
+        return getChallengerRoleUseCase.isChapterPresidentInGisu(
+            requesterMemberId, project.getGisuId(), project.getChapterId());
     }
 }

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormControllerTest.java
@@ -138,7 +138,7 @@ class ProjectApplicationFormControllerTest {
 
     @Test
     void GET_폼이_있으면_구조_반환() throws Exception {
-        given(getProjectApplicationFormUseCase.findByProjectId(42L)).willReturn(Optional.of(
+        given(getProjectApplicationFormUseCase.findByProjectId(42L, TEST_MEMBER_ID)).willReturn(Optional.of(
             ApplicationFormInfo.builder()
                 .projectId(42L).applicationFormId(100L)
                 .title("Triple 지원서").description(null)
@@ -153,7 +153,7 @@ class ProjectApplicationFormControllerTest {
 
     @Test
     void GET_폼이_없으면_result_null() throws Exception {
-        given(getProjectApplicationFormUseCase.findByProjectId(42L)).willReturn(Optional.empty());
+        given(getProjectApplicationFormUseCase.findByProjectId(42L, TEST_MEMBER_ID)).willReturn(Optional.empty());
 
         mockMvc.perform(get("/api/v1/projects/42/application-form"))
             .andExpect(status().isOk())

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
@@ -218,10 +218,6 @@ class ProjectApplicationFormQueryServiceTest {
         ProjectApplicationForm applicationForm = createApplicationForm(project);
 
         given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
-        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
-            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID)
-        ));
         given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
         given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
             .willReturn(false);
@@ -232,6 +228,10 @@ class ProjectApplicationFormQueryServiceTest {
         assertThatThrownBy(() -> sut.findByProjectId(PROJECT_ID, requesterMemberId))
             .isInstanceOf(ProjectDomainException.class)
             .hasFieldOrPropertyWithValue("baseCode", ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED);
+
+        // 외부 사용자는 권한 검증 단계에서 차단되어 폼/정책 조회는 발생하지 않음
+        then(getFormUseCase).should(never()).getFormWithStructure(any());
+        then(loadPolicyPort).should(never()).listByApplicationFormId(any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
@@ -1,10 +1,14 @@
 package com.umc.product.project.application.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
@@ -14,6 +18,8 @@ import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import com.umc.product.project.domain.enums.FormSectionType;
 import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import com.umc.product.survey.domain.enums.FormStatus;
@@ -31,21 +37,34 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationFormQueryServiceTest {
 
+    private static final Long PROJECT_ID = 42L;
+    private static final Long APPLICATION_FORM_ID = 100L;
+    private static final Long FORM_ID = 500L;
+    private static final Long GISU_ID = 1L;
+    private static final Long CHAPTER_ID = 7L;
+    private static final Long PM_MEMBER_ID = 10L;
+    private static final Long COMMON_SECTION_ID = 1000L;
+    private static final Long PART_SECTION_ID = 1001L;
+
     @Mock
     LoadProjectApplicationFormPort loadApplicationFormPort;
     @Mock
     LoadProjectApplicationFormPolicyPort loadPolicyPort;
     @Mock
     GetFormUseCase getFormUseCase;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @InjectMocks
     ProjectApplicationFormQueryService sut;
 
     @Test
     void findByProjectId_폼이_없으면_empty_반환() {
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.empty());
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.empty());
 
-        Optional<ApplicationFormInfo> result = sut.findByProjectId(42L);
+        Optional<ApplicationFormInfo> result = sut.findByProjectId(PROJECT_ID, PM_MEMBER_ID);
 
         assertThat(result).isEmpty();
         then(getFormUseCase).should(never()).getFormWithStructure(any());
@@ -53,58 +72,210 @@ class ProjectApplicationFormQueryServiceTest {
     }
 
     @Test
-    void findByProjectId_폼이_있으면_FormWithStructure와_정책을_합성() {
+    void findByProjectId_PM_본인은_전체_섹션_노출() {
         // given
-        Project project = createProject(42L);
-        ProjectApplicationForm applicationForm = createApplicationForm(project, 100L, 500L);
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
 
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(applicationForm));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(buildFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
-            ProjectApplicationFormPolicy.createCommon(applicationForm, 1000L),
-            ProjectApplicationFormPolicy.createForParts(applicationForm, 1001L,
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, PART_SECTION_ID,
                 Set.of(ChallengerPart.WEB, ChallengerPart.IOS))
         ));
 
-        // when
-        ApplicationFormInfo result = sut.findByProjectId(42L).orElseThrow();
+        // when — 호출자가 PM 본인
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, PM_MEMBER_ID).orElseThrow();
 
-        // then
-        assertThat(result.projectId()).isEqualTo(42L);
-        assertThat(result.applicationFormId()).isEqualTo(100L);
-        assertThat(result.title()).isEqualTo("Triple 지원서");
+        // then — 전체 섹션 노출, Challenger 조회는 발생하지 않음
         assertThat(result.sections()).hasSize(2);
-
         var commonSection = result.sections().get(0);
-        assertThat(commonSection.sectionId()).isEqualTo(1000L);
         assertThat(commonSection.type()).isEqualTo(FormSectionType.COMMON);
-        assertThat(commonSection.allowedParts()).isEmpty();
-        assertThat(commonSection.questions()).hasSize(1);
 
         var partSection = result.sections().get(1);
-        assertThat(partSection.sectionId()).isEqualTo(1001L);
         assertThat(partSection.type()).isEqualTo(FormSectionType.PART);
         assertThat(partSection.allowedParts())
             .containsExactlyInAnyOrder(ChallengerPart.WEB, ChallengerPart.IOS);
-        assertThat(partSection.questions()).hasSize(1);
-        assertThat(partSection.questions().get(0).options()).hasSize(2);
+
+        then(getChallengerUseCase).should(never()).findByMemberIdAndGisuId(any(), any());
+        then(getChallengerRoleUseCase).should(never()).isCentralCoreInGisu(any(), any());
     }
 
     @Test
-    void findByProjectId_정책이_누락된_섹션은_PART와_빈_parts로_폴백() {
-        // given — Survey 단엔 섹션 2개 있지만 Project 정책은 1개만 (데이터 정합 깨진 시나리오)
-        Project project = createProject(42L);
-        ProjectApplicationForm applicationForm = createApplicationForm(project, 100L, 500L);
+    void findByProjectId_CentralCore는_전체_섹션_노출() {
+        // given
+        Long requesterMemberId = 999L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
 
-        given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(applicationForm));
-        given(getFormUseCase.getFormWithStructure(500L)).willReturn(buildFormStructure());
-        given(loadPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
-            ProjectApplicationFormPolicy.createCommon(applicationForm, 1000L)
-            // 1001L 정책 누락
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, PART_SECTION_ID,
+                Set.of(ChallengerPart.WEB))
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(true);
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, requesterMemberId).orElseThrow();
+
+        // then
+        assertThat(result.sections()).hasSize(2);
+        then(getChallengerUseCase).should(never()).findByMemberIdAndGisuId(any(), any());
+    }
+
+    @Test
+    void findByProjectId_프로젝트_지부의_지부장은_전체_섹션_노출() {
+        // given
+        Long requesterMemberId = 888L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, PART_SECTION_ID,
+                Set.of(ChallengerPart.WEB))
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
+            .willReturn(true);
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, requesterMemberId).orElseThrow();
+
+        // then
+        assertThat(result.sections()).hasSize(2);
+        then(getChallengerUseCase).should(never()).findByMemberIdAndGisuId(any(), any());
+    }
+
+    @Test
+    void findByProjectId_챌린저_지원자_본인_파트가_매칭되지_않으면_COMMON만_노출() {
+        // given — 지원자 파트(ANDROID) 가 PART 섹션의 allowedParts(WEB/IOS) 에 포함되지 않는 케이스
+        Long requesterMemberId = 777L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, PART_SECTION_ID,
+                Set.of(ChallengerPart.WEB, ChallengerPart.IOS))
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
+            .willReturn(false);
+        given(getChallengerUseCase.findByMemberIdAndGisuId(requesterMemberId, GISU_ID))
+            .willReturn(Optional.of(challengerInfoWithPart(ChallengerPart.ANDROID)));
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, requesterMemberId).orElseThrow();
+
+        // then — PART 섹션은 매칭 실패로 제외, COMMON 만 남음
+        assertThat(result.sections()).hasSize(1);
+        assertThat(result.sections().get(0).type()).isEqualTo(FormSectionType.COMMON);
+        assertThat(result.sections().get(0).sectionId()).isEqualTo(COMMON_SECTION_ID);
+    }
+
+    @Test
+    void findByProjectId_챌린저_지원자_본인_파트가_매칭되면_PART도_함께_노출() {
+        // given
+        Long requesterMemberId = 777L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID),
+            ProjectApplicationFormPolicy.createForParts(applicationForm, PART_SECTION_ID,
+                Set.of(ChallengerPart.WEB, ChallengerPart.IOS))
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
+            .willReturn(false);
+        given(getChallengerUseCase.findByMemberIdAndGisuId(requesterMemberId, GISU_ID))
+            .willReturn(Optional.of(challengerInfoWithPart(ChallengerPart.WEB)));
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, requesterMemberId).orElseThrow();
+
+        // then
+        assertThat(result.sections()).hasSize(2);
+        assertThat(result.sections().get(0).sectionId()).isEqualTo(COMMON_SECTION_ID);
+        assertThat(result.sections().get(1).sectionId()).isEqualTo(PART_SECTION_ID);
+    }
+
+    @Test
+    void findByProjectId_프로젝트_기수_챌린저가_아닌_외부사용자는_403() {
+        // given
+        Long requesterMemberId = 666L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID)
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
+            .willReturn(false);
+        given(getChallengerUseCase.findByMemberIdAndGisuId(requesterMemberId, GISU_ID))
+            .willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> sut.findByProjectId(PROJECT_ID, requesterMemberId))
+            .isInstanceOf(ProjectDomainException.class)
+            .hasFieldOrPropertyWithValue("baseCode", ProjectErrorCode.APPLICATION_FORM_ACCESS_NOT_ALLOWED);
+    }
+
+    @Test
+    void findByProjectId_지원자_시점에서_정책이_누락된_섹션은_노출하지_않음() {
+        // given — Survey 단엔 섹션 2개 있지만 Project 정책은 1개만 (데이터 정합 깨진 시나리오)
+        Long requesterMemberId = 777L;
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID)
+            // PART_SECTION_ID 정책 누락
+        ));
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(requesterMemberId, GISU_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.isChapterPresidentInGisu(requesterMemberId, GISU_ID, CHAPTER_ID))
+            .willReturn(false);
+        given(getChallengerUseCase.findByMemberIdAndGisuId(requesterMemberId, GISU_ID))
+            .willReturn(Optional.of(challengerInfoWithPart(ChallengerPart.WEB)));
+
+        // when
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, requesterMemberId).orElseThrow();
+
+        // then — 정책 없는 섹션은 안전 차원에서 차단
+        assertThat(result.sections()).hasSize(1);
+        assertThat(result.sections().get(0).sectionId()).isEqualTo(COMMON_SECTION_ID);
+    }
+
+    @Test
+    void findByProjectId_PM_시점에서는_정책이_누락된_섹션도_PART_빈_parts로_폴백() {
+        // given — 운영진 우회 케이스에서는 기존의 of() 폴백 동작 유지
+        Project project = createProject();
+        ProjectApplicationForm applicationForm = createApplicationForm(project);
+
+        given(loadApplicationFormPort.findByProjectId(PROJECT_ID)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(FORM_ID)).willReturn(buildFormStructure());
+        given(loadPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID)).willReturn(List.of(
+            ProjectApplicationFormPolicy.createCommon(applicationForm, COMMON_SECTION_ID)
+            // PART_SECTION_ID 정책 누락
         ));
 
         // when
-        ApplicationFormInfo result = sut.findByProjectId(42L).orElseThrow();
+        ApplicationFormInfo result = sut.findByProjectId(PROJECT_ID, PM_MEMBER_ID).orElseThrow();
 
         // then
         var orphanSection = result.sections().get(1);
@@ -116,7 +287,7 @@ class ProjectApplicationFormQueryServiceTest {
         return org.mockito.ArgumentMatchers.any();
     }
 
-    private Project createProject(Long id) {
+    private Project createProject() {
         Project project;
         try {
             var constructor = Project.class.getDeclaredConstructor();
@@ -125,31 +296,40 @@ class ProjectApplicationFormQueryServiceTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        ReflectionTestUtils.setField(project, "id", id);
-        ReflectionTestUtils.setField(project, "gisuId", 1L);
-        ReflectionTestUtils.setField(project, "chapterId", 1L);
-        ReflectionTestUtils.setField(project, "status", ProjectStatus.DRAFT);
+        ReflectionTestUtils.setField(project, "id", PROJECT_ID);
+        ReflectionTestUtils.setField(project, "gisuId", GISU_ID);
+        ReflectionTestUtils.setField(project, "chapterId", CHAPTER_ID);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.IN_PROGRESS);
         ReflectionTestUtils.setField(project, "name", "Triple");
-        ReflectionTestUtils.setField(project, "productOwnerMemberId", 10L);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", PM_MEMBER_ID);
         return project;
     }
 
-    private ProjectApplicationForm createApplicationForm(Project project, Long id, Long formId) {
-        ProjectApplicationForm form = ProjectApplicationForm.create(project, formId);
-        ReflectionTestUtils.setField(form, "id", id);
+    private ProjectApplicationForm createApplicationForm(Project project) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, FORM_ID);
+        ReflectionTestUtils.setField(form, "id", APPLICATION_FORM_ID);
         return form;
+    }
+
+    private ChallengerInfo challengerInfoWithPart(ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(1L)
+            .memberId(0L)
+            .gisuId(GISU_ID)
+            .part(part)
+            .build();
     }
 
     private FormWithStructureInfo buildFormStructure() {
         return FormWithStructureInfo.builder()
-            .formId(500L)
+            .formId(FORM_ID)
             .title("Triple 지원서")
             .description(null)
             .status(FormStatus.DRAFT)
             .isAnonymous(false)
             .sections(List.of(
                 FormWithStructureInfo.SectionWithQuestions.builder()
-                    .sectionId(1000L)
+                    .sectionId(COMMON_SECTION_ID)
                     .title("공통 문항")
                     .description(null)
                     .orderNo(1L)
@@ -166,7 +346,7 @@ class ProjectApplicationFormQueryServiceTest {
                     ))
                     .build(),
                 FormWithStructureInfo.SectionWithQuestions.builder()
-                    .sectionId(1001L)
+                    .sectionId(PART_SECTION_ID)
                     .title("프론트엔드")
                     .description(null)
                     .orderNo(2L)


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #802 

## 🚀 작업 내용

### 섹션 마스킹 개요
1. **PM(PO), CC(Central Core), 프로젝트 지부의 지부장** : `COMMON`, `PART` 전체 섹션 노출
2. **본인 파트와 섹션의 파트가 매칭된 챌린저** : `COMMON` + 본인 `PART` 섹션 노출
3. **본인 파트와 섹션의 파트가 매칭되지 않은 챌린저** : `COMMON`만 노출
4. **프로젝트 기수에 챌린저 기록이 없는 사용자** : `403`
---
### 정책이 누락된 섹션일 경우 폴백
- **일반 챌린저** : 노출 안 됨 (위험 차단)
- **'섹션 마스킹 개요' 1번에서 언급된 사용자** : 노출됨 (직접 보고 문제를 발견할 수 있도록)

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

