### PR TITLE
[Feat] 여러 프로젝트의 멤버를 한 번에 조회하는 API 구현

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -108,7 +108,7 @@ public class ProjectQueryController {
         @CurrentMember MemberPrincipal memberPrincipal,
         @RequestParam List<Long> projectIds
     ) {
-        return assembler.membersForBatch(projectIds, memberPrincipal.getMemberId());
+        return assembler.listProjectMembers(projectIds, memberPrincipal.getMemberId());
     }
 
     @GetMapping("/me/managed")

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -18,6 +18,8 @@ import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -90,6 +92,23 @@ public class ProjectQueryController {
         @PathVariable Long projectId
     ) {
         return assembler.membersFor(projectId);
+    }
+
+    @GetMapping("/members")
+    @Operation(
+        summary = "[PROJECT-004] 프로젝트 팀원 구성 일괄 조회",
+        description = "복수의 projectId에 대한 팀원 구성을 조회합니다. 권한이 없거나 조회에 실패한 프로젝트는 결과에서 제외됩니다."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        permission = PermissionType.READ,
+        message = "프로젝트 조회 권한이 없습니다."
+    )
+    public Map<Long, ProjectMembersResponse> getBatchMembers(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @RequestParam List<Long> projectIds
+    ) {
+        return assembler.membersForBatch(projectIds, memberPrincipal.getMemberId());
     }
 
     @GetMapping("/me/managed")

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -1,5 +1,9 @@
 package com.umc.product.project.adapter.in.web.assembler;
 
