### PR TITLE
[Feat] 로그 JSON 구조화 도입 및 Self-Hosted 모니터링 환경 대비

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ repositories {
 }
 
 // 의존성 버전
-val springDocVersion = "2.8.14"
-val queryDslVersion = "5.0.0"
+val springDocVersion = "2.8.17"
+val queryDslVersion = "5.1.0"
 val jwtVersion = "0.12.5"
 val awsVersion = "2.40.12"
 val springAiVersion = "1.1.5"
@@ -128,6 +128,10 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("com.github.loki4j:loki-logback-appender:1.5.2")
     implementation("io.micrometer:micrometer-registry-otlp")
+
+    // --- Structured Logging (ADR-016) ---
+    // dev/staging/prod 환경의 JSON 단일 라인 로그 encoder. local 은 텍스트 유지.
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
     // --- Sentry ---
     implementation(platform("io.sentry:sentry-bom:8.31.0"))

--- a/docker/monitoring/README.md
+++ b/docker/monitoring/README.md
@@ -1,0 +1,88 @@
+# 자체 호스팅 모니터링 스택 (ADR-014 Phase 1)
+
+[ADR-014](../../docs/adr/014-self-hosted-monitoring-stack-migration.md) 의 Phase 1 docker-compose 스택. 앱이 이미 사용 중인 **OTLP push 송신을 그대로 두고 URL 만 본 스택의 endpoint 로 바꾸면** metrics / traces / logs 가 자체 호스팅 백엔드로 흘러 들어간다.
+
+```
+앱 ──OTLP──▶ otel-collector ─┬─▶ prometheus  (metrics)
+                              ├─▶ tempo       (traces)
+                              └─▶ loki        (logs, OTLP receiver)
+
+앱 ──Loki push API──▶ loki    (기존 loki4j 어펜더, URL 만 바꿔 사용 가능)
+```
+
+## 빠른 시작
+
+```bash
+cd docker/monitoring
+cp env.example .env
+docker compose up -d
+```
+
+기본 접속:
+
+- Grafana: <http://localhost:3000> (`.env` 의 `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`)
+- Prometheus: <http://localhost:9090>
+- Loki: <http://localhost:3100>
+- Tempo: <http://localhost:3200>
+- OTel Collector OTLP: gRPC `:4317`, HTTP `:4318`
+
+## 앱 환경변수 매핑
+
+운영 / 로컬 앱의 환경변수만 본 스택의 endpoint 로 바꾸면 OTLP 송신이 그대로 자체 호스팅 백엔드로 전달된다.
+
+| 앱 환경변수 | Grafana Cloud (기존) | Self-hosted (본 스택) |
+|---|---|---|
+| `PROM_URL` | `https://otlp-gateway-*.grafana.net/.../v1/metrics` | `http://<host>:4318/v1/metrics` |
+| `TEMPO_URL` | `https://otlp-gateway-*.grafana.net/...` | `http://<host>:4318` |
+| `LOKI_URL` | `https://logs-*.grafana.net/loki/api/v1/push` | `http://<host>:3100/loki/api/v1/push` |
+| `PROM_AUTH` / `TEMPO_AUTH` | `Basic ...` | Phase 1 미사용 (Phase 2 에서 Basic Auth + TLS 추가) |
+| `LOKI_USERNAME` / `GRAFANA_API_KEY` | Cloud credential | Phase 1 미사용 |
+
+- `<host>` 는 운영 서버에서 본 스택에 도달 가능한 hostname. Phase 1 로컬 검증 단계에서는 `localhost`, 운영 이관 단계에서는 Cloudflare Tunnel 의 public hostname (예: `otel.umc.it.kr`) 으로 교체.
+- **Metrics / Traces** 는 OTel Collector (`4318/v1/metrics` / `4318` ) 로 직접 송신. Collector 가 내부에서 prometheus / tempo 로 분배한다.
+- **Logs** 는 두 가지 경로:
+    1. 기존 `loki4j` 어펜더 그대로 — `LOKI_URL` 만 `http://<host>:3100/loki/api/v1/push` 로 변경.
+    2. OTLP 로 보내려면 OTel Collector 의 `4318/v1/logs` 로 보내면 Loki 의 OTLP receiver (`/otlp/v1/logs`) 가 받는다.
+
+## 디렉터리 구조
+
+```
+docker/monitoring/
+├── env.example               # 호스트 포트 / Grafana admin / Discord webhook (`.env.*` 가 gitignore 에 걸려 점 없는 이름 사용)
+├── README.md                 # 본 파일
+├── docker-compose.yml        # 스택 정의 (Commit 2 이후)
+└── config/
+    ├── prometheus/           # metric backend config
+    ├── tempo/                # trace backend config
+    ├── loki/                 # log backend config
+    ├── otel-collector/       # OTLP 게이트웨이 config
+    ├── alertmanager/         # 알람 라우팅 / Discord webhook
+    └── grafana/
+        ├── dashboards/       # provisioned dashboards (JSON)
+        └── provisioning/
+            ├── datasources/  # prometheus / tempo / loki datasource
+            └── dashboards/   # dashboard provider 정의
+```
+
+## 컴포넌트 책임
+
+| 컴포넌트 | 역할 |
+|---|---|
+| `otel-collector` | 앱의 OTLP 송신을 받아 prometheus / tempo / loki 로 분배. 향후 Cloud + Self dual-write 가 필요해지면 exporter 추가만 하면 된다. |
+| `prometheus` | OTLP write receiver (`/api/v1/otlp/v1/metrics`) 활성. 자체 scrape 는 prometheus / node-exporter 만. |
+| `tempo` | OTLP 4317/4318 native 수신. 로컬 디스크 backend, 기본 7일 보존. |
+| `loki` | Loki push API + OTLP logs receiver 양쪽 지원. 기본 30일 보존. |
+| `grafana` | 3종 datasource 와 ADR-016 의 api-performance dashboard 자동 provisioning. |
+| `alertmanager` | Prometheus alerting rule 의 라우팅. Discord webhook 으로 송신. |
+| `node-exporter` | 호스트 메트릭 (CPU / disk / network) 노출, prometheus 가 scrape. |
+
+## 운영 주의사항
+
+- 본 스택은 **Phase 1 로컬 검증용** 이다. Phase 2 에서는 Basic Auth / TLS / Cloudflare Tunnel / object storage backend 등이 추가된다 (ADR-014 §Phase 2~3).
+- Grafana 의 `GRAFANA_ADMIN_PASSWORD` 는 운영 전 반드시 강한 값으로 교체.
+- Loki / Tempo / Prometheus 의 retention 은 docker volume 디스크 크기에 직결된다. 운영 노드의 디스크 모니터링 (`node-exporter` 의 `node_filesystem_avail_bytes`) 필수.
+
+## 참고
+
+- [ADR-014: 모니터링 스택을 Grafana Cloud 에서 자체 홈서버로 이관한다](../../docs/adr/014-self-hosted-monitoring-stack-migration.md)
+- [ADR-016: API 로그를 MDC 기반 JSON 구조화 로그로 전환한다](../../docs/adr/016-structured-json-logging-with-mdc.md) — Loki 의 `| json` 쿼리 / dashboard 의 LogQL 룰

--- a/docker/monitoring/config/alertmanager/config.yml
+++ b/docker/monitoring/config/alertmanager/config.yml
@@ -1,0 +1,38 @@
+# Alertmanager — 자체 호스팅 알람 라우팅 (ADR-014 Phase 1)
+#
+# Prometheus / Loki 의 alerting rule 이 발화하면 본 alertmanager 가 라우팅을 담당한다.
+# 디폴트 라우트는 Discord webhook 으로 전송 — application 코드의 webhook URL
+# (app.webhook.discord) 과 분리되어 인프라 알람 전용으로 사용한다.
+#
+# 운영 주의:
+# - DISCORD_ALERT_WEBHOOK 가 비어 있으면 알람은 발화하되 채널 송신은 skip (alertmanager
+#   가 빈 URL 에 POST 시도하여 실패 로그를 남기므로, 운영 배포 전 반드시 채울 것).
+# - Phase 2 에서 PagerDuty / 별도 채널 라우팅이 필요해지면 routes 트리 확장.
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: discord
+  group_by: [ alertname, severity ]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: discord
+    discord_configs:
+      - send_resolved: true
+        webhook_url: ${DISCORD_ALERT_WEBHOOK}
+        title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}'
+        message: |
+          {{ range .Alerts }}
+          • {{ .Annotations.summary }}{{ if .Annotations.description }}
+            {{ .Annotations.description }}{{ end }}
+          {{ end }}
+
+inhibit_rules:
+  # 동일 alertname 의 critical 발화 중에는 warning 알람을 중복 전송하지 않는다.
+  - source_matchers: [ 'severity="critical"' ]
+    target_matchers: [ 'severity="warning"' ]
+    equal: [ 'alertname' ]

