### PR TITLE
[Feat] 매칭 차수 사이에 질문 수정 기능 추가

### DIFF
--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -8,6 +8,7 @@ import com.umc.product.project.application.port.in.command.dto.UpsertApplication
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
@@ -15,6 +16,7 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.command.ManageFormSectionUseCase;
@@ -25,6 +27,7 @@ import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCom
 import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
@@ -41,6 +44,7 @@ import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInf
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
 import com.umc.product.survey.domain.enums.QuestionType;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -70,6 +74,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         Set.of(QuestionType.RADIO, QuestionType.CHECKBOX, QuestionType.DROPDOWN);
 
     private final LoadProjectPort loadProjectPort;
+    private final LoadProjectMatchingRoundPort loadMatchingRoundPort;
     private final LoadProjectApplicationFormPort loadApplicationFormPort;
     private final SaveProjectApplicationFormPort saveApplicationFormPort;
     private final LoadProjectApplicationFormPolicyPort loadPolicyPort;
@@ -87,7 +92,10 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         validateOptionTypeRules(command.sections());
 
         Project project = loadProjectPort.getById(command.projectId());
-        project.validateApplicationFormEditable();
+        boolean hasActiveRound = !loadMatchingRoundPort.listOpenAt(project.getChapterId(), Instant.now()).isEmpty();
+        project.validateApplicationFormEditable(hasActiveRound);
+
+        boolean shouldFork = project.getStatus() == ProjectStatus.IN_PROGRESS;
 
         ProjectApplicationForm applicationForm;
         FormWithStructureInfo existingStructure;
@@ -104,7 +112,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
             existingStructure = emptyStructureFor(applicationForm.getFormId());
         }
 
-        applyDiff(applicationForm, existingStructure, command);
+        applyDiff(applicationForm, existingStructure, command, shouldFork);
 
         return assembleResponse(applicationForm);
     }
@@ -173,7 +181,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
     private void applyDiff(
         ProjectApplicationForm applicationForm,
         FormWithStructureInfo existing,
-        UpsertApplicationFormCommand command
+        UpsertApplicationFormCommand command,
+        boolean shouldFork
     ) {
         Map<Long, SectionWithQuestions> existingSectionById = existing.sections().stream()
             .collect(Collectors.toMap(SectionWithQuestions::sectionId, Function.identity()));
@@ -185,7 +194,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         validateQuestionAndOptionIds(command.sections(), existingSectionById);
 
         List<Long> orderedSectionIds = applySectionDiff(
-            applicationForm, command, existingSectionById, policyByFormSectionId
+            applicationForm, command, existingSectionById, policyByFormSectionId, shouldFork
         );
 
         deleteRemovedSections(command.sections(), existing.sections(), command.requesterMemberId());
@@ -205,7 +214,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         ProjectApplicationForm applicationForm,
         UpsertApplicationFormCommand command,
         Map<Long, SectionWithQuestions> existingSectionById,
-        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId
+        Map<Long, ProjectApplicationFormPolicy> policyByFormSectionId,
+        boolean shouldFork
     ) {
         List<Long> orderedSectionIds = new ArrayList<>();
         for (ApplicationFormSectionEntry entry : command.sections()) {
@@ -215,7 +225,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
                     entry,
                     existingSectionById.get(entry.sectionId()),
                     policyByFormSectionId.get(entry.sectionId()),
-                    command.requesterMemberId()
+                    command.requesterMemberId(),
+                    shouldFork
                 );
             orderedSectionIds.add(sectionId);
         }
@@ -260,7 +271,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
         ApplicationFormSectionEntry entry,
         SectionWithQuestions existingSection,
         ProjectApplicationFormPolicy existingPolicy,
