### PR TITLE
[Feat] Kakao OAuth 로그인 시 Authorization Code를 사용하는 API 추가

### DIFF
--- a/docs/adr/007-extend-kakao-login-with-authorization-code.md
+++ b/docs/adr/007-extend-kakao-login-with-authorization-code.md
@@ -1,0 +1,279 @@
+# ADR-007: Kakao 로그인은 Authorization Code + Redirect URI 흐름을 추가로 지원하도록 확장한다
+
+## Status
+
+Proposed
+
+## Context
+
+UMC PRODUCT 서비스는 현재 Kakao 로그인을 다음과 같은 구조로 처리하고 있다.
+
+- `POST /api/v1/auth/login/kakao` 가 [`KakaoLoginRequest(String accessToken)`](../../src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java)를 받는다.
+- [`AuthenticationController#kakaoOAuthLogin`](../../src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java#L42-L48)에서 [`AccessTokenLoginCommand(provider, token)`](../../src/main/java/com/umc/product/authentication/application/port/in/command/dto/AccessTokenLoginCommand.java)로 변환해 [`OAuthAuthenticationService#accessTokenLogin`](../../src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java#L74-L91)으로 위임한다.
+- [`OAuthTokenVerificationAdapter`](../../src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java)가 provider에 따라 [`KakaoTokenVerifier#verifyAccessToken`](../../src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java#L46-L82)을 호출해 `https://kapi.kakao.com/v2/user/me`로 사용자 정보를 조회한다.
+
+이 흐름은 **클라이언트가 Kakao SDK로 직접 access token까지 받아둔 경우**(주로 iOS/Android 네이티브 SDK)에만 적합하다. 그러나 다음 두 가지 요구가 발생했다.
+
+1. **웹/하이브리드 클라이언트에서 redirect URI 기반 OAuth 흐름이 필요하다.**
+   - Kakao 로그인 페이지에서 `redirect_uri`로 돌아오는 표준 OAuth2 authorization code grant 흐름을 그대로 사용하고 싶다.
+   - 이 경우 클라이언트가 가진 것은 access token이 아니라 **authorization code + 인가 시 사용된 redirect URI** 이다.
+   - Kakao token endpoint(`https://kauth.kakao.com/oauth/token`)는 [code 교환 시 `redirect_uri`가 인가 요청 때와 정확히 일치해야 한다](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token). 즉 서버는 어떤 `redirect_uri`로 발급된 code인지 알고 있어야 한다.
+2. **client secret을 서버에서만 관리해야 한다.**
+   - Kakao token endpoint 호출에 사용되는 `client_secret`(보안 모드 설정 시)은 서버에서만 보관해야 하므로, 프론트가 token 교환을 대신 수행하게 둘 수 없다.
+
+현재 구조는 다음과 같은 한계를 가진다.
+
+- `KakaoLoginRequest`가 access token 한 가지 필드만 받는 단일 record라 redirect URI를 추가하면 access token 흐름과의 의미가 섞인다.
+- `AccessTokenLoginCommand`는 이름이 곧 의미(access token 기반)인 record라 authorization code를 같은 record에 끼워 넣으면 명명 규약([Domain/Application 계층 의미 기반 네이밍](../../CLAUDE.md#read-operation-methods-usecase--adapterrepository))과 충돌한다.
+- `VerifyOAuthTokenPort#verify(provider, token)`는 토큰 한 개만 받는 시그니처라 `redirect_uri`처럼 흐름별로 다른 파라미터를 표현할 수 없다.
+- ADR-001에서 Apple은 동일한 문제(다른 흐름·파라미터)를 [`verifyAppleAuthorizationCode(code, clientType)`](../../src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java#L34) + `AppleAuthorizationCodeResult`로 분리해 해결한 선례가 있다. Kakao에도 같은 방향을 적용하는 것이 자연스럽다.
+
+따라서 **기존 access token 흐름은 그대로 유지**하면서, **authorization code + redirect URI 흐름을 부수적으로 추가**할 수 있는 확장 설계가 필요하다.
+
+## Decision
+
+우리는 Kakao 로그인의 두 가지 진입 방식(access token, authorization code)을 **Command/Port/Verifier 계층에서 명시적으로 분리**하고, **Request DTO 레벨에서는 진입 방식별로 record를 분리**하기로 결정한다. 컨트롤러는 두 record를 각각의 엔드포인트(`/login/kakao`, `/login/kakao/code`)에 매핑하여, 진입 방식이 URL과 DTO 양쪽에서 구분되도록 한다.
+
+구체적인 결정사항은 다음과 같다.
+
+1. **요청 DTO 분리**
+   - 기존 `KakaoLoginRequest(String accessToken)`은 유지한다(하위 호환).
+   - 신규 record `KakaoCodeLoginRequest(@NotBlank String authorizationCode, @NotBlank String redirectUri)`를 `authentication/adapter/in/web/dto/request` 패키지에 추가한다.
+   - `redirectUri`는 클라이언트가 Kakao 인가 요청에 사용한 값을 그대로 전달하며, 서버는 [화이트리스트 검증](#redirect-uri-화이트리스트) 후 Kakao token endpoint 호출에 동일 값으로 사용한다.
+
+2. **Application Command 분리**
+   - 기존 `AccessTokenLoginCommand(provider, token)`은 유지한다.
+   - 신규 record `AuthorizationCodeLoginCommand(OAuthProvider provider, String authorizationCode, String redirectUri)`를 추가한다.
+   - 차후 Google 등 다른 provider에서 동일한 흐름이 필요할 경우 같은 Command를 재사용할 수 있도록 `provider`를 유지한다.
+
+3. **UseCase 확장**
+   - [`OAuthAuthenticationUseCase`](../../src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java)에 다음 메서드를 추가한다.
+
+     ```java
+     OAuthTokenLoginResult authorizationCodeLogin(AuthorizationCodeLoginCommand command);
+     ```
+   - 내부 구현은 access token 흐름과 동일하게 `VerifyOAuthTokenPort`를 통해 검증한 뒤 `loginWithOAuth2Attributes(...)` 공통 메서드로 위임한다(코드 재사용).
+
+4. **Outbound Port 확장**
+   - [`VerifyOAuthTokenPort`](../../src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java)에 Kakao 전용이 아닌 **provider 일반화된** 메서드를 추가한다.
+
+     ```java
+     OAuth2Attributes verifyAuthorizationCode(
+         OAuthProvider provider,
+         String authorizationCode,
+         String redirectUri
+     );
+     ```
+   - Apple은 `client_id`(=`ClientType`) 분기와 refresh token 반환이 필요하므로 [기존 `verifyAppleAuthorizationCode`](../../src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java#L34)를 그대로 둔다. Kakao는 refresh token 보관이 현재 요구사항이 아니므로 `OAuth2Attributes`만 반환한다(향후 필요 시 `KakaoAuthorizationCodeResult` 도입 가능).
+
+5. **Kakao Verifier 확장**
+   - `KakaoTokenVerifier`에 다음을 추가한다.
+
+     ```java
+     OAuth2Attributes verifyAuthorizationCode(String authorizationCode, String redirectUri);
+     ```
+   - 동작:
+     1. `https://kauth.kakao.com/oauth/token`에 `grant_type=authorization_code`로 POST하여 access token을 교환한다(`client_id`/`client_secret`은 서버 설정값 사용).
+     2. 받은 access token을 기존 `verifyAccessToken(accessToken)` 흐름에 재사용하여 `OAuth2Attributes`를 만든다.
+   - 즉 신규 메서드는 **token 교환 책임만** 가지며, 사용자 정보 매핑은 기존 메서드를 재사용해 중복을 피한다.
+
+6. **Adapter Facade 라우팅**
+   - [`OAuthTokenVerificationAdapter#verifyAuthorizationCode`](../../src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java)는 `switch(provider)` 분기로 `KAKAO`만 우선 구현하고, 다른 provider는 `UnsupportedOperationException`이 아닌 `AuthenticationDomainException`(예: `UNSUPPORTED_OAUTH_FLOW`)을 반환한다.
+   - Apple은 `verifyAppleAuthorizationCode` 경로를 계속 사용한다(필드와 결과 타입이 다르므로 통합하지 않는다).
+
+7. **Controller 라우팅**
+   - 새 엔드포인트 `POST /api/v1/auth/login/kakao/code`를 추가하고, `KakaoCodeLoginRequest`를 받는다.
+   - 기존 `POST /api/v1/auth/login/kakao`는 access token 흐름으로 유지한다.
+   - 두 핸들러 모두 결과를 `processOAuthLoginResult(OAuthProvider.KAKAO, result)` 같은 기존 helper로 위임해 JWT 발급 / 신규회원 분기를 공통화한다.
+
+8. **Redirect URI 화이트리스트**
+   - `AppleOAuthProperties`처럼 `KakaoOAuthProperties`를 도입하여 `client-id`, `client-secret`, `allowed-redirect-uris: List<String>`를 보관한다.
+   - `KakaoTokenVerifier.verifyAuthorizationCode`는 호출 직후 `redirectUri ∈ allowedRedirectUris`인지 검증한다. 불일치 시 `AuthenticationErrorCode.INVALID_OAUTH_TOKEN`을 던진다.
+   - 이는 [공개 클라이언트가 임의 redirect URI를 주입해 Kakao 응답을 가로채는 경우를 차단](https://datatracker.ietf.org/doc/html/rfc6749#section-10.6)하기 위한 방어선이다.
+
+## Alternatives Considered
+
+### 단일 `KakaoLoginRequest`에 nullable 필드 추가
+
+`KakaoLoginRequest(String accessToken, String authorizationCode, String redirectUri)` 형태로 모든 필드를 한 record에 모으고, 컨트롤러/서비스에서 비어 있지 않은 쪽을 보고 분기하는 방식이다.
+
+장점:
+
+- DTO 클래스 수가 늘지 않는다.
+- 엔드포인트도 하나만 유지된다.
+- 클라이언트 입장에서 "Kakao 로그인 = 한 엔드포인트" 라는 단순한 인상을 준다.
+
+단점:
+
+- record 안에서 "필드 A 또는 (필드 B + 필드 C)" 같은 상호배타 조건을 표현해야 해서 `@AssertTrue` 같은 검증을 record 내부에 끼워 넣어야 한다. 검증이 빠지면 두 흐름이 동시에 들어오거나 모두 누락된 요청이 통과될 수 있다.
+- Swagger 문서가 모든 필드를 optional로 표기하게 되어, 클라이언트가 어느 조합이 유효한지 문서만 보고 알 수 없다.
+- `AccessTokenLoginCommand` ↔ `AuthorizationCodeLoginCommand` 의미 분리 원칙(`CLAUDE.md` "Read Operation Methods" 와 같은 의미 기반 네이밍 컨벤션)과 충돌한다.
+
+선택하지 않은 이유:
+"한 record에 두 가지 흐름을 섞는다"는 모호함이, "record/엔드포인트가 하나 늘어난다"는 비용보다 크다. 인증 흐름은 의미가 다르면 타입도 분리해야 디버깅과 운영이 명확해진다.
+
+### `KakaoLoginRequest`를 `sealed interface` + 두 구현체
+
+`sealed interface KakaoLoginRequest permits KakaoAccessTokenLoginRequest, KakaoCodeLoginRequest`로 만들고, Jackson 다형성 역직렬화(`@JsonTypeInfo(use = DEDUCTION)` 또는 `property = "type"`)로 단일 엔드포인트가 두 형태를 모두 받게 하는 방식이다.
+
+장점:
+
+- 엔드포인트 한 개로 유지된다.
+- 컴파일러가 분기 누락을 잡아준다.
+- 흐름별 의미 분리는 유지된다.
+
+단점:
+
+- Jackson polymorphic deserialization은 디버깅이 어렵고, 잘못된 페이로드에 대한 오류 메시지가 직관적이지 않다.
+- DEDUCTION 방식은 필드 충돌 시 깨지기 쉽고, discriminator 방식(`type: "code"`)은 클라이언트와 별도 약속이 필요하다.
+- Swagger/OpenAPI 문서에서 oneOf 표현이 SDK 자동 생성기마다 다르게 처리된다(특히 정적 타입 SDK에서 깨지기 쉽다).
+
+선택하지 않은 이유:
+"한 엔드포인트 유지"라는 작은 이득을 위해, 직렬화/문서화의 모호함을 끌어들이게 된다. URL이 흐름을 식별하는 가장 단순한 메커니즘이고, 클라이언트도 보통 두 흐름을 동시에 사용하지 않는다.
+
+### Apple처럼 `KakaoAuthorizationCodeResult`까지 분리
+
+Apple은 `AppleAuthorizationCodeResult(attrs, refreshToken, clientId)`를 반환한다. Kakao도 동일하게 별도 결과 타입을 만들어 일관성을 맞추는 방식이다.
+
+장점:
+
+- Apple/Kakao가 같은 패턴으로 보인다.
+- 추후 refresh token이나 scope 정보를 보관해야 할 때 확장 지점이 이미 마련되어 있다.
+
+단점:
+
+- 현재 Kakao는 refresh token을 회원 단위로 영속화하지 않는다(연동 해제는 Admin Key 또는 사용자 access token 재발급으로 수행). 결과 타입이 1필드(`attrs`)뿐인 wrapper가 되어 의미가 없다.
+- 미래에만 의미 있는 추상화는 [CLAUDE.md의 "Don't design for hypothetical future requirements"](../../CLAUDE.md) 원칙에 어긋난다.
+
+선택하지 않은 이유:
+지금은 `OAuth2Attributes` 단일 반환으로 충분하다. 필요해질 때 도입한다(YAGNI). 단, 도입 가능성이 있으므로 Port 시그니처는 `OAuth2Attributes verifyAuthorizationCode(...)`로 두되, 향후 `KakaoAuthorizationCodeResult`로 바꿔도 호출부 변경 범위가 좁도록 KAKAO 분기만 어댑터 내부에 가둔다.
+
+### 신규 흐름만 두고 access token 흐름은 제거(Deprecate)
+
+OAuth2 표준은 authorization code grant이므로, 표준 흐름 하나로 통일하자는 방안이다.
+
+장점:
+
+- 흐름이 한 개로 줄어 코드 양이 작아진다.
+- 보안적으로도 일관된다.
+
+단점:
+
+- 이미 Kakao 모바일 SDK 기반으로 access token을 받아 보내는 모바일 클라이언트가 존재한다. 즉 제거는 클라이언트 측 변경을 강제한다.
+- Kakao는 모바일 SDK(`UserApi.shared.loginWithKakaoTalk(...)`)가 token까지 직접 발급하는 흐름을 공식적으로 권장한다. 모바일에서 redirect_uri 흐름을 강제하면 UX가 크게 저하된다.
+
+선택하지 않은 이유:
+모바일 네이티브 SDK 사용을 포기해야 하므로 ADR-001에서 Apple "단일 client_id로 통합"을 거부한 것과 같은 이유로 부적절하다.
+
+## Consequences
+
+### Positive
+
+- 웹 OAuth 표준(authorization code grant)을 정식으로 지원하게 되어, 브라우저에서 redirect URI를 거치는 모든 클라이언트(예: 운영툴, 외부 임베드 페이지)와 호환된다.
+- Kakao `client_secret`이 프론트로 노출되지 않는다. token 교환은 전적으로 서버에서 수행된다.
+- `KakaoLoginRequest`와 `AccessTokenLoginCommand`는 그대로 두므로, 기존 모바일 클라이언트의 동작과 API 계약이 깨지지 않는다.
+- Application 계층의 Command 분리(`AccessTokenLoginCommand` vs `AuthorizationCodeLoginCommand`)로 인증 흐름의 의도가 코드만 봐도 드러난다.
+- Apple과 동일한 "Port에 흐름별 메서드 추가" 패턴을 따라 일관성이 유지된다. 향후 Google 등에서 같은 흐름이 필요하면 `verifyAuthorizationCode`의 `switch` 분기에 추가만 하면 된다.
+
+### Negative
+
+- 엔드포인트가 한 개 늘어난다(`/login/kakao/code`). 클라이언트 팀에 두 진입점의 사용 시점을 명확히 공지해야 한다.
+- Kakao 환경 설정에 `client-secret`, `allowed-redirect-uris`가 추가되어 모든 환경(local/dev/prod)에서 누락 없이 세팅해야 한다. 한쪽이라도 비면 해당 환경 로그인 전체가 실패한다.
+- `redirect_uri` 화이트리스트 관리 책임이 서버에 생긴다. Kakao Developers Console에 등록한 redirect URI와 서버 화이트리스트가 어긋나면 디버깅이 까다롭다(둘 다 일치해야 함).
+- `KakaoTokenVerifier`가 외부 호출(token endpoint, user info)을 두 번 수행하게 되어 단건 로그인 지연이 소폭 늘어난다(~수십 ms 추가).
+
+### Neutral / Trade-offs
+
+- `verifyAuthorizationCode(provider, code, redirectUri)`를 일반화 시그니처로 두지만 Apple은 여전히 별도 메서드를 사용한다. "일반화된 형태"와 "특수화된 형태"가 공존하는 어색함이 있으나, Apple의 `clientType`/`refreshToken`/`clientId` 요구가 다른 provider와 다르므로 강제로 한 시그니처에 욱여넣지 않는 편이 명확하다(ADR-001의 결정 연장선).
+- Kakao token endpoint를 호출한 뒤 다시 user info endpoint를 호출한다(2-hop). 1-hop으로 줄이려면 token 응답에 포함된 id_token을 직접 파싱해야 하는데, Kakao id_token 검증은 JWKS 캐싱 등 추가 작업이 필요하므로 본 결정에서는 보류한다.
+- `client_secret`을 사용할지 여부는 Kakao 앱의 "보안 모드" 설정과 동기화되어야 한다. 보안 모드 활성 시 서버 호출에 누락되면 `KOE320` 류 오류가 발생한다.
+
+## Implementation Notes
+
+### 패키지/파일 추가
+
+```
+authentication/adapter/in/web/dto/request/KakaoCodeLoginRequest.java   # 신규
+authentication/application/port/in/command/dto/AuthorizationCodeLoginCommand.java  # 신규
+authentication/adapter/out/external/KakaoOAuthProperties.java          # 신규
+```
+
+### 기존 파일 변경 지점
+
+- [`OAuthAuthenticationUseCase`](../../src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java) — `authorizationCodeLogin(AuthorizationCodeLoginCommand)` 추가
+- [`OAuthAuthenticationService`](../../src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java) — 신규 메서드 구현. 내부에서 `verifyAuthorizationCode(...)` 호출 후 `loginWithOAuth2Attributes(...)` 재사용
+- [`VerifyOAuthTokenPort`](../../src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java) — `verifyAuthorizationCode(provider, code, redirectUri)` 추가
+- [`OAuthTokenVerificationAdapter`](../../src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java) — KAKAO 분기 추가, 나머지는 `UNSUPPORTED_OAUTH_FLOW` 예외
+- [`KakaoTokenVerifier`](../../src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java) — `verifyAuthorizationCode(code, redirectUri)` 추가(token endpoint 호출 + 기존 `verifyAccessToken` 재사용)
+- [`AuthenticationController`](../../src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java) — `POST /login/kakao/code` 핸들러 추가, 기존 `/login/kakao` 유지
+- [`AuthenticationControllerInterface`](../../src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java) — Swagger 정의 추가
+- [`AuthenticationErrorCode`](../../src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java) — `UNSUPPORTED_OAUTH_FLOW`, `INVALID_OAUTH_REDIRECT_URI` 추가 검토
+
+### 환경 변수
+
+`application.yml`의 `app.oauth2.kakao` 섹션:
+
+```yaml
+app:
+  oauth2:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID}
+      client-secret: ${KAKAO_CLIENT_SECRET}      # Kakao 앱 보안 모드 사용 시 필수
+      admin-key: ${KAKAO_ADMIN_KEY}              # 기존 unlink-by-admin 용도
+      allowed-redirect-uris:
+        - https://app.umc-product.com/oauth/kakao/callback
+        - https://dev.umc-product.com/oauth/kakao/callback
+        - http://localhost:5173/oauth/kakao/callback   # local only
+```
+
+### Token Exchange 호출 형태(Kakao 공식 스펙)
+
+```text
+POST https://kauth.kakao.com/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+client_id={REST API KEY}
+redirect_uri={요청 시 사용한 redirect_uri}
+code={authorization_code}
+client_secret={선택, 보안 모드 시 필수}
+```
+
+응답의 `access_token`을 기존 `verifyAccessToken(...)` 흐름에 그대로 전달한다.
+
+### 검증 순서 권장
+
+1. `KakaoCodeLoginRequest` Bean Validation (`@NotBlank`)
+2. `redirectUri ∈ allowedRedirectUris` (서버 화이트리스트)
+3. Kakao token endpoint 교환 (실패 시 `INVALID_OAUTH_TOKEN`)
+4. Kakao user info 조회 (기존 로직 재사용)
+5. `loginWithOAuth2Attributes(...)` — 기존/신규 회원 분기
+
+### 테스트 가이드
+
+- `KakaoTokenVerifier#verifyAuthorizationCode`는 Kakao token endpoint와 user info endpoint를 모두 호출하므로, `MockRestServiceServer` 또는 WireMock으로 두 호출을 한 테스트에서 stub해야 한다.
+- 화이트리스트 검증 실패, token endpoint 4xx 응답, user info 4xx 응답 세 가지 실패 경로에 대해 각각 `void Kakao_인가코드_로그인_redirectUri_불일치_실패()` 등 `@DisplayName`을 한국어로 단 테스트를 추가한다.
+- `OAuthAuthenticationService#authorizationCodeLogin`은 verifier를 mocking한 단위 테스트만으로도 충분하다(기존 `accessTokenLogin` 테스트 구조 재사용).
+
+### 운영 시 주의사항
+
+- Kakao Developers Console에 등록된 Redirect URI와 서버 `allowed-redirect-uris`가 어긋나면 token 교환이 `KOE320`/`invalid_grant`로 실패한다. 둘 다 동일하게 관리해야 한다.
+- `client_secret`은 절대 로그에 남기지 않는다(현재 `KakaoTokenVerifier`에 로그는 ID/email 수준까지만 노출되도록 유지).
+- 모바일 클라이언트는 기존 `/login/kakao`(access token 흐름)을 그대로 사용해도 되며, 강제로 신규 엔드포인트로 옮길 필요가 없다.
+
+## References
+
+- 관련 기존 코드
+    - [`KakaoLoginRequest`](../../src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java)
+    - [`AccessTokenLoginCommand`](../../src/main/java/com/umc/product/authentication/application/port/in/command/dto/AccessTokenLoginCommand.java)
+    - [`KakaoTokenVerifier`](../../src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java)
+    - [`OAuthAuthenticationService`](../../src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java)
+    - [`VerifyOAuthTokenPort`](../../src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java)
+- 관련 선행 ADR
+    - [ADR-001: Apple 로그인은 ClientType 기반으로 client_id를 분기한다](001-apple-signin-client-type-routing.md)
+- Kakao 공식 문서
+    - [Kakao 로그인 REST API — 토큰 받기](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token)
+    - [Kakao 로그인 REST API — 사용자 정보 가져오기](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info)
+    - [Kakao 로그인 REST API — 연결 끊기](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink)
+- 표준
+    - [RFC 6749 §10.6 — Authorization Code Redirection URI Manipulation](https://datatracker.ietf.org/doc/html/rfc6749#section-10.6)

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
@@ -2,17 +2,20 @@ package com.umc.product.authentication.adapter.in.web;
 
 import com.umc.product.authentication.adapter.in.web.dto.request.AppleLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.GoogleLoginRequest;
+import com.umc.product.authentication.adapter.in.web.dto.request.KakaoCodeLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.KakaoLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.response.OAuthLoginResponse;
 import com.umc.product.authentication.adapter.in.web.swagger.AuthenticationControllerInterface;
 import com.umc.product.authentication.application.port.in.command.OAuthAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.AccessTokenLoginCommand;
+import com.umc.product.authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand;
 import com.umc.product.authentication.application.port.in.command.dto.OAuthTokenLoginResult;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.annotation.Public;
+import jakarta.validation.Valid;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,6 +48,23 @@ public class AuthenticationController implements AuthenticationControllerInterfa
         @RequestBody KakaoLoginRequest request
     ) {
         return processAccessTokenLogin(OAuthProvider.KAKAO, request.accessToken());
+    }
+
+    @Override
+    @PostMapping("login/kakao/code")
+    @Public
+    public OAuthLoginResponse kakaoOAuthCodeLogin(
+        @Valid @RequestBody KakaoCodeLoginRequest request
+    ) {
+        OAuthTokenLoginResult result = oAuthAuthenticationUseCase.authorizationCodeLogin(
+            new AuthorizationCodeLoginCommand(
+                OAuthProvider.KAKAO,
+                request.authorizationCode(),
+                request.redirectUri()
+            )
+        );
+
+        return buildLoginResponse(OAuthProvider.KAKAO, result);
     }
 
     @Override

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoCodeLoginRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoCodeLoginRequest.java
@@ -1,0 +1,16 @@
+package com.umc.product.authentication.adapter.in.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Kakao Authorization Code 기반 로그인 요청.
+ * <p>
+ * 표준 OAuth2 authorization code grant 흐름을 사용하는 클라이언트(주로 웹)가
+ * Kakao에서 받은 authorization code와 인가 요청 시 사용한 redirect URI를 전달합니다.
+ * 모바일 네이티브 SDK 사용 시에는 기존 {@link KakaoLoginRequest}(access token) 흐름을 사용해주세요.
+ */
+public record KakaoCodeLoginRequest(
+    @NotBlank String authorizationCode,
+    @NotBlank String redirectUri
+) {
+}

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
@@ -29,7 +29,7 @@ public interface AuthenticationControllerInterface {
         @RequestBody GoogleLoginRequest request
     );
 
-    @Operation(summary = "[LOGIN-002] Kakao 로그인",
+    @Operation(summary = "[LOGIN-005] Kakao 로그인",
         description = """
             Web에서 Redirect 방식으로 사용하려면 아래의 Link를 참고해주세요.
 
@@ -47,7 +47,7 @@ public interface AuthenticationControllerInterface {
         @RequestBody KakaoLoginRequest request
     );
 
-    @Operation(summary = "[LOGIN-002-1] Kakao 로그인 (Authorization Code 흐름)",
+    @Operation(summary = "[LOGIN-006] Kakao 로그인 (Authorization Code 흐름)",
         description = """
             표준 OAuth2 authorization code grant 흐름을 사용하는 클라이언트(주로 웹)를 위한 엔드포인트입니다.
 
@@ -65,7 +65,7 @@ public interface AuthenticationControllerInterface {
         @RequestBody KakaoCodeLoginRequest request
     );
 
-    @Operation(summary = "[LOGIN-003] Apple 로그인",
+    @Operation(summary = "[LOGIN-010] Apple 로그인",
         description = """
             Web에서 Redirect 방식으로 사용하려면 아래의 Link를 참고해주세요.
 

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java
@@ -2,6 +2,7 @@ package com.umc.product.authentication.adapter.in.web.swagger;
 
 import com.umc.product.authentication.adapter.in.web.dto.request.AppleLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.GoogleLoginRequest;
+import com.umc.product.authentication.adapter.in.web.dto.request.KakaoCodeLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.KakaoLoginRequest;
 import com.umc.product.authentication.adapter.in.web.dto.response.OAuthLoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +45,24 @@ public interface AuthenticationControllerInterface {
             """)
     OAuthLoginResponse kakaoOAuthLogin(
         @RequestBody KakaoLoginRequest request
+    );
+
+    @Operation(summary = "[LOGIN-002-1] Kakao 로그인 (Authorization Code 흐름)",
+        description = """
+            표준 OAuth2 authorization code grant 흐름을 사용하는 클라이언트(주로 웹)를 위한 엔드포인트입니다.
+
+            Kakao 로그인 페이지에서 받은 `authorizationCode`와 인가 요청 시 사용한 `redirectUri`를 함께 전달해주세요.
+            서버가 Kakao token endpoint를 호출해 access token으로 교환한 뒤, 사용자 정보를 조회하여 인증을 처리합니다.
+
+            `redirectUri`는 서버 화이트리스트에 등록된 값과 일치해야 하며, 일치하지 않으면 `INVALID_OAUTH_REDIRECT_URI` 에러가 발생합니다.
+            모바일 네이티브 SDK 사용 시에는 기존 `/login/kakao` 엔드포인트(access token)를 그대로 사용해주세요.
+
+            **응답 설명:**
+            - `success=true, code=LOGIN_SUCCESS`: 기존 회원 로그인 성공. accessToken, refreshToken 발급됨.
+            - `success=true, code=REGISTER_REQUIRED`: OAuth 인증 성공, 회원가입 필요. oAuthVerificationToken 발급됨.
+            """)
+    OAuthLoginResponse kakaoOAuthCodeLogin(
+        @RequestBody KakaoCodeLoginRequest request
     );
 
     @Operation(summary = "[LOGIN-003] Apple 로그인",

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoOAuthProperties.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoOAuthProperties.java
@@ -1,0 +1,31 @@
+package com.umc.product.authentication.adapter.out.external;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Kakao OAuth 설정값.
+ * <p>
+ * Authorization Code 흐름에서 token endpoint 호출과 redirect URI 검증에 사용합니다.
+ * Spring Security OAuth2 자동 구성용 `spring.security.oauth2.client.registration.kakao`와는 별개로,
+ * 직접 token endpoint를 호출하기 위해 필요한 값을 명시적으로 관리합니다.
+ */
+@ConfigurationProperties(prefix = "app.oauth2.kakao")
+public record KakaoOAuthProperties(
+    String clientId,
+    String clientSecret,
+    String adminKey,
+    List<String> allowedRedirectUris
+) {
+    /**
+     * 주어진 redirect URI가 화이트리스트에 포함되어 있는지 확인합니다.
+     * <p>
+     * 공개 클라이언트가 임의 redirect URI를 주입해 Kakao 응답을 가로채는 경우를 차단하기 위한 방어선입니다.
+     */
+    public boolean isAllowedRedirectUri(String redirectUri) {
+        if (allowedRedirectUris == null || redirectUri == null) {
+            return false;
+        }
+        return allowedRedirectUris.contains(redirectUri);
+    }
+}

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
@@ -26,13 +26,84 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class KakaoTokenVerifier {
 
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
     private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
 
     private final RestClient restClient;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
 
     @Value("${app.oauth2.kakao.admin-key:}")
     private String kakaoAdminKey;
+
+    /**
+     * Kakao Authorization Code를 교환하고 OAuth2Attributes로 변환합니다.
+     * <p>
+     * 동작:
+     * <ol>
+     *     <li>전달받은 redirect URI가 화이트리스트에 포함되는지 검증한다.</li>
+     *     <li>Kakao token endpoint에 grant_type=authorization_code로 POST하여 access token을 교환한다.</li>
+     *     <li>받은 access token으로 기존 verifyAccessToken 흐름을 재사용해 사용자 정보를 조회한다.</li>
+     * </ol>
+     *
+     * @param authorizationCode Kakao에서 발급받은 authorization code
+     * @param redirectUri       클라이언트가 Kakao 인가 요청에 사용한 redirect URI (화이트리스트와 일치해야 함)
+     * @return OAuth2Attributes
+     * @throws AuthenticationDomainException redirect URI 불일치, 토큰 교환 실패, 또는 사용자 정보 조회 실패 시
+     */
+    public OAuth2Attributes verifyAuthorizationCode(String authorizationCode, String redirectUri) {
+        log.debug("Kakao Authorization Code 교환 시작");
+
+        if (!kakaoOAuthProperties.isAllowedRedirectUri(redirectUri)) {
+            log.warn("허용되지 않은 Kakao redirect URI: {}", redirectUri);
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_REDIRECT_URI);
+        }
+
+        String accessToken = exchangeAuthorizationCode(authorizationCode, redirectUri);
+        return verifyAccessToken(accessToken);
+    }
+
+    /**
+     * Kakao token endpoint를 호출하여 authorization code를 access token으로 교환합니다.
+     * <p>
+     * client_secret은 Kakao 앱이 보안 모드일 때만 필요하며, 비어 있으면 form data에서 제외합니다.
+     */
+    private String exchangeAuthorizationCode(String authorizationCode, String redirectUri) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", kakaoOAuthProperties.clientId());
+        formData.add("redirect_uri", redirectUri);
+        formData.add("code", authorizationCode);
+        if (kakaoOAuthProperties.clientSecret() != null && !kakaoOAuthProperties.clientSecret().isBlank()) {
+            formData.add("client_secret", kakaoOAuthProperties.clientSecret());
+        }
+
+        try {
+            KakaoTokenResponse response = restClient.post()
+                .uri(KAKAO_TOKEN_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formData)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("Kakao 토큰 교환 실패: status={}", res.getStatusCode());
+                    throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
+                })
+                .body(KakaoTokenResponse.class);
+
+            if (response == null || response.accessToken() == null) {
+                throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+            }
+
+            log.info("Kakao 토큰 교환 성공");
+            return response.accessToken();
+
+        } catch (AuthenticationDomainException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Kakao 토큰 교환 중 오류 발생", e);
+            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+        }
+    }
 
     /**
      * Kakao Access Token을 검증하고 OAuth2Attributes로 변환합니다.
@@ -178,6 +249,19 @@ public class KakaoTokenVerifier {
     }
 
     // ===== Response DTOs =====
+
+    private record KakaoTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+        @JsonProperty("token_type")
+        String tokenType,
+        @JsonProperty("refresh_token")
+        String refreshToken,
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+        String scope
+    ) {
+    }
 
     private record KakaoUserResponse(
         Long id,

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/OAuthTokenVerificationAdapter.java
@@ -4,6 +4,8 @@ import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.application.port.out.RevokeOAuthTokenPort;
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,22 @@ public class OAuthTokenVerificationAdapter implements VerifyOAuthTokenPort, Revo
             // Apple은 일반 verify가 아닌 verifyAppleAuthorizationCode 사용을 권장하지만,
             // ID Token 직접 검증이 필요한 경우를 위해 web Services ID 기준으로 audience를 검증한다.
             case APPLE -> appleTokenVerifier.verifyIdToken(token, appleOAuthProperties.webClientId());
+        };
+    }
+
+    @Override
+    public OAuth2Attributes verifyAuthorizationCode(OAuthProvider provider, String authorizationCode,
+                                                    String redirectUri) {
+        log.info("OAuth Authorization Code 교환 시작: provider={}", provider);
+
+        return switch (provider) {
+            case KAKAO -> kakaoTokenVerifier.verifyAuthorizationCode(authorizationCode, redirectUri);
+            // Apple은 client_id 분기와 refresh token 반환이 필요하므로 verifyAppleAuthorizationCode를 사용해야 한다.
+            // Google은 현재 access token 흐름만 지원한다.
+            case APPLE, GOOGLE -> {
+                log.warn("Authorization code 흐름을 지원하지 않는 provider: {}", provider);
+                throw new AuthenticationDomainException(AuthenticationErrorCode.UNSUPPORTED_OAUTH_FLOW);
+            }
         };
     }
 

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/OAuthAuthenticationUseCase.java
@@ -2,6 +2,7 @@ package com.umc.product.authentication.application.port.in.command;
 
 import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.in.command.dto.AccessTokenLoginCommand;
+import com.umc.product.authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand;
 import com.umc.product.authentication.application.port.in.command.dto.LinkOAuthCommand;
 import com.umc.product.authentication.application.port.in.command.dto.OAuthTokenLoginResult;
 import com.umc.product.authentication.application.port.in.command.dto.UnlinkOAuthCommand;
@@ -21,6 +22,14 @@ public interface OAuthAuthenticationUseCase {
     OAuthTokenLoginResult loginWithOAuth2Attributes(OAuth2Attributes oAuth2Attributes);
 
     OAuthTokenLoginResult accessTokenLogin(AccessTokenLoginCommand command);
+
+    /**
+     * Authorization Code 기반 OAuth 로그인 처리.
+     * <p>
+     * 표준 OAuth2 authorization code grant 흐름을 사용하는 웹/하이브리드 클라이언트가 진입점입니다.
+     * 내부적으로 token endpoint 호출 후 access token 흐름과 동일한 공통 로직을 재사용합니다.
+     */
+    OAuthTokenLoginResult authorizationCodeLogin(AuthorizationCodeLoginCommand command);
 
     /**
      * member에 새로운 OAuth 계정을 연동합니다.

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/AuthorizationCodeLoginCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/AuthorizationCodeLoginCommand.java
@@ -1,0 +1,29 @@
+package com.umc.product.authentication.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.OAuthProvider;
+import java.util.Objects;
+
+/**
+ * Authorization Code 기반 OAuth 로그인 Command.
+ * <p>
+ * 표준 OAuth2 authorization code grant 흐름에서 클라이언트가 받은 code와
+ * 인가 요청에 사용한 redirect URI를 함께 전달받습니다.
+ * <p>
+ * Apple은 클라이언트 플랫폼별 client_id 분기와 refresh token 영속화가 필요하므로
+ * 별도의 {@link com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult} 경로를 사용합니다.
+ *
+ * @param provider          OAuth Provider (현재는 KAKAO만 지원)
+ * @param authorizationCode 발급받은 authorization code
+ * @param redirectUri       인가 요청에 사용한 redirect URI (token 교환 시 동일 값이어야 함)
+ */
+public record AuthorizationCodeLoginCommand(
+    OAuthProvider provider,
+    String authorizationCode,
+    String redirectUri
+) {
+    public AuthorizationCodeLoginCommand {
+        Objects.requireNonNull(provider, "provider must not be null");
+        Objects.requireNonNull(authorizationCode, "authorizationCode must not be null");
+        Objects.requireNonNull(redirectUri, "redirectUri must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/VerifyOAuthTokenPort.java
@@ -21,6 +21,21 @@ public interface VerifyOAuthTokenPort {
     OAuth2Attributes verify(OAuthProvider provider, String token);
 
     /**
+     * Authorization Code를 교환하여 사용자 정보를 추출합니다.
+     * <p>
+     * Apple은 별도 {@link #verifyAppleAuthorizationCode}를 사용하므로 이 메서드는 호출하지 않습니다.
+     * Apple은 클라이언트 플랫폼별 client_id 분기와 refresh token 반환이 필요하기 때문입니다.
+     *
+     * @param provider          OAuth Provider (현재는 KAKAO만 지원)
+     * @param authorizationCode 발급받은 authorization code
+     * @param redirectUri       인가 요청에 사용한 redirect URI (token 교환 시 동일 값이어야 함)
+     * @return OAuth2Attributes
+     * @throws com.umc.product.authentication.domain.exception.AuthenticationDomainException
+     *     지원하지 않는 provider이거나 코드 교환 실패 시
+     */
+    OAuth2Attributes verifyAuthorizationCode(OAuthProvider provider, String authorizationCode, String redirectUri);
+
+    /**
      * Apple Authorization Code를 교환하여 사용자 정보를 추출합니다.
      * <p>
      * Apple은 플랫폼별로 다른 client_id(Bundle ID vs Services ID)를 사용하므로

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -3,6 +3,7 @@ package com.umc.product.authentication.application.service;
 import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.in.command.OAuthAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.AccessTokenLoginCommand;
+import com.umc.product.authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand;
 import com.umc.product.authentication.application.port.in.command.dto.LinkOAuthCommand;
 import com.umc.product.authentication.application.port.in.command.dto.OAuthTokenLoginResult;
 import com.umc.product.authentication.application.port.in.command.dto.UnlinkOAuthCommand;
@@ -81,6 +82,27 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         );
 
         log.info("OAuth 토큰 검증 성공: provider={}, providerId={}, email={}",
+            oauthAttrs.getProvider(),
+            oauthAttrs.getProviderId(),
+            oauthAttrs.getEmail()
+        );
+
+        // 2. 공통 비즈니스 로직 재사용
+        return loginWithOAuth2Attributes(oauthAttrs);
+    }
+
+    @Override
+    public OAuthTokenLoginResult authorizationCodeLogin(AuthorizationCodeLoginCommand command) {
+        log.info("Authorization Code 기반 OAuth 로그인 시도: provider={}", command.provider());
+
+        // 1. Authorization Code 교환 및 사용자 정보 추출 (Port Out 호출)
+        OAuth2Attributes oauthAttrs = verifyIdTokenPort.verifyAuthorizationCode(
+            command.provider(),
+            command.authorizationCode(),
+            command.redirectUri()
+        );
+
+        log.info("OAuth Authorization Code 교환 성공: provider={}, providerId={}, email={}",
             oauthAttrs.getProvider(),
             oauthAttrs.getProviderId(),
             oauthAttrs.getEmail()

--- a/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
@@ -60,6 +60,12 @@ public enum AuthenticationErrorCode implements BaseCode {
     // ID 존재 여부 / 비밀번호 오류 / 자격증명 미등록 등을 외부에 구분 노출하지 않기 위한 단일 에러
     INVALID_LOGIN_CREDENTIAL(HttpStatus.UNAUTHORIZED, "AUTHENTICATION-0022",
         "로그인 ID 또는 비밀번호가 올바르지 않습니다."),
+
+    // OAuth Authorization Code Flow 관련 에러
+    UNSUPPORTED_OAUTH_FLOW(HttpStatus.BAD_REQUEST, "AUTHENTICATION-0023",
+        "해당 OAuth Provider는 요청한 인증 흐름을 지원하지 않습니다."),
+    INVALID_OAUTH_REDIRECT_URI(HttpStatus.BAD_REQUEST, "AUTHENTICATION-0024",
+        "허용되지 않은 OAuth redirect URI입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -279,7 +279,10 @@ app:
       key-id: ${APPLE_KEY_ID}
       private-key: ${APPLE_PRIVATE_KEY}
     kakao:
+      client-id: ${KAKAO_CLIENT_ID:}
+      client-secret: ${KAKAO_CLIENT_SECRET:}
       admin-key: ${KAKAO_ADMIN_KEY:}
+      allowed-redirect-uris: ${KAKAO_ALLOWED_REDIRECT_URIS:}
     frontend-redirect-url: ${OAUTH2_FRONTEND_REDIRECT_URL}
 
 storage:


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- related to #827

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

`login/kakao/code` 엔드포인트를 사용하는 API를 추가하였습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

ADR-007 단계 1: 향후 추가될 Kakao authorization code 로그인 흐름에서 사용할
UNSUPPORTED_OAUTH_FLOW(AUTHENTICATION-0023), INVALID_OAUTH_REDIRECT_URI(AUTHENTICATION-0024)
에러 코드를 미리 정의한다.