### PR TITLE
[Feat] Apple Sign-In 시 클라이언트 별로 Client ID 분기 처리

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
@@ -53,16 +53,16 @@ public class AuthenticationController implements AuthenticationControllerInterfa
     public OAuthLoginResponse appleOAuthLogin(
         @RequestBody AppleLoginRequest request
     ) {
-        // Authorization Code 방식
+        // Authorization Code 방식. Apple은 플랫폼별로 다른 client_id를 사용하므로 clientType을 함께 전달한다.
         AppleAuthorizationCodeResult codeResult = verifyOAuthTokenPort.verifyAppleAuthorizationCode(
-            request.authorizationCode()
+            request.authorizationCode(), request.clientType()
         );
         OAuthTokenLoginResult result = oAuthAuthenticationUseCase.loginWithOAuth2Attributes(codeResult.attrs());
 
         if (result.isExistingMember() && codeResult.refreshToken() != null) {
-            // 기존 회원: MemberOAuth에 appleRefreshToken 바로 업데이트
+            // 기존 회원: MemberOAuth에 appleRefreshToken과 appleClientId 갱신
             oAuthAuthenticationUseCase.updateAppleRefreshToken(
-                OAuthProvider.APPLE, result.providerId(), codeResult.refreshToken()
+                OAuthProvider.APPLE, result.providerId(), codeResult.refreshToken(), codeResult.clientId()
             );
         }
 

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/AppleLoginRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/AppleLoginRequest.java
@@ -1,11 +1,19 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
+import com.umc.product.common.domain.enums.ClientType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record AppleLoginRequest(
     // Apple 로그인은 ID Token 대신 Authorization Code를 이용함.
     // 추후 revoke를 위해 필요한 refresh token은 ID Token으로는 발급이 불가능하기 때문이며,
     // 자세한 사항은 Apple Developer 문서를 참고해주세요.
     // https://developer.apple.com/documentation/signinwithapplerestapi/tokenresponse
     // https://developer.apple.com/documentation/signinwithapplerestapi/revoke-tokens
-    String authorizationCode
+    @NotBlank String authorizationCode,
+
+    // 클라이언트 플랫폼. Apple은 플랫폼별로 다른 client_id(Bundle ID vs Services ID)를 사용하므로,
+    // authorization code 교환 시 정확한 client_id를 매칭하기 위해 필요함.
+    @NotNull ClientType clientType
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
@@ -54,7 +54,9 @@ public interface AuthenticationControllerInterface {
             [Development](https://dev.api.umc.it.kr/api/v1/auth/oauth2/authorization/apple)
             [Production](https://api.umc.it.kr/api/v1/auth/oauth2/authorization/apple)
 
-            Apple 로그인은 제옹과 협의 후에 구현 예정입니다.
+            Apple 측에서 받은 authorization code와 함께 클라이언트 플랫폼(`clientType`)을 전달해주세요.
+            Apple은 플랫폼별로 서로 다른 client_id(iOS Bundle ID vs Web Services ID)를 사용하므로
+            `clientType`(ANDROID, IOS, WEB)을 정확히 명시해야 토큰 교환이 가능합니다.
             """)
     OAuthLoginResponse appleOAuthLogin(
         @RequestBody AppleLoginRequest request

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleOAuthProperties.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleOAuthProperties.java
@@ -1,13 +1,30 @@
 package com.umc.product.authentication.adapter.out.external;
 
 
+import com.umc.product.common.domain.enums.ClientType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.oauth2.apple")
 public record AppleOAuthProperties(
-    String clientId,
+    String iosClientId,
+    String webClientId,
     String teamId,
     String keyId,
     String privateKey
 ) {
+    /**
+     * ClientType에 매칭되는 Apple client_id를 반환합니다.
+     * <p>
+     * Apple Sign-In은 플랫폼별로 다른 client_id를 사용합니다.
+     * <ul>
+     *     <li>IOS: Native Sign in with Apple → Bundle ID</li>
+     *     <li>WEB / ANDROID: Sign in with Apple JS(웹 플로우) → Services ID</li>
+     * </ul>
+     */
+    public String resolveClientId(ClientType clientType) {
+        return switch (clientType) {
+            case IOS -> iosClientId;
+            case WEB, ANDROID -> webClientId;
+        };
+    }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -5,11 +5,13 @@ import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.common.domain.enums.ClientType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
 import java.io.StringReader;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -30,12 +32,16 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
 
 /**
  * Apple Sign-In 토큰 검증 Adapter
  * <p>
  * Apple ID Token(JWT) 서명 검증과 Authorization Code 교환을 담당합니다.
+ * <p>
+ * Apple Sign-In은 플랫폼별로 다른 client_id를 사용하므로(iOS Bundle ID vs Web Services ID),
+ * authorization code 교환 / token revoke 시 클라이언트 플랫폼에 맞는 client_id를 사용해야 합니다.
  */
 @Slf4j
 @Component
@@ -56,12 +62,13 @@ public class AppleTokenVerifier {
      * <p>
      * Apple JWKS 공개키로 서명을 검증하고, issuer/audience를 확인합니다.
      *
-     * @param idToken Apple에서 발급받은 identity token (JWT)
+     * @param idToken  Apple에서 발급받은 identity token (JWT)
+     * @param clientId audience 검증에 사용할 client_id (플랫폼별로 다름)
      * @return OAuth2Attributes
      * @throws AuthenticationDomainException 토큰 검증 실패 시
      */
-    public OAuth2Attributes verifyIdToken(String idToken) {
-        log.debug("Apple ID Token 검증 시작");
+    public OAuth2Attributes verifyIdToken(String idToken, String clientId) {
+        log.debug("Apple ID Token 검증 시작: clientId={}", clientId);
 
         try {
             // 1. ID Token의 header에서 kid 추출
@@ -74,7 +81,7 @@ public class AppleTokenVerifier {
             Claims claims = Jwts.parser()
                 .verifyWith(publicKey)
                 .requireIssuer(APPLE_ISSUER)
-                .requireAudience(appleProperties.clientId())
+                .requireAudience(clientId)
                 .build()
                 .parseSignedClaims(idToken)
                 .getPayload();
@@ -104,19 +111,22 @@ public class AppleTokenVerifier {
      * Authorization Code로 Apple token endpoint에 요청하여 id_token을 받은 뒤, 해당 토큰을 검증합니다.
      *
      * @param authorizationCode Apple에서 발급받은 authorization code
-     * @return OAuth2Attributes
+     * @param clientType        클라이언트 플랫폼 (Apple client_id 매칭용)
+     * @return OAuth2Attributes, refresh token, 그리고 사용된 client_id (DB에 저장하기 위함)
      * @throws AuthenticationDomainException 코드 교환 또는 토큰 검증 실패 시
      */
-    public AppleAuthorizationCodeResult verifyAuthorizationCode(String authorizationCode) {
-        log.debug("Apple Authorization Code 교환 시작");
+    public AppleAuthorizationCodeResult verifyAuthorizationCode(String authorizationCode, ClientType clientType) {
+        log.debug("Apple Authorization Code 교환 시작: clientType={}", clientType);
 
         try {
+            String clientId = appleProperties.resolveClientId(clientType);
+
             // 1. client_secret 생성
-            String clientSecret = generateClientSecret();
+            String clientSecret = generateClientSecret(clientId);
 
             // 2. Apple token endpoint에 authorization code 교환 요청
             MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-            formData.add("client_id", appleProperties.clientId());
+            formData.add("client_id", clientId);
             formData.add("client_secret", clientSecret);
             formData.add("code", authorizationCode);
             formData.add("grant_type", "authorization_code");
@@ -139,8 +149,8 @@ public class AppleTokenVerifier {
             log.info("Apple Authorization Code 교환 성공, ID Token 검증 진행");
 
             // 3. 받은 id_token을 검증
-            OAuth2Attributes attrs = verifyIdToken(response.idToken());
-            return new AppleAuthorizationCodeResult(attrs, response.refreshToken());
+            OAuth2Attributes attrs = verifyIdToken(response.idToken(), clientId);
+            return new AppleAuthorizationCodeResult(attrs, response.refreshToken(), clientId);
 
         } catch (AuthenticationDomainException e) {
             throw e;
@@ -154,15 +164,16 @@ public class AppleTokenVerifier {
      * Apple refresh token을 revoke합니다.
      *
      * @param refreshToken Apple에서 발급받은 refresh token
+     * @param clientId     해당 refresh token을 발급받을 때 사용한 client_id (DB에 저장된 값)
      */
-    public void revokeToken(String refreshToken) {
-        log.info("Apple token revoke 시작");
+    public void revokeToken(String refreshToken, String clientId) {
+        log.info("Apple token revoke 시작: clientId={}", clientId);
 
         try {
-            String clientSecret = generateClientSecret();
+            String clientSecret = generateClientSecret(clientId);
 
             MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-            formData.add("client_id", appleProperties.clientId());
+            formData.add("client_id", clientId);
             formData.add("client_secret", clientSecret);
             formData.add("token", refreshToken);
             formData.add("token_type_hint", "refresh_token");
@@ -173,7 +184,8 @@ public class AppleTokenVerifier {
                 .body(formData)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Apple token revoke 실패: status={}", res.getStatusCode());
+                    String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
+                    log.error("Apple token revoke 실패: status={}, body={}", res.getStatusCode(), body);
                     throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
                 })
                 .toBodilessEntity();
@@ -191,13 +203,15 @@ public class AppleTokenVerifier {
     /**
      * Apple client_secret JWT를 생성합니다.
      * <p>
-     * Apple Developer 문서에 따라 ES256으로 서명된 JWT를 생성합니다.
+     * Apple Developer 문서에 따라 ES256으로 서명된 JWT를 생성하며,
+     * subject claim에는 호출 시 전달된 client_id가 들어갑니다.
      *
+     * @param clientId client_secret JWT의 subject claim으로 사용할 client_id
      * @see <a
      * href="https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret">Creating
      * a client secret</a>
      */
-    public String generateClientSecret() {
+    public String generateClientSecret(String clientId) {
         try {
             Instant now = Instant.now();
             Instant expiration = now.plusSeconds(3600);
@@ -209,7 +223,7 @@ public class AppleTokenVerifier {
                 .issuer(appleProperties.teamId())
                 .issuedAt(Date.from(now)).expiration(Date.from(expiration))
                 .audience().add(APPLE_ISSUER).and()
-                .subject(appleProperties.clientId())
+                .subject(clientId)
                 .signWith(getPrivateKey(), SIG.ES256)
                 .compact();
 

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java
@@ -4,6 +4,7 @@ import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.application.port.out.RevokeOAuthTokenPort;
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ public class OAuthTokenVerificationAdapter implements VerifyOAuthTokenPort, Revo
     private final GoogleTokenVerifier googleTokenVerifier;
     private final KakaoTokenVerifier kakaoTokenVerifier;
     private final AppleTokenVerifier appleTokenVerifier;
+    private final AppleOAuthProperties appleOAuthProperties;
 
     @Override
     public OAuth2Attributes verify(OAuthProvider provider, String token) {
@@ -30,20 +32,22 @@ public class OAuthTokenVerificationAdapter implements VerifyOAuthTokenPort, Revo
         return switch (provider) {
             case GOOGLE -> googleTokenVerifier.verifyAccessToken(token);
             case KAKAO -> kakaoTokenVerifier.verifyAccessToken(token);
-            case APPLE -> appleTokenVerifier.verifyIdToken(token);
+            // Apple은 일반 verify가 아닌 verifyAppleAuthorizationCode 사용을 권장하지만,
+            // ID Token 직접 검증이 필요한 경우를 위해 web Services ID 기준으로 audience를 검증한다.
+            case APPLE -> appleTokenVerifier.verifyIdToken(token, appleOAuthProperties.webClientId());
         };
     }
 
     @Override
-    public AppleAuthorizationCodeResult verifyAppleAuthorizationCode(String authorizationCode) {
-        log.info("Apple Authorization Code 교환 시작");
-        return appleTokenVerifier.verifyAuthorizationCode(authorizationCode);
+    public AppleAuthorizationCodeResult verifyAppleAuthorizationCode(String authorizationCode, ClientType clientType) {
+        log.info("Apple Authorization Code 교환 시작: clientType={}", clientType);
+        return appleTokenVerifier.verifyAuthorizationCode(authorizationCode, clientType);
     }
 
     @Override
-    public void revokeAppleToken(String refreshToken) {
-        log.info("Apple token revoke 시작");
-        appleTokenVerifier.revokeToken(refreshToken);
+    public void revokeAppleToken(String refreshToken, String clientId) {
+        log.info("Apple token revoke 시작: clientId={}", clientId);
+        appleTokenVerifier.revokeToken(refreshToken, clientId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java
@@ -35,7 +35,10 @@ public interface OAuthAuthenticationUseCase {
     void unlinkOAuth(UnlinkOAuthCommand command);
 
     /**
-     * Apple OAuth의 refresh token을 업데이트합니다.
+     * Apple OAuth의 refresh token과 client_id를 업데이트합니다.
+     * <p>
+     * Apple은 플랫폼별로 다른 client_id를 사용하기 때문에 refresh token과 함께 발급 시 사용된
+     * client_id도 저장하여 추후 revoke 시 동일한 client_id를 사용할 수 있도록 합니다.
      */
-    void updateAppleRefreshToken(OAuthProvider provider, String providerId, String refreshToken);
+    void updateAppleRefreshToken(OAuthProvider provider, String providerId, String refreshToken, String clientId);
 }

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LinkOAuthCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LinkOAuthCommand.java
@@ -9,7 +9,8 @@ public record LinkOAuthCommand(
     Long memberId,
     OAuthProvider provider,
     String providerId,
-    String appleRefreshToken
+    String appleRefreshToken,
+    String appleClientId
 ) {
     public static MemberOAuth toEntity(LinkOAuthCommand command) {
         return MemberOAuth.builder()
@@ -17,6 +18,7 @@ public record LinkOAuthCommand(
             .provider(command.provider())
             .providerId(command.providerId())
             .appleRefreshToken(command.appleRefreshToken())
+                .appleClientId(command.appleClientId())
             .build();
     }
 }

--- a/src/main/java/com/umc/product/authentication/application/port/out/AppleAuthorizationCodeResult.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/AppleAuthorizationCodeResult.java
@@ -2,5 +2,12 @@ package com.umc.product.authentication.application.port.out;
 
 import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 
-public record AppleAuthorizationCodeResult(OAuth2Attributes attrs, String refreshToken) {
+/**
+ * Apple Authorization Code 교환 결과.
+ *
+ * @param attrs        OAuth2 attributes
+ * @param refreshToken Apple refresh token (revoke 시 필요)
+ * @param clientId     교환 시 사용된 Apple client_id (revoke 시 동일한 값을 사용해야 하므로 DB에 함께 보관)
+ */
+public record AppleAuthorizationCodeResult(OAuth2Attributes attrs, String refreshToken, String clientId) {
 }

--- a/src/main/java/com/umc/product/authentication/application/port/out/RevokeOAuthTokenPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/RevokeOAuthTokenPort.java
@@ -1,7 +1,13 @@
 package com.umc.product.authentication.application.port.out;
 
 public interface RevokeOAuthTokenPort {
-    void revokeAppleToken(String refreshToken);
+    /**
+     * Apple refresh token을 revoke합니다.
+     *
+     * @param refreshToken Apple refresh token
+     * @param clientId     해당 refresh token을 발급받을 때 사용한 client_id
+     */
+    void revokeAppleToken(String refreshToken, String clientId);
 
     /**
      * Kakao Access Token을 사용하여 앱과 사용자의 연결을 해제합니다.

--- a/src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java
@@ -1,6 +1,7 @@
 package com.umc.product.authentication.application.port.out;
 
 import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 
 /**
@@ -21,10 +22,14 @@ public interface VerifyOAuthTokenPort {
 
     /**
      * Apple Authorization Code를 교환하여 사용자 정보를 추출합니다.
+     * <p>
+     * Apple은 플랫폼별로 다른 client_id(Bundle ID vs Services ID)를 사용하므로
+     * code 교환 시 클라이언트 플랫폼 정보가 필요합니다.
      *
      * @param authorizationCode Apple에서 발급받은 authorization code
-     * @return OAuth2Attributes
+     * @param clientType        클라이언트 플랫폼
+     * @return Apple authorization code 교환 결과 (사용자 정보 + refresh token + 사용된 client_id)
      * @throws com.umc.product.authentication.domain.exception.AuthenticationDomainException 코드 교환 또는 토큰 검증 실패 시
      */
-    AppleAuthorizationCodeResult verifyAppleAuthorizationCode(String authorizationCode);
+    AppleAuthorizationCodeResult verifyAppleAuthorizationCode(String authorizationCode, ClientType clientType);
 }

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -177,11 +177,17 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
     private void revokeProviderToken(MemberOAuth memberOAuth, UnlinkOAuthCommand command) {
         switch (memberOAuth.getProvider()) {
             case APPLE -> {
-                if (memberOAuth.getAppleRefreshToken() != null) {
-                    revokeOAuthTokenPort.revokeAppleToken(memberOAuth.getAppleRefreshToken());
+                if (memberOAuth.getAppleRefreshToken() != null && memberOAuth.getAppleClientId() != null) {
+                    revokeOAuthTokenPort.revokeAppleToken(
+                            memberOAuth.getAppleRefreshToken(),
+                            memberOAuth.getAppleClientId()
+                    );
                 } else {
-                    log.warn("[Apple 계정 연동 해제] refresh token이 없어 revoke를 skip합니다: memberId={} memberOAuthId={}",
-                        memberOAuth.getMemberId(), memberOAuth.getId());
+                    log.warn("[Apple 계정 연동 해제] refresh token 또는 client_id가 없어 revoke를 skip합니다: "
+                                    + "memberId={} memberOAuthId={} hasRefreshToken={} hasClientId={}",
+                            memberOAuth.getMemberId(), memberOAuth.getId(),
+                            memberOAuth.getAppleRefreshToken() != null,
+                            memberOAuth.getAppleClientId() != null);
                 }
             }
             case KAKAO -> {
@@ -204,11 +210,12 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
     }
 
     @Override
-    public void updateAppleRefreshToken(OAuthProvider provider, String providerId, String refreshToken) {
+    public void updateAppleRefreshToken(OAuthProvider provider, String providerId, String refreshToken,
+                                        String clientId) {
         MemberOAuth memberOAuth = loadMemberOAuthPort.findByProviderAndProviderId(provider, providerId)
             .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.MEMBER_OAUTH_NOT_FOUND));
 
-        memberOAuth.updateRefreshToken(refreshToken);
+        memberOAuth.updateAppleCredentials(refreshToken, clientId);
         saveMemberOAuthPort.save(memberOAuth);
     }
 }

--- a/src/main/java/com/umc/product/authentication/domain/MemberOAuth.java
+++ b/src/main/java/com/umc/product/authentication/domain/MemberOAuth.java
@@ -44,16 +44,30 @@ public class MemberOAuth extends BaseEntity {
     @Column(name = "apple_refresh_token", length = 512)
     private String appleRefreshToken;
 
+    /**
+     * Apple Sign-In 시 사용된 client_id (Bundle ID 또는 Services ID).
+     * <p>
+     * Apple은 플랫폼별로 서로 다른 client_id를 사용하므로 revoke 시 발급 시점과 동일한 값이 필요해 보관한다.
+     */
+    @Column(name = "apple_client_id", length = 255)
+    private String appleClientId;
+
     @Builder
-    private MemberOAuth(Long memberId, OAuthProvider provider, String providerId, String appleRefreshToken) {
+    private MemberOAuth(Long memberId, OAuthProvider provider, String providerId, String appleRefreshToken,
+                        String appleClientId) {
         this.memberId = memberId;
         this.provider = provider;
         this.providerId = providerId;
         this.appleRefreshToken = appleRefreshToken;
+        this.appleClientId = appleClientId;
     }
 
-    public void updateRefreshToken(String refreshToken) {
+    /**
+     * Apple 재로그인 시 refresh token과 client_id를 함께 갱신한다. 사용자가 다른 플랫폼(Web ↔ iOS)에서 다시 로그인하면 client_id가 바뀔 수 있다.
+     */
+    public void updateAppleCredentials(String refreshToken, String clientId) {
         this.appleRefreshToken = refreshToken;
+        this.appleClientId = clientId;
     }
 
     /**

--- a/src/main/java/com/umc/product/common/domain/enums/ClientType.java
+++ b/src/main/java/com/umc/product/common/domain/enums/ClientType.java
@@ -1,0 +1,7 @@
+package com.umc.product.common.domain.enums;
+
+public enum ClientType {
+    ANDROID,
+    IOS,
+    WEB
+}

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -82,6 +82,7 @@ public class MemberCommandController {
             .profileImageId(request.profileImageId())
             .termConsents(request.termsAgreements().stream().map(TermConsents::fromRequest).toList())
             .appleRefreshToken(request.appleRefreshToken())
+            .appleClientId(request.appleClientId())
             .build();
 
         Long createdMemberId = registerOAuthMemberUseCase.register(command);

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
@@ -44,6 +44,9 @@ public record OAuthRegisterMemberRequest(
     List<TermConsentStatus> termsAgreements,
 
     @Schema(description = "Apple OAuth refresh token (Apple 로그인 회원가입 시 전달)")
-    String appleRefreshToken
+    String appleRefreshToken,
+
+    @Schema(description = "Apple OAuth client_id (Apple 로그인 회원가입 시 전달, Bundle ID 또는 Services ID)")
+    String appleClientId
 ) {
 }

--- a/src/main/java/com/umc/product/member/application/port/in/command/dto/OAuthRegisterMemberCommand.java
+++ b/src/main/java/com/umc/product/member/application/port/in/command/dto/OAuthRegisterMemberCommand.java
@@ -17,6 +17,8 @@ import lombok.Builder;
  * @param email
  * @param schoolId
  * @param profileImageId
+ * @param appleRefreshToken Apple 회원가입 시 전달되는 refresh token
+ * @param appleClientId     Apple 회원가입 시 전달되는 client_id (Bundle ID 또는 Services ID)
  */
 @Builder
 public record OAuthRegisterMemberCommand(
@@ -28,7 +30,8 @@ public record OAuthRegisterMemberCommand(
     Long schoolId,
     String profileImageId,
     List<TermConsents> termConsents,
-    String appleRefreshToken
+    String appleRefreshToken,
+    String appleClientId
 ) {
 
     public Member toEntity() {

--- a/src/main/java/com/umc/product/member/application/service/MemberService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberService.java
@@ -63,6 +63,7 @@ public class MemberService implements ManageMemberUseCase, RegisterOAuthMemberUs
                 .provider(command.provider())
                 .providerId(command.providerId())
                 .appleRefreshToken(command.appleRefreshToken())
+                .appleClientId(command.appleClientId())
                 .build()
         );
 

--- a/src/main/java/com/umc/product/test/controller/TestController.java
+++ b/src/main/java/com/umc/product/test/controller/TestController.java
@@ -2,7 +2,9 @@ package com.umc.product.test.controller;
 
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.authentication.adapter.out.external.AppleOAuthProperties;
 import com.umc.product.authentication.adapter.out.external.AppleTokenVerifier;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.global.response.ApiResponse;
@@ -47,6 +49,7 @@ public class TestController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AppleTokenVerifier appleTokenVerifier;
+    private final AppleOAuthProperties appleOAuthProperties;
     private final SendWebhookAlarmUseCase sendWebhookAlarmUseCase;
     private final GetFileUseCase getFileUseCase;
     private final SendEmailUseCase sendEmailUseCase;
@@ -55,7 +58,7 @@ public class TestController {
     /**
      * 파일 정보 및 접근 URL을 조회합니다.
      */
-    @Operation(summary = "[개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.", description = """
+    @Operation(summary = "[TEST-001] [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.", description = """
         local 및 development 환경에서만 사용 가능합니다.
 
         크롤링을 방지하기 위한 절차입니다. 파일이 정상적으로 업로드되었는지 확인하는 용도로만 사용하세요.
@@ -67,7 +70,7 @@ public class TestController {
         return ApiResponse.onSuccess(FileResponse.from(fileInfo));
     }
 
-    @Operation(summary = "FCM 푸시 알림 테스트 전송")
+    @Operation(summary = "[TEST-002] FCM 푸시 알림 테스트 전송")
     @PostMapping("/fcm/test-send")
     public void sendTestNotification(@RequestBody FcmTestSendRequest request) {
         sendNotificationToAudienceUseCase.sendToMember(request.toCommand());
@@ -94,7 +97,7 @@ public class TestController {
         description = "'내용 : ' + #result.content"
     )
     @GetMapping("webhook/aop-test")
-    @Operation(summary = "AOP로 전송하는 알람 테스트")
+    @Operation(summary = "[TEST-003] AOP로 전송하는 알람 테스트")
     public TestAopAlarmResponse sendAopWebhookAlarm(
         @RequestParam String title,
         @RequestParam String content
@@ -107,7 +110,7 @@ public class TestController {
     }
 
     @PostMapping("webhook/alarm")
-    @Operation(summary = "웹훅 알람 전송 테스트")
+    @Operation(summary = "[TEST-004] 웹훅 알람 전송 테스트")
     public void sendWebhookAlarm(
         @RequestParam String title,
         @RequestParam String content
@@ -123,7 +126,7 @@ public class TestController {
 
     // buffer alarm test
     @PostMapping("webhook/alarm/buffer")
-    @Operation(summary = "웹훅 알람 버퍼 전송 테스트")
+    @Operation(summary = "[TEST-005] 웹훅 알람 버퍼 전송 테스트")
     public void sendBufferedWebhookAlarm(
         @RequestParam String title,
         @RequestParam String content,
@@ -144,13 +147,13 @@ public class TestController {
     }
 
     @GetMapping("apple-client-secret")
-    @Operation(summary = "Apple Client Secret 생성")
-    String getAppleClientSecret() {
-        return appleTokenVerifier.generateClientSecret();
+    @Operation(summary = "[TEST-006] Apple Client Secret 생성")
+    String getAppleClientSecret(@RequestParam ClientType clientType) {
+        return appleTokenVerifier.generateClientSecret(appleOAuthProperties.resolveClientId(clientType));
     }
 
     @Public
-    @Operation(summary = "AccessToken 발급")
+    @Operation(summary = "[TEST-007] AccessToken 발급")
     @GetMapping("/token/access")
     public String getAccessToken(
         @RequestParam Long memberId,
@@ -163,21 +166,21 @@ public class TestController {
             jwtTokenProvider.createAccessToken(memberId, null, expirationInMinutes * 60);
     }
 
-    @Operation(summary = "RefreshToken 발급")
+    @Operation(summary = "[TEST-008] RefreshToken 발급")
     @Public
     @GetMapping("/token/refresh")
     public String getRefreshToken(@RequestParam Long memberId) {
         return jwtTokenProvider.createRefreshToken(memberId);
     }
 
-    @Operation(summary = "EmailVerificationToken 발급")
+    @Operation(summary = "[TEST-009] EmailVerificationToken 발급")
     @Public
     @GetMapping("/token/email")
     public String getEmailVerification(@RequestParam String email) {
         return jwtTokenProvider.createEmailVerificationToken(email);
     }
 
-    @Operation(summary = "oAuthVerificationToken 발급")
+    @Operation(summary = "[TEST-010] oAuthVerificationToken 발급")
     @Public
     @GetMapping("/token/oauth")
     public String getOAuthVerificationToken(OAuthProvider provider, String providerId, String email) {
@@ -185,14 +188,14 @@ public class TestController {
     }
 
 
-    @Operation(summary = "헬스 체크 API")
+    @Operation(summary = "[TEST-011] 헬스 체크 API")
     @Public
     @GetMapping("/health-check")
     public String healthCheck() {
         return "OK";
     }
 
-    @Operation(summary = "인증된 사용자인지 여부를 확인합니다.", description = "인증되지 않은 사용자인 경우 401을 반환합니다.")
+    @Operation(summary = "[TEST-012] 인증된 사용자인지 여부를 확인합니다.", description = "인증되지 않은 사용자인 경우 401을 반환합니다.")
     @GetMapping("/check-authenticated")
     public ApiResponse<String> checkAuthenticated(@CurrentMember MemberPrincipal currentUser) {
         return ApiResponse.onSuccess(currentUser.toString());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -273,7 +273,8 @@ app:
     google:
       client-id-list: ${GOOGLE_CLIENT_ID_LIST:}
     apple:
-      client-id: ${APPLE_CLIENT_ID}
+      ios-client-id: ${APPLE_IOS_CLIENT_ID}
+      web-client-id: ${APPLE_WEB_CLIENT_ID}
       team-id: ${APPLE_TEAM_ID}
       key-id: ${APPLE_KEY_ID}
       private-key: ${APPLE_PRIVATE_KEY}

--- a/src/main/resources/db/migration/V2026.05.06.20.00__add_apple_client_id_to_member_oauth.sql
+++ b/src/main/resources/db/migration/V2026.05.06.20.00__add_apple_client_id_to_member_oauth.sql
@@ -1,0 +1,9 @@
+-- Apple Sign-In은 플랫폼별로 다른 client_id(iOS Bundle ID vs Web Services ID)를 사용한다.
+-- refresh token revoke 시 발급 당시와 동일한 client_id가 필요하므로 plain text로 보관한다.
+ALTER TABLE member_oauth
+    ADD COLUMN apple_client_id VARCHAR(255);
+
+-- 기존 APPLE provider 행은 단일 client_id를 사용했던 시절이므로 'com.umc.product'로 일괄 backfill한다.
+UPDATE member_oauth
+SET apple_client_id = 'com.umc.product'
+WHERE oauth_provider = 'APPLE';


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #827

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 이슈 #827 ("UMC Web에서 Apple Login을 지원함에 따라서, client id가 달라져서 로그인 시 환경을 분리해서 받도록 변경") 해결을 목표로 작업했어요.
- 커밋 3건(`46bc8315`, `c742708a`, `c848c88c`)이 모두 2026-05-06에 작성되어 있어요.
- 변경 범위는 authentication 도메인 전 레이어, member 도메인 회원가입 진입점, `common/domain/enums`, `test` 컨트롤러, `application.yml`, Flyway 마이그레이션 1건이에요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: 멀티 플랫폼 분기용 `ClientType` enum(`ANDROID` / `IOS` / `WEB`)을 추가했어요. (commit `46bc8315`)
   - **어떻게**: `com.umc.product.common.domain.enums.ClientType` 으로 신설했어요.
   - **왜**: 커밋 메시지에 따르면 "추후 Apple Sign-In 플랫폼별 client_id 분기 등 멀티 플랫폼 분기 처리에 공용으로 사용"하기 위함이에요. 이슈 #827 본문의 bonus 항목("FCM 등록 및 로그인 시에도 받아 추후 통계 자료로 활용")과도 연결돼요.

2. **무엇을**: Apple Sign-In 토큰 검증·취소 로직을 플랫폼별 `client_id` 기준으로 분기 처리하도록 리팩터링했어요. (commit `c742708a`)
   - **어떻게**:
     - `AppleOAuthProperties` 를 `ios-client-id` / `web-client-id` 로 분리하고 `ClientType` 별 `resolveClientId` 매핑 메서드를 제공했어요.
     - `AppleTokenVerifier` 의 `verifyAuthorizationCode`, `verifyIdToken`, `generateClientSecret`, `revokeToken` 을 모두 `clientId` 기준으로 분기하도록 시그니처를 변경했어요.
     - `VerifyOAuthTokenPort`, `RevokeOAuthTokenPort`, `OAuthAuthenticationUseCase`, `OAuthAuthenticationService` 시그니처에 `clientType` · `clientId` 를 전파했어요.
     - `AppleAuthorizationCodeResult` 에 사용된 `clientId` 를 포함시켜 호출자가 DB에 보관할 수 있게 했어요.
     - `AppleLoginRequest` 에 `clientType` 필드를 추가했고, `AuthenticationController` 가 교환 요청 시 함께 전달해요.
     - `MemberOAuth` 에 `apple_client_id` 컬럼과 `updateAppleCredentials` 도메인 메서드를 추가했고, revoke 시 발급 시점과 동일한 `client_id` 를 재사용하도록 했어요.
     - 기존 APPLE 행을 `com.umc.product` 로 backfill 하는 Flyway 마이그레이션 `V2026.05.06.20.00__add_apple_client_id_to_member_oauth.sql` 을 추가했어요.
     - 테스트용 client-secret 엔드포인트도 `ClientType` 파라미터로 분기하도록 했어요.
   - **왜**: 커밋 메시지에 따르면 "Apple Sign-In은 플랫폼에 따라 서로 다른 client_id(iOS Bundle ID vs Web Services ID)를 사용한다. 단일 client_id로는 한쪽 플랫폼에서 authorization code 교환이 invalid_grant로 실패"하기 때문이에요.

3. **무엇을**: Apple 회원가입 흐름이 `appleClientId` 를 끝까지 전파하도록 연결했어요. (commit `c848c88c`)
   - **어떻게**: `OAuthRegisterMemberRequest` / `OAuthRegisterMemberCommand` 에 `appleClientId` 필드를 추가하고, `MemberCommandController` 와 `MemberService.register` 가 `LinkOAuthCommand` 에 그 값을 전달하도록 수정했어요.
   - **왜**: 커밋 메시지에 따르면 "신규 Apple 회원의 MemberOAuth 레코드에도 발급 시 사용된 client_id 가 영속화되도록" 하기 위함이에요.

## 💬 리뷰 중점사항

- **DB 마이그레이션**: `V2026.05.06.20.00__add_apple_client_id_to_member_oauth.sql` 이 `member_oauth` 에 `apple_client_id` 컬럼을 추가하고, 기존 `oauth_provider = 'APPLE'` 행을 `com.umc.product` 로 일괄 backfill 해요. 운영 DB의 기존 APPLE 사용자가 정말로 단일 `com.umc.product` client_id 로 가입했는지 확인 부탁드려요.
- **환경 변수 분리**: `application.yml` 에서 `app.oauth.apple.client-id` 가 `ios-client-id` / `web-client-id` 로 분리되어, 환경 변수도 `APPLE_IOS_CLIENT_ID` / `APPLE_WEB_CLIENT_ID` 로 변경됐어요. 배포 환경의 환경 변수 세팅 마이그레이션 필요해요.
- **인증 흐름 시그니처 변경**: `OAuthAuthenticationService`, `AppleTokenVerifier`, `VerifyOAuthTokenPort`, `RevokeOAuthTokenPort`, `OAuthAuthenticationUseCase` 의 시그니처가 모두 변경됐어요. 호출 경로(로그인/회원가입/회원탈퇴 시 revoke)에 올바른 `clientType` 이 전달되는지 확인 부탁드려요.
- **외부 API 호출**: `AppleTokenVerifier` 가 Apple token endpoint 호출 시 사용하는 `client_id` 가 발급 시점 값과 다르면 `invalid_grant` 가 발생해요. revoke 경로에서 `MemberOAuth.apple_client_id` 가 정확히 조회·전달되는지 확인이 필요해요.