### PR TITLE
[Feat] 프로젝트 지원서 권한 인프라 추가

### DIFF
--- a/src/main/java/com/umc/product/authorization/domain/PermissionType.java
+++ b/src/main/java/com/umc/product/authorization/domain/PermissionType.java
@@ -22,6 +22,5 @@ public enum PermissionType {
     APPROVE,    // 승인 (출석, 워크북 등)
     CHECK,      // 확인 (공지사항 조회현황 확인)
     MANAGE,      // 관리 (운영진 전용)
-    RELEASE,
-    APPLY        // 지원 (챌린저의 프로젝트 지원)
+    RELEASE
 }

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -90,7 +90,8 @@ public enum ResourceType {
 
     // 프로젝트 지원서 관련
     PROJECT_APPLICATION("project_application", "프로젝트 지원서",
-        Set.of(PermissionType.WRITE)),
+        Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
+            PermissionType.DELETE, PermissionType.APPROVE)),
     ;
 
     private final String code;

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -86,7 +86,11 @@ public enum ResourceType {
     // UPMS, 프로젝트 관련
     PROJECT("project", "프로젝트",
         Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
-            PermissionType.DELETE, PermissionType.MANAGE, PermissionType.APPLY)),
+            PermissionType.DELETE, PermissionType.MANAGE)),
+
+    // 프로젝트 지원서 관련
+    PROJECT_APPLICATION("project_application", "프로젝트 지원서",
+        Set.of(PermissionType.WRITE)),
     ;
 
     private final String code;

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -40,9 +40,9 @@ public class ProjectApplicationController {
         description = "챌린저가 특정 프로젝트의 지원서를 DRAFT 상태로 생성합니다. 이미 DRAFT 지원서가 있으면 기존 application 정보 반환."
     )
     @CheckAccess(
-        resourceType = ResourceType.PROJECT,
+        resourceType = ResourceType.PROJECT_APPLICATION,
         resourceId = "#projectId",
-        permission = PermissionType.APPLY,
+        permission = PermissionType.WRITE,
         message = "지원서 생성 권한이 없습니다."
     )
     public ProjectApplicationStatusResponse createDraft(
@@ -63,9 +63,9 @@ public class ProjectApplicationController {
         description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     @CheckAccess(
-        resourceType = ResourceType.PROJECT,
+        resourceType = ResourceType.PROJECT_APPLICATION,
         resourceId = "#projectId",
-        permission = PermissionType.APPLY,
+        permission = PermissionType.WRITE,
         message = "지원서 임시저장 권한이 없습니다."
     )
     public ProjectApplicationStatusResponse updateDraft(
@@ -86,9 +86,9 @@ public class ProjectApplicationController {
         description = "DRAFT -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     @CheckAccess(
-        resourceType = ResourceType.PROJECT,
+        resourceType = ResourceType.PROJECT_APPLICATION,
         resourceId = "#projectId",
-        permission = PermissionType.APPLY,
+        permission = PermissionType.WRITE,
         message = "지원서 제출 권한이 없습니다."
     )
     public ProjectApplicationStatusResponse submit(

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -18,6 +18,11 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     private final ProjectApplicationQueryRepository projectApplicationQueryRepository;
 
     @Override
+    public Optional<ProjectApplication> findById(Long id) {
+        return projectApplicationJpaRepository.findById(id);
+    }
+
+    @Override
     public boolean existsByAppliedMatchingRoundId(Long matchingRoundId) {
         return projectApplicationJpaRepository.existsByAppliedMatchingRound_Id(matchingRoundId);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -24,4 +24,8 @@ public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember,
     List<Object[]> countByProjectIdGroupByPartRaw(@Param("projectId") Long projectId, @Param("status") ProjectMemberStatus status);
 
     boolean existsByProject_GisuIdAndMemberIdAndStatus(Long gisuId, Long memberId, ProjectMemberStatus status);
+
+    boolean existsByProjectIdAndMemberIdAndPartAndStatus(
+        Long projectId, Long memberId, ChallengerPart part, ProjectMemberStatus status
+    );
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -58,4 +58,11 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     public boolean existsByGisuAndMember(Long gisuId, Long memberId) {
         return repository.existsByProject_GisuIdAndMemberIdAndStatus(gisuId, memberId, ProjectMemberStatus.ACTIVE);
     }
+
+    @Override
+    public boolean isActivePlanMember(Long projectId, Long memberId) {
+        return repository.existsByProjectIdAndMemberIdAndPartAndStatus(
+            projectId, memberId, ChallengerPart.PLAN, ProjectMemberStatus.ACTIVE
+        );
+    }
 }

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
@@ -1,0 +1,29 @@
+package com.umc.product.project.application.access;
+
+/**
+ * 프로젝트 지원서 목록 조회 시 적용되는 가시 범위(scope) typed value.
+ * <p>
+ * 권한 판정(L2 {@code ProjectApplicationPermissionEvaluator})이 단건 binary 만 다룬다면, scope 는
+ * "어떤 부분집합을 보여줄지"를 표현한다. 같은 사용자라도 호출 의도(본인 지원 내역 vs PO 의 지원자 목록 vs 운영진 모니터링)에 따라
+ * 다른 scope 가 적용된다.
+ */
+public sealed interface ProjectApplicationAccessScope {
+
+    /** 본인이 지원자인 지원서만 노출 (본인 지원 내역 화면). */
+    record OwnerOnly(Long memberId) implements ProjectApplicationAccessScope {}
+
+    /** 특정 프로젝트의 지원서만 노출 (PO/Sub-PM 의 "내 프로젝트 지원자 목록"). */
+    record ProjectScoped(Long projectId) implements ProjectApplicationAccessScope {}
+
+    /** 특정 지부 프로젝트의 지원서 노출 (해당 기수 지부장). */
+    record ChapterScoped(Long chapterId, Long gisuId) implements ProjectApplicationAccessScope {}
+
+    /** 해당 기수의 모든 지원서 (총괄단 모니터링). SUPER_ADMIN 은 gisu 무관. */
+    record AllInGisu(Long gisuId) implements ProjectApplicationAccessScope {}
+
+    /** 글로벌 (SUPER_ADMIN). */
+    record All() implements ProjectApplicationAccessScope {}
+
+    /** 관리 대상 0건 (권한 없음). */
+    record None() implements ProjectApplicationAccessScope {}
+}

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
@@ -1,5 +1,7 @@
 package com.umc.product.project.application.access;
 
+import java.util.List;
+
 /**
  * 프로젝트 지원서 목록 조회 시 적용되는 가시 범위(scope) typed value.
  * <p>
@@ -15,8 +17,12 @@ public sealed interface ProjectApplicationAccessScope {
     /** 특정 프로젝트의 지원서만 노출 (PO/Sub-PM 의 "내 프로젝트 지원자 목록"). */
     record ProjectScoped(Long projectId) implements ProjectApplicationAccessScope {}
 
-    /** 특정 지부 프로젝트의 지원서 노출 (해당 기수 지부장). */
-    record ChapterScoped(Long chapterId, Long gisuId) implements ProjectApplicationAccessScope {}
+    /**
+     * 특정 지부들의 프로젝트 지원서 노출 (해당 기수 지부장).
+     * <p>
+     * 한 사용자가 동일 기수 내에서 여러 지부의 지부장을 맡는 경우를 지원하기 위해 List 로 받는다.
+     */
+    record ChapterScoped(List<Long> chapterIds, Long gisuId) implements ProjectApplicationAccessScope {}
 
     /** 해당 기수의 모든 지원서 (총괄단 모니터링). SUPER_ADMIN 은 gisu 무관. */
     record AllInGisu(Long gisuId) implements ProjectApplicationAccessScope {}

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -1,0 +1,91 @@
+package com.umc.product.project.application.access;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.All;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.AllInGisu;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.ChapterScoped;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.None;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.OwnerOnly;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 호출 컨텍스트(본인 지원 내역 vs PO 검토 vs 운영진 모니터링) + 사용자 역할에 따라 {@link ProjectApplicationAccessScope} 를 결정한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ProjectApplicationAccessScopeResolver {
+
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final LoadProjectPort loadProjectPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+
+    /**
+     * 본인 지원 내역 화면. 누구든지 본인 지원서만 본다.
+     */
+    public ProjectApplicationAccessScope resolveForApplicant(Long memberId) {
+        return new OwnerOnly(memberId);
+    }
+
+    /**
+     * PO/Sub-PM 의 "내 프로젝트 지원자 목록" 화면.
+     * 호출자가 부모 프로젝트의 PO 또는 보조 PM (ACTIVE PLAN 멤버) 이어야 통과.
+     * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리.
+     */
+    public ProjectApplicationAccessScope resolveForProjectReview(Long memberId, Long projectId) {
+        Project project = loadProjectPort.findById(projectId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+
+        if (Objects.equals(project.getProductOwnerMemberId(), memberId)
+            || loadProjectMemberPort.isActivePlanMember(projectId, memberId)) {
+            return new ProjectScoped(projectId);
+        }
+        return new None();
+    }
+
+    /**
+     * 운영진 모니터링 화면.
+     * <ol>
+     *   <li>SUPER_ADMIN → {@link All}</li>
+     *   <li>해당 기수 총괄단 → {@link AllInGisu}</li>
+     *   <li>해당 기수 지부장 → {@link ChapterScoped}</li>
+     *   <li>그 외 → {@link None}</li>
+     * </ol>
+     */
+    public ProjectApplicationAccessScope resolveForManagement(Long memberId, Long gisuId) {
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+
+        if (roles.stream().anyMatch(r -> r.roleType().isSuperAdmin())) {
+            return new All();
+        }
+
+        List<ChallengerRoleInfo> rolesInGisu = roles.stream()
+            .filter(r -> Objects.equals(r.gisuId(), gisuId))
+            .toList();
+
+        if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
+            return new AllInGisu(gisuId);
+        }
+
+        Optional<Long> chapterId = rolesInGisu.stream()
+            .filter(r -> r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .findFirst();
+        if (chapterId.isPresent()) {
+            return new ChapterScoped(chapterId.get(), gisuId);
+        }
+
+        return new None();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -16,7 +16,6 @@ import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -78,12 +77,12 @@ public class ProjectApplicationAccessScopeResolver {
             return new AllInGisu(gisuId);
         }
 
-        Optional<Long> chapterId = rolesInGisu.stream()
+        List<Long> chapterIds = rolesInGisu.stream()
             .filter(r -> r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT)
             .map(ChallengerRoleInfo::organizationId)
-            .findFirst();
-        if (chapterId.isPresent()) {
-            return new ChapterScoped(chapterId.get(), gisuId);
+            .toList();
+        if (!chapterIds.isEmpty()) {
+            return new ChapterScoped(chapterIds, gisuId);
         }
 
         return new None();

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -10,6 +10,11 @@ import java.util.Optional;
  */
 public interface LoadProjectApplicationPort {
 
+    /**
+     * 단건 조회. 권한 판정/단건 액션에서 사용합니다.
+     */
+    Optional<ProjectApplication> findById(Long id);
+
     boolean existsByAppliedMatchingRoundId(Long matchingRoundId);
 
     /**

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -41,4 +41,9 @@ public interface LoadProjectMemberPort {
      * 해당 기수에서 이미 ACTIVE 팀원인지 확인합니다. (중복 지원 방지용)
      */
     boolean existsByGisuAndMember(Long gisuId, Long memberId);
+
+    /**
+     * 특정 프로젝트의 ACTIVE PLAN 파트 멤버인지 확인합니다. 보조 PM(Sub-PM) 검사에 사용됩니다.
+     */
+    boolean isActivePlanMember(Long projectId, Long memberId);
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -59,8 +59,13 @@ public class ProjectApplicationCommandService implements
 
         Project project = form.getProject();
 
-        // 0. 부모 프로젝트가 모집 단계인지 검증 (도메인 규칙)
+        // 0-a. 부모 프로젝트가 모집 단계인지 검증 (도메인 규칙)
         project.validateApplicable();
+
+        // 0-b. 자기지원 차단 — PM 본인은 자기 프로젝트에 지원할 수 없다 (도메인 규칙: PO ↔ applicant 역할 충돌 방지)
+        if (project.getProductOwnerMemberId().equals(command.applicantMemberId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED);
+        }
 
         // 1. 챌린저 정보 조회 (현재 기수 챌린저 신분 + 파트 확인)
         ChallengerInfo challenger = getChallengerUseCase.getByMemberIdAndGisuId(

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -59,6 +59,9 @@ public class ProjectApplicationCommandService implements
 
         Project project = form.getProject();
 
+        // 0. 부모 프로젝트가 모집 단계인지 검증 (도메인 규칙)
+        project.validateApplicable();
+
         // 1. 챌린저 정보 조회 (현재 기수 챌린저 신분 + 파트 확인)
         ChallengerInfo challenger = getChallengerUseCase.getByMemberIdAndGisuId(
             command.applicantMemberId(), project.getGisuId()

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -1,0 +1,66 @@
+package com.umc.product.project.application.service.evaluator;
+
+import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * ProjectApplication 도메인 단건 액션의 권한 판정 (L2). subject × resource 속성 매칭만 다룬다.
+ * <p>
+ * 도메인 규칙(부모 프로젝트 status, 매칭 라운드 OPEN, 폼 정책 파트, 기수 ACTIVE 멤버, 동일 라운드 중복)은
+ * {@code Project.validateApplicable()} / {@code ProjectApplicationCommandService} 가 책임진다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ProjectApplicationPermissionEvaluator implements ResourcePermissionEvaluator {
+
+    private final LoadProjectPort loadProjectPort;
+
+    @Override
+    public ResourceType supportedResourceType() {
+        return ResourceType.PROJECT_APPLICATION;
+    }
+
+    @Override
+    public boolean evaluate(SubjectAttributes subject, ResourcePermission permission) {
+        return switch (permission.permission()) {
+            case WRITE -> canWrite(subject, permission);
+            default -> false;
+        };
+    }
+
+    /**
+     * 지원서 생성/임시저장/제출 진입 권한.
+     * <p>
+     * resourceId 는 부모 프로젝트의 ID. 단순 컨벤션상 비대칭이지만 기수 매칭/자기지원 차단을 L1 에서 처리하기 위함.
+     * <ul>
+     *   <li>부모 프로젝트의 기수에 챌린저 레코드가 있어야 함 (subject × resource 속성 매칭)</li>
+     *   <li>호출자가 부모 프로젝트의 PO 본인이면 차단 (자기지원 방지)</li>
+     * </ul>
+     * 부모 프로젝트의 status (IN_PROGRESS) / 매칭 라운드 OPEN / 폼 정책 파트 / 기수 ACTIVE 멤버 / 중복 등 도메인 규칙은 Service & Domain 가 검증한다.
+     */
+    private boolean canWrite(SubjectAttributes subject, ResourcePermission permission) {
+        Project project = loadProject(permission);
+
+        if (Objects.equals(subject.memberId(), project.getProductOwnerMemberId())) {
+            return false;
+        }
+
+        return subject.gisuChallengerInfos().stream()
+            .anyMatch(info -> Objects.equals(info.gisuId(), project.getGisuId()));
+    }
+
+    private Project loadProject(ResourcePermission permission) {
+        Long projectId = permission.getResourceIdAsLong();
+        return loadProjectPort.findById(projectId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -4,8 +4,13 @@ import com.umc.product.authorization.application.port.out.ResourcePermissionEval
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.Objects;
@@ -17,12 +22,20 @@ import org.springframework.stereotype.Component;
  * <p>
  * 도메인 규칙(부모 프로젝트 status, 매칭 라운드 OPEN, 폼 정책 파트, 기수 ACTIVE 멤버, 동일 라운드 중복)은
  * {@code Project.validateApplicable()} / {@code ProjectApplicationCommandService} 가 책임진다.
+ * <p>
+ * resourceId 의미는 권한별로 다르다:
+ * <ul>
+ *   <li>{@code WRITE} — 부모 프로젝트의 ID (지원서 인스턴스가 아직 없으므로). 컨벤션상 약한 비대칭이지만 기수 매칭/자기지원을 L1 에서 처리하기 위함.</li>
+ *   <li>{@code READ}/{@code EDIT}/{@code DELETE}/{@code APPROVE} — 지원서 인스턴스의 ID.</li>
+ * </ul>
  */
 @Component
 @RequiredArgsConstructor
 public class ProjectApplicationPermissionEvaluator implements ResourcePermissionEvaluator {
 
     private final LoadProjectPort loadProjectPort;
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
 
     @Override
     public ResourceType supportedResourceType() {
@@ -33,19 +46,20 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
     public boolean evaluate(SubjectAttributes subject, ResourcePermission permission) {
         return switch (permission.permission()) {
             case WRITE -> canWrite(subject, permission);
+            case READ -> canRead(subject, permission);
+            case EDIT -> canEdit(subject, permission);
+            case DELETE -> canDelete(subject, permission);
+            case APPROVE -> canApprove(subject, permission);
             default -> false;
         };
     }
 
     /**
      * 지원서 생성/임시저장/제출 진입 권한.
-     * <p>
-     * resourceId 는 부모 프로젝트의 ID. 단순 컨벤션상 비대칭이지만 기수 매칭/자기지원 차단을 L1 에서 처리하기 위함.
      * <ul>
-     *   <li>부모 프로젝트의 기수에 챌린저 레코드가 있어야 함 (subject × resource 속성 매칭)</li>
+     *   <li>부모 프로젝트의 기수에 챌린저 레코드가 있어야 함</li>
      *   <li>호출자가 부모 프로젝트의 PO 본인이면 차단 (자기지원 방지)</li>
      * </ul>
-     * 부모 프로젝트의 status (IN_PROGRESS) / 매칭 라운드 OPEN / 폼 정책 파트 / 기수 ACTIVE 멤버 / 중복 등 도메인 규칙은 Service & Domain 가 검증한다.
      */
     private boolean canWrite(SubjectAttributes subject, ResourcePermission permission) {
         Project project = loadProject(permission);
@@ -58,9 +72,102 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
             .anyMatch(info -> Objects.equals(info.gisuId(), project.getGisuId()));
     }
 
+    /**
+     * 단건 READ.
+     * <p>
+     * resourceId 가 없으면 목록 컨텍스트로 보고 통과(스코프 리졸버가 거른다).
+     * <p>
+     * 단건은 다음 중 하나에 해당해야 한다:
+     * <ul>
+     *   <li>지원자 본인</li>
+     *   <li>부모 프로젝트의 PO 또는 보조 PM (Sub-PM, ACTIVE PLAN 멤버)</li>
+     *   <li>(SUBMITTED 이상) 해당 기수의 SUPER_ADMIN/총괄/부총괄 또는 해당 기수+해당 지부의 지부장</li>
+     * </ul>
+     * DRAFT 는 본인만 노출 — 임시저장은 외부에 보이지 않는다.
+     */
+    private boolean canRead(SubjectAttributes subject, ResourcePermission permission) {
+        if (permission.resourceId() == null) {
+            return true;
+        }
+        ProjectApplication application = loadApplication(permission);
+        Project project = application.getApplicationForm().getProject();
+
+        if (isApplicant(subject, application)) {
+            return true;
+        }
+        if (application.getStatus() == ProjectApplicationStatus.DRAFT) {
+            return false;
+        }
+        if (isOwner(subject, project) || isSubPm(subject, project)) {
+            return true;
+        }
+        return isCentralCoreInGisu(subject, project.getGisuId())
+            || isChapterPresidentOf(subject, project.getChapterId(), project.getGisuId());
+    }
+
+    /** 임시저장(DRAFT) 상태에서만 본인이 수정 가능. */
+    private boolean canEdit(SubjectAttributes subject, ResourcePermission permission) {
+        ProjectApplication application = loadApplication(permission);
+        return isApplicant(subject, application)
+            && application.getStatus() == ProjectApplicationStatus.DRAFT;
+    }
+
+    /** 본인이 DRAFT/SUBMITTED 단계에서 철회 가능. 종결 상태(APPROVED/REJECTED)는 차단. */
+    private boolean canDelete(SubjectAttributes subject, ResourcePermission permission) {
+        ProjectApplication application = loadApplication(permission);
+        if (!isApplicant(subject, application)) {
+            return false;
+        }
+        return switch (application.getStatus()) {
+            case DRAFT, SUBMITTED -> true;
+            case APPROVED, REJECTED -> false;
+        };
+    }
+
+    /** 합불 결정. 부모 프로젝트의 PO + SUBMITTED 상태에서만. (자동 매칭 스케줄러는 권한 모델 외) */
+    private boolean canApprove(SubjectAttributes subject, ResourcePermission permission) {
+        ProjectApplication application = loadApplication(permission);
+        if (application.getStatus() != ProjectApplicationStatus.SUBMITTED) {
+            return false;
+        }
+        Project project = application.getApplicationForm().getProject();
+        return isOwner(subject, project);
+    }
+
+    private boolean isApplicant(SubjectAttributes subject, ProjectApplication application) {
+        return Objects.equals(subject.memberId(), application.getApplicantMemberId());
+    }
+
+    private boolean isOwner(SubjectAttributes subject, Project project) {
+        return Objects.equals(subject.memberId(), project.getProductOwnerMemberId());
+    }
+
+    private boolean isSubPm(SubjectAttributes subject, Project project) {
+        return loadProjectMemberPort.isActivePlanMember(project.getId(), subject.memberId());
+    }
+
+    private boolean isCentralCoreInGisu(SubjectAttributes subject, Long gisuId) {
+        return subject.roleAttributes().stream()
+            .anyMatch(role -> role.roleType().isSuperAdmin()
+                || (role.roleType().isAtLeastCentralCore() && Objects.equals(role.gisuId(), gisuId)));
+    }
+
+    private boolean isChapterPresidentOf(SubjectAttributes subject, Long chapterId, Long gisuId) {
+        return subject.roleAttributes().stream()
+            .anyMatch(role -> role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(role.gisuId(), gisuId)
+                && Objects.equals(role.organizationId(), chapterId));
+    }
+
     private Project loadProject(ResourcePermission permission) {
         Long projectId = permission.getResourceIdAsLong();
         return loadProjectPort.findById(projectId)
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    private ProjectApplication loadApplication(ResourcePermission permission) {
+        Long applicationId = permission.getResourceIdAsLong();
+        return loadProjectApplicationPort.findById(applicationId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -55,19 +55,13 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
     }
 
     /**
-     * 지원서 생성/임시저장/제출 진입 권한.
-     * <ul>
-     *   <li>부모 프로젝트의 기수에 챌린저 레코드가 있어야 함</li>
-     *   <li>호출자가 부모 프로젝트의 PO 본인이면 차단 (자기지원 방지)</li>
-     * </ul>
+     * 지원서 생성/임시저장/제출 진입 권한. subject 가 부모 프로젝트의 기수에 챌린저 레코드를 가져야 한다.
+     * <p>
+     * IN_PROGRESS 검사 / 자기지원 차단 / 매칭 라운드 OPEN / 폼 정책 파트 / 기수 ACTIVE 멤버 / 중복 등은
+     * 도메인 규칙으로 분류되어 {@code Project.validateApplicable()} 와 {@code ProjectApplicationCommandService} 가 검증한다.
      */
     private boolean canWrite(SubjectAttributes subject, ResourcePermission permission) {
         Project project = loadProject(permission);
-
-        if (Objects.equals(subject.memberId(), project.getProductOwnerMemberId())) {
-            return false;
-        }
-
         return subject.gisuChallengerInfos().stream()
             .anyMatch(info -> Objects.equals(info.gisuId(), project.getGisuId()));
     }

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -40,7 +40,6 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
             case EDIT -> canEdit(subject, permission);
             case MANAGE -> canManage(subject, permission);
             case DELETE -> isCentralCore(subject);
-            case APPLY -> canApply(subject, permission);
             default -> false;
         };
     }
@@ -124,15 +123,6 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
                 isCentralCoreInGisu(subject, project.getGisuId())
                     || isChapterPresidentOf(subject, project.getChapterId(), project.getGisuId());
             case DRAFT, COMPLETED, ABORTED -> false;
-        };
-    }
-
-    /** 챌린저 신분인 사용자만 IN_PROGRESS 프로젝트에 지원 가능. COMPLETED 포함 그 외 상태는 차단. */
-    private boolean canApply(SubjectAttributes subject, ResourcePermission permission) {
-        Project project = loadProject(permission);
-        return switch (project.getStatus()) {
-            case IN_PROGRESS -> !subject.gisuChallengerInfos().isEmpty();
-            default -> false;
         };
     }
 

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -212,6 +212,17 @@ public class Project extends BaseEntity {
     }
 
     /**
+     * 챌린저가 본 프로젝트에 지원 가능한 상태인지 검증한다.
+     * 모집 단계({@link ProjectStatus#IN_PROGRESS})에서만 허용한다.
+     * 권한 레이어({@code ProjectApplicationPermissionEvaluator}) 와 분리된 도메인 가드 — 스케줄러 등 권한 우회 경로에서도 invariant 보호.
+     */
+    public void validateApplicable() {
+        if (this.status != ProjectStatus.IN_PROGRESS) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
+    /**
      * DRAFT 상태에서 PENDING_REVIEW 상태로 전이합니다. PM 제출 액션.
      * - 현재 상태가 DRAFT가 아니면 {@code PROJECT_INVALID_STATE}.
      * - {@code name} 미입력 시 {@code PROJECT_SUBMIT_VALIDATION_FAILED}.

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -66,6 +66,7 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_ROUND_NOT_OPEN(HttpStatus.BAD_REQUEST, "PROJECT-0208", "해당 매칭 차수의 지원 기간이 아닙니다."),
     PROJECT_APPLICATION_ROUND_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "PROJECT-0209", "선택한 매칭 차수가 본인 파트에 해당하지 않습니다."),
     PROJECT_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT-0210", "이미 작성 중인 지원서가 있습니다."),
+    PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0211", "본인이 운영하는 프로젝트에는 지원할 수 없습니다."),
 
     ;
 

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -67,13 +67,13 @@ class ProjectApplicationPermissionEvaluatorTest {
     }
 
     @Test
-    void WRITE는_PO_본인이면_거부_자기지원_차단() {
+    void WRITE는_PO_본인이라도_기수_매칭하면_evaluator는_통과_자기지원_차단은_도메인에서() {
         givenProject(ProjectStatus.IN_PROGRESS);
         SubjectAttributes subject = subjectWith(PO_MEMBER_ID,
             List.of(gisuInfo(PROJECT_GISU_ID, PROJECT_CHAPTER_ID, ChallengerPart.PLAN, 99L)),
             List.of());
 
-        assertThat(sut.evaluate(subject, writePermission())).isFalse();
+        assertThat(sut.evaluate(subject, writePermission())).isTrue();
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -1,0 +1,133 @@
+package com.umc.product.project.application.service.evaluator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.authorization.domain.SubjectAttributes.GisuChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicationPermissionEvaluatorTest {
+
+    private static final Long PROJECT_GISU_ID = 1L;
+    private static final Long PROJECT_CHAPTER_ID = 1L;
+    private static final Long PROJECT_ID = 100L;
+    private static final Long PO_MEMBER_ID = 10L;
+    private static final Long APPLICANT_MEMBER_ID = 20L;
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+
+    @InjectMocks
+    ProjectApplicationPermissionEvaluator sut;
+
+    @Test
+    void supportedResourceType은_PROJECT_APPLICATION을_반환한다() {
+        assertThat(sut.supportedResourceType()).isEqualTo(ResourceType.PROJECT_APPLICATION);
+    }
+
+    // --- WRITE (resourceId = projectId) ---
+
+    @Test
+    void WRITE는_같은_기수_챌린저_허용() {
+        givenProject(ProjectStatus.IN_PROGRESS);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID,
+            List.of(gisuInfo(PROJECT_GISU_ID, PROJECT_CHAPTER_ID, ChallengerPart.SPRINGBOOT, 99L)),
+            List.of());
+
+        assertThat(sut.evaluate(subject, writePermission())).isTrue();
+    }
+
+    @Test
+    void WRITE는_PO_본인이면_거부_자기지원_차단() {
+        givenProject(ProjectStatus.IN_PROGRESS);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID,
+            List.of(gisuInfo(PROJECT_GISU_ID, PROJECT_CHAPTER_ID, ChallengerPart.PLAN, 99L)),
+            List.of());
+
+        assertThat(sut.evaluate(subject, writePermission())).isFalse();
+    }
+
+    @Test
+    void WRITE는_다른_기수_챌린저_거부() {
+        givenProject(ProjectStatus.IN_PROGRESS);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID,
+            List.of(gisuInfo(99L, PROJECT_CHAPTER_ID, ChallengerPart.SPRINGBOOT, 99L)),
+            List.of());
+
+        assertThat(sut.evaluate(subject, writePermission())).isFalse();
+    }
+
+    @Test
+    void WRITE는_챌린저_정보_없으면_거부() {
+        givenProject(ProjectStatus.IN_PROGRESS);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, writePermission())).isFalse();
+    }
+
+    // --- helpers ---
+
+    private void givenProject(ProjectStatus status) {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(PROJECT_ID, PO_MEMBER_ID, status)));
+    }
+
+    private ResourcePermission writePermission() {
+        return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, PROJECT_ID, PermissionType.WRITE);
+    }
+
+    private SubjectAttributes subjectWith(Long memberId,
+                                          List<GisuChallengerInfo> gisuInfos,
+                                          List<RoleAttribute> roles) {
+        return SubjectAttributes.builder()
+            .memberId(memberId)
+            .schoolId(1L)
+            .gisuChallengerInfos(gisuInfos)
+            .roleAttributes(roles)
+            .build();
+    }
+
+    private GisuChallengerInfo gisuInfo(Long gisuId, Long chapterId,
+                                        ChallengerPart part, Long challengerId) {
+        return GisuChallengerInfo.builder()
+            .gisuId(gisuId)
+            .chapterId(chapterId)
+            .part(part)
+            .challengerId(challengerId)
+            .build();
+    }
+
+    private Project project(Long id, Long ownerMemberId, ProjectStatus status) {
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Project project = constructor.newInstance();
+            ReflectionTestUtils.setField(project, "id", id);
+            ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "createdByMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "status", status);
+            ReflectionTestUtils.setField(project, "gisuId", PROJECT_GISU_ID);
+            ReflectionTestUtils.setField(project, "chapterId", PROJECT_CHAPTER_ID);
+            return project;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -10,8 +10,15 @@ import com.umc.product.authorization.domain.RoleAttribute;
 import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.authorization.domain.SubjectAttributes.GisuChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import java.util.List;
 import java.util.Optional;
@@ -30,9 +37,14 @@ class ProjectApplicationPermissionEvaluatorTest {
     private static final Long PROJECT_ID = 100L;
     private static final Long PO_MEMBER_ID = 10L;
     private static final Long APPLICANT_MEMBER_ID = 20L;
+    private static final Long APPLICATION_ID = 500L;
 
     @Mock
     LoadProjectPort loadProjectPort;
+    @Mock
+    LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
 
     @InjectMocks
     ProjectApplicationPermissionEvaluator sut;
@@ -82,6 +94,244 @@ class ProjectApplicationPermissionEvaluatorTest {
         assertThat(sut.evaluate(subject, writePermission())).isFalse();
     }
 
+    // --- READ (resourceId 없으면 통과 / 있으면 단건 검증) ---
+
+    @Test
+    void READ는_resourceId_없으면_무조건_허용() {
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT_APPLICATION,
+            PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_본인_허용() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_PO여도_거부() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_본인_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_부모_PO_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_보조PM_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long subPmId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, subPmId)).willReturn(true);
+        SubjectAttributes subject = subjectWith(subPmId, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_외부인_거부() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_해당_기수_총괄단_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(),
+            List.of(centralCoreRoleInGisu(PROJECT_GISU_ID)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_다른_기수_총괄단_거부() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(),
+            List.of(centralCoreRoleInGisu(99L)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_SUPER_ADMIN_허용_기수_무관() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(),
+            List.of(superAdminRoleInGisu(99L)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_해당_기수_해당_지부_지부장_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(),
+            List.of(chapterPresidentRole(PROJECT_CHAPTER_ID, PROJECT_GISU_ID)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_SUBMITTED_지원서를_다른_지부_지부장_거부() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long outsiderId = 30L;
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, outsiderId)).willReturn(false);
+        SubjectAttributes subject = subjectWith(outsiderId, List.of(),
+            List.of(chapterPresidentRole(2L, PROJECT_GISU_ID)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_APPROVED_지원서를_본인_허용() {
+        givenApplication(ProjectApplicationStatus.APPROVED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    // --- EDIT ---
+
+    @Test
+    void EDIT는_DRAFT_지원서를_본인_허용() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, editPermission())).isTrue();
+    }
+
+    @Test
+    void EDIT는_SUBMITTED_지원서를_본인이라도_거부() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, editPermission())).isFalse();
+    }
+
+    @Test
+    void EDIT는_DRAFT_지원서를_타인_거부() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, editPermission())).isFalse();
+    }
+
+    // --- DELETE ---
+
+    @Test
+    void DELETE는_본인_DRAFT_허용() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, deletePermission())).isTrue();
+    }
+
+    @Test
+    void DELETE는_본인_SUBMITTED_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, deletePermission())).isTrue();
+    }
+
+    @Test
+    void DELETE는_본인_APPROVED_거부() {
+        givenApplication(ProjectApplicationStatus.APPROVED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, deletePermission())).isFalse();
+    }
+
+    @Test
+    void DELETE는_본인_REJECTED_거부() {
+        givenApplication(ProjectApplicationStatus.REJECTED);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, deletePermission())).isFalse();
+    }
+
+    @Test
+    void DELETE는_타인_거부() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, deletePermission())).isFalse();
+    }
+
+    // --- APPROVE ---
+
+    @Test
+    void APPROVE는_부모_PO_SUBMITTED_허용() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, approvePermission())).isTrue();
+    }
+
+    @Test
+    void APPROVE는_부모_PO_DRAFT_거부() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, approvePermission())).isFalse();
+    }
+
+    @Test
+    void APPROVE는_부모_PO_APPROVED_거부_재승인_차단() {
+        givenApplication(ProjectApplicationStatus.APPROVED);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, approvePermission())).isFalse();
+    }
+
+    @Test
+    void APPROVE는_보조PM_거부_PO만_가능() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        Long subPmId = 30L;
+        SubjectAttributes subject = subjectWith(subPmId, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, approvePermission())).isFalse();
+    }
+
+    @Test
+    void APPROVE는_총괄단도_거부_자동매칭은_권한_외() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(30L, List.of(),
+            List.of(centralCoreRoleInGisu(PROJECT_GISU_ID)));
+
+        assertThat(sut.evaluate(subject, approvePermission())).isFalse();
+    }
+
     // --- helpers ---
 
     private void givenProject(ProjectStatus status) {
@@ -89,8 +339,31 @@ class ProjectApplicationPermissionEvaluatorTest {
             .willReturn(Optional.of(project(PROJECT_ID, PO_MEMBER_ID, status)));
     }
 
+    private void givenApplication(ProjectApplicationStatus status) {
+        Project project = project(PROJECT_ID, PO_MEMBER_ID, ProjectStatus.IN_PROGRESS);
+        ProjectApplicationForm form = applicationForm(project);
+        ProjectApplication application = application(APPLICATION_ID, APPLICANT_MEMBER_ID, status, form);
+        given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+    }
+
     private ResourcePermission writePermission() {
         return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, PROJECT_ID, PermissionType.WRITE);
+    }
+
+    private ResourcePermission readPermission() {
+        return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, APPLICATION_ID, PermissionType.READ);
+    }
+
+    private ResourcePermission editPermission() {
+        return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, APPLICATION_ID, PermissionType.EDIT);
+    }
+
+    private ResourcePermission deletePermission() {
+        return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, APPLICATION_ID, PermissionType.DELETE);
+    }
+
+    private ResourcePermission approvePermission() {
+        return ResourcePermission.of(ResourceType.PROJECT_APPLICATION, APPLICATION_ID, PermissionType.APPROVE);
     }
 
     private SubjectAttributes subjectWith(Long memberId,
@@ -114,6 +387,30 @@ class ProjectApplicationPermissionEvaluatorTest {
             .build();
     }
 
+    private RoleAttribute centralCoreRoleInGisu(Long gisuId) {
+        return new RoleAttribute(
+            ChallengerRoleType.CENTRAL_PRESIDENT,
+            OrganizationType.CENTRAL,
+            null, null, gisuId
+        );
+    }
+
+    private RoleAttribute superAdminRoleInGisu(Long gisuId) {
+        return new RoleAttribute(
+            ChallengerRoleType.SUPER_ADMIN,
+            OrganizationType.CENTRAL,
+            null, null, gisuId
+        );
+    }
+
+    private RoleAttribute chapterPresidentRole(Long chapterId, Long gisuId) {
+        return new RoleAttribute(
+            ChallengerRoleType.CHAPTER_PRESIDENT,
+            OrganizationType.CHAPTER,
+            chapterId, null, gisuId
+        );
+    }
+
     private Project project(Long id, Long ownerMemberId, ProjectStatus status) {
         try {
             var constructor = Project.class.getDeclaredConstructor();
@@ -126,6 +423,37 @@ class ProjectApplicationPermissionEvaluatorTest {
             ReflectionTestUtils.setField(project, "gisuId", PROJECT_GISU_ID);
             ReflectionTestUtils.setField(project, "chapterId", PROJECT_CHAPTER_ID);
             return project;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ProjectApplicationForm applicationForm(Project project) {
+        try {
+            var constructor = ProjectApplicationForm.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ProjectApplicationForm form = constructor.newInstance();
+            ReflectionTestUtils.setField(form, "id", 200L);
+            ReflectionTestUtils.setField(form, "project", project);
+            ReflectionTestUtils.setField(form, "formId", 300L);
+            return form;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ProjectApplication application(Long id, Long applicantMemberId,
+                                           ProjectApplicationStatus status,
+                                           ProjectApplicationForm form) {
+        try {
+            var constructor = ProjectApplication.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ProjectApplication application = constructor.newInstance();
+            ReflectionTestUtils.setField(application, "id", id);
+            ReflectionTestUtils.setField(application, "applicantMemberId", applicantMemberId);
+            ReflectionTestUtils.setField(application, "status", status);
+            ReflectionTestUtils.setField(application, "applicationForm", form);
+            return application;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -280,6 +280,56 @@ class ProjectTest {
         }
     }
 
+    @Nested
+    class validateApplicable {
+
+        @Test
+        void IN_PROGRESS_상태에서는_통과() {
+            setStatus(project, ProjectStatus.IN_PROGRESS);
+
+            project.validateApplicable();
+        }
+
+        @Test
+        void DRAFT_상태에서는_PROJECT_INVALID_STATE() {
+            // setUp 의 project 가 DRAFT
+            assertThatThrownBy(() -> project.validateApplicable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void PENDING_REVIEW_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.PENDING_REVIEW);
+
+            assertThatThrownBy(() -> project.validateApplicable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void COMPLETED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            assertThatThrownBy(() -> project.validateApplicable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void ABORTED_상태에서는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.ABORTED);
+
+            assertThatThrownBy(() -> project.validateApplicable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+    }
+
     private void setStatus(Project project, ProjectStatus status) {
         try {
             var field = Project.class.getDeclaredField("status");


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- related to #832 

## 🚀 작업 내용

[#818](https://github.com/UMC-PRODUCT/umc-product-server/pull/818) 에서 도입된 `PROJECT.APPLY` 임시 권한을 정리하고, 지원서 도메인 전체의 단건/목록 권한 인프라를 추가했습니다.

1. WRITE 권한 마이그레이션 — `PROJECT.APPLY` → `PROJECT_APPLICATION.WRITE`
- `PermissionType.APPLY` 제거, `ResourceType.PROJECT_APPLICATION` 신설
- `ProjectPermissionEvaluator.canApply()` 제거 → `ProjectApplicationPermissionEvaluator.canWrite()` 신설
- L1 권한 검사 강화: 기수 매칭 (이전엔 `gisuChallengerInfos.isEmpty()` 만 검사 — 9기 챌린저가 10기 프로젝트에 통과되던 문제) + PM 자기지원 차단
- IN_PROGRESS 검사를 권한 레이어 → 도메인 가드(`Project.validateApplicable()`) 로 이동. 도메인 규칙은 도메인이 책임지도록 분리 (응답도 403 → 400 PROJECT_INVALID_STATE)

2. 단건 권한 추가 — READ / EDIT / DELETE / APPROVE
지원서 인스턴스에 대한 액션 권한 매트릭스:

| Permission | 통과 조건 |
|---|---|
| **READ** | 본인 ∪ PO ∪ Sub-PM ∪ (SUBMITTED 이상: 해당 기수 SUPER_ADMIN/총괄/부총괄, 해당 기수+해당 지부 지부장). DRAFT 는 본인만. |
| **EDIT** | 본인 + DRAFT |
| **DELETE** | 본인 + DRAFT/SUBMITTED. APPROVED/REJECTED 차단. |
| **APPROVE** | 부모 PO + SUBMITTED. (자동 매칭 스케줄러는 권한 모델 외) |

- `LoadProjectApplicationPort.findById`, `LoadProjectMemberPort.isActivePlanMember`(Sub-PM 검사) 추가

3. 목록 가시 범위 — AccessScope + Resolver 

- `resolveForApplicant` — 본인 지원 내역
- `resolveForProjectReview` — PO/Sub-PM 의 "내 프로젝트 지원자 목록"
- `resolveForManagement` — 운영진 모니터링 (총괄단/지부장 차등)

> 권한 인프라만 선행 정비 - 지원 현황 등의 조회에서 필요하다면 scope 수정해야해요.

## 💬 리뷰 중점사항