### PR TITLE
[Feat] 챌린저 프로젝트 지원 플로우 API 구현

### DIFF
--- a/src/main/java/com/umc/product/authorization/domain/PermissionType.java
+++ b/src/main/java/com/umc/product/authorization/domain/PermissionType.java
@@ -22,5 +22,6 @@ public enum PermissionType {
     APPROVE,    // 승인 (출석, 워크북 등)
     CHECK,      // 확인 (공지사항 조회현황 확인)
     MANAGE,      // 관리 (운영진 전용)
-    RELEASE
+    RELEASE,
+    APPLY        // 지원 (챌린저의 프로젝트 지원)
 }

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -86,7 +86,7 @@ public enum ResourceType {
     // UPMS, 프로젝트 관련
     PROJECT("project", "프로젝트",
         Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
-            PermissionType.DELETE, PermissionType.MANAGE)),
+            PermissionType.DELETE, PermissionType.MANAGE, PermissionType.APPLY)),
     ;
 
     private final String code;

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -24,7 +24,7 @@ public class ProjectApplicationController {
     @PostMapping("/{projectId}/applications")
     @Operation(
         summary = "[APPLY-001] 챌린저 지원서 Draft 생성",
-        description = "챌린저가 특정 프로젝트의 지원서를 PENDING 상태로 생성합니다. 이미 PENDING 지원서가 있으면 기존 application 정보 반환."
+        description = "챌린저가 특정 프로젝트의 지원서를 DRAFT 상태로 생성합니다. 이미 DRAFT 지원서가 있으면 기존 application 정보 반환."
     )
     public ProjectApplicationStatusResponse createDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
@@ -36,7 +36,7 @@ public class ProjectApplicationController {
     @PutMapping("/{projectId}/applications/me")
     @Operation(
         summary = "[APPLY-002] 챌린저 지원서 임시저장",
-        description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 PENDING 지원서에서만 호출 가능."
+        description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     public ProjectApplicationStatusResponse updateDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
@@ -49,7 +49,7 @@ public class ProjectApplicationController {
     @PostMapping("/{projectId}/applications/me/submit")
     @Operation(
         summary = "[APPLY-003] 챌린저 지원서 최종 제출",
-        description = "PENDING -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 PENDING 지원서에서만 호출 가능."
+        description = "DRAFT -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     public ProjectApplicationStatusResponse submit(
         @CurrentMember MemberPrincipal memberPrincipal,

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -4,6 +4,11 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationAnswersRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicationStatusResponse;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,6 +26,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Project | 챌린저 지원서", description = "챌린저의 프로젝트 지원서 Draft 생성 / 임시저장 / 제출 / 조회 (APPLY-001~004)")
 public class ProjectApplicationController {
 
+    private final CreateDraftProjectApplicationUseCase createDraftProjectApplicationUseCase;
+    private final UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
+    private final SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
+
     @PostMapping("/{projectId}/applications")
     @Operation(
         summary = "[APPLY-001] 챌린저 지원서 Draft 생성",
@@ -30,7 +39,14 @@ public class ProjectApplicationController {
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId
     ) {
-        return null;
+        return ProjectApplicationStatusResponse.from(
+            createDraftProjectApplicationUseCase.create(
+                CreateDraftProjectApplicationCommand.builder()
+                    .projectId(projectId)
+                    .applicantMemberId(memberPrincipal.getMemberId())
+                    .build()
+            )
+        );
     }
 
     @PutMapping("/{projectId}/applications/me")
@@ -43,7 +59,11 @@ public class ProjectApplicationController {
         @PathVariable Long projectId,
         @Valid @RequestBody UpdateApplicationAnswersRequest request
     ) {
-        return null;
+        return ProjectApplicationStatusResponse.from(
+            updateProjectApplicationDraftUseCase.update(
+                request.toCommand(projectId, memberPrincipal.getMemberId())
+            )
+        );
     }
 
     @PostMapping("/{projectId}/applications/me/submit")
@@ -55,6 +75,13 @@ public class ProjectApplicationController {
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId
     ) {
-        return null;
+        return ProjectApplicationStatusResponse.from(
+            submitProjectApplicationUseCase.submit(
+                SubmitProjectApplicationCommand.builder()
+                    .projectId(projectId)
+                    .requesterMemberId(memberPrincipal.getMemberId())
+                    .build()
+            )
+        );
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -1,5 +1,8 @@
 package com.umc.product.project.adapter.in.web;
 
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationAnswersRequest;
@@ -35,6 +38,12 @@ public class ProjectApplicationController {
         summary = "[APPLY-001] 챌린저 지원서 Draft 생성",
         description = "챌린저가 특정 프로젝트의 지원서를 DRAFT 상태로 생성합니다. 이미 DRAFT 지원서가 있으면 기존 application 정보 반환."
     )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.APPLY,
+        message = "지원서 생성 권한이 없습니다."
+    )
     public ProjectApplicationStatusResponse createDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId
@@ -54,6 +63,12 @@ public class ProjectApplicationController {
         summary = "[APPLY-002] 챌린저 지원서 임시저장",
         description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 DRAFT 지원서에서만 호출 가능."
     )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.APPLY,
+        message = "지원서 임시저장 권한이 없습니다."
+    )
     public ProjectApplicationStatusResponse updateDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId,
@@ -70,6 +85,12 @@ public class ProjectApplicationController {
     @Operation(
         summary = "[APPLY-003] 챌린저 지원서 최종 제출",
         description = "DRAFT -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 DRAFT 지원서에서만 호출 가능."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.APPLY,
+        message = "지원서 제출 권한이 없습니다."
     )
     public ProjectApplicationStatusResponse submit(
         @CurrentMember MemberPrincipal memberPrincipal,

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -1,0 +1,60 @@
+package com.umc.product.project.adapter.in.web;
+
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationAnswersRequest;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicationStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+@Tag(name = "Project | 챌린저 지원서", description = "챌린저의 프로젝트 지원서 Draft 생성 / 임시저장 / 제출 / 조회 (APPLY-001~004)")
+public class ProjectApplicationController {
+
+    @PostMapping("/{projectId}/applications")
+    @Operation(
+        summary = "[APPLY-001] 챌린저 지원서 Draft 생성",
+        description = "챌린저가 특정 프로젝트의 지원서를 PENDING 상태로 생성합니다. 이미 PENDING 지원서가 있으면 기존 application 정보 반환."
+    )
+    public ProjectApplicationStatusResponse createDraft(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        return null;
+    }
+
+    @PutMapping("/{projectId}/applications/me")
+    @Operation(
+        summary = "[APPLY-002] 챌린저 지원서 임시저장",
+        description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 PENDING 지원서에서만 호출 가능."
+    )
+    public ProjectApplicationStatusResponse updateDraft(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @Valid @RequestBody UpdateApplicationAnswersRequest request
+    ) {
+        return null;
+    }
+
+    @PostMapping("/{projectId}/applications/me/submit")
+    @Operation(
+        summary = "[APPLY-003] 챌린저 지원서 최종 제출",
+        description = "PENDING -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 PENDING 지원서에서만 호출 가능."
+    )
+    public ProjectApplicationStatusResponse submit(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        return null;
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -10,12 +10,13 @@ import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicationSta
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
-import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import com.umc.product.project.adapter.in.web.dto.request.CreateProjectApplicationRequest;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,14 +47,12 @@ public class ProjectApplicationController {
     )
     public ProjectApplicationStatusResponse createDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
-        @PathVariable Long projectId
+        @PathVariable Long projectId,
+        @Valid @RequestBody CreateProjectApplicationRequest request
     ) {
         return ProjectApplicationStatusResponse.from(
             createDraftProjectApplicationUseCase.create(
-                CreateDraftProjectApplicationCommand.builder()
-                    .projectId(projectId)
-                    .applicantMemberId(memberPrincipal.getMemberId())
-                    .build()
+                request.toCommand(projectId, memberPrincipal.getMemberId())
             )
         );
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationAnswerItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationAnswerItem.java
@@ -1,0 +1,27 @@
+package com.umc.product.project.adapter.in.web.dto.common;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 한 질문의 답변 입력 항목 (APPLY-002 Request).
+ * <p>
+ * 질문 type 별 사용 필드:
+ * <ul>
+ *   <li>SHORT_TEXT / LONG_TEXT -> {@code textValue}</li>
+ *   <li>RADIO / DROPDOWN -> {@code selectedOptionIds} 1개</li>
+ *   <li>CHECKBOX -> {@code selectedOptionIds} 1개 이상</li>
+ *   <li>FILE -> {@code fileIds} 1개 이상</li>
+ *   <li>PORTFOLIO -> {@code textValue} (링크) 또는 {@code fileIds}</li>
+ * </ul>
+ */
+@Builder
+public record ApplicationAnswerItem(
+    @NotNull(message = "questionId는 필수입니다")
+    Long questionId,
+    String textValue,
+    List<Long> selectedOptionIds,
+    List<String> fileIds
+) {
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationAnswerItem.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/common/ApplicationAnswerItem.java
@@ -1,5 +1,6 @@
 package com.umc.product.project.adapter.in.web.dto.common;
 
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand.AnswerEntry;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Builder;
@@ -24,4 +25,13 @@ public record ApplicationAnswerItem(
     List<Long> selectedOptionIds,
     List<String> fileIds
 ) {
+
+    public AnswerEntry toEntry() {
+        return AnswerEntry.builder()
+            .questionId(questionId)
+            .textValue(textValue)
+            .selectedOptionIds(selectedOptionIds == null ? List.of() : selectedOptionIds)
+            .fileIds(fileIds == null ? List.of() : fileIds)
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CreateProjectApplicationRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CreateProjectApplicationRequest.java
@@ -1,0 +1,26 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 Draft 생성 요청 (APPLY-001).
+ * <p>
+ * FE에서 지원할 매칭 차수를 명시한다. 서버는 해당 차수의 오픈 여부와 내 파트 타입 일치 여부를 검증한다.
+ * 지원 가능한 차수 목록은 MATCHING-001 API로 사전 조회한다.
+ */
+@Builder
+public record CreateProjectApplicationRequest(
+    @NotNull(message = "matchingRoundId는 필수입니다")
+    Long matchingRoundId
+) {
+
+    public CreateDraftProjectApplicationCommand toCommand(Long projectId, Long applicantMemberId) {
+        return CreateDraftProjectApplicationCommand.builder()
+            .projectId(projectId)
+            .applicantMemberId(applicantMemberId)
+            .matchingRoundId(matchingRoundId)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.adapter.in.web.dto.request;
 
 import com.umc.product.project.adapter.in.web.dto.common.ApplicationAnswerItem;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -18,4 +19,12 @@ public record UpdateApplicationAnswersRequest(
     @Valid
     List<ApplicationAnswerItem> answers
 ) {
+
+    public UpdateProjectApplicationDraftCommand toCommand(Long projectId, Long requesterMemberId) {
+        return UpdateProjectApplicationDraftCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(requesterMemberId)
+            .answers(answers.stream().map(ApplicationAnswerItem::toEntry).toList())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.adapter.in.web.dto.common.ApplicationAnswerItem;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 임시저장 요청 (APPLY-002).
+ * <p>
+ * PUT 시멘틱 — {@code answers} 가 곧 새 전체 상태. 빠진 questionId 의 기존 답변은 삭제됨.
+ * 빈 리스트 허용 (모든 답변 제거).
+ */
+@Builder
+public record UpdateApplicationAnswersRequest(
+    @NotNull(message = "answers는 null 일 수 없습니다 (빈 리스트는 허용)")
+    @Valid
+    List<ApplicationAnswerItem> answers
+) {
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectApplicationStatusResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectApplicationStatusResponse.java
@@ -1,5 +1,6 @@
 package com.umc.product.project.adapter.in.web.dto.response;
 
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import lombok.Builder;
 
@@ -13,4 +14,8 @@ public record ProjectApplicationStatusResponse(
     Long applicationId,
     ProjectApplicationStatus status
 ) {
+
+    public static ProjectApplicationStatusResponse from(ProjectApplicationInfo info) {
+        return new ProjectApplicationStatusResponse(info.applicationId(), info.status());
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectApplicationStatusResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectApplicationStatusResponse.java
@@ -1,0 +1,16 @@
+package com.umc.product.project.adapter.in.web.dto.response;
+
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 라이프사이클 응답 (APPLY-001 / 002 / 003).
+ * <p>
+ * 이 호출 이후 application의 현재 상태.
+ */
+@Builder
+public record ProjectApplicationStatusResponse(
+    Long applicationId,
+    ProjectApplicationStatus status
+) {
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -34,6 +34,19 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     }
 
     @Override
+    public boolean existsByRoundAndApplicantAndStatus(
+        Long roundId,
+        Long applicantMemberId,
+        ProjectApplicationStatus status
+    ) {
+        return projectApplicationQueryRepository.existsByRoundAndApplicantAndStatus(
+            roundId,
+            applicantMemberId,
+            status
+        );
+    }
+
+    @Override
     public ProjectApplication save(ProjectApplication application) {
         return projectApplicationJpaRepository.save(application);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -1,17 +1,40 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicationPort {
+public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicationPort, SaveProjectApplicationPort {
 
-    private final ProjectApplicationJpaRepository jpaRepository;
+    private final ProjectApplicationJpaRepository projectApplicationJpaRepository;
+    private final ProjectApplicationQueryRepository projectApplicationQueryRepository;
 
     @Override
     public boolean existsByAppliedMatchingRoundId(Long matchingRoundId) {
-        return jpaRepository.existsByAppliedMatchingRound_Id(matchingRoundId);
+        return projectApplicationJpaRepository.existsByAppliedMatchingRound_Id(matchingRoundId);
+    }
+
+    @Override
+    public Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndStatus(
+        Long projectId,
+        Long applicantMemberId,
+        ProjectApplicationStatus status
+    ) {
+        return projectApplicationQueryRepository.findByProjectIdAndApplicantMemberIdAndStatus(
+            projectId,
+            applicantMemberId,
+            status
+        );
+    }
+
+    @Override
+    public ProjectApplication save(ProjectApplication application) {
+        return projectApplicationJpaRepository.save(application);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -4,6 +4,8 @@ import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -46,6 +48,16 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
             roundId,
             status
         );
+    }
+
+    @Override
+    public ProjectApplication getDraftByProjectAndMember(Long projectId, Long memberId) {
+        return projectApplicationQueryRepository
+            .findByProjectIdAndApplicantMemberIdAndStatus(
+                projectId,
+                memberId,
+                ProjectApplicationStatus.DRAFT
+            ).orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -34,6 +34,21 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     }
 
     @Override
+    public Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+        Long projectId,
+        Long applicantMemberId,
+        Long roundId,
+        ProjectApplicationStatus status
+    ) {
+        return projectApplicationQueryRepository.findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+            projectId,
+            applicantMemberId,
+            roundId,
+            status
+        );
+    }
+
+    @Override
     public boolean existsByRoundAndApplicantAndStatus(
         Long roundId,
         Long applicantMemberId,

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -15,6 +15,21 @@ public class ProjectApplicationQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    /** 동일 차수에 특정 상태의 지원서가 존재하는지 확인. */
+    public boolean existsByRoundAndApplicantAndStatus(
+        Long roundId, Long applicantMemberId, ProjectApplicationStatus status
+    ) {
+        return queryFactory
+            .selectOne()
+            .from(projectApplication)
+            .where(
+                projectApplication.appliedMatchingRound.id.eq(roundId),
+                projectApplication.applicantMemberId.eq(applicantMemberId),
+                projectApplication.status.eq(status)
+            )
+            .fetchFirst() != null;
+    }
+
     /**
      * (projectId, applicantMemberId, status) 조합으로 단건 조회.
      * applicationForm.project.id 를 통해 projectId 까지 타고 들어간다.

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -1,0 +1,36 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static com.umc.product.project.domain.QProjectApplication.projectApplication;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectApplicationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * (projectId, applicantMemberId, status) 조합으로 단건 조회.
+     * applicationForm.project.id 를 통해 projectId 까지 타고 들어간다.
+     */
+    public Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndStatus(
+        Long projectId, Long applicantMemberId, ProjectApplicationStatus status
+    ) {
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(projectApplication)
+                .where(
+                    projectApplication.applicationForm.project.id.eq(projectId),
+                    projectApplication.applicantMemberId.eq(applicantMemberId),
+                    projectApplication.status.eq(status)
+                )
+                .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -15,6 +15,23 @@ public class ProjectApplicationQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    /** (projectId, applicantMemberId, roundId, status) 조합으로 단건 조회. */
+    public Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+        Long projectId, Long applicantMemberId, Long roundId, ProjectApplicationStatus status
+    ) {
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(projectApplication)
+                .where(
+                    projectApplication.applicationForm.project.id.eq(projectId),
+                    projectApplication.applicantMemberId.eq(applicantMemberId),
+                    projectApplication.appliedMatchingRound.id.eq(roundId),
+                    projectApplication.status.eq(status)
+                )
+                .fetchOne()
+        );
+    }
+
     /** 동일 차수에 특정 상태의 지원서가 존재하는지 확인. */
     public boolean existsByRoundAndApplicantAndStatus(
         Long roundId, Long applicantMemberId, ProjectApplicationStatus status

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -22,4 +22,6 @@ public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember,
         + "WHERE pm.project.id = :projectId AND pm.status = :status "
         + "GROUP BY pm.part")
     List<Object[]> countByProjectIdGroupByPartRaw(@Param("projectId") Long projectId, @Param("status") ProjectMemberStatus status);
+
+    boolean existsByProject_GisuIdAndMemberIdAndStatus(Long gisuId, Long memberId, ProjectMemberStatus status);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -53,4 +53,9 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     public Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId) {
         return repository.findByProjectIdAndMemberId(projectId, memberId);
     }
+
+    @Override
+    public boolean existsByGisuAndMember(Long gisuId, Long memberId) {
+        return repository.existsByProject_GisuIdAndMemberIdAndStatus(gisuId, memberId, ProjectMemberStatus.ACTIVE);
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
@@ -13,6 +13,8 @@ public interface ProjectPartQuotaJpaRepository extends JpaRepository<ProjectPart
 
     List<ProjectPartQuota> findByProjectId(Long projectId);
 
+    boolean existsByProjectIdAndPart(Long projectId, ChallengerPart part);
+
     @Modifying
     @Query("DELETE FROM ProjectPartQuota q "
         + "WHERE q.project.id = :projectId AND q.part IN :parts")

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
@@ -22,6 +22,11 @@ public class ProjectPartQuotaPersistenceAdapter
     }
 
     @Override
+    public boolean existsByProjectIdAndPart(Long projectId, ChallengerPart part) {
+        return repository.existsByProjectIdAndPart(projectId, part);
+    }
+
+    @Override
     public ProjectPartQuota save(ProjectPartQuota quota) {
         return repository.save(quota);
     }

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectApplicationUseCase.java
@@ -6,8 +6,8 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationI
 /**
  * 챌린저 지원서 Draft 생성 UseCase (APPLY-001).
  * <p>
- * 인증된 챌린저가 특정 프로젝트의 지원서를 PENDING 상태로 신규 생성한다.
- * 동일 (projectId, applicantMemberId) 조합에 이미 PENDING 지원서가 있으면 기존 application 정보를 그대로 반환한다.
+ * 인증된 챌린저가 특정 프로젝트의 지원서를 Draft 상태로 신규 생성한다.
+ * 동일 (projectId, applicantMemberId) 조합에 이미 DRAFT 지원서가 있으면 기존 application 정보를 그대로 반환한다.
  * Survey 의 {@code ManageFormResponseUseCase.createDraft}를 함께 호출하여 빈 응답지(FormResponse, status=DRAFT)를 매핑한다.
  */
 public interface CreateDraftProjectApplicationUseCase {

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectApplicationUseCase.java
@@ -1,0 +1,15 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+
+/**
+ * 챌린저 지원서 Draft 생성 UseCase (APPLY-001).
+ * <p>
+ * 인증된 챌린저가 특정 프로젝트의 지원서를 PENDING 상태로 신규 생성한다.
+ * 동일 (projectId, applicantMemberId) 조합에 이미 PENDING 지원서가 있으면 기존 application 정보를 그대로 반환한다.
+ * Survey 의 {@code ManageFormResponseUseCase.createDraft}를 함께 호출하여 빈 응답지(FormResponse, status=DRAFT)를 매핑한다.
+ */
+public interface CreateDraftProjectApplicationUseCase {
+    ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectApplicationUseCase.java
@@ -1,0 +1,14 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+
+/**
+ * 챌린저 지원서 최종 제출 UseCase (APPLY-003).
+ * <p>
+ * PENDING -> SUBMITTED 전이. 본인만 호출 가능.
+ * Survey 의 {@code ManageFormResponseUseCase.submitDraft}가 필수 답변 누락 검증을 수행하고 FormResponse를 SUBMITTED로 전이시킨다.
+ */
+public interface SubmitProjectApplicationUseCase {
+    ProjectApplicationInfo submit(SubmitProjectApplicationCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/SubmitProjectApplicationUseCase.java
@@ -6,7 +6,7 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationI
 /**
  * 챌린저 지원서 최종 제출 UseCase (APPLY-003).
  * <p>
- * PENDING -> SUBMITTED 전이. 본인만 호출 가능.
+ * DRAFT -> SUBMITTED 전이. 본인만 호출 가능.
  * Survey 의 {@code ManageFormResponseUseCase.submitDraft}가 필수 답변 누락 검증을 수행하고 FormResponse를 SUBMITTED로 전이시킨다.
  */
 public interface SubmitProjectApplicationUseCase {

--- a/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectApplicationDraftUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectApplicationDraftUseCase.java
@@ -7,7 +7,7 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationI
  * 챌린저 지원서 임시저장 UseCase (APPLY-002).
  * <p>
  * PUT 시멘틱 — 본문이 곧 새 전체 답변 상태가 된다. 본인만 호출 가능.
- * status 는 PENDING(임시저장)일 때만 호출 가능하며, SUBMITTED 이후의 답변 수정은 별도 정책으로 처리한다.
+ * status 는 DRAFT(임시저장)일 때만 호출 가능하며, SUBMITTED 이후의 답변 수정은 별도 정책으로 처리한다.
  * Survey의 {@code ManageFormResponseUseCase.updateDraft}에 위임한다.
  */
 public interface UpdateProjectApplicationDraftUseCase {

--- a/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectApplicationDraftUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/UpdateProjectApplicationDraftUseCase.java
@@ -1,0 +1,15 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+
+/**
+ * 챌린저 지원서 임시저장 UseCase (APPLY-002).
+ * <p>
+ * PUT 시멘틱 — 본문이 곧 새 전체 답변 상태가 된다. 본인만 호출 가능.
+ * status 는 PENDING(임시저장)일 때만 호출 가능하며, SUBMITTED 이후의 답변 수정은 별도 정책으로 처리한다.
+ * Survey의 {@code ManageFormResponseUseCase.updateDraft}에 위임한다.
+ */
+public interface UpdateProjectApplicationDraftUseCase {
+    ProjectApplicationInfo update(UpdateProjectApplicationDraftCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 /**
  * 챌린저 지원서 Draft 생성 Command (APPLY-001).
  * <p>
- * 동일 (projectId, applicantMemberId) 조합에 PENDING 지원서가 이미 있으면 Service 단에서 멱등 처리한다.
+ * 동일 (projectId, applicantMemberId) 조합에 DRAFT 지원서가 이미 있으면 Service 단에서 멱등 처리한다.
  */
 @Builder
 public record CreateDraftProjectApplicationCommand(

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
@@ -1,0 +1,16 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 Draft 생성 Command (APPLY-001).
+ * <p>
+ * 동일 (projectId, applicantMemberId) 조합에 PENDING 지원서가 이미 있으면 Service 단에서 멱등 처리한다.
+ */
+@Builder
+public record CreateDraftProjectApplicationCommand(
+    Long projectId,
+    Long applicantMemberId
+) {
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CreateDraftProjectApplicationCommand.java
@@ -1,16 +1,17 @@
 package com.umc.product.project.application.port.in.command.dto;
 
-import java.util.Objects;
 import lombok.Builder;
 
 /**
  * 챌린저 지원서 Draft 생성 Command (APPLY-001).
  * <p>
- * 동일 (projectId, applicantMemberId) 조합에 DRAFT 지원서가 이미 있으면 Service 단에서 멱등 처리한다.
+ * FE에서 지원할 매칭 차수를 명시하고, 서버는 해당 차수의 오픈 여부와 파트 타입을 검증한다.
+ * 동일 (projectId, applicantMemberId, matchingRoundId) 조합에 DRAFT 지원서가 이미 있으면 Service 단에서 멱등 처리한다.
  */
 @Builder
 public record CreateDraftProjectApplicationCommand(
     Long projectId,
-    Long applicantMemberId
+    Long applicantMemberId,
+    Long matchingRoundId
 ) {
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
@@ -1,0 +1,17 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 최종 제출 Command (APPLY-003).
+ * <p>
+ * (projectId, requesterMemberId) 로 본인의 PENDING 지원서를 식별 — applicationId 를 path 에 노출하지 않는다.
+ * PENDING -> SUBMITTED 전이. 필수 답변 누락 검증은 Survey {@code ManageFormResponseUseCase.submitDraft}가 담당.
+ */
+@Builder
+public record SubmitProjectApplicationCommand(
+    Long projectId,
+    Long requesterMemberId
+) {
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 /**
  * 챌린저 지원서 최종 제출 Command (APPLY-003).
  * <p>
- * (projectId, requesterMemberId) 로 본인의 PENDING 지원서를 식별 — applicationId 를 path 에 노출하지 않는다.
- * PENDING -> SUBMITTED 전이. 필수 답변 누락 검증은 Survey {@code ManageFormResponseUseCase.submitDraft}가 담당.
+ * (projectId, requesterMemberId) 로 본인의 DRAFT 지원서를 식별 — applicationId 를 path 에 노출하지 않는다.
+ * DRAFT -> SUBMITTED 전이. 필수 답변 누락 검증은 Survey {@code ManageFormResponseUseCase.submitDraft}가 담당.
  */
 @Builder
 public record SubmitProjectApplicationCommand(

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
@@ -1,0 +1,31 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 챌린저 지원서 임시저장 Command (APPLY-002).
+ * <p>
+ * (projectId, requesterMemberId)로 본인의 PENDING 지원서를 식별 — applicationId 를 path에 노출하지 않는다.
+ * PUT 시멘틱 — {@code answers}가 곧 새 전체 상태이며, 빠진 questionId의 기존 답변은 삭제된다.
+ * Survey의 {@code ManageFormResponseUseCase.updateDraft}에 위임된다.
+ */
+@Builder
+public record UpdateProjectApplicationDraftCommand(
+    Long projectId,
+    Long requesterMemberId,
+    List<AnswerEntry> answers
+) {
+    /**
+     * 한 질문에 대한 응답 입력값. type 별 사용 필드는 Survey {@code AnswerCommand}와 동일.
+     */
+    @Builder
+    public record AnswerEntry(
+        Long questionId,
+        String textValue,
+        List<Long> selectedOptionIds,
+        List<String> fileIds
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 /**
  * 챌린저 지원서 임시저장 Command (APPLY-002).
  * <p>
- * (projectId, requesterMemberId)로 본인의 PENDING 지원서를 식별 — applicationId 를 path에 노출하지 않는다.
+ * (projectId, requesterMemberId)로 본인의 DRAFT 지원서를 식별 — applicationId 를 path에 노출하지 않는다.
  * PUT 시멘틱 — {@code answers}가 곧 새 전체 상태이며, 빠진 questionId의 기존 답변은 삭제된다.
  * Survey의 {@code ManageFormResponseUseCase.updateDraft}에 위임된다.
  */

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectApplicationInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectApplicationInfo.java
@@ -1,19 +1,22 @@
 package com.umc.product.project.application.port.in.query.dto;
 
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.time.Instant;
 import lombok.Builder;
 
 /**
  * ProjectApplication 라이프사이클 스냅샷.
  * <p>
  * Create / Update / Submit UseCase 의 통일 반환 타입. Web 응답 record 가 이걸 받아 변환한다.
- * {@code lastSavedAt} 은 Survey FormResponse 의 값 — ProjectApplication 엔티티에는 없으므로 Service 가 조립한다.
  */
 @Builder
 public record ProjectApplicationInfo(
     Long applicationId,
-    ProjectApplicationStatus status,
-    Instant lastSavedAt
+    ProjectApplicationStatus status
 ) {
+    public static ProjectApplicationInfo of(
+        Long applicationId,
+        ProjectApplicationStatus status
+    ) {
+        return new ProjectApplicationInfo(applicationId, status);
+    }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectApplicationInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/ProjectApplicationInfo.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.time.Instant;
+import lombok.Builder;
+
+/**
+ * ProjectApplication 라이프사이클 스냅샷.
+ * <p>
+ * Create / Update / Submit UseCase 의 통일 반환 타입. Web 응답 record 가 이걸 받아 변환한다.
+ * {@code lastSavedAt} 은 Survey FormResponse 의 값 — ProjectApplication 엔티티에는 없으므로 Service 가 조립한다.
+ */
+@Builder
+public record ProjectApplicationInfo(
+    Long applicationId,
+    ProjectApplicationStatus status,
+    Instant lastSavedAt
+) {
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -1,6 +1,22 @@
 package com.umc.product.project.application.port.out;
 
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.Optional;
+
+/**
+ * {@code findBy*} — 없어도 정상 ({@link Optional})
+ * {@code getBy*} — 반드시 있어야 하며 없으면 {@code ProjectDomainException}
+ */
 public interface LoadProjectApplicationPort {
 
     boolean existsByAppliedMatchingRoundId(Long matchingRoundId);
+
+    /**
+     * (projectId, applicantMemberId, status) 조합으로 본인 지원서를 조회합니다.
+     * 멱등 처리(APPLY-001) 및 본인 지원서 식별(APPLY-002/003)에 사용됩니다.
+     */
+    Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndStatus(
+        Long projectId, Long applicantMemberId, ProjectApplicationStatus status
+    );
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -19,4 +19,11 @@ public interface LoadProjectApplicationPort {
     Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndStatus(
         Long projectId, Long applicantMemberId, ProjectApplicationStatus status
     );
+
+    /**
+     * 동일 차수에 이미 제출된 지원서가 있는지 확인합니다. (중복 제출 방지용)
+     */
+    boolean existsByRoundAndApplicantAndStatus(
+        Long roundId, Long applicantMemberId, ProjectApplicationStatus status
+    );
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -21,6 +21,14 @@ public interface LoadProjectApplicationPort {
     );
 
     /**
+     * (projectId, applicantMemberId, roundId, status) 조합으로 조회합니다.
+     * 현재 오픈된 차수 기준으로 기존 DRAFT를 찾을 때 사용합니다.
+     */
+    Optional<ProjectApplication> findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+        Long projectId, Long applicantMemberId, Long roundId, ProjectApplicationStatus status
+    );
+
+    /**
      * 동일 차수에 이미 제출된 지원서가 있는지 확인합니다. (중복 제출 방지용)
      */
     boolean existsByRoundAndApplicantAndStatus(

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -29,6 +29,12 @@ public interface LoadProjectApplicationPort {
     );
 
     /**
+     * 본인의 DRAFT 지원서를 반드시 존재하는 것으로 조회합니다. 없으면 {@code PROJECT_APPLICATION_NOT_FOUND} 예외.
+     * update / submit 에서 사용합니다.
+     */
+    ProjectApplication getDraftByProjectAndMember(Long projectId, Long memberId);
+
+    /**
      * 동일 차수에 이미 제출된 지원서가 있는지 확인합니다. (중복 제출 방지용)
      */
     boolean existsByRoundAndApplicantAndStatus(

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -36,4 +36,9 @@ public interface LoadProjectMemberPort {
      * PROJECT-005(멤버 제거)에서 사용 — 이미 비활성화된 row 도 idempotent 처리하기 위함.
      */
     Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId);
+
+    /**
+     * 해당 기수에서 이미 ACTIVE 팀원인지 확인합니다. (중복 지원 방지용)
+     */
+    boolean existsByGisuAndMember(Long gisuId, Long memberId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPartQuotaPort.java
@@ -1,5 +1,6 @@
 package com.umc.product.project.application.port.out;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.domain.ProjectPartQuota;
 import java.util.List;
 
@@ -9,4 +10,7 @@ import java.util.List;
 public interface LoadProjectPartQuotaPort {
 
     List<ProjectPartQuota> listByProjectId(Long projectId);
+
+    /** 해당 프로젝트가 특정 파트를 모집 중인지 (정원 등록 여부) 확인합니다. */
+    boolean existsByProjectIdAndPart(Long projectId, ChallengerPart part);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationPort.java
@@ -1,0 +1,7 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectApplication;
+
+public interface SaveProjectApplicationPort {
+    ProjectApplication save(ProjectApplication application);
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -1,0 +1,119 @@
+package com.umc.product.project.application.service.command;
+
+import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
+import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectApplicationCommandService implements
+    CreateDraftProjectApplicationUseCase,
+    UpdateProjectApplicationDraftUseCase,
+    SubmitProjectApplicationUseCase {
+
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
+    private final SaveProjectApplicationPort saveProjectApplicationPort;
+    private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+    private final ManageFormResponseUseCase manageFormResponseUseCase;
+
+    @Override
+    public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
+        ProjectApplicationForm form = loadProjectApplicationFormPort.findByProjectId(command.projectId())
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_NOT_FOUND));
+
+        // 멱등 처리 — 기존 DRAFT 있으면 그대로 반환
+        return loadProjectApplicationPort
+            .findByProjectIdAndApplicantMemberIdAndStatus(
+                command.projectId(), command.applicantMemberId(), ProjectApplicationStatus.DRAFT)
+            .map(existing -> ProjectApplicationInfo.of(existing.getId(), existing.getStatus()))
+            .orElseGet(() -> createNew(form, command));
+    }
+
+    private ProjectApplicationInfo createNew(ProjectApplicationForm form, CreateDraftProjectApplicationCommand command) {
+        Long formResponseId = manageFormResponseUseCase.createDraft(
+            CreateDraftFormResponseCommand.builder()
+                .formId(form.getFormId())
+                .respondentMemberId(command.applicantMemberId())
+                .build()
+        );
+
+        // TODO: 매칭라운드 PR 머지 후 appliedMatchingRound 연결
+        ProjectApplication saved = saveProjectApplicationPort.save(
+            ProjectApplication.create(form, formResponseId, command.applicantMemberId(), null)
+        );
+
+        return ProjectApplicationInfo.of(saved.getId(), saved.getStatus());
+    }
+
+    @Override
+    public ProjectApplicationInfo update(UpdateProjectApplicationDraftCommand command) {
+        ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
+
+        manageFormResponseUseCase.updateDraft(
+            UpdateDraftFormResponseCommand.builder()
+                .formResponseId(application.getFormResponseId())
+                .requesterMemberId(command.requesterMemberId())
+                .answers(toAnswerCommands(command.answers()))
+                .build()
+        );
+
+        return ProjectApplicationInfo.of(application.getId(), application.getStatus());
+    }
+
+    @Override
+    public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
+        ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
+
+        // Survey submitDraft — 필수 답변 누락 검증 포함
+        manageFormResponseUseCase.submitDraft(
+            SubmitDraftFormResponseCommand.builder()
+                .formResponseId(application.getFormResponseId())
+                .requesterMemberId(command.requesterMemberId())
+                .build()
+        );
+
+        application.submit();
+        saveProjectApplicationPort.save(application);
+
+        return ProjectApplicationInfo.of(application.getId(), application.getStatus());
+    }
+
+    private ProjectApplication getDraftOrThrow(Long projectId, Long memberId) {
+        return loadProjectApplicationPort
+            .findByProjectIdAndApplicantMemberIdAndStatus(projectId, memberId, ProjectApplicationStatus.DRAFT)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
+    }
+
+    private List<AnswerCommand> toAnswerCommands(List<UpdateProjectApplicationDraftCommand.AnswerEntry> entries) {
+        return entries.stream()
+            .map(e -> AnswerCommand.builder()
+                .questionId(e.questionId())
+                .textValue(e.textValue())
+                .selectedOptionIds(e.selectedOptionIds() == null ? List.of() : e.selectedOptionIds())
+                .fileIds(e.fileIds() == null ? List.of() : e.fileIds())
+                .build())
+            .toList();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -1,5 +1,8 @@
 package com.umc.product.project.application.service.command;
 
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
@@ -9,9 +12,15 @@ import com.umc.product.project.application.port.in.command.dto.UpdateProjectAppl
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
@@ -20,6 +29,7 @@ import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,7 +46,11 @@ public class ProjectApplicationCommandService implements
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectApplicationPort saveProjectApplicationPort;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+    private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
 
     @Override
     public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
@@ -52,6 +66,36 @@ public class ProjectApplicationCommandService implements
     }
 
     private ProjectApplicationInfo createNew(ProjectApplicationForm form, CreateDraftProjectApplicationCommand command) {
+        Project project = form.getProject();
+
+        // 1. 챌린저 정보 조회 (현재 기수 챌린저 신분 + 파트 확인)
+        ChallengerInfo challenger = getChallengerUseCase.getByMemberIdAndGisuId(
+            command.applicantMemberId(), project.getGisuId()
+        );
+
+        // 2. 파트 체크 - 이 프로젝트가 내 파트를 모집 중인지
+        if (!loadProjectPartQuotaPort.existsByProjectIdAndPart(command.projectId(), challenger.part())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_PART_NOT_ALLOWED);
+        }
+
+        // 3. 기수 팀원 여부 체크 — 이미 이 기수에 소속된 팀이 있으면 불가
+        if (loadProjectMemberPort.existsByGisuAndMember(project.getGisuId(), command.applicantMemberId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM);
+        }
+
+        // 4. 현재 open 매칭 차수 조회
+        MatchingType matchingType = challenger.part() == ChallengerPart.DESIGN
+            ? MatchingType.PLAN_DESIGN
+            : MatchingType.PLAN_DEVELOPER;
+        ProjectMatchingRound round = loadProjectMatchingRoundPort
+            .listOpenAt(project.getChapterId(), Instant.now())
+            .stream()
+            .filter(r -> r.getType() == matchingType)
+            .findFirst()
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FOUND,
+                "현재 지원 가능한 매칭 차수가 없습니다."));
+
+        // 5. Survey FormResponse 생성 (DRAFT)
         Long formResponseId = manageFormResponseUseCase.createDraft(
             CreateDraftFormResponseCommand.builder()
                 .formId(form.getFormId())
@@ -59,9 +103,8 @@ public class ProjectApplicationCommandService implements
                 .build()
         );
 
-        // TODO: 매칭라운드 PR 머지 후 appliedMatchingRound 연결
         ProjectApplication saved = saveProjectApplicationPort.save(
-            ProjectApplication.create(form, formResponseId, command.applicantMemberId(), null)
+            ProjectApplication.create(form, formResponseId, command.applicantMemberId(), round)
         );
 
         return ProjectApplicationInfo.of(saved.getId(), saved.getStatus());
@@ -85,6 +128,15 @@ public class ProjectApplicationCommandService implements
     @Override
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
         ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
+
+        // 동일 차수 중복 제출 체크
+        if (application.getAppliedMatchingRound() != null
+            && loadProjectApplicationPort.existsByRoundAndApplicantAndStatus(
+                application.getAppliedMatchingRound().getId(),
+                command.requesterMemberId(),
+                ProjectApplicationStatus.SUBMITTED)) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DUPLICATE_SUBMISSION);
+        }
 
         // Survey submitDraft — 필수 답변 누락 검증 포함
         manageFormResponseUseCase.submitDraft(

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -133,6 +133,12 @@ public class ProjectApplicationCommandService implements
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
         ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
 
+        // 차수 마감 여부 체크 - 제출 시점에 차수가 닫혀있으면 불가
+        if (application.getAppliedMatchingRound() != null
+            && !application.getAppliedMatchingRound().isOpenAt(Instant.now())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_CLOSED);
+        }
+
         // 동일 차수 중복 제출 체크
         if (application.getAppliedMatchingRound() != null
             && loadProjectApplicationPort.existsByRoundAndApplicantAndStatus(

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -116,7 +116,8 @@ public class ProjectApplicationCommandService implements
 
     @Override
     public ProjectApplicationInfo update(UpdateProjectApplicationDraftCommand command) {
-        ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
+        ProjectApplication application = loadProjectApplicationPort
+            .getDraftByProjectAndMember(command.projectId(), command.requesterMemberId());
 
         manageFormResponseUseCase.updateDraft(
             UpdateDraftFormResponseCommand.builder()
@@ -131,7 +132,8 @@ public class ProjectApplicationCommandService implements
 
     @Override
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
-        ProjectApplication application = getDraftOrThrow(command.projectId(), command.requesterMemberId());
+        ProjectApplication application = loadProjectApplicationPort
+            .getDraftByProjectAndMember(command.projectId(), command.requesterMemberId());
 
         // 차수 마감 여부 체크 - 제출 시점에 차수가 닫혀있으면 불가
         if (application.getAppliedMatchingRound() != null
@@ -160,12 +162,6 @@ public class ProjectApplicationCommandService implements
         saveProjectApplicationPort.save(application);
 
         return ProjectApplicationInfo.of(application.getId(), application.getStatus());
-    }
-
-    private ProjectApplication getDraftOrThrow(Long projectId, Long memberId) {
-        return loadProjectApplicationPort
-            .findByProjectIdAndApplicantMemberIdAndStatus(projectId, memberId, ProjectApplicationStatus.DRAFT)
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
     }
 
     private List<AnswerCommand> toAnswerCommands(List<UpdateProjectApplicationDraftCommand.AnswerEntry> entries) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -74,17 +74,19 @@ public class ProjectApplicationCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM);
         }
 
-        // 4. 현재 open 매칭 차수 조회
-        MatchingType matchingType = challenger.part() == ChallengerPart.DESIGN
+        // 4. FE가 지정한 매칭 차수 조회 + 검증
+        ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(command.matchingRoundId());
+
+        if (!round.isOpenAt(Instant.now())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_NOT_OPEN);
+        }
+
+        MatchingType expectedType = challenger.part() == ChallengerPart.DESIGN
             ? MatchingType.PLAN_DESIGN
             : MatchingType.PLAN_DEVELOPER;
-        ProjectMatchingRound round = loadProjectMatchingRoundPort
-            .listOpenAt(project.getChapterId(), Instant.now())
-            .stream()
-            .filter(r -> r.getType() == matchingType)
-            .findFirst()
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FOUND,
-                "현재 지원 가능한 매칭 차수가 없습니다."));
+        if (round.getType() != expectedType) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_TYPE_MISMATCH);
+        }
 
         // 5. 멱등 처리 - 현재 오픈된 차수 기준으로 기존 DRAFT 조회
         return loadProjectApplicationPort
@@ -138,7 +140,7 @@ public class ProjectApplicationCommandService implements
         // 차수 마감 여부 체크 - 제출 시점에 차수가 닫혀있으면 불가
         if (application.getAppliedMatchingRound() != null
             && !application.getAppliedMatchingRound().isOpenAt(Instant.now())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_CLOSED);
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_NOT_OPEN);
         }
 
         // 동일 차수 중복 제출 체크

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -57,15 +57,6 @@ public class ProjectApplicationCommandService implements
         ProjectApplicationForm form = loadProjectApplicationFormPort.findByProjectId(command.projectId())
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_NOT_FOUND));
 
-        // 멱등 처리 — 기존 DRAFT 있으면 그대로 반환
-        return loadProjectApplicationPort
-            .findByProjectIdAndApplicantMemberIdAndStatus(
-                command.projectId(), command.applicantMemberId(), ProjectApplicationStatus.DRAFT)
-            .map(existing -> ProjectApplicationInfo.of(existing.getId(), existing.getStatus()))
-            .orElseGet(() -> createNew(form, command));
-    }
-
-    private ProjectApplicationInfo createNew(ProjectApplicationForm form, CreateDraftProjectApplicationCommand command) {
         Project project = form.getProject();
 
         // 1. 챌린저 정보 조회 (현재 기수 챌린저 신분 + 파트 확인)
@@ -95,16 +86,29 @@ public class ProjectApplicationCommandService implements
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FOUND,
                 "현재 지원 가능한 매칭 차수가 없습니다."));
 
-        // 5. Survey FormResponse 생성 (DRAFT)
+        // 5. 멱등 처리 - 현재 오픈된 차수 기준으로 기존 DRAFT 조회
+        return loadProjectApplicationPort
+            .findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+                command.projectId(),
+                command.applicantMemberId(),
+                round.getId(),
+                ProjectApplicationStatus.DRAFT
+            ).map(existing -> ProjectApplicationInfo.of(existing.getId(), existing.getStatus()))
+            .orElseGet(() -> createNew(form, command.applicantMemberId(), round));
+    }
+
+    private ProjectApplicationInfo createNew(
+        ProjectApplicationForm form, Long applicantMemberId, ProjectMatchingRound round
+    ) {
         Long formResponseId = manageFormResponseUseCase.createDraft(
             CreateDraftFormResponseCommand.builder()
                 .formId(form.getFormId())
-                .respondentMemberId(command.applicantMemberId())
+                .respondentMemberId(applicantMemberId)
                 .build()
         );
 
         ProjectApplication saved = saveProjectApplicationPort.save(
-            ProjectApplication.create(form, formResponseId, command.applicantMemberId(), round)
+            ProjectApplication.create(form, formResponseId, applicantMemberId, round)
         );
 
         return ProjectApplicationInfo.of(saved.getId(), saved.getStatus());

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -88,15 +88,17 @@ public class ProjectApplicationCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ROUND_TYPE_MISMATCH);
         }
 
-        // 5. 멱등 처리 - 현재 오픈된 차수 기준으로 기존 DRAFT 조회
-        return loadProjectApplicationPort
-            .findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
-                command.projectId(),
-                command.applicantMemberId(),
-                round.getId(),
-                ProjectApplicationStatus.DRAFT
-            ).map(existing -> ProjectApplicationInfo.of(existing.getId(), existing.getStatus()))
-            .orElseGet(() -> createNew(form, command.applicantMemberId(), round));
+        // 5. 동일 차수 기준 DRAFT 중복 체크 — 이미 있으면 409
+        if (loadProjectApplicationPort.findByProjectIdAndApplicantMemberIdAndRoundIdAndStatus(
+            command.projectId(),
+            command.applicantMemberId(),
+            round.getId(),
+            ProjectApplicationStatus.DRAFT
+        ).isPresent()) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_ALREADY_EXISTS);
+        }
+
+        return createNew(form, command.applicantMemberId(), round);
     }
 
     private ProjectApplicationInfo createNew(

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -40,6 +40,7 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
             case EDIT -> canEdit(subject, permission);
             case MANAGE -> canManage(subject, permission);
             case DELETE -> isCentralCore(subject);
+            case APPLY -> canApply(subject, permission);
             default -> false;
         };
     }
@@ -123,6 +124,15 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
                 isCentralCoreInGisu(subject, project.getGisuId())
                     || isChapterPresidentOf(subject, project.getChapterId(), project.getGisuId());
             case DRAFT, COMPLETED, ABORTED -> false;
+        };
+    }
+
+    /** 챌린저 신분인 사용자만 IN_PROGRESS 프로젝트에 지원 가능. COMPLETED 포함 그 외 상태는 차단. */
+    private boolean canApply(SubjectAttributes subject, ResourcePermission permission) {
+        Project project = loadProject(permission);
+        return switch (project.getStatus()) {
+            case IN_PROGRESS -> !subject.gisuChallengerInfos().isEmpty();
+            default -> false;
         };
     }
 

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -81,7 +81,7 @@ public class ProjectApplication extends BaseEntity {
         this.formResponseId = formResponseId;
         this.applicantMemberId = applicantMemberId;
         this.appliedMatchingRound = appliedMatchingRound;
-        this.status = ProjectApplicationStatus.PENDING;
+        this.status = ProjectApplicationStatus.DRAFT;
     }
 
     public static ProjectApplication create(
@@ -134,7 +134,7 @@ public class ProjectApplication extends BaseEntity {
 //        validateIsSubmitted("지원서가 제출된 상태에서만 철회할 수 있습니다.");
 
         // HARD DELETE 로직
-        // PENDING일 떄, 즉 임시저장본 일 때 삭제하는 로직 또한 필요할 것 같음
+        // Draft일 떄, 즉 임시저장본 일 때 삭제하는 로직 또한 필요할 것 같음
 
         // TODO: 악악악...
     }
@@ -143,15 +143,15 @@ public class ProjectApplication extends BaseEntity {
      * 지원서 제출 처리 (임시저장에서만 이동 가능)
      */
     public void submit() {
-        if (!this.isPending()) {
+        if (!this.isDraft()) {
             throw new ProjectDomainException(ProjectErrorCode.APPLICATION_NOT_SUBMITTED);
         }
 
         this.status = ProjectApplicationStatus.SUBMITTED;
     }
 
-    public boolean isPending() {
-        return this.status == ProjectApplicationStatus.PENDING;
+    public boolean isDraft() {
+        return this.status == ProjectApplicationStatus.DRAFT;
     }
 
     public boolean isSubmitted() {

--- a/src/main/java/com/umc/product/project/domain/enums/ProjectApplicationStatus.java
+++ b/src/main/java/com/umc/product/project/domain/enums/ProjectApplicationStatus.java
@@ -1,7 +1,7 @@
 package com.umc.product.project.domain.enums;
 
 public enum ProjectApplicationStatus {
-    PENDING,  // 아직 임시저장 상태로, 제출 이전임.
+    DRAFT,  // 아직 임시저장 상태로, 제출 이전임.
     SUBMITTED, // 지원서 제출 완료
 
     APPROVED, // 합격

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -60,6 +60,9 @@ public enum ProjectErrorCode implements BaseCode {
 
     // ProjectApplication (APPLY-001/002/003)
     PROJECT_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0204", "작성 중인 지원서를 찾을 수 없습니다."),
+    PROJECT_APPLICATION_PART_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0205", "해당 프로젝트에 지원 가능한 파트가 아닙니다."),
+    PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM(HttpStatus.CONFLICT, "PROJECT-0206", "이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다."),
+    PROJECT_APPLICATION_DUPLICATE_SUBMISSION(HttpStatus.CONFLICT, "PROJECT-0207", "동일한 매칭 차수에 이미 제출된 지원서가 있습니다."),
 
     ;
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -58,6 +58,9 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER(HttpStatus.BAD_REQUEST, "PROJECT-0305",
         "time 기준 조회는 chapterId와 함께 요청해야 합니다."),
 
+    // ProjectApplication (APPLY-001/002/003)
+    PROJECT_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0204", "작성 중인 지원서를 찾을 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -65,6 +65,7 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_DUPLICATE_SUBMISSION(HttpStatus.CONFLICT, "PROJECT-0207", "동일한 매칭 차수에 이미 제출된 지원서가 있습니다."),
     PROJECT_APPLICATION_ROUND_NOT_OPEN(HttpStatus.BAD_REQUEST, "PROJECT-0208", "해당 매칭 차수의 지원 기간이 아닙니다."),
     PROJECT_APPLICATION_ROUND_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "PROJECT-0209", "선택한 매칭 차수가 본인 파트에 해당하지 않습니다."),
+    PROJECT_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT-0210", "이미 작성 중인 지원서가 있습니다."),
 
     ;
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -63,6 +63,7 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_PART_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0205", "해당 프로젝트에 지원 가능한 파트가 아닙니다."),
     PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM(HttpStatus.CONFLICT, "PROJECT-0206", "이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다."),
     PROJECT_APPLICATION_DUPLICATE_SUBMISSION(HttpStatus.CONFLICT, "PROJECT-0207", "동일한 매칭 차수에 이미 제출된 지원서가 있습니다."),
+    PROJECT_APPLICATION_ROUND_CLOSED(HttpStatus.BAD_REQUEST, "PROJECT-0208", "지원 차수가 마감되어 제출할 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -63,7 +63,8 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_PART_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0205", "해당 프로젝트에 지원 가능한 파트가 아닙니다."),
     PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM(HttpStatus.CONFLICT, "PROJECT-0206", "이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다."),
     PROJECT_APPLICATION_DUPLICATE_SUBMISSION(HttpStatus.CONFLICT, "PROJECT-0207", "동일한 매칭 차수에 이미 제출된 지원서가 있습니다."),
-    PROJECT_APPLICATION_ROUND_CLOSED(HttpStatus.BAD_REQUEST, "PROJECT-0208", "지원 차수가 마감되어 제출할 수 없습니다."),
+    PROJECT_APPLICATION_ROUND_NOT_OPEN(HttpStatus.BAD_REQUEST, "PROJECT-0208", "해당 매칭 차수의 지원 기간이 아닙니다."),
+    PROJECT_APPLICATION_ROUND_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "PROJECT-0209", "선택한 매칭 차수가 본인 파트에 해당하지 않습니다."),
 
     ;
 

--- a/src/main/resources/db/migration/V2026.05.03.19.28__rename_project_application_pending_to_draft.sql
+++ b/src/main/resources/db/migration/V2026.05.03.19.28__rename_project_application_pending_to_draft.sql
@@ -1,0 +1,7 @@
+-- ProjectApplicationStatus 의 임시저장 상태명 변경: PENDING -> DRAFT
+-- Survey FormResponse 의 DRAFT 상태와 의미적 일관성 확보 (#801)
+-- @Enumerated(EnumType.STRING) 사용 -> DB에 enum 이름 그대로 저장되므로 row 값 정정 필요.
+
+UPDATE project_application
+SET status = 'DRAFT'
+WHERE status = 'PENDING';


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #801 

## 🚀 작업 내용
이슈 #801 의 챌린저 지원 플로우 중 생성/임시저장/제출 API를 구현했습니다.
조회 API (APPLY-004 내 지원서 조회, APPLY-101 지원자 목록, APPLY-102 지원서 상세) 는 PM 측 지원자 목록 조회 UseCase 와 함께 별도 PR에서 처리합니다.
                                              
  | API | 엔드포인트 | 설명 |
  |---|---|---|
  | APPLY-001 | `POST /api/v1/projects/{projectId}/applications` |  챌린저 지원서 Draft 생성 (멱등 처리 포함) |
  | APPLY-002 | `PUT /api/v1/projects/{projectId}/applications/me` |  임시저장 — PUT 시멘틱, 본문이 곧 새 전체 답변 상태 |
  | APPLY-003 | `POST /api/v1/projects/{projectId}/applications/me/submit` | 최종 제출 (필수 답변 누락 시 400) |
                                                                     
1. `ProjectApplicationStatus.PENDING -> DRAFT` 변경
Survey 의 `FormResponse.status = DRAFT` 와 의미적 일관성을 위해 임시저장 상태명을 변경했습니다.
`V2026.05.03.19.28` 마이그레이션으로 기존 row 를 일괄 정정합니다.

2. 권한 설계 — `PermissionType.APPLY` 신규
기존 `PROJECT.READ` 권한 재사용에 대해 고민했지만, `APPLY`를 신규 추가했습니다.                                                                       
- `PROJECT.READ`는 COMPLETED 프로젝트도 허용 -> 모집 종료 후에도 지원 가능해지는 문제
  - `PROJECT.APPLY`의 `canApply()` 는 `IN_PROGRESS` 만 허용하여 L1 레벨에서 명시적 차단
  -  권한 레이어를 참고하여, 
    - L1 `@CheckAccess(PROJECT, APPLY)` -> 프로젝트 `IN_PROGRESS` + 챌린저 신분 체크
    - L3-B Service -> 파트 체크, 기수 팀원 여부, 동일 차수 중복 제출      

 3. 지원 가능 조건
- 파트 제한  
   - `ProjectPartQuota.existsByProjectIdAndPart` — 정원이 등록된 파트만 지원 가능 
- 기수 팀원 여부
  - `existsByGisuAndMember(gisuId, memberId, ACTIVE)` - 동일 기수에 이미 소속된 팀 있으면 차단 (강제배정 포함) 
- 동일 차수 중복 제출 
  - `existsByRoundAndApplicantAndStatus(..., SUBMITTED)` — 같은 매칭 차수에 이미 제출된 지원서 있으면 차단 

 4. Survey 도메인 연동
  지원서 본문(답변)의 실제 데이터는 Survey 도메인의 `FormResponse` /  `Answer` 가 owner 입니다.
  - 생성: `ManageFormResponseUseCase.createDraft` -> `formResponseId`를 `ProjectApplication` 이 참조                                        
  - 임시저장: `ManageFormResponseUseCase.updateDraft` - PUT 그대로 위임 (delete-all-then-insert)                                 
  - 제출: `ManageFormResponseUseCase.submitDraft` - 필수 답변 누락 검증 포함                                                                
 
>  미반영 항목 (후속 PR)
  - `cancel()` 도메인 메서드 미구현 (TODO 유지)
  - 조회 API (APPLY-004/101/102) — 별도 PR 

## 💬 리뷰 중점사항
1. PLAN 파트 챌린저의 MatchingType 분류    
    현재 로직:                                                         
    ```                                                        
    MatchingType matchingType = challenger.part() == 
    ChallengerPart.DESIGN                                                
        ? MatchingType.PLAN_DESIGN                                       
        : MatchingType.PLAN_DEVELOPER;          
   ```
  PLAN_DESIGN 은 "기획-디자인 매칭", PLAN_DEVELOPER 는 "기획-개발자 매칭" 입니다.
  PLAN 파트 지원자의 경우 지원서를 작성할 일이 있는지 확인 부탁드립니다. 현재는 별도 로직을 넣지 않았습니다.

2. PLAN 파트(PM) 의 자기 프로젝트 지원 허용 여부
  규약에 명시가 없어 임의 차단하지 않았는데, PM 이 본인 프로젝트에 지원서를 만들 수 없다면 명시적으로 막아야 할지 의견 부탁드립니다. 

3. PermissionType.APPLY 신규 추가 - 컨벤션 검토
 신규 PermissionType 값을 추가했습니다. 
`PROJECT_APPLICATION.WRITE` 또는 `PROJECT.WRITE`를 사용하지 않은 이유는 다음과 같습니다.
  - `PROJECT.WRITE`는 이미 `canWrite()`에서 "PLAN 파트 챌린저의 프로젝트 신규 생성" 의미로 사용 중입니다. 같은 permission에 "지원서 생성" 의미를 함께 넣으면 의미 충돌이 발생합니다.
  - `PROJECT_APPLICATION.WRITE`는 기술적으로 동작하지만, 코드베이스 패턴상 `resourceType` 과 `resourceId` 가 같은 리소스를    
  가리켜야 합니다 (`CommunityCommentPermissionEvaluator` = commentId,`ProjectPermissionEvaluator` = projectId). 
    - CUD path 에 `applicationId` 가 없고 `projectId` 만 있기 때문에, `PROJECT_APPLICATION` Evaluator 가 `projectId` 를 받아 `Project`를 조회하는 구조가 되어 `resourceType` <-> `resourceId` 불일치가 발생합니다.

  따라서 `PROJECT.APPLY` 를 신규 추가하여, "이 projectId 의 프로젝트에 지원 가능한가" 라는 의미를 명시적으로 표현했습니다. 
