### PR TITLE
[Refactor] 프로젝트 여러개 등록 가능하도록 DRAFT 룰 확장

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -158,10 +158,10 @@ public class ProjectResponseAssembler {
     }
 
     /**
-     * PROJECT-103 PM의 내 Draft 조회. Draft가 없으면 {@code null} 반환.
+     * PROJECT-103 내가 작성 중인 Draft 조회 (creator 기준). Draft 가 없으면 {@code null} 반환.
      */
     public DraftProjectResponse draftFor(Long memberId, Long gisuId) {
-        Optional<ProjectInfo> maybe = getProjectUseCase.findDraftByOwnerAndGisu(memberId, gisuId);
+        Optional<ProjectInfo> maybe = getProjectUseCase.findDraftByCreatorAndGisu(memberId, gisuId);
         if (maybe.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -1,12 +1,17 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 
-    Optional<Project> findByProductOwnerMemberIdAndGisuId(Long productOwnerMemberId, Long gisuId);
-
     boolean existsByProductOwnerMemberIdAndGisuId(Long productOwnerMemberId, Long gisuId);
+
+    Optional<Project> findByCreatedByMemberIdAndGisuIdAndStatus(
+        Long createdByMemberId, Long gisuId, ProjectStatus status);
+
+    boolean existsByCreatedByMemberIdAndGisuIdAndStatus(
+        Long createdByMemberId, Long gisuId, ProjectStatus status);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.List;
@@ -31,13 +32,20 @@ public class ProjectPersistenceAdapter implements LoadProjectPort, SaveProjectPo
     }
 
     @Override
-    public Optional<Project> findByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
-        return jpaRepository.findByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
+    public boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
+        return jpaRepository.existsByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
     }
 
     @Override
