### PR TITLE
[Fix] 내가 관리하는 스터디 그룹 목록을 조회하지 못하는 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/organization/adapter/in/web/StudyGroupQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/StudyGroupQueryController.java
@@ -26,10 +26,10 @@ public class StudyGroupQueryController implements StudyGroupQueryControllerApi {
     private final GetStudyGroupUseCase getStudyGroupUseCase;
 
     /**
-     * 내 스터디 그룹 목록 조회 - 유저의 schoolId/part 기반 자동 조회
+     * 사용자의 schoolId/part 기반으로, 내가 관리할 수 있는 스터디 그룹의 목록을 반환
      */
     @Override
-    @GetMapping("/me")
+    @GetMapping("/managed")
     public CursorResponse<StudyGroupResponse> getStudyGroups(
         @CurrentMember MemberPrincipal memberPrincipal,
         @RequestParam(required = false) Long cursor,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/dto/response/studygroup/StudyGroupResponse.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/dto/response/studygroup/StudyGroupResponse.java
@@ -3,6 +3,7 @@ package com.umc.product.organization.adapter.in.web.dto.response.studygroup;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
 import java.util.List;
 
 @Schema(description = "스터디 그룹 요약 정보")
@@ -17,6 +18,8 @@ public record StudyGroupResponse(
 
     ChallengerPart studyPart,
 
+    Instant createdAt,
+
     @Schema(description = "파트장 목록")
     List<StudyGroupMemberResponse> mentors,
 
@@ -30,6 +33,7 @@ public record StudyGroupResponse(
             info.name(),
             info.gisuId(),
             info.part(),
+            info.createdAt(),
             info.mentors().stream().map(StudyGroupMemberResponse::from).toList(),
             info.members().stream().map(StudyGroupMemberResponse::from).toList());
     }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepository.java
@@ -165,7 +165,8 @@ public class StudyGroupQueryRepository {
                     studyGroup.id,
                     studyGroup.name,
                     studyGroup.gisuId,
-                    studyGroup.part
+                    studyGroup.part,
+                    studyGroup.createdAt
                 )
             )
             .from(studyGroup)
@@ -251,6 +252,7 @@ public class StudyGroupQueryRepository {
         return StudyGroupInfo.create(
             header.groupId(), header.name(),
             header.gisuId(), header.part(),
+            header.createdAt(),
             mentorsByGroup.get(header.groupId()), membersByGroup.get(header.groupId())
         );
     }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepository.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.organization.adapter.out.persistence.studygroup.projection.StudyGroupHeaderRow;
 import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupInfo;
 import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupMemberInfo;
 import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupNameInfo;
@@ -394,17 +395,5 @@ public class StudyGroupQueryRepository {
             school.name,
             member.profileImageId
         );
-    }
-
-    /**
-     * {@link #fetchGroupHeaders} 용 상위 그룹 헤더 Projection.
-     *
-     * @param groupId 스터디 그룹 ID
-     * @param name    스터디 그룹 이름
-     */
-    private record StudyGroupHeaderRow(
-        Long groupId, String name,
-        Long gisuId, ChallengerPart part
-    ) {
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/projection/StudyGroupHeaderRow.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/projection/StudyGroupHeaderRow.java
@@ -1,0 +1,15 @@
+package com.umc.product.organization.adapter.out.persistence.studygroup.projection;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
+/**
+ * {@link #fetchGroupHeaders} 용 상위 그룹 헤더 Projection.
+ *
+ * @param groupId 스터디 그룹 ID
+ * @param name    스터디 그룹 이름
+ */
+public record StudyGroupHeaderRow(
+    Long groupId, String name,
+    Long gisuId, ChallengerPart part
+) {
+}

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/projection/StudyGroupHeaderRow.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/studygroup/projection/StudyGroupHeaderRow.java
@@ -1,15 +1,20 @@
 package com.umc.product.organization.adapter.out.persistence.studygroup.projection;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
+import java.time.Instant;
 
 /**
  * {@link #fetchGroupHeaders} 용 상위 그룹 헤더 Projection.
  *
- * @param groupId 스터디 그룹 ID
- * @param name    스터디 그룹 이름
+ * @param groupId   스터디 그룹 ID
+ * @param name      스터디 그룹 이름
+ * @param gisuId    소속 기수 ID
+ * @param part      스터디 파트
+ * @param createdAt 생성 시각
  */
 public record StudyGroupHeaderRow(
     Long groupId, String name,
-    Long gisuId, ChallengerPart part
+    Long gisuId, ChallengerPart part,
+    Instant createdAt
 ) {
 }

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/studygroup/StudyGroupInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/studygroup/StudyGroupInfo.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.application.port.in.query.dto.studygroup;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
+import java.time.Instant;
 import java.util.List;
 
 public record StudyGroupInfo(
@@ -8,17 +9,20 @@ public record StudyGroupInfo(
     String name,
     Long gisuId,
     ChallengerPart part,
+    Instant createdAt,
     List<StudyGroupMemberInfo> mentors,
     List<StudyGroupMemberInfo> members
 ) {
     public static StudyGroupInfo create(
         Long groupId, String name,
         Long gisuId, ChallengerPart part,
+        Instant createdAt,
         List<StudyGroupMemberInfo> mentors, List<StudyGroupMemberInfo> members
     ) {
         return new StudyGroupInfo(
             groupId, name,
             gisuId, part,
+            createdAt,
             mentors, members
         );
     }

--- a/src/main/java/com/umc/product/organization/application/port/service/query/StudyGroupQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/StudyGroupQueryService.java
@@ -136,6 +136,7 @@ public class StudyGroupQueryService implements GetStudyGroupUseCase {
             group.getName(),
             group.getGisuId(),
             group.getPart(),
+            group.getCreatedAt(),
             loadStudyGroupPort.findStudyGroupMentors(studyGroupId),
             loadStudyGroupPort.findStudyGroupMembers(studyGroupId)
         );
@@ -221,6 +222,7 @@ public class StudyGroupQueryService implements GetStudyGroupUseCase {
                     studyGroup.name(),
                     studyGroup.gisuId(),
                     studyGroup.part(),
+                    studyGroup.createdAt(),
                     resolveMemberProfileUrls(studyGroup.mentors()),
                     resolveMemberProfileUrls(studyGroup.members())
                 )


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #812 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

1. QueryDSL에서 Projection record가 private으로 정의되어 있어서 contructor를 찾지 못해 발생하던 오류를 수정했습니다.
2. AN측에서 추가로 요청한, 스터디 그룹 정보에 `createdAt` 추가


## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

