### PR TITLE
[Fix] 스터디 그룹에서 담당 파트장이 없을 때 Iterator에서 NPE가 발생하는 오류 해결

### DIFF
--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/studygroup/StudyGroupInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/studygroup/StudyGroupInfo.java
@@ -13,6 +13,10 @@ public record StudyGroupInfo(
     List<StudyGroupMemberInfo> mentors,
     List<StudyGroupMemberInfo> members
 ) {
+    public StudyGroupInfo {
+        mentors = mentors == null ? List.of() : List.copyOf(mentors);
+        members = members == null ? List.of() : List.copyOf(members);
+    }
     public static StudyGroupInfo create(
         Long groupId, String name,
         Long gisuId, ChallengerPart part,


### PR DESCRIPTION
- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🚀 작업 내용

### 문제 상황
- resolveStudyGroupListUrls에서 StudyGroupInfo를 통해 StudyGroupMemberInfo mentor : group.mentors() 하는 경우에 mentors가 NULL인 경우 iterator에 NULL이 들어가 에러가 발생합니다.
```java
        for (StudyGroupInfo group : studyGroups) {
            for (StudyGroupMemberInfo mentor : group.mentors()) { 
                if (mentor.profileImageUrl() != null) {
                    imageIds.add(mentor.profileImageUrl());
                }
            }
```
### 해결
StudyGroupInfo를 만들 때 mentors가 NULL이 들어갈 수 없게 하여 방지합니다
```java
    public StudyGroupInfo {
        mentors = mentors == null ? List.of() : List.copyOf(mentors);
        members = members == null ? List.of() : List.copyOf(members);
    }
```

## 💬 리뷰 중점사항