-    public boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
-        return jpaRepository.existsByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
+    public Optional<Project> findDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId) {
+        return jpaRepository.findByCreatedByMemberIdAndGisuIdAndStatus(
+            creatorMemberId, gisuId, ProjectStatus.DRAFT);
+    }
+
+    @Override
+    public boolean existsDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId) {
+        return jpaRepository.existsByCreatedByMemberIdAndGisuIdAndStatus(
+            creatorMemberId, gisuId, ProjectStatus.DRAFT);
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CreateDraftProjectUseCase.java
@@ -5,7 +5,9 @@ import com.umc.product.project.application.port.in.command.dto.CreateDraftProjec
 /**
  * 프로젝트 Draft 생성 UseCase (PROJECT-101).
  * <p>
- * 한 PM이 한 기수에 가질 수 있는 프로젝트는 1개. 이미 존재하면 {@code PROJECT_DUPLICATE_IN_GISU}.
+ * (creator, gisu) 당 작성 중인 DRAFT 는 1 개로 제한된다. 이미 작성 중인 DRAFT 가 있으면
+ * {@code PROJECT_DRAFT_ALREADY_IN_PROGRESS}. DRAFT 가 PENDING_REVIEW 로 전이되면 슬롯이 풀려
+ * 같은 creator 가 새 DRAFT 를 시작할 수 있다. PO 측 유일성 제약은 적용하지 않는다.
  * 프론트는 {@code GET /projects/me/draft?gisuId=X}로 사전 확인 후 호출하는 것을 권장.
  */
 public interface CreateDraftProjectUseCase {

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectUseCase.java
@@ -7,7 +7,7 @@ import java.util.Optional;
  * 단건 프로젝트 조회 UseCase.
  * <ul>
  *   <li>{@link #getById(Long)} — 프로젝트 상세 조회 (PROJECT-002). 반드시 존재해야 하며, 없으면 예외.</li>
- *   <li>{@link #findDraftByOwnerAndGisu(Long, Long)} — PM의 내 Draft 조회 (PROJECT-103). 없으면 {@link Optional#empty()}.</li>
+ *   <li>{@link #findDraftByCreatorAndGisu(Long, Long)} — 내가 작성 중인 Draft 조회 (PROJECT-103). 없으면 {@link Optional#empty()}.</li>
  * </ul>
  * <p>
  * 목록/검색 조회는 {@link SearchProjectUseCase}를 참고하세요.
@@ -23,12 +23,13 @@ public interface GetProjectUseCase {
     ProjectInfo getById(Long projectId);
 
     /**
-     * 특정 PM이 특정 기수에 작성한 Draft 프로젝트를 조회합니다.
-     * PM이 아직 만들지 않았거나 상태가 DRAFT가 아닌 경우 {@link Optional#empty()}.
+     * 특정 creator 가 특정 기수에 작성 중인 Draft 프로젝트를 조회합니다.
+     * 등록 화면 재진입용 — creator 본인이 만든 DRAFT 만 노출되며,
+     * (creator, gisu) 당 DRAFT 1 개 제약이라 단건이 보장됩니다.
      *
-     * @param productOwnerMemberId PO(작성자) Member ID
-     * @param gisuId               기수 ID
+     * @param creatorMemberId 작성자(creator) Member ID
+     * @param gisuId          기수 ID
      * @return Draft Info, 없으면 empty
      */
-    Optional<ProjectInfo> findDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+    Optional<ProjectInfo> findDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
@@ -26,16 +26,22 @@ public interface LoadProjectPort {
     Project getById(Long id);
 
     /**
-     * 특정 PM이 특정 기수에 등록한 프로젝트를 조회합니다. 상태 필터 없이 단건 반환
-     * (한 PM당 한 기수 1개 UNIQUE 제약).
-     */
-    Optional<Project> findByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
-
-    /**
-     * 특정 PM이 특정 기수에 이미 프로젝트를 보유하고 있는지 확인합니다.
-     * 중복 생성 방지(PROJECT-101)용 빠른 체크.
+     * 특정 멤버가 특정 기수에 PO 인 프로젝트가 하나라도 존재하는지 확인합니다.
+     * Access scope 판정용 (OwnerOnly 부여 여부) — 동일 기수 내 PO 중복은 더 이상 차단되지 않으므로 다중 매치 가능.
      */
     boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+
+    /**
+     * 특정 creator 가 특정 기수에 작성 중인 DRAFT 프로젝트를 조회합니다.
+     * (creator, gisu) 당 DRAFT 1 개 UNIQUE 제약이라 단건이 보장됩니다.
+     */
+    Optional<Project> findDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId);
+
+    /**
+     * 특정 creator 가 특정 기수에 작성 중인 DRAFT 를 보유하고 있는지 확인합니다.
+     * Draft 동시 생성 방지(PROJECT-101)용 빠른 체크.
+     */
+    boolean existsDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId);
 
     /**
      * 동적 조건으로 프로젝트 목록을 페이지 조회합니다.

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -73,8 +73,8 @@ public class ProjectCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
         }
 
-        if (loadProjectPort.existsByOwnerAndGisu(command.productOwnerMemberId(), command.gisuId())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+        if (loadProjectPort.existsDraftByCreatorAndGisu(command.requesterMemberId(), command.gisuId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
         }
 
         MemberInfo member = getMemberUseCase.getById(command.productOwnerMemberId());
@@ -177,10 +177,6 @@ public class ProjectCommandService implements
         );
         if (newOwner.part() != ChallengerPart.PLAN) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
-        }
-
-        if (loadProjectPort.existsByOwnerAndGisu(command.newOwnerMemberId(), project.getGisuId())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
         }
 
         // 도메인 가드 fail-fast — COMPLETED/ABORTED 시 cross-domain 호출 회피

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -59,9 +59,8 @@ public class ProjectQueryService implements
     }
 
     @Override
-    public Optional<ProjectInfo> findDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
-        return loadProjectPort.findByOwnerAndGisu(productOwnerMemberId, gisuId)
-            .filter(project -> project.getStatus() == ProjectStatus.DRAFT)
+    public Optional<ProjectInfo> findDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId) {
+        return loadProjectPort.findDraftByCreatorAndGisu(creatorMemberId, gisuId)
             .map(this::toProjectInfo);
     }
 

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -34,7 +34,7 @@ public enum ProjectErrorCode implements BaseCode {
     APPLICATION_FORM_OPTIONS_REQUIRED(HttpStatus.BAD_REQUEST, "PROJECT-0018", "선택지 타입 질문에는 1개 이상의 옵션이 필요합니다."),
 
     // Project Draft flow (PROJECT-101, 102, 107)
-    PROJECT_DUPLICATE_IN_GISU(HttpStatus.CONFLICT, "PROJECT-0008", "이미 해당 기수에 등록한 프로젝트가 있습니다."),
+    PROJECT_DRAFT_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "PROJECT-0008", "작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다."),
     PROJECT_INVALID_STATE(HttpStatus.BAD_REQUEST, "PROJECT-0009", "현재 상태에서 수행할 수 없는 작업입니다."),
     PROJECT_OWNER_NOT_PLAN_CHALLENGER(HttpStatus.BAD_REQUEST, "PROJECT-0010", "프로젝트 PO는 PLAN 파트 챌린저여야 합니다."),
     PROJECT_SUBMIT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "PROJECT-0011", "제출에 필요한 필수 정보가 누락되었습니다."),

--- a/src/main/resources/db/migration/V2026.05.10.14.00__add_unique_creator_gisu_draft_to_project.sql
+++ b/src/main/resources/db/migration/V2026.05.10.14.00__add_unique_creator_gisu_draft_to_project.sql
@@ -1,0 +1,6 @@
+-- (creator, gisu) 당 DRAFT 1개 제약을 DB 레벨에서 강제한다.
+-- PostgreSQL partial unique index — DRAFT 상태에 한해서만 유일성 보장.
+-- DRAFT → PENDING_REVIEW 로 전이되는 즉시 슬롯이 풀려 새 DRAFT 시작이 가능해진다.
+CREATE UNIQUE INDEX uk_project_creator_gisu_draft
+    ON project (created_by_member_id, gisu_id)
+    WHERE status = 'DRAFT';

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
@@ -85,7 +85,7 @@ class ProjectResponseAssemblerTest {
     @Test
     void draftFor_Draft가_있으면_applicationFormId_hydrate() {
         ProjectInfo info = projectInfo(42L);
-        given(getProjectUseCase.findDraftByOwnerAndGisu(99L, 1L)).willReturn(Optional.of(info));
+        given(getProjectUseCase.findDraftByCreatorAndGisu(99L, 1L)).willReturn(Optional.of(info));
         given(getMemberUseCase.findAllByIds(java.util.Set.of(99L)))
             .willReturn(Map.of(99L, memberInfo(99L)));
 
@@ -100,7 +100,7 @@ class ProjectResponseAssemblerTest {
 
     @Test
     void draftFor_Draft가_없으면_null_반환() {
-        given(getProjectUseCase.findDraftByOwnerAndGisu(99L, 1L)).willReturn(Optional.empty());
+        given(getProjectUseCase.findDraftByCreatorAndGisu(99L, 1L)).willReturn(Optional.empty());
 
         DraftProjectResponse response = sut.draftFor(99L, 1L);
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
@@ -120,7 +121,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(saveProjectPort.save(any())).willAnswer(inv -> {
@@ -154,7 +155,7 @@ class ProjectCommandServiceTest {
         }
 
         @Test
-        void 중복_프로젝트면_예외() {
+        void creator가_같은_기수에_DRAFT_보유시_예외() {
             var command = CreateDraftProjectCommand.builder()
                 .gisuId(1L)
                 .productOwnerMemberId(100L)
@@ -164,12 +165,61 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(true);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(100L, 1L)).willReturn(true);
 
             assertThatThrownBy(() -> sut.create(command))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
+                .isEqualTo(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
+        }
+
+        @Test
+        void admin이_creator일_때_admin_기준으로_DRAFT_보유_검증() {
+            // 운영진(requester=200)이 다른 PM(productOwner=100)을 임명해 생성 시,
+            // creator-DRAFT 검증은 productOwnerMemberId 가 아닌 requesterMemberId 로 수행되어야 한다.
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .requesterMemberId(200L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsDraftByCreatorAndGisu(200L, 1L)).willReturn(true);
+
+            assertThatThrownBy(() -> sut.create(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
+        }
+
+        @Test
+        void creator_DRAFT_미보유면_PO_기수_중복은_검증하지_않고_생성_성공() {
+            // PO 룰 제거 검증: 기존엔 existsByOwnerAndGisu 로 PO 중복을 검사했지만
+            // 이제는 호출 자체가 사라졌다. PM 이 같은 기수에 PENDING_REVIEW 등 다른 프로젝트를
+            // 보유한 채 새 DRAFT 를 시작해도 차단되지 않는다.
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .requesterMemberId(100L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
+            given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
+            given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
+            given(saveProjectPort.save(any())).willAnswer(inv -> {
+                Project p = inv.getArgument(0);
+                ReflectionTestUtils.setField(p, "id", 99L);
+                return p;
+            });
+
+            sut.create(command);
+
+            then(loadProjectPort).should(never()).existsByOwnerAndGisu(any(), any());
         }
 
         @Test
@@ -183,7 +233,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of(
@@ -211,7 +261,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of(
@@ -239,7 +289,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of(
@@ -263,7 +313,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of(
@@ -291,7 +341,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of(
@@ -315,7 +365,7 @@ class ProjectCommandServiceTest {
             given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(100L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(getChallengerRoleUseCase.findAllByMemberId(200L)).willReturn(java.util.List.of());
@@ -449,7 +499,6 @@ class ProjectCommandServiceTest {
             given(loadProjectPort.getById(1L)).willReturn(project);
             given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
                 .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(false);
             given(getMemberUseCase.getById(200L)).willReturn(memberInfo(8L));
             given(getChapterUseCase.byGisuAndSchool(1L, 8L)).willReturn(new ChapterInfo(3L, "인천"));
 
@@ -485,31 +534,33 @@ class ProjectCommandServiceTest {
         }
 
         @Test
-        void 새_PM이_같은_기수에_이미_프로젝트_있으면_예외() {
-            Project project = createProject(ProjectStatus.DRAFT);
-            given(loadProjectPort.getById(1L)).willReturn(project);
-            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
-                .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(true);
-
-            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_DUPLICATE_IN_GISU);
-        }
-
-        @Test
         void COMPLETED_상태는_양도_불가() {
             Project project = createProject(ProjectStatus.COMPLETED);
             given(loadProjectPort.getById(1L)).willReturn(project);
             given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
                 .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
-            given(loadProjectPort.existsByOwnerAndGisu(200L, 1L)).willReturn(false);
 
             assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void 양도_시_새_PM의_PO_기수_중복은_검증하지_않고_성공() {
+            // PO 룰 제거 검증: 기존엔 새 PM 이 같은 기수에 다른 프로젝트의 PO 면 차단했지만,
+            // 이제는 호출 자체가 사라져 새 PM 이 PO 인 프로젝트가 있어도 양도가 허용된다.
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
+                .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
+            given(getMemberUseCase.getById(200L)).willReturn(memberInfo(8L));
+            given(getChapterUseCase.byGisuAndSchool(1L, 8L)).willReturn(new ChapterInfo(3L, "인천"));
+
+            sut.transfer(transferCommand(100L, 200L));
+
+            assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
+            then(loadProjectPort).should(never()).existsByOwnerAndGisu(any(), any());
         }
 
         private TransferProjectOwnershipCommand transferCommand(Long requester, Long newOwner) {

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -113,10 +113,10 @@ class ProjectQueryServiceTest {
     }
 
     @Test
-    void findDraftByOwnerAndGisu_DRAFT_프로젝트_반환() {
+    void findDraftByCreatorAndGisu_DRAFT_프로젝트_반환() {
         // given
         Project project = createProject(1L, ProjectStatus.DRAFT);
-        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
+        given(loadProjectPort.findDraftByCreatorAndGisu(10L, 1L))
             .willReturn(Optional.of(project));
         given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
             .willReturn(List.of());
@@ -125,7 +125,7 @@ class ProjectQueryServiceTest {
             .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
 
         // when
-        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
+        Optional<ProjectInfo> result = sut.findDraftByCreatorAndGisu(10L, 1L);
 
         // then
         assertThat(result).isPresent();
@@ -133,27 +133,13 @@ class ProjectQueryServiceTest {
     }
 
     @Test
-    void findDraftByOwnerAndGisu_DRAFT가_아니면_empty() {
+    void findDraftByCreatorAndGisu_프로젝트_없으면_empty() {
         // given
-        Project project = createProject(1L, ProjectStatus.IN_PROGRESS);
-        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
-            .willReturn(Optional.of(project));
-
-        // when
-        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
-
-        // then
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void findDraftByOwnerAndGisu_프로젝트_없으면_empty() {
-        // given
-        given(loadProjectPort.findByOwnerAndGisu(10L, 1L))
+        given(loadProjectPort.findDraftByCreatorAndGisu(10L, 1L))
             .willReturn(Optional.empty());
 
         // when
-        Optional<ProjectInfo> result = sut.findDraftByOwnerAndGisu(10L, 1L);
+        Optional<ProjectInfo> result = sut.findDraftByCreatorAndGisu(10L, 1L);
 
         // then
         assertThat(result).isEmpty();


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치: `develop`
- [x] PR 제목 컨벤션 준수

## 🔥 연관 이슈

- resolves #841

## 🚀 작업 내용

기존 `(PO, gisu) 1개` 룰이 제출 후 동일 PM 의 다음 프로젝트 등록까지 막고 있었습니다.
요구사항대로 **creator 기준 DRAFT 유일성**만 강제하도록 제약 모델을 재구성하고, PO 측 가드는 모두 제거했습니다.

### 룰 변경

| 항목 | AS-IS | TO-BE |
|---|---|---|
| PO 유일성 | (PO, gisu) 1개 (모든 상태) | **제거** |
| Creator DRAFT 유일성 | 없음 | **(creator, gisu) DRAFT 1개** |
| DRAFT 슬롯 해제 시점 | — | DRAFT → PENDING_REVIEW 전이 즉시 |
| 차단 에러 코드 | `PROJECT_DUPLICATE_IN_GISU` | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` |

### 동작 시나리오

| # | 시나리오 | AS-IS | TO-BE |
|---|---|---|---|
| 1 | PM-A submit(PENDING_REVIEW) → PM-A 가 또 자기 DRAFT 시도 | ❌ PO 중복 | **✅ 허용** |
| 2 | PM-A 가 같은 기수에 PENDING_REVIEW + DRAFT 동시 보유 | 불가 | **✅ 가능** |
| 3 | Admin 이 PM-A DRAFT 작성 직후, 같은 admin 이 PM-B DRAFT 시도 | ✅ | ❌ Creator 중복 |
| 4 | Admin 이 PM-A 에 만든 DRAFT submit 후 PM-B 에게 새 DRAFT | ✅ | ✅ |
| 5 | 양도 시 새 PM 이 다른 프로젝트 PO 여도 양도 | ❌ PO 중복 | **✅ 허용** |