### PR TITLE
[Feat] 프로젝트 매칭 선발 도메인 API 개발

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandler.java
@@ -1,0 +1,31 @@
+package com.umc.product.project.adapter.in.scheduler;
+
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매칭 차수 결정 마감 시점에 트리거되어 자동 선발 UseCase 를 호출하는 driving adapter.
+ * <p>
+ * out-side {@link com.umc.product.project.adapter.out.scheduler.MatchingRoundDeadlineScheduler}
+ * 가 {@link org.springframework.scheduling.TaskScheduler} 에 본 컴포넌트의 {@link #handle(Long)} 를 묶어 등록한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MatchingRoundDeadlineHandler {
+
+    private final AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+
+    /**
+     * deadline 시점에 1회 호출되어 자동 선발을 실행한다. 예외는 swallow 하여 다음 task 진행을 막지 않는다.
+     */
+    public void handle(Long matchingRoundId) {
+        try {
+            autoDecideUseCase.autoDecide(matchingRoundId, null);
+        } catch (Exception e) {
+            log.error("Failed to auto-decide matching round {}", matchingRoundId, e);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistry.java
+++ b/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistry.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +43,7 @@ public class MatchingRoundDeadlineRegistry implements ScheduleMatchingRoundDeadl
 
     public MatchingRoundDeadlineRegistry(
         @Qualifier("matchingDeadlineTaskScheduler") TaskScheduler taskScheduler,
-        AutoDecideProjectMatchingRoundUseCase autoDecideUseCase,
+        @Lazy AutoDecideProjectMatchingRoundUseCase autoDecideUseCase,
         LoadProjectMatchingRoundPort loadProjectMatchingRoundPort
     ) {
         this.taskScheduler = taskScheduler;

--- a/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistry.java
+++ b/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistry.java
@@ -1,0 +1,101 @@
+package com.umc.product.project.adapter.in.scheduler;
+
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import jakarta.annotation.PostConstruct;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매칭 차수 종료 시점에 {@link AutoDecideProjectMatchingRoundUseCase} 를 자동으로 호출하는 동적 스케줄러.
+ * <p>
+ * 매칭 차수 lifecycle 메서드({@code create} / {@code update} / {@code delete}) 가 호출하며,
+ * 부팅 시점에 미처리 round 를 모두 재등록하여 JVM 재시작에도 안전하다.
+ * <p>
+ * 매일 polling 하지 않고 정확히 {@code decisionDeadline} 시점에만 1회 실행되므로 불필요한 자원 소비가 없다.
+ * 다중 인스턴스 환경에서 동시 등록되어도 서비스 측 멱등성({@code autoDecisionExecutedAt != null}) 으로 방어된다.
+ * <p>
+ * {@code scheduler.matching-round-deadline.enabled=false} 로 비활성화 가능 (default 활성).
+ */
+@Component
+@ConditionalOnProperty(
+    name = "scheduler.matching-round-deadline.enabled",
+    havingValue = "true",
+    matchIfMissing = true
+)
+@Slf4j
+public class MatchingRoundDeadlineRegistry implements ScheduleMatchingRoundDeadlinePort {
+
+    private final TaskScheduler taskScheduler;
+    private final AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+    private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+
+    private final Map<Long, ScheduledFuture<?>> pendingTasks = new ConcurrentHashMap<>();
+
+    public MatchingRoundDeadlineRegistry(
+        @Qualifier("matchingDeadlineTaskScheduler") TaskScheduler taskScheduler,
+        AutoDecideProjectMatchingRoundUseCase autoDecideUseCase,
+        LoadProjectMatchingRoundPort loadProjectMatchingRoundPort
+    ) {
+        this.taskScheduler = taskScheduler;
+        this.autoDecideUseCase = autoDecideUseCase;
+        this.loadProjectMatchingRoundPort = loadProjectMatchingRoundPort;
+    }
+
+    /**
+     * 부팅 시 자동 선발이 아직 실행되지 않은 모든 매칭 차수를 재등록한다.
+     * deadline 이 이미 경과한 round 는 {@link TaskScheduler} 가 즉시 실행한다.
+     */
+    @PostConstruct
+    public void recoverPendingTasks() {
+        loadProjectMatchingRoundPort.listAllNotAutoDecided().forEach(this::schedule);
+    }
+
+    /**
+     * 매칭 차수의 결정 마감 시점에 자동 선발을 1회 실행하도록 등록한다.
+     * 기존 등록이 있다면 취소 후 재등록한다 ({@code update} 시 사용).
+     */
+    public void schedule(ProjectMatchingRound round) {
+        Long roundId = round.getId();
+        cancel(roundId);
+
+        ScheduledFuture<?> future = taskScheduler.schedule(
+            () -> runAutoDecide(roundId),
+            round.getDecisionDeadline()
+        );
+        pendingTasks.put(roundId, future);
+    }
+
+    /**
+     * 매칭 차수 삭제 시 등록된 task 를 취소한다.
+     */
+    public void cancel(Long roundId) {
+        ScheduledFuture<?> future = pendingTasks.remove(roundId);
+        if (future != null) {
+            future.cancel(false);
+        }
+    }
+
+    /** 테스트 용 — 현재 등록된 task 가 있는지 확인. */
+    public boolean isScheduled(Long roundId) {
+        return pendingTasks.containsKey(roundId);
+    }
+
+    private void runAutoDecide(Long roundId) {
+        try {
+            autoDecideUseCase.autoDecide(roundId, null);
+        } catch (Exception e) {
+            log.error("Failed to auto-decide matching round {}", roundId, e);
+        } finally {
+            pendingTasks.remove(roundId);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -5,18 +5,20 @@ import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.dto.request.CreateProjectApplicationRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationAnswersRequest;
+import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationDecisionRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicationStatusResponse;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
-import com.umc.product.project.adapter.in.web.dto.request.CreateProjectApplicationRequest;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -33,6 +35,7 @@ public class ProjectApplicationController {
     private final CreateDraftProjectApplicationUseCase createDraftProjectApplicationUseCase;
     private final UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
     private final SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
+    private final DecideApplicationUseCase decideApplicationUseCase;
 
     @PostMapping("/{projectId}/applications")
     @Operation(
@@ -101,6 +104,35 @@ public class ProjectApplicationController {
                     .projectId(projectId)
                     .requesterMemberId(memberPrincipal.getMemberId())
                     .build()
+            )
+        );
+    }
+
+    @PatchMapping("/{projectId}/applications/{applicationId}/decision")
+    @Operation(
+        summary = "[APPLY-103] 지원서 합/불 결정 (단일 PATCH)",
+        description = """
+            PM 이 지원서의 status 를 토글합니다.
+            - 매칭 차수 진행 중에만 가능 (decisionDeadline 까지)
+            - SUBMITTED ↔ APPROVED ↔ REJECTED 자유 토글 (재토글 허용)
+            - PENDING 입력은 도메인의 SUBMITTED 로 매핑되어 결정을 "대기" 로 되돌림
+            """
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT_APPLICATION,
+        resourceId = "#applicationId",
+        permission = PermissionType.APPROVE,
+        message = "지원서 합/불 결정 권한이 없습니다."
+    )
+    public ProjectApplicationStatusResponse decide(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @PathVariable Long applicationId,
+        @Valid @RequestBody UpdateApplicationDecisionRequest request
+    ) {
+        return ProjectApplicationStatusResponse.from(
+            decideApplicationUseCase.decide(
+                applicationId, request.status(), request.reason(), memberPrincipal.getMemberId()
             )
         );
     }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java
@@ -6,6 +6,7 @@ import com.umc.product.project.adapter.in.web.dto.request.CreateProjectMatchingR
 import com.umc.product.project.adapter.in.web.dto.request.UpdateProjectMatchingRoundRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectMatchingRoundCreateResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectMatchingRoundResponse;
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.CreateProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectMatchingRoundUseCase;
@@ -37,6 +38,7 @@ public class ProjectMatchingRoundController {
     private final CreateProjectMatchingRoundUseCase createProjectMatchingRoundUseCase;
     private final UpdateProjectMatchingRoundUseCase updateProjectMatchingRoundUseCase;
     private final DeleteProjectMatchingRoundUseCase deleteProjectMatchingRoundUseCase;
+    private final AutoDecideProjectMatchingRoundUseCase autoDecideProjectMatchingRoundUseCase;
 
     @GetMapping
     @Operation(
@@ -119,5 +121,25 @@ public class ProjectMatchingRoundController {
         @PathVariable Long matchingRoundId
     ) {
         deleteProjectMatchingRoundUseCase.delete(matchingRoundId, memberPrincipal.getMemberId());
+    }
+
+    @PostMapping("/{matchingRoundId}/auto-decide")
+    @Operation(
+        summary = "[PROJECT-MATCHING-201] 매칭 차수 자동 선발 실행 (운영진 수동 트리거)",
+        description = """
+            결정 마감(decisionDeadline) 이후 매칭 차수의 자동 선발을 실행합니다.
+            - 중앙운영사무국 총괄단 이상은 모든 지부의 매칭 차수에 대해 실행할 수 있습니다.
+            - 지부장은 본인 지부의 매칭 차수만 실행할 수 있습니다.
+            - 결정 마감 시각이 지나기 전에는 실행할 수 없으며 400을 반환합니다.
+            - 이미 자동 선발이 실행된 매칭 차수에 대해서는 멱등 (no-op).
+            - 정책 매트릭스(디자이너 / 개발자)에 따라 SUBMITTED 우선 random 보충 후 부족하면 REJECTED 까지 override 합니다.
+            - 합격자에게는 ProjectMember 가 자동으로 생성됩니다.
+            """
+    )
+    public void autoDecide(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long matchingRoundId
+    ) {
+        autoDecideProjectMatchingRoundUseCase.autoDecide(matchingRoundId, memberPrincipal.getMemberId());
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationDecisionRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationDecisionRequest.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * APPLY-103 — PM 의 합/불 결정 요청.
+ * <p>
+ * {@code reason} 은 nullable. 현재 UI 에 입력 칸은 없으나 도메인/DB 인프라가 이미 받게 되어 있어
+ * 향후 사유 입력이 추가되거나 자동 매칭에서 시스템 메시지가 들어갈 수 있도록 열어둔다.
+ */
+public record UpdateApplicationDecisionRequest(
+    @NotNull(message = "결정 상태는 필수입니다.")
+    ApplicationDecisionStatus status,
+
+    @Size(max = 500, message = "결정 사유는 500자 이내여야 합니다.")
+    String reason
+) {}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationJpaRepository.java
@@ -1,9 +1,12 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.domain.ProjectApplication;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectApplicationJpaRepository extends JpaRepository<ProjectApplication, Long> {
 
     boolean existsByAppliedMatchingRound_Id(Long matchingRoundId);
+
+    List<ProjectApplication> findAllByAppliedMatchingRound_Id(Long matchingRoundId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -6,6 +6,8 @@ import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -81,5 +83,15 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     @Override
     public ProjectApplication save(ProjectApplication application) {
         return projectApplicationJpaRepository.save(application);
+    }
+
+    @Override
+    public List<ProjectApplication> saveAll(Collection<ProjectApplication> applications) {
+        return projectApplicationJpaRepository.saveAll(applications);
+    }
+
+    @Override
+    public List<ProjectApplication> listByMatchingRoundId(Long matchingRoundId) {
+        return projectApplicationJpaRepository.findAllByAppliedMatchingRound_Id(matchingRoundId);
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMatchingRoundJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMatchingRoundJpaRepository.java
@@ -55,4 +55,6 @@ public interface ProjectMatchingRoundJpaRepository extends JpaRepository<Project
         @Param("startsAt") Instant startsAt,
         @Param("decisionDeadline") Instant decisionDeadline
     );
+
+    List<ProjectMatchingRound> findAllByAutoDecisionExecutedAtIsNullOrderByDecisionDeadlineAsc();
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMatchingRoundPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMatchingRoundPersistenceAdapter.java
@@ -91,6 +91,11 @@ public class ProjectMatchingRoundPersistenceAdapter
     }
 
     @Override
+    public List<ProjectMatchingRound> listAllNotAutoDecided() {
+        return jpaRepository.findAllByAutoDecisionExecutedAtIsNullOrderByDecisionDeadlineAsc();
+    }
+
+    @Override
     public ProjectMatchingRound save(ProjectMatchingRound matchingRound) {
         return jpaRepository.save(matchingRound);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -27,6 +27,11 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     }
 
     @Override
+    public List<ProjectMember> saveAll(Collection<ProjectMember> members) {
+        return repository.saveAll(members);
+    }
+
+    @Override
     public void hardDelete(Long projectMemberId) {
         repository.deleteById(projectMemberId);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
@@ -5,6 +5,8 @@ import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort
 import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -35,6 +37,15 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDeadlinePort {
 
+    /**
+     * 자동 선발 발화 시점을 deadline 정각이 아닌 buffer 만큼 뒤로 미룬다.
+     * <p>
+     * - 클럭 정밀도: deadline 정각에 발화 시 {@code isDecisionDeadlinePassed} 가 false 가 돼 NOT_FINALIZABLE 로 종료될 위험 회피
+     * - PM 마지막 토글과의 race 보호
+     * - 다른 도메인 자정 cron 부하와 분리
+     */
+    static final Duration DEADLINE_BUFFER = Duration.ofMinutes(10);
+
     private final TaskScheduler taskScheduler;
     private final MatchingRoundDeadlineHandler handler;
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
@@ -61,6 +72,7 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
         Long roundId = round.getId();
         cancel(roundId);
 
+        Instant runAt = round.getDecisionDeadline().plus(DEADLINE_BUFFER);
         ScheduledFuture<?> future = taskScheduler.schedule(
             () -> {
                 try {
@@ -69,7 +81,7 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
                     pendingTasks.remove(roundId);
                 }
             },
-            round.getDecisionDeadline()
+            runAt
         );
         pendingTasks.put(roundId, future);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
@@ -1,6 +1,6 @@
-package com.umc.product.project.adapter.in.scheduler;
+package com.umc.product.project.adapter.out.scheduler;
 
-import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
 import com.umc.product.project.domain.ProjectMatchingRound;
@@ -11,20 +11,20 @@ import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 /**
- * 매칭 차수 종료 시점에 {@link AutoDecideProjectMatchingRoundUseCase} 를 자동으로 호출하는 동적 스케줄러.
+ * {@link ScheduleMatchingRoundDeadlinePort} 의 driven adapter 구현.
  * <p>
- * 매칭 차수 lifecycle 메서드({@code create} / {@code update} / {@code delete}) 가 호출하며,
- * 부팅 시점에 미처리 round 를 모두 재등록하여 JVM 재시작에도 안전하다.
+ * 매칭 차수 lifecycle ({@code create} / {@code update} / {@code delete}) 호출에 맞춰
+ * {@link TaskScheduler} 에 결정 마감 시점의 1회성 task 를 등록한다.
+ * 등록된 task 는 in-side {@link MatchingRoundDeadlineHandler} 가 실행하며,
+ * 본 클래스는 등록/취소/상태 보관만 담당한다.
  * <p>
- * 매일 polling 하지 않고 정확히 {@code decisionDeadline} 시점에만 1회 실행되므로 불필요한 자원 소비가 없다.
- * 다중 인스턴스 환경에서 동시 등록되어도 서비스 측 멱등성({@code autoDecisionExecutedAt != null}) 으로 방어된다.
- * <p>
- * {@code scheduler.matching-round-deadline.enabled=false} 로 비활성화 가능 (default 활성).
+ * 부팅 시 자동 선발이 아직 실행되지 않은 모든 매칭 차수를 다시 등록하여 JVM 재시작에도 안전하다.
+ * 다중 인스턴스 환경에서 동일 round 가 중복 등록되어도 service 측 멱등성
+ * ({@code autoDecisionExecutedAt != null}) 으로 방어된다.
  */
 @Component
 @ConditionalOnProperty(
@@ -33,51 +33,48 @@ import org.springframework.stereotype.Component;
     matchIfMissing = true
 )
 @Slf4j
-public class MatchingRoundDeadlineRegistry implements ScheduleMatchingRoundDeadlinePort {
+public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDeadlinePort {
 
     private final TaskScheduler taskScheduler;
-    private final AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+    private final MatchingRoundDeadlineHandler handler;
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
 
     private final Map<Long, ScheduledFuture<?>> pendingTasks = new ConcurrentHashMap<>();
 
-    public MatchingRoundDeadlineRegistry(
+    public MatchingRoundDeadlineScheduler(
         @Qualifier("matchingDeadlineTaskScheduler") TaskScheduler taskScheduler,
-        @Lazy AutoDecideProjectMatchingRoundUseCase autoDecideUseCase,
+        MatchingRoundDeadlineHandler handler,
         LoadProjectMatchingRoundPort loadProjectMatchingRoundPort
     ) {
         this.taskScheduler = taskScheduler;
-        this.autoDecideUseCase = autoDecideUseCase;
+        this.handler = handler;
         this.loadProjectMatchingRoundPort = loadProjectMatchingRoundPort;
     }
 
-    /**
-     * 부팅 시 자동 선발이 아직 실행되지 않은 모든 매칭 차수를 재등록한다.
-     * deadline 이 이미 경과한 round 는 {@link TaskScheduler} 가 즉시 실행한다.
-     */
     @PostConstruct
     public void recoverPendingTasks() {
         loadProjectMatchingRoundPort.listAllNotAutoDecided().forEach(this::schedule);
     }
 
-    /**
-     * 매칭 차수의 결정 마감 시점에 자동 선발을 1회 실행하도록 등록한다.
-     * 기존 등록이 있다면 취소 후 재등록한다 ({@code update} 시 사용).
-     */
+    @Override
     public void schedule(ProjectMatchingRound round) {
         Long roundId = round.getId();
         cancel(roundId);
 
         ScheduledFuture<?> future = taskScheduler.schedule(
-            () -> runAutoDecide(roundId),
+            () -> {
+                try {
+                    handler.handle(roundId);
+                } finally {
+                    pendingTasks.remove(roundId);
+                }
+            },
             round.getDecisionDeadline()
         );
         pendingTasks.put(roundId, future);
     }
 
-    /**
-     * 매칭 차수 삭제 시 등록된 task 를 취소한다.
-     */
+    @Override
     public void cancel(Long roundId) {
         ScheduledFuture<?> future = pendingTasks.remove(roundId);
         if (future != null) {
@@ -88,15 +85,5 @@ public class MatchingRoundDeadlineRegistry implements ScheduleMatchingRoundDeadl
     /** 테스트 용 — 현재 등록된 task 가 있는지 확인. */
     public boolean isScheduled(Long roundId) {
         return pendingTasks.containsKey(roundId);
-    }
-
-    private void runAutoDecide(Long roundId) {
-        try {
-            autoDecideUseCase.autoDecide(roundId, null);
-        } catch (Exception e) {
-            log.error("Failed to auto-decide matching round {}", roundId, e);
-        } finally {
-            pendingTasks.remove(roundId);
-        }
     }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/AutoDecideProjectMatchingRoundUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/AutoDecideProjectMatchingRoundUseCase.java
@@ -1,0 +1,22 @@
+package com.umc.product.project.application.port.in.command;
+
+/**
+ * 매칭 차수 자동 선발 UseCase (MATCHING-201 + 스케줄러 공통 진입점).
+ * <p>
+ * 차수 종료 시점에 정책 매트릭스 기반으로 SUBMITTED 지원자를 자동 보충하고
+ * 합격자에 대해 ProjectMember 자동 추가까지 수행합니다.
+ * <p>
+ * 호출자:
+ * <ul>
+ *   <li>운영진 수동: {@code POST /api/v1/project/matching-rounds/{id}/auto-decide}</li>
+ *   <li>스케줄러: {@code MatchingRoundDeadlineRegistry} (deadline 시점 자동 트리거)</li>
+ * </ul>
+ */
+public interface AutoDecideProjectMatchingRoundUseCase {
+
+    /**
+     * @param matchingRoundId    자동 선발 대상 매칭 차수 ID
+     * @param executedByMemberId 운영진 수동 호출 시 본인 ID, 스케줄러 호출 시 {@code null}
+     */
+    void autoDecide(Long matchingRoundId, Long executedByMemberId);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/DecideApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/DecideApplicationUseCase.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+
+/**
+ * 지원서 합/불 결정 UseCase (APPLY-103).
+ * <p>
+ * PM 이 매칭 차수 진행 중에 SUBMITTED ↔ APPROVED ↔ REJECTED 사이를 자유롭게 토글한다.
+ * 권한은 {@code @CheckAccess(PROJECT_APPLICATION, APPROVE)} 가 책임지고,
+ * 차수 잠금 검증은 도메인 메서드({@code ProjectApplication.approve / reject / revertToPending}) 가 책임진다.
+ */
+public interface DecideApplicationUseCase {
+
+    ProjectApplicationInfo decide(
+        Long applicationId,
+        ApplicationDecisionStatus targetStatus,
+        String reason,
+        Long decidedByMemberId
+    );
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/ApplicationDecisionStatus.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/ApplicationDecisionStatus.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+/**
+ * PM 이 지원서에 내릴 수 있는 결정.
+ * <p>
+ * UI 의 "대기" 옵션은 {@code PENDING} 으로 표현하며, 도메인 레이어에서
+ * {@link com.umc.product.project.domain.enums.ProjectApplicationStatus#SUBMITTED} 로 매핑된다.
+ * <p>
+ * 도메인 enum 을 직접 노출하지 않는 이유:
+ * <ul>
+ *   <li>DRAFT 등 결정 대상이 아닌 status 입력을 enum 자체로 차단</li>
+ *   <li>도메인 enum 변경이 API 계약 변경을 강제하지 않도록 결합 회피</li>
+ * </ul>
+ */
+public enum ApplicationDecisionStatus {
+    APPROVED,
+    REJECTED,
+    PENDING
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -2,6 +2,7 @@ package com.umc.product.project.application.port.out;
 
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -45,4 +46,9 @@ public interface LoadProjectApplicationPort {
     boolean existsByRoundAndApplicantAndStatus(
         Long roundId, Long applicantMemberId, ProjectApplicationStatus status
     );
+
+    /**
+     * 매칭 차수에 속한 모든 지원서를 조회합니다. 자동 선발 알고리즘 입력으로 사용됩니다.
+     */
+    List<ProjectApplication> listByMatchingRoundId(Long matchingRoundId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMatchingRoundPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMatchingRoundPort.java
@@ -26,4 +26,11 @@ public interface LoadProjectMatchingRoundPort {
     List<ProjectMatchingRound> listOverlappingExceptId(
         Long id, Long chapterId, Instant startsAt, Instant decisionDeadline
     );
+
+    /**
+     * 자동 선발이 아직 실행되지 않은 매칭 차수 전체를 조회합니다 (deadline 경과 여부 무관).
+     * <p>
+     * 동적 스케줄링 컴포넌트가 부팅 시 미처리 round 를 모두 등록하기 위해 사용합니다.
+     */
+    List<ProjectMatchingRound> listAllNotAutoDecided();
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationPort.java
@@ -1,7 +1,15 @@
 package com.umc.product.project.application.port.out;
 
 import com.umc.product.project.domain.ProjectApplication;
+import java.util.Collection;
+import java.util.List;
 
 public interface SaveProjectApplicationPort {
+
     ProjectApplication save(ProjectApplication application);
+
+    /**
+     * 자동 선발 시점에 다수 지원서의 status 를 일괄 갱신할 때 사용합니다.
+     */
+    List<ProjectApplication> saveAll(Collection<ProjectApplication> applications);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectMemberPort.java
@@ -1,6 +1,8 @@
 package com.umc.product.project.application.port.out;
 
 import com.umc.product.project.domain.ProjectMember;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * ProjectMember 영속화 Port (Driven / Port Out).
@@ -11,6 +13,11 @@ import com.umc.product.project.domain.ProjectMember;
 public interface SaveProjectMemberPort {
 
     ProjectMember save(ProjectMember member);
+
+    /**
+     * 여러 멤버를 한 번에 저장합니다. 자동 선발 등 batch 컨텍스트에서 N개 INSERT 를 줄이기 위해 사용합니다.
+     */
+    List<ProjectMember> saveAll(Collection<ProjectMember> members);
 
     /**
      * 프로젝트 멤버 row 를 DB 에서 완전 삭제합니다.

--- a/src/main/java/com/umc/product/project/application/port/out/ScheduleMatchingRoundDeadlinePort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/ScheduleMatchingRoundDeadlinePort.java
@@ -1,0 +1,23 @@
+package com.umc.product.project.application.port.out;
+
+import com.umc.product.project.domain.ProjectMatchingRound;
+
+/**
+ * 매칭 차수 결정 마감 시점에 자동 선발을 트리거하는 동적 스케줄링 Port.
+ * <p>
+ * 매칭 차수 lifecycle ({@code create} / {@code update} / {@code delete}) 에 맞춰 호출되어
+ * 결정 마감 정확한 시점에 1회 실행되는 task 를 등록한다.
+ */
+public interface ScheduleMatchingRoundDeadlinePort {
+
+    /**
+     * 결정 마감 시점에 자동 선발을 1회 실행하도록 등록한다.
+     * 동일 ID 의 등록이 이미 있다면 취소 후 재등록한다.
+     */
+    void schedule(ProjectMatchingRound round);
+
+    /**
+     * 등록된 task 를 취소한다. 등록되지 않은 ID 는 no-op.
+     */
+    void cancel(Long roundId);
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -4,8 +4,10 @@ import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
@@ -41,7 +43,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectApplicationCommandService implements
     CreateDraftProjectApplicationUseCase,
     UpdateProjectApplicationDraftUseCase,
-    SubmitProjectApplicationUseCase {
+    SubmitProjectApplicationUseCase,
+    DecideApplicationUseCase {
 
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectApplicationPort saveProjectApplicationPort;
@@ -173,6 +176,26 @@ public class ProjectApplicationCommandService implements
         application.submit();
         saveProjectApplicationPort.save(application);
 
+        return ProjectApplicationInfo.of(application.getId(), application.getStatus());
+    }
+
+    @Override
+    public ProjectApplicationInfo decide(
+        Long applicationId,
+        ApplicationDecisionStatus targetStatus,
+        String reason,
+        Long decidedByMemberId
+    ) {
+        ProjectApplication application = loadProjectApplicationPort.findById(applicationId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
+
+        switch (targetStatus) {
+            case APPROVED -> application.approve(decidedByMemberId, reason);
+            case REJECTED -> application.reject(decidedByMemberId, reason);
+            case PENDING -> application.revertToPending(decidedByMemberId);
+        }
+
+        saveProjectApplicationPort.save(application);
         return ProjectApplicationInfo.of(application.getId(), application.getStatus());
     }
 

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -33,6 +33,9 @@ import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormRes
 import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -258,10 +261,10 @@ public class ProjectApplicationCommandService implements
             return 0;
         }
 
-        java.util.Set<Long> memberIds = candidates.stream()
+        Set<Long> memberIds = candidates.stream()
             .map(ProjectApplication::getApplicantMemberId)
-            .collect(java.util.stream.Collectors.toSet());
-        java.util.Map<Long, com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo> challengerByMember =
+            .collect(Collectors.toSet());
+        Map<Long, ChallengerInfo> challengerByMember =
             getChallengerUseCase.batchGetByMemberIdsAndGisuId(memberIds, gisuId);
 
         return (int) candidates.stream()

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -189,6 +189,11 @@ public class ProjectApplicationCommandService implements
         ProjectApplication application = loadProjectApplicationPort.findById(applicationId)
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
 
+        if (targetStatus == ApplicationDecisionStatus.APPROVED
+            && application.getStatus() != ProjectApplicationStatus.APPROVED) {
+            validateRemainingQuota(application);
+        }
+
         switch (targetStatus) {
             case APPROVED -> application.approve(decidedByMemberId, reason);
             case REJECTED -> application.reject(decidedByMemberId, reason);
@@ -197,6 +202,58 @@ public class ProjectApplicationCommandService implements
 
         saveProjectApplicationPort.save(application);
         return ProjectApplicationInfo.of(application.getId(), application.getStatus());
+    }
+
+    /**
+     * APPROVED 토글 시 잔여 자리 검증.
+     * <p>
+     * 잔여 자리 = 전체 TO − (이전 차수까지 ACTIVE 멤버) − (현재 차수에서 같은 (project, part) 의 APPROVED 카운트).
+     * 이 값이 0 이하면 자리가 없으므로 예외를 던진다.
+     */
+    private void validateRemainingQuota(ProjectApplication application) {
+        Project project = application.getApplicationForm().getProject();
+        Long projectId = project.getId();
+        Long gisuId = project.getGisuId();
+        Long roundId = application.getAppliedMatchingRound().getId();
+
+        ChallengerPart part = getChallengerUseCase
+            .getByMemberIdAndGisuId(application.getApplicantMemberId(), gisuId)
+            .part();
+
+        int totalQuota = loadProjectPartQuotaPort.listByProjectId(projectId).stream()
+            .filter(q -> q.getPart() == part)
+            .findFirst()
+            .map(q -> q.getQuota().intValue())
+            .orElse(0);
+
+        int activeMemberCount = loadProjectMemberPort
+            .countByProjectIdGroupByPart(projectId)
+            .getOrDefault(part, 0L)
+            .intValue();
+
+        int currentRoundApproved = countApprovedInSameRoundProjectPart(
+            roundId, projectId, part, gisuId, application.getId()
+        );
+
+        if (activeMemberCount + currentRoundApproved + 1 > totalQuota) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_QUOTA_EXCEEDED);
+        }
+    }
+
+    /**
+     * 본 차수의 같은 (project, part) 안에서 APPROVED 인 application 수를 카운트한다 (현재 application 제외).
+     */
+    private int countApprovedInSameRoundProjectPart(
+        Long roundId, Long projectId, ChallengerPart part, Long gisuId, Long excludingApplicationId
+    ) {
+        return (int) loadProjectApplicationPort.listByMatchingRoundId(roundId).stream()
+            .filter(a -> !a.getId().equals(excludingApplicationId))
+            .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED)
+            .filter(a -> a.getApplicationForm().getProject().getId().equals(projectId))
+            .filter(a -> getChallengerUseCase
+                .getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId)
+                .part() == part)
+            .count();
     }
 
     private List<AnswerCommand> toAnswerCommands(List<UpdateProjectApplicationDraftCommand.AnswerEntry> entries) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -242,17 +242,30 @@ public class ProjectApplicationCommandService implements
 
     /**
      * 본 차수의 같은 (project, part) 안에서 APPROVED 인 application 수를 카운트한다 (현재 application 제외).
+     * <p>
+     * project / status 필터를 먼저 in-memory 로 좁혀 candidate 만 추린 뒤, candidate 들의 challenger 정보를
+     * batch 한 번에 조회해 part 비교한다 (N+1 제거).
      */
     private int countApprovedInSameRoundProjectPart(
         Long roundId, Long projectId, ChallengerPart part, Long gisuId, Long excludingApplicationId
     ) {
-        return (int) loadProjectApplicationPort.listByMatchingRoundId(roundId).stream()
+        List<ProjectApplication> candidates = loadProjectApplicationPort.listByMatchingRoundId(roundId).stream()
             .filter(a -> !a.getId().equals(excludingApplicationId))
             .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED)
             .filter(a -> a.getApplicationForm().getProject().getId().equals(projectId))
-            .filter(a -> getChallengerUseCase
-                .getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId)
-                .part() == part)
+            .toList();
+        if (candidates.isEmpty()) {
+            return 0;
+        }
+
+        java.util.Set<Long> memberIds = candidates.stream()
+            .map(ProjectApplication::getApplicantMemberId)
+            .collect(java.util.stream.Collectors.toSet());
+        java.util.Map<Long, com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo> challengerByMember =
+            getChallengerUseCase.batchGetByMemberIdsAndGisuId(memberIds, gisuId);
+
+        return (int) candidates.stream()
+            .filter(a -> challengerByMember.get(a.getApplicantMemberId()).part() == part)
             .count();
     }
 

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
@@ -2,7 +2,10 @@ package com.umc.product.project.application.service.command;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.CreateProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectMatchingRoundUseCase;
@@ -10,15 +13,29 @@ import com.umc.product.project.application.port.in.command.dto.CreateProjectMatc
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectMatchingRoundCommand;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.service.policy.AutoDecisionResult;
+import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,13 +46,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectMatchingRoundCommandService implements
     CreateProjectMatchingRoundUseCase,
     UpdateProjectMatchingRoundUseCase,
-    DeleteProjectMatchingRoundUseCase {
+    DeleteProjectMatchingRoundUseCase,
+    AutoDecideProjectMatchingRoundUseCase {
 
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final SaveProjectMatchingRoundPort saveProjectMatchingRoundPort;
     private final LoadProjectApplicationPort loadProjectApplicationPort;
+    private final SaveProjectApplicationPort saveProjectApplicationPort;
+    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final SaveProjectMemberPort saveProjectMemberPort;
+    private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
+    private final Random matchingRandom;
 
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
 
     @Override
     public Long create(CreateProjectMatchingRoundCommand command) {
@@ -104,6 +128,126 @@ public class ProjectMatchingRoundCommandService implements
 
         saveProjectMatchingRoundPort.delete(matchingRound);
     }
+
+    @Override
+    public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
+        ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(matchingRoundId);
+
+        if (round.getAutoDecisionExecutedAt() != null) {
+            return;
+        }
+        if (!round.isDecisionDeadlinePassed(Instant.now())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
+        }
+
+        MatchingDecisionPolicy policy = resolvePolicy(round.getType());
+
+        List<ProjectApplication> applicants = loadProjectApplicationPort
+            .listByMatchingRoundId(matchingRoundId).stream()
+            .filter(a -> isDecidableStatus(a.getStatus()))
+            .toList();
+
+        if (applicants.isEmpty()) {
+            round.executeAutoDecision(executedByMemberId);
+            return;
+        }
+
+        Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
+        Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
+
+        Set<Long> approvedIds = new HashSet<>();
+        Set<Long> rejectedIds = new HashSet<>();
+        for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
+            int quota = findQuota(entry.getKey().projectId(), entry.getKey().part());
+            AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
+            approvedIds.addAll(result.approvedIds());
+            rejectedIds.addAll(result.rejectedIds());
+        }
+
+        applyDecisions(applicants, approvedIds, rejectedIds, executedByMemberId);
+        saveProjectApplicationPort.saveAll(applicants);
+
+        registerApprovedMembers(applicants, approvedIds, applicantPart, executedByMemberId);
+
+        round.executeAutoDecision(executedByMemberId);
+    }
+
+    private MatchingDecisionPolicy resolvePolicy(MatchingType type) {
+        return matchingDecisionPolicies.stream()
+            .filter(p -> p.supportedType() == type)
+            .findFirst()
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND));
+    }
+
+    private boolean isDecidableStatus(ProjectApplicationStatus status) {
+        return status == ProjectApplicationStatus.SUBMITTED
+            || status == ProjectApplicationStatus.APPROVED
+            || status == ProjectApplicationStatus.REJECTED;
+    }
+
+    private Map<Long, ChallengerPart> resolveApplicantParts(List<ProjectApplication> applicants) {
+        Long gisuId = applicants.get(0).getApplicationForm().getProject().getGisuId();
+        return applicants.stream().collect(Collectors.toMap(
+            ProjectApplication::getId,
+            a -> getChallengerUseCase.getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId).part()
+        ));
+    }
+
+    private Map<ProjectPartKey, List<ProjectApplication>> groupByProjectAndPart(
+        List<ProjectApplication> applicants, Map<Long, ChallengerPart> applicantPart
+    ) {
+        return applicants.stream().collect(Collectors.groupingBy(
+            a -> new ProjectPartKey(
+                a.getApplicationForm().getProject().getId(),
+                applicantPart.get(a.getId())
+            )
+        ));
+    }
+
+    private int findQuota(Long projectId, ChallengerPart part) {
+        return loadProjectPartQuotaPort.listByProjectId(projectId).stream()
+            .filter(q -> q.getPart() == part)
+            .findFirst()
+            .map(q -> q.getQuota().intValue())
+            .orElse(0);
+    }
+
+    private void applyDecisions(
+        List<ProjectApplication> applicants,
+        Set<Long> approvedIds,
+        Set<Long> rejectedIds,
+        Long executedByMemberId
+    ) {
+        for (ProjectApplication app : applicants) {
+            ProjectApplicationStatus target = approvedIds.contains(app.getId())
+                ? ProjectApplicationStatus.APPROVED
+                : ProjectApplicationStatus.REJECTED;
+            if (app.getStatus() != target) {
+                app.applyAutoDecision(target, executedByMemberId);
+            }
+        }
+    }
+
+    private void registerApprovedMembers(
+        List<ProjectApplication> applicants,
+        Set<Long> approvedIds,
+        Map<Long, ChallengerPart> applicantPart,
+        Long executedByMemberId
+    ) {
+        for (ProjectApplication app : applicants) {
+            if (!approvedIds.contains(app.getId())) {
+                continue;
+            }
+            Project project = app.getApplicationForm().getProject();
+            ChallengerPart part = applicantPart.get(app.getId());
+            ProjectMember member = ProjectMember.create(
+                project, app.getApplicantMemberId(), part, executedByMemberId
+            );
+            saveProjectMemberPort.save(member);
+        }
+    }
+
+    private record ProjectPartKey(Long projectId, ChallengerPart part) {}
 
     private void validateNoOverlap(
         Long chapterId, Instant startsAt, Instant endsAt, Instant decisionDeadline

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
@@ -133,6 +133,11 @@ public class ProjectMatchingRoundCommandService implements
     public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
         ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(matchingRoundId);
 
+        // executedByMemberId == null 은 스케줄러 호출. 권한 검증은 운영진 수동 호출에만 적용.
+        if (executedByMemberId != null) {
+            validateManageAccess(executedByMemberId, round.getChapterId());
+        }
+
         if (round.getAutoDecisionExecutedAt() != null) {
             return;
         }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
@@ -17,6 +17,7 @@ import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
 import com.umc.product.project.application.service.policy.AutoDecisionResult;
 import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
 import com.umc.product.project.domain.Project;
@@ -55,6 +56,7 @@ public class ProjectMatchingRoundCommandService implements
     private final SaveProjectApplicationPort saveProjectApplicationPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     private final SaveProjectMemberPort saveProjectMemberPort;
+    private final ScheduleMatchingRoundDeadlinePort scheduleMatchingRoundDeadlinePort;
     private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
     private final Random matchingRandom;
 
@@ -80,7 +82,9 @@ public class ProjectMatchingRoundCommandService implements
             command.decisionDeadline()
         );
 
-        return saveProjectMatchingRoundPort.save(matchingRound).getId();
+        ProjectMatchingRound saved = saveProjectMatchingRoundPort.save(matchingRound);
+        scheduleMatchingRoundDeadlinePort.schedule(saved);
+        return saved.getId();
     }
 
     @Override
@@ -115,6 +119,7 @@ public class ProjectMatchingRoundCommandService implements
             endsAt,
             decisionDeadline
         );
+        scheduleMatchingRoundDeadlinePort.schedule(matchingRound);
     }
 
     @Override
@@ -127,6 +132,7 @@ public class ProjectMatchingRoundCommandService implements
         }
 
         saveProjectMatchingRoundPort.delete(matchingRound);
+        scheduleMatchingRoundDeadlinePort.cancel(matchingRoundId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * 매칭 차수의 CRUD lifecycle 만 담당한다.
@@ -66,7 +68,7 @@ public class ProjectMatchingRoundCommandService implements
         );
 
         ProjectMatchingRound saved = saveProjectMatchingRoundPort.save(matchingRound);
-        scheduleMatchingRoundDeadlinePort.schedule(saved);
+        scheduleAfterCommit(saved);
         return saved.getId();
     }
 
@@ -102,7 +104,7 @@ public class ProjectMatchingRoundCommandService implements
             endsAt,
             decisionDeadline
         );
-        scheduleMatchingRoundDeadlinePort.schedule(matchingRound);
+        scheduleAfterCommit(matchingRound);
     }
 
     @Override
@@ -115,7 +117,7 @@ public class ProjectMatchingRoundCommandService implements
         }
 
         saveProjectMatchingRoundPort.delete(matchingRound);
-        scheduleMatchingRoundDeadlinePort.cancel(matchingRoundId);
+        cancelAfterCommit(matchingRoundId);
     }
 
     private void validateNoOverlap(
@@ -135,6 +137,39 @@ public class ProjectMatchingRoundCommandService implements
             id, chapterId, startsAt, decisionDeadline).isEmpty()) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_PERIOD_OVERLAPPED);
         }
+    }
+
+    /**
+     * 트랜잭션 커밋 이후에 스케줄을 등록한다. 롤백 시 in-memory task 만 남는 사고를 방지한다.
+     */
+    private void scheduleAfterCommit(ProjectMatchingRound round) {
+        runAfterCommit(() -> scheduleMatchingRoundDeadlinePort.schedule(round));
+    }
+
+    /**
+     * 트랜잭션 커밋 이후에 스케줄을 취소한다. 롤백 시 잘못된 task 가 남거나 의도치 않게 취소되는 사고를 방지한다.
+     */
+    private void cancelAfterCommit(Long roundId) {
+        runAfterCommit(() -> scheduleMatchingRoundDeadlinePort.cancel(roundId));
+    }
+
+    /**
+     * 트랜잭션 동기화가 활성화돼 있으면 commit 이후로 미루고, 그렇지 않으면 즉시 실행한다.
+     * <p>
+     * 단위 테스트처럼 트랜잭션 컨텍스트 없이 호출되는 경우에도 동작하도록 fallback 을 둔다.
+     */
+    private static void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        action.run();
+                    }
+                });
+            return;
+        }
+        action.run();
     }
 
     private void validateManageAccess(Long memberId, Long chapterId) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandService.java
@@ -2,10 +2,7 @@ package com.umc.product.project.application.service.command;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
-import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
-import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
-import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.CreateProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectMatchingRoundUseCase;
@@ -13,55 +10,41 @@ import com.umc.product.project.application.port.in.command.dto.CreateProjectMatc
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectMatchingRoundCommand;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
-import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
-import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
-import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
-import com.umc.product.project.application.service.policy.AutoDecisionResult;
-import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
-import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectMatchingRound;
-import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
-import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 매칭 차수의 CRUD lifecycle 만 담당한다.
+ * <p>
+ * 차수 종료 시점의 자동 선발(autoDecide) 처리는
+ * {@link ProjectMatchingRoundFinalizationCommandService} 가 담당한다.
+ * 두 책임을 분리하지 않으면 lifecycle 호출 흐름과 트리거 흐름이 한 클래스에 모여 순환 의존성이 발생한다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ProjectMatchingRoundCommandService implements
     CreateProjectMatchingRoundUseCase,
     UpdateProjectMatchingRoundUseCase,
-    DeleteProjectMatchingRoundUseCase,
-    AutoDecideProjectMatchingRoundUseCase {
+    DeleteProjectMatchingRoundUseCase {
 
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final SaveProjectMatchingRoundPort saveProjectMatchingRoundPort;
     private final LoadProjectApplicationPort loadProjectApplicationPort;
-    private final SaveProjectApplicationPort saveProjectApplicationPort;
-    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
-    private final SaveProjectMemberPort saveProjectMemberPort;
     private final ScheduleMatchingRoundDeadlinePort scheduleMatchingRoundDeadlinePort;
-    private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
-    private final Random matchingRandom;
 
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
-    private final GetChallengerUseCase getChallengerUseCase;
 
     @Override
     public Long create(CreateProjectMatchingRoundCommand command) {
@@ -134,131 +117,6 @@ public class ProjectMatchingRoundCommandService implements
         saveProjectMatchingRoundPort.delete(matchingRound);
         scheduleMatchingRoundDeadlinePort.cancel(matchingRoundId);
     }
-
-    @Override
-    public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
-        ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(matchingRoundId);
-
-        // executedByMemberId == null 은 스케줄러 호출. 권한 검증은 운영진 수동 호출에만 적용.
-        if (executedByMemberId != null) {
-            validateManageAccess(executedByMemberId, round.getChapterId());
-        }
-
-        if (round.getAutoDecisionExecutedAt() != null) {
-            return;
-        }
-        if (!round.isDecisionDeadlinePassed(Instant.now())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
-        }
-
-        MatchingDecisionPolicy policy = resolvePolicy(round.getType());
-
-        List<ProjectApplication> applicants = loadProjectApplicationPort
-            .listByMatchingRoundId(matchingRoundId).stream()
-            .filter(a -> isDecidableStatus(a.getStatus()))
-            .toList();
-
-        if (applicants.isEmpty()) {
-            round.executeAutoDecision(executedByMemberId);
-            return;
-        }
-
-        Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
-        Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
-
-        Set<Long> approvedIds = new HashSet<>();
-        Set<Long> rejectedIds = new HashSet<>();
-        for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
-            int quota = findQuota(entry.getKey().projectId(), entry.getKey().part());
-            AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
-            approvedIds.addAll(result.approvedIds());
-            rejectedIds.addAll(result.rejectedIds());
-        }
-
-        applyDecisions(applicants, approvedIds, rejectedIds, executedByMemberId);
-        saveProjectApplicationPort.saveAll(applicants);
-
-        registerApprovedMembers(applicants, approvedIds, applicantPart, executedByMemberId);
-
-        round.executeAutoDecision(executedByMemberId);
-    }
-
-    private MatchingDecisionPolicy resolvePolicy(MatchingType type) {
-        return matchingDecisionPolicies.stream()
-            .filter(p -> p.supportedType() == type)
-            .findFirst()
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND));
-    }
-
-    private boolean isDecidableStatus(ProjectApplicationStatus status) {
-        return status == ProjectApplicationStatus.SUBMITTED
-            || status == ProjectApplicationStatus.APPROVED
-            || status == ProjectApplicationStatus.REJECTED;
-    }
-
-    private Map<Long, ChallengerPart> resolveApplicantParts(List<ProjectApplication> applicants) {
-        Long gisuId = applicants.get(0).getApplicationForm().getProject().getGisuId();
-        return applicants.stream().collect(Collectors.toMap(
-            ProjectApplication::getId,
-            a -> getChallengerUseCase.getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId).part()
-        ));
-    }
-
-    private Map<ProjectPartKey, List<ProjectApplication>> groupByProjectAndPart(
-        List<ProjectApplication> applicants, Map<Long, ChallengerPart> applicantPart
-    ) {
-        return applicants.stream().collect(Collectors.groupingBy(
-            a -> new ProjectPartKey(
-                a.getApplicationForm().getProject().getId(),
-                applicantPart.get(a.getId())
-            )
-        ));
-    }
-
-    private int findQuota(Long projectId, ChallengerPart part) {
-        return loadProjectPartQuotaPort.listByProjectId(projectId).stream()
-            .filter(q -> q.getPart() == part)
-            .findFirst()
-            .map(q -> q.getQuota().intValue())
-            .orElse(0);
-    }
-
-    private void applyDecisions(
-        List<ProjectApplication> applicants,
-        Set<Long> approvedIds,
-        Set<Long> rejectedIds,
-        Long executedByMemberId
-    ) {
-        for (ProjectApplication app : applicants) {
-            ProjectApplicationStatus target = approvedIds.contains(app.getId())
-                ? ProjectApplicationStatus.APPROVED
-                : ProjectApplicationStatus.REJECTED;
-            if (app.getStatus() != target) {
-                app.applyAutoDecision(target, executedByMemberId);
-            }
-        }
-    }
-
-    private void registerApprovedMembers(
-        List<ProjectApplication> applicants,
-        Set<Long> approvedIds,
-        Map<Long, ChallengerPart> applicantPart,
-        Long executedByMemberId
-    ) {
-        for (ProjectApplication app : applicants) {
-            if (!approvedIds.contains(app.getId())) {
-                continue;
-            }
-            Project project = app.getApplicationForm().getProject();
-            ChallengerPart part = applicantPart.get(app.getId());
-            ProjectMember member = ProjectMember.create(
-                project, app.getApplicantMemberId(), part, executedByMemberId
-            );
-            saveProjectMemberPort.save(member);
-        }
-    }
-
-    private record ProjectPartKey(Long projectId, ChallengerPart part) {}
 
     private void validateNoOverlap(
         Long chapterId, Instant startsAt, Instant endsAt, Instant decisionDeadline

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -1,0 +1,197 @@
+package com.umc.product.project.application.service.command;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.service.policy.AutoDecisionResult;
+import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 매칭 차수 종료 시점에 자동 선발을 실행하는 서비스 (MATCHING-201 + 스케줄러 공통 진입점).
+ * <p>
+ * CRUD lifecycle (생성/수정/삭제) 은 {@link ProjectMatchingRoundCommandService} 가 책임지며,
+ * 본 서비스는 lifecycle 종료 트리거({@code decisionDeadline} 도달) 후의 처리만 담당한다.
+ * <p>
+ * CRUD 와 분리한 이유: lifecycle 호출 흐름({@code Service → Registry})과 트리거 흐름
+ * ({@code Registry → Service}) 의 양 방향이 한 클래스에 모이면 순환 의존성이 발생하기 때문이다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectMatchingRoundFinalizationCommandService implements
+    AutoDecideProjectMatchingRoundUseCase {
+
+    private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
+    private final SaveProjectApplicationPort saveProjectApplicationPort;
+    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final SaveProjectMemberPort saveProjectMemberPort;
+    private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
+    private final Random matchingRandom;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+
+    @Override
+    public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
+        ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(matchingRoundId);
+
+        // executedByMemberId == null 은 스케줄러 호출. 권한 검증은 운영진 수동 호출에만 적용.
+        if (executedByMemberId != null) {
+            validateManageAccess(executedByMemberId, round.getChapterId());
+        }
+
+        if (round.getAutoDecisionExecutedAt() != null) {
+            return;
+        }
+        if (!round.isDecisionDeadlinePassed(Instant.now())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
+        }
+
+        MatchingDecisionPolicy policy = resolvePolicy(round.getType());
+
+        List<ProjectApplication> applicants = loadProjectApplicationPort
+            .listByMatchingRoundId(matchingRoundId).stream()
+            .filter(a -> isDecidableStatus(a.getStatus()))
+            .toList();
+
+        if (applicants.isEmpty()) {
+            round.executeAutoDecision(executedByMemberId);
+            return;
+        }
+
+        Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
+        Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
+
+        Set<Long> approvedIds = new HashSet<>();
+        Set<Long> rejectedIds = new HashSet<>();
+        for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
+            int quota = findQuota(entry.getKey().projectId(), entry.getKey().part());
+            AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
+            approvedIds.addAll(result.approvedIds());
+            rejectedIds.addAll(result.rejectedIds());
+        }
+
+        applyDecisions(applicants, approvedIds, rejectedIds, executedByMemberId);
+        saveProjectApplicationPort.saveAll(applicants);
+
+        registerApprovedMembers(applicants, approvedIds, applicantPart, executedByMemberId);
+
+        round.executeAutoDecision(executedByMemberId);
+    }
+
+    private MatchingDecisionPolicy resolvePolicy(MatchingType type) {
+        return matchingDecisionPolicies.stream()
+            .filter(p -> p.supportedType() == type)
+            .findFirst()
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND));
+    }
+
+    private boolean isDecidableStatus(ProjectApplicationStatus status) {
+        return status == ProjectApplicationStatus.SUBMITTED
+            || status == ProjectApplicationStatus.APPROVED
+            || status == ProjectApplicationStatus.REJECTED;
+    }
+
+    private Map<Long, ChallengerPart> resolveApplicantParts(List<ProjectApplication> applicants) {
+        Long gisuId = applicants.get(0).getApplicationForm().getProject().getGisuId();
+        return applicants.stream().collect(Collectors.toMap(
+            ProjectApplication::getId,
+            a -> getChallengerUseCase.getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId).part()
+        ));
+    }
+
+    private Map<ProjectPartKey, List<ProjectApplication>> groupByProjectAndPart(
+        List<ProjectApplication> applicants, Map<Long, ChallengerPart> applicantPart
+    ) {
+        return applicants.stream().collect(Collectors.groupingBy(
+            a -> new ProjectPartKey(
+                a.getApplicationForm().getProject().getId(),
+                applicantPart.get(a.getId())
+            )
+        ));
+    }
+
+    private int findQuota(Long projectId, ChallengerPart part) {
+        return loadProjectPartQuotaPort.listByProjectId(projectId).stream()
+            .filter(q -> q.getPart() == part)
+            .findFirst()
+            .map(q -> q.getQuota().intValue())
+            .orElse(0);
+    }
+
+    private void applyDecisions(
+        List<ProjectApplication> applicants,
+        Set<Long> approvedIds,
+        Set<Long> rejectedIds,
+        Long executedByMemberId
+    ) {
+        for (ProjectApplication app : applicants) {
+            ProjectApplicationStatus target = approvedIds.contains(app.getId())
+                ? ProjectApplicationStatus.APPROVED
+                : ProjectApplicationStatus.REJECTED;
+            if (app.getStatus() != target) {
+                app.applyAutoDecision(target, executedByMemberId);
+            }
+        }
+    }
+
+    private void registerApprovedMembers(
+        List<ProjectApplication> applicants,
+        Set<Long> approvedIds,
+        Map<Long, ChallengerPart> applicantPart,
+        Long executedByMemberId
+    ) {
+        for (ProjectApplication app : applicants) {
+            if (!approvedIds.contains(app.getId())) {
+                continue;
+            }
+            Project project = app.getApplicationForm().getProject();
+            ChallengerPart part = applicantPart.get(app.getId());
+            ProjectMember member = ProjectMember.create(
+                project, app.getApplicantMemberId(), part, executedByMemberId
+            );
+            saveProjectMemberPort.save(member);
+        }
+    }
+
+    private void validateManageAccess(Long memberId, Long chapterId) {
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+        boolean allowed = roles.stream()
+            .anyMatch(role -> role.roleType().isAtLeastCentralCore()
+                || (role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(role.organizationId(), chapterId)));
+
+        if (!allowed) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
+        }
+    }
+
+    private record ProjectPartKey(Long projectId, ChallengerPart part) {}
+}

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -122,10 +122,12 @@ public class ProjectMatchingRoundFinalizationCommandService implements
     }
 
     private Map<Long, ChallengerPart> resolveApplicantParts(List<ProjectApplication> applicants) {
-        Long gisuId = applicants.get(0).getApplicationForm().getProject().getGisuId();
         return applicants.stream().collect(Collectors.toMap(
             ProjectApplication::getId,
-            a -> getChallengerUseCase.getByMemberIdAndGisuId(a.getApplicantMemberId(), gisuId).part()
+            a -> getChallengerUseCase.getByMemberIdAndGisuId(
+                a.getApplicantMemberId(),
+                a.getApplicationForm().getProject().getGisuId()
+            ).part()
         ));
     }
 

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -8,6 +8,7 @@ import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
@@ -52,6 +53,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectApplicationPort saveProjectApplicationPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
     private final SaveProjectMemberPort saveProjectMemberPort;
     private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
     private final Random matchingRandom;