-        Long requesterMemberId
+        Long requesterMemberId,
+        boolean shouldFork
     ) {
         if (sectionMetaChanged(existingSection, entry)) {
             manageFormSectionUseCase.updateSection(
@@ -278,7 +290,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
             savePolicyPort.save(existingPolicy);
         }
 
-        applyQuestionDiff(entry, existingSection, requesterMemberId);
+        applyQuestionDiff(entry, existingSection, requesterMemberId, shouldFork);
         return entry.sectionId();
     }
 
@@ -309,7 +321,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
     private void applyQuestionDiff(
         ApplicationFormSectionEntry sectionEntry,
         SectionWithQuestions existingSection,
-        Long requesterMemberId
+        Long requesterMemberId,
+        boolean shouldFork
     ) {
         Map<Long, QuestionWithOptions> existingQuestionById = existingSection.questions().stream()
             .collect(Collectors.toMap(QuestionWithOptions::questionId, Function.identity()));
@@ -321,7 +334,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
                 : updateExistingQuestion(
                     questionEntry,
                     existingQuestionById.get(questionEntry.questionId()),
-                    requesterMemberId
+                    requesterMemberId,
+                    shouldFork
                 );
             orderedQuestionIds.add(questionId);
         }
@@ -372,9 +386,32 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
     private Long updateExistingQuestion(
         ApplicationQuestionEntry entry,
         QuestionWithOptions existingQuestion,
-        Long requesterMemberId
+        Long requesterMemberId,
+        boolean shouldFork
     ) {
         if (questionMetaChanged(existingQuestion, entry)) {
+            if (shouldFork) {
+                Long newQuestionId = manageQuestionUseCase.forkQuestion(
+                    ForkQuestionCommand.builder()
+                        .originQuestionId(entry.questionId())
+                        .requesterMemberId(requesterMemberId)
+                        .build()
+                );
+                List<Long> newOptionIds = new ArrayList<>();
+                for (ApplicationQuestionOptionEntry optionEntry : entry.options()) {
+                    newOptionIds.add(createNewOption(newQuestionId, optionEntry, requesterMemberId));
+                }
+                if (!newOptionIds.isEmpty()) {
+                    manageQuestionOptionUseCase.reorderOptions(
+                        ReorderQuestionOptionsCommand.builder()
+                            .questionId(newQuestionId)
+                            .requesterMemberId(requesterMemberId)
+                            .orderedOptionIds(newOptionIds)
+                            .build()
+                    );
+                }
+                return newQuestionId;
+            }
             manageQuestionUseCase.updateQuestion(
                 UpdateQuestionCommand.builder()
                     .questionId(entry.questionId())

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -340,7 +340,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
             orderedQuestionIds.add(questionId);
         }
 
-        deleteRemovedQuestions(sectionEntry.questions(), existingSection.questions(), requesterMemberId);
+        deleteRemovedQuestions(sectionEntry.questions(), existingSection.questions(), requesterMemberId, shouldFork);
 
         if (!orderedQuestionIds.isEmpty()) {
             manageQuestionUseCase.reorderQuestions(
@@ -431,7 +431,8 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
     private void deleteRemovedQuestions(
         List<ApplicationQuestionEntry> requestQuestions,
         List<QuestionWithOptions> existingQuestions,
-        Long requesterMemberId
+        Long requesterMemberId,
+        boolean shouldFork
     ) {
         Set<Long> requestedExistingIds = requestQuestions.stream()
             .map(ApplicationQuestionEntry::questionId)
@@ -442,12 +443,17 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
             if (requestedExistingIds.contains(existing.questionId())) {
                 continue;
             }
-            manageQuestionUseCase.deleteQuestion(
-                DeleteQuestionCommand.builder()
-                    .questionId(existing.questionId())
-                    .requesterMemberId(requesterMemberId)
-                    .build()
-            );
+            if (shouldFork) {
+                // 차수 사이 수정: 기존 응답자의 Answer 보존을 위해 물리 삭제 대신 비활성화
+                manageQuestionUseCase.deactivateQuestion(existing.questionId());
+            } else {
+                manageQuestionUseCase.deleteQuestion(
+                    DeleteQuestionCommand.builder()
+                        .questionId(existing.questionId())
+                        .requesterMemberId(requesterMemberId)
+                        .build()
+                );
+            }
         }
     }
 

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -201,14 +201,16 @@ public class Project extends BaseEntity {
     /**
      * 지원 폼을 편집 가능한 상태인지 검증한다.
      * <p>
-     * Form 은 Project 가 IN_PROGRESS 로 전이되는 시점(PROJECT-108)에 PUBLISHED 로 같이 전이되므로,
-     * 편집은 {@code DRAFT} / {@code PENDING_REVIEW} 단계에서만 허용된다.
-     * Survey 단의 {@code SURVEY_ALREADY_PUBLISHED} 가드와 2단 방어 관계.
+     * - {@code DRAFT} / {@code PENDING_REVIEW}: 항상 허용.
+     * - {@code IN_PROGRESS}: 활성 매칭 차수가 없을 때(차수 사이)만 허용. 차수 진행 중에는 금지.
+     * - 그 외 상태: 금지.
+     *
+     * @param hasActiveRound 현재 시점에 활성화된 매칭 차수 존재 여부
      */
-    public void validateApplicationFormEditable() {
-        if (this.status != ProjectStatus.DRAFT && this.status != ProjectStatus.PENDING_REVIEW) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
-        }
+    public void validateApplicationFormEditable(boolean hasActiveRound) {
+        if (this.status == ProjectStatus.DRAFT || this.status == ProjectStatus.PENDING_REVIEW) return;
+        if (this.status == ProjectStatus.IN_PROGRESS && !hasActiveRound) return;
+        throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
     }
 
     /**

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
@@ -16,19 +16,20 @@ public class QuestionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 섹션에 속한 모든 질문을 orderNo 오름차순으로 조회.
+     * 섹션에 속한 Active 질문을 orderNo 오름차순으로 조회.
      */
     public List<Question> findAllBySectionId(Long sectionId) {
         QQuestion q = QQuestion.question;
         return queryFactory
             .selectFrom(q)
-            .where(q.formSection.id.eq(sectionId))
+            .where(q.formSection.id.eq(sectionId)
+                .and(q.isActive.isTrue()))
             .orderBy(q.orderNo.asc())
             .fetch();
     }
 
     /**
-     * 여러 섹션의 모든 질문을 벌크 조회. orderNo 오름차순 정렬.
+     * 여러 섹션의 Active 질문을 벌크 조회. orderNo 오름차순 정렬.
      */
     public List<Question> findAllBySectionIdIn(Set<Long> sectionIds) {
         if (sectionIds.isEmpty()) {
@@ -37,7 +38,8 @@ public class QuestionQueryRepository {
         QQuestion q = QQuestion.question;
         return queryFactory
             .selectFrom(q)
-            .where(q.formSection.id.in(sectionIds))
+            .where(q.formSection.id.in(sectionIds)
+                .and(q.isActive.isTrue()))
             .orderBy(q.orderNo.asc())
             .fetch();
     }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
@@ -49,7 +49,8 @@ public interface ManageQuestionUseCase {
 
     /**
      * 기존 질문을 기반으로 새 버전을 생성한다 (Copy-on-Write).
-     * 원본 질문의 모든 속성과 선택지를 복사하고, 원본은 비활성화(isActive=false)된다.
+     * 원본 질문의 속성을 복사하고 원본은 비활성화(isActive=false)한다.
+     * 선택지는 호출 측(ProjectApplicationFormCommandService)에서 요청 데이터를 기반으로 별도 생성한다.
      * 차수 사이 폼 수정 시 기존 응답자의 질문 내용을 보존하기 위해 사용한다.
      *
      * @return 새로 생성된 Question ID

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
@@ -2,6 +2,7 @@ package com.umc.product.survey.application.port.in.command;
 
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
 
@@ -39,4 +40,13 @@ public interface ManageQuestionUseCase {
      * 섹션에 속한 모든 질문 ID가 포함되어야 한다.
      */
     void reorderQuestions(ReorderQuestionsCommand command);
+
+    /**
+     * 기존 질문을 기반으로 새 버전을 생성한다 (Copy-on-Write).
+     * 원본 질문의 모든 속성과 선택지를 복사하고, 원본은 비활성화(isActive=false)된다.
+     * 차수 사이 폼 수정 시 기존 응답자의 질문 내용을 보존하기 위해 사용한다.
+     *
+     * @return 새로 생성된 Question ID
+     */
+    Long forkQuestion(ForkQuestionCommand command);
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/ManageQuestionUseCase.java
@@ -42,6 +42,12 @@ public interface ManageQuestionUseCase {
     void reorderQuestions(ReorderQuestionsCommand command);
 
     /**
+     * 질문을 비활성화한다 (isActive = false).
+     * 차수 사이 폼 수정 시 질문을 폼에서 제거할 때 사용하며, 기존 응답자의 Answer를 보존하기 위해 물리 삭제 대신 비활성화만 수행한다.
+     */
+    void deactivateQuestion(Long questionId);
+
+    /**
      * 기존 질문을 기반으로 새 버전을 생성한다 (Copy-on-Write).
      * 원본 질문의 모든 속성과 선택지를 복사하고, 원본은 비활성화(isActive=false)된다.
      * 차수 사이 폼 수정 시 기존 응답자의 질문 내용을 보존하기 위해 사용한다.

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/ForkQuestionCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/ForkQuestionCommand.java
@@ -1,0 +1,14 @@
+package com.umc.product.survey.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * 기존 질문을 기반으로 새 버전을 생성하는 Command (Copy-on-Write).
+ * 원본 질문의 모든 속성과 선택지를 복사하며, 원본은 비활성화된다.
+ */
+@Builder
+public record ForkQuestionCommand(
+    Long originQuestionId,
+    Long requesterMemberId
+) {
+}

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -7,14 +7,12 @@ import com.umc.product.survey.application.port.in.command.dto.ForkQuestionComman
 import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
 import com.umc.product.survey.application.port.out.LoadFormSectionPort;
-import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.survey.application.port.out.LoadQuestionPort;
 import com.umc.product.survey.application.port.out.SaveAnswerPort;
 import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
 import com.umc.product.survey.application.port.out.SaveQuestionPort;
 import com.umc.product.survey.domain.FormSection;
 import com.umc.product.survey.domain.Question;
-import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
@@ -36,7 +34,6 @@ public class QuestionCommandService implements ManageQuestionUseCase {
 
     private final LoadFormSectionPort loadFormSectionPort;
     private final LoadQuestionPort loadQuestionPort;
-    private final LoadQuestionOptionPort loadQuestionOptionPort;
     private final SaveQuestionPort saveQuestionPort;
     private final SaveQuestionOptionPort saveQuestionOptionPort;
     private final SaveAnswerPort saveAnswerPort;
@@ -125,13 +122,6 @@ public class QuestionCommandService implements ManageQuestionUseCase {
 
         origin.deactivate();
         saveQuestionPort.save(origin);
-
-        List<QuestionOption> originOptions = loadQuestionOptionPort.listByQuestionId(origin.getId());
-        for (QuestionOption originOption : originOptions) {
-            QuestionOption copied = QuestionOption.copyFrom(originOption);
-            copied.assignTo(forked);
-            saveQuestionOptionPort.save(copied);
-        }
 
         return forked.getId();
     }

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -3,15 +3,18 @@ package com.umc.product.survey.application.service.command;
 import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateQuestionCommand;
 import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.survey.application.port.out.LoadQuestionPort;
 import com.umc.product.survey.application.port.out.SaveAnswerPort;
 import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
 import com.umc.product.survey.application.port.out.SaveQuestionPort;
 import com.umc.product.survey.domain.FormSection;
 import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
@@ -33,6 +36,7 @@ public class QuestionCommandService implements ManageQuestionUseCase {
 
     private final LoadFormSectionPort loadFormSectionPort;
     private final LoadQuestionPort loadQuestionPort;
+    private final LoadQuestionOptionPort loadQuestionOptionPort;
     private final SaveQuestionPort saveQuestionPort;
     private final SaveQuestionOptionPort saveQuestionOptionPort;
     private final SaveAnswerPort saveAnswerPort;
@@ -108,6 +112,28 @@ public class QuestionCommandService implements ManageQuestionUseCase {
         }
 
         saveQuestionPort.saveAll(questions);
+    }
+
+    @Override
+    public Long forkQuestion(ForkQuestionCommand command) {
+        Question origin = loadQuestionPort.findById(command.originQuestionId())
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
+
+        Question forked = Question.fork(origin);
+        forked.assignTo(origin.getFormSection());
+        saveQuestionPort.save(forked);
+
+        origin.deactivate();
+        saveQuestionPort.save(origin);
+
+        List<QuestionOption> originOptions = loadQuestionOptionPort.listByQuestionId(origin.getId());
+        for (QuestionOption originOption : originOptions) {
+            QuestionOption copied = QuestionOption.copyFrom(originOption);
+            copied.assignTo(forked);
+            saveQuestionOptionPort.save(copied);
+        }
+
+        return forked.getId();
     }
 
     /**

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -112,6 +112,14 @@ public class QuestionCommandService implements ManageQuestionUseCase {
     }
 
     @Override
+    public void deactivateQuestion(Long questionId) {
+        Question question = loadQuestionPort.findById(questionId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));
+        question.deactivate();
+        saveQuestionPort.save(question);
+    }
+
+    @Override
     public Long forkQuestion(ForkQuestionCommand command) {
         Question origin = loadQuestionPort.findById(command.originQuestionId())
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.QUESTION_NOT_FOUND));

--- a/src/main/java/com/umc/product/survey/domain/Question.java
+++ b/src/main/java/com/umc/product/survey/domain/Question.java
@@ -37,6 +37,13 @@ public class Question extends BaseEntity {
     @Column(name = "order_no", nullable = false)
     private Long orderNo;
 
+    @Column(name = "parent_question_id")
+    private Long parentQuestionId;
+
+    @Builder.Default
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
     public static Question create(
         String title,
         QuestionType type,
@@ -48,11 +55,32 @@ public class Question extends BaseEntity {
             .type(type)
             .isRequired(isRequired)
             .orderNo(orderNo)
+            .isActive(true)
+            .build();
+    }
+
+    /**
+     * 기존 질문을 원본으로 새 질문을 생성한다 (Copy-on-Write).
+     * 원본 질문에 이미 응답이 존재할 때 호출하며, 호출 측에서 origin.deactivate() 를 함께 수행해야 한다.
+     */
+    public static Question fork(Question origin) {
+        return Question.builder()
+            .title(origin.title)
+            .description(origin.description)
+            .type(origin.type)
+            .isRequired(origin.isRequired)
+            .orderNo(origin.orderNo)
+            .parentQuestionId(origin.id)
+            .isActive(true)
             .build();
     }
 
     public void assignTo(FormSection section) {
         this.formSection = section;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
     }
 
     /**

--- a/src/main/java/com/umc/product/survey/domain/QuestionOption.java
+++ b/src/main/java/com/umc/product/survey/domain/QuestionOption.java
@@ -38,14 +38,6 @@ public class QuestionOption extends BaseEntity {
             .build();
     }
 
-    public static QuestionOption copyFrom(QuestionOption origin) {
-        return QuestionOption.builder()
-            .content(origin.content)
-            .orderNo(origin.orderNo)
-            .isOther(origin.isOther)
-            .build();
-    }
-
     /**
      * 선택지 속성 부분 업데이트.
      * null 인 필드는 기존 값 유지.

--- a/src/main/java/com/umc/product/survey/domain/QuestionOption.java
+++ b/src/main/java/com/umc/product/survey/domain/QuestionOption.java
@@ -38,6 +38,14 @@ public class QuestionOption extends BaseEntity {
             .build();
     }
 
+    public static QuestionOption copyFrom(QuestionOption origin) {
+        return QuestionOption.builder()
+            .content(origin.content)
+            .orderNo(origin.orderNo)
+            .isOther(origin.isOther)
+            .build();
+    }
+
     /**
      * 선택지 속성 부분 업데이트.
      * null 인 필드는 기존 값 유지.

--- a/src/main/resources/db/migration/V2026.05.07.20.42__add_question_versioning.sql
+++ b/src/main/resources/db/migration/V2026.05.07.20.42__add_question_versioning.sql
@@ -1,0 +1,3 @@
+ALTER TABLE question
+    ADD COLUMN parent_question_id  BIGINT  NULL REFERENCES question (id),
+    ADD COLUMN is_active           BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -18,6 +18,7 @@ import com.umc.product.project.application.port.in.command.dto.UpsertApplication
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
@@ -36,6 +37,7 @@ import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCom
 import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
@@ -50,9 +52,12 @@ import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInf
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
 import com.umc.product.survey.domain.enums.FormStatus;
 import com.umc.product.survey.domain.enums.QuestionType;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,11 +67,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationFormCommandServiceTest {
 
     @Mock
     LoadProjectPort loadProjectPort;
+    @Mock
+    LoadProjectMatchingRoundPort loadMatchingRoundPort;
     @Mock
     LoadProjectApplicationFormPort loadApplicationFormPort;
     @Mock
@@ -88,6 +98,11 @@ class ProjectApplicationFormCommandServiceTest {
 
     @InjectMocks
     ProjectApplicationFormCommandService sut;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(loadMatchingRoundPort.listOpenAt(any(), any(Instant.class))).thenReturn(List.of());
+    }
 
     /* =====================================================
      * 폼 라이프사이클 (C6 회귀 보장)
@@ -185,14 +200,61 @@ class ProjectApplicationFormCommandServiceTest {
         }
 
         @Test
-        void Project가_IN_PROGRESS면_PROJECT_INVALID_STATE() {
+        void Project가_IN_PROGRESS이고_활성_차수_있으면_PROJECT_INVALID_STATE() {
             Project project = createProject(42L, ProjectStatus.IN_PROGRESS, "Triple");
             given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadMatchingRoundPort.listOpenAt(any(), any(Instant.class)))
+                .willReturn(List.of(mock(com.umc.product.project.domain.ProjectMatchingRound.class)));
 
             assertThatThrownBy(() -> sut.upsert(emptyCommand(42L)))
-                .isInstanceOf(ProjectDomainException.class);
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
 
             then(manageFormUseCase).should(never()).createDraft(any());
+        }
+    }
+
+    /* =====================================================
+     * fork 시나리오 (차수 사이 질문 수정)
+     * ===================================================== */
+
+    @Nested
+    class forkScenario {
+
+        @Test
+        @DisplayName("IN_PROGRESS 차수 사이에 질문 title 변경 시 forkQuestion 호출")
+        void IN_PROGRESS_차수_사이_질문_title_변경시_forkQuestion_호출() {
+            Project project = createProject(42L, ProjectStatus.IN_PROGRESS, "Triple");
+            ProjectApplicationForm form = createApplicationForm(project, 100L, 500L);
+
+            given(loadProjectPort.getById(42L)).willReturn(project);
+            given(loadApplicationFormPort.findByProjectId(42L)).willReturn(Optional.of(form));
+            given(getFormUseCase.getFormWithStructure(500L))
+                .willReturn(structure(List.of(
+                    existingSection(1000L, "공통", null, 1L, List.of(
+                        existingQuestion(2000L, QuestionType.SHORT_TEXT, "기존 질문", null, true, 1L, List.of())
+                    ))
+                )))
+                .willReturn(structure(List.of(
+                    existingSection(1000L, "공통", null, 1L, List.of(
+                        existingQuestion(9999L, QuestionType.SHORT_TEXT, "변경된 질문", null, true, 1L, List.of())
+                    ))
+                )));
+            given(loadPolicyPort.listByApplicationFormId(100L))
+                .willReturn(List.of(ProjectApplicationFormPolicy.createCommon(form, 1000L)));
+            given(manageQuestionUseCase.forkQuestion(any())).willReturn(9999L);
+
+            sut.upsert(commandWithSections(42L, List.of(
+                section(1000L, FormSectionType.COMMON, Set.of(), "공통", 1, List.of(
+                    shortTextQuestion(2000L, "변경된 질문", true)
+                ))
+            )));
+
+            ArgumentCaptor<ForkQuestionCommand> captor = ArgumentCaptor.forClass(ForkQuestionCommand.class);
+            then(manageQuestionUseCase).should().forkQuestion(captor.capture());
+            assertThat(captor.getValue().originQuestionId()).isEqualTo(2000L);
+            then(manageQuestionUseCase).should(never()).updateQuestion(any());
         }
     }
 

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -239,21 +239,28 @@ class ProjectTest {
         @Test
         void DRAFT_상태에서는_통과() {
             // setUp 의 project 가 DRAFT
-            project.validateApplicationFormEditable();
+            project.validateApplicationFormEditable(false);
         }
 
         @Test
         void PENDING_REVIEW_상태에서는_통과() {
             setStatus(project, ProjectStatus.PENDING_REVIEW);
 
-            project.validateApplicationFormEditable();
+            project.validateApplicationFormEditable(false);
         }
 
         @Test
-        void IN_PROGRESS_상태에서는_PROJECT_INVALID_STATE() {
+        void IN_PROGRESS_차수_사이에는_통과() {
             setStatus(project, ProjectStatus.IN_PROGRESS);
 
-            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+            project.validateApplicationFormEditable(false);
+        }
+
+        @Test
+        void IN_PROGRESS_활성_차수_중에는_PROJECT_INVALID_STATE() {
+            setStatus(project, ProjectStatus.IN_PROGRESS);
+
+            assertThatThrownBy(() -> project.validateApplicationFormEditable(true))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
@@ -263,7 +270,7 @@ class ProjectTest {
         void COMPLETED_상태에서는_PROJECT_INVALID_STATE() {
             setStatus(project, ProjectStatus.COMPLETED);
 
-            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+            assertThatThrownBy(() -> project.validateApplicationFormEditable(false))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
@@ -273,7 +280,7 @@ class ProjectTest {
         void ABORTED_상태에서는_PROJECT_INVALID_STATE() {
             setStatus(project, ProjectStatus.ABORTED);
 
-            assertThatThrownBy(() -> project.validateApplicationFormEditable())
+            assertThatThrownBy(() -> project.validateApplicationFormEditable(false))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #822 

## 🚀 작업 내용

매칭 차수와 차수 사이에 PM이 지원서 폼의 질문 내용을 수정할 수 있어야 한다는 요구사항이 있었습니다.
단, 이전 차수에서 이미 답변한 지원자의 응답을 조회할 때는 답변 당시의 질문 내용이 표시되어야 합니다.

기존 질문 객체를 수정하면 기존 답변자의 `Answer.question` FK가 가리키는 내용이 바뀌는 문제가 있으므로, 수정 시 새 Question 엔티티를 생성하고 원본을 비활성화하는 방식을 채택했습니다.                                              
해당 방향은 대면으로 논의된 사항이며, 논의 당시에는 `parentQuestionId`를 두고 최신 폼 조회 시 leaf question(자식이 없는 가장 최신 Question)을 조회하는 방식으로 이야기되었으나, leaf 탐색의 쿼리 복잡도를 고려하여 임의로 `isActive` 플래그를 추가하였습니다. 의견 부탁드립니다.
                                                           
[수정 전]
Question A (isActive=true)
  └─ Option O1, O2

[수정 후]
Question A  (isActive=false) <- 기존 Answer들이 여전히 참조
  └─ Option O1, O2           <- AnswerChoice FK 보존
                                                                               
Question A' (isActive=true, parentQuestionId=A.id)  <- 현재 폼에 노출           
  └─ Option O1', O2'         <- 요청 데이터로 신규 생성

- 폼 조회: `isActive = true` 질문만 조회
- 기존 답변 조회: `Answer.question` FK가 자동으로 당시 질문을 가리킴
- fork 후 API 응답: 최신 폼 구조(새 questionId 포함) 반환

1. DB Migration
- `question` 테이블에 `parent_question_id`, `is_active` 추가

2. Survey 도메인
- `Question` 엔티티: `parentQuestionId`, `isActive` 필드 추가 / `fork()`, `deactivate()` 도메인 메서드 추가
- `ManageQuestionUseCase`: `forkQuestion(ForkQuestionCommand)` 추가
- `QuestionQueryRepository`: 질문 조회 시 `isActive = true` 필터 추가

3. Project 도메인
- `Project.validateApplicationFormEditable(boolean hasActiveRound)`: IN_PROGRESS + 활성 차수 없음(차수 사이)도 허용하도록 확장
- `ProjectApplicationFormCommandService`: 활성 차수 조회 후 IN_PROGRESS 상태면 `updateQuestion` 대신 `forkQuestion` 호출
                                                          
엔드포인트는 기존 `PUT /api/v1/projects/{projectId}/application-form` 그대로 사용합니다. 
피그마 코멘트를 통해, 임시저장과 마찬가지로 차수 사이 수정 상황에서도 전체 폼을 한 번에 PUT하는 구조임을 확인했습니다. ([코멘트](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ?node-id=2024-27172#1749475421))

## 💬 리뷰 중점사항
1. Form 레벨 버저닝 미채택
PM이 "특정 차수 시점의 폼 전체 스냅샷"을 단독 조회하는 요구사항이 없으므로,    
Form 레벨 버저닝은 오버엔지니어링으로 판단하여 미채택했습니다. `Answer -> question FK` 역추적으로 충분합니다. 

2. UseCase 분리 여부 (의견 요청)
현재 구조는 `UpsertProjectApplicationFormUseCase` 하나에서 DRAFT 편집과 차수 사이 fork 편집을 모두 처리하며, `shouldFork` boolean 플래그를 5단계 메서드(`applyDiff -> applySectionDiff -> updateExistingSection -> applyQuestionDiff  -> updateExistingQuestion`)로 전파합니다.

이 구조에 대한 의견 부탁드립니다. 고려중인 다른 대안으로는, 
- `UpsertProjectApplicationFormUseCase` — DRAFT/PENDING_REVIEW 전용으로 원상복구
- `ReviseProjectApplicationFormUseCase` — IN_PROGRESS 차수 사이 전용, 항상 fork
- Controller에서 project status 기반으로 두 UseCase 중 하나에 라우팅           

이 경우 추가적으로 필요한 공수는 공통 diff 로직(`applyDiff` 등)을 별도 추출해야 한다는 점입니다.         

현재 단일 UseCase + shouldFork 구조와 UseCase 분리 + Controller 라우팅 중 어느 쪽이 더 적절한지 의견 부탁드립니다.

3. fork 시 옵션 처리 방식
fork 후 옵션은 요청 데이터로 새롭게 생성합니다. (기존 origin option을 DB에서 읽어 복사하는 방식이 아닌, 오케스트레이터인 `ProjectApplicationFormCommandService`가 요청 데이터로 직접 생성)