+import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -21,9 +25,13 @@ import com.umc.product.project.application.port.out.LoadProjectApplicationFormPo
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectMember;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +48,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ProjectResponseAssembler {
 
     private final GetProjectUseCase getProjectUseCase;
@@ -47,6 +57,7 @@ public class ProjectResponseAssembler {
     private final GetMemberUseCase getMemberUseCase;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
+    private final CheckPermissionUseCase checkPermissionUseCase;
 
     /**
      * PROJECT-001 프로젝트 목록 조회.
@@ -125,36 +136,67 @@ public class ProjectResponseAssembler {
             ? Map.of()
             : getMemberUseCase.findAllByIds(memberIds);
 
-        MemberBrief productOwner = toBrief(memberMap.get(info.productOwnerMemberId()));
+        return buildMembersResponse(projectId, info, members, memberMap);
+    }
 
-        Map<ChallengerPart, List<MemberBrief>> partToMembers = new EnumMap<>(ChallengerPart.class);
-        for (ProjectMember m : members) {
-            MemberBrief brief = toBrief(memberMap.get(m.getMemberId()));
-            if (brief == null) continue;
-            partToMembers.computeIfAbsent(m.getPart(), p -> new java.util.ArrayList<>()).add(brief);
+    /**
+     * PROJECT-004 프로젝트 팀원 구성 일괄 조회.
+     * <p>
+     * 각 projectId에 대해 per-project 권한 체크 및 데이터 조회를 수행하며, 실패한 프로젝트는 결과에서 제외 멤버 정보는 유효한 프로젝트 전체를 모아 한 번에 조회한다.
+     */
+    public Map<Long, ProjectMembersResponse> membersForBatch(List<Long> projectIds, Long memberId) {
+        // Step 1: 권한 체크 + 프로젝트 정보 조회 (실패 시 skip)
+        Map<Long, ProjectInfo> validProjects = new LinkedHashMap<>();
+        for (Long projectId : projectIds) {
+            boolean hasAccess = checkPermissionUseCase.check(
+                memberId, ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ));
+            if (!hasAccess) {
+                log.warn("프로젝트 팀원 일괄 조회 - 접근 권한 없음: memberId={}, projectId={}", memberId, projectId);
+                continue;
+            }
+            try {
+                validProjects.put(projectId, getProjectUseCase.getById(projectId));
+            } catch (Exception e) {
+                log.warn("프로젝트 팀원 일괄 조회 - 프로젝트 조회 실패: projectId={}, reason={}", projectId, e.getMessage());
+            }
         }
 
-        Comparator<MemberBrief> byNickname = Comparator.comparing(
-            MemberBrief::nickname, Comparator.nullsLast(Comparator.naturalOrder()));
+        if (validProjects.isEmpty()) {
+            return Map.of();
+        }
 
-        List<MemberBrief> coProductOwners = partToMembers.getOrDefault(ChallengerPart.PLAN, List.of()).stream()
-            .filter(b -> !Objects.equals(b.memberId(), info.productOwnerMemberId()))
-            .sorted(byNickname)
-            .toList();
+        // Step 2: 파트 멤버 목록 조회 (실패 시 skip)
+        Map<Long, List<ProjectMember>> projectMembersMap = new HashMap<>();
+        for (Long projectId : validProjects.keySet()) {
+            try {
+                projectMembersMap.put(projectId, loadProjectMemberPort.listByProjectId(projectId));
+            } catch (Exception e) {
+                log.warn("프로젝트 팀원 일괄 조회 - 멤버 목록 조회 실패: projectId={}, reason={}", projectId, e.getMessage());
+            }
+        }
 
-        List<PartGroup> partGroups = java.util.Arrays.stream(ChallengerPart.values())
-            .filter(p -> p != ChallengerPart.PLAN)
-            .map(p -> new PartGroup(p,
-                partToMembers.getOrDefault(p, List.of()).stream().sorted(byNickname).toList()))
-            .filter(g -> !g.members().isEmpty())
-            .toList();
+        // Step 3: 유효한 전체 프로젝트의 멤버 ID를 모아 한 번에 조회
+        Set<Long> allMemberIds = new HashSet<>();
+        validProjects.forEach((projectId, info) -> {
+            allMemberIds.add(info.productOwnerMemberId());
+            projectMembersMap.getOrDefault(projectId, List.of())
+                .forEach(m -> allMemberIds.add(m.getMemberId()));
+        });
+        Map<Long, MemberInfo> memberMap = allMemberIds.isEmpty()
+            ? Map.of()
+            : getMemberUseCase.findAllByIds(allMemberIds);
 
-        return ProjectMembersResponse.builder()
-            .projectId(projectId)
-            .productOwner(productOwner)
-            .coProductOwners(coProductOwners)
-            .partGroups(partGroups)
-            .build();
+        // Step 4: 응답 조립 (멤버 목록 조회까지 성공한 프로젝트만 포함)
+        Map<Long, ProjectMembersResponse> result = new LinkedHashMap<>();
+        validProjects.forEach((projectId, info) -> {
+            if (!projectMembersMap.containsKey(projectId)) {
+                return;
+            }
+            result.put(projectId, buildMembersResponse(
+                projectId, info, projectMembersMap.get(projectId), memberMap));
+        });
+
+        return result;
     }
 
     /**
@@ -175,6 +217,43 @@ public class ProjectResponseAssembler {
             .toList();
 
         return DraftProjectResponse.from(info, owner, coOwners, resolveApplicationFormId(info.id()));
+    }
+
+    private ProjectMembersResponse buildMembersResponse(
+        Long projectId, ProjectInfo info, List<ProjectMember> members, Map<Long, MemberInfo> memberMap
+    ) {
+        MemberBrief productOwner = toBrief(memberMap.get(info.productOwnerMemberId()));
+
+        Map<ChallengerPart, List<MemberBrief>> partToMembers = new EnumMap<>(ChallengerPart.class);
+        for (ProjectMember m : members) {
+            MemberBrief brief = toBrief(memberMap.get(m.getMemberId()));
+            if (brief == null) {
+                continue;
+            }
+            partToMembers.computeIfAbsent(m.getPart(), p -> new ArrayList<>()).add(brief);
+        }
+
+        Comparator<MemberBrief> byNickname = Comparator.comparing(
+            MemberBrief::nickname, Comparator.nullsLast(Comparator.naturalOrder()));
+
+        List<MemberBrief> coProductOwners = partToMembers.getOrDefault(ChallengerPart.PLAN, List.of()).stream()
+            .filter(b -> !Objects.equals(b.memberId(), info.productOwnerMemberId()))
+            .sorted(byNickname)
+            .toList();
+
+        List<PartGroup> partGroups = Arrays.stream(ChallengerPart.values())
+            .filter(p -> p != ChallengerPart.PLAN)
+            .map(p -> new PartGroup(p,
+                partToMembers.getOrDefault(p, List.of()).stream().sorted(byNickname).toList()))
+            .filter(g -> !g.members().isEmpty())
+            .toList();
+
+        return ProjectMembersResponse.builder()
+            .projectId(projectId)
+            .productOwner(productOwner)
+            .coProductOwners(coProductOwners)
+            .partGroups(partGroups)
+            .build();
     }
 
     private Long resolveApplicationFormId(Long projectId) {

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -143,7 +143,7 @@ public class ProjectResponseAssembler {
      * <p>
      * 각 projectId에 대해 per-project 권한 체크 및 데이터 조회를 수행하며, 실패한 프로젝트는 결과에서 제외 멤버 정보는 유효한 프로젝트 전체를 모아 한 번에 조회한다.
      */
-    public Map<Long, ProjectMembersResponse> membersForBatch(List<Long> projectIds, Long memberId) {
+    public Map<Long, ProjectMembersResponse> listProjectMembers(List<Long> projectIds, Long memberId) {
         // Step 1: 권한 체크 + 프로젝트 정보 조회 (실패 시 skip)
         Map<Long, ProjectInfo> validProjects = new LinkedHashMap<>();
         for (Long projectId : projectIds) {

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -165,17 +164,13 @@ public class ProjectResponseAssembler {
             return Map.of();
         }
 
-        // Step 2: 파트 멤버 목록 조회 (실패 시 skip)
-        Map<Long, List<ProjectMember>> projectMembersMap = new HashMap<>();
-        for (Long projectId : validProjects.keySet()) {
-            try {
-                projectMembersMap.put(projectId, loadProjectMemberPort.listByProjectId(projectId));
-            } catch (Exception e) {
-                log.warn("프로젝트 팀원 일괄 조회 - 멤버 목록 조회 실패: projectId={}, reason={}", projectId, e.getMessage());
-            }
-        }
+        // Step 2: 유효한 전체 프로젝트의 파트 멤버를 IN 쿼리 한 번으로 조회 후 메모리 grouping
+        Map<Long, List<ProjectMember>> projectMembersMap =
+            loadProjectMemberPort.listByProjectIds(validProjects.keySet());
 
         // Step 3: 유효한 전체 프로젝트의 멤버 ID를 모아 한 번에 조회
+        // TODO: getProjectUseCase.getById() N+1 — validProjects 수만큼 호출됨.
+        //       GetProjectUseCase.listByIds() 배치 메서드 추가 후 개선 필요.
         Set<Long> allMemberIds = new HashSet<>();
         validProjects.forEach((projectId, info) -> {
             allMemberIds.add(info.productOwnerMemberId());
@@ -186,15 +181,11 @@ public class ProjectResponseAssembler {
             ? Map.of()
             : getMemberUseCase.findAllByIds(allMemberIds);
 
-        // Step 4: 응답 조립 (멤버 목록 조회까지 성공한 프로젝트만 포함)
+        // Step 4: 응답 조립
         Map<Long, ProjectMembersResponse> result = new LinkedHashMap<>();
-        validProjects.forEach((projectId, info) -> {
-            if (!projectMembersMap.containsKey(projectId)) {
-                return;
-            }
+        validProjects.forEach((projectId, info) ->
             result.put(projectId, buildMembersResponse(
-                projectId, info, projectMembersMap.get(projectId), memberMap));
-        });
+                projectId, info, projectMembersMap.getOrDefault(projectId, List.of()), memberMap)));
 
         return result;
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -3,6 +3,7 @@ package com.umc.product.project.adapter.out.persistence;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,8 @@ public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember,
     List<ProjectMember> findByProjectIdAndPartAndStatus(Long projectId, ChallengerPart part, ProjectMemberStatus status);
 
     List<ProjectMember> findByProjectIdAndStatus(Long projectId, ProjectMemberStatus status);
+
+    List<ProjectMember> findByProjectIdInAndStatus(Collection<Long> projectIds, ProjectMemberStatus status);
 
     Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId);
 

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -11,6 +11,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +40,13 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     @Override
     public List<ProjectMember> listByProjectId(Long projectId) {
         return repository.findByProjectIdAndStatus(projectId, ProjectMemberStatus.ACTIVE);
+    }
+
+    @Override
+    public Map<Long, List<ProjectMember>> listByProjectIds(Collection<Long> projectIds) {
+        return repository.findByProjectIdInAndStatus(projectIds, ProjectMemberStatus.ACTIVE)
+            .stream()
+            .collect(Collectors.groupingBy(pm -> pm.getProject().getId()));
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -19,6 +19,13 @@ public interface LoadProjectMemberPort {
     List<ProjectMember> listByProjectId(Long projectId);
 
     /**
+     * 여러 프로젝트의 활성(ACTIVE) 멤버를 한 번에 조회합니다 (N+1 방지용 IN 쿼리). PROJECT-004(팀원 일괄 조회)에서 사용.
+     *
+     * @return projectId → 활성 멤버 목록 맵. 활성 멤버가 없는 프로젝트는 엔트리 없음.
+     */
+    Map<Long, List<ProjectMember>> listByProjectIds(Collection<Long> projectIds);
+
+    /**
      * 특정 프로젝트의 특정 파트에 속한 ACTIVE 멤버 목록을 조회합니다. PLAN 파트 조회 시 보조 PM(coPM) 추출에 사용됩니다.
      */
     List<ProjectMember> listByProjectIdAndPart(Long projectId, ChallengerPart part);


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #809 

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

기존 GET api/v1/projects/{projectId}/members 를 이전에 말씀 주신 것처럼 projectId를 쿼리 파라미터 형식으로 여러 개 받아서 각 프로젝트들의 members 를 조회하고, Map으로 묶어 조회를 실패한 프로젝트는 조회되지 않도록 수정하였습니다. 기존 API 자체를 수정하지는 않고, 일단 유지 후 새롭게 추가하였습니다.

쿼리파라미터로 projectId를 받기 때문에, 2개 이상의 프로젝트 일괄 조회일 경우 @CheckAccess에서 resourceId를 파싱할 수 없어 내부에서 role에 대한 검증을 진행하는 방향으로 코드를 수정하였습니다.  

기존 프로젝트 별 member를 조회하는 방식에서, projectIds를 이용해 한 번에 member를 조회한 후, 응답을 재조립 하는 방식으로 수정함으로써 쿼리를 1회만 호출될 수 있도록 수정하였습니다.

 projectId를 쿼리 파라미터 형식으로 바꾸면서 기존 API는 삭제하면 되는건지 여쭤보고싶습니다!

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