--- a/docker/monitoring/config/grafana/dashboards/api-performance.json
+++ b/docker/monitoring/config/grafana/dashboards/api-performance.json
@@ -1,0 +1,138 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "ADR-016 의 api_request_completed JSON 라인을 uriTemplate / statusCode / durationMs 기준으로 집계하는 성능 개선용 대시보드. LogQL `| json` 파서를 사용한다.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "uriTemplate 별 요청 처리 시간 P95 (5분 윈도우). ADR-016 §Commit #9.",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "quantile_over_time(0.95, {application=~\".*umc-product-api\"} | json | event=\"api_request_completed\" | unwrap durationMs [5m]) by (uriTemplate)",
+          "legendFormat": "{{uriTemplate}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "API P95 latency by uriTemplate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "description": "uriTemplate 별 요청 처리 시간 P99 (5분 윈도우). ADR-016 §Commit #9.",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "quantile_over_time(0.99, {application=~\".*umc-product-api\"} | json | event=\"api_request_completed\" | unwrap durationMs [5m]) by (uriTemplate)",
+          "legendFormat": "{{uriTemplate}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "API P99 latency by uriTemplate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "description": "5xx 상태 코드의 시계열 카운트 (uriTemplate 별). 알람 룰의 기반.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "sum by (uriTemplate) (count_over_time({application=~\".*umc-product-api\"} | json | event=\"api_request_completed\" | statusCode >= 500 [5m]))",
+          "legendFormat": "{{uriTemplate}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx count by uriTemplate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "description": "1초 이상 소요된 느린 요청 카운트. durationMs > 1000 기준.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "sum by (uriTemplate) (count_over_time({application=~\".*umc-product-api\"} | json | event=\"api_request_completed\" | durationMs > 1000 [5m]))",
+          "legendFormat": "{{uriTemplate}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Slow requests (>1s) by uriTemplate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "description": "외부 API 호출 (external_api_called) 의 실패율. provider 별 / operation 별. ADR-016 §Commit #7 의 ExternalApiCallLogger hook 을 사용하는 도메인이 적용된 뒤에 동작한다.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "sum by (provider, operation) (count_over_time({application=~\".*umc-product-api\"} | json | logger=\"external_api\" | result=\"FAILURE\" [5m])) / sum by (provider, operation) (count_over_time({application=~\".*umc-product-api\"} | json | logger=\"external_api\" [5m]))",
+          "legendFormat": "{{provider}}/{{operation}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "External API failure rate by provider/operation (5m)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["umc-product", "api", "performance", "adr-016"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "UMC PRODUCT — API performance (ADR-016)",
+  "uid": "umc-product-api-performance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/monitoring/config/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker/monitoring/config/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,18 @@
+# Grafana dashboard provisioning (ADR-016 Commit #9)
+#
+# /etc/grafana/provisioning/dashboards/ 로 마운트되며, providers.folder 의 path
+# 가 컨테이너 내부 경로다. 본 저장소에서는 docker/monitoring/config/grafana/dashboards/
+# 가 /var/lib/grafana/dashboards/ 로 마운트되는 것을 가정한다.
+apiVersion: 1
+
+providers:
+  - name: "UMC PRODUCT — file"
+    orgId: 1
+    folder: "UMC PRODUCT"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/monitoring/config/grafana/provisioning/datasources/datasources.yaml
+++ b/docker/monitoring/config/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,45 @@
+# Grafana datasource provisioning (ADR-014 Phase 1)
+#
+# 3종 datasource 의 UID 는 ADR-016 의 dashboard JSON (api-performance.json) 이
+# 참조하는 값과 동일하게 유지한다 ("loki", "prometheus", "tempo").
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 30s
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      # 로그 한 줄의 traceId 필드를 자동으로 Tempo 링크로 변환.
+      # ADR-016 의 JSON 로그가 \"traceId\":\"...\" 형식으로 들어온다는 가정.
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: '"traceId":"(\w+)"'
+          name: traceId
+          url: '$${__value.raw}'
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true

--- a/docker/monitoring/config/loki/loki.yml
+++ b/docker/monitoring/config/loki/loki.yml
@@ -1,0 +1,48 @@
+# Loki config — 자체 호스팅 로그 백엔드 (ADR-014 Phase 1, ADR-016)
+#
+# 두 수신 경로를 모두 지원한다.
+#   1) Loki push API: /loki/api/v1/push    ← 기존 loki4j 어펜더
+#   2) OTLP logs:     /otlp/v1/logs         ← otel-collector 경유
+#
+# 앱이 ADR-016 의 JSON 한 줄 로그를 송신하면, `| json` 파서로 traceId / uriTemplate /
+# durationMs 등을 필드 기반으로 검색할 수 있다.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  # 30d 보존. 디스크 사용량을 보고 Phase 2 운영 데이터로 결정 (ADR-014 §Phase 2).
+  retention_period: 720h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  # OTLP logs 가 들고 들어오는 resource attribute 를 structured metadata 로 받기 위해 필수.
+  allow_structured_metadata: true
+
+# alertmanager 는 Commit 5 에서 추가된다. 그 전까지는 ruler 가 비활성 상태로 동작.
+# ruler:
+#   alertmanager_url: http://alertmanager:9093

--- a/docker/monitoring/config/loki/loki.yml
+++ b/docker/monitoring/config/loki/loki.yml
@@ -43,6 +43,5 @@ limits_config:
   # OTLP logs 가 들고 들어오는 resource attribute 를 structured metadata 로 받기 위해 필수.
   allow_structured_metadata: true
 
-# alertmanager 는 Commit 5 에서 추가된다. 그 전까지는 ruler 가 비활성 상태로 동작.
-# ruler:
-#   alertmanager_url: http://alertmanager:9093
+ruler:
+  alertmanager_url: http://alertmanager:9093

--- a/docker/monitoring/config/otel-collector/config.yaml
+++ b/docker/monitoring/config/otel-collector/config.yaml
@@ -1,0 +1,70 @@
+# OTel Collector — 자체 호스팅 OTLP 게이트웨이 (ADR-014 Phase 0~1)
+#
+# 앱은 OTLP 송신 URL (PROM_URL / TEMPO_URL) 만 본 Collector 의 endpoint 로 바꾸면
+# metrics / traces 가 자동으로 prometheus / tempo 로 분배된다. 로그도 OTLP 로 보내면
+# Loki 의 OTLP receiver 로 전달된다.
+#
+#   앱 ──OTLP──▶ otel-collector ─┬─▶ prometheus  (metrics, /api/v1/otlp)
+#                                  ├─▶ tempo       (traces,  4318)
+#                                  └─▶ loki        (logs,    /otlp)
+#
+# 향후 Cloud + Self dual-write (ADR-014 Phase 2) 가 필요해지면 본 파일의 exporters
+# 섹션에 otlphttp/cloud 를 추가하고, service.pipelines 의 exporters 리스트에 끼워
+# 넣으면 된다.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+  resource:
+    # 본 스택을 통과한 모든 신호에 cluster 라벨을 붙여, Phase 2 의 dual-write 비교
+    # 시점에 Cloud / Self 데이터를 구분 가능하게 한다.
+    attributes:
+      - key: cluster
+        value: umc-product-self-hosted
+        action: upsert
+
+exporters:
+  # Metrics → Prometheus 의 OTLP write receiver
+  otlphttp/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp
+    tls:
+      insecure: true
+
+  # Traces → Tempo 의 OTLP HTTP (4318)
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+    tls:
+      insecure: true
+
+  # Logs → Loki 의 OTLP logs receiver
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ otlp ]
+      processors: [ resource, batch ]
+      exporters: [ otlphttp/prometheus ]
+    traces:
+      receivers: [ otlp ]
+      processors: [ resource, batch ]
+      exporters: [ otlphttp/tempo ]
+    logs:
+      receivers: [ otlp ]
+      processors: [ resource, batch ]
+      exporters: [ otlphttp/loki ]
+  telemetry:
+    logs:
+      level: info

--- a/docker/monitoring/config/prometheus/prometheus.yml
+++ b/docker/monitoring/config/prometheus/prometheus.yml
@@ -1,0 +1,27 @@
+# Prometheus config — 자체 호스팅 메트릭 백엔드 (ADR-014 Phase 1)
+#
+# 본 스택에서 prometheus 는 두 가지 수신 경로를 가진다.
+#   1) OTLP write receiver: /api/v1/otlp/v1/metrics
+#      앱 / otel-collector 가 OTLP push 로 메트릭을 보낼 수 있다.
+#      활성화는 docker-compose 의 --enable-feature=otlp-write-receiver 가 담당.
+#   2) Scrape (pull): 본 파일의 scrape_configs.
+#      prometheus 자신과 node-exporter 만 scrape 한다. 앱 메트릭은 OTLP push 로 받는다.
+
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    cluster: umc-product-self-hosted
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+
+  # node-exporter 는 후속 커밋에서 추가된다 (Commit 5). 그 전까지는 endpoint 가 없어
+  # "context deadline exceeded" 류 오류가 발생할 수 있지만 prometheus 자체 동작에는 영향 없다.
+  - job_name: node-exporter
+    static_configs:
+      - targets: [ 'node-exporter:9100' ]
+
+# alerting / rule_files 는 alertmanager 도입 (Commit 5) 시점에 함께 채운다.

--- a/docker/monitoring/config/prometheus/prometheus.yml
+++ b/docker/monitoring/config/prometheus/prometheus.yml
@@ -24,4 +24,11 @@ scrape_configs:
     static_configs:
       - targets: [ 'node-exporter:9100' ]
 
-# alerting / rule_files 는 alertmanager 도입 (Commit 5) 시점에 함께 채운다.
+# alerting / rule_files (Commit 5).
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: [ 'alertmanager:9093' ]
+
+# 실제 alerting rule 파일은 운영 정책이 정해지면 ./config/prometheus/rules/ 하위에 두고
+# 본 파일에서 reference 한다 (예: rule_files: [ rules/*.yml ]). Phase 1 범위 밖.

--- a/docker/monitoring/config/tempo/tempo.yml
+++ b/docker/monitoring/config/tempo/tempo.yml
@@ -1,0 +1,40 @@
+# Tempo config — 자체 호스팅 trace 백엔드 (ADR-014 Phase 1)
+#
+# OTLP 4317 (gRPC) / 4318 (HTTP) 으로 trace 를 native 수신한다. 앱은 본 ADR 의 권장대로
+# otel-collector 를 경유하지만, tempo 가 직접 OTLP 도 받을 수 있게 두어 디버깅 / fallback
+# 경로를 남긴다.
+#
+# 스토리지는 local backend. Phase 3 에서 S3 / R2 로 전환할 때는 storage.trace.backend 만 교체.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  # 짧은 max_block_duration 은 디버깅 시 trace 를 빨리 검색 가능하게 한다.
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    # 7d 보존. 디스크 사용량을 보고 Phase 2 운영 데이터로 결정한다 (ADR-014 §Phase 2 체크리스트).
+    block_retention: 168h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+# metrics_generator 는 service map / span metrics 같은 부가 기능을 켜는 영역이다.
+# Phase 2 에서 datasource 의 serviceMap 을 활성화할 때 함께 켠다.

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -1,0 +1,74 @@
+# 자체 호스팅 모니터링 스택 (ADR-014 Phase 1)
+#
+# 본 compose 파일은 자체 호스팅 백엔드 (prometheus / tempo / loki) 만 정의한다.
+# OTLP 게이트웨이 (otel-collector), Grafana, alertmanager, node-exporter 는
+# 후속 커밋에서 추가된다.
+#
+# 동작 검증:
+#   cp env.example .env && docker compose up -d prometheus tempo loki
+name: umc-product-monitoring
+
+services:
+
+  # --- Metric backend ---
+  # OTLP write receiver 가 활성화되어 있어, 앱 / otel-collector 가
+  # http://prometheus:9090/api/v1/otlp/v1/metrics 로 OTLP push 를 보낼 수 있다.
+  prometheus:
+    image: prom/prometheus:v2.55.0
+    container_name: umc-product-prometheus
+    volumes:
+      - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=14d
+      - --enable-feature=otlp-write-receiver
+      - --web.enable-lifecycle
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks: [monitoring]
+    restart: unless-stopped
+
+  # --- Trace backend ---
+  # 4317 (gRPC) / 4318 (HTTP) 로 OTLP 직접 수신 가능. 단, 운영 앱은 본 ADR-014 의
+  # 권장대로 otel-collector 를 거치게 하고, tempo 의 OTLP 포트는 호스트로 노출만 해둔다.
+  tempo:
+    image: grafana/tempo:2.6.0
+    container_name: umc-product-tempo
+    command: [ "-config.file=/etc/tempo.yml" ]
+    volumes:
+      - ./config/tempo/tempo.yml:/etc/tempo.yml:ro
+      - tempo-data:/var/tempo
+    ports:
+      - "${TEMPO_HTTP_PORT:-3200}:3200"
+      - "${TEMPO_OTLP_GRPC_PORT:-14317}:4317"
+      - "${TEMPO_OTLP_HTTP_PORT:-14318}:4318"
+    networks: [monitoring]
+    restart: unless-stopped
+
+  # --- Log backend ---
+  # 두 수신 경로를 모두 지원한다.
+  #   1) Loki push API: http://loki:3100/loki/api/v1/push   ← 기존 loki4j 어펜더
+  #   2) OTLP logs:     http://loki:3100/otlp/v1/logs        ← otel-collector 경유
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: umc-product-loki
+    command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    volumes:
+      - ./config/loki/loki.yml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    ports:
+      - "${LOKI_PORT:-3100}:3100"
+    networks: [monitoring]
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  tempo-data:
+  loki-data:
+
+networks:
+  monitoring:
+    name: umc-product-monitoring
+    driver: bridge

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -106,11 +106,47 @@ services:
     networks: [monitoring]
     restart: unless-stopped
 
+  # --- Alerting ---
+  # prometheus / loki 의 alerting rule 발화를 Discord webhook 으로 전송.
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: umc-product-alertmanager
+    command:
+      - --config.file=/etc/alertmanager/config.yml
+      - --storage.path=/alertmanager
+    environment:
+      - DISCORD_ALERT_WEBHOOK=${DISCORD_ALERT_WEBHOOK:-}
+    volumes:
+      - ./config/alertmanager/config.yml:/etc/alertmanager/config.yml:ro
+      - alertmanager-data:/alertmanager
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    networks: [monitoring]
+    restart: unless-stopped
+
+  # --- Host metrics ---
+  # 호스트 (홈서버) 자체의 CPU / disk / network / filesystem 메트릭을 prometheus 가 scrape.
+  # 디스크 임계 알람 (Loki / Tempo chunk 누적) 의 데이터 소스.
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: umc-product-node-exporter
+    command:
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    ports:
+      - "${NODE_EXPORTER_PORT:-9100}:9100"
+    networks: [monitoring]
+    restart: unless-stopped
+
 volumes:
   prometheus-data:
   tempo-data:
   loki-data:
   grafana-data:
+  alertmanager-data:
 
 networks:
   monitoring:

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -47,6 +47,25 @@ services:
     networks: [monitoring]
     restart: unless-stopped
 
+  # --- OTLP 게이트웨이 ---
+  # 앱은 PROM_URL / TEMPO_URL 등 환경변수만 본 collector 의 endpoint 로 바꾸면 된다.
+  # collector 가 prometheus / tempo / loki 로 신호를 분배한다.
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.114.0
+    container_name: umc-product-otel-collector
+    command: [ "--config=/etc/otel-collector/config.yaml" ]
+    volumes:
+      - ./config/otel-collector/config.yaml:/etc/otel-collector/config.yaml:ro
+    ports:
+      - "${OTEL_OTLP_GRPC_PORT:-4317}:4317"
+      - "${OTEL_OTLP_HTTP_PORT:-4318}:4318"
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+    networks: [monitoring]
+    restart: unless-stopped
+
   # --- Log backend ---
   # 두 수신 경로를 모두 지원한다.
   #   1) Loki push API: http://loki:3100/loki/api/v1/push   ← 기존 loki4j 어펜더

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -82,10 +82,35 @@ services:
     networks: [monitoring]
     restart: unless-stopped
 
+  # --- Visualization ---
+  # provisioning/ 디렉터리가 컨테이너 안의 /etc/grafana/provisioning 으로 마운트되어
+  # datasource (datasources.yaml) 와 dashboard provider (dashboards/dashboards.yaml) 가
+  # 컨테이너 부팅 시 자동 등록된다. 실제 dashboard JSON 들은 dashboards/ 로 마운트.
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: umc-product-grafana
+    volumes:
+      - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./config/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    environment:
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:3000}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+    networks: [monitoring]
+    restart: unless-stopped
+
 volumes:
   prometheus-data:
   tempo-data:
   loki-data:
+  grafana-data:
 
 networks:
   monitoring:

--- a/docker/monitoring/env.example
+++ b/docker/monitoring/env.example
@@ -1,0 +1,38 @@
+# 자체 호스팅 모니터링 스택 환경변수 (ADR-014 Phase 1)
+#
+# 사용:
+#   cd docker/monitoring
+#   cp env.example .env
+#   docker compose up -d
+#
+# (`.env.*` 가 .gitignore 에 걸려 있어 본 템플릿은 점 없는 env.example 로 둔다.)
+#
+# 본 파일은 컨테이너가 호스트에 노출할 포트와 Grafana 관리자 계정만 정의한다.
+# 앱 (운영 서버) 측의 PROM_URL / TEMPO_URL / LOKI_URL 등은 본 .env 가 아니라
+# 운영 환경의 환경변수에서 본 스택의 endpoint 로 지정한다. 매핑은 README.md 참고.
+
+# ===== Grafana =====
+GRAFANA_PORT=3000
+GRAFANA_ROOT_URL=http://localhost:3000
+GRAFANA_ADMIN_USER=admin
+# 운영 배포 전에 반드시 강한 패스워드로 교체.
+GRAFANA_ADMIN_PASSWORD=change-me
+
+# ===== Backends (호스트 측 디버그용 포트. 운영 시에는 외부 노출 불필요) =====
+PROMETHEUS_PORT=9090
+LOKI_PORT=3100
+TEMPO_HTTP_PORT=3200
+TEMPO_OTLP_GRPC_PORT=14317
+TEMPO_OTLP_HTTP_PORT=14318
+
+# ===== OTel Collector — 앱이 OTLP 로 송신하는 게이트웨이 =====
+OTEL_OTLP_GRPC_PORT=4317
+OTEL_OTLP_HTTP_PORT=4318
+
+# ===== Alertmanager / Node Exporter =====
+ALERTMANAGER_PORT=9093
+NODE_EXPORTER_PORT=9100
+
+# ===== Alertmanager — Discord webhook (옵션) =====
+# 채워두면 모든 알람이 본 채널로 전송된다. 비워두면 알람은 발화하되 채널 송신은 skip.
+DISCORD_ALERT_WEBHOOK=

--- a/docs/adr/016-structured-json-logging-with-mdc.md
+++ b/docs/adr/016-structured-json-logging-with-mdc.md
@@ -85,11 +85,13 @@ Accepted (2026-05-12)
 
 > **보강 (2026-05-12, Accepted 승격 시):** 본 ADR 의 최초 작성 시점에는 `staging` 프로필 분기가 누락되어 있었다. 현재 [logback-spring.xml](../../src/main/resources/logback-spring.xml) 은 `local` / `dev` / `prod` 만 분기하므로, 본 ADR 의 Commit #3 에서 `staging` 프로필 분기를 **함께 신규 추가** 한다. `staging` 의 어펜더 구성은 `dev` 와 동일 (CONSOLE_JSON + LOKI, Sentry 없음) 로 한다.
 
-1. **요청 문맥 (`requestId`, `userId`, `method`, `path`, `uriTemplate`) 은 MDC 에 넣는다.** 모든 요청은 `LoggingInterceptor` 의 `preHandle` 에서 MDC 에 push, `afterCompletion` 의 finally 에서 `MDC.clear()` 로 비운다.
+1. **요청 문맥 (`memberId`, `method`, `path`, `uriTemplate`) 은 MDC 에 넣는다.** 모든 요청은 `LoggingInterceptor` 의 `preHandle` 에서 MDC 에 push, `afterCompletion` 의 finally 에서 `MDC.clear()` 로 비운다. 사용자 식별자는 일반 OAuth 컨벤션의 `userId` 가 아니라 우리 서비스 도메인 명명인 `memberId` 그대로 사용한다.
 2. **요청 완료 1줄 (`api_request_completed`) 의 event 키를 표준화**한다. 기존 `[REQ]` / `[RES]` 두 줄 로그는 `event=api_request_started` / `event=api_request_completed` 의 구조화된 이벤트로 대체한다.
 3. **민감 필드는 로그에 절대 남기지 않는다.** Authorization, accessToken, refreshToken, OAuth authorization code, identity token, 이메일 인증번호, request body 전문, response body 전문, 첨부파일 내용. 필요한 경우 길이 / 개수 같은 요약값만 남긴다.
 4. **Loki4j 의 운영을 ADR-014 의 결정에 위임한다.** 본 ADR 은 어펜더 자체의 송신 경로를 손대지 않는다. `loki-logback-appender` 의 `<format><message>` 패턴만 JSON encoder 의 출력 (한 줄 JSON) 으로 교체한다.
-5. **`requestId` 와 Micrometer `traceId` 는 공존시키되 역할을 분리한다.** `traceId` 는 분산 추적용 (Tempo), `requestId` 는 단일 서버 내부 추적용 (Loki 검색용 fallback). 두 값 모두 MDC 에 둔다.
+5. **단일 요청 식별자는 Micrometer Tracing 의 `traceId` 를 그대로 사용한다.** 별도의 UUID 기반 `requestId` 는 발급하지 않는다.
+
+> **보강 (2026-05-12, Accepted 승격 후 정정):** ADR 초안 시점에는 `traceId` (Tempo 분산 추적용) 와 `requestId` (Loki 검색용 fallback) 를 공존시킨다고 결정했으나, 이후 FE 가 이미 `X-Trace-Id` 응답 헤더와 `traceId` 키로 운영 중인 흐름을 깨지 않기 위해 단일 식별자 (`traceId`) 만 사용하기로 정정한다. Loki 의 단일 요청 검색은 `| json | traceId="..."` 한 줄로 동일한 효용을 얻는다. 응답 헤더는 기존대로 `X-Trace-Id` 만 노출하며, `X-Request-Id` 는 도입하지 않는다.
 
 ### 본 ADR 의 범위 밖
 
@@ -417,11 +419,11 @@ public void afterCompletion(HttpServletRequest request, HttpServletResponse resp
 검증:
 
 - 단위 테스트 추가: MDC 가 `preHandle` 에서 set, `afterCompletion` finally 에서 clear 되는지.
-- 실제 dev 환경 배포 후 stdout JSON 에 `requestId`, `method`, `path`, `uriTemplate`, `statusCode`, `durationMs` 가 들어가는지 grep.
+- 실제 dev 환경 배포 후 stdout JSON 에 `traceId`, `method`, `path`, `uriTemplate`, `statusCode`, `durationMs` 가 들어가는지 grep.
 
 #### Commit #5 — `feat: put memberId into MDC after JWT authentication`
 
-목적: 인증된 사용자의 `memberId` 를 MDC `userId` 로 등록한다. `JwtAuthenticationFilter` 가 인증을 끝낸 직후가 가장 빠른 시점이지만, Filter 는 Interceptor 보다 앞에서 동작하므로 두 가지 선택이 있다.
+목적: 인증된 사용자의 `memberId` 를 MDC `memberId` 키로 등록한다. 서비스 도메인 명명을 그대로 사용 (`userId` 아님). `JwtAuthenticationFilter` 가 인증을 끝낸 직후가 가장 빠른 시점이지만, Filter 는 Interceptor 보다 앞에서 동작하므로 두 가지 선택이 있다.
 
 선택 A — Filter 에서 등록 (권장):
 
@@ -456,11 +458,11 @@ private void putUserIdToMdcIfAuthenticated() {
 주의:
 
 - `MemberPrincipal.getMemberId()` 는 Long. MDC 값은 String 이므로 `String.valueOf(...)`.
-- 익명 사용자 (`principal == "anonymousUser"`) 의 경우 MDC `userId` 를 넣지 않는다 (검색 시 `userId is null` 로 익명 트래픽 식별).
+- 익명 사용자 (`principal == "anonymousUser"`) 의 경우 MDC `memberId` 를 넣지 않는다 (검색 시 `memberId is null` 로 익명 트래픽 식별).
 
 #### Commit #6 — `chore: drop access-log noise from JwtAuthenticationFilter`
 
-목적: JSON 로그가 들어왔으니, 기존 텍스트 시대의 진단용 한 줄 로그 (`log.info("JWT TOKEN Authenticated: memberId={}", memberId)`) 를 제거하거나 DEBUG 로 낮춘다. `api_request_completed` JSON 에 `userId` 가 자동으로 들어가므로 중복이다.
+목적: JSON 로그가 들어왔으니, 기존 텍스트 시대의 진단용 한 줄 로그 (`log.info("JWT TOKEN Authenticated: memberId={}", memberId)`) 를 제거하거나 DEBUG 로 낮춘다. `api_request_completed` JSON 에 `memberId` 가 자동으로 들어가므로 중복이다.
 
 변경 파일:
 
@@ -580,8 +582,8 @@ sum by (uriTemplate) (
   )
 )
 
-# 특정 requestId 의 모든 로그
-{application=~".*umc-product-api"} |= "9f1a2c7b"
+# 특정 traceId 의 모든 로그 (응답 헤더 X-Trace-Id 와 동일 값)
+{application=~".*umc-product-api"} | json | traceId="9f1a2c7b..."
 ```
 
 본 커밋은 ADR-014 의 자체 호스팅 이관과 시점이 겹친다. 현재 Grafana Cloud 에 직접 panel 을 만드는 작업 + ADR-014 의 self-hosted Grafana provisioning 디렉터리 모두 같은 LogQL 을 공유한다.
@@ -592,10 +594,9 @@ sum by (uriTemplate) (
 
 | 키 | 출처 | 수명 | 용도 |
 |---|---|---|---|
-| `traceId` | Micrometer Tracing | 요청 1개 | Tempo 분산 추적 |
+| `traceId` | Micrometer Tracing | 요청 1개 | Tempo 분산 추적 + Loki 단일 요청 식별 (응답 헤더 `X-Trace-Id` 로 노출) |
 | `spanId` | Micrometer Tracing | span 1개 | Tempo 내부 |
-| `requestId` | LoggingInterceptor | 요청 1개 | Loki 단일 요청 식별 |
-| `userId` | LoggingInterceptor | 요청 1개 | 인증된 `memberId` |
+| `memberId` | LoggingInterceptor | 요청 1개 | 인증된 사용자 식별자. 서비스 도메인 명명 (`memberId`) 그대로 사용. 익명 사용자는 비워둔다 |
 | `method` | LoggingInterceptor | 요청 1개 | HTTP 메서드 |
 | `path` | LoggingInterceptor | 요청 1개 | 실제 URI (예: `/forms/123`) |
 | `uriTemplate` | LoggingInterceptor | 응답 시점 | 매칭된 패턴 (예: `/forms/{formId}`) |
@@ -635,7 +636,7 @@ SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun | jq .
 
 - [ ] Loki 에서 `| json` 파싱이 100% 의 라인에 성공하는가? (`json_parse_error` 가 0 인지)
 - [ ] `api_request_completed` 의 `durationMs` 가 P50 / P95 / P99 dashboard 에 표시되는가?
-- [ ] MDC 누수 점검: 같은 스레드의 연속된 요청에서 `userId` 가 잘못 섞이는 사례가 없는가? (특정 사용자의 요청에서 다른 `userId` 가 1% 이상 검출되면 누수 의심)
+- [ ] MDC 누수 점검: 같은 스레드의 연속된 요청에서 `memberId` 가 잘못 섞이는 사례가 없는가? (특정 사용자의 요청에서 다른 `memberId` 가 1% 이상 검출되면 누수 의심)
 - [ ] Sentry 의 issue 그루핑이 깨지지 않았는가? (Sentry 는 logger message 를 사용하므로 `api_request_completed` 가 너무 잦으면 group 하나에 몰릴 수 있음 — minimum level 을 다시 조정)
 - [ ] 민감 필드 검색: `| json |~ "(?i)(bearer |access[_-]?token|authorization=)"` 가 0 line 인지 정기 점검.
 

--- a/docs/adr/016-structured-json-logging-with-mdc.md
+++ b/docs/adr/016-structured-json-logging-with-mdc.md
@@ -1,0 +1,664 @@
+# ADR-016: API 로그를 MDC 기반 JSON 구조화 로그로 전환한다
+
+## Status
+
+Accepted (2026-05-12)
+
+## Context
+
+본 ADR 작성 시점(2026-05-12) 기준 UMC PRODUCT 서버의 로그는 Logback의 텍스트 패턴 기반으로 출력되고, Loki4j 어펜더를 통해 Grafana Cloud Loki로 push 되고 있다.
+
+### 1. 현행 로깅 구조
+
+#### 1.1 출력 포맷 (logback-spring.xml)
+
+`src/main/resources/logback-spring.xml` 의 패턴은 다음과 같다.
+
+```text
+%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId}] [%thread] %logger{40} : %msg%n
+```
+
+즉 모든 프로필에서 사람이 읽기 쉬운 한 줄 문자열 로그를 출력한다. ([logback-spring.xml §15-16](../../src/main/resources/logback-spring.xml#L15-L16))
+
+- `local` 프로필은 `LOCAL_CONSOLE` (컬러 + 축약 traceId) + `LOKI` 두 어펜더.
+- `dev` 프로필은 `ECS_CONSOLE` + `LOKI`.
+- `prod` 프로필은 `ECS_CONSOLE` + `LOKI` + `SENTRY` (WARN 이상).
+
+#### 1.2 LoggingInterceptor 의 현행 로그 두 줄
+
+[LoggingInterceptor.java](../../src/main/java/com/umc/product/global/config/LoggingInterceptor.java) 는 요청·응답 시점에 다음과 같이 두 줄의 로그를 찍는다.
+
+```text
+[REQ] 💗 GET /forms/123/answers?cursor=10
+[RES] ✅ 200 /forms/123/answers 842ms | Query Count: 12, Time: 65ms | IP: 1.2.3.4
+```
+
+문자열 안에 메서드, URI, 상태, durationMs, Query Count, Time, IP 가 한 문자열로 합쳐져 있다. 따라서:
+
+- Loki/CloudWatch에서 `durationMs > 1000` 같은 **숫자 비교 쿼리가 불가능**하다 (regex 추출이 강제됨).
+- `uriTemplate` 이 아니라 `requestURI` 기준이라 `/forms/123/answers` 와 `/forms/124/answers` 가 다른 라인으로 집계되어 P95·P99 같은 **API 단위 통계가 불가능**하다.
+- 요청 ID는 Micrometer의 `traceId` 가 MDC 에 들어 있을 뿐, `requestId` / `userId` 가 MDC에 들어 있지 않다.
+- 인증된 사용자라도 `memberId` 가 로그에 남지 않아, 한 사용자의 요청 흐름을 추적하려면 controller 로그를 따로 봐야 한다.
+
+#### 1.3 인증 객체
+
+[MemberPrincipal.java](../../src/main/java/com/umc/product/global/security/MemberPrincipal.java) 는 `memberId : Long` 만 들고 있는 OAuth2User 구현체다. [JwtAuthenticationFilter.java](../../src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java) 에서 인증이 완료된 뒤 `SecurityContextHolder` 에 들어간다. 즉 Interceptor 가 동작하는 시점에는 이미 인증이 끝나 있어, `MemberPrincipal.getMemberId()` 로 `userId` 를 꺼낼 수 있다.
+
+#### 1.4 의존성
+
+[build.gradle.kts §128-141](../../build.gradle.kts#L127-L141) 의 관측 의존성은 다음과 같다.
+
+- `io.micrometer:micrometer-registry-prometheus`, `micrometer-registry-otlp`
+- `com.github.loki4j:loki-logback-appender:1.5.2`
+- `io.sentry:sentry-bom:8.31.0` + `sentry-spring-boot-starter-jakarta` + `sentry-logback`
+- `io.micrometer:micrometer-tracing-bridge-otel`, `opentelemetry-exporter-otlp`, `context-propagation`
+
+`net.logstash.logback:logstash-logback-encoder` 는 아직 추가되어 있지 않다.
+
+#### 1.5 운영 상의 한계
+
+- 특정 `traceId` 가 아니라 임의의 키워드 (`durationMs > 1000`, `statusCode >= 500`, 특정 `userId`) 로 필터링하려면 LogQL `| regexp` 가 필요하다. cardinality 가 큰 정규식 추출은 Loki 에서 query latency 가 크다.
+- ADR-014 에서 결정한 자체 호스팅 Grafana 스택으로 이관하면, Loki 의 chunk 가 자체 인프라에 누적된다. 텍스트 로그를 1년치 쌓으면 같은 정보를 JSON 으로 쌓는 것보다 검색 비용이 누적적으로 더 커진다.
+- Sentry / OpenTelemetry breadcrumb 에 들어가는 로그 message 도 텍스트 한 줄이라, Sentry 의 issue grouping 이나 attribute 기반 search 에서 효용이 떨어진다.
+
+### 2. 결정이 필요한 이유
+
+다음 요인이 누적되어 있다.
+
+1. **분산 추적 / 사용자 추적 / 성능 디버깅 요구사항이 커지고 있다.** LLM / GitHub / Apple / 카카오 / 이메일 등 외부 API 호출이 늘면서, 어느 외부 API 가 느린지, 어느 `uriTemplate` 이 느린지, 특정 `memberId` 가 실패하는 패턴이 있는지 데이터 기반으로 보고 싶다.
+2. **로그 시스템 (Loki) 의 활용 한계가 보인다.** 현재 패턴 로그는 Loki label (`application`, `level`) 외의 모든 필드를 정규식으로 추출해야 한다. JSON 로그로 바꾸면 `| json | durationMs > 1000` 한 줄이면 된다.
+3. **ADR-014 의 자체 호스팅 이관과 시점이 맞는다.** 어차피 collector / scrape 구조를 손대는 시점에 로그 포맷도 함께 정리하면 변경 비용이 한 번에 끝난다.
+4. **사용자 식별이 traceId 만으로는 부족하다.** Micrometer 의 `traceId` 는 요청 1개에 한정된다. 같은 사용자의 30분 동안의 모든 실패를 보고 싶을 때 `userId` 가 MDC 에 있어야 한다.
+
+다만 다음 비용을 함께 짊어진다.
+
+- **로컬 개발 UX 저하**: JSON 한 줄은 사람이 읽기 어렵다. 로컬에서 무지성으로 JSON 로 바꾸면 개발 생산성이 떨어진다.
+- **MDC 누수 위험**: ThreadLocal 기반 MDC는 finally 블록의 `MDC.clear()` 가 누락되면 스레드풀에서 이전 요청의 `userId` 가 다음 요청에 섞인다.
+- **민감정보 노출 위험**: JSON 으로 필드를 잘게 쪼개면, 무심코 `request.body` / `Authorization` 헤더 / 인증번호 등을 MDC 에 넣고 그대로 stdout 으로 흘려보낼 수 있다. 텍스트 로그는 사람이 한번 더 의심하는 단계가 있지만, JSON 은 "그냥 한 필드 추가" 로 보여 경계가 약해진다.
+- **logback-spring.xml 의 dual-config 부담**: 프로필별로 어펜더가 다르면 관리 대상이 늘어난다.
+
+본 ADR 은 이 trade-off 를 가시화하고, **JSON 구조화 로그를 단계적·커밋 단위로 도입** 하는 결정을 명시한다.
+
+## Decision
+
+우리는 **`local` 은 기존 텍스트 로그를 유지하고, `dev` / `staging` / `prod` 는 `logstash-logback-encoder` 기반 JSON 단일 라인 로그로 출력**하기로 결정한다. 그리고 다음 운영 규약을 함께 채택한다.
+
+> **보강 (2026-05-12, Accepted 승격 시):** 본 ADR 의 최초 작성 시점에는 `staging` 프로필 분기가 누락되어 있었다. 현재 [logback-spring.xml](../../src/main/resources/logback-spring.xml) 은 `local` / `dev` / `prod` 만 분기하므로, 본 ADR 의 Commit #3 에서 `staging` 프로필 분기를 **함께 신규 추가** 한다. `staging` 의 어펜더 구성은 `dev` 와 동일 (CONSOLE_JSON + LOKI, Sentry 없음) 로 한다.
+
+1. **요청 문맥 (`requestId`, `userId`, `method`, `path`, `uriTemplate`) 은 MDC 에 넣는다.** 모든 요청은 `LoggingInterceptor` 의 `preHandle` 에서 MDC 에 push, `afterCompletion` 의 finally 에서 `MDC.clear()` 로 비운다.
+2. **요청 완료 1줄 (`api_request_completed`) 의 event 키를 표준화**한다. 기존 `[REQ]` / `[RES]` 두 줄 로그는 `event=api_request_started` / `event=api_request_completed` 의 구조화된 이벤트로 대체한다.
+3. **민감 필드는 로그에 절대 남기지 않는다.** Authorization, accessToken, refreshToken, OAuth authorization code, identity token, 이메일 인증번호, request body 전문, response body 전문, 첨부파일 내용. 필요한 경우 길이 / 개수 같은 요약값만 남긴다.
+4. **Loki4j 의 운영을 ADR-014 의 결정에 위임한다.** 본 ADR 은 어펜더 자체의 송신 경로를 손대지 않는다. `loki-logback-appender` 의 `<format><message>` 패턴만 JSON encoder 의 출력 (한 줄 JSON) 으로 교체한다.
+5. **`requestId` 와 Micrometer `traceId` 는 공존시키되 역할을 분리한다.** `traceId` 는 분산 추적용 (Tempo), `requestId` 는 단일 서버 내부 추적용 (Loki 검색용 fallback). 두 값 모두 MDC 에 둔다.
+
+### 본 ADR 의 범위 밖
+
+- ADR-014 에서 다루는 Grafana Cloud → 자체 호스팅 이관 자체.
+- Sentry 의 error grouping 정책 변경.
+- OpenTelemetry log signal (OTLP logs) 도입. 본 ADR 은 logback → stdout JSON 만 다룬다. OTLP logs 는 Phase 2 ADR 후보로 분리.
+- 외부 API 호출 (`external_api_called`) 의 구조화 이벤트는 본 ADR 의 인프라 위에서 후속 작업으로 점진 추가한다 (커밋 #7 에서 hook 만 제공, 도메인별 적용은 별도 PR).
+
+## Alternatives Considered
+
+### 1. 현행 텍스트 패턴 + Loki regex 추출 유지
+
+장점:
+
+- 로컬 / 운영 양쪽에서 사람이 한 줄로 읽기 쉽다.
+- 이미 동작하고 있어 변경 비용이 0.
+
+단점:
+
+- LogQL 에서 `durationMs > 1000`, `statusCode >= 500` 같은 숫자 비교가 정규식 추출 후에야 가능. 대규모 시간 범위 쿼리에서 query latency 가 크다.
+- `path` 와 `uriTemplate` 의 구분이 없어 API 단위 P95 / P99 집계 자체가 어렵다.
+- 새로운 필드를 추가할 때마다 LogQL 의 regex 도 같이 수정해야 한다.
+
+선택하지 않은 이유:
+현재 도메인 (LLM / GitHub / 외부 API / 인증 / 댓글) 이 커지면서, 정규식이 아니라 필드 기반 검색이 디버깅의 1차 도구가 되어야 한다. 텍스트 유지의 단기 이득보다 1년치 누적 쿼리 비용이 크다.
+
+### 2. 모든 프로필을 JSON 로 통일
+
+장점:
+
+- 환경별 분기가 사라져 설정이 단순해진다.
+- 로컬과 운영의 로그 포맷이 동일해 "로컬에서는 보이지만 운영에서는 보이지 않는다" 식의 차이가 사라진다.
+
+단점:
+
+- 로컬 개발자 콘솔에서 한 줄 JSON 은 사람이 읽기 어렵다. `jq` 파이프를 강제하거나 IDE 의 JSON pretty-print 가 필요.
+- IDE 의 stacktrace 클릭 가능성이 줄어든다 (logger 의 한 줄에 stacktrace 가 escaped JSON 으로 들어감).
+
+선택하지 않은 이유:
+로컬은 사람이 즉시 읽는 환경, 운영은 기계가 검색하는 환경. 같은 포맷을 강제하면 둘 중 하나의 UX 가 무조건 손해본다. `local` 텍스트 / `dev,prod` JSON 분기가 작은 비용으로 둘 다 만족시킨다.
+
+### 3. `log.info("event=X key1=v1 key2=v2")` 의 logfmt 한 줄 텍스트
+
+장점:
+
+- JSON 보다 사람이 읽기 좋다.
+- Loki 의 `| logfmt` 파서가 그대로 지원.
+
+단점:
+
+- nested 구조 (예: `{event: ..., http: {method: ..., status: ...}}`) 를 표현할 수 없다.
+- escape 규칙이 모호 (값에 공백·따옴표가 들어가면 깨진다).
+- stacktrace 를 한 줄에 직렬화하기 어렵다.
+
+선택하지 않은 이유:
+현재의 외부 API 호출 / GitHub webhook / LLM provider 호출은 nested 필드가 자연스럽다. JSON 이 long-term 확장에 유리하고, Loki `| json` 파서도 마찬가지로 1급 지원이다.
+
+### 4. ECS Logging Format (Elastic Common Schema) 어펜더 사용
+
+장점:
+
+- 필드명이 ECS 표준 (e.g. `http.request.method`, `http.response.status_code`) 으로 통일.
+- Kibana / Elasticsearch 와 연동 시 변환 비용 0.
+
+단점:
+
+- 우리는 ELK 가 아니라 Loki 기반이다. ECS 의 nested 표기 (`http.request.method`) 가 Loki `| json` 에서 다소 어색.
+- 필드명이 길어 한 줄 로그의 크기가 커진다.
+- 운영자가 ECS 스키마를 학습해야 한다.
+
+선택하지 않은 이유:
+우리는 Elasticsearch 를 운영할 계획이 없고, ECS 의 학습 비용이 본 ADR 의 동기 (디버깅 / 검색) 에 추가 이득을 주지 않는다. logstash-logback-encoder 의 평탄한 flat 필드명이 LogQL `| json` 과 더 잘 맞는다.
+
+### 5. SLF4J 2.x 의 fluent API + KeyValuePair 만 사용 (encoder 변경 없이)
+
+장점:
+
+- 코드 레벨에서 `log.atInfo().addKeyValue("userId", id).log("msg")` 로 키-값을 추가.
+- encoder 를 안 바꿔도 SLF4J 가 자동 fluent 처리.
+
+단점:
+
+- 패턴 인코더는 KeyValuePair 를 `%kvp` 변환자로만 한 줄에 풀어쓴다 — JSON 화는 별개.
+- 즉 출력 포맷 (텍스트 vs JSON) 은 여전히 encoder 가 결정한다.
+
+선택하지 않은 이유:
+fluent API 는 "코드 작성 방식" 의 선택이고, JSON 포맷은 "출력 방식" 의 선택이다. 두 결정은 독립적이며, 본 ADR 은 출력 포맷 결정이 우선. fluent API 도입은 별도로 도입할 수 있다 (커밋 #6 의 `StructuredArguments.kv(...)` 가 같은 효과를 제공).
+
+## Consequences
+
+### Positive
+
+- Loki / CloudWatch / Kibana 어느 수집기를 쓰더라도 `| json` 한 줄로 필드 기반 검색이 가능해진다.
+- `uriTemplate` 기준 P95 / P99 / count 집계가 LogQL 한 줄로 가능 (`| json | uriTemplate="..."`).
+- 특정 `userId` 의 30분간 실패 흐름 / 특정 `requestId` 의 단일 요청 흐름을 1쿼리로 추적 가능.
+- 외부 API 호출 (`provider=GITHUB operation=FETCH_PULL_REQUESTS`) 의 성공률 / 평균 응답시간을 dashboard 에 올릴 수 있다 (커밋 #7 의 hook).
+- Sentry / Tempo / Loki 모두 같은 `traceId` 로 jump 가능해, incident 분석에서 도구 간 context 손실이 줄어든다.
+- 로그 한 줄의 의미가 사람이 읽는 message 가 아니라 event name + 구조화된 필드가 되므로, 자동화된 alerting 룰 (e.g. `event=external_api_called result=FAILURE` 가 5분에 N 회 이상) 작성이 단순해진다.
+
+### Negative
+
+- 로컬은 텍스트, 운영은 JSON 으로 갈라지므로 "로컬에서 잘 보였는데 운영 로그에서 같은 string match 가 안 된다" 류의 혼동이 가능. message 본문에 의존하지 않고 event 이름으로 검색하도록 운영 규약을 함께 안내해야 한다.
+- MDC 누수 위험이 새로 들어온다. `MDC.clear()` 를 빠뜨리면 스레드풀에서 이전 요청의 `userId` 가 다음 요청 로그에 섞인다. 본 ADR 은 `LoggingInterceptor.afterCompletion()` 의 `try/finally` 로 강제하고, 비동기 / scheduler / WebSocket 경로는 별도 처리 (커밋 #5).
+- logstash-logback-encoder 의 의존성이 새로 추가된다 (deploy size 약 +300KB jar).
+- 로그 1줄 크기가 텍스트 (~200~300B) → JSON (~600~900B) 으로 2~3배 증가. Loki ingestion / 저장 비용에 직접 영향. ADR-014 의 자체 호스팅 retention 정책에서 함께 고려.
+- 기존 dashboard 의 LogQL 룰이 `| regexp` 기반이라면 모두 `| json` 기반으로 리팩토링해야 한다 (커밋 #9 에서 일괄).
+- `[REQ] 💗` 같은 이모지 로그는 사라진다. 운영 로그를 사람이 한눈에 보는 UX 가 일부 손해.
+
+### Neutral / Trade-offs
+
+- `path` 와 `uriTemplate` 을 같이 남기므로 한 줄 로그 크기가 늘지만, 분석 효용이 더 크다.
+- `traceId` 와 `requestId` 를 둘 다 남기므로 cardinality 가 두 배가 되지만, 둘 다 Loki **label 이 아니라 JSON body** 에 들어가므로 Loki cardinality 폭발에는 영향 없다 (ADR-014 §13).
+- `local` 만 텍스트 유지하므로, 로컬에서 JSON 출력 결과를 확인하려면 일시적으로 `--spring.profiles.active=dev` 로 띄우는 운영 트릭이 필요.
+- 새 어펜더의 timezone 은 `Asia/Seoul` 로 고정. CloudWatch / Loki 의 timestamp 표시가 KST 로 통일되지만, UTC 운영 도구와 jump 할 때 변환이 필요할 수 있다.
+
+## Implementation Notes
+
+### 커밋 단위 실행 계획
+
+본 ADR 의 변경은 **9 개의 커밋으로 쪼개서 PR 1~3 개에 묶어 머지**한다. 각 커밋은 독립적으로 빌드 가능하고, 운영에 배포되어도 안전한 상태여야 한다. 회피해야 할 패턴은 "한 PR 에 logback-spring.xml + Interceptor + LoggingFilter 를 모두 바꿔서 무엇이 깨졌는지 모르는 상태" 다.
+
+#### Commit #1 — `chore: add logstash-logback-encoder dependency`
+
+목적: 라이브러리만 추가하고 아무 동작도 바꾸지 않는다. 별도 PR 로 분리해도 좋다.
+
+변경 파일:
+
+- [build.gradle.kts](../../build.gradle.kts)
+
+내용:
+
+```kotlin
+// build.gradle.kts §128~141 영역
+dependencies {
+    // 기존
+    implementation("io.micrometer:micrometer-registry-prometheus")
+    implementation("com.github.loki4j:loki-logback-appender:1.5.2")
+    implementation("io.micrometer:micrometer-registry-otlp")
+
+    // 신규 — JSON 구조화 로그 encoder
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+    // ...
+}
+```
+
+검증:
+
+- `./gradlew build` 가 성공한다.
+- 기존 로그 출력 포맷이 그대로 (텍스트) 인지 확인.
+
+#### Commit #2 — `feat: introduce JSON console appender for dev/prod profiles`
+
+목적: 새로운 `CONSOLE_JSON` 어펜더를 추가하되 **아직 어떤 root 에도 연결하지 않는다**. 즉 새 어펜더는 정의만 되고 동작하지 않는 dead-code 상태. 어펜더 정의 자체에 오타가 있어도 운영에는 영향 없다.
+
+변경 파일:
+
+- [logback-spring.xml](../../src/main/resources/logback-spring.xml)
+
+내용:
+
+```xml
+<springProperty name="APP_NAME" source="spring.application.name" defaultValue="umc-product-api"/>
+<springProperty name="ENV" source="spring.profiles.active" defaultValue="local"/>
+
+<appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+        <providers>
+            <timestamp>
+                <fieldName>timestamp</fieldName>
+                <timeZone>Asia/Seoul</timeZone>
+            </timestamp>
+            <logLevel><fieldName>level</fieldName></logLevel>
+            <loggerName><fieldName>logger</fieldName></loggerName>
+            <threadName><fieldName>thread</fieldName></threadName>
+            <message><fieldName>message</fieldName></message>
+            <mdc/>
+            <stackTrace><fieldName>stackTrace</fieldName></stackTrace>
+            <globalCustomFields>
+                {"service":"${APP_NAME}","environment":"${ENV}"}
+            </globalCustomFields>
+        </providers>
+    </encoder>
+</appender>
+```
+
+검증:
+
+- 기존 `local` / `dev` / `prod` root 의 어펜더 참조는 그대로다.
+- 빌드 / 부팅 / 로그 포맷이 모두 변경 전과 동일.
+
+#### Commit #3 — `feat: switch dev/prod root appender to CONSOLE_JSON`
+
+목적: 실제 포맷 전환. 이 커밋부터 `dev` / `prod` 의 stdout 이 JSON 한 줄이 된다.
+
+변경 파일:
+
+- [logback-spring.xml](../../src/main/resources/logback-spring.xml)
+
+내용:
+
+```xml
+<springProfile name="local">
+    <root level="INFO">
+        <appender-ref ref="LOCAL_CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+</springProfile>
+
+<springProfile name="dev">
+    <logger name="com.umc.product" level="DEBUG"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE_JSON"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+</springProfile>
+
+<springProfile name="prod">
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <options><dsn>${SENTRY_DSN:-}</dsn></options>
+        <minimumEventLevel>WARN</minimumEventLevel>
+        <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
+    </appender>
+
+    <logger name="com.umc.product" level="${LOGGING_APP_LEVEL:-INFO}"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE_JSON"/>
+        <appender-ref ref="LOKI"/>
+        <appender-ref ref="SENTRY"/>
+    </root>
+</springProfile>
+```
+
+주의:
+
+- `loki4j` 의 `<format><message>` 패턴은 본 커밋에서 변경하지 않는다. Loki 로 가는 메시지는 여전히 기존 `${FULL_LOG_PATTERN}` 텍스트. stdout (CloudWatch / kubectl logs) 만 JSON 으로 바뀐다. Loki 송신을 JSON 으로 바꾸는 작업은 ADR-014 의 OTel Collector 이관과 함께 다룬다.
+- 배포 직후 운영 dashboard 에서 `[REQ]` / `[RES]` regex 기반 패널이 깨질 수 있다. **이 커밋의 배포 전에 커밋 #9 (LogQL 룰 업데이트) 의 PR 을 함께 준비**해 둔다.
+
+검증:
+
+- `SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun` 으로 띄운 뒤 stdout 이 `{"timestamp":...,"level":"INFO",...}` 한 줄인지 확인.
+- `SPRING_PROFILES_ACTIVE=local ./gradlew bootRun` 의 stdout 은 여전히 텍스트.
+
+#### Commit #4 — `refactor: rename LoggingInterceptor methods and unify request log to api_request_completed`
+
+목적: 기존 `LoggingInterceptor` 를 JSON 로그 친화적인 구조로 다듬는다. 클래스명 / 패키지는 그대로 두고 (Java 컴파일 영향 0), 로그 라인의 message 와 MDC 사용만 바꾼다.
+
+변경 파일:
+
+- [LoggingInterceptor.java](../../src/main/java/com/umc/product/global/config/LoggingInterceptor.java)
+
+내용 (요지):
+
+```java
+@Override
+public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    request.setAttribute(START_TIME_ATTR, Instant.now());
+    request.setAttribute(CLIENT_IP_ATTR, extractClientIp(request));
+    QueryStatsHolder.init();
+
+    // 1. requestId 발급 + MDC 등록
+    String requestId = UUID.randomUUID().toString();
+    MDC.put("requestId", requestId);
+    MDC.put("method", request.getMethod());
+    MDC.put("path", request.getRequestURI());
+
+    // 2. 인증된 사용자만 userId 를 MDC 에 등록 (커밋 #4 에서는 placeholder, 본 등록은 커밋 #5)
+    // MDC.put("userId", ...);
+
+    // 3. 응답 헤더로 외부에 노출 (디버깅용)
+    response.setHeader("X-Request-Id", requestId);
+
+    String traceId = MDC.get("traceId");
+    if (traceId != null) {
+        response.setHeader("X-Trace-Id", traceId);
+    }
+
+    log.info("api_request_started");
+    return true;
+}
+
+@Override
+public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    try {
+        Instant startTime = (Instant) request.getAttribute(START_TIME_ATTR);
+        if (startTime == null) {
+            return;
+        }
+
+        long durationMs = Duration.between(startTime, Instant.now()).toMillis();
+        long queryCount = QueryStatsHolder.getQueryCount();
+        long queryTimeMs = QueryStatsHolder.getTotalTimeMs();
+        QueryStatsHolder.clear();
+
+        String uriTemplate = (String) request.getAttribute(
+            HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
+        );
+
+        MDC.put("event", "api_request_completed");
+        MDC.put("uriTemplate", uriTemplate != null ? uriTemplate : "UNKNOWN");
+        MDC.put("statusCode", String.valueOf(response.getStatus()));
+        MDC.put("durationMs", String.valueOf(durationMs));
+        MDC.put("queryCount", String.valueOf(queryCount));
+        MDC.put("queryTimeMs", String.valueOf(queryTimeMs));
+        MDC.put("clientIp", (String) request.getAttribute(CLIENT_IP_ATTR));
+
+        if (ex != null) {
+            MDC.put("exception", ex.getClass().getSimpleName());
+            log.error("api_request_completed", ex);
+        } else {
+            log.info("api_request_completed");
+        }
+    } finally {
+        MDC.clear();
+    }
+}
+```
+
+주의 / 제거 항목:
+
+- 기존 `log.info("[REQ] 💗 {} {}", method, fullPath)` / `log.info("[RES] {} {} {} {}ms ...", ...)` 의 이모지·문자열 결합은 모두 제거. 사람이 봐서 좋았던 정보는 모두 MDC 필드로 분리되어 JSON 에 포함된다.
+- `getStatusEmoji()` 도 제거.
+- `MDC.clear()` 는 절대 누락 금지. `try/finally` 강제.
+- query string 의 `URLDecoder.decode(...)` 는 본 커밋에서 제거하지 않지만, 디코딩된 query string 을 MDC 에 넣지 않는다 (민감 파라미터가 들어올 수 있음).
+
+검증:
+
+- 단위 테스트 추가: MDC 가 `preHandle` 에서 set, `afterCompletion` finally 에서 clear 되는지.
+- 실제 dev 환경 배포 후 stdout JSON 에 `requestId`, `method`, `path`, `uriTemplate`, `statusCode`, `durationMs` 가 들어가는지 grep.
+
+#### Commit #5 — `feat: put memberId into MDC after JWT authentication`
+
+목적: 인증된 사용자의 `memberId` 를 MDC `userId` 로 등록한다. `JwtAuthenticationFilter` 가 인증을 끝낸 직후가 가장 빠른 시점이지만, Filter 는 Interceptor 보다 앞에서 동작하므로 두 가지 선택이 있다.
+
+선택 A — Filter 에서 등록 (권장):
+
+```java
+// JwtAuthenticationFilter.doFilterInternal()
+SecurityContextHolder.getContext().setAuthentication(authentication);
+MDC.put("userId", String.valueOf(memberId));
+```
+
+선택 B — Interceptor 의 preHandle 에서 SecurityContextHolder 조회:
+
+```java
+private void putUserIdToMdcIfAuthenticated() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth == null || !auth.isAuthenticated()) return;
+    if (auth.getPrincipal() instanceof MemberPrincipal mp) {
+        MDC.put("userId", String.valueOf(mp.getMemberId()));
+    }
+}
+```
+
+본 ADR 은 **선택 B 를 채택**한다. 이유:
+
+- Filter 에서 MDC 를 넣으면, SecurityContext 가 cleared 되는 시점 (보통 Servlet 컨테이너 종료) 과 MDC clear 시점 (Interceptor afterCompletion) 이 어긋날 수 있다.
+- Interceptor 는 `try/finally` + `MDC.clear()` 로 lifecycle 이 한 곳에 모인다.
+- Filter 는 인증 검사 외의 책임을 갖지 않는 게 더 단순.
+
+변경 파일:
+
+- [LoggingInterceptor.java](../../src/main/java/com/umc/product/global/config/LoggingInterceptor.java) — `preHandle` 마지막에 `putUserIdToMdcIfAuthenticated()` 호출.
+
+주의:
+
+- `MemberPrincipal.getMemberId()` 는 Long. MDC 값은 String 이므로 `String.valueOf(...)`.
+- 익명 사용자 (`principal == "anonymousUser"`) 의 경우 MDC `userId` 를 넣지 않는다 (검색 시 `userId is null` 로 익명 트래픽 식별).
+
+#### Commit #6 — `chore: drop access-log noise from JwtAuthenticationFilter`
+
+목적: JSON 로그가 들어왔으니, 기존 텍스트 시대의 진단용 한 줄 로그 (`log.info("JWT TOKEN Authenticated: memberId={}", memberId)`) 를 제거하거나 DEBUG 로 낮춘다. `api_request_completed` JSON 에 `userId` 가 자동으로 들어가므로 중복이다.
+
+변경 파일:
+
+- [JwtAuthenticationFilter.java](../../src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java#L42) — `log.info(...)` 를 `log.debug(...)` 로 변경 또는 삭제.
+
+또한 다른 패키지에서 같은 패턴의 `log.info("userId={}, ...")` 가 있는지 일괄 검토 후 별도 PR 가능. 본 커밋은 가장 시끄러운 한 줄만 처리.
+
+#### Commit #7 — `feat: add ExternalApiCallLogger helper for structured external_api_called events`
+
+목적: GitHub / Apple / Kakao / LLM provider / 이메일 등 외부 API 호출의 성공·실패·duration 을 통일된 JSON 이벤트로 남길 수 있게 hook 을 제공한다. 본 커밋은 helper 만 추가하고, 도메인별 적용 PR 은 분리.
+
+권장 위치:
+
+- `src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java` (신규)
+
+API 예시:
+
+```java
+public final class ExternalApiCallLogger {
+
+    private static final Logger log = LoggerFactory.getLogger("external_api");
+
+    public static <T> T measure(
+        String provider,
+        String operation,
+        Supplier<T> call
+    ) {
+        long start = System.currentTimeMillis();
+        try {
+            T result = call.get();
+            log.info(
+                "external_api_called",
+                kv("provider", provider),
+                kv("operation", operation),
+                kv("result", "SUCCESS"),
+                kv("durationMs", System.currentTimeMillis() - start)
+            );
+            return result;
+        } catch (RuntimeException e) {
+            log.warn(
+                "external_api_called",
+                kv("provider", provider),
+                kv("operation", operation),
+                kv("result", "FAILURE"),
+                kv("durationMs", System.currentTimeMillis() - start),
+                kv("errorClass", e.getClass().getSimpleName())
+            );
+            throw e;
+        }
+    }
+}
+```
+
+주의:
+
+- `kv` 는 `net.logstash.logback.argument.StructuredArguments.kv` 의 static import.
+- 예외 메시지는 그대로 찍지 않는다. 메시지에 OAuth code, accessToken, 사용자 입력이 섞일 수 있다. `errorClass` 만 남기고, 메시지가 꼭 필요한 경우 `errorMessageHash` (SHA256 짧은 prefix) 같은 우회 수단을 검토.
+
+도메인별 적용 PR (분리):
+
+- GitHub PR fetch / repository sync (010 ADR)
+- LLM provider 호출 (008 ADR, 012 ADR 의 비동기 경로 포함)
+- Apple / Kakao 인증
+- 이메일 / Discord webhook
+
+#### Commit #8 — `feat: scrub sensitive headers and bodies from any incidental logging`
+
+목적: 본 ADR §10 의 민감정보 정책을 코드 레벨에서 강제한다.
+
+변경 영역:
+
+- 전역 `RestClient` / `WebClient` 의 request-logging interceptor 가 있는지 점검 ([RestClientConfig.java](../../src/main/java/com/umc/product/global/config/RestClientConfig.java)).
+- 있으면 `Authorization`, `Cookie`, `X-Api-Key` 헤더는 `***` 로 마스킹.
+- request body / response body 를 통째로 찍는 코드가 있으면 길이 + content-type 요약으로 대체.
+- 인증번호 / 이메일 인증 코드 / OAuth authorization code 를 직접 다루는 controller / service 에서 해당 변수를 `log.debug` 에라도 넣고 있는 부분이 있는지 grep 후 제거.
+
+본 커밋은 변경 범위가 도메인 전반에 걸칠 수 있어 단독 PR 로 분리하는 게 안전하다.
+
+검증 방법:
+
+- `git grep -nE 'log\\.(info|debug|warn|error).*(token|code|authorization)' src/main/java` 에서 hit 가 0 인지 확인.
+- 단위 테스트: mock interceptor 에 `Authorization: Bearer xxx` 를 흘려보내고, 로그 캡처 결과에 `xxx` 가 포함되지 않는지 assert.
+
+#### Commit #9 — `chore: update Grafana dashboards and LogQL rules to | json parser`
+
+목적: 운영 dashboard / alerting rule 을 `| regexp` 에서 `| json` 으로 마이그레이션. JSON 전환의 효용은 dashboard 가 따라와야 비로소 실현된다.
+
+변경 영역:
+
+- Grafana provisioning (현재 디렉터리 골격만 있음: [docker/monitoring/config/grafana/provisioning/](../../docker/monitoring/config/grafana/provisioning/)) 에 JSON 기반 panel JSON 들을 추가.
+- 기존 alerting rule (있다면) 의 `| regexp` 부분을 `| json | durationMs > 1000` 식으로 교체.
+
+운영 LogQL 예시:
+
+```logql
+# 1초 이상 느린 요청
+{application=~".*umc-product-api"}
+| json
+| durationMs > 1000
+
+# 특정 uriTemplate 의 P95
+quantile_over_time(0.95,
+  {application=~".*umc-product-api"}
+  | json
+  | uriTemplate="/forms/{formId}/answers"
+  | unwrap durationMs
+  [5m]
+)
+
+# 5xx 에러 시계열
+sum by (uriTemplate) (
+  count_over_time(
+    {application=~".*umc-product-api"}
+    | json
+    | statusCode >= 500
+    [5m]
+  )
+)
+
+# 특정 requestId 의 모든 로그
+{application=~".*umc-product-api"} |= "9f1a2c7b"
+```
+
+본 커밋은 ADR-014 의 자체 호스팅 이관과 시점이 겹친다. 현재 Grafana Cloud 에 직접 panel 을 만드는 작업 + ADR-014 의 self-hosted Grafana provisioning 디렉터리 모두 같은 LogQL 을 공유한다.
+
+### MDC 키 표준
+
+본 ADR 채택 후, 다음 키 이름을 표준으로 한다. 새 코드는 이 이름만 사용한다.
+
+| 키 | 출처 | 수명 | 용도 |
+|---|---|---|---|
+| `traceId` | Micrometer Tracing | 요청 1개 | Tempo 분산 추적 |
+| `spanId` | Micrometer Tracing | span 1개 | Tempo 내부 |
+| `requestId` | LoggingInterceptor | 요청 1개 | Loki 단일 요청 식별 |
+| `userId` | LoggingInterceptor | 요청 1개 | 인증된 `memberId` |
+| `method` | LoggingInterceptor | 요청 1개 | HTTP 메서드 |
+| `path` | LoggingInterceptor | 요청 1개 | 실제 URI (예: `/forms/123`) |
+| `uriTemplate` | LoggingInterceptor | 응답 시점 | 매칭된 패턴 (예: `/forms/{formId}`) |
+| `statusCode` | LoggingInterceptor | 응답 시점 | HTTP 상태 코드 |
+| `durationMs` | LoggingInterceptor | 응답 시점 | 처리 시간 |
+| `queryCount` | LoggingInterceptor | 응답 시점 | SQL 호출 수 |
+| `queryTimeMs` | LoggingInterceptor | 응답 시점 | SQL 누적 시간 |
+| `clientIp` | LoggingInterceptor | 응답 시점 | 클라이언트 IP |
+| `event` | 로그 작성자 | 로그 1줄 | 이벤트 분류 (e.g. `api_request_completed`, `external_api_called`) |
+| `provider`, `operation`, `result`, `retryCount`, `externalStatusCode` | 호출자 | 로그 1줄 | 외부 API 호출 컨텍스트 |
+
+### 비동기 / Scheduler / WebSocket 경로의 MDC
+
+`LoggingInterceptor` 는 HTTP 동기 요청에만 동작한다. 다음 경로는 별도로 다룬다 (본 ADR 의 범위 밖이지만 후속 작업 가이드).
+
+- `@Async` 메서드: Micrometer 의 `context-propagation` 이 이미 의존성에 들어 있으므로 [AsyncConfig.java](../../src/main/java/com/umc/product/global/config/AsyncConfig.java) 의 TaskDecorator 가 MDC 를 자동 전파하도록 설정. 미설정 시 자식 스레드에서 MDC 가 비어있다.
+- `@Scheduled` 잡: 스케줄러 시작 시 `MDC.put("event", "scheduled_job_started")` 같은 별도 사이클로 관리. requestId 는 무의미하므로 생성하지 않음.
+- STOMP / WebSocket ([ADR-011](011-inquiry-domain-with-websocket-stomp.md)): inbound channel interceptor 에서 별도 MDC 부여. message 단위로 `event=ws_message_received` 같은 이벤트 추가.
+
+### 로컬에서 JSON 출력 확인
+
+로컬에서 운영 포맷을 사람 눈으로 보고 싶다면:
+
+```bash
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun | jq .
+```
+
+또는 IntelliJ 의 run configuration 에 `Active Profiles=dev` 로 임시 전환.
+
+### 롤백 절차
+
+- 커밋 #3 (root 어펜더 전환) 만 revert 하면 stdout 이 즉시 텍스트로 복귀.
+- 커밋 #4 (Interceptor MDC) 를 별도 revert 하면 `api_request_completed` 이벤트가 사라지고 `[REQ]/[RES]` 두 줄로 복귀.
+- 커밋 #1 / #2 는 동작 영향이 없어 revert 불필요.
+
+### 적용 후 운영 점검 (배포 +1 주)
+
+- [ ] Loki 에서 `| json` 파싱이 100% 의 라인에 성공하는가? (`json_parse_error` 가 0 인지)
+- [ ] `api_request_completed` 의 `durationMs` 가 P50 / P95 / P99 dashboard 에 표시되는가?
+- [ ] MDC 누수 점검: 같은 스레드의 연속된 요청에서 `userId` 가 잘못 섞이는 사례가 없는가? (특정 사용자의 요청에서 다른 `userId` 가 1% 이상 검출되면 누수 의심)
+- [ ] Sentry 의 issue 그루핑이 깨지지 않았는가? (Sentry 는 logger message 를 사용하므로 `api_request_completed` 가 너무 잦으면 group 하나에 몰릴 수 있음 — minimum level 을 다시 조정)
+- [ ] 민감 필드 검색: `| json |~ "(?i)(bearer |access[_-]?token|authorization=)"` 가 0 line 인지 정기 점검.
+
+## References
+
+- 관련 ADR
+    - [ADR-014: 모니터링 스택을 Grafana Cloud 에서 자체 홈서버로 이관한다](014-self-hosted-monitoring-stack-migration.md) — 본 ADR 의 JSON 로그는 ADR-014 의 self-hosted Loki 이관 시점과 정렬되며, LogQL `| json` 룰을 공유한다.
+    - [ADR-013: k6 기반 부하·성능 테스트 도입 전략](013-k6-load-and-performance-testing-strategy.md) — 본 ADR 의 `uriTemplate` / `durationMs` 필드가 k6 결과와 동일 축에서 비교 가능해진다.
+    - [ADR-012: LLM 호출의 동기 대기 병목 완화 전략](012-llm-call-blocking-bottleneck-mitigation.md) — `external_api_called` 이벤트가 LLM provider 별 성능 개선 측정의 1차 도구.
+    - [ADR-011: 문의 도메인 WebSocket/STOMP 채택](011-inquiry-domain-with-websocket-stomp.md) — Interceptor 외 경로의 MDC 처리 가이드.
+    - [ADR-010: GitHub App OAuth 및 Webhook 통합](010-github-app-oauth-and-webhook-integration.md) — `external_api_called` 의 첫 적용 후보.
+    - [ADR-008: LLM 도메인 provider 전략](008-llm-domain-provider-strategy.md) — 동일.
+- 기존 코드 / 설정
+    - [build.gradle.kts §127-141 (관측 의존성)](../../build.gradle.kts#L127-L141)
+    - [src/main/resources/logback-spring.xml](../../src/main/resources/logback-spring.xml)
+    - [src/main/resources/application.yml §252-298 (management / tracing / metrics)](../../src/main/resources/application.yml#L252-L298)
+    - [src/main/java/com/umc/product/global/config/LoggingInterceptor.java](../../src/main/java/com/umc/product/global/config/LoggingInterceptor.java)
+    - [src/main/java/com/umc/product/global/config/WebMvcConfig.java](../../src/main/java/com/umc/product/global/config/WebMvcConfig.java)
+    - [src/main/java/com/umc/product/global/security/MemberPrincipal.java](../../src/main/java/com/umc/product/global/security/MemberPrincipal.java)
+    - [src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java](../../src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java)
+- 외부 자료
+    - [logstash-logback-encoder README](https://github.com/logfellow/logstash-logback-encoder)
+    - [SLF4J MDC documentation](https://www.slf4j.org/manual.html#mdc)
+    - [Loki — JSON parser & label_format](https://grafana.com/docs/loki/latest/query/log_queries/#parser-expression)
+    - [Spring Framework — HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/HandlerMapping.html#BEST_MATCHING_PATTERN_ATTRIBUTE)
+    - [net.logstash.logback.argument.StructuredArguments](https://github.com/logfellow/logstash-logback-encoder#event-specific-custom-fields)

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -1,6 +1,9 @@
 package com.umc.product.authentication.adapter.out.external;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.authentication.adapter.in.oauth.OAuth2Attributes;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
@@ -55,6 +58,7 @@ public class AppleTokenVerifier {
 
     private final AppleOAuthProperties appleProperties;
     private final RestClient restClient;
+    private final ObjectMapper objectMapper;
     private PrivateKey cachedPrivateKey;
 
     /**
@@ -246,30 +250,20 @@ public class AppleTokenVerifier {
      * Apple token endpoint 의 에러 응답 JSON 에서 {@code error} 코드만 안전하게 꺼낸다.
      *
      * <p>응답 본문 전체를 로그에 남기면 잘못 분기되어 성공 응답이 흘러왔을 때 access_token /
-     * id_token / refresh_token 이 stdout 으로 새어나갈 수 있다. 따라서 본문에서
-     * {@code "error": "..."} 값만 추출하고, 추출에 실패하면 {@code "unknown"} 으로 대체한다.
+     * id_token / refresh_token 이 stdout 으로 새어나갈 수 있다. 따라서 Jackson 으로 트리를
+     * 파싱한 뒤 {@code error} 필드 값만 추출하고, 파싱 실패 또는 필드 부재 시 {@code "unknown"}
+     * 으로 대체한다 (수동 indexOf 파싱은 공백·필드 순서·유사 키 변화에 취약하므로 사용하지 않는다).
      */
     private String extractAppleErrorCode(String body) {
         if (body == null || body.isEmpty()) {
             return "unknown";
         }
-        int idx = body.indexOf("\"error\"");
-        if (idx == -1) {
+        try {
+            JsonNode error = objectMapper.readTree(body).path("error");
+            return error.isTextual() ? error.asText() : "unknown";
+        } catch (JsonProcessingException e) {
             return "unknown";
         }
-        int colon = body.indexOf(":", idx);
-        if (colon == -1) {
-            return "unknown";
-        }
-        int start = body.indexOf("\"", colon + 1);
-        if (start == -1) {
-            return "unknown";
-        }
-        int end = body.indexOf("\"", start + 1);
-        if (end == -1) {
-            return "unknown";
-        }
-        return body.substring(start + 1, end);
     }
 
     /**

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -137,9 +137,13 @@ public class AppleTokenVerifier {
                 .body(formData)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    // ADR-016 §민감 필드 정책: 성공 응답 body 에는 access_token / id_token / refresh_token
+                    // 이 포함되어 있어 통째로 로깅하면 토큰이 stdout / Loki 에 남는다. 에러 응답이라도
+                    // 잘못된 분기로 성공 body 가 흘러올 수 있으므로 status / errorCode 만 남긴다.
                     String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
-                    log.error("Apple token endpoint 호출 실패: status={}, headers={}, body={}",
-                        res.getStatusCode(), res.getHeaders(), body);
+                    String errorCode = extractAppleErrorCode(body);
+                    log.error("Apple token endpoint 호출 실패: status={}, errorCode={}, bodyLength={}",
+                        res.getStatusCode(), errorCode, body.length());
                     throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
                 })
                 .body(AppleTokenResponse.class);
@@ -186,8 +190,11 @@ public class AppleTokenVerifier {
                 .body(formData)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    // ADR-016 §민감 필드 정책: revoke 응답 본문 통째로 로깅하지 않는다.
                     String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
-                    log.error("Apple token revoke 실패: status={}, body={}", res.getStatusCode(), body);
+                    String errorCode = extractAppleErrorCode(body);
+                    log.error("Apple token revoke 실패: status={}, errorCode={}, bodyLength={}",
+                        res.getStatusCode(), errorCode, body.length());
                     throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
                 })
                 .toBodilessEntity();
@@ -233,6 +240,36 @@ public class AppleTokenVerifier {
             log.error("Failed to generate Apple client secret", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
+    }
+
+    /**
+     * Apple token endpoint 의 에러 응답 JSON 에서 {@code error} 코드만 안전하게 꺼낸다.
+     *
+     * <p>응답 본문 전체를 로그에 남기면 잘못 분기되어 성공 응답이 흘러왔을 때 access_token /
+     * id_token / refresh_token 이 stdout 으로 새어나갈 수 있다. 따라서 본문에서
+     * {@code "error": "..."} 값만 추출하고, 추출에 실패하면 {@code "unknown"} 으로 대체한다.
+     */
+    private String extractAppleErrorCode(String body) {
+        if (body == null || body.isEmpty()) {
+            return "unknown";
+        }
+        int idx = body.indexOf("\"error\"");
+        if (idx == -1) {
+            return "unknown";
+        }
+        int colon = body.indexOf(":", idx);
+        if (colon == -1) {
+            return "unknown";
+        }
+        int start = body.indexOf("\"", colon + 1);
+        if (start == -1) {
+            return "unknown";
+        }
+        int end = body.indexOf("\"", start + 1);
+        if (end == -1) {
+            return "unknown";
+        }
+        return body.substring(start + 1, end);
     }
 
     /**

--- a/src/main/java/com/umc/product/authentication/application/service/UmcProductOAuth2UserService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/UmcProductOAuth2UserService.java
@@ -63,9 +63,8 @@ public class UmcProductOAuth2UserService extends DefaultOAuth2UserService {
             reg.getProviderDetails().getIssuerUri()
         );
 
-        log.debug("Access Token: {}\nID Token: {}",
-            userRequest.getAccessToken().getTokenValue(),
-            userRequest.getAdditionalParameters().get("id_token"));
+        // ADR-016 §민감 필드 정책: access token / id token 의 원문은 어떤 레벨에서도 로깅하지 않는다.
+        // 토큰 검증 흐름 디버깅이 필요하면 길이 / type / 만료 시각 같은 비민감 요약값만 남긴다.
 
         // Attributes를 파싱하는 역할은 OAuth2Attributes가 담당
         OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -1,5 +1,6 @@
 package com.umc.product.global.config;
 
+import com.umc.product.global.security.MemberPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
@@ -7,6 +8,8 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
@@ -32,6 +35,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
     // ===== MDC keys (ADR-016 §MDC 키 표준) =====
     private static final String MDC_REQUEST_ID = "requestId";
+    private static final String MDC_USER_ID = "userId";
     private static final String MDC_METHOD = "method";
     private static final String MDC_PATH = "path";
     private static final String MDC_URI_TEMPLATE = "uriTemplate";
@@ -69,8 +73,31 @@ public class LoggingInterceptor implements HandlerInterceptor {
             response.setHeader(TRACE_ID_HEADER, traceId);
         }
 
+        // 인증된 사용자라면 memberId 를 MDC userId 로 등록.
+        // 익명 사용자는 userId 를 비워둠 — Loki 에서 `userId is null` 로 익명 트래픽 식별.
+        putUserIdToMdcIfAuthenticated();
+
         log.info(EVENT_REQUEST_STARTED);
         return true;
+    }
+
+    /**
+     * SecurityContextHolder 에서 인증된 {@link MemberPrincipal} 을 조회해 MDC {@code userId} 를 채운다.
+     *
+     * <p>Filter 가 아니라 Interceptor 에서 채우는 이유:
+     * <ul>
+     *     <li>MDC 의 lifecycle (put / clear) 이 Interceptor 한 곳에 모여 누수 위험이 줄어든다.</li>
+     *     <li>인증 책임은 Filter, 로그 컨텍스트 책임은 Interceptor 로 분리된다.</li>
+     * </ul>
+     */
+    private void putUserIdToMdcIfAuthenticated() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return;
+        }
+        if (authentication.getPrincipal() instanceof MemberPrincipal memberPrincipal) {
+            MDC.put(MDC_USER_ID, String.valueOf(memberPrincipal.getMemberId()));
+        }
     }
 
     @Override

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -24,7 +24,8 @@ import org.springframework.web.servlet.HandlerMapping;
  * 별도의 UUID 기반 requestId 는 발급하지 않는다 — FE 등 외부 시스템이 이미 {@code X-Trace-Id} 응답 헤더로
  * 알고 있는 식별자를 변경하지 않기 위해서다.
  *
- * <p>MDC 누수를 막기 위해 {@link #afterCompletion} 의 finally 블록에서 반드시 {@link MDC#clear()} 를 호출한다.
+ * <p>ThreadLocal 누수를 막기 위해 {@link #afterCompletion} 의 finally 블록에서 반드시
+ * {@link QueryStatsHolder#clear()} 와 {@link MDC#clear()} 를 호출한다 — 조기 반환 / 예외 경로 모두 포함.
  */
 @Slf4j
 @Component
@@ -113,7 +114,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
             long durationMs = Duration.between(startTime, Instant.now()).toMillis();
             long queryCount = QueryStatsHolder.getQueryCount();
             long queryTimeMs = QueryStatsHolder.getTotalTimeMs();
-            QueryStatsHolder.clear();
 
             // uriTemplate: Spring 이 매칭한 패턴 (예: /forms/{formId}/answers).
             // path 가 가변이라 dashboard 의 P95/P99 집계가 불가능했던 문제를 해결한다.
@@ -141,6 +141,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
                 log.info(EVENT_REQUEST_COMPLETED);
             }
         } finally {
+            // ThreadLocal 누수 방지: 조기 반환 / try 블록 내 예외 경로 모두에서
+            // QueryStatsHolder 와 MDC 를 반드시 비운다 (톰캣 스레드 재사용 대응).
+            QueryStatsHolder.clear();
             MDC.clear();
         }
     }

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -2,20 +2,23 @@ package com.umc.product.global.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.HandlerMapping;
 
 /**
- * HTTP 요청/응답 로깅 인터셉터
+ * HTTP 요청/응답 로깅 인터셉터 (ADR-016 구조화 로그 기반)
  *
- * <p>모든 HTTP 요청의 메서드, URI, 응답 상태 코드, 처리 시간, 쿼리 통계, 클라이언트 IP를 로깅합니다.
+ * <p>요청 진입 시점에 {@code requestId} / {@code method} / {@code path} 를 MDC 에 push 하고,
+ * 응답 완료 시점에 {@code uriTemplate} / {@code statusCode} / {@code durationMs} / {@code queryCount} /
+ * {@code queryTimeMs} / {@code clientIp} 를 MDC 에 채워 {@code api_request_completed} 이벤트 한 줄을 남긴다.
+ *
+ * <p>MDC 누수를 막기 위해 {@link #afterCompletion} 의 finally 블록에서 반드시 {@link MDC#clear()} 를 호출한다.
  */
 @Slf4j
 @Component
@@ -23,8 +26,26 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
     private static final String START_TIME_ATTR = "startTime";
     private static final String CLIENT_IP_ATTR = "clientIp";
+
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
-    private static final String TRACE_ID = "traceId";
+
+    // ===== MDC keys (ADR-016 §MDC 키 표준) =====
+    private static final String MDC_REQUEST_ID = "requestId";
+    private static final String MDC_METHOD = "method";
+    private static final String MDC_PATH = "path";
+    private static final String MDC_URI_TEMPLATE = "uriTemplate";
+    private static final String MDC_STATUS_CODE = "statusCode";
+    private static final String MDC_DURATION_MS = "durationMs";
+    private static final String MDC_QUERY_COUNT = "queryCount";
+    private static final String MDC_QUERY_TIME_MS = "queryTimeMs";
+    private static final String MDC_CLIENT_IP = "clientIp";
+    private static final String MDC_EVENT = "event";
+    private static final String MDC_EXCEPTION = "exception";
+    private static final String MDC_TRACE_ID = "traceId";
+
+    private static final String EVENT_REQUEST_STARTED = "api_request_started";
+    private static final String EVENT_REQUEST_COMPLETED = "api_request_completed";
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -34,35 +55,22 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
         QueryStatsHolder.init();
 
-        // URI와 Query String 조합
-        String requestUri = request.getRequestURI();
+        // requestId 발급 + MDC 등록 (단일 요청 식별자)
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(MDC_REQUEST_ID, requestId);
+        MDC.put(MDC_METHOD, request.getMethod());
+        MDC.put(MDC_PATH, request.getRequestURI());
 
-        String queryString = request.getQueryString();
-        if (queryString != null) {
-            // 인코딩된 문자열을 사람이 읽을 수 있게 디코딩
-            queryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);
-        }
+        // 응답 헤더로 외부에 노출 (디버깅 / 운영자 grep 용)
+        response.setHeader(REQUEST_ID_HEADER, requestId);
 
-        String fullPath = (queryString != null) ? requestUri + "?" + queryString : requestUri;
-
-        log.info("[REQ] 💗 {} {}", request.getMethod(), fullPath);
-
-        log.debug("[MDC] {}", MDC.getCopyOfContextMap());
-
-        String traceId = MDC.get(TRACE_ID);
+        String traceId = MDC.get(MDC_TRACE_ID);
         if (traceId != null) {
             response.setHeader(TRACE_ID_HEADER, traceId);
         }
 
+        log.info(EVENT_REQUEST_STARTED);
         return true;
-    }
-
-    @Override
-    public void postHandle(
-        HttpServletRequest request, HttpServletResponse response,
-        Object handler, ModelAndView modelAndView
-    ) {
-        // Controller 실행 후, View 렌더링 전
     }
 
     @Override
@@ -70,32 +78,44 @@ public class LoggingInterceptor implements HandlerInterceptor {
         HttpServletRequest request, HttpServletResponse response,
         Object handler, Exception ex
     ) {
-        Instant startTime = (Instant) request.getAttribute(START_TIME_ATTR);
-        if (startTime == null) {
-            return;
-        }
+        try {
+            Instant startTime = (Instant) request.getAttribute(START_TIME_ATTR);
+            if (startTime == null) {
+                return;
+            }
 
-        long durationMs = Duration.between(startTime, Instant.now()).toMillis();
-        long queryCount = QueryStatsHolder.getQueryCount();
-        long queryTimeMs = QueryStatsHolder.getTotalTimeMs();
-        String clientIp = (String) request.getAttribute(CLIENT_IP_ATTR);
+            long durationMs = Duration.between(startTime, Instant.now()).toMillis();
+            long queryCount = QueryStatsHolder.getQueryCount();
+            long queryTimeMs = QueryStatsHolder.getTotalTimeMs();
+            QueryStatsHolder.clear();
 
-        QueryStatsHolder.clear();
+            // uriTemplate: Spring 이 매칭한 패턴 (예: /forms/{formId}/answers).
+            // path 가 가변이라 dashboard 의 P95/P99 집계가 불가능했던 문제를 해결한다.
+            Object bestMatchingPattern = request.getAttribute(
+                HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
+            );
+            String uriTemplate = bestMatchingPattern instanceof String s ? s : "UNKNOWN";
 
-        String status = getStatusEmoji(response.getStatus());
+            String clientIp = (String) request.getAttribute(CLIENT_IP_ATTR);
 
-        log.info("[RES] {} {} {} {}ms | Query Count: {}, Time: {}ms | IP: {}",
-            status,
-            response.getStatus(),
-            request.getRequestURI(),
-            durationMs,
-            queryCount,
-            queryTimeMs,
-            clientIp
-        );
+            MDC.put(MDC_EVENT, EVENT_REQUEST_COMPLETED);
+            MDC.put(MDC_URI_TEMPLATE, uriTemplate);
+            MDC.put(MDC_STATUS_CODE, String.valueOf(response.getStatus()));
+            MDC.put(MDC_DURATION_MS, String.valueOf(durationMs));
+            MDC.put(MDC_QUERY_COUNT, String.valueOf(queryCount));
+            MDC.put(MDC_QUERY_TIME_MS, String.valueOf(queryTimeMs));
+            if (clientIp != null) {
+                MDC.put(MDC_CLIENT_IP, clientIp);
+            }
 
-        if (ex != null) {
-            log.error("  └─ Exception: {}", ex.getMessage());
+            if (ex != null) {
+                MDC.put(MDC_EXCEPTION, ex.getClass().getSimpleName());
+                log.error(EVENT_REQUEST_COMPLETED, ex);
+            } else {
+                log.info(EVENT_REQUEST_COMPLETED);
+            }
+        } finally {
+            MDC.clear();
         }
     }
 
@@ -108,18 +128,5 @@ public class LoggingInterceptor implements HandlerInterceptor {
         }
 
         return request.getRemoteAddr();
-    }
-
-    private String getStatusEmoji(int status) {
-        if (status >= 200 && status < 300) {
-            return "✅";
-        }
-        if (status >= 300 && status < 400) {
-            return "🔄";
-        }
-        if (status >= 400 && status < 500) {
-            return "⚠️";
-        }
-        return "❌";
     }
 }

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -145,8 +145,13 @@ public class LoggingInterceptor implements HandlerInterceptor {
             }
 
             if (ex != null) {
+                // ADR-016 §민감 필드 정책: throwable 을 log.error 에 넘기면 JSON layout 의
+                // <stackTrace> 프로바이더가 전체 스택을 직렬화하고, 예외 메시지에 토큰 / 사용자
+                // 입력이 섞여 stdout / Loki 로 노출될 수 있다. 본 이벤트는 dashboard 집계용
+                // 메타 (exception 클래스명) 만 MDC 로 남기고, 스택 자체는 전역 예외 핸들러 /
+                // 컨트롤러 등 책임 지점의 로그에 맡긴다.
                 MDC.put(MDC_EXCEPTION, ex.getClass().getSimpleName());
-                log.error(EVENT_REQUEST_COMPLETED, ex);
+                log.error(EVENT_REQUEST_COMPLETED);
             } else {
                 log.info(EVENT_REQUEST_COMPLETED);
             }

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
@@ -17,9 +16,13 @@ import org.springframework.web.servlet.HandlerMapping;
 /**
  * HTTP 요청/응답 로깅 인터셉터 (ADR-016 구조화 로그 기반)
  *
- * <p>요청 진입 시점에 {@code requestId} / {@code method} / {@code path} 를 MDC 에 push 하고,
- * 응답 완료 시점에 {@code uriTemplate} / {@code statusCode} / {@code durationMs} / {@code queryCount} /
+ * <p>요청 진입 시점에 {@code method} / {@code path} 를 MDC 에 push 하고, 응답 완료 시점에
+ * {@code uriTemplate} / {@code statusCode} / {@code durationMs} / {@code queryCount} /
  * {@code queryTimeMs} / {@code clientIp} 를 MDC 에 채워 {@code api_request_completed} 이벤트 한 줄을 남긴다.
+ *
+ * <p>단일 요청 식별자는 Micrometer Tracing 이 자동으로 MDC 에 넣는 {@code traceId} 를 그대로 재사용한다.
+ * 별도의 UUID 기반 requestId 는 발급하지 않는다 — FE 등 외부 시스템이 이미 {@code X-Trace-Id} 응답 헤더로
+ * 알고 있는 식별자를 변경하지 않기 위해서다.
  *
  * <p>MDC 누수를 막기 위해 {@link #afterCompletion} 의 finally 블록에서 반드시 {@link MDC#clear()} 를 호출한다.
  */
@@ -30,12 +33,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
     private static final String START_TIME_ATTR = "startTime";
     private static final String CLIENT_IP_ATTR = "clientIp";
 
-    private static final String REQUEST_ID_HEADER = "X-Request-Id";
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
 
     // ===== MDC keys (ADR-016 §MDC 키 표준) =====
-    private static final String MDC_REQUEST_ID = "requestId";
-    private static final String MDC_USER_ID = "userId";
+    private static final String MDC_MEMBER_ID = "memberId";
     private static final String MDC_METHOD = "method";
     private static final String MDC_PATH = "path";
     private static final String MDC_URI_TEMPLATE = "uriTemplate";
@@ -59,30 +60,28 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
         QueryStatsHolder.init();
 
-        // requestId 발급 + MDC 등록 (단일 요청 식별자)
-        String requestId = UUID.randomUUID().toString();
-        MDC.put(MDC_REQUEST_ID, requestId);
         MDC.put(MDC_METHOD, request.getMethod());
         MDC.put(MDC_PATH, request.getRequestURI());
 
-        // 응답 헤더로 외부에 노출 (디버깅 / 운영자 grep 용)
-        response.setHeader(REQUEST_ID_HEADER, requestId);
-
+        // Micrometer Tracing 이 채워 둔 traceId 를 FE 디버깅용으로 응답 헤더에 노출.
+        // 별도 requestId UUID 는 발급하지 않는다 (FE 호환성 — X-Trace-Id 가 이미 사용 중).
         String traceId = MDC.get(MDC_TRACE_ID);
         if (traceId != null) {
             response.setHeader(TRACE_ID_HEADER, traceId);
         }
 
-        // 인증된 사용자라면 memberId 를 MDC userId 로 등록.
-        // 익명 사용자는 userId 를 비워둠 — Loki 에서 `userId is null` 로 익명 트래픽 식별.
-        putUserIdToMdcIfAuthenticated();
+        // 인증된 사용자라면 memberId 를 MDC 에 등록.
+        // 익명 사용자는 비워둔다 — Loki 에서 `memberId is null` 로 익명 트래픽을 식별한다.
+        putMemberIdToMdcIfAuthenticated();
 
         log.info(EVENT_REQUEST_STARTED);
         return true;
     }
 
     /**
-     * SecurityContextHolder 에서 인증된 {@link MemberPrincipal} 을 조회해 MDC {@code userId} 를 채운다.
+     * SecurityContextHolder 에서 인증된 {@link MemberPrincipal} 을 조회해 MDC {@code memberId} 를 채운다.
+     *
+     * <p>서비스 도메인 명명을 그대로 사용 (`userId` 가 아니라 `memberId`).
      *
      * <p>Filter 가 아니라 Interceptor 에서 채우는 이유:
      * <ul>
@@ -90,13 +89,13 @@ public class LoggingInterceptor implements HandlerInterceptor {
      *     <li>인증 책임은 Filter, 로그 컨텍스트 책임은 Interceptor 로 분리된다.</li>
      * </ul>
      */
-    private void putUserIdToMdcIfAuthenticated() {
+    private void putMemberIdToMdcIfAuthenticated() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             return;
         }
         if (authentication.getPrincipal() instanceof MemberPrincipal memberPrincipal) {
-            MDC.put(MDC_USER_ID, String.valueOf(memberPrincipal.getMemberId()));
+            MDC.put(MDC_MEMBER_ID, String.valueOf(memberPrincipal.getMemberId()));
         }
     }
 

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -75,7 +75,16 @@ public class LoggingInterceptor implements HandlerInterceptor {
         // 익명 사용자는 비워둔다 — Loki 에서 `memberId is null` 로 익명 트래픽을 식별한다.
         putMemberIdToMdcIfAuthenticated();
 
-        log.info(EVENT_REQUEST_STARTED);
+        // ADR-016 §MDC 키 표준: api_request_completed 와 동일하게 event 필드를 채워
+        // LogQL `| json | event="api_request_started"` 필터링이 가능하도록 한다.
+        // 단, event 는 해당 로그 라인에만 묶여야 하므로 (이후 컨트롤러/서비스 로그 오염 방지)
+        // 로깅 직후 즉시 제거한다.
+        MDC.put(MDC_EVENT, EVENT_REQUEST_STARTED);
+        try {
+            log.info(EVENT_REQUEST_STARTED);
+        } finally {
+            MDC.remove(MDC_EVENT);
+        }
         return true;
     }
 

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -3,8 +3,6 @@ package com.umc.product.global.config;
 import com.umc.product.global.security.MemberPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.Duration;
-import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
@@ -56,7 +54,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 
-        request.setAttribute(START_TIME_ATTR, Instant.now());
+        // 경과 시간 측정은 monotonic clock 인 nanoTime 을 사용한다.
+        // Instant.now / currentTimeMillis 는 NTP 동기화 등 wall-clock 보정 시
+        // 뒤로 점프할 수 있어 durationMs 가 음수/왜곡으로 찍힌다.
+        request.setAttribute(START_TIME_ATTR, System.nanoTime());
         request.setAttribute(CLIENT_IP_ATTR, extractClientIp(request));
 
         QueryStatsHolder.init();
@@ -115,12 +116,12 @@ public class LoggingInterceptor implements HandlerInterceptor {
         Object handler, Exception ex
     ) {
         try {
-            Instant startTime = (Instant) request.getAttribute(START_TIME_ATTR);
-            if (startTime == null) {
+            Long startNanos = (Long) request.getAttribute(START_TIME_ATTR);
+            if (startNanos == null) {
                 return;
             }
 
-            long durationMs = Duration.between(startTime, Instant.now()).toMillis();
+            long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
             long queryCount = QueryStatsHolder.getQueryCount();
             long queryTimeMs = QueryStatsHolder.getTotalTimeMs();
 

--- a/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
+++ b/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
@@ -59,7 +59,9 @@ public final class ExternalApiCallLogger {
      * @return {@code call} 의 반환값
      */
     public static <T> T measure(String provider, String operation, Supplier<T> call) {
-        long start = System.currentTimeMillis();
+        // 경과 시간 측정은 monotonic clock 인 nanoTime 을 사용한다.
+        // currentTimeMillis 는 NTP 동기화 등 wall-clock 보정 시 뒤로 점프할 수 있어 durationMs 가 왜곡된다.
+        long startNanos = System.nanoTime();
         try {
             T result = call.get();
             log.info(
@@ -67,7 +69,7 @@ public final class ExternalApiCallLogger {
                 kv("provider", provider),
                 kv("operation", operation),
                 kv("result", "SUCCESS"),
-                kv("durationMs", System.currentTimeMillis() - start)
+                kv("durationMs", (System.nanoTime() - startNanos) / 1_000_000L)
             );
             return result;
         } catch (RuntimeException e) {
@@ -76,7 +78,7 @@ public final class ExternalApiCallLogger {
                 kv("provider", provider),
                 kv("operation", operation),
                 kv("result", "FAILURE"),
-                kv("durationMs", System.currentTimeMillis() - start),
+                kv("durationMs", (System.nanoTime() - startNanos) / 1_000_000L),
                 kv("errorClass", e.getClass().getSimpleName())
             );
             throw e;

--- a/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
+++ b/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
@@ -1,0 +1,96 @@
+package com.umc.product.global.logging;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 외부 API 호출(예: GitHub / Apple / Kakao / LLM provider / 이메일)을 통일된
+ * 구조화 이벤트({@code external_api_called})로 기록하기 위한 헬퍼다.
+ *
+ * <p>본 헬퍼는 hook 만 제공한다. 도메인별 적용 (Apple / Kakao / GitHub / LLM …)은 ADR-016
+ * 의 범위 밖에서 별도 PR 로 점진적으로 추가한다.
+ *
+ * <h2>호출 예시</h2>
+ * <pre>{@code
+ * GithubPullRequest pr = ExternalApiCallLogger.measure(
+ *     "GITHUB",
+ *     "FETCH_PULL_REQUESTS",
+ *     () -> githubClient.fetchPullRequests(repo)
+ * );
+ * }</pre>
+ *
+ * <h2>출력되는 JSON 필드</h2>
+ * <ul>
+ *     <li>{@code provider} — 외부 서비스 식별자 (예: {@code GITHUB}, {@code OPENAI})</li>
+ *     <li>{@code operation} — 호출 동작 (예: {@code FETCH_PULL_REQUESTS})</li>
+ *     <li>{@code result} — {@code SUCCESS} / {@code FAILURE}</li>
+ *     <li>{@code durationMs} — 호출 소요 시간</li>
+ *     <li>{@code errorClass} — 실패 시 예외의 단순 클래스명 (메시지는 의도적으로 제외)</li>
+ * </ul>
+ *
+ * <h2>민감정보 처리</h2>
+ * 예외 메시지를 그대로 로깅하지 않는다. 메시지에 OAuth code / access token / 사용자 입력이
+ * 섞일 수 있어 ADR-016 §민감 필드 정책을 위반할 수 있다. 메시지가 꼭 필요한 경우 호출자가
+ * 직접 마스킹한 뒤 별도 로그 라인으로 남긴다.
+ */
+public final class ExternalApiCallLogger {
+
+    /** 외부 API 호출 전용 logger. JSON 라인의 {@code logger} 필드로 식별된다. */
+    private static final Logger log = LoggerFactory.getLogger("external_api");
+
+    private static final String EVENT = "external_api_called";
+
+    private ExternalApiCallLogger() {
+        // util
+    }
+
+    /**
+     * 외부 API 호출을 감싸 성공/실패와 소요 시간을 구조화 이벤트로 남긴다.
+     *
+     * <p>예외는 그대로 재던지므로 호출자의 흐름이 변하지 않는다.
+     *
+     * @param provider  외부 서비스 식별자 (예: {@code GITHUB}, {@code APPLE})
+     * @param operation 호출 동작 (예: {@code FETCH_PULL_REQUESTS}, {@code EXCHANGE_TOKEN})
+     * @param call      실제 호출 람다
+     * @param <T>       호출 결과 타입
+     * @return {@code call} 의 반환값
+     */
+    public static <T> T measure(String provider, String operation, Supplier<T> call) {
+        long start = System.currentTimeMillis();
+        try {
+            T result = call.get();
+            log.info(
+                EVENT,
+                kv("provider", provider),
+                kv("operation", operation),
+                kv("result", "SUCCESS"),
+                kv("durationMs", System.currentTimeMillis() - start)
+            );
+            return result;
+        } catch (RuntimeException e) {
+            log.warn(
+                EVENT,
+                kv("provider", provider),
+                kv("operation", operation),
+                kv("result", "FAILURE"),
+                kv("durationMs", System.currentTimeMillis() - start),
+                kv("errorClass", e.getClass().getSimpleName())
+            );
+            throw e;
+        }
+    }
+
+    /**
+     * 반환값이 없는 외부 API 호출용 오버로드. {@link #measure(String, String, Supplier)} 와 동일한
+     * 이벤트 스키마를 사용한다.
+     */
+    public static void measure(String provider, String operation, Runnable call) {
+        measure(provider, operation, () -> {
+            call.run();
+            return null;
+        });
+    }
+}

--- a/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
@@ -39,7 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     Long memberId = jwtTokenProvider.parseAccessToken(token);
                     List<String> roles = jwtTokenProvider.getRolesFromAccessToken(token);
 
-                    log.info("JWT TOKEN Authenticated: memberId={}", memberId);
+                    // ADR-016: 모든 요청은 LoggingInterceptor 가 api_request_completed JSON 라인에
+                    // userId(=memberId) 를 MDC 로 포함하므로 인증 한 줄 텍스트 로그는 중복이다.
+                    // 토큰 검증 흐름 디버깅이 필요한 경우에만 보이도록 DEBUG 로 강등.
+                    log.debug("JWT authenticated: memberId={}", memberId);
 
                     MemberPrincipal memberPrincipal = new MemberPrincipal(memberId);
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -100,7 +100,6 @@
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="LOCAL_CONSOLE"/>
-            <appender-ref ref="LOKI"/>
         </root>
     </springProfile>
 
@@ -134,7 +133,7 @@
         </root>
     </springProfile>
 
-    <!-- ========== prod: stdout JSON + LOKI + SENTRY (CloudWatch) ========== -->
+    <!-- ========== 프로덕션: stdout JSON + LOKI + SENTRY (CloudWatch) ========== -->
     <springProfile name="prod">
         <!-- Sentry Appender -->
         <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
@@ -145,7 +144,7 @@
             <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
         </appender>
 
-        <!-- 우리 앱 패키지만 DEBUG -->
+        <!-- 우리 앱에 대한 로그 기록 수준은 환경변수에 따름 -->
         <logger name="com.umc.product" level="${LOGGING_APP_LEVEL:-INFO}"/>
 
         <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,6 +8,10 @@
     <property name="LOG_DIR" value="./logs"/>
     <property name="LOG_NAME" value="umc-product"/>
 
+    <!-- ========== 구조화 로그용 메타 (ADR-016) ========== -->
+    <springProperty name="APP_NAME" source="spring.application.name" defaultValue="umc-product-api"/>
+    <springProperty name="ENV" source="spring.profiles.active" defaultValue="local"/>
+
     <!-- ========== 콘솔 로깅 패턴 정의 ========== -->
     <property name="LOCAL_CONSOLE_LOG_PATTERN"
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} %customHighlight(%-5level) [%-4.-4X{traceId}] [%thread] %logger{40} : %msg%n"/>
@@ -29,6 +33,47 @@
 
         <encoder>
             <pattern>${FULL_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!--
+        ========== JSON 구조화 로그 어펜더 (ADR-016) ==========
+        dev / staging / prod 환경의 stdout 을 JSON 한 줄로 출력.
+        본 커밋(#2)에서는 정의만 하고 어떤 root 에도 연결하지 않는다 (dead-code).
+        root 연결은 Commit #3 에서 수행한다.
+    -->
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE_JSON">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>timestamp</fieldName>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <logLevel>
+                    <fieldName>level</fieldName>
+                </logLevel>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <message>
+                    <fieldName>message</fieldName>
+                </message>
+                <mdc/>
+                <arguments/>
+                <stackTrace>
+                    <fieldName>stackTrace</fieldName>
+                </stackTrace>
+                <globalCustomFields>
+                    {"service":"${APP_NAME}","environment":"${ENV}"}
+                </globalCustomFields>
+            </providers>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -105,35 +105,36 @@
     </springProfile>
 
 
+    <!--
+        ========== dev: stdout JSON + LOKI (ADR-016) ==========
+        본 시점부터 dev stdout 은 한 줄 JSON. Loki 송신은 여전히 텍스트 (loki4j 의 message pattern).
+        Loki 송신의 JSON 화는 ADR-014 의 OTel Collector 이관과 함께 다룬다.
+    -->
     <springProfile name="dev">
-        <!-- dev용 파일 appender -->
-        <!--        <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE">-->
-        <!--            <encoder>-->
-        <!--                <pattern>${FULL_LOG_PATTERN}</pattern>-->
-        <!--            </encoder>-->
-
-        <!--            <file>${LOG_DIR}/${LOG_NAME}.log</file>-->
-
-        <!--            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">-->
-        <!--                <fileNamePattern>${LOG_DIR}/${LOG_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>-->
-
-        <!--                <maxFileSize>50MB</maxFileSize>-->
-        <!--                <maxHistory>30</maxHistory>-->
-        <!--                <totalSizeCap>2GB</totalSizeCap>-->
-        <!--            </rollingPolicy>-->
-        <!--        </appender>-->
-
         <!-- 우리 앱 패키지만 DEBUG -->
         <logger name="com.umc.product" level="DEBUG"/>
 
         <root level="INFO">
-            <appender-ref ref="ECS_CONSOLE"/>
+            <appender-ref ref="CONSOLE_JSON"/>
             <appender-ref ref="LOKI"/>
-            <!--            <appender-ref ref="FILE"/>-->
         </root>
     </springProfile>
 
-    <!-- ========== prod용은 ECS인 관계로 stdout으로 내보내기 (CloudWatch) ========== -->
+    <!--
+        ========== staging: dev 와 동일 구성 (ADR-016) ==========
+        Sentry 는 prod 전용. staging 은 트래픽 / 데이터 패턴 검증 환경이므로
+        dev 와 동일하게 JSON stdout + Loki 만 둔다.
+    -->
+    <springProfile name="staging">
+        <logger name="com.umc.product" level="${LOGGING_APP_LEVEL:-INFO}"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_JSON"/>
+            <appender-ref ref="LOKI"/>
+        </root>
+    </springProfile>
+
+    <!-- ========== prod: stdout JSON + LOKI + SENTRY (CloudWatch) ========== -->
     <springProfile name="prod">
         <!-- Sentry Appender -->
         <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
@@ -148,7 +149,7 @@
         <logger name="com.umc.product" level="${LOGGING_APP_LEVEL:-INFO}"/>
 
         <root level="INFO">
-            <appender-ref ref="ECS_CONSOLE"/>
+            <appender-ref ref="CONSOLE_JSON"/>
             <appender-ref ref="LOKI"/>
             <appender-ref ref="SENTRY"/>
         </root>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -95,7 +95,13 @@
         </http>
         <format>
             <label>
-                <pattern>application=${SPRING_APPLICATION_NAME},level=%level</pattern>
+                <!--
+                    application 라벨은 위에서 선언한 springProperty APP_NAME (source=spring.application.name,
+                    defaultValue=umc-product-api) 을 그대로 사용한다. SPRING_APPLICATION_NAME 환경변수를
+                    직접 참조하면 미설정 환경에서 라벨이 빈 문자열이 되어 LogQL `{application=~".*umc-product-api"}`
+                    매칭이 실패한다.
+                -->
+                <pattern>application=${APP_NAME},level=%level</pattern>
             </label>
             <message class="net.logstash.logback.layout.LoggingEventCompositeJsonLayout">
                 <providers>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -77,7 +77,14 @@
         </encoder>
     </appender>
 
-    <!-- Loki -->
+    <!--
+        ========== LOKI APPENDER (ADR-016) ==========
+        Grafana dashboard 의 LogQL 은 `| json | event="..." | unwrap durationMs` 형태로
+        구조화 필드를 직접 참조한다. 따라서 LOKI 송신도 CONSOLE_JSON 과 동일한 한 줄 JSON
+        스키마로 맞춘다 (MDC + arguments 포함). loki4j 의 <message class="..."> 슬롯에
+        logstash-logback-encoder 의 JsonLayout 을 끼워 KVP (StructuredArguments.kv) 까지
+        함께 직렬화한다.
+    -->
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
             <url>${LOKI_URL:-http://localhost:3100/loki/api/v1/push}</url>
@@ -90,8 +97,33 @@
             <label>
                 <pattern>application=${SPRING_APPLICATION_NAME},level=%level</pattern>
             </label>
-            <message>
-                <pattern>${FULL_LOG_PATTERN}</pattern>
+            <message class="net.logstash.logback.layout.LoggingEventCompositeJsonLayout">
+                <providers>
+                    <timestamp>
+                        <fieldName>timestamp</fieldName>
+                        <timeZone>Asia/Seoul</timeZone>
+                    </timestamp>
+                    <logLevel>
+                        <fieldName>level</fieldName>
+                    </logLevel>
+                    <loggerName>
+                        <fieldName>logger</fieldName>
+                    </loggerName>
+                    <threadName>
+                        <fieldName>thread</fieldName>
+                    </threadName>
+                    <message>
+                        <fieldName>message</fieldName>
+                    </message>
+                    <mdc/>
+                    <arguments/>
+                    <stackTrace>
+                        <fieldName>stackTrace</fieldName>
+                    </stackTrace>
+                    <globalCustomFields>
+                        {"service":"${APP_NAME}","environment":"${ENV}"}
+                    </globalCustomFields>
+                </providers>
             </message>
         </format>
     </appender>
@@ -106,8 +138,9 @@
 
     <!--
         ========== dev: stdout JSON + LOKI (ADR-016) ==========
-        본 시점부터 dev stdout 은 한 줄 JSON. Loki 송신은 여전히 텍스트 (loki4j 의 message pattern).
-        Loki 송신의 JSON 화는 ADR-014 의 OTel Collector 이관과 함께 다룬다.
+        dev stdout 과 Loki 모두 동일한 한 줄 JSON 스키마 (MDC + arguments 포함) 로 송신한다.
+        ADR-014 의 OTel Collector 이관은 후속 작업이지만, 그때까지는 loki4j 가 JsonLayout 으로
+        직접 Loki 에 push 한다.
     -->
     <springProfile name="dev">
         <!-- 우리 앱 패키지만 DEBUG -->

--- a/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
@@ -1,0 +1,154 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * ADR-016 의 LoggingInterceptor MDC 라이프사이클을 검증한다.
+ *
+ * <p>Spring Context 를 띄우지 않는 순수 단위 테스트로, preHandle 시점의 MDC put
+ * 과 afterCompletion 시점의 finally MDC.clear 가 보장되는지 확인한다.
+ *
+ * <p>JSON 어펜더가 실제로 직렬화하는 MDC 스냅샷은 ILoggingEvent.getMDCPropertyMap() 로
+ * 캡처해서 검증한다 (실제 운영에서는 logstash-logback-encoder 가 같은 map 을 사용).
+ */
+class LoggingInterceptorTest {
+
+    private final LoggingInterceptor interceptor = new LoggingInterceptor();
+
+    private Logger interceptorLogger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        interceptorLogger = (Logger) LoggerFactory.getLogger(LoggingInterceptor.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        interceptorLogger.addAppender(listAppender);
+        interceptorLogger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        interceptorLogger.detachAppender(listAppender);
+        // 테스트 간 MDC 누수 방지
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("preHandle 시 requestId / method / path 가 MDC 에 들어가고 X-Request-Id 헤더가 채워진다")
+    void preHandle_MDC_등록_성공() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123/answers");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(MDC.get("requestId")).isNotBlank();
+        assertThat(MDC.get("method")).isEqualTo("GET");
+        assertThat(MDC.get("path")).isEqualTo("/forms/123/answers");
+        assertThat(response.getHeader("X-Request-Id")).isEqualTo(MDC.get("requestId"));
+    }
+
+    @Test
+    @DisplayName("afterCompletion 의 finally 에서 MDC 가 반드시 비워진다")
+    void afterCompletion_MDC_누수_방지() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        interceptor.preHandle(request, response, new Object());
+
+        // pre-condition: MDC 에 값이 들어있다
+        assertThat(MDC.get("requestId")).isNotBlank();
+
+        // when
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        // then
+        assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    @DisplayName("api_request_completed 로그의 MDC 스냅샷에 uriTemplate / statusCode / durationMs 가 포함된다")
+    void afterCompletion_응답_필드_MDC_등록() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123/answers");
+        request.setAttribute(
+            HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE,
+            "/forms/{formId}/answers"
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+        interceptor.preHandle(request, response, new Object());
+
+        // when
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        // then — 로그 이벤트의 MDC 스냅샷을 캡처해서 확인
+        Map<String, String> snapshot = findEventMdc("api_request_completed");
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot).containsEntry("event", "api_request_completed");
+        assertThat(snapshot).containsEntry("uriTemplate", "/forms/{formId}/answers");
+        assertThat(snapshot).containsEntry("statusCode", "200");
+        assertThat(snapshot).containsKey("durationMs");
+        assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    @DisplayName("preHandle 이 호출되지 않은 상태에서 afterCompletion 이 호출되어도 안전하게 종료된다")
+    void afterCompletion_startTime_없을_때_안전_종료() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when / then — 예외 없이 통과
+        interceptor.afterCompletion(request, response, new Object(), null);
+        assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 있으면 첫 번째 IP 가 clientIp 로 채워진다")
+    void clientIp_X_Forwarded_For_우선() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms");
+        request.addHeader("X-Forwarded-For", "203.0.113.7, 10.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        interceptor.preHandle(request, response, new Object());
+
+        // when
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        // then
+        Map<String, String> snapshot = findEventMdc("api_request_completed");
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot).containsEntry("clientIp", "203.0.113.7");
+    }
+
+    private Map<String, String> findEventMdc(String message) {
+        List<ILoggingEvent> events = listAppender.list;
+        for (ILoggingEvent event : events) {
+            if (message.equals(event.getMessage())) {
+                return event.getMDCPropertyMap();
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
@@ -56,9 +56,10 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    @DisplayName("preHandle 시 requestId / method / path 가 MDC 에 들어가고 X-Request-Id 헤더가 채워진다")
+    @DisplayName("preHandle 시 method / path 가 MDC 에 들어가고 traceId 가 있으면 X-Trace-Id 헤더가 채워진다")
     void preHandle_MDC_등록_성공() {
-        // given
+        // given — Micrometer Tracing 이 채웠을 traceId 를 시뮬레이션
+        MDC.put("traceId", "test-trace-abc123");
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123/answers");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
@@ -67,10 +68,26 @@ class LoggingInterceptorTest {
 
         // then
         assertThat(result).isTrue();
-        assertThat(MDC.get("requestId")).isNotBlank();
         assertThat(MDC.get("method")).isEqualTo("GET");
         assertThat(MDC.get("path")).isEqualTo("/forms/123/answers");
-        assertThat(response.getHeader("X-Request-Id")).isEqualTo(MDC.get("requestId"));
+        assertThat(response.getHeader("X-Trace-Id")).isEqualTo("test-trace-abc123");
+        // 별도 requestId UUID 는 발급하지 않는다 (FE 호환성)
+        assertThat(MDC.get("requestId")).isNull();
+        assertThat(response.getHeader("X-Request-Id")).isNull();
+    }
+
+    @Test
+    @DisplayName("traceId 가 없으면 X-Trace-Id 헤더도 비어 있어야 한다")
+    void preHandle_traceId_없을_때_헤더_미설정() {
+        // given — traceId 미주입 상태 (테스트 환경에는 Micrometer Tracing 가 없을 수 있다)
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(response.getHeader("X-Trace-Id")).isNull();
     }
 
     @Test
@@ -81,8 +98,8 @@ class LoggingInterceptorTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
         interceptor.preHandle(request, response, new Object());
 
-        // pre-condition: MDC 에 값이 들어있다
-        assertThat(MDC.get("requestId")).isNotBlank();
+        // pre-condition: MDC 에 method 등 값이 들어있다
+        assertThat(MDC.get("method")).isEqualTo("GET");
 
         // when
         interceptor.afterCompletion(request, response, new Object(), null);
@@ -130,8 +147,8 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    @DisplayName("인증된 MemberPrincipal 이 있으면 memberId 가 MDC userId 로 채워진다")
-    void preHandle_인증된_사용자_userId_MDC_등록() {
+    @DisplayName("인증된 MemberPrincipal 이 있으면 memberId 가 MDC 에 채워진다")
+    void preHandle_인증된_사용자_memberId_MDC_등록() {
         // given
         MemberPrincipal principal = new MemberPrincipal(42L);
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
@@ -146,12 +163,14 @@ class LoggingInterceptorTest {
         interceptor.preHandle(request, response, new Object());
 
         // then
-        assertThat(MDC.get("userId")).isEqualTo("42");
+        assertThat(MDC.get("memberId")).isEqualTo("42");
+        // 서비스 도메인 명명을 사용하므로 userId 는 사용하지 않는다
+        assertThat(MDC.get("userId")).isNull();
     }
 
     @Test
-    @DisplayName("익명 사용자는 MDC userId 가 채워지지 않는다")
-    void preHandle_익명_사용자_userId_MDC_미등록() {
+    @DisplayName("익명 사용자는 MDC memberId 가 채워지지 않는다")
+    void preHandle_익명_사용자_memberId_MDC_미등록() {
         // given — SecurityContext 가 비어있는 상태
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -160,7 +179,7 @@ class LoggingInterceptorTest {
         interceptor.preHandle(request, response, new Object());
 
         // then
-        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("memberId")).isNull();
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
@@ -6,6 +6,8 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.umc.product.global.security.MemberPrincipal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +18,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.HandlerMapping;
 
 /**
@@ -46,8 +50,9 @@ class LoggingInterceptorTest {
     @AfterEach
     void tearDown() {
         interceptorLogger.detachAppender(listAppender);
-        // 테스트 간 MDC 누수 방지
+        // 테스트 간 MDC / SecurityContext 누수 방지
         MDC.clear();
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -122,6 +127,40 @@ class LoggingInterceptorTest {
         // when / then — 예외 없이 통과
         interceptor.afterCompletion(request, response, new Object(), null);
         assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    @DisplayName("인증된 MemberPrincipal 이 있으면 memberId 가 MDC userId 로 채워진다")
+    void preHandle_인증된_사용자_userId_MDC_등록() {
+        // given
+        MemberPrincipal principal = new MemberPrincipal(42L);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+            principal, null, Collections.emptyList()
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(MDC.get("userId")).isEqualTo("42");
+    }
+
+    @Test
+    @DisplayName("익명 사용자는 MDC userId 가 채워지지 않는다")
+    void preHandle_익명_사용자_userId_MDC_미등록() {
+        // given — SecurityContext 가 비어있는 상태
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(MDC.get("userId")).isNull();
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/logging/ExternalApiCallLoggerTest.java
+++ b/src/test/java/com/umc/product/global/logging/ExternalApiCallLoggerTest.java
@@ -1,0 +1,132 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import net.logstash.logback.argument.StructuredArgument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ExternalApiCallLogger 가 external_api_called 이벤트를 통일된 스키마로 남기는지 검증한다.
+ *
+ * <p>핵심 invariant:
+ * <ul>
+ *     <li>성공 시: INFO, result=SUCCESS, durationMs 포함</li>
+ *     <li>실패 시: WARN, result=FAILURE, errorClass 포함, 예외 그대로 재던짐</li>
+ *     <li>예외 메시지는 어떤 필드에도 노출되지 않는다 (민감정보 정책)</li>
+ * </ul>
+ */
+class ExternalApiCallLoggerTest {
+
+    private Logger externalApiLogger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        externalApiLogger = (Logger) LoggerFactory.getLogger("external_api");
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        externalApiLogger.addAppender(listAppender);
+        externalApiLogger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        externalApiLogger.detachAppender(listAppender);
+    }
+
+    @Test
+    @DisplayName("성공 호출은 INFO + result=SUCCESS + durationMs 로 기록되고 반환값을 그대로 돌려준다")
+    void measure_성공_INFO_로깅() {
+        // when
+        String result = ExternalApiCallLogger.measure(
+            "GITHUB",
+            "FETCH_PULL_REQUESTS",
+            () -> "pr-list"
+        );
+
+        // then
+        assertThat(result).isEqualTo("pr-list");
+
+        ILoggingEvent event = onlyEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getMessage()).isEqualTo("external_api_called");
+        assertThat(kvOf(event, "provider")).isEqualTo("GITHUB");
+        assertThat(kvOf(event, "operation")).isEqualTo("FETCH_PULL_REQUESTS");
+        assertThat(kvOf(event, "result")).isEqualTo("SUCCESS");
+        assertThat(event.getArgumentArray()).anyMatch(arg -> arg.toString().contains("durationMs"));
+    }
+
+    @Test
+    @DisplayName("RuntimeException 발생 시 WARN + result=FAILURE + errorClass 가 기록되고 예외는 재던져진다")
+    void measure_실패_WARN_로깅_및_예외_재던지기() {
+        // given
+        IllegalStateException boom = new IllegalStateException("Bearer ya29.SECRET should not be logged");
+
+        // when / then
+        assertThatThrownBy(() ->
+            ExternalApiCallLogger.measure("OPENAI", "CHAT_COMPLETION", () -> {
+                throw boom;
+            })
+        ).isSameAs(boom);
+
+        ILoggingEvent event = onlyEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+        assertThat(event.getMessage()).isEqualTo("external_api_called");
+        assertThat(kvOf(event, "provider")).isEqualTo("OPENAI");
+        assertThat(kvOf(event, "operation")).isEqualTo("CHAT_COMPLETION");
+        assertThat(kvOf(event, "result")).isEqualTo("FAILURE");
+        assertThat(kvOf(event, "errorClass")).isEqualTo("IllegalStateException");
+
+        // 민감정보 정책: 예외 메시지가 어떤 필드에도 포함되지 않는다
+        for (Object arg : event.getArgumentArray()) {
+            assertThat(arg.toString()).doesNotContain("ya29.SECRET");
+        }
+    }
+
+    @Test
+    @DisplayName("Runnable 오버로드도 동일한 이벤트 스키마로 기록한다")
+    void measure_Runnable_오버로드() {
+        // when
+        ExternalApiCallLogger.measure("APPLE", "EXCHANGE_TOKEN", () -> { /* no-op */ });
+
+        // then
+        ILoggingEvent event = onlyEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(kvOf(event, "provider")).isEqualTo("APPLE");
+        assertThat(kvOf(event, "operation")).isEqualTo("EXCHANGE_TOKEN");
+        assertThat(kvOf(event, "result")).isEqualTo("SUCCESS");
+    }
+
+    private ILoggingEvent onlyEvent() {
+        List<ILoggingEvent> events = listAppender.list;
+        assertThat(events).hasSize(1);
+        return events.get(0);
+    }
+
+    /**
+     * StructuredArgument 의 key={@code key} 인 값을 string 으로 꺼낸다.
+     * logstash-logback-encoder 의 {@code kv(...)} 는 toString 이 {@code key=value} 형식이다.
+     */
+    private String kvOf(ILoggingEvent event, String key) {
+        for (Object arg : event.getArgumentArray()) {
+            if (arg instanceof StructuredArgument structured) {
+                String s = structured.toString();
+                String prefix = key + "=";
+                if (s.startsWith(prefix)) {
+                    return s.substring(prefix.length());
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #846
- related to [ADR-016: API 로그를 MDC 기반 JSON 구조화 로그로 전환한다](../blob/develop/docs/adr/016-structured-json-logging-with-mdc.md)
- related to [ADR-014: 모니터링 스택을 Grafana Cloud 에서 자체 홈서버로 이관한다](../blob/develop/docs/adr/014-self-hosted-monitoring-stack-migration.md)

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 2026-05-12 develop 브랜치를 기준으로 작업했어요.
- 변경 범위는 두 트랙이에요.
  - **앱 측 로깅 레이어**: `global/config/LoggingInterceptor.java`, `global/logging/ExternalApiCallLogger.java`(신규), `global/security/JwtAuthenticationFilter.java`, `authentication/adapter/out/external/AppleTokenVerifier.java`, `authentication/application/service/UmcProductOAuth2UserService.java`, `src/main/resources/logback-spring.xml`, `build.gradle.kts`
  - **인프라**: `docker/monitoring/` 하위 신규 (docker-compose + 7 컴포넌트 config + Grafana dashboard / datasource provisioning)

### 무엇을 · 어떻게 · 왜

1. **무엇을**: API 요청 / 응답 로그를 `[REQ]` / `[RES]` 텍스트 두 줄에서 `api_request_started` / `api_request_completed` JSON 단일 이벤트로 전환했어요.
   - **어떻게**: `logstash-logback-encoder:7.4` 의존성을 추가하고 `CONSOLE_JSON` 어펜더를 새로 정의했어요. `local` 프로필은 기존 텍스트 패턴을 유지하고 `dev` / `staging` / `prod` 만 JSON 으로 송신해요. `LoggingInterceptor` 를 다시 써서 `method`, `path`, `uriTemplate`, `statusCode`, `durationMs`, `queryCount`, `queryTimeMs`, `clientIp`, `memberId` 를 MDC 로 넣고, `afterCompletion` 의 `try/finally` 블록에서 `MDC.clear()` 를 강제했어요.
   - **왜**: Loki / Kibana 등에서 `| json | durationMs > 1000`, `uriTemplate="..."` 같은 필드 기반 검색이 가능해져요. 기존 텍스트 로그는 `path` 기준이라 P95 / P99 집계가 사실상 불가능했어요. 자세한 결정 배경은 [ADR-016](../blob/develop/docs/adr/016-structured-json-logging-with-mdc.md) 을 참고해 주세요.

2. **무엇을**: 단일 요청 식별자 키 이름을 FE 가 이미 사용 중인 `traceId` 그대로 두고, 사용자 식별자도 서비스 도메인 명명인 `memberId` 로 통일했어요.
   - **어떻게**: 초안에서는 별도 `requestId` UUID 를 발급하고 `X-Request-Id` 응답 헤더를 노출하려 했지만, FE 가 이미 `X-Trace-Id` / `traceId` 키로 운영 중이라 정정했어요. Micrometer Tracing 이 채운 `traceId` 를 그대로 노출하고, `MDC_USER_ID` 도 `MDC_MEMBER_ID` 로 변경했어요. ADR-016 본문의 Decision §1·§5 와 MDC 키 표준 표도 같이 정정했어요.
   - **왜**: FE 호환성을 깨지 않으면서 서비스 도메인 명명 (`memberId`) 으로 통일하기 위해서예요.

3. **무엇을**: 외부 API 호출 (GitHub / Apple / Kakao / LLM provider / 이메일 등) 의 성공·실패·소요시간을 통일된 `external_api_called` JSON 이벤트로 남기는 헬퍼 `ExternalApiCallLogger.measure(provider, operation, supplier)` 를 추가했어요.
   - **어떻게**: 성공 시 INFO + `result=SUCCESS` + `durationMs`, 실패 시 WARN + `result=FAILURE` + `errorClass` 를 남기고 예외는 재던져요. 예외 메시지는 의도적으로 노출하지 않아요(민감 정보 정책). 본 PR 은 hook 만 제공하고, 도메인별 적용 (GitHub / LLM 등) 은 별도 PR 로 분리해요.
   - **왜**: 외부 API 의 성공률 / 평균 응답시간 대시보드 / alerting 룰을 한 줄 LogQL 로 작성하기 위해서예요. ADR-016 §Commit #7 참고.

4. **무엇을**: 민감정보가 stdout / Loki 로 새어나갈 수 있는 두 지점을 정리했어요.
   - **어떻게**: `UmcProductOAuth2UserService` 의 `log.debug("Access Token: {} ID Token: {}", ...)` 라인을 제거했고, `AppleTokenVerifier` 의 token endpoint / revoke endpoint 에러 응답 본문 통째 로그를 `status + errorCode + bodyLength` 요약으로 교체했어요 (`extractAppleErrorCode` 헬퍼 추가).
   - **왜**: `dev` 프로필이 `com.umc.product` DEBUG 이고, Apple token endpoint 응답에는 access_token / id_token / refresh_token 이 포함되어 있어 기존 코드에는 토큰 평문 누출 위험이 있었어요.

5. **무엇을**: `docker/monitoring/` 하위에 자체 호스팅 모니터링 스택을 docker-compose 로 구성했어요. 7 개 컴포넌트 (prometheus, tempo, loki, otel-collector, grafana, alertmanager, node-exporter) 가 같은 네트워크에서 동작해요.
   - **어떻게**: OTel Collector 를 OTLP 게이트웨이로 두고, 앱이 보낸 metrics / traces / logs 를 각각 prometheus / tempo / loki 로 분배해요. Prometheus 는 `--enable-feature=otlp-write-receiver` 로 OTLP push 를 직접 받고, Tempo 는 OTLP 4317/4318 native, Loki 는 push API + OTLP logs 양쪽을 지원해요. Grafana 는 3 종 datasource 와 ADR-016 의 `api-performance` 대시보드를 provisioning 으로 자동 등록해요.
   - **왜**: 앱 코드를 손대지 않고 환경변수 `PROM_URL` / `TEMPO_URL` / `LOKI_URL` 만 본 스택의 endpoint 로 바꾸면 metrics / traces / logs 가 자체 호스팅 백엔드로 그대로 흘러가요. Phase 0 dual-write 가 필요해지면 collector 의 exporter 한 줄만 추가하면 돼요. 자세한 결정 배경은 [ADR-014](../blob/develop/docs/adr/014-self-hosted-monitoring-stack-migration.md) 의 Phase 1 을 참고해 주세요.

6. **무엇을**: 운영 대시보드와 알람 라우팅 골격을 추가했어요.
   - **어떻게**: Grafana `api-performance.json` 패널 5 종 (uriTemplate 별 P95 / P99 / 5xx count / slow request count / external API failure rate). Alertmanager 는 Discord webhook 으로 전송하도록 라우팅하고, critical / warning inhibit 룰을 두어 중복 송신을 막아요. Prometheus 의 `alerting` 섹션과 Loki 의 `ruler` 도 함께 활성화했어요.
   - **왜**: ADR-016 의 JSON 라인이 들어오는 즉시 대시보드와 알람이 동작 가능해야 트래픽 패턴 / SLA 측정이 시작돼요.

### 검증

- `./gradlew compileJava compileTestJava` — 통과 (기존 deprecation 경고 외 신규 에러 0)
- `./gradlew test --tests LoggingInterceptorTest --tests ExternalApiCallLoggerTest` — 11 / 11 통과 (preHandle MDC put / finally `MDC.clear()` / `api_request_completed` 의 MDC 스냅샷 / `X-Forwarded-For` clientIp / 인증 / 익명 사용자 / 외부 API 성공 / 실패 / 민감정보 미노출)
- `docker compose --env-file .env config --quiet` — 종료 코드 0, 7 개 서비스 모두 정상 파싱

## 💬 리뷰 중점사항

- **MDC 누수 / 익명 사용자 처리**: `LoggingInterceptor#afterCompletion` 의 `try/finally` 안에서 `MDC.clear()` 가 어떤 분기에서도 빠지지 않는지 확인 부탁드려요. 비동기 / `@Scheduled` / WebSocket 경로는 본 PR 범위 밖이라 별도 PR 에서 다룰 예정이에요.
- **민감정보 마스킹**: `AppleTokenVerifier` 의 `extractAppleErrorCode` 가 응답 본문에서 `error` 코드만 추출하는데, 본문이 빈/비정상 형식일 때 `"unknown"` 으로 fallback 되는 분기까지 확인 부탁드려요. 이메일 / `providerId` 같은 PII 마스킹은 본 PR 의 범위 밖이라 별도 정책 PR 로 분리할 예정이에요.
- **logback / 의존성 변경**: `build.gradle.kts` 의 `logstash-logback-encoder:7.4` 신규 추가와 `logback-spring.xml` 의 `CONSOLE_JSON` 어펜더 / `staging` 프로필 분기를 같이 봐주세요. ECR / CI 환경의 `SPRING_PROFILES_ACTIVE` 가 의도한 어펜더로 라우팅되는지 (특히 `staging` 신규 분기) 확인이 필요해요.
- **로그 1줄 크기 증가**: 텍스트(~200–300B) → JSON(~600–900B) 으로 2~3배 늘어나요. Loki ingestion / 디스크 사용량 모니터링 필요해요 (ADR-016 §Consequences §Negative).
- **인프라 보안 기본값**: `docker/monitoring/env.example` 의 `GRAFANA_ADMIN_PASSWORD=change-me` 와 `DISCORD_ALERT_WEBHOOK=`(빈 값) 은 로컬 검증용 디폴트예요. 운영 배포 전에는 반드시 강한 패스워드와 실제 webhook 으로 교체해야 해요. Cloudflare Tunnel / Basic Auth / TLS / object storage 는 Phase 2~3 작업으로 분리되어 있어요.
- **앱 환경변수 교체 시점**: 운영의 `PROM_URL` / `TEMPO_URL` / `LOKI_URL` 을 본 스택 endpoint 로 바꾸기 전에 ADR-014 §Phase 2 의 dual-write 검증 단계가 선행돼야 해요. 본 PR 만 머지된다고 운영 트래픽이 즉시 자체 호스팅으로 옮겨가는 건 아니에요.