@@ -92,7 +94,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         Set<Long> approvedIds = new HashSet<>();
         Set<Long> rejectedIds = new HashSet<>();
         for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
-            int quota = findQuota(entry.getKey().projectId(), entry.getKey().part());
+            int quota = findRemainingQuota(entry.getKey().projectId(), entry.getKey().part());
             AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
             approvedIds.addAll(result.approvedIds());
             rejectedIds.addAll(result.rejectedIds());
@@ -138,12 +140,23 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         ));
     }
 
-    private int findQuota(Long projectId, ChallengerPart part) {
-        return loadProjectPartQuotaPort.listByProjectId(projectId).stream()
+    /**
+     * 본 차수에서 정책 적용 시 입력으로 사용할 남은 자리 수.
+     * 전체 TO 가 아니라 이전 차수까지 채워진 ACTIVE 멤버 수를 차감한 값을 반환한다.
+     */
+    private int findRemainingQuota(Long projectId, ChallengerPart part) {
+        int totalQuota = loadProjectPartQuotaPort.listByProjectId(projectId).stream()
             .filter(q -> q.getPart() == part)
             .findFirst()
             .map(q -> q.getQuota().intValue())
             .orElse(0);
+
+        int activeCount = loadProjectMemberPort
+            .countByProjectIdGroupByPart(projectId)
+            .getOrDefault(part, 0L)
+            .intValue();
+
+        return Math.max(0, totalQuota - activeCount);
     }
 
     private void applyDecisions(

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -14,7 +14,6 @@ import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.service.policy.AutoDecisionResult;
 import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
-import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.ProjectMember;
@@ -22,6 +21,7 @@ import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -91,10 +91,12 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
         Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
 
+        Map<ProjectPartKey, Integer> remainingQuotaByKey = buildRemainingQuotaMap(grouped.keySet());
+
         Set<Long> approvedIds = new HashSet<>();
         Set<Long> rejectedIds = new HashSet<>();
         for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
-            int quota = findRemainingQuota(entry.getKey().projectId(), entry.getKey().part());
+            int quota = remainingQuotaByKey.getOrDefault(entry.getKey(), 0);
             AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
             approvedIds.addAll(result.approvedIds());
             rejectedIds.addAll(result.rejectedIds());
@@ -121,13 +123,23 @@ public class ProjectMatchingRoundFinalizationCommandService implements
             || status == ProjectApplicationStatus.REJECTED;
     }
 
+    /**
+     * 지원자 전원의 챌린저 파트를 한 번의 batch 조회로 해석한다.
+     * <p>
+     * 한 차수 안의 모든 application 은 동일한 gisu 에 속한다는 도메인 invariant 를 활용해
+     * memberId 집합으로 일괄 조회한 뒤 in-memory 매핑한다.
+     */
     private Map<Long, ChallengerPart> resolveApplicantParts(List<ProjectApplication> applicants) {
+        Long gisuId = applicants.get(0).getApplicationForm().getProject().getGisuId();
+        Set<Long> memberIds = applicants.stream()
+            .map(ProjectApplication::getApplicantMemberId)
+            .collect(Collectors.toSet());
+        Map<Long, ChallengerInfo> challengerByMember = getChallengerUseCase
+            .batchGetByMemberIdsAndGisuId(memberIds, gisuId);
+
         return applicants.stream().collect(Collectors.toMap(
             ProjectApplication::getId,
-            a -> getChallengerUseCase.getByMemberIdAndGisuId(
-                a.getApplicantMemberId(),
-                a.getApplicationForm().getProject().getGisuId()
-            ).part()
+            a -> challengerByMember.get(a.getApplicantMemberId()).part()
         ));
     }
 
@@ -143,22 +155,44 @@ public class ProjectMatchingRoundFinalizationCommandService implements
     }
 
     /**
-     * 본 차수에서 정책 적용 시 입력으로 사용할 남은 자리 수.
-     * 전체 TO 가 아니라 이전 차수까지 채워진 ACTIVE 멤버 수를 차감한 값을 반환한다.
+     * 본 차수에서 정책 적용 시 입력으로 사용할 (project, part) 별 남은 자리 수 맵을 한 번에 구한다.
+     * <p>
+     * 그룹 수만큼 DB 를 두 번씩 치던 기존 단건 호출 대신, projectId 집합 단위로 partQuota 와 active 멤버 수를
+     * 일괄 조회한 뒤 in-memory 로 차감한다.
      */
-    private int findRemainingQuota(Long projectId, ChallengerPart part) {
-        int totalQuota = loadProjectPartQuotaPort.listByProjectId(projectId).stream()
-            .filter(q -> q.getPart() == part)
-            .findFirst()
-            .map(q -> q.getQuota().intValue())
-            .orElse(0);
+    private Map<ProjectPartKey, Integer> buildRemainingQuotaMap(Set<ProjectPartKey> keys) {
+        if (keys.isEmpty()) {
+            return Map.of();
+        }
+        Set<Long> projectIds = keys.stream()
+            .map(ProjectPartKey::projectId)
+            .collect(Collectors.toSet());
 
-        int activeCount = loadProjectMemberPort
-            .countByProjectIdGroupByPart(projectId)
-            .getOrDefault(part, 0L)
-            .intValue();
+        Map<Long, Map<ChallengerPart, Integer>> totalQuotaByProject = loadProjectPartQuotaPort
+            .listByProjectIdsGroupedByProjectId(projectIds).entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().stream().collect(Collectors.toMap(
+                    com.umc.product.project.domain.ProjectPartQuota::getPart,
+                    q -> q.getQuota().intValue()
+                ))
+            ));
 
-        return Math.max(0, totalQuota - activeCount);
+        Map<Long, Map<ChallengerPart, Long>> activeByProject = loadProjectMemberPort
+            .countByProjectIdsGroupByProjectIdAndPart(projectIds);
+
+        Map<ProjectPartKey, Integer> result = new java.util.HashMap<>();
+        for (ProjectPartKey key : keys) {
+            int total = totalQuotaByProject
+                .getOrDefault(key.projectId(), Map.of())
+                .getOrDefault(key.part(), 0);
+            int active = activeByProject
+                .getOrDefault(key.projectId(), Map.of())
+                .getOrDefault(key.part(), 0L)
+                .intValue();
+            result.put(key, Math.max(0, total - active));
+        }
+        return result;
     }
 
     private void applyDecisions(
@@ -183,16 +217,18 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         Map<Long, ChallengerPart> applicantPart,
         Long executedByMemberId
     ) {
-        for (ProjectApplication app : applicants) {
-            if (!approvedIds.contains(app.getId())) {
-                continue;
-            }
-            Project project = app.getApplicationForm().getProject();
-            ChallengerPart part = applicantPart.get(app.getId());
-            ProjectMember member = ProjectMember.create(
-                project, app.getApplicantMemberId(), part, executedByMemberId
-            );
-            saveProjectMemberPort.save(member);
+        List<ProjectMember> membersToSave = applicants.stream()
+            .filter(app -> approvedIds.contains(app.getId()))
+            .map(app -> ProjectMember.create(
+                app.getApplicationForm().getProject(),
+                app.getApplicantMemberId(),
+                applicantPart.get(app.getId()),
+                executedByMemberId
+            ))
+            .toList();
+
+        if (!membersToSave.isEmpty()) {
+            saveProjectMemberPort.saveAll(membersToSave);
         }
     }
 

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -118,14 +118,24 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
         };
     }
 
-    /** 합불 결정. 부모 프로젝트의 PO + SUBMITTED 상태에서만. (자동 매칭 스케줄러는 권한 모델 외) */
+    /**
+     * 합불 결정. 부모 프로젝트의 PO 가 SUBMITTED / APPROVED / REJECTED 상태에서 자유롭게 토글한다.
+     * 차수 진행 중 잠금 해제는 도메인 메서드({@code ProjectMatchingRound.validateIsMutableAt}) 가 책임진다.
+     * (자동 매칭 스케줄러는 권한 모델 외)
+     */
     private boolean canApprove(SubjectAttributes subject, ResourcePermission permission) {
         ProjectApplication application = loadApplication(permission);
-        if (application.getStatus() != ProjectApplicationStatus.SUBMITTED) {
+        if (!isDecidableStatus(application.getStatus())) {
             return false;
         }
         Project project = application.getApplicationForm().getProject();
         return isOwner(subject, project);
+    }
+
+    private boolean isDecidableStatus(ProjectApplicationStatus status) {
+        return status == ProjectApplicationStatus.SUBMITTED
+            || status == ProjectApplicationStatus.APPROVED
+            || status == ProjectApplicationStatus.REJECTED;
     }
 
     private boolean isApplicant(SubjectAttributes subject, ProjectApplication application) {

--- a/src/main/java/com/umc/product/project/application/service/policy/AutoDecisionResult.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/AutoDecisionResult.java
@@ -1,0 +1,16 @@
+package com.umc.product.project.application.service.policy;
+
+import java.util.Set;
+
+/**
+ * 매칭 차수 종료 시 자동 보충 결과.
+ * <p>
+ * 한 application id 가 두 집합에 모두 속하지는 않는다 (PM 의 기존 결정 + 정책 random 보충 합산 결과).
+ *
+ * @param approvedIds 합격으로 확정될 application id 집합 (PM APPROVED + 정책 random 보충)
+ * @param rejectedIds 불합격으로 확정될 application id 집합 (PM REJECTED 잔여 + SUBMITTED 잔여)
+ */
+public record AutoDecisionResult(
+    Set<Long> approvedIds,
+    Set<Long> rejectedIds
+) {}

--- a/src/main/java/com/umc/product/project/application/service/policy/DesignerMatchingPolicy.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/DesignerMatchingPolicy.java
@@ -1,0 +1,26 @@
+package com.umc.product.project.application.service.policy;
+
+import com.umc.product.project.domain.enums.MatchingType;
+import org.springframework.stereotype.Component;
+
+/**
+ * PLAN_DESIGN 매칭 정책.
+ * <ul>
+ *   <li>지원자 1명: 선택 의무 없음 (PM 자유)</li>
+ *   <li>지원자 2명 이상: 최소 1명 합격 의무</li>
+ * </ul>
+ * TO 와 무관하다.
+ */
+@Component
+public class DesignerMatchingPolicy implements MatchingDecisionPolicy {
+
+    @Override
+    public MatchingType supportedType() {
+        return MatchingType.PLAN_DESIGN;
+    }
+
+    @Override
+    public int minimumRequired(int applicantsCount, int quota) {
+        return applicantsCount >= 2 ? 1 : 0;
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/policy/DeveloperMatchingPolicy.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/DeveloperMatchingPolicy.java
@@ -1,0 +1,36 @@
+package com.umc.product.project.application.service.policy;
+
+import com.umc.product.project.domain.enums.MatchingType;
+import org.springframework.stereotype.Component;
+
+/**
+ * PLAN_DEVELOPER 매칭 정책 (지원자가 TO 대비 어느 비율인지로 판정).
+ * <ul>
+ *   <li>지원자 ≥ TO (100% 이상): 최소 ceil(TO × 0.5) 명</li>
+ *   <li>TO 대비 50% 초과 ~ 100% 미만: 최소 ceil(TO × 0.25) 명</li>
+ *   <li>50% 이하: 의무 없음</li>
+ * </ul>
+ */
+@Component
+public class DeveloperMatchingPolicy implements MatchingDecisionPolicy {
+
+    @Override
+    public MatchingType supportedType() {
+        return MatchingType.PLAN_DEVELOPER;
+    }
+
+    @Override
+    public int minimumRequired(int applicantsCount, int quota) {
+        if (applicantsCount >= quota) {
+            return ceilOfRatio(quota, 0.5);
+        }
+        if (applicantsCount * 2 > quota) {
+            return ceilOfRatio(quota, 0.25);
+        }
+        return 0;
+    }
+
+    private static int ceilOfRatio(int quota, double ratio) {
+        return (int) Math.ceil(quota * ratio);
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/policy/MatchingDeadlineSchedulerConfig.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/MatchingDeadlineSchedulerConfig.java
@@ -1,0 +1,25 @@
+package com.umc.product.project.application.service.policy;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * 매칭 차수 종료 시점에 자동 선발을 트리거하는 동적 스케줄러용 {@link TaskScheduler} 설정.
+ * <p>
+ * 본 도메인 전용 풀로 분리하여 다른 도메인의 {@code @Scheduled} 풀과 자원이 섞이지 않도록 한다.
+ */
+@Configuration
+public class MatchingDeadlineSchedulerConfig {
+
+    @Bean(name = "matchingDeadlineTaskScheduler", destroyMethod = "shutdown")
+    public TaskScheduler matchingDeadlineTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        scheduler.setThreadNamePrefix("matching-deadline-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/policy/MatchingDecisionPolicy.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/MatchingDecisionPolicy.java
@@ -1,0 +1,100 @@
+package com.umc.product.project.application.service.policy;
+
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * 매칭 차수 종료 시 자동 보충 정책.
+ * <p>
+ * Strategy 패턴 — {@link MatchingType} 별로 구현체가 다르며 Spring 이 {@link #supportedType()} 으로 매핑한다.
+ * <p>
+ * 알고리즘 전체는 {@link #decideAutomatically} default 메서드가 책임지고, 구현체는
+ * {@link #minimumRequired} (최소 합격 인원 계산) 만 채우면 된다.
+ */
+public interface MatchingDecisionPolicy {
+
+    /** 본 정책이 적용되는 매칭 종류. */
+    MatchingType supportedType();
+
+    /**
+     * 정책상 최소 합격 인원.
+     *
+     * @param applicantsCount 본 차수 본 프로젝트의 전체 지원자 수 (status 무관, CANCELLED 제외)
+     * @param quota           본 프로젝트의 해당 파트 정원
+     * @return 최소 합격 인원 (정책 의무 없음 → 0)
+     */
+    int minimumRequired(int applicantsCount, int quota);
+
+    /**
+     * 차수 종료 시 자동 보충 알고리즘 (final-api.md §3 매트릭스 ③).
+     * <p>
+     * <ol>
+     *   <li>이미 APPROVED 인 지원자는 그대로 합격 유지</li>
+     *   <li>합격 카운트가 정책 최소치 미만이면 SUBMITTED 풀에서 random 보충</li>
+     *   <li>SUBMITTED 풀이 부족하면 REJECTED 풀에서 추가 random 보충 (PM 결정 override)</li>
+     *   <li>그 외 SUBMITTED / REJECTED 는 모두 REJECTED 로 확정</li>
+     * </ol>
+     */
+    default AutoDecisionResult decideAutomatically(
+        List<ProjectApplication> applicants, int quota, Random random
+    ) {
+        Set<Long> approvedIds = new HashSet<>();
+        Set<Long> rejectedIds = new HashSet<>();
+
+        List<ProjectApplication> alreadyApproved = filterByStatus(applicants, ProjectApplicationStatus.APPROVED);
+        alreadyApproved.forEach(a -> approvedIds.add(a.getId()));
+
+        int required = minimumRequired(applicants.size(), quota);
+        int needed = Math.max(0, required - alreadyApproved.size());
+
+        List<ProjectApplication> submittedPool = filterByStatus(applicants, ProjectApplicationStatus.SUBMITTED);
+        int pickFromSubmitted = Math.min(needed, submittedPool.size());
+        randomPick(submittedPool, pickFromSubmitted, random, approvedIds, rejectedIds);
+
+        int remainingNeeded = needed - pickFromSubmitted;
+        List<ProjectApplication> rejectedPool = filterByStatus(applicants, ProjectApplicationStatus.REJECTED);
+        randomPick(rejectedPool, remainingNeeded, random, approvedIds, rejectedIds);
+
+        return new AutoDecisionResult(approvedIds, rejectedIds);
+    }
+
+    private static List<ProjectApplication> filterByStatus(
+        List<ProjectApplication> applicants, ProjectApplicationStatus status
+    ) {
+        return applicants.stream()
+            .filter(a -> a.getStatus() == status)
+            .toList();
+    }
+
+    /**
+     * pool 을 셔플한 뒤 앞에서 {@code pickCount} 개를 approvedIds 로, 나머지는 rejectedIds 로 분류한다.
+     */
+    private static void randomPick(
+        List<ProjectApplication> pool,
+        int pickCount,
+        Random random,
+        Set<Long> approvedIds,
+        Set<Long> rejectedIds
+    ) {
+        if (pool.isEmpty()) {
+            return;
+        }
+        List<ProjectApplication> shuffled = new ArrayList<>(pool);
+        Collections.shuffle(shuffled, random);
+        for (int i = 0; i < shuffled.size(); i++) {
+            Long id = shuffled.get(i).getId();
+            if (i < pickCount) {
+                approvedIds.add(id);
+            } else {
+                rejectedIds.add(id);
+            }
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/service/policy/MatchingRandomConfig.java
+++ b/src/main/java/com/umc/product/project/application/service/policy/MatchingRandomConfig.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.service.policy;
+
+import java.util.Random;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 자동 선발 알고리즘에 주입되는 {@link Random} 인스턴스 빈 등록.
+ * <p>
+ * 테스트에서는 시드를 고정한 {@code Random(seed)} 를 직접 주입하여 결정성을 확보한다.
+ */
+@Configuration
+public class MatchingRandomConfig {
+
+    @Bean
+    public Random matchingRandom() {
+        return new Random();
+    }
+}

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -134,6 +134,28 @@ public class ProjectApplication extends BaseEntity {
     }
 
     /**
+     * 차수 종료 시점의 자동 선발 결과를 반영합니다.
+     * <p>
+     * PM 의 단건 토글({@link #approve}/{@link #reject})과 달리 차수 잠금 검증을 거치지 않으며,
+     * 정책에 따라 도출된 최종 status (APPROVED 또는 REJECTED) 를 그대로 적용합니다.
+     * <p>
+     * 호출자: 자동 선발 서비스 (스케줄러 / 운영진 수동 트리거 공용).
+     *
+     * @param targetStatus      APPROVED 또는 REJECTED 만 허용
+     * @param executedByMemberId 자동 선발을 실행한 운영진 ID. 스케줄러 호출 시 {@code null}
+     */
+    public void applyAutoDecision(ProjectApplicationStatus targetStatus, Long executedByMemberId) {
+        validateCanBeDecided();
+        if (targetStatus != ProjectApplicationStatus.APPROVED
+            && targetStatus != ProjectApplicationStatus.REJECTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+        this.status = targetStatus;
+        this.statusChangedMemberId = executedByMemberId;
+        this.statusChangeReason = "auto-decide";
+    }
+
+    /**
      * APPROVED / REJECTED 결정을 SUBMITTED ("대기") 로 되돌립니다.
      * <p>
      * UI 상의 "대기" 옵션이며, 차수 진행 중에만 호출 가능합니다.

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -5,6 +5,7 @@ import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.domain.FormResponse;
+import java.time.Instant;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -97,13 +98,17 @@ public class ProjectApplication extends BaseEntity {
     }
 
     /**
-     * 지원서를 합격시킬 때 사용합니다.
+     * 지원서를 합격 처리합니다.
+     * <p>
+     * 매칭 차수가 진행 중인 동안 PM 이 자유롭게 토글할 수 있으며, REJECTED 또는 APPROVED 상태에서도 재호출 가능합니다.
+     * 차수 종료 후엔 {@link ProjectErrorCode#PROJECT_MATCHING_ROUND_LOCKED} 가 발생합니다.
      *
      * @param decidedByMemberId 결정한 PO 또는 운영진 ID
      * @param reason            결정 사유 (필수 아님)
      */
     public void approve(Long decidedByMemberId, String reason) {
-        validateIsSubmitted("지원서가 제출된 상태에서만 합격 처리할 수 있습니다.");
+        validateCanBeDecided();
+        appliedMatchingRound.validateIsMutableAt(Instant.now());
 
         this.status = ProjectApplicationStatus.APPROVED;
         this.statusChangedMemberId = decidedByMemberId;
@@ -111,17 +116,50 @@ public class ProjectApplication extends BaseEntity {
     }
 
     /**
-     * 지원서를 불합격시킬 때 사용합니다.
+     * 지원서를 불합격 처리합니다.
+     * <p>
+     * 매칭 차수가 진행 중인 동안 PM 이 자유롭게 토글할 수 있으며, APPROVED 또는 REJECTED 상태에서도 재호출 가능합니다.
+     * 차수 종료 후엔 {@link ProjectErrorCode#PROJECT_MATCHING_ROUND_LOCKED} 가 발생합니다.
      *
      * @param decidedByMemberId 결정한 PO 또는 운영진 ID
      * @param reason            결정 사유 (필수 아님)
      */
     public void reject(Long decidedByMemberId, String reason) {
-        validateIsSubmitted("지원서가 제출된 상태에서만 불합격 처리할 수 있습니다.");
+        validateCanBeDecided();
+        appliedMatchingRound.validateIsMutableAt(Instant.now());
 
         this.status = ProjectApplicationStatus.REJECTED;
         this.statusChangedMemberId = decidedByMemberId;
         this.statusChangeReason = reason;
+    }
+
+    /**
+     * APPROVED / REJECTED 결정을 SUBMITTED ("대기") 로 되돌립니다.
+     * <p>
+     * UI 상의 "대기" 옵션이며, 차수 진행 중에만 호출 가능합니다.
+     *
+     * @param revertedByMemberId 되돌린 PO 또는 운영진 ID
+     */
+    public void revertToPending(Long revertedByMemberId) {
+        if (status != ProjectApplicationStatus.APPROVED && status != ProjectApplicationStatus.REJECTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+        appliedMatchingRound.validateIsMutableAt(Instant.now());
+
+        this.status = ProjectApplicationStatus.SUBMITTED;
+        this.statusChangedMemberId = revertedByMemberId;
+        this.statusChangeReason = null;
+    }
+
+    /**
+     * 합/불 결정 대상이 되는 status 인지 검증합니다. SUBMITTED / APPROVED / REJECTED 만 통과합니다.
+     */
+    private void validateCanBeDecided() {
+        if (status != ProjectApplicationStatus.SUBMITTED
+            && status != ProjectApplicationStatus.APPROVED
+            && status != ProjectApplicationStatus.REJECTED) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
     }
 
     /**

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -163,6 +163,7 @@ public class ProjectApplication extends BaseEntity {
         this.status = targetStatus;
         this.statusChangedMemberId = executedByMemberId;
         this.statusChangeReason = "auto-decide";
+        this.statusChangedAt = Instant.now();
     }
 
     /**
@@ -181,6 +182,7 @@ public class ProjectApplication extends BaseEntity {
         this.status = ProjectApplicationStatus.SUBMITTED;
         this.statusChangedMemberId = revertedByMemberId;
         this.statusChangeReason = null;
+        this.statusChangedAt = Instant.now();
     }
 
     /**

--- a/src/main/java/com/umc/product/project/domain/ProjectMatchingRound.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMatchingRound.java
@@ -240,4 +240,18 @@ public class ProjectMatchingRound extends BaseEntity {
     public boolean isDecisionDeadlinePassed(Instant now) {
         return decisionDeadline.isBefore(now);
     }
+
+    /**
+     * PM 의 합/불 토글이 허용되는 시점인지 검증합니다.
+     * <p>
+     * {@code startsAt <= now <= decisionDeadline} 범위에서만 mutable.
+     * 차수 시작 전이거나 결정 마감을 넘긴 경우 {@link ProjectErrorCode#PROJECT_MATCHING_ROUND_LOCKED} 도메인 예외를 던집니다.
+     *
+     * @param now 기준 시각
+     */
+    public void validateIsMutableAt(Instant now) {
+        if (now.isBefore(startsAt) || now.isAfter(decisionDeadline)) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+    }
 }

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -57,6 +57,8 @@ public enum ProjectErrorCode implements BaseCode {
         "연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다."),
     PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER(HttpStatus.BAD_REQUEST, "PROJECT-0305",
         "time 기준 조회는 chapterId와 함께 요청해야 합니다."),
+    PROJECT_MATCHING_ROUND_LOCKED(HttpStatus.BAD_REQUEST, "PROJECT-0306",
+        "매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다."),
 
     // ProjectApplication (APPLY-001/002/003)
     PROJECT_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0204", "작성 중인 지원서를 찾을 수 없습니다."),
@@ -67,6 +69,8 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_ROUND_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "PROJECT-0209", "선택한 매칭 차수가 본인 파트에 해당하지 않습니다."),
     PROJECT_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT-0210", "이미 작성 중인 지원서가 있습니다."),
     PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0211", "본인이 운영하는 프로젝트에는 지원할 수 없습니다."),
+    PROJECT_APPLICATION_DECISION_INVALID_TRANSITION(HttpStatus.BAD_REQUEST, "PROJECT-0212",
+        "현재 상태에서는 합/불 결정을 변경할 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -59,6 +59,10 @@ public enum ProjectErrorCode implements BaseCode {
         "time 기준 조회는 chapterId와 함께 요청해야 합니다."),
     PROJECT_MATCHING_ROUND_LOCKED(HttpStatus.BAD_REQUEST, "PROJECT-0306",
         "매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다."),
+    PROJECT_MATCHING_ROUND_NOT_FINALIZABLE(HttpStatus.BAD_REQUEST, "PROJECT-0307",
+        "결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다."),
+    PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "PROJECT-0308",
+        "해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다."),
 
     // ProjectApplication (APPLY-001/002/003)
     PROJECT_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0204", "작성 중인 지원서를 찾을 수 없습니다."),

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -75,6 +75,8 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PROJECT-0211", "본인이 운영하는 프로젝트에는 지원할 수 없습니다."),
     PROJECT_APPLICATION_DECISION_INVALID_TRANSITION(HttpStatus.BAD_REQUEST, "PROJECT-0212",
         "현재 상태에서는 합/불 결정을 변경할 수 없습니다."),
+    PROJECT_APPLICATION_QUOTA_EXCEEDED(HttpStatus.CONFLICT, "PROJECT-0213",
+        "해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다."),
 
     ;
 

--- a/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandlerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandlerTest.java
@@ -1,0 +1,36 @@
+package com.umc.product.project.adapter.in.scheduler;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingRoundDeadlineHandlerTest {
+
+    @Mock
+    AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+
+    @InjectMocks
+    MatchingRoundDeadlineHandler sut;
+
+    @Test
+    void handle은_autoDecide를_null_executor로_호출한다() {
+        sut.handle(42L);
+
+        then(autoDecideUseCase).should().autoDecide(42L, null);
+    }
+
+    @Test
+    void autoDecide_예외는_swallow되어_상위로_전파되지_않는다() {
+        willThrow(new RuntimeException("boom")).given(autoDecideUseCase).autoDecide(42L, null);
+
+        sut.handle(42L);
+        // 예외 미전파 — 호출이 정상 종료
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineRegistryTest.java
@@ -1,0 +1,174 @@
+package com.umc.product.project.adapter.in.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingRoundDeadlineRegistryTest {
+
+    @Mock
+    TaskScheduler taskScheduler;
+    @Mock
+    AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+    @Mock
+    LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    @Mock
+    ScheduledFuture<?> scheduledFuture;
+    @Mock
+    ScheduledFuture<?> scheduledFuture2;
+
+    MatchingRoundDeadlineRegistry sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new MatchingRoundDeadlineRegistry(
+            taskScheduler, autoDecideUseCase, loadProjectMatchingRoundPort
+        );
+    }
+
+    @Nested
+    class schedule {
+
+        @Test
+        void deadline_시점에_task가_등록된다() {
+            ProjectMatchingRound round = roundWithId(1L);
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture);
+
+            sut.schedule(round);
+
+            assertThat(sut.isScheduled(1L)).isTrue();
+            then(taskScheduler).should().schedule(any(Runnable.class), eq(round.getDecisionDeadline()));
+        }
+
+        @Test
+        void 동일_id_재등록시_기존_task는_취소되고_새_task가_등록된다() {
+            ProjectMatchingRound round = roundWithId(1L);
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture)
+                .willAnswer(invocation -> scheduledFuture2);
+
+            sut.schedule(round);
+            sut.schedule(round);
+
+            then(scheduledFuture).should().cancel(false);
+            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        void 등록된_task가_실행되면_autoDecide가_null_executor로_호출된다() {
+            ProjectMatchingRound round = roundWithId(1L);
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            given(taskScheduler.schedule(taskCaptor.capture(), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture);
+
+            sut.schedule(round);
+            taskCaptor.getValue().run();
+
+            then(autoDecideUseCase).should().autoDecide(1L, null);
+        }
+
+        @Test
+        void task_실행_중_예외가_발생해도_swallow되고_등록은_제거된다() {
+            ProjectMatchingRound round = roundWithId(1L);
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            given(taskScheduler.schedule(taskCaptor.capture(), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture);
+            org.mockito.Mockito.doThrow(new RuntimeException("boom"))
+                .when(autoDecideUseCase).autoDecide(any(), any());
+
+            sut.schedule(round);
+            taskCaptor.getValue().run();
+
+            assertThat(sut.isScheduled(1L)).isFalse();
+        }
+    }
+
+    @Nested
+    class cancel {
+
+        @Test
+        void 등록되지_않은_id면_no_op() {
+            sut.cancel(999L);
+
+            then(scheduledFuture).should(never()).cancel(any(boolean.class));
+        }
+
+        @Test
+        void 등록된_id면_task_취소하고_제거된다() {
+            ProjectMatchingRound round = roundWithId(1L);
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture);
+            sut.schedule(round);
+
+            sut.cancel(1L);
+
+            then(scheduledFuture).should().cancel(false);
+            assertThat(sut.isScheduled(1L)).isFalse();
+        }
+    }
+
+    @Nested
+    class recoverPendingTasks {
+
+        @Test
+        void 부팅_시_미처리_round_모두_재등록된다() {
+            ProjectMatchingRound round1 = roundWithId(1L);
+            ProjectMatchingRound round2 = roundWithId(2L);
+            given(loadProjectMatchingRoundPort.listAllNotAutoDecided())
+                .willReturn(List.of(round1, round2));
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                .willAnswer(invocation -> scheduledFuture);
+
+            sut.recoverPendingTasks();
+
+            assertThat(sut.isScheduled(1L)).isTrue();
+            assertThat(sut.isScheduled(2L)).isTrue();
+            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        void 미처리_round가_없으면_등록되는_task도_없다() {
+            given(loadProjectMatchingRoundPort.listAllNotAutoDecided()).willReturn(List.of());
+
+            sut.recoverPendingTasks();
+
+            then(taskScheduler).should(never()).schedule(any(Runnable.class), any(Instant.class));
+        }
+    }
+
+    private ProjectMatchingRound roundWithId(Long id) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭 " + id, null,
+            MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
+            Instant.now().plusSeconds(86_400),
+            Instant.now().plusSeconds(172_800),
+            Instant.now().plusSeconds(259_200)
+        );
+        ReflectionTestUtils.setField(round, "id", id);
+        return round;
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
@@ -1,0 +1,209 @@
+package com.umc.product.project.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.dto.request.UpdateApplicationDecisionRequest;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ProjectApplicationController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProjectApplicationControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+    private static final Long PROJECT_ID = 42L;
+    private static final Long APPLICATION_ID = 500L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    CreateDraftProjectApplicationUseCase createDraftProjectApplicationUseCase;
+
+    @MockitoBean
+    UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
+
+    @MockitoBean
+    SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
+
+    @MockitoBean
+    DecideApplicationUseCase decideApplicationUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Nested
+    class PATCH_decision {
+
+        @Test
+        void APPROVED_요청시_200_및_status_반환() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.APPROVED, "역량 우수"
+            );
+            given(decideApplicationUseCase.decide(
+                eq(APPLICATION_ID), eq(ApplicationDecisionStatus.APPROVED), eq("역량 우수"), eq(TEST_MEMBER_ID)
+            )).willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.APPROVED));
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.applicationId").value(APPLICATION_ID))
+                .andExpect(jsonPath("$.result.status").value("APPROVED"));
+        }
+
+        @Test
+        void REJECTED_요청시_200_및_status_반환() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.REJECTED, null
+            );
+            given(decideApplicationUseCase.decide(
+                eq(APPLICATION_ID), eq(ApplicationDecisionStatus.REJECTED), eq(null), eq(TEST_MEMBER_ID)
+            )).willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.REJECTED));
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("REJECTED"));
+        }
+
+        @Test
+        void PENDING_요청시_도메인의_SUBMITTED로_매핑된_응답을_반환한다() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.PENDING, null
+            );
+            given(decideApplicationUseCase.decide(
+                eq(APPLICATION_ID), eq(ApplicationDecisionStatus.PENDING), eq(null), eq(TEST_MEMBER_ID)
+            )).willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.SUBMITTED));
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("SUBMITTED"));
+        }
+
+        @Test
+        void status_누락시_400() throws Exception {
+            String body = """
+                { "reason": "사유" }
+                """;
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(body).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+            then(decideApplicationUseCase).should(never()).decide(any(), any(), any(), any());
+        }
+
+        @Test
+        void status가_허용된_enum이_아니면_400() throws Exception {
+            String body = """
+                { "status": "UNKNOWN" }
+                """;
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(body).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+            then(decideApplicationUseCase).should(never()).decide(any(), any(), any(), any());
+        }
+
+        @Test
+        void reason이_500자를_초과하면_400() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.APPROVED, "a".repeat(501)
+            );
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+            then(decideApplicationUseCase).should(never()).decide(any(), any(), any(), any());
+        }
+
+        @Test
+        void 차수_종료_후_도메인_예외시_400_PROJECT_MATCHING_ROUND_LOCKED() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.APPROVED, null
+            );
+            given(decideApplicationUseCase.decide(any(), any(), any(), any()))
+                .willThrow(new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED));
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PROJECT-0306"));
+        }
+
+        @Test
+        void DRAFT_상태_도메인_예외시_400_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() throws Exception {
+            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
+                ApplicationDecisionStatus.APPROVED, null
+            );
+            given(decideApplicationUseCase.decide(any(), any(), any(), any()))
+                .willThrow(new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION));
+
+            mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("PROJECT-0212"));
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
@@ -1,14 +1,15 @@
-package com.umc.product.project.adapter.in.scheduler;
+package com.umc.product.project.adapter.out.scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
-import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.enums.MatchingPhase;
@@ -27,12 +28,12 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-class MatchingRoundDeadlineRegistryTest {
+class MatchingRoundDeadlineSchedulerTest {
 
     @Mock
     TaskScheduler taskScheduler;
     @Mock
-    AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+    MatchingRoundDeadlineHandler handler;
     @Mock
     LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     @Mock
@@ -40,12 +41,12 @@ class MatchingRoundDeadlineRegistryTest {
     @Mock
     ScheduledFuture<?> scheduledFuture2;
 
-    MatchingRoundDeadlineRegistry sut;
+    MatchingRoundDeadlineScheduler sut;
 
     @BeforeEach
     void setUp() {
-        sut = new MatchingRoundDeadlineRegistry(
-            taskScheduler, autoDecideUseCase, loadProjectMatchingRoundPort
+        sut = new MatchingRoundDeadlineScheduler(
+            taskScheduler, handler, loadProjectMatchingRoundPort
         );
     }
 
@@ -79,7 +80,7 @@ class MatchingRoundDeadlineRegistryTest {
         }
 
         @Test
-        void 등록된_task가_실행되면_autoDecide가_null_executor로_호출된다() {
+        void 등록된_task가_실행되면_handler에_위임한다() {
             ProjectMatchingRound round = roundWithId(1L);
             ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
             given(taskScheduler.schedule(taskCaptor.capture(), any(Instant.class)))
@@ -88,20 +89,24 @@ class MatchingRoundDeadlineRegistryTest {
             sut.schedule(round);
             taskCaptor.getValue().run();
 
-            then(autoDecideUseCase).should().autoDecide(1L, null);
+            then(handler).should().handle(1L);
+            assertThat(sut.isScheduled(1L)).isFalse();
         }
 
         @Test
-        void task_실행_중_예외가_발생해도_swallow되고_등록은_제거된다() {
+        void handler_예외가_상위로_전파되어도_등록은_제거된다() {
             ProjectMatchingRound round = roundWithId(1L);
             ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
             given(taskScheduler.schedule(taskCaptor.capture(), any(Instant.class)))
                 .willAnswer(invocation -> scheduledFuture);
-            org.mockito.Mockito.doThrow(new RuntimeException("boom"))
-                .when(autoDecideUseCase).autoDecide(any(), any());
+            willThrow(new RuntimeException("boom")).given(handler).handle(1L);
 
             sut.schedule(round);
-            taskCaptor.getValue().run();
+            try {
+                taskCaptor.getValue().run();
+            } catch (RuntimeException ignored) {
+                // 등록 제거 보장이 본 케이스의 검증 대상
+            }
 
             assertThat(sut.isScheduled(1L)).isFalse();
         }

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
@@ -54,7 +54,7 @@ class MatchingRoundDeadlineSchedulerTest {
     class schedule {
 
         @Test
-        void deadline_시점에_task가_등록된다() {
+        void deadline_buffer_적용된_시점에_task가_등록된다() {
             ProjectMatchingRound round = roundWithId(1L);
             given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
                 .willAnswer(invocation -> scheduledFuture);
@@ -62,7 +62,8 @@ class MatchingRoundDeadlineSchedulerTest {
             sut.schedule(round);
 
             assertThat(sut.isScheduled(1L)).isTrue();
-            then(taskScheduler).should().schedule(any(Runnable.class), eq(round.getDecisionDeadline()));
+            Instant expectedRunAt = round.getDecisionDeadline().plus(MatchingRoundDeadlineScheduler.DEADLINE_BUFFER);
+            then(taskScheduler).should().schedule(any(Runnable.class), eq(expectedRunAt));
         }
 
         @Test

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -1,0 +1,196 @@
+package com.umc.product.project.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicationCommandServiceTest {
+
+    private static final Long APPLICATION_ID = 500L;
+    private static final Long APPLICANT_MEMBER_ID = 100L;
+    private static final Long DECIDER_MEMBER_ID = 200L;
+
+    private static final Instant NOW = Instant.now();
+    private static final Instant ROUND_STARTS_AT = NOW.minusSeconds(86_400);
+    private static final Instant ROUND_ENDS_AT = NOW.plusSeconds(43_200);
+    private static final Instant ROUND_DECISION_DEADLINE = NOW.plusSeconds(86_400);
+
+    @Mock
+    LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
+    SaveProjectApplicationPort saveProjectApplicationPort;
+    @Mock
+    LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+    @Mock
+    LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
+    LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    @Mock
+    ManageFormResponseUseCase manageFormResponseUseCase;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+
+    @InjectMocks
+    ProjectApplicationCommandService sut;
+
+    @Nested
+    class decide {
+
+        @Test
+        void APPROVED_입력시_도메인_approve_호출_후_저장한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            ProjectApplicationInfo info = sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, "역량 우수", DECIDER_MEMBER_ID
+            );
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("역량 우수");
+            assertThat(info.applicationId()).isEqualTo(APPLICATION_ID);
+            assertThat(info.status()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            then(saveProjectApplicationPort).should(times(1)).save(application);
+        }
+
+        @Test
+        void REJECTED_입력시_도메인_reject_호출_후_저장한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.REJECTED, "면접 결과", DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            assertThat(application.getStatusChangeReason()).isEqualTo("면접 결과");
+            then(saveProjectApplicationPort).should(times(1)).save(application);
+        }
+
+        @Test
+        void PENDING_입력시_도메인_revertToPending_호출하고_사유는_초기화된다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
+            ReflectionTestUtils.setField(application, "statusChangeReason", "이전 사유");
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.PENDING, "무시되는 사유", DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+            assertThat(application.getStatusChangeReason()).isNull();
+            then(saveProjectApplicationPort).should(times(1)).save(application);
+        }
+
+        @Test
+        void reason이_null이어도_정상_처리된다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatusChangeReason()).isNull();
+        }
+
+        @Test
+        void 존재하지_않는_지원서면_PROJECT_APPLICATION_NOT_FOUND() {
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        void DRAFT_상태_지원서면_도메인_예외_전파_후_저장하지_않는다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.DRAFT);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        void 차수_종료_후에는_도메인_예외_전파_후_저장하지_않는다() {
+            ProjectMatchingRound expiredRound = openRound();
+            ReflectionTestUtils.setField(expiredRound, "decisionDeadline", NOW.minusSeconds(60));
+            ProjectApplication application = ProjectApplication.create(
+                applicationForm(), 999L, APPLICANT_MEMBER_ID, expiredRound
+            );
+            ReflectionTestUtils.setField(application, "id", APPLICATION_ID);
+            ReflectionTestUtils.setField(application, "status", ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+    }
+
+    private ProjectApplication applicationWithStatus(ProjectApplicationStatus status) {
+        ProjectApplication application = ProjectApplication.create(
+            applicationForm(), 999L, APPLICANT_MEMBER_ID, openRound()
+        );
+        ReflectionTestUtils.setField(application, "id", APPLICATION_ID);
+        ReflectionTestUtils.setField(application, "status", status);
+        return application;
+    }
+
+    private ProjectMatchingRound openRound() {
+        return ProjectMatchingRound.create(
+            "기획-디자인 1차 매칭", null,
+            MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
+            ROUND_STARTS_AT, ROUND_ENDS_AT, ROUND_DECISION_DEADLINE
+        );
+    }
+
+    private ProjectApplicationForm applicationForm() {
+        Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
+        return ProjectApplicationForm.create(project, 500L);
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -223,6 +223,11 @@ class ProjectApplicationCommandServiceTest {
                     otherApprovedApplication(701L, 71L, application.getApplicationForm()),
                     otherApprovedApplication(702L, 72L, application.getApplicationForm())
                 ));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+                .willReturn(Map.of(
+                    71L, challengerWith(71L, ChallengerPart.WEB),
+                    72L, challengerWith(72L, ChallengerPart.WEB)
+                ));
 
             assertThatThrownBy(() -> sut.decide(
                 APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
@@ -281,8 +286,8 @@ class ProjectApplicationCommandServiceTest {
                 .willReturn(List.of(iosApp));
             given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
                 .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(71L), any()))
-                .willReturn(challengerWith(71L, ChallengerPart.IOS));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+                .willReturn(Map.of(71L, challengerWith(71L, ChallengerPart.IOS)));
 
             sut.decide(APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID);
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -3,12 +3,15 @@ package com.umc.product.project.application.service.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
@@ -21,6 +24,7 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
@@ -28,16 +32,23 @@ import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ProjectApplicationCommandServiceTest {
 
     private static final Long APPLICATION_ID = 500L;
@@ -68,6 +79,19 @@ class ProjectApplicationCommandServiceTest {
 
     @InjectMocks
     ProjectApplicationCommandService sut;
+
+    @BeforeEach
+    void setUpQuotaMocks() {
+        // 기본: quota 충분 (ChallengerPart.WEB, TO 6, active 0, 같은 차수 APPROVED 0)
+        given(getChallengerUseCase.getByMemberIdAndGisuId(any(), any()))
+            .willReturn(challengerWithPart(ChallengerPart.WEB));
+        given(loadProjectPartQuotaPort.listByProjectId(any()))
+            .willReturn(List.of(partQuotaForWeb(6L)));
+        given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+            .willReturn(Map.of());
+        given(loadProjectApplicationPort.listByMatchingRoundId(any()))
+            .willReturn(List.of());
+    }
 
     @Nested
     class decide {
@@ -170,6 +194,100 @@ class ProjectApplicationCommandServiceTest {
                 .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
             then(saveProjectApplicationPort).should(never()).save(any());
         }
+
+        @Test
+        void APPROVED_토글시_active_멤버가_TO를_채워_남은_자리가_없으면_QUOTA_EXCEEDED() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 6L));   // active 6 == TO 6 → 남은 자리 0
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_QUOTA_EXCEEDED);
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        void APPROVED_토글시_active_멤버와_현재차수_APPROVED_합산이_TO를_초과하면_QUOTA_EXCEEDED() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 4L));   // active 4
+            // 현재 차수 APPROVED 2명 (다른 application) → 4 + 2 + 1 = 7 > TO 6
+            given(loadProjectApplicationPort.listByMatchingRoundId(any()))
+                .willReturn(List.of(
+                    otherApprovedApplication(701L, 71L, application.getApplicationForm()),
+                    otherApprovedApplication(702L, 72L, application.getApplicationForm())
+                ));
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_QUOTA_EXCEEDED);
+        }
+
+        @Test
+        void 이미_APPROVED인_지원서를_다시_APPROVED로_토글하면_quota_검증_우회() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            // active 6 으로 quota 초과 상황이라도 — 이미 APPROVED 인 application 재토글은 검증 우회
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 6L));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.APPROVED, "재확인", DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            then(saveProjectApplicationPort).should(times(1)).save(application);
+        }
+
+        @Test
+        void REJECTED_토글은_quota_검증을_적용하지_않는다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 99L));   // 초과 상황이지만 REJECTED 는 무관
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.REJECTED, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void PENDING_토글은_quota_검증을_적용하지_않는다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 99L));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.PENDING, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+        }
+
+        @Test
+        void 다른_part로_APPROVED인_application은_현재_part_quota_검증에_영향을_주지_않는다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            ProjectApplication iosApp = otherApprovedApplication(701L, 71L, application.getApplicationForm());
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
+                .willReturn(Map.of(ChallengerPart.WEB, 5L));   // WEB active 5, TO 6 → 남은 1
+            given(loadProjectApplicationPort.listByMatchingRoundId(any()))
+                .willReturn(List.of(iosApp));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
+                .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(71L), any()))
+                .willReturn(challengerWith(71L, ChallengerPart.IOS));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+        }
     }
 
     private ProjectApplication applicationWithStatus(ProjectApplicationStatus status) {
@@ -191,6 +309,33 @@ class ProjectApplicationCommandServiceTest {
 
     private ProjectApplicationForm applicationForm() {
         Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
+        ReflectionTestUtils.setField(project, "id", 100L);
         return ProjectApplicationForm.create(project, 500L);
+    }
+
+    private ChallengerInfo challengerWithPart(ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(1L).memberId(APPLICANT_MEMBER_ID).gisuId(1L)
+            .part(part).challengerPoints(new ArrayList<>()).totalPoints(0.0)
+            .build();
+    }
+
+    private ProjectPartQuota partQuotaForWeb(Long quota) {
+        Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
+        return ProjectPartQuota.create(project, ChallengerPart.WEB, quota, 999L);
+    }
+
+    private ProjectApplication otherApprovedApplication(Long id, Long applicantMemberId, ProjectApplicationForm form) {
+        ProjectApplication app = ProjectApplication.create(form, 999L, applicantMemberId, openRound());
+        ReflectionTestUtils.setField(app, "id", id);
+        ReflectionTestUtils.setField(app, "status", ProjectApplicationStatus.APPROVED);
+        return app;
+    }
+
+    private ChallengerInfo challengerWith(Long memberId, ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(memberId * 10).memberId(memberId).gisuId(1L)
+            .part(part).challengerPoints(new ArrayList<>()).totalPoints(0.0)
+            .build();
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
@@ -16,12 +16,15 @@ import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.project.application.port.in.command.dto.CreateProjectMatchingRoundCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectMatchingRoundCommand;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
 import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
 import com.umc.product.project.application.service.policy.DeveloperMatchingPolicy;
 import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
@@ -75,6 +78,8 @@ class ProjectMatchingRoundCommandServiceTest {
     @Mock
     SaveProjectMemberPort saveProjectMemberPort;
     @Mock
+    ScheduleMatchingRoundDeadlinePort scheduleMatchingRoundDeadlinePort;
+    @Mock
     GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock
     GetChallengerUseCase getChallengerUseCase;
@@ -90,6 +95,7 @@ class ProjectMatchingRoundCommandServiceTest {
             saveProjectApplicationPort,
             loadProjectPartQuotaPort,
             saveProjectMemberPort,
+            scheduleMatchingRoundDeadlinePort,
             List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
             new Random(42L),
             getChallengerRoleUseCase,
@@ -305,6 +311,7 @@ class ProjectMatchingRoundCommandServiceTest {
                 saveProjectApplicationPort,
                 loadProjectPartQuotaPort,
                 saveProjectMemberPort,
+                scheduleMatchingRoundDeadlinePort,
                 List.<MatchingDecisionPolicy>of(),
                 new Random(42L),
                 getChallengerRoleUseCase,
@@ -396,6 +403,113 @@ class ProjectMatchingRoundCommandServiceTest {
 
             assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
         }
+    }
+
+    @Nested
+    class lifecycleHooks {
+
+        @Test
+        void create는_저장_후_scheduleMatchingRoundDeadlinePort에_schedule_호출한다() {
+            CreateProjectMatchingRoundCommand command = createCommand(1L);
+            ProjectMatchingRound saved = futureRound(MatchingType.PLAN_DESIGN);
+            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+                .willReturn(List.of(centralCoreRole()));
+            given(loadProjectMatchingRoundPort.listOverlapping(any(), any(), any()))
+                .willReturn(List.of());
+            given(saveProjectMatchingRoundPort.save(any())).willReturn(saved);
+
+            sut.create(command);
+
+            then(scheduleMatchingRoundDeadlinePort).should().schedule(saved);
+        }
+
+        @Test
+        void update는_도메인_갱신_후_scheduleMatchingRoundDeadlinePort에_schedule_호출한다() {
+            ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
+            UpdateProjectMatchingRoundCommand command = updateCommand(ROUND_ID);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
+            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+                .willReturn(List.of(centralCoreRole()));
+            given(loadProjectMatchingRoundPort.listOverlappingExceptId(any(), any(), any(), any()))
+                .willReturn(List.of());
+
+            sut.update(command);
+
+            then(scheduleMatchingRoundDeadlinePort).should().schedule(existing);
+        }
+
+        @Test
+        void delete는_도메인_삭제_후_scheduleMatchingRoundDeadlinePort에_cancel_호출한다() {
+            ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
+            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+                .willReturn(List.of(centralCoreRole()));
+            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID))
+                .willReturn(false);
+
+            sut.delete(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            then(scheduleMatchingRoundDeadlinePort).should().cancel(ROUND_ID);
+        }
+
+        @Test
+        void delete는_연관_지원서가_있으면_예외_발생하고_cancel_호출되지_않는다() {
+            ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
+            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+                .willReturn(List.of(centralCoreRole()));
+            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID))
+                .willReturn(true);
+
+            assertThatThrownBy(() -> sut.delete(ROUND_ID, EXECUTOR_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_DELETE_CONFLICT);
+            then(scheduleMatchingRoundDeadlinePort).should(never()).cancel(any());
+        }
+    }
+
+    private CreateProjectMatchingRoundCommand createCommand(Long chapterId) {
+        Instant startsAt = Instant.now().plusSeconds(86_400);
+        Instant endsAt = startsAt.plusSeconds(86_400);
+        Instant decisionDeadline = endsAt.plusSeconds(86_400);
+        return CreateProjectMatchingRoundCommand.builder()
+            .name("기획-디자인 1차")
+            .description(null)
+            .type(MatchingType.PLAN_DESIGN)
+            .phase(MatchingPhase.FIRST)
+            .chapterId(chapterId)
+            .startsAt(startsAt)
+            .endsAt(endsAt)
+            .decisionDeadline(decisionDeadline)
+            .requesterMemberId(EXECUTOR_MEMBER_ID)
+            .build();
+    }
+
+    private UpdateProjectMatchingRoundCommand updateCommand(Long roundId) {
+        return UpdateProjectMatchingRoundCommand.builder()
+            .matchingRoundId(roundId)
+            .name("이름 수정")
+            .description(null)
+            .type(null)
+            .phase(null)
+            .startsAt(null)
+            .endsAt(null)
+            .decisionDeadline(null)
+            .requesterMemberId(EXECUTOR_MEMBER_ID)
+            .build();
+    }
+
+    private ProjectMatchingRound futureRound(MatchingType type) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭", null,
+            type, MatchingPhase.FIRST, 1L,
+            Instant.now().plusSeconds(86_400),
+            Instant.now().plusSeconds(172_800),
+            Instant.now().plusSeconds(259_200)
+        );
+        ReflectionTestUtils.setField(round, "id", ROUND_ID);
+        return round;
     }
 
     private ProjectMatchingRound expiredRound(MatchingType type) {

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
@@ -1,0 +1,393 @@
+package com.umc.product.project.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
+import com.umc.product.project.application.service.policy.DeveloperMatchingPolicy;
+import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectMatchingRoundCommandServiceTest {
+
+    private static final Long ROUND_ID = 1L;
+    private static final Long PROJECT_ID = 100L;
+    private static final Long GISU_ID = 5L;
+    private static final Long EXECUTOR_MEMBER_ID = 999L;
+
+    private static final Instant ROUND_DECISION_DEADLINE = Instant.now().minusSeconds(60);
+
+    @Mock
+    LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    @Mock
+    SaveProjectMatchingRoundPort saveProjectMatchingRoundPort;
+    @Mock
+    LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
+    SaveProjectApplicationPort saveProjectApplicationPort;
+    @Mock
+    LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    @Mock
+    SaveProjectMemberPort saveProjectMemberPort;
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+
+    ProjectMatchingRoundCommandService sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new ProjectMatchingRoundCommandService(
+            loadProjectMatchingRoundPort,
+            saveProjectMatchingRoundPort,
+            loadProjectApplicationPort,
+            saveProjectApplicationPort,
+            loadProjectPartQuotaPort,
+            saveProjectMemberPort,
+            List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
+            new Random(42L),
+            getChallengerRoleUseCase,
+            getChallengerUseCase
+        );
+    }
+
+    @Nested
+    class autoDecide {
+
+        @Test
+        void 차수가_이미_자동선발_실행됐으면_no_op() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "autoDecisionExecutedAt", Instant.now());
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            then(loadProjectApplicationPort).should(never()).listByMatchingRoundId(any());
+            then(saveProjectApplicationPort).should(never()).saveAll(any());
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 결정_마감_전이면_PROJECT_MATCHING_ROUND_NOT_FINALIZABLE() {
+            ProjectMatchingRound round = futureDeadlineRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
+        }
+
+        @Test
+        void 지원자가_없으면_round만_executeAutoDecision_처리하고_종료() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
+            then(saveProjectApplicationPort).should(never()).saveAll(any());
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 디자이너_차수_지원자_2명_PM_미결정시_random_1명_합격_및_member_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app1 = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app2 = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(app1, app2));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = List.of(app1, app2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            long rejectedCount = List.of(app1, app2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.REJECTED).count();
+            assertThat(approvedCount).isEqualTo(1);
+            assertThat(rejectedCount).isEqualTo(1);
+            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+        }
+
+        @Test
+        void PM이_이미_충분히_APPROVED했으면_SUBMITTED는_REJECTED로_확정되고_새_member는_PM_APPROVED만큼만_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication approved = application(101L, 11L, ProjectApplicationStatus.APPROVED, project, round);
+            ProjectApplication submitted = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(approved, submitted));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(approved.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            ArgumentCaptor<ProjectMember> captor = ArgumentCaptor.forClass(ProjectMember.class);
+            then(saveProjectMemberPort).should().save(captor.capture());
+            assertThat(captor.getValue().getMemberId()).isEqualTo(11L);
+        }
+
+        @Test
+        void PM이_모두_REJECTED한_경우_REJECTED에서_random_1명_override하여_member_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication rejected1 = application(101L, 11L, ProjectApplicationStatus.REJECTED, project, round);
+            ProjectApplication rejected2 = application(102L, 12L, ProjectApplicationStatus.REJECTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(rejected1, rejected2));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = List.of(rejected1, rejected2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(approvedCount).isEqualTo(1);
+            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+        }
+
+        @Test
+        void 의무_없는_케이스_지원자_1명_DESIGN은_REJECTED_확정되고_member_추가_없음() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of(app));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(app.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 개발자_차수_프로젝트_파트별로_정책_독립적으로_적용된다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication web1 = application(201L, 21L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication web2 = application(202L, 22L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication ios1 = application(203L, 23L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(web1, web2, ios1));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
+                .willReturn(challenger(21L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
+                .willReturn(challenger(22L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
+                .willReturn(challenger(23L, ChallengerPart.IOS));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(
+                    partQuota(project, ChallengerPart.WEB, 2L),
+                    partQuota(project, ChallengerPart.IOS, 4L)
+                ));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            // WEB: 지원자 2명, TO 2 (100% 이상) → ceil(2*0.5) = 1명 합격 의무
+            long webApproved = List.of(web1, web2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(webApproved).isEqualTo(1);
+
+            // IOS: 지원자 1명, TO 4 (25% 이하) → 의무 없음, 모두 REJECTED
+            assertThat(ios1.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void DRAFT_또는_CANCELLED_상태_application은_정책_입력에서_제외된다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication submitted = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication draft = application(102L, 12L, ProjectApplicationStatus.DRAFT, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(submitted, draft));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            // DRAFT 는 그대로 유지, SUBMITTED 만 처리
+            assertThat(draft.getStatus()).isEqualTo(ProjectApplicationStatus.DRAFT);
+            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void 정책이_없는_MatchingType이면_PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND() {
+            ProjectMatchingRoundCommandService sutWithoutPolicy = new ProjectMatchingRoundCommandService(
+                loadProjectMatchingRoundPort,
+                saveProjectMatchingRoundPort,
+                loadProjectApplicationPort,
+                saveProjectApplicationPort,
+                loadProjectPartQuotaPort,
+                saveProjectMemberPort,
+                List.<MatchingDecisionPolicy>of(),
+                new Random(42L),
+                getChallengerRoleUseCase,
+                getChallengerUseCase
+            );
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            assertThatThrownBy(() -> sutWithoutPolicy.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND);
+        }
+
+        @Test
+        void 자동_선발_실행_정보가_round에_기록된다_운영진_호출() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
+        }
+
+        @Test
+        void 자동_선발_실행_정보가_round에_기록된다_스케줄러_호출_null() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, null);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isNull();
+        }
+    }
+
+    private ProjectMatchingRound expiredRound(MatchingType type) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭", null,
+            type, MatchingPhase.FIRST, 1L,
+            Instant.now().minusSeconds(7_200),
+            Instant.now().minusSeconds(3_600),
+            ROUND_DECISION_DEADLINE
+        );
+        ReflectionTestUtils.setField(round, "id", ROUND_ID);
+        return round;
+    }
+
+    private ProjectMatchingRound futureDeadlineRound(MatchingType type) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭", null,
+            type, MatchingPhase.FIRST, 1L,
+            Instant.now().minusSeconds(86_400),
+            Instant.now().plusSeconds(43_200),
+            Instant.now().plusSeconds(86_400)
+        );
+        ReflectionTestUtils.setField(round, "id", ROUND_ID);
+        return round;
+    }
+
+    private Project projectWithId(Long projectId) {
+        Project project = Project.createDraft(GISU_ID, 2L, 999L, 7L, 999L);
+        ReflectionTestUtils.setField(project, "id", projectId);
+        return project;
+    }
+
+    private ProjectApplication application(
+        Long id, Long applicantMemberId, ProjectApplicationStatus status,
+        Project project, ProjectMatchingRound round
+    ) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, 500L);
+        ProjectApplication application = ProjectApplication.create(form, 999L, applicantMemberId, round);
+        ReflectionTestUtils.setField(application, "id", id);
+        ReflectionTestUtils.setField(application, "status", status);
+        return application;
+    }
+
+    private ChallengerInfo challenger(Long memberId, ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(memberId * 10)
+            .memberId(memberId)
+            .gisuId(GISU_ID)
+            .part(part)
+            .challengerPoints(new ArrayList<>())
+            .totalPoints(0.0)
+            .build();
+    }
+
+    private ProjectPartQuota partQuota(Project project, ChallengerPart part, Long quota) {
+        return ProjectPartQuota.create(project, part, quota, 999L);
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
@@ -10,9 +10,12 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
@@ -44,9 +47,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ProjectMatchingRoundCommandServiceTest {
 
     private static final Long ROUND_ID = 1L;
@@ -89,6 +95,9 @@ class ProjectMatchingRoundCommandServiceTest {
             getChallengerRoleUseCase,
             getChallengerUseCase
         );
+        // 운영진 권한 통과 mock — 권한 거부 테스트는 자체적으로 다시 stubbing
+        given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+            .willReturn(List.of(centralCoreRole()));
     }
 
     @Nested
@@ -333,6 +342,60 @@ class ProjectMatchingRoundCommandServiceTest {
             assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
             assertThat(round.getAutoDecisionExecutedMemberId()).isNull();
         }
+
+        @Test
+        void 스케줄러_호출은_권한_검증을_우회한다_executedByMemberId_null() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, null);
+
+            then(getChallengerRoleUseCase).should(never()).findAllByMemberId(any());
+        }
+
+        @Test
+        void 운영진이_아닌_사용자가_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
+            Long unauthorizedMemberId = 555L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(getChallengerRoleUseCase.findAllByMemberId(unauthorizedMemberId)).willReturn(List.of());
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, unauthorizedMemberId))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
+        }
+
+        @Test
+        void 다른_지부_지부장이_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
+            Long otherChapterPresidentId = 777L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "chapterId", 1L);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(getChallengerRoleUseCase.findAllByMemberId(otherChapterPresidentId))
+                .willReturn(List.of(chapterPresidentRole(99L)));
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, otherChapterPresidentId))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
+        }
+
+        @Test
+        void 본인_지부_지부장은_권한_통과한다() {
+            Long chapterPresidentId = 888L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "chapterId", 1L);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+            given(getChallengerRoleUseCase.findAllByMemberId(chapterPresidentId))
+                .willReturn(List.of(chapterPresidentRole(1L)));
+
+            sut.autoDecide(ROUND_ID, chapterPresidentId);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+        }
     }
 
     private ProjectMatchingRound expiredRound(MatchingType type) {
@@ -389,5 +452,23 @@ class ProjectMatchingRoundCommandServiceTest {
 
     private ProjectPartQuota partQuota(Project project, ChallengerPart part, Long quota) {
         return ProjectPartQuota.create(project, part, quota, 999L);
+    }
+
+    private ChallengerRoleInfo centralCoreRole() {
+        return ChallengerRoleInfo.builder()
+            .roleType(ChallengerRoleType.CENTRAL_PRESIDENT)
+            .organizationType(OrganizationType.CENTRAL)
+            .organizationId(null)
+            .gisuId(GISU_ID)
+            .build();
+    }
+
+    private ChallengerRoleInfo chapterPresidentRole(Long chapterId) {
+        return ChallengerRoleInfo.builder()
+            .roleType(ChallengerRoleType.CHAPTER_PRESIDENT)
+            .organizationType(OrganizationType.CHAPTER)
+            .organizationId(chapterId)
+            .gisuId(GISU_ID)
+            .build();
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundCommandServiceTest.java
@@ -1,69 +1,42 @@
 package com.umc.product.project.application.service.command;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
-import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
-import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.project.application.port.in.command.dto.CreateProjectMatchingRoundCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectMatchingRoundCommand;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
-import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
-import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMatchingRoundPort;
-import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
-import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
-import com.umc.product.project.application.service.policy.DeveloperMatchingPolicy;
-import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
-import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.ProjectApplication;
-import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectMatchingRound;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
-import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class ProjectMatchingRoundCommandServiceTest {
 
     private static final Long ROUND_ID = 1L;
-    private static final Long PROJECT_ID = 100L;
-    private static final Long GISU_ID = 5L;
     private static final Long EXECUTOR_MEMBER_ID = 999L;
-
-    private static final Instant ROUND_DECISION_DEADLINE = Instant.now().minusSeconds(60);
 
     @Mock
     LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
@@ -72,337 +45,17 @@ class ProjectMatchingRoundCommandServiceTest {
     @Mock
     LoadProjectApplicationPort loadProjectApplicationPort;
     @Mock
-    SaveProjectApplicationPort saveProjectApplicationPort;
-    @Mock
-    LoadProjectPartQuotaPort loadProjectPartQuotaPort;
-    @Mock
-    SaveProjectMemberPort saveProjectMemberPort;
-    @Mock
     ScheduleMatchingRoundDeadlinePort scheduleMatchingRoundDeadlinePort;
     @Mock
     GetChallengerRoleUseCase getChallengerRoleUseCase;
-    @Mock
-    GetChallengerUseCase getChallengerUseCase;
 
+    @InjectMocks
     ProjectMatchingRoundCommandService sut;
 
     @BeforeEach
-    void setUp() {
-        sut = new ProjectMatchingRoundCommandService(
-            loadProjectMatchingRoundPort,
-            saveProjectMatchingRoundPort,
-            loadProjectApplicationPort,
-            saveProjectApplicationPort,
-            loadProjectPartQuotaPort,
-            saveProjectMemberPort,
-            scheduleMatchingRoundDeadlinePort,
-            List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
-            new Random(42L),
-            getChallengerRoleUseCase,
-            getChallengerUseCase
-        );
-        // 운영진 권한 통과 mock — 권한 거부 테스트는 자체적으로 다시 stubbing
+    void setUpRoleMock() {
         given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
             .willReturn(List.of(centralCoreRole()));
-    }
-
-    @Nested
-    class autoDecide {
-
-        @Test
-        void 차수가_이미_자동선발_실행됐으면_no_op() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            ReflectionTestUtils.setField(round, "autoDecisionExecutedAt", Instant.now());
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            then(loadProjectApplicationPort).should(never()).listByMatchingRoundId(any());
-            then(saveProjectApplicationPort).should(never()).saveAll(any());
-            then(saveProjectMemberPort).should(never()).save(any());
-        }
-
-        @Test
-        void 결정_마감_전이면_PROJECT_MATCHING_ROUND_NOT_FINALIZABLE() {
-            ProjectMatchingRound round = futureDeadlineRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-
-            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
-        }
-
-        @Test
-        void 지원자가_없으면_round만_executeAutoDecision_처리하고_종료() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
-            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
-            then(saveProjectApplicationPort).should(never()).saveAll(any());
-            then(saveProjectMemberPort).should(never()).save(any());
-        }
-
-        @Test
-        void 디자이너_차수_지원자_2명_PM_미결정시_random_1명_합격_및_member_추가() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication app1 = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
-            ProjectApplication app2 = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
-                .willReturn(List.of(app1, app2));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            long approvedCount = List.of(app1, app2).stream()
-                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
-            long rejectedCount = List.of(app1, app2).stream()
-                .filter(a -> a.getStatus() == ProjectApplicationStatus.REJECTED).count();
-            assertThat(approvedCount).isEqualTo(1);
-            assertThat(rejectedCount).isEqualTo(1);
-            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
-            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
-        }
-
-        @Test
-        void PM이_이미_충분히_APPROVED했으면_SUBMITTED는_REJECTED로_확정되고_새_member는_PM_APPROVED만큼만_추가() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication approved = application(101L, 11L, ProjectApplicationStatus.APPROVED, project, round);
-            ProjectApplication submitted = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
-                .willReturn(List.of(approved, submitted));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            assertThat(approved.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
-            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-            ArgumentCaptor<ProjectMember> captor = ArgumentCaptor.forClass(ProjectMember.class);
-            then(saveProjectMemberPort).should().save(captor.capture());
-            assertThat(captor.getValue().getMemberId()).isEqualTo(11L);
-        }
-
-        @Test
-        void PM이_모두_REJECTED한_경우_REJECTED에서_random_1명_override하여_member_추가() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication rejected1 = application(101L, 11L, ProjectApplicationStatus.REJECTED, project, round);
-            ProjectApplication rejected2 = application(102L, 12L, ProjectApplicationStatus.REJECTED, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
-                .willReturn(List.of(rejected1, rejected2));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            long approvedCount = List.of(rejected1, rejected2).stream()
-                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
-            assertThat(approvedCount).isEqualTo(1);
-            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
-        }
-
-        @Test
-        void 의무_없는_케이스_지원자_1명_DESIGN은_REJECTED_확정되고_member_추가_없음() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication app = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of(app));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            assertThat(app.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-            then(saveProjectMemberPort).should(never()).save(any());
-        }
-
-        @Test
-        void 개발자_차수_프로젝트_파트별로_정책_독립적으로_적용된다() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication web1 = application(201L, 21L, ProjectApplicationStatus.SUBMITTED, project, round);
-            ProjectApplication web2 = application(202L, 22L, ProjectApplicationStatus.SUBMITTED, project, round);
-            ProjectApplication ios1 = application(203L, 23L, ProjectApplicationStatus.SUBMITTED, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
-                .willReturn(List.of(web1, web2, ios1));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
-                .willReturn(challenger(21L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
-                .willReturn(challenger(22L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
-                .willReturn(challenger(23L, ChallengerPart.IOS));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(
-                    partQuota(project, ChallengerPart.WEB, 2L),
-                    partQuota(project, ChallengerPart.IOS, 4L)
-                ));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            // WEB: 지원자 2명, TO 2 (100% 이상) → ceil(2*0.5) = 1명 합격 의무
-            long webApproved = List.of(web1, web2).stream()
-                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
-            assertThat(webApproved).isEqualTo(1);
-
-            // IOS: 지원자 1명, TO 4 (25% 이하) → 의무 없음, 모두 REJECTED
-            assertThat(ios1.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-        }
-
-        @Test
-        void DRAFT_또는_CANCELLED_상태_application은_정책_입력에서_제외된다() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            Project project = projectWithId(PROJECT_ID);
-            ProjectApplication submitted = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
-            ProjectApplication draft = application(102L, 12L, ProjectApplicationStatus.DRAFT, project, round);
-
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
-                .willReturn(List.of(submitted, draft));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            // DRAFT 는 그대로 유지, SUBMITTED 만 처리
-            assertThat(draft.getStatus()).isEqualTo(ProjectApplicationStatus.DRAFT);
-            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-        }
-
-        @Test
-        void 정책이_없는_MatchingType이면_PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND() {
-            ProjectMatchingRoundCommandService sutWithoutPolicy = new ProjectMatchingRoundCommandService(
-                loadProjectMatchingRoundPort,
-                saveProjectMatchingRoundPort,
-                loadProjectApplicationPort,
-                saveProjectApplicationPort,
-                loadProjectPartQuotaPort,
-                saveProjectMemberPort,
-                scheduleMatchingRoundDeadlinePort,
-                List.<MatchingDecisionPolicy>of(),
-                new Random(42L),
-                getChallengerRoleUseCase,
-                getChallengerUseCase
-            );
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-
-            assertThatThrownBy(() -> sutWithoutPolicy.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND);
-        }
-
-        @Test
-        void 자동_선발_실행_정보가_round에_기록된다_운영진_호출() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
-
-            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
-
-            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
-            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
-        }
-
-        @Test
-        void 자동_선발_실행_정보가_round에_기록된다_스케줄러_호출_null() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
-
-            sut.autoDecide(ROUND_ID, null);
-
-            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
-            assertThat(round.getAutoDecisionExecutedMemberId()).isNull();
-        }
-
-        @Test
-        void 스케줄러_호출은_권한_검증을_우회한다_executedByMemberId_null() {
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
-
-            sut.autoDecide(ROUND_ID, null);
-
-            then(getChallengerRoleUseCase).should(never()).findAllByMemberId(any());
-        }
-
-        @Test
-        void 운영진이_아닌_사용자가_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
-            Long unauthorizedMemberId = 555L;
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(getChallengerRoleUseCase.findAllByMemberId(unauthorizedMemberId)).willReturn(List.of());
-
-            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, unauthorizedMemberId))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
-        }
-
-        @Test
-        void 다른_지부_지부장이_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
-            Long otherChapterPresidentId = 777L;
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            ReflectionTestUtils.setField(round, "chapterId", 1L);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(getChallengerRoleUseCase.findAllByMemberId(otherChapterPresidentId))
-                .willReturn(List.of(chapterPresidentRole(99L)));
-
-            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, otherChapterPresidentId))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
-        }
-
-        @Test
-        void 본인_지부_지부장은_권한_통과한다() {
-            Long chapterPresidentId = 888L;
-            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
-            ReflectionTestUtils.setField(round, "chapterId", 1L);
-            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
-            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
-            given(getChallengerRoleUseCase.findAllByMemberId(chapterPresidentId))
-                .willReturn(List.of(chapterPresidentRole(1L)));
-
-            sut.autoDecide(ROUND_ID, chapterPresidentId);
-
-            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
-        }
     }
 
     @Nested
@@ -412,10 +65,7 @@ class ProjectMatchingRoundCommandServiceTest {
         void create는_저장_후_scheduleMatchingRoundDeadlinePort에_schedule_호출한다() {
             CreateProjectMatchingRoundCommand command = createCommand(1L);
             ProjectMatchingRound saved = futureRound(MatchingType.PLAN_DESIGN);
-            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
-                .willReturn(List.of(centralCoreRole()));
-            given(loadProjectMatchingRoundPort.listOverlapping(any(), any(), any()))
-                .willReturn(List.of());
+            given(loadProjectMatchingRoundPort.listOverlapping(any(), any(), any())).willReturn(List.of());
             given(saveProjectMatchingRoundPort.save(any())).willReturn(saved);
 
             sut.create(command);
@@ -428,8 +78,6 @@ class ProjectMatchingRoundCommandServiceTest {
             ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
             UpdateProjectMatchingRoundCommand command = updateCommand(ROUND_ID);
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
-            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
-                .willReturn(List.of(centralCoreRole()));
             given(loadProjectMatchingRoundPort.listOverlappingExceptId(any(), any(), any(), any()))
                 .willReturn(List.of());
 
@@ -442,10 +90,7 @@ class ProjectMatchingRoundCommandServiceTest {
         void delete는_도메인_삭제_후_scheduleMatchingRoundDeadlinePort에_cancel_호출한다() {
             ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
-            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
-                .willReturn(List.of(centralCoreRole()));
-            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID))
-                .willReturn(false);
+            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID)).willReturn(false);
 
             sut.delete(ROUND_ID, EXECUTOR_MEMBER_ID);
 
@@ -456,10 +101,7 @@ class ProjectMatchingRoundCommandServiceTest {
         void delete는_연관_지원서가_있으면_예외_발생하고_cancel_호출되지_않는다() {
             ProjectMatchingRound existing = futureRound(MatchingType.PLAN_DESIGN);
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(existing);
-            given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
-                .willReturn(List.of(centralCoreRole()));
-            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID))
-                .willReturn(true);
+            given(loadProjectApplicationPort.existsByAppliedMatchingRoundId(ROUND_ID)).willReturn(true);
 
             assertThatThrownBy(() -> sut.delete(ROUND_ID, EXECUTOR_MEMBER_ID))
                 .isInstanceOf(ProjectDomainException.class)
@@ -512,77 +154,12 @@ class ProjectMatchingRoundCommandServiceTest {
         return round;
     }
 
-    private ProjectMatchingRound expiredRound(MatchingType type) {
-        ProjectMatchingRound round = ProjectMatchingRound.create(
-            "테스트 매칭", null,
-            type, MatchingPhase.FIRST, 1L,
-            Instant.now().minusSeconds(7_200),
-            Instant.now().minusSeconds(3_600),
-            ROUND_DECISION_DEADLINE
-        );
-        ReflectionTestUtils.setField(round, "id", ROUND_ID);
-        return round;
-    }
-
-    private ProjectMatchingRound futureDeadlineRound(MatchingType type) {
-        ProjectMatchingRound round = ProjectMatchingRound.create(
-            "테스트 매칭", null,
-            type, MatchingPhase.FIRST, 1L,
-            Instant.now().minusSeconds(86_400),
-            Instant.now().plusSeconds(43_200),
-            Instant.now().plusSeconds(86_400)
-        );
-        ReflectionTestUtils.setField(round, "id", ROUND_ID);
-        return round;
-    }
-
-    private Project projectWithId(Long projectId) {
-        Project project = Project.createDraft(GISU_ID, 2L, 999L, 7L, 999L);
-        ReflectionTestUtils.setField(project, "id", projectId);
-        return project;
-    }
-
-    private ProjectApplication application(
-        Long id, Long applicantMemberId, ProjectApplicationStatus status,
-        Project project, ProjectMatchingRound round
-    ) {
-        ProjectApplicationForm form = ProjectApplicationForm.create(project, 500L);
-        ProjectApplication application = ProjectApplication.create(form, 999L, applicantMemberId, round);
-        ReflectionTestUtils.setField(application, "id", id);
-        ReflectionTestUtils.setField(application, "status", status);
-        return application;
-    }
-
-    private ChallengerInfo challenger(Long memberId, ChallengerPart part) {
-        return ChallengerInfo.builder()
-            .challengerId(memberId * 10)
-            .memberId(memberId)
-            .gisuId(GISU_ID)
-            .part(part)
-            .challengerPoints(new ArrayList<>())
-            .totalPoints(0.0)
-            .build();
-    }
-
-    private ProjectPartQuota partQuota(Project project, ChallengerPart part, Long quota) {
-        return ProjectPartQuota.create(project, part, quota, 999L);
-    }
-
     private ChallengerRoleInfo centralCoreRole() {
         return ChallengerRoleInfo.builder()
             .roleType(ChallengerRoleType.CENTRAL_PRESIDENT)
             .organizationType(OrganizationType.CENTRAL)
             .organizationId(null)
-            .gisuId(GISU_ID)
-            .build();
-    }
-
-    private ChallengerRoleInfo chapterPresidentRole(Long chapterId) {
-        return ChallengerRoleInfo.builder()
-            .roleType(ChallengerRoleType.CHAPTER_PRESIDENT)
-            .organizationType(OrganizationType.CHAPTER)
-            .organizationId(chapterId)
-            .gisuId(GISU_ID)
+            .gisuId(5L)
             .build();
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
@@ -18,6 +18,7 @@ import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
@@ -38,6 +39,7 @@ import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -70,6 +72,8 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
     @Mock
     LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
     SaveProjectMemberPort saveProjectMemberPort;
     @Mock
     GetChallengerRoleUseCase getChallengerRoleUseCase;
@@ -85,6 +89,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             loadProjectApplicationPort,
             saveProjectApplicationPort,
             loadProjectPartQuotaPort,
+            loadProjectMemberPort,
             saveProjectMemberPort,
             List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
             new Random(42L),
@@ -298,6 +303,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
                     loadProjectApplicationPort,
                     saveProjectApplicationPort,
                     loadProjectPartQuotaPort,
+                    loadProjectMemberPort,
                     saveProjectMemberPort,
                     List.<MatchingDecisionPolicy>of(),
                     new Random(42L),
@@ -389,6 +395,95 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             sut.autoDecide(ROUND_ID, chapterPresidentId);
 
             assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+        }
+
+        @Test
+        void 이전_차수_active_멤버가_있으면_남은_TO_기준으로_정책이_적용된다() {
+            // 개발자 매칭, 전체 TO 6, 이전 차수까지 ACTIVE WEB 4명 → 남은 TO 2
+            // 본 차수 지원자 4명 → 4 vs 남은 TO 2 → 100% 이상 → 의무 ceil(2 * 0.5) = 1명
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app1 = application(201L, 21L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app2 = application(202L, 22L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app3 = application(203L, 23L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app4 = application(204L, 24L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(app1, app2, app3, app4));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
+                .willReturn(challenger(21L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
+                .willReturn(challenger(22L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
+                .willReturn(challenger(23L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(24L), anyLong()))
+                .willReturn(challenger(24L, ChallengerPart.WEB));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
+                .willReturn(Map.of(ChallengerPart.WEB, 4L));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = List.of(app1, app2, app3, app4).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(approvedCount).isEqualTo(1);
+        }
+
+        @Test
+        void 남은_TO가_0이면_의무_없음으로_처리되어_SUBMITTED는_모두_REJECTED() {
+            // 전체 TO 6, 이전 차수까지 ACTIVE WEB 6명 → 남은 TO 0
+            // applicantsCount=2, quota=0 → applicantsCount(2) >= quota(0) → ceil(0 * 0.5) = 0 의무
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app1 = application(201L, 21L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app2 = application(202L, 22L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(app1, app2));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
+                .willReturn(challenger(21L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
+                .willReturn(challenger(22L, ChallengerPart.WEB));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
+                .willReturn(Map.of(ChallengerPart.WEB, 6L));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(app1.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            assertThat(app2.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void active_멤버가_없으면_전체_TO_기준으로_정책이_적용된다() {
+            // 1차 매칭이라 active 0. 전체 TO 6, 지원자 6 → 100% 이상 → 의무 ceil(6 * 0.5) = 3명
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
+            Project project = projectWithId(PROJECT_ID);
+            List<ProjectApplication> apps = new ArrayList<>();
+            for (long i = 1; i <= 6; i++) {
+                ProjectApplication app = application(200L + i, 20L + i, ProjectApplicationStatus.SUBMITTED, project, round);
+                apps.add(app);
+                given(getChallengerUseCase.getByMemberIdAndGisuId(eq(20L + i), anyLong()))
+                    .willReturn(challenger(20L + i, ChallengerPart.WEB));
+            }
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(apps);
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
+            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
+                .willReturn(Map.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = apps.stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(approvedCount).isEqualTo(3);
         }
     }
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
@@ -1,0 +1,468 @@
+package com.umc.product.project.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
+import com.umc.product.project.application.service.policy.DeveloperMatchingPolicy;
+import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProjectMatchingRoundFinalizationCommandServiceTest {
+
+    private static final Long ROUND_ID = 1L;
+    private static final Long PROJECT_ID = 100L;
+    private static final Long GISU_ID = 5L;
+    private static final Long EXECUTOR_MEMBER_ID = 999L;
+
+    private static final Instant ROUND_DECISION_DEADLINE = Instant.now().minusSeconds(60);
+
+    @Mock
+    LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    @Mock
+    LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
+    SaveProjectApplicationPort saveProjectApplicationPort;
+    @Mock
+    LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    @Mock
+    SaveProjectMemberPort saveProjectMemberPort;
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+
+    ProjectMatchingRoundFinalizationCommandService sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new ProjectMatchingRoundFinalizationCommandService(
+            loadProjectMatchingRoundPort,
+            loadProjectApplicationPort,
+            saveProjectApplicationPort,
+            loadProjectPartQuotaPort,
+            saveProjectMemberPort,
+            List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
+            new Random(42L),
+            getChallengerRoleUseCase,
+            getChallengerUseCase
+        );
+        given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
+            .willReturn(List.of(centralCoreRole()));
+    }
+
+    @Nested
+    class autoDecide {
+
+        @Test
+        void 차수가_이미_자동선발_실행됐으면_no_op() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "autoDecisionExecutedAt", Instant.now());
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            then(loadProjectApplicationPort).should(never()).listByMatchingRoundId(any());
+            then(saveProjectApplicationPort).should(never()).saveAll(any());
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 결정_마감_전이면_PROJECT_MATCHING_ROUND_NOT_FINALIZABLE() {
+            ProjectMatchingRound round = futureDeadlineRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_NOT_FINALIZABLE);
+        }
+
+        @Test
+        void 지원자가_없으면_round만_executeAutoDecision_처리하고_종료() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
+            then(saveProjectApplicationPort).should(never()).saveAll(any());
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 디자이너_차수_지원자_2명_PM_미결정시_random_1명_합격_및_member_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app1 = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication app2 = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(app1, app2));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = List.of(app1, app2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            long rejectedCount = List.of(app1, app2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.REJECTED).count();
+            assertThat(approvedCount).isEqualTo(1);
+            assertThat(rejectedCount).isEqualTo(1);
+            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+        }
+
+        @Test
+        void PM이_이미_충분히_APPROVED했으면_SUBMITTED는_REJECTED로_확정되고_새_member는_PM_APPROVED만큼만_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication approved = application(101L, 11L, ProjectApplicationStatus.APPROVED, project, round);
+            ProjectApplication submitted = application(102L, 12L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(approved, submitted));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(approved.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            ArgumentCaptor<ProjectMember> captor = ArgumentCaptor.forClass(ProjectMember.class);
+            then(saveProjectMemberPort).should().save(captor.capture());
+            assertThat(captor.getValue().getMemberId()).isEqualTo(11L);
+        }
+
+        @Test
+        void PM이_모두_REJECTED한_경우_REJECTED에서_random_1명_override하여_member_추가() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication rejected1 = application(101L, 11L, ProjectApplicationStatus.REJECTED, project, round);
+            ProjectApplication rejected2 = application(102L, 12L, ProjectApplicationStatus.REJECTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(rejected1, rejected2));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
+                .willReturn(challenger(12L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            long approvedCount = List.of(rejected1, rejected2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(approvedCount).isEqualTo(1);
+            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+        }
+
+        @Test
+        void 의무_없는_케이스_지원자_1명_DESIGN은_REJECTED_확정되고_member_추가_없음() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication app = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of(app));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(app.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            then(saveProjectMemberPort).should(never()).save(any());
+        }
+
+        @Test
+        void 개발자_차수_프로젝트_파트별로_정책_독립적으로_적용된다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication web1 = application(201L, 21L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication web2 = application(202L, 22L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication ios1 = application(203L, 23L, ProjectApplicationStatus.SUBMITTED, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(web1, web2, ios1));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
+                .willReturn(challenger(21L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
+                .willReturn(challenger(22L, ChallengerPart.WEB));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
+                .willReturn(challenger(23L, ChallengerPart.IOS));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(
+                    partQuota(project, ChallengerPart.WEB, 2L),
+                    partQuota(project, ChallengerPart.IOS, 4L)
+                ));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            // WEB: 지원자 2명, TO 2 (100% 이상) → ceil(2*0.5) = 1명 합격 의무
+            long webApproved = List.of(web1, web2).stream()
+                .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
+            assertThat(webApproved).isEqualTo(1);
+
+            // IOS: 지원자 1명, TO 4 (25% 이하) → 의무 없음, 모두 REJECTED
+            assertThat(ios1.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void DRAFT_또는_CANCELLED_상태_application은_정책_입력에서_제외된다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectApplication submitted = application(101L, 11L, ProjectApplicationStatus.SUBMITTED, project, round);
+            ProjectApplication draft = application(102L, 12L, ProjectApplicationStatus.DRAFT, project, round);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
+                .willReturn(List.of(submitted, draft));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
+                .willReturn(challenger(11L, ChallengerPart.DESIGN));
+            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
+                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(draft.getStatus()).isEqualTo(ProjectApplicationStatus.DRAFT);
+            assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void 정책이_없는_MatchingType이면_PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND() {
+            ProjectMatchingRoundFinalizationCommandService sutWithoutPolicy =
+                new ProjectMatchingRoundFinalizationCommandService(
+                    loadProjectMatchingRoundPort,
+                    loadProjectApplicationPort,
+                    saveProjectApplicationPort,
+                    loadProjectPartQuotaPort,
+                    saveProjectMemberPort,
+                    List.<MatchingDecisionPolicy>of(),
+                    new Random(42L),
+                    getChallengerRoleUseCase,
+                    getChallengerUseCase
+                );
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+
+            assertThatThrownBy(() -> sutWithoutPolicy.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND);
+        }
+
+        @Test
+        void 자동_선발_실행_정보가_round에_기록된다_운영진_호출() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
+        }
+
+        @Test
+        void 자동_선발_실행_정보가_round에_기록된다_스케줄러_호출_null() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, null);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+            assertThat(round.getAutoDecisionExecutedMemberId()).isNull();
+        }
+
+        @Test
+        void 스케줄러_호출은_권한_검증을_우회한다_executedByMemberId_null() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, null);
+
+            then(getChallengerRoleUseCase).should(never()).findAllByMemberId(any());
+        }
+
+        @Test
+        void 운영진이_아닌_사용자가_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
+            Long unauthorizedMemberId = 555L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(getChallengerRoleUseCase.findAllByMemberId(unauthorizedMemberId)).willReturn(List.of());
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, unauthorizedMemberId))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
+        }
+
+        @Test
+        void 다른_지부_지부장이_호출하면_PROJECT_MATCHING_ROUND_ACCESS_DENIED() {
+            Long otherChapterPresidentId = 777L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "chapterId", 1L);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(getChallengerRoleUseCase.findAllByMemberId(otherChapterPresidentId))
+                .willReturn(List.of(chapterPresidentRole(99L)));
+
+            assertThatThrownBy(() -> sut.autoDecide(ROUND_ID, otherChapterPresidentId))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_ACCESS_DENIED);
+        }
+
+        @Test
+        void 본인_지부_지부장은_권한_통과한다() {
+            Long chapterPresidentId = 888L;
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
+            ReflectionTestUtils.setField(round, "chapterId", 1L);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+            given(getChallengerRoleUseCase.findAllByMemberId(chapterPresidentId))
+                .willReturn(List.of(chapterPresidentRole(1L)));
+
+            sut.autoDecide(ROUND_ID, chapterPresidentId);
+
+            assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
+        }
+    }
+
+    private ProjectMatchingRound expiredRound(MatchingType type) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭", null,
+            type, MatchingPhase.FIRST, 1L,
+            Instant.now().minusSeconds(7_200),
+            Instant.now().minusSeconds(3_600),
+            ROUND_DECISION_DEADLINE
+        );
+        ReflectionTestUtils.setField(round, "id", ROUND_ID);
+        return round;
+    }
+
+    private ProjectMatchingRound futureDeadlineRound(MatchingType type) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "테스트 매칭", null,
+            type, MatchingPhase.FIRST, 1L,
+            Instant.now().minusSeconds(86_400),
+            Instant.now().plusSeconds(43_200),
+            Instant.now().plusSeconds(86_400)
+        );
+        ReflectionTestUtils.setField(round, "id", ROUND_ID);
+        return round;
+    }
+
+    private Project projectWithId(Long projectId) {
+        Project project = Project.createDraft(GISU_ID, 2L, 999L, 7L, 999L);
+        ReflectionTestUtils.setField(project, "id", projectId);
+        return project;
+    }
+
+    private ProjectApplication application(
+        Long id, Long applicantMemberId, ProjectApplicationStatus status,
+        Project project, ProjectMatchingRound round
+    ) {
+        ProjectApplicationForm form = ProjectApplicationForm.create(project, 500L);
+        ProjectApplication application = ProjectApplication.create(form, 999L, applicantMemberId, round);
+        ReflectionTestUtils.setField(application, "id", id);
+        ReflectionTestUtils.setField(application, "status", status);
+        return application;
+    }
+
+    private ChallengerInfo challenger(Long memberId, ChallengerPart part) {
+        return ChallengerInfo.builder()
+            .challengerId(memberId * 10)
+            .memberId(memberId)
+            .gisuId(GISU_ID)
+            .part(part)
+            .challengerPoints(new ArrayList<>())
+            .totalPoints(0.0)
+            .build();
+    }
+
+    private ProjectPartQuota partQuota(Project project, ChallengerPart part, Long quota) {
+        return ProjectPartQuota.create(project, part, quota, 999L);
+    }
+
+    private ChallengerRoleInfo centralCoreRole() {
+        return ChallengerRoleInfo.builder()
+            .roleType(ChallengerRoleType.CENTRAL_PRESIDENT)
+            .organizationType(OrganizationType.CENTRAL)
+            .organizationId(null)
+            .gisuId(GISU_ID)
+            .build();
+    }
+
+    private ChallengerRoleInfo chapterPresidentRole(Long chapterId) {
+        return ChallengerRoleInfo.builder()
+            .roleType(ChallengerRoleType.CHAPTER_PRESIDENT)
+            .organizationType(OrganizationType.CHAPTER)
+            .organizationId(chapterId)
+            .gisuId(GISU_ID)
+            .build();
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -113,7 +112,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
 
             then(loadProjectApplicationPort).should(never()).listByMatchingRoundId(any());
             then(saveProjectApplicationPort).should(never()).saveAll(any());
-            then(saveProjectMemberPort).should(never()).save(any());
+            then(saveProjectMemberPort).should(never()).saveAll(any());
         }
 
         @Test
@@ -138,7 +137,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
             assertThat(round.getAutoDecisionExecutedMemberId()).isEqualTo(EXECUTOR_MEMBER_ID);
             then(saveProjectApplicationPort).should(never()).saveAll(any());
-            then(saveProjectMemberPort).should(never()).save(any());
+            then(saveProjectMemberPort).should(never()).saveAll(any());
         }
 
         @Test
@@ -151,12 +150,13 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(app1, app2));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    11L, challenger(11L, ChallengerPart.DESIGN),
+                    12L, challenger(12L, ChallengerPart.DESIGN)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.DESIGN, 1L))));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
@@ -166,7 +166,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
                 .filter(a -> a.getStatus() == ProjectApplicationStatus.REJECTED).count();
             assertThat(approvedCount).isEqualTo(1);
             assertThat(rejectedCount).isEqualTo(1);
-            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+            then(saveProjectMemberPort).should().saveAll(any());
             assertThat(round.getAutoDecisionExecutedAt()).isNotNull();
         }
 
@@ -180,20 +180,22 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(approved, submitted));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    11L, challenger(11L, ChallengerPart.DESIGN),
+                    12L, challenger(12L, ChallengerPart.DESIGN)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.DESIGN, 1L))));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
             assertThat(approved.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
             assertThat(submitted.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-            ArgumentCaptor<ProjectMember> captor = ArgumentCaptor.forClass(ProjectMember.class);
-            then(saveProjectMemberPort).should().save(captor.capture());
-            assertThat(captor.getValue().getMemberId()).isEqualTo(11L);
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<java.util.Collection<ProjectMember>> captor = ArgumentCaptor.forClass(java.util.Collection.class);
+            then(saveProjectMemberPort).should().saveAll(captor.capture());
+            assertThat(captor.getValue()).extracting(ProjectMember::getMemberId).containsExactly(11L);
         }
 
         @Test
@@ -206,19 +208,20 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(rejected1, rejected2));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(12L), anyLong()))
-                .willReturn(challenger(12L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    11L, challenger(11L, ChallengerPart.DESIGN),
+                    12L, challenger(12L, ChallengerPart.DESIGN)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.DESIGN, 1L))));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
             long approvedCount = List.of(rejected1, rejected2).stream()
                 .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
             assertThat(approvedCount).isEqualTo(1);
-            then(saveProjectMemberPort).should().save(any(ProjectMember.class));
+            then(saveProjectMemberPort).should().saveAll(any());
         }
 
         @Test
@@ -229,15 +232,15 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
 
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of(app));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(11L, challenger(11L, ChallengerPart.DESIGN)));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.DESIGN, 1L))));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
             assertThat(app.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-            then(saveProjectMemberPort).should(never()).save(any());
+            then(saveProjectMemberPort).should(never()).saveAll(any());
         }
 
         @Test
@@ -251,17 +254,17 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(web1, web2, ios1));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
-                .willReturn(challenger(21L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
-                .willReturn(challenger(22L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
-                .willReturn(challenger(23L, ChallengerPart.IOS));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    21L, challenger(21L, ChallengerPart.WEB),
+                    22L, challenger(22L, ChallengerPart.WEB),
+                    23L, challenger(23L, ChallengerPart.IOS)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(
                     partQuota(project, ChallengerPart.WEB, 2L),
                     partQuota(project, ChallengerPart.IOS, 4L)
-                ));
+                )));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
@@ -284,10 +287,10 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(submitted, draft));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(11L), anyLong()))
-                .willReturn(challenger(11L, ChallengerPart.DESIGN));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(11L, challenger(11L, ChallengerPart.DESIGN)));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.DESIGN, 1L))));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
@@ -411,18 +414,17 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(app1, app2, app3, app4));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
-                .willReturn(challenger(21L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
-                .willReturn(challenger(22L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(23L), anyLong()))
-                .willReturn(challenger(23L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(24L), anyLong()))
-                .willReturn(challenger(24L, ChallengerPart.WEB));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
-            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
-                .willReturn(Map.of(ChallengerPart.WEB, 4L));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    21L, challenger(21L, ChallengerPart.WEB),
+                    22L, challenger(22L, ChallengerPart.WEB),
+                    23L, challenger(23L, ChallengerPart.WEB),
+                    24L, challenger(24L, ChallengerPart.WEB)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.WEB, 6L))));
+            given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(any()))
+                .willReturn(Map.of(PROJECT_ID, Map.of(ChallengerPart.WEB, 4L)));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
@@ -443,20 +445,21 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID))
                 .willReturn(List.of(app1, app2));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(21L), anyLong()))
-                .willReturn(challenger(21L, ChallengerPart.WEB));
-            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(22L), anyLong()))
-                .willReturn(challenger(22L, ChallengerPart.WEB));
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
-            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
-                .willReturn(Map.of(ChallengerPart.WEB, 6L));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(Map.of(
+                    21L, challenger(21L, ChallengerPart.WEB),
+                    22L, challenger(22L, ChallengerPart.WEB)
+                ));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.WEB, 6L))));
+            given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(any()))
+                .willReturn(Map.of(PROJECT_ID, Map.of(ChallengerPart.WEB, 6L)));
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
 
             assertThat(app1.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
             assertThat(app2.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-            then(saveProjectMemberPort).should(never()).save(any());
+            then(saveProjectMemberPort).should(never()).saveAll(any());
         }
 
         @Test
@@ -465,18 +468,20 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER);
             Project project = projectWithId(PROJECT_ID);
             List<ProjectApplication> apps = new ArrayList<>();
+            Map<Long, ChallengerInfo> challengerByMember = new java.util.HashMap<>();
             for (long i = 1; i <= 6; i++) {
                 ProjectApplication app = application(200L + i, 20L + i, ProjectApplicationStatus.SUBMITTED, project, round);
                 apps.add(app);
-                given(getChallengerUseCase.getByMemberIdAndGisuId(eq(20L + i), anyLong()))
-                    .willReturn(challenger(20L + i, ChallengerPart.WEB));
+                challengerByMember.put(20L + i, challenger(20L + i, ChallengerPart.WEB));
             }
 
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
             given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(apps);
-            given(loadProjectPartQuotaPort.listByProjectId(PROJECT_ID))
-                .willReturn(List.of(partQuota(project, ChallengerPart.WEB, 6L)));
-            given(loadProjectMemberPort.countByProjectIdGroupByPart(PROJECT_ID))
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), anyLong()))
+                .willReturn(challengerByMember);
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(partQuota(project, ChallengerPart.WEB, 6L))));
+            given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(any()))
                 .willReturn(Map.of());
 
             sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -307,11 +307,19 @@ class ProjectApplicationPermissionEvaluatorTest {
     }
 
     @Test
-    void APPROVE는_부모_PO_APPROVED_거부_재승인_차단() {
+    void APPROVE는_부모_PO_APPROVED_허용_재토글_가능() {
         givenApplication(ProjectApplicationStatus.APPROVED);
         SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
 
-        assertThat(sut.evaluate(subject, approvePermission())).isFalse();
+        assertThat(sut.evaluate(subject, approvePermission())).isTrue();
+    }
+
+    @Test
+    void APPROVE는_부모_PO_REJECTED_허용_재토글_가능() {
+        givenApplication(ProjectApplicationStatus.REJECTED);
+        SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, approvePermission())).isTrue();
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/policy/DesignerMatchingPolicyTest.java
+++ b/src/test/java/com/umc/product/project/application/service/policy/DesignerMatchingPolicyTest.java
@@ -1,0 +1,166 @@
+package com.umc.product.project.application.service.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DesignerMatchingPolicyTest {
+
+    private static final long FIXED_SEED = 42L;
+
+    DesignerMatchingPolicy sut = new DesignerMatchingPolicy();
+
+    @Test
+    void supportedType은_PLAN_DESIGN을_반환한다() {
+        assertThat(sut.supportedType()).isEqualTo(MatchingType.PLAN_DESIGN);
+    }
+
+    /**
+     * final-api.md §3 매트릭스 ① — TO 무관, 지원자 수 자체로 판정.
+     * <pre>
+     * 지원자 1명     → 0 (자유)
+     * 지원자 2명 이상 → 1
+     * </pre>
+     */
+    @Nested
+    class minimumRequired {
+
+        @ParameterizedTest(name = "지원자 {0}명 (TO {1}) → 최소 {2}명")
+        @CsvSource({
+            "1, 1, 0",
+            "1, 2, 0",
+            "1, 5, 0",
+            "2, 1, 1",
+            "2, 5, 1",
+            "3, 2, 1",
+            "5, 1, 1",
+            "10, 3, 1"
+        })
+        void TO_무관_지원자_수만으로_결정(int applicants, int quota, int expectedMin) {
+            assertThat(sut.minimumRequired(applicants, quota)).isEqualTo(expectedMin);
+        }
+    }
+
+    @Nested
+    class decideAutomatically {
+
+        @Test
+        void 지원자_1명만_있고_의무_없음이면_SUBMITTED는_REJECTED로_확정() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.SUBMITTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).isEmpty();
+            assertThat(result.rejectedIds()).containsExactly(1L);
+        }
+
+        @Test
+        void PM이_이미_충분히_APPROVED했으면_SUBMITTED는_REJECTED로_확정() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.APPROVED),
+                application(2L, ProjectApplicationStatus.SUBMITTED),
+                application(3L, ProjectApplicationStatus.SUBMITTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).containsExactly(1L);
+            assertThat(result.rejectedIds()).containsExactlyInAnyOrder(2L, 3L);
+        }
+
+        @Test
+        void 지원자_2명이상이고_PM이_0명_APPROVED면_SUBMITTED중_random_1명_합격() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.SUBMITTED),
+                application(2L, ProjectApplicationStatus.SUBMITTED),
+                application(3L, ProjectApplicationStatus.SUBMITTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).hasSize(1);
+            assertThat(result.rejectedIds()).hasSize(2);
+            assertThat(result.approvedIds()).isSubsetOf(1L, 2L, 3L);
+        }
+
+        @Test
+        void PM이_모두_REJECTED했고_SUBMITTED_없으면_REJECTED_중_random_1명_합격_override() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.REJECTED),
+                application(2L, ProjectApplicationStatus.REJECTED),
+                application(3L, ProjectApplicationStatus.REJECTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).hasSize(1);
+            assertThat(result.rejectedIds()).hasSize(2);
+            assertThat(result.approvedIds()).isSubsetOf(1L, 2L, 3L);
+        }
+
+        @Test
+        void SUBMITTED와_REJECTED가_섞여있고_의무_미충족이면_SUBMITTED_우선_random_보충() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.REJECTED),
+                application(2L, ProjectApplicationStatus.SUBMITTED),
+                application(3L, ProjectApplicationStatus.REJECTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).containsExactly(2L);
+            assertThat(result.rejectedIds()).containsExactlyInAnyOrder(1L, 3L);
+        }
+
+        @Test
+        void 동일_seed면_동일_결과를_반환한다() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.SUBMITTED),
+                application(2L, ProjectApplicationStatus.SUBMITTED),
+                application(3L, ProjectApplicationStatus.SUBMITTED)
+            );
+
+            AutoDecisionResult first = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+            AutoDecisionResult second = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(first).isEqualTo(second);
+        }
+
+        @Test
+        void approvedIds와_rejectedIds는_disjoint하다() {
+            List<ProjectApplication> applicants = List.of(
+                application(1L, ProjectApplicationStatus.APPROVED),
+                application(2L, ProjectApplicationStatus.SUBMITTED),
+                application(3L, ProjectApplicationStatus.REJECTED)
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 1, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).doesNotContainAnyElementsOf(result.rejectedIds());
+        }
+    }
+
+    private ProjectApplication application(Long id, ProjectApplicationStatus status) {
+        try {
+            var constructor = ProjectApplication.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ProjectApplication application = constructor.newInstance();
+            ReflectionTestUtils.setField(application, "id", id);
+            ReflectionTestUtils.setField(application, "status", status);
+            return application;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/policy/DeveloperMatchingPolicyTest.java
+++ b/src/test/java/com/umc/product/project/application/service/policy/DeveloperMatchingPolicyTest.java
@@ -1,0 +1,201 @@
+package com.umc.product.project.application.service.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DeveloperMatchingPolicyTest {
+
+    private static final long FIXED_SEED = 42L;
+
+    DeveloperMatchingPolicy sut = new DeveloperMatchingPolicy();
+
+    @Test
+    void supportedType은_PLAN_DEVELOPER를_반환한다() {
+        assertThat(sut.supportedType()).isEqualTo(MatchingType.PLAN_DEVELOPER);
+    }
+
+    /**
+     * final-api.md §3 매트릭스 ② — 지원자 비율로 분기.
+     * <pre>
+     * 지원자 ≥ TO (100%↑)        → ceil(TO × 0.5)
+     * 50% 초과 ~ 100% 미만        → ceil(TO × 0.25)
+     * 50% 이하                   → 0
+     * </pre>
+     */
+    @Nested
+    class minimumRequired {
+
+        @ParameterizedTest(name = "TO {0}, 지원자 100% 이상({1}명) → 최소 {2}명 (50% rule)")
+        @CsvSource({
+            "3, 3, 2",
+            "3, 5, 2",
+            "4, 4, 2",
+            "4, 10, 2",
+            "5, 5, 3",
+            "6, 6, 3",
+            "7, 7, 4",
+            "8, 8, 4"
+        })
+        void TO_대비_100퍼센트_이상이면_50퍼센트_올림(int quota, int applicants, int expectedMin) {
+            assertThat(sut.minimumRequired(applicants, quota)).isEqualTo(expectedMin);
+        }
+
+        @ParameterizedTest(name = "TO {0}, 지원자 50%~100%({1}명) → 최소 {2}명 (25% rule)")
+        @CsvSource({
+            "3, 2, 1",
+            "4, 3, 1",
+            "5, 3, 2",
+            "5, 4, 2",
+            "6, 4, 2",
+            "6, 5, 2",
+            "7, 5, 2",
+            "7, 6, 2",
+            "8, 5, 2",
+            "8, 7, 2"
+        })
+        void TO_대비_50퍼센트_초과_100퍼센트_미만이면_25퍼센트_올림(int quota, int applicants, int expectedMin) {
+            assertThat(sut.minimumRequired(applicants, quota)).isEqualTo(expectedMin);
+        }
+
+        @ParameterizedTest(name = "TO {0}, 지원자 50% 이하({1}명) → 의무 없음")
+        @CsvSource({
+            "3, 1, 0",
+            "4, 1, 0",
+            "4, 2, 0",
+            "5, 2, 0",
+            "6, 2, 0",
+            "6, 3, 0",
+            "7, 3, 0",
+            "8, 3, 0",
+            "8, 4, 0"
+        })
+        void TO_대비_50퍼센트_이하면_의무_없음(int quota, int applicants, int expectedMin) {
+            assertThat(sut.minimumRequired(applicants, quota)).isEqualTo(expectedMin);
+        }
+    }
+
+    @Nested
+    class decideAutomatically {
+
+        @Test
+        void 의무_없음이면_SUBMITTED는_REJECTED로_확정() {
+            List<ProjectApplication> applicants = applications(2, ProjectApplicationStatus.SUBMITTED);
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 5, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).isEmpty();
+            assertThat(result.rejectedIds()).hasSize(2);
+        }
+
+        @Test
+        void 의무_충족이면_SUBMITTED는_REJECTED로_확정() {
+            List<ProjectApplication> applicants = new ArrayList<>();
+            applicants.addAll(applicationsWithIds(List.of(1L, 2L, 3L), ProjectApplicationStatus.APPROVED));
+            applicants.addAll(applicationsWithIds(List.of(4L, 5L, 6L), ProjectApplicationStatus.SUBMITTED));
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 6, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).containsExactlyInAnyOrder(1L, 2L, 3L);
+            assertThat(result.rejectedIds()).containsExactlyInAnyOrder(4L, 5L, 6L);
+        }
+
+        @Test
+        void 의무_미충족이면_SUBMITTED_우선_random_보충() {
+            List<ProjectApplication> applicants = new ArrayList<>();
+            applicants.addAll(applicationsWithIds(List.of(1L), ProjectApplicationStatus.APPROVED));
+            applicants.addAll(applicationsWithIds(List.of(2L, 3L, 4L, 5L, 6L), ProjectApplicationStatus.SUBMITTED));
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 6, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).hasSize(3);
+            assertThat(result.approvedIds()).contains(1L);
+            assertThat(result.approvedIds()).isSubsetOf(1L, 2L, 3L, 4L, 5L, 6L);
+            assertThat(result.rejectedIds()).hasSize(3);
+        }
+
+        @Test
+        void SUBMITTED_부족하면_REJECTED에서_추가_보충_PM_override() {
+            List<ProjectApplication> applicants = new ArrayList<>();
+            applicants.addAll(applicationsWithIds(List.of(1L), ProjectApplicationStatus.APPROVED));
+            applicants.addAll(applicationsWithIds(List.of(2L), ProjectApplicationStatus.SUBMITTED));
+            applicants.addAll(applicationsWithIds(List.of(3L, 4L, 5L, 6L), ProjectApplicationStatus.REJECTED));
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 6, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).hasSize(3);
+            assertThat(result.approvedIds()).contains(1L, 2L);
+            assertThat(result.rejectedIds()).hasSize(3);
+        }
+
+        @Test
+        void PM이_모두_REJECTED했고_SUBMITTED_없으면_REJECTED_중_random_보충() {
+            List<ProjectApplication> applicants = applicationsWithIds(
+                List.of(1L, 2L, 3L, 4L, 5L, 6L), ProjectApplicationStatus.REJECTED
+            );
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 6, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).hasSize(3);
+            assertThat(result.rejectedIds()).hasSize(3);
+            assertThat(result.approvedIds()).isSubsetOf(1L, 2L, 3L, 4L, 5L, 6L);
+        }
+
+        @Test
+        void TO_50퍼센트_이하라_의무_없는_상황에서_SUBMITTED는_REJECTED로_확정() {
+            List<ProjectApplication> applicants = applications(2, ProjectApplicationStatus.SUBMITTED);
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 6, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).isEmpty();
+            assertThat(result.rejectedIds()).hasSize(2);
+        }
+
+        @Test
+        void approvedIds와_rejectedIds는_disjoint하다() {
+            List<ProjectApplication> applicants = new ArrayList<>();
+            applicants.addAll(applicationsWithIds(List.of(1L), ProjectApplicationStatus.APPROVED));
+            applicants.addAll(applicationsWithIds(List.of(2L, 3L), ProjectApplicationStatus.SUBMITTED));
+            applicants.addAll(applicationsWithIds(List.of(4L, 5L), ProjectApplicationStatus.REJECTED));
+
+            AutoDecisionResult result = sut.decideAutomatically(applicants, 5, new Random(FIXED_SEED));
+
+            assertThat(result.approvedIds()).doesNotContainAnyElementsOf(result.rejectedIds());
+        }
+    }
+
+    private List<ProjectApplication> applications(int count, ProjectApplicationStatus status) {
+        List<ProjectApplication> list = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            list.add(application((long) i, status));
+        }
+        return list;
+    }
+
+    private List<ProjectApplication> applicationsWithIds(List<Long> ids, ProjectApplicationStatus status) {
+        return ids.stream().map(id -> application(id, status)).toList();
+    }
+
+    private ProjectApplication application(Long id, ProjectApplicationStatus status) {
+        try {
+            var constructor = ProjectApplication.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ProjectApplication application = constructor.newInstance();
+            ReflectionTestUtils.setField(application, "id", id);
+            ReflectionTestUtils.setField(application, "status", status);
+            return application;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
@@ -1,0 +1,209 @@
+package com.umc.product.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ProjectApplicationTest {
+
+    private static final Long APPLICANT_MEMBER_ID = 100L;
+    private static final Long DECIDER_MEMBER_ID = 200L;
+    private static final Long FORM_RESPONSE_ID = 300L;
+
+    /**
+     * 매칭 차수가 진행 중이라고 가정하기 위해 시작/마감을 현재 시각 기준 ±1일로 설정한다.
+     */
+    private static final Instant NOW = Instant.now();
+    private static final Instant ROUND_STARTS_AT = NOW.minusSeconds(86_400);
+    private static final Instant ROUND_ENDS_AT = NOW.plusSeconds(43_200);
+    private static final Instant ROUND_DECISION_DEADLINE = NOW.plusSeconds(86_400);
+
+    ProjectApplication application;
+    ProjectMatchingRound round;
+
+    @BeforeEach
+    void setUp() {
+        round = openRound();
+        application = ProjectApplication.create(applicationForm(), FORM_RESPONSE_ID, APPLICANT_MEMBER_ID, round);
+        setStatus(application, ProjectApplicationStatus.SUBMITTED);
+    }
+
+    @Nested
+    class approve {
+
+        @Test
+        void SUBMITTED를_APPROVED로_전이한다() {
+            application.approve(DECIDER_MEMBER_ID, "역량 우수");
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("역량 우수");
+        }
+
+        @Test
+        void REJECTED를_APPROVED로_재토글한다() {
+            setStatus(application, ProjectApplicationStatus.REJECTED);
+
+            application.approve(DECIDER_MEMBER_ID, null);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+        }
+
+        @Test
+        void APPROVED에서_같은_status로_호출해도_예외_없이_갱신된다() {
+            setStatus(application, ProjectApplicationStatus.APPROVED);
+
+            assertThatCode(() -> application.approve(DECIDER_MEMBER_ID, "재확인"))
+                .doesNotThrowAnyException();
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+        }
+
+        @Test
+        void DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            setStatus(application, ProjectApplicationStatus.DRAFT);
+
+            assertThatThrownBy(() -> application.approve(DECIDER_MEMBER_ID, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+
+        @Test
+        void 차수_종료_후에는_PROJECT_MATCHING_ROUND_LOCKED() {
+            setRoundDeadline(round, NOW.minusSeconds(60));
+
+            assertThatThrownBy(() -> application.approve(DECIDER_MEMBER_ID, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+    }
+
+    @Nested
+    class reject {
+
+        @Test
+        void SUBMITTED를_REJECTED로_전이한다() {
+            application.reject(DECIDER_MEMBER_ID, "면접 결과 부적합");
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("면접 결과 부적합");
+        }
+
+        @Test
+        void APPROVED를_REJECTED로_재토글한다() {
+            setStatus(application, ProjectApplicationStatus.APPROVED);
+
+            application.reject(DECIDER_MEMBER_ID, null);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            setStatus(application, ProjectApplicationStatus.DRAFT);
+
+            assertThatThrownBy(() -> application.reject(DECIDER_MEMBER_ID, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+
+        @Test
+        void 차수_종료_후에는_PROJECT_MATCHING_ROUND_LOCKED() {
+            setRoundDeadline(round, NOW.minusSeconds(60));
+
+            assertThatThrownBy(() -> application.reject(DECIDER_MEMBER_ID, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+    }
+
+    @Nested
+    class revertToPending {
+
+        @Test
+        void APPROVED를_SUBMITTED로_되돌리고_사유는_초기화한다() {
+            setStatus(application, ProjectApplicationStatus.APPROVED);
+            ReflectionTestUtils.setField(application, "statusChangeReason", "이전 사유");
+
+            application.revertToPending(DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isNull();
+        }
+
+        @Test
+        void REJECTED를_SUBMITTED로_되돌린다() {
+            setStatus(application, ProjectApplicationStatus.REJECTED);
+
+            application.revertToPending(DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+        }
+
+        @Test
+        void SUBMITTED_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+
+        @Test
+        void DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            setStatus(application, ProjectApplicationStatus.DRAFT);
+
+            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+
+        @Test
+        void 차수_종료_후에는_PROJECT_MATCHING_ROUND_LOCKED() {
+            setStatus(application, ProjectApplicationStatus.APPROVED);
+            setRoundDeadline(round, NOW.minusSeconds(60));
+
+            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+    }
+
+    private void setStatus(ProjectApplication application, ProjectApplicationStatus status) {
+        ReflectionTestUtils.setField(application, "status", status);
+    }
+
+    private void setRoundDeadline(ProjectMatchingRound round, Instant deadline) {
+        ReflectionTestUtils.setField(round, "decisionDeadline", deadline);
+    }
+
+    private ProjectMatchingRound openRound() {
+        return ProjectMatchingRound.create(
+            "기획-디자인 1차 매칭", null,
+            MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
+            ROUND_STARTS_AT, ROUND_ENDS_AT, ROUND_DECISION_DEADLINE
+        );
+    }
+
+    private ProjectApplicationForm applicationForm() {
+        Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
+        return ProjectApplicationForm.create(project, 500L);
+    }
+}

--- a/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
@@ -133,6 +133,74 @@ class ProjectApplicationTest {
     }
 
     @Nested
+    class applyAutoDecision {
+
+        @Test
+        void SUBMITTED를_APPROVED로_확정한다() {
+            application.applyAutoDecision(ProjectApplicationStatus.APPROVED, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("auto-decide");
+        }
+
+        @Test
+        void SUBMITTED를_REJECTED로_확정한다() {
+            application.applyAutoDecision(ProjectApplicationStatus.REJECTED, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+        }
+
+        @Test
+        void executedByMemberId가_null이어도_정상_처리된다_스케줄러_호출_케이스() {
+            application.applyAutoDecision(ProjectApplicationStatus.APPROVED, null);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isNull();
+        }
+
+        @Test
+        void REJECTED를_APPROVED로_override한다_PM_결정_무시() {
+            setStatus(application, ProjectApplicationStatus.REJECTED);
+
+            application.applyAutoDecision(ProjectApplicationStatus.APPROVED, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+        }
+
+        @Test
+        void 차수_종료_후에도_차수_검증_없이_정상_적용된다() {
+            setRoundDeadline(round, NOW.minusSeconds(60));
+
+            assertThatCode(() -> application.applyAutoDecision(
+                ProjectApplicationStatus.APPROVED, DECIDER_MEMBER_ID
+            )).doesNotThrowAnyException();
+        }
+
+        @Test
+        void DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            setStatus(application, ProjectApplicationStatus.DRAFT);
+
+            assertThatThrownBy(() -> application.applyAutoDecision(
+                ProjectApplicationStatus.APPROVED, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+
+        @Test
+        void targetStatus가_SUBMITTED면_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            assertThatThrownBy(() -> application.applyAutoDecision(
+                ProjectApplicationStatus.SUBMITTED, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+    }
+
+    @Nested
     class revertToPending {
 
         @Test

--- a/src/test/java/com/umc/product/project/domain/ProjectMatchingRoundTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectMatchingRoundTest.java
@@ -1,0 +1,75 @@
+package com.umc.product.project.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProjectMatchingRoundTest {
+
+    private static final Instant STARTS_AT = Instant.parse("2026-05-10T00:00:00Z");
+    private static final Instant ENDS_AT = Instant.parse("2026-05-15T00:00:00Z");
+    private static final Instant DECISION_DEADLINE = Instant.parse("2026-05-17T00:00:00Z");
+
+    ProjectMatchingRound round;
+
+    @BeforeEach
+    void setUp() {
+        round = ProjectMatchingRound.create(
+            "기획-디자인 1차 매칭", null,
+            MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
+            STARTS_AT, ENDS_AT, DECISION_DEADLINE
+        );
+    }
+
+    @Nested
+    class validateIsMutableAt {
+
+        @Test
+        void startsAt_정각이면_정상_통과() {
+            assertThatCode(() -> round.validateIsMutableAt(STARTS_AT))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 진행_중이면_정상_통과() {
+            Instant midPoint = Instant.parse("2026-05-12T12:00:00Z");
+
+            assertThatCode(() -> round.validateIsMutableAt(midPoint))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        void decisionDeadline_정각이면_정상_통과() {
+            assertThatCode(() -> round.validateIsMutableAt(DECISION_DEADLINE))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        void startsAt_이전이면_PROJECT_MATCHING_ROUND_LOCKED() {
+            Instant beforeStart = STARTS_AT.minusSeconds(1);
+
+            assertThatThrownBy(() -> round.validateIsMutableAt(beforeStart))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+
+        @Test
+        void decisionDeadline_경과시_PROJECT_MATCHING_ROUND_LOCKED() {
+            Instant afterDeadline = DECISION_DEADLINE.plusSeconds(1);
+
+            assertThatThrownBy(() -> round.validateIsMutableAt(afterDeadline))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치: `develop`
- [x] PR 제목 컨벤션 준수

## 🔥 연관 이슈

- resolves #807

## 🚀 작업 내용

매칭차수 동안 PM 이 합/불 토글, 차수 종료 시 정책 매트릭스 기반 자동 보충, ProjectMember 자동 등록까지 한 흐름으로 구현.

### 주요 시나리오

| # | 시나리오 | 동작 |
|---|---|---|
| A | PM 무결정 + deadline 도달 (TO=4 개발자, 지원자 8명) | deadline+10분 후 스케줄러 발화 → 정책상 최소 2명 random APPROVED, 6명 REJECTED, ProjectMember 2개 생성 |
| B | PM 일부만 결정 (TO=4, 지원자 5명, PM가 1명 APPROVED) | needed=1 → SUBMITTED 풀에서 random 1명 추가 → 최종 APPROVED 2명 |
| C | PM 가 TO 초과 토글 시도 (TO=2, 이미 2명 APPROVED) | `validateRemainingQuota` 가 차단 → `QUOTA_EXCEEDED` 409 |
| D | 차수 종료 후 토글 시도 | `validateIsMutableAt` 가 차단 → `MATCHING_ROUND_LOCKED` 400 |
| E | 다중 차수 누적 (1차에서 1명 합격 후 2차) | 2차 자동 선발 입력 quota = 전체 TO − ACTIVE 멤버 수 |
| F | update 트랜잭션 롤백 | `afterCommit` 으로 미뤄진 schedule 콜백이 실행되지 않음 → in-memory task 와 DB state 일관성 유지 |
| G | JVM 재시작 | `@PostConstruct` 가 미처리 round 모두 재등록, deadline+10 이 과거면 즉시 발화 |

### API (2개)

| ID | Method | Path | 권한 |
|---|---|---|---|
| **APPLY-103** | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | `PROJECT_APPLICATION.APPROVE` (PO) |
| **MATCHING-201** | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 운영진 (중앙 총괄단 / 본 지부 지부장) |

### 정책 매트릭스

- **Designer**: 지원자 ≥2명 → 최소 1명 합격 / 1명 → 자유
- **Developer**: TO 대비 100%↑ → ceil(TO×0.5) / 50%↑ → ceil(TO×0.25) / 50%↓ → 자유
- **알고리즘**: 이미 APPROVED 유지 → 부족분 SUBMITTED 풀 random pick → 그래도 부족하면 REJECTED 풀 override

### 동적 스케줄링 설계

- create/update/delete lifecycle 마다 `TaskScheduler` 에 1회성 task 등록/취소
- 발화 시점은 `decisionDeadline + 10분` (클럭 정밀도 + 자정 cron 부하 분리 + PM 마지막 토글 race 보호)
- 트랜잭션 commit 후 등록 (`TransactionSynchronizationManager.afterCommit`) — 롤백 시 stale task 방지
- 부팅 시 `@PostConstruct` 로 미처리 round 모두 재등록

## 💬 리뷰 중점사항

**테스트 케이스 위주로 봐주세요**. 정책 매트릭스 표가 `@ParameterizedTest` 로 1:1 대응돼 있고, 시나리오별 분기를 단위 테스트로 만들어놨어요.

| 보고 싶은 영역 | 테스트 파일 |
|---|---|
| 정책 매트릭스 ① (디자이너) | `DesignerMatchingPolicyTest` |
| 정책 매트릭스 ② (개발자) | `DeveloperMatchingPolicyTest` |
| 정책 알고리즘 ③ + 자동 선발 부수효과 + 멱등성 + 권한 | `ProjectMatchingRoundFinalizationCommandServiceTest` |
| PM 토글 + 잔여 quota 검증 + status 분기 | `ProjectApplicationCommandServiceTest` |
| 도메인 (재토글 / revertToPending / lock / applyAutoDecision) | `ProjectApplicationTest`, `ProjectMatchingRoundTest` |
| 동적 스케줄링 (등록/취소/재등록/recovery/buffer) | `MatchingRoundDeadlineSchedulerTest` |
| 권한 evaluator 완화 (SUBMITTED → APPROVED/REJECTED 도 통과) | `ProjectApplicationPermissionEvaluatorTest` |