### PR TITLE
[Feat] 운영진 대시보드에서 KPI를 확인할 수 있는 API 구현

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+goals = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude
+.codex
 
 src/main/generated/
 

--- a/docs/analysis/project-survey-user-flow-2026-05-12.md
+++ b/docs/analysis/project-survey-user-flow-2026-05-12.md
@@ -1,0 +1,803 @@
+# Project · Survey 도메인 사용자 Flow 및 미구현 영역 분석 보고서
+
+- **작성일**: 2026-05-12
+- **분석 범위**: `src/main/java/com/umc/product/project`, `src/main/java/com/umc/product/survey`, Flyway 마이그레이션, 현재 open PR
+- **분석 대상 PR**
+  - `#843` [Refactor] 프로젝트 여러개 등록 가능하도록 DRAFT 룰 확장 (creator 기준)
+  - `#840` [Feat] 프로젝트 매칭 선발 도메인 API 개발 (PM 토글 + 자동 선발 + 동적 스케줄러)
+  - `#780` [Release] v2.0.0 (Survey 도메인이 Recruitment 를 대체했다는 history 확인용)
+- **목적**: 두 도메인의 현재 구현 상태를 사용자 입장 flow 로 정리하고, flow 별로 아직 채워지지 않은 영역을 식별해 다음 작업 우선순위를 도출
+
+---
+
+## 1. 도메인 개요
+
+### 1.1 Project 도메인
+헥사고날 아키텍처 (`domain` / `application` / `adapter`) 를 엄격히 따릅니다. UMC PRODUCT 의 한 기수 안에서 **프로젝트 등록 → 모집 → 매칭 → 팀 구성 → 종료** 까지의 생명주기를 담당합니다.
+
+**핵심 엔티티 (7개)**
+
+| 엔티티 | 책임 | 위치 |
+|---|---|---|
+| `Project` | 프로젝트 본체 · 상태 머신 (DRAFT/PENDING_REVIEW/IN_PROGRESS/COMPLETED/ABORTED) | [Project.java](src/main/java/com/umc/product/project/domain/Project.java) |
+| `ProjectApplication` | 챌린저 지원서 · 상태 머신 (DRAFT/SUBMITTED/APPROVED/REJECTED) | [ProjectApplication.java](src/main/java/com/umc/product/project/domain/ProjectApplication.java) |
+| `ProjectApplicationForm` | 프로젝트별 지원 폼 (Survey `Form` 으로 위임) | [ProjectApplicationForm.java](src/main/java/com/umc/product/project/domain/ProjectApplicationForm.java) |
+| `ProjectApplicationFormPolicy` | 폼 섹션 가시성 정책 (COMMON / PART) | [ProjectApplicationFormPolicy.java](src/main/java/com/umc/product/project/domain/ProjectApplicationFormPolicy.java) |
+| `ProjectMember` | 프로젝트 팀원 (ACTIVE/COMPLETED/WITHDRAWN/DISMISSED) | [ProjectMember.java](src/main/java/com/umc/product/project/domain/ProjectMember.java) |
+| `ProjectMatchingRound` | 매칭 차수 (지부별 · 차수 · 타입 단위, 일정 + 합불 마감) | [ProjectMatchingRound.java](src/main/java/com/umc/product/project/domain/ProjectMatchingRound.java) |
+| `ProjectPartQuota` | 파트별 정원(TO) | [ProjectPartQuota.java](src/main/java/com/umc/product/project/domain/ProjectPartQuota.java) |
+
+**상태 머신 요약**
+
+```
+Project:
+  DRAFT --submit--> PENDING_REVIEW --publish--> IN_PROGRESS --complete--> COMPLETED
+   │                       │                        │
+   └───────────────────────┴────── abort(reason) ──┴──> ABORTED
+
+ProjectApplication:
+  DRAFT --submit--> SUBMITTED --approve/reject--> APPROVED/REJECTED
+                              (auto-decide 도 동일 전이를 사용 — PR #840)
+```
+
+### 1.2 Survey 도메인
+독립적인 범용 설문 엔진. **Project 의 지원 폼**, **Notice 의 투표** 두 곳이 소비자입니다.
+
+| 엔티티 | 책임 |
+|---|---|
+| `Form` / `FormSection` / `Question` / `QuestionOption` | 폼 구조 (DRAFT/PUBLISHED) |
+| `FormResponse` | 한 응답자의 응답 루트 (DRAFT/SUBMITTED) |
+| `Answer` / `AnswerChoice` | 질문별 답변 (텍스트·파일·시간·객관식 선택) |
+
+**중요**: Survey 도메인은 **자체 Controller 가 없습니다.** Project 도메인의 `ProjectApplicationFormController` 와 Notice 의 투표 컨트롤러가 진입점입니다.
+
+### 1.3 Recruitment 도메인은 폐기됨
+`V2026.04.13.00.08__delete_recruitment_domain.sql` 에서 Recruitment 관련 7개 테이블이 일괄 DROP 되었습니다. Survey 가 그 자리를 완전히 대체합니다. 단 다음 잔재는 남아있습니다.
+
+- `QuestionType` enum 에 `PREFERRED_PART` (현재 미사용, deprecated)
+- `Form` 의 `starts_at` / `ends_at_exclusive` 컬럼은 V2026.04.21 마이그레이션으로 삭제 완료
+
+---
+
+## 2. 사용자 역할 정의
+
+본 보고서에서 사용하는 사용자(actor) 역할입니다.
+
+| Actor | 정의 | 권한 진입 |
+|---|---|---|
+| **PM (Project Manager / PO)** | `Project.productOwnerMemberId` 에 매핑된 PLAN 파트 챌린저 | EDIT (자기 프로젝트), APPROVE (지원서 합불) |
+| **Creator** | 프로젝트 DRAFT 를 작성한 주체 (`Project.createdByMemberId`). PM 본인일 수도, 운영진일 수도 있음 | DRAFT 단계 EDIT |
+| **챌린저** | 기수에 속한 일반 챌린저 (DESIGN/BE/FE 등). PLAN 챌린저는 PM 후보 | WRITE (프로젝트 지원), 자기 지원서 READ/EDIT/DELETE |
+| **지부장 / 학교장** | 운영진. `chapter`/`school` scope 의 MANAGE 권한 | MANAGE (publish, 매칭 차수 운영) |
+| **중앙 총괄단 (SUPER_ADMIN)** | 글로벌 운영진 | DELETE 포함 모든 권한 |
+| **시스템 (스케줄러)** | `MatchingRoundDeadlineScheduler` — 합불 마감 시각 + 10분 후 자동 발화 (PR #840) | `AutoDecideProjectMatchingRoundUseCase` 호출 |
+
+---
+
+## 3. 사용자 관점 Flow
+
+각 flow 는 **Actor**, **트리거 API / 이벤트**, **상태 전이**, **선후행 의존성**, **현재 구현 상태** 순으로 정리합니다. API ID 는 코드의 `Swagger summary` 기준입니다.
+
+### Flow A. PM 또는 운영진이 프로젝트 DRAFT 를 생성 · 작성 · 제출
+
+**Actor**: PLAN 파트 챌린저 (자기 자신을 PO 로) 또는 운영진 (다른 PLAN 챌린저를 PO 로 임명)
+
+**선결 조건**: 대상 기수가 존재하고, PO 후보가 해당 기수의 PLAN 파트 챌린저여야 함
+
+```
+1. [PROJECT-101] POST /api/v1/projects
+   → Project.createDraft() · status = DRAFT
+   → (creator, gisu) DRAFT 1개 제약 적용 (PR #843)
+
+2. [PROJECT-103] GET /api/v1/projects/me/draft?gisuId={gisuId}
+   → 화면 재진입 시 본인이 작성 중인 DRAFT 확인 (creator 기준)
+
+3. [PROJECT-102] PATCH /api/v1/projects/{projectId}
+   → Project.updateBasicInfo() · name/description/링크/로고/썸네일 보완
+
+4. [PROJECT-106] PUT /api/v1/projects/{projectId}/application-form
+   → Survey Form/Section/Question/Option 3계층 diff 동기화
+   → 섹션별 ProjectApplicationFormPolicy(COMMON / PART) 설정
+
+5. [PROJECT-105] PUT /api/v1/projects/{projectId}/part-quotas
+   → 파트별 정원(TO) 입력 — PLAN/DESIGN/BE/FE
+
+6. [PROJECT-107] POST /api/v1/projects/{projectId}/submit
+   → Project.submit() · DRAFT → PENDING_REVIEW
+   → (PR #843) 이 시점에 DRAFT 슬롯이 풀려 같은 creator 가 다음 DRAFT 시작 가능
+```
+
+**PR #843 으로 인한 룰 변경 (이 flow 의 핵심 차이)**
+
+| 항목 | AS-IS (v2.0.0) | TO-BE (PR #843) |
+|---|---|---|
+| 동일 기수 PO 중복 | (PO, gisu) 1개 강제 (모든 상태) | **제거** — PO 가 같은 기수에 여러 프로젝트 가능 |
+| Creator DRAFT 슬롯 | 없음 | **(creator, gisu) DRAFT 1개** · PostgreSQL partial unique index |
+| 차단 에러 코드 | `PROJECT_DUPLICATE_IN_GISU` | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` |
+| 슬롯 해제 시점 | — | DRAFT → PENDING_REVIEW 전이 즉시 |
+
+**시나리오**
+
+- 일반 PM 흐름: PM-A 가 본인을 PO 로 DRAFT 1개 작성 → 제출 → 동일 기수 두 번째 프로젝트 DRAFT 작성 가능
+- 운영진 일괄 등록: 운영진(requester) 이 PM-A 를 PO 로 DRAFT 만든 뒤 제출하면 그 즉시 PM-B 를 PO 로 새 DRAFT 시작 가능 (운영진 본인이 creator 로 슬롯 점유)
+
+**미구현 / 잔여 작업**
+
+- 없음 — PR #843 이 룰 변경의 코드 / 마이그레이션 / 테스트를 모두 포함
+
+---
+
+### Flow B. 운영진의 프로젝트 공개 (PENDING_REVIEW → IN_PROGRESS)
+
+**Actor**: 중앙 총괄단 또는 해당 지부장
+
+**선결 조건**: 대상 프로젝트가 `PENDING_REVIEW` 상태
+
+```
+[PROJECT-108] POST /api/v1/projects/{projectId}/publish
+  → ProjectPermissionEvaluator.MANAGE 권한 검사
+  → Project.publish() · PENDING_REVIEW → IN_PROGRESS
+  → 이후부터 챌린저가 지원 가능
+```
+
+**미구현 / 잔여 작업**
+
+- (P2) **publish 단계의 정원 / 폼 유효성 재검증 미흡**: `Project.submit()` 시점 검증과 publish 시점 검증이 별도 가드 없이 같은 도메인 메서드만 호출하는 구조. 정책 결정(예: 운영진이 publish 직전 폼을 마지막으로 확인하는 hook) 이 필요한지 확정 필요
+
+---
+
+### Flow C. 운영진의 매칭 차수 운영 (CRUD)
+
+**Actor**: 중앙 총괄단 또는 해당 지부장 (scope 는 Service 내부 검증)
+
+```
+[MATCHING-001] GET  /api/v1/project/matching-rounds            (목록 · chapterId/time 필터)
+[MATCHING-101] POST /api/v1/project/matching-rounds            (생성)
+[MATCHING-102] PATCH /api/v1/project/matching-rounds/{id}      (일정/메타 수정)
+[MATCHING-103] DELETE /api/v1/project/matching-rounds/{id}     (삭제, 연관 지원서 있으면 409)
+```
+
+**도메인 불변식**
+
+- `startsAt < endsAt < decisionDeadline` 순서 강제
+- 같은 (type, phase, chapter) 조합 UNIQUE (`uk_project_matching_round_type_phase_chapter`)
+- `validateNoOverlap`: 같은 지부 내 기간 중첩 차단
+
+**PR #840 으로 추가된 점**
+
+- 매칭 차수 생명주기(create/update/delete) 마다 `TaskScheduler` 에 1회성 task 를 등록/취소
+- `decisionDeadline + 10분` 에 자동 마감 finalize task 발화
+- 트랜잭션 commit 후(`afterCommit`) 등록 → 롤백 시 stale task 방지
+- JVM 부팅 시 `@PostConstruct` 로 미처리 round 모두 재등록, deadline+10 이 과거면 즉시 발화
+
+**미구현 / 잔여 작업**
+
+| 우선 | 항목 | 근거 |
+|---|---|---|
+| **P1** | **1차 매칭 시작 후 모든 차수 일정 PATCH 차단 정책 미구현** (= QA-14). 현재 `ProjectMatchingRound.reschedule()` / Service 모두 시작 이후 잠금 가드 없음. FE 가 disable 했더라도 BE 단에서 직접 PATCH 호출은 통과 | QA-14, [ProjectMatchingRound.java](src/main/java/com/umc/product/project/domain/ProjectMatchingRound.java) 의 `validateDates` / `reschedule` |
+
+---
+
+### Flow D. 챌린저 지원서 작성 → 제출
+
+**Actor**: 대상 기수의 DESIGN/BE/FE 챌린저 (PLAN 챌린저는 본인 프로젝트 대상 지원 불가 규칙은 별도 확인 필요)
+
+**선결 조건**
+
+- 부모 프로젝트가 `IN_PROGRESS`
+- 본인 파트 정원(`ProjectPartQuota`) 보유
+- 해당 매칭 차수가 OPEN (`startsAt ≤ now ≤ endsAt`)
+- 차수 타입이 본인 파트와 매칭 (DESIGN → `PLAN_DESIGN`, BE/FE → `PLAN_DEVELOPER`)
+- 기수 내 이미 ACTIVE 인 ProjectMember 가 아닐 것
+
+```
+1. [APPLY-001] POST /api/v1/projects/{projectId}/applications
+   → ProjectApplication.create() · status = DRAFT
+   → 내부적으로 Survey FormResponse(status=DRAFT) 함께 생성
+
+2. [APPLY-002] PUT  /api/v1/projects/{projectId}/applications/me
+   → FormResponse 답변 임시저장 (여러 번 가능, 형식 검증만)
+
+3. [APPLY-003] POST /api/v1/projects/{projectId}/applications/me/submit
+   → ProjectApplication.submit() · DRAFT → SUBMITTED
+   → submittedAt 기록 · 필수 답변 누락 검증
+```
+
+**가시성 규칙 (ProjectApplicationPermissionEvaluator)**
+
+- DRAFT 지원서는 **본인만** 조회 가능
+- SUBMITTED 부터 PO/Sub-PM/운영진에게 노출
+
+**미구현 / 잔여 작업**
+
+| 우선 | 항목 | 위치 |
+|---|---|---|
+| **P1** | `ProjectApplication.cancel()` (지원 철회) 도메인 메서드가 **빈 본문**. 사용자가 자신의 DRAFT/SUBMITTED 지원서를 철회할 수 있는 시나리오를 차단 중 | [ProjectApplication.java#L149](src/main/java/com/umc/product/project/domain/ProjectApplication.java) |
+| **P1** | DELETE 엔드포인트(예: `DELETE /api/v1/projects/{projectId}/applications/me`) 미존재. 권한 모델은 `ProjectApplicationPermissionEvaluator.DELETE` 가 이미 정의되어 있으나 호출처가 없음 |  |
+| **P2** | 동일 (form, round, applicant) 에 cancel 후 재지원 시 UK 충돌을 어떻게 풀지 미정 — soft delete (CANCELLED status 추가) 또는 UK 완화 결정 필요 |  |
+
+---
+
+### Flow E. PM 의 지원자 합 / 불 결정 (수동)
+
+**Actor**: 해당 프로젝트의 PO (또는 위임된 Sub-PM)
+
+```
+1. [APPLY-101] GET /api/v1/projects/{projectId}/applications
+       ?matchingRoundId=&part=&status=
+   → 지원자 목록 조회 (DRAFT 제외)
+
+2. [APPLY-102] GET /api/v1/projects/{projectId}/applications/{applicationId}
+   → 지원서 단건 상세 (폼 구조 + 답변 + 첨부 파일)
+
+3. [APPLY-103] PATCH /api/v1/projects/{projectId}/applications/{applicationId}/decision   ← PR #840
+   → ApplicationDecisionStatus = APPROVED | REJECTED | PENDING(=재토글)
+   → ProjectApplication.approve()/reject()/revertToPending()
+   → 잔여 quota 검증 (validateRemainingQuota) → QUOTA_EXCEEDED 시 409
+   → 차수 종료 후 시도 시 → MATCHING_ROUND_LOCKED 400
+```
+
+**미구현 / 잔여 작업**
+
+| 우선 | 항목 |
+|---|---|
+| **P1** | `ProjectApplicationQueryController` 의 [APPLY-101], [APPLY-102] 에 **`@CheckAccess` 가 아직 적용되지 않음**. 현재는 일반 챌린저가 호출해도 다른 프로젝트 지원자를 조회할 수 있는 보안 이슈. 코드 내 TODO 명시 ([ProjectApplicationQueryController.java](src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java) 87, 122 라인) |
+| **P2** | `ProjectQueryService` N+1 문제 — 페이지당 (3 × size + 1) 쿼리 발생 (코드 TODO) — 지원자 목록이 커질수록 영향 증가 |
+
+---
+
+### Flow F. 매칭 차수 자동 마감 + 자동 선발 (시스템) ⭐ PR #840
+
+**Actor**: 시스템 스케줄러 (`MatchingRoundDeadlineScheduler` → `MatchingRoundDeadlineHandler`)
+
+**트리거**: `ProjectMatchingRound.decisionDeadline + 10분` 도달
+
+```
+1. 스케줄러 발화
+   → AutoDecideProjectMatchingRoundUseCase 호출
+   → ProjectMatchingRoundFinalizationCommandService 실행 (멱등 보장)
+
+2. 정책 매트릭스 평가 (per Project × per Part)
+   ─ Designer 정책 (DesignerMatchingPolicy)
+     · 지원자 ≥ 2명 → 최소 1명 합격 강제
+     · 지원자 1명 → PM 결정 자유 (자동 합격 시키지 않음)
+   ─ Developer 정책 (DeveloperMatchingPolicy)
+     · 지원자 ≥ TO × 100% → 최소 ceil(TO × 0.5) 명 합격 강제
+     · TO × 50% ~ 100% → 최소 ceil(TO × 0.25) 명 합격 강제
+     · TO × 50% 미만 → 자동 합격 강제 없음
+
+3. 자동 선발 알고리즘
+   ─ 이미 PM 이 APPROVED 한 인원 유지
+   ─ 부족분 → SUBMITTED 풀에서 random pick
+   ─ 그래도 부족하면 → REJECTED 풀에서 override 합격
+
+4. ProjectApplication.applyAutoDecision() 으로 상태 전이
+   → SUBMITTED/REJECTED → APPROVED 또는 SUBMITTED → REJECTED
+
+5. APPROVED 결과 → ProjectMember 자동 생성 (part, decidedAt, application FK)
+6. ProjectMatchingRound.executeAutoDecision() 으로 실행 기록 (autoDecisionExecutedAt)
+```
+
+**Manual override**: `POST /api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` (운영진용 동일 진입점)
+
+**도메인 가드 / 멱등성**
+
+- `autoDecisionExecutedAt` 이 이미 채워진 round 는 재실행 차단
+- update 트랜잭션 롤백 시 `afterCommit` 으로 미뤄진 schedule 콜백이 실행되지 않음 → in-memory task ↔ DB 상태 일관성 유지
+
+**미구현 / 잔여 작업**
+
+- (P3) 차수 종료 후 ProjectMember 가 자동 등록되는 부수효과의 후속 알림(FCM/Discord 등) 연결은 본 PR 범위 외. 추후 필요 시 별도 use case 로 신설
+
+---
+
+### Flow G. 본인 지원 내역 조회
+
+**Actor**: 챌린저 본인
+
+```
+[APPLY-004] GET /api/v1/projects/me/applications?gisuId={gisuId}&status={status}
+  → MyProjectApplicationResponse 카드 리스트
+     1) application 카드 — SUBMITTED/APPROVED/REJECTED (DRAFT 제외)
+     2) RANDOM_MATCHING 카드 — ACTIVE 멤버이면서 application 이 없는 경우
+        (THIRD 라운드 이후 자동 랜덤 매칭 / 운영진 강제 배정 케이스)
+  → 정렬: 매칭 라운드 시작일 ASC → 갱신일 DESC
+```
+
+**미구현 / 잔여 작업**
+
+- (P3) RANDOM_MATCHING 카드가 합성되는 트리거(THIRD 라운드 후 자동 랜덤 매칭 / 운영진 강제 배정) 의 진입점은 아직 명시적으로 노출된 API 가 없음 — Flow H 의 `POST /members` 또는 별도 random matching use case 신설 필요 여부 검토
+
+---
+
+### Flow H. 프로젝트 팀원 관리 · 소유권 양도
+
+**Actor**: PO (또는 운영진의 강제 배정)
+
+```
+[PROJECT-004]  POST   /api/v1/projects/{projectId}/members         (팀원 추가)
+[PROJECT-005]  DELETE /api/v1/projects/{projectId}/members/{memberId} (팀원 제거)
+[PROJECT-104]  POST   /api/v1/projects/{projectId}/transfer-ownership  (소유권 양도)
+```
+
+**팀원 제거 정책**
+
+- DRAFT / PENDING_REVIEW: hard delete
+- IN_PROGRESS: soft delete (`status = DISMISSED`, 사유 저장)
+- COMPLETED / ABORTED: 불가
+
+**소유권 양도 (PR #843 변경 반영)**
+
+- 새 PO 가 PLAN 파트 챌린저 여부 검증
+- (PR #843 이전) 새 PO 가 같은 기수에 다른 프로젝트의 PO 였으면 차단 → **(PR #843 이후) 차단 제거 — 동일 기수에서 PO 가 여러 프로젝트를 가질 수 있음**
+- `productOwnerSchoolId`, `chapterId` 도 새 PO 기준으로 동기화
+
+**미구현 / 잔여 작업**
+
+- (P2) `ProjectMemberJpaRepository` 의 QueryDSL 마이그레이션이 일부 미적용 (코드 TODO) — 일관성 차원의 후속 정리
+- (P3) 운영진이 강제 배정 시 PM 에게 통보하는 알림 채널이 명시되어 있지 않음
+
+---
+
+### Flow I. 프로젝트 생명주기 마감 (COMPLETED / ABORTED)
+
+**Actor**: 운영진 (또는 시스템에 의한 기수 종료 일괄 처리)
+
+```
+정상 종료: Project.complete() · IN_PROGRESS → COMPLETED
+와해:    Project.abort(reason, decidedByMemberId) · 어떤 상태든 → ABORTED
+```
+
+**미구현 / 잔여 작업**
+
+| 우선 | 항목 |
+|---|---|
+| **P1** | **현재 코드에 `complete` / `abort` 를 외부에서 트리거할 수 있는 Controller endpoint 가 노출되어 있지 않음.** 도메인 메서드(`Project.complete()`, `Project.abort()`) 와 상태 enum 만 존재. 기수 종료 시 일괄 종료 흐름 또는 운영진 단건 abort 흐름의 API · UseCase 정의 필요 |
+| **P2** | 종료 시 `ProjectMember.status` (ACTIVE → COMPLETED/WITHDRAWN) 일괄 전이 로직 미정. 종료 use case 가 부수효과로 멤버 상태도 갱신해야 일관성 유지 |
+
+---
+
+### Flow J. Survey 폼 자체 운영 (직접 호출 경로)
+
+**Actor**: 현재로서는 **Project 도메인의 Service 만**
+
+Survey 도메인은 **자체 Controller 가 없습니다.** 외부에서 직접 호출 가능한 진입점은 다음 둘만 존재합니다.
+
+- `ProjectApplicationFormController` (`/api/v1/projects/{projectId}/application-form`) — PUT/GET
+- Notice 도메인의 투표 컨트롤러 (`POST /api/v1/notices/{noticeId}/votes` 등)
+
+**Survey UseCase 의 미구현 / 결정 보류 항목 (코드 TODO 기준)**
+
+| 우선 | 항목 |
+|---|---|
+| **P2** | `ManageFormUseCase.updateForm()`: 발행된 폼도 수정 가능한지 정책 미확정 |
+| **P2** | `ManageFormSectionUseCase`: 발행된 폼 / 응답이 들어온 폼의 섹션 구조 변경 차단 정책 미확정 |
+| **P2** | `ManageQuestionUseCase`: 발행된 폼에서 질문 수정 불가(=`SURVEY_NOT_DRAFT`) 정책 적용 미확정. Project 도메인의 `shouldFork` 플래그로 Copy-on-Write 우회로만 존재 |
+| **P2** | `ManageQuestionOptionUseCase`: 발행된 폼 / 응답이 들어온 폼의 선택지 변경 차단 정책 미확정 |
+| **P3** | `QuestionCommandService`: 질문 type 변경 시 기존 응답(Answer) 무효화 정책 미정 (현재는 보존) |
+| **P3** | `CreateDraftFormCommand`: `form.title` 이 `nullable=false` 라 최초 생성 시 빈 값 허용 불가 — UX 결정 필요 |
+| **P3** | `AnswerChoice` 의 집계 JPQL 미작성 (코드 TODO) — 투표 선택지별 카운트 등 결과 집계 API 가 추가될 때 같이 필요 |
+| **P3** | **Survey 도메인 전용 통합 테스트 없음** — Project 통합 테스트가 간접적으로 커버 |
+
+---
+
+## 4. 미구현 영역 종합 정리
+
+### 4.1 차단성 (P1) — 운영 배포 전 반드시 해결
+
+| # | 영역 | 항목 | 근거 |
+|---|---|---|---|
+| 1 | Flow D · 보안 | `ProjectApplicationQueryController` [APPLY-101], [APPLY-102] 에 `@CheckAccess` 미적용 → 일반 챌린저가 다른 프로젝트 지원자 조회 가능 | 코드 TODO ([ProjectApplicationQueryController.java#L87](src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java#L87), L122) |
+| 2 | Flow D | 지원서 철회 (`ProjectApplication.cancel()`) 도메인 메서드가 빈 본문, DELETE 엔드포인트도 부재 | [ProjectApplication.java#L44](src/main/java/com/umc/product/project/domain/ProjectApplication.java#L44), L149 |
+| 3 | Flow I | 프로젝트 `complete` / `abort` 를 외부에서 트리거할 수 있는 Controller / UseCase 부재 | 코드 전수 조사 결과 endpoint 없음 |
+
+### 4.2 정책 미확정 (P2) — 결정만 되면 빠르게 구현 가능
+
+| # | 영역 | 항목 |
+|---|---|---|
+| 1 | Flow J | Survey 폼 / 섹션 / 질문 / 선택지의 **발행 후 편집 정책** 4건 미확정 (Form, FormSection, Question, QuestionOption) |
+| 2 | Flow D | 지원 철회 후 재지원 시 UK (`uk_project_application_form_member_matching_round`) 충돌 처리 방식 미정 |
+| 3 | Flow B | publish 직전 폼 / 정원 재검증 hook 필요 여부 미정 |
+| 4 | Flow I | 종료 시 `ProjectMember.status` 일괄 전이 정책 미정 |
+| 5 | Flow C (QA-14) | **1차 매칭 시작 후 모든 차수 일정 PATCH 잠금 정책 미구현**. FE 는 비활성화 표시하나 BE 가드 부재 → 직접 PATCH 호출 시 통과 |
+| 6 | Flow E (QA-11) | **Admin 의 매칭 종료 후 합/불 토글 우회 정책 미구현**. 현재 `MATCHING_ROUND_LOCKED` 가드는 권한 무관하게 일괄 차단 → 운영진 override 분기 필요 |
+| 7 | Flow H (QA-16) | **운영진의 임의 팀원 배정 endpoint 권한 분기 미구현**. 현재 `POST /projects/{id}/members` 는 `EDIT` (PO 권한) 만 통과 → MANAGE 권한자에게도 허용하는 분기 필요. ACTIVE 멤버 후보 필터링 (다른 프로젝트 중복 차단) 도 함께 |
+
+### 4.3 성능 / 일관성 / UX (P3) — 후속 작업
+
+| # | 영역 | 항목 |
+|---|---|---|
+| 1 | Flow E · 성능 | `ProjectQueryService` N+1: 페이지당 (3 × size + 1) 쿼리 (코드 TODO) |
+| 2 | Flow H · 일관성 | `ProjectMemberJpaRepository` QueryDSL 마이그레이션 미완 (코드 TODO) |
+| 3 | Flow G | RANDOM_MATCHING 카드 합성 트리거 (랜덤 매칭 / 강제 배정) 의 명시적 API 미존재 |
+| 4 | Flow F · 알림 | 자동 선발 후 합/불 통보 채널 연결 (FCM / Discord) |
+| 5 | Flow J · 테스트 | Survey 도메인 단위 / 통합 테스트 부재 (현재 Project 통합 테스트로 간접 커버) |
+| 6 | Flow J · UX | `Form.title` nullable 정책, `QuestionType.PREFERRED_PART` 레거시 enum 정리 |
+| 7 | Flow J · 기능 | 폼 응답 결과 집계 API (선택지별 카운트 등) 부재 |
+
+---
+
+## 5. 권장 다음 작업
+
+PR 의존성을 고려한 추천 순서입니다. 상세 PR 묶음은 §6.5 (구현 실행 계획) 참고.
+
+1. **PR-1** (§6.5) — PR #843 / #840 회귀 안전망 테스트 (Flow A · F · E 일부)
+2. **PR-2** (§6.5) — P1 차단성 3건 (권한 분기 / 지원 철회 / 프로젝트 종료)
+3. **PR-3** (§6.5) — 노션 QA 미구현 3건 (QA-11 Admin override / QA-14 1차 시작 후 PATCH 잠금 / QA-16 운영진 강제 배정)
+4. **PR-4** (§6.5) — 응답 메타 보강 + 잔여 회귀 안전망 (노션 QA 의 응답 스키마 검증 9건)
+5. **PR-5** (§6.5) — P2 정책 미확정 항목 7건을 **단일 ADR 1편** 으로 결정 후 후속 PR (Survey 발행 후 편집 / 지원 철회 후 재지원 UK / publish hook / 종료 시 멤버 전이 / 1차 시작 후 PATCH 잠금 범위 / Admin override 사유 모델 / 운영진 임의 배정 후보 정책)
+6. P3 성능 항목 (N+1, QueryDSL 마이그레이션) 은 별도 refactor PR 로 분리 — 기능 PR 과 섞으면 review 부담 증가
+
+---
+
+## 6. e2e 검증 시나리오 (Project Integration Test 매핑)
+
+> **출처**: 본 섹션의 시나리오는 (1) 코드 베이스(도메인 메서드 / 권한
+> evaluator / Flyway UK / PR #843·#840 본문) 와 (2) 노션 [📌 UPMS 관련 QA](https://www.notion.so/UPMS-QA-35e39ff67177804eb1d5c76e0f2fd9ca)
+> 데이터베이스의 QA 시나리오 25건을 종합하여 정의했습니다. 각 노션 항목은
+> `QA-NN` 형식으로 식별합니다 (매핑은 §6.2 표 참고).
+
+### 6.1 노션 QA 시나리오 25건 분류 (백엔드 검증 가능성)
+
+각 QA 항목을 **백엔드 e2e 테스트로 검증 가능한 것 / FE 단독 / 분석 범위 외**
+3분류로 정리합니다.
+
+| QA | 권한 | 기능 | 테스트 케이스 (요약) | 분류 | 매핑 Flow |
+|---|---|---|---|---|---|
+| QA-01 | Plan Chal, Admin | 프로젝트 등록 | 지원 문항 화면에서 [임시 저장] | 🟦 **BE** | Flow A (폼 PUT) |
+| QA-02 | Plan Chal | 지원 현황 | 매칭 기간 종료 후 합/불/대기 토글 시도 (PM) | 🟦 **BE** | Flow E |
+| QA-03 | Plan Chal, Admin | 지원 현황 | 지원 현황 탭 진입 — 통계·필터·페이지네이션 | 🟦 **BE 부분** | Flow E (목록 API) |
+| QA-04 | Plan Chal, Admin | 프로젝트 등록 | 등록 중 페이지 이탈 모달 | ⬜ **FE only** | — |
+| QA-05 | Admin | 공지 | 공지 작성 | ⚪ 범위 외 | Notice 도메인 |
+| QA-06 | Plan Chal, Admin | 프로젝트 등록 | [등록하기] 버튼 → 등록 완료 모달 | 🟦 **BE** | Flow A (submit) |
+| QA-07 | Plan Chal, Other Chal | 공지 | 타 지부 공지 열람 차단 | ⚪ 범위 외 | Notice access scope |
+| QA-08 | Plan Chal, Admin | 프로젝트 등록 | 기본 정보 다음 → 2단계 건너뛰고 3단계 | ⬜ **FE only** | — |
+| QA-09 | Other Chal | 프로젝트 목록 | 내 지부 프로젝트 클릭 → [지원하기] 활성 | 🟦 **BE** | Flow D (진입 조건) |
+| QA-10 | Admin | 공지 | 공지 수정 | ⚪ 범위 외 | Notice 도메인 |
+| QA-11 | Admin | 지원 현황 | 매칭 기간 종료 후 합/불 토글 (Admin 우회) | 🟦 **BE 미구현** | Flow E (관리자 override) |
+| QA-12 | Other Chal | 프로젝트 목록 | 본인이 지원한 프로젝트 → [내 지원서 확인하기] | 🟦 **BE** | Flow D + G |
+| QA-13 | Admin, Plan Chal, Other Chal | 프로젝트 관리 | 상태 변경 후 지원자 화면에서 일치 반영 | 🟦 **BE** | Flow E ↔ G |
+| QA-14 | Admin | 매칭 차수 설정 | 1차 매칭 시작 이후 차수 기간 PATCH 차단 | 🟦 **BE 미구현** | Flow C |
+| QA-15 | Admin | 매칭 차수 설정 | 일정 누락 후 저장 → validation 차단 | 🟦 **BE** | Flow C (POST/PATCH validation) |
+| QA-16 | Admin | 매칭 현황 | 빈칸 클릭 → 운영진 임의 배정 | 🟦 **BE 미구현** | Flow H (운영진 add-member) |
+| QA-17 | Admin | 매칭 차수 설정 | 입력 후 다른 탭 이탈 모달 | ⬜ **FE only** | — |
+| QA-18 | Admin | 매칭 현황 | 배정 팀원 이름 클릭 → 파트 지원서 모달 + 상태 재변경 | 🟦 **BE** | Flow E (재토글) |
+| QA-19 | Admin | 프로젝트 목록 | 프로젝트 클릭 → [모집 문항 보기] 노출 (Admin) | 🟦 **BE** | Flow J (Admin 폼 READ) |
+| QA-20 | Plan Chal | 프로젝트 목록 | 내 지부 프로젝트 → [모집 문항 보기] (PM) | 🟦 **BE** | Flow J (PM 폼 READ) |
+| QA-21 | Plan Chal, Admin | 프로젝트 등록 | 섹션 사용 토글 + 문항 편집 | 🟦 **BE** | Flow J (PUT diff) |
+| QA-22 | Other Chal | 프로젝트 목록 | 타 지부 프로젝트 → 지원 버튼 숨김 | 🟦 **BE** | Flow D (access scope) |
+| QA-23 | Other Chal | 프로젝트 목록 | 지원하지 않은 타 프로젝트 열람 → 지원 버튼 숨김 | 🟦 **BE** | Flow D (access scope) |
+| QA-24 | Plan Chal, Admin | 프로젝트 등록 | 1단계 미완료 상태 → 다음 단계 클릭 차단 | ⬜ **FE only** | — |
+| QA-25 | Plan Chal, Admin | 프로젝트 등록 | 1단계 필수 누락 후 [다음] | 🟦 **BE 부분** | Flow A (submit validation) |
+
+**요약**
+
+- 🟦 **BE 검증 가능 (16건)**: e2e 테스트로 직접 옮기는 대상
+- 🟦 **BE 미구현 (3건)**: QA-11 (Admin 매칭 종료 후 우회), QA-14 (1차 시작 후 PATCH 차단), QA-16 (운영진 임의 배정) — 도메인 / endpoint 보강 후 RED → GREEN
+- ⬜ **FE only (4건)**: 페이지 이탈 모달, 세그먼트 이동, 툴팁 등 — 백엔드 변경 없음
+- ⚪ **분석 범위 외 (2건)**: Notice 도메인 — 본 보고서는 Project/Survey 한정이라 제외 (다만 QA-07 의 "지부별 공지 access scope" 패턴은 Project Flow D 의 access scope 검증과 동일 구조)
+
+---
+
+### 6.2 테스트 인프라 — 어디에 어떻게 작성하나
+
+본 프로젝트는 `IntegrationTestSupport` 패턴이 이미 정착되어 있어 각 flow 를
+바로 e2e 통합 테스트로 옮길 수 있습니다.
+
+**베이스 ([IntegrationTestSupport.java](src/test/java/com/umc/product/support/IntegrationTestSupport.java))**
+
+- `@SpringBootTest` + Testcontainers PostgreSQL/PostGIS 로 전체 Spring
+  컨텍스트 부트업, MockMvc 자동 구성
+- `@DatabaseIsolation` — 각 테스트 종료 후 모든 테이블 TRUNCATE (FK CASCADE)
+- 외부 시스템(메일/JWT/FCM/GCS/StoragePort) 만 `@MockitoBean` 으로 대체.
+  **도메인 / 애플리케이션 빈은 모킹 금지**
+
+**Fixture (src/test/java/com/umc/product/support/fixture/)**
+
+- 이미 구비: `MemberFixture`, `GisuFixture`, `ChapterFixture`, `SchoolFixture`,
+  `ChallengerFixture`, `ChallengerRoleFixture`
+- **신규 필요**: `ProjectFixture`, `ProjectApplicationFormFixture`,
+  `ProjectMatchingRoundFixture`, `ProjectPartQuotaFixture`,
+  `ProjectApplicationFixture`, `ProjectMemberFixture`
+  - 패턴은 [GisuFixture](src/test/java/com/umc/product/support/fixture/GisuFixture.java) 동일
+    (Save Port 를 주입받아 도메인 팩토리 메서드로 생성·저장)
+
+**참고 예시**: [ProjectMatchingRoundControllerIntegrationTest.java](src/test/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundControllerIntegrationTest.java) —
+이 클래스의 구조(인증 헬퍼 + Fixture 주입 + MockMvc DSL)를 그대로 차용
+
+**컨벤션 (CLAUDE.md 발췌)**
+
+- 테스트 클래스명: `{Domain}IntegrationTest` 또는 시나리오 단위 `{Flow}E2ETest`
+- 메서드명은 한국어 (`@DisplayName` 또는 메서드 본명)
+- Given / When / Then 주석으로 단계 구분
+- `new` 로 도메인 엔티티 직접 생성 금지 — Fixture 또는 도메인 팩토리 메서드 사용
+- 통합 테스트 클래스에 `@Transactional` 부여 금지 (운영 트랜잭션 경계 위배)
+
+### 6.3 Flow ↔ Test 시나리오 매핑
+
+각 시나리오는 `Given (사전 상태)` → `When (HTTP 호출 또는 시스템 이벤트)`
+→ `Then (HTTP 응답 + DB 상태 + 도메인 불변식)` 으로 표현하며, 검증 포인트가
+하나라도 깨지면 실패해야 합니다. **상태표(Status)** 는 본 보고서 기준 추천
+상태입니다 (✅ 즉시 구현 가능 / 🟡 차단 항목 해결 필요 / 🔴 미구현 — RED
+테스트로 먼저 작성 권장).
+
+---
+
+#### Flow A — `ProjectDraftE2ETest` (PR #843 룰 검증)
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| A1 | PLAN 챌린저가 본인을 PO 로 DRAFT 생성 후 PROJECT-103 으로 재진입 | 기수+지부+PLAN 챌린저(memberId=100) | POST /projects → GET /projects/me/draft?gisuId | 201 응답 projectId 와 GET 응답 projectId 동일, `project.status=DRAFT`, `created_by_member_id=100`, `product_owner_member_id=100` | — | ✅ |
+| A2 | 동일 creator 가 같은 기수에 두 번째 DRAFT 시도 → 409 차단 | A1 직후 DRAFT 보유 | POST /projects 재호출 | HTTP 409 `PROJECT_DRAFT_ALREADY_IN_PROGRESS`, DB row 수 변화 없음 | — | ✅ |
+| A3 | A1 의 DRAFT 를 submit 한 직후 같은 creator 가 새 DRAFT 시도 → 허용 | A1 의 DRAFT → POST submit | POST /projects 재호출 | 201, 새 projectId, partial unique index `uk_project_creator_gisu_draft` 충돌 없음 | — | ✅ |
+| A4 | PO 가 같은 기수에 이미 다른 프로젝트 PO 인 경우 새 DRAFT 가 별도 creator 로 들어와도 허용 | PM-A 가 기수=1 PO 인 PENDING_REVIEW 프로젝트 보유 | 운영진(creator=200) 이 PM-A 를 PO 로 DRAFT 생성 | 201, `project.product_owner_member_id=PM-A`, `created_by_member_id=200` (= PR #843 의 핵심 — PO 중복 차단 제거 검증) | — | ✅ |
+| A5 | DRAFT 단계 폼 PUT/정원 PUT → submit | A1 의 DRAFT | PUT /application-form → PUT /part-quotas → POST /submit | submit 응답 200, `project.status=PENDING_REVIEW`, `form` / `form_section` / `question` / `question_option` / `project_part_quota` 행 존재 | QA-01, QA-06 | ✅ |
+| A6 | 운영진이 PM-A 임명 DRAFT → 제출 → 즉시 PM-B 임명 DRAFT 시작 | 운영진 creator=200 | POST /projects(PO=PM-A) → submit → POST /projects(PO=PM-B) | 두 번째 POST 도 201 (PR #843 시나리오 #4) | — | ✅ |
+| A7 | submit 시 필수 항목 누락 → 400 | DRAFT, name 또는 part_quotas 미입력 | POST /submit | 400 `PROJECT_SUBMIT_VALIDATION_FAILED`, 상태 미변경 | QA-25 | ✅ |
+
+**필요 Fixture 추가**: `ProjectFixture.draftBy(creatorMemberId, productOwnerMemberId, gisuId, chapterId)`
+
+---
+
+#### Flow B — `ProjectPublishE2ETest`
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| B1 | 지부장이 PENDING_REVIEW 프로젝트 publish | PENDING_REVIEW 프로젝트 + 지부장 권한 | POST /projects/{id}/publish | 200, `project.status=IN_PROGRESS` | — | ✅ |
+| B2 | 일반 챌린저가 publish 시도 → 403 | PENDING_REVIEW + 일반 챌린저 | 동일 호출 | 403, 상태 미변경 | — | ✅ |
+| B3 | DRAFT 상태에서 publish 시도 → 400 | DRAFT | 동일 호출 | 400 (도메인 invalid state), 상태 미변경 | — | ✅ |
+| B4 | 이미 IN_PROGRESS 인 프로젝트 publish → 400 | IN_PROGRESS | 동일 호출 | 400 | — | ✅ |
+
+---
+
+#### Flow C — `ProjectMatchingRoundIntegrationTest` (확장)
+
+기존 [ProjectMatchingRoundControllerIntegrationTest](src/test/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundControllerIntegrationTest.java) 에 통합.
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| C1 | 지부장이 본인 지부 매칭 차수 생성 | 지부장 권한 | POST /project/matching-rounds | 201, DB 행 존재 | — | ✅ (기존) |
+| C2 | 다른 지부에 매칭 차수 생성 시도 → 403 | 지부장 | 다른 chapterId 로 POST | 403 | — | ✅ |
+| C3 | 동일 (type, phase, chapter) 중복 생성 → 409 | C1 직후 | 동일 조합 POST | 409, UK `uk_project_matching_round_type_phase_chapter` 충돌 | — | ✅ |
+| C4 | startsAt ≥ endsAt 인 요청 → 400 | — | POST 잘못된 날짜 | 400 (`validateDates`) | QA-15 | ✅ |
+| C5 | 동일 지부 기간 중복 → 409 | C1 직후 | 겹치는 기간 POST | 409 (`validateNoOverlap`) | — | ✅ |
+| C6 | 연관 지원서가 있는 차수 삭제 → 409 | C1 직후 지원서 1건 | DELETE | 409, 행 미삭제 | — | ✅ |
+| C7 | 차수 update 시 스케줄러 task 재등록 | C1 + 스케줄러 spy | PATCH (decisionDeadline 변경) | 기존 task cancel + 새 task register, JVM 재시작 후에도 `@PostConstruct` 로 재등록 | — | ✅ (PR #840) |
+| C8 | 일정 일부 누락 → 400 | startsAt 또는 decisionDeadline 미입력 | POST | 400, 명확한 필드별 에러 메시지 (각 일정 필드 단위로) | QA-15 | ✅ |
+| C9 | **1차 매칭 startsAt 이 경과한 시점 이후, 1차 ~ 랜덤 매칭의 모든 차수 일정 PATCH 차단** | 1차 round `startsAt < now` 인 round 가 chapter 에 존재 | 어떤 round 든 PATCH (startsAt/endsAt/decisionDeadline 중 하나) | 400 `MATCHING_ROUND_PERIOD_LOCKED` 같은 도메인 에러, 행 미변경 | **QA-14** | 🔴 **미구현** |
+
+---
+
+#### Flow D — `ProjectApplicationLifecycleE2ETest`
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| D1 | DESIGN 챌린저가 PLAN_DESIGN 차수 OPEN 상태에서 APPLY-001/002/003 흐름 | IN_PROGRESS 프로젝트 + DESIGN 정원 보유 + 매칭 차수 OPEN | POST → PUT → POST submit | 각 단계 응답 200/201, `project_application.status` 가 `DRAFT → SUBMITTED`, `submitted_at` 기록, `form_response.status=SUBMITTED` | — | ✅ |
+| D2 | BE 챌린저가 PLAN_DESIGN 차수에 지원 시도 → 400 | 동일 + BE 챌린저 | POST APPLY-001 | 400 (차수 타입 불일치) | — | ✅ |
+| D3 | 정원이 0 인 파트에 지원 시도 → 400 | 정원 0 | POST APPLY-001 | 400 | — | ✅ |
+| D4 | 차수 OPEN 시각 이전 / 이후 지원 → 400 | 차수 startsAt 미도래 또는 endsAt 경과 | POST APPLY-001 | 400 (`isOpenAt=false`) | — | ✅ |
+| D5 | 동일 (form, round, applicant) 중복 SUBMITTED 차단 | D1 SUBMITTED 직후 재호출 | POST APPLY-001 | 409, UK `uk_project_application_form_member_matching_round` 충돌 | — | ✅ |
+| D6 | 본인 SUBMITTED 지원서를 다른 챌린저가 GET 시도 → 403 | D1 SUBMITTED | 다른 챌린저 토큰으로 APPLY-102 호출 | 403 (현재는 미적용 → **RED 로 우선 작성**) | — | 🟡 P1 #1 |
+| D7 | 본인이 SUBMITTED 지원서 cancel | D1 SUBMITTED | DELETE /projects/{}/applications/me | 200, `status=CANCELLED` (또는 행 삭제 후 재지원 허용) | — | 🔴 P1 #2 |
+| D8 | DRAFT 상태 지원서가 다른 사용자에게 노출되지 않음 | D1 DRAFT 단계 | 다른 챌린저로 APPLY-101 호출 | 응답 목록에 미포함 | — | ✅ |
+| D9 | 본인 지부 IN_PROGRESS 프로젝트 GET → 응답에 지원 가능 플래그 (`canApply=true`) | 일반 챌린저 + 본인 지부 IN_PROGRESS 프로젝트 (미지원) | GET /projects/{id} | 응답 메타에 `canApply=true` (또는 동치 필드) — FE 가 [지원하기] 버튼 활성화 판단 근거 | QA-09, QA-20 | ✅ (응답 스키마 확인 필요) |
+| D10 | 본인이 이미 지원한 프로젝트 GET → `myApplicationId` 노출 + `canApply=false` | D1 SUBMITTED 후 | GET /projects/{id} | 응답 메타에 `myApplicationId` 채워짐, FE 는 [내 지원서 확인하기] 분기 | QA-12 | ✅ (응답 스키마 확인 필요) |
+| D11 | 타 지부 프로젝트 GET → 지원 불가 (`canApply=false`) | 일반 챌린저 + 타 지부 IN_PROGRESS 프로젝트 | GET /projects/{id} | 200 응답, 메타에 `canApply=false`, POST APPLY-001 시도 시 400/403 | QA-22, QA-23 | ✅ (access scope) |
+| D12 | DRAFT/PENDING_REVIEW 프로젝트 GET → 일반 챌린저 차단 | 비공개 상태 프로젝트 | 일반 챌린저 GET | 403 (`ProjectPermissionEvaluator.READ` 분기) | — | ✅ |
+
+> D7 은 도메인 메서드 `ProjectApplication.cancel()` 와 DELETE endpoint 구현이
+> 선행되어야 합니다. 테스트를 **RED 상태로 먼저 작성** 하면 P1 #2 의 진척을
+> 자연스럽게 강제할 수 있습니다.
+
+---
+
+#### Flow E — `ProjectApplicationDecisionE2ETest` (PR #840 [APPLY-103])
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| E1 | PO 가 SUBMITTED 지원서를 APPROVED 로 토글 | SUBMITTED + PO 인증 | PATCH /applications/{id}/decision (APPROVED) | 200, `status=APPROVED`, `status_changed_member_id=PO`, `status_changed_at` 기록 | QA-02 (positive) | ✅ |
+| E2 | 잔여 quota 초과 토글 → 409 | TO=2 + 이미 APPROVED 2건 | PATCH (APPROVED) | 409 `QUOTA_EXCEEDED` (PR #840 시나리오 C) | — | ✅ |
+| E3 | **PM 이 차수 종료 후 토글 → 400** | endsAt 경과 또는 auto-decide 완료 + PO 인증 | PATCH | 400 `MATCHING_ROUND_LOCKED` (PR #840 시나리오 D) | **QA-02** | ✅ |
+| E4 | APPROVED → PENDING 재토글 | E1 직후 | PATCH (PENDING) | 200, `status=SUBMITTED`, 사유 저장 | QA-18 | ✅ |
+| E5 | 다른 프로젝트 PO 가 토글 시도 → 403 | 다른 PO 토큰 | PATCH | 403 | — | ✅ |
+| E6 | 일반 챌린저가 APPLY-101 로 다른 프로젝트 지원자 목록 조회 → 403 | — | 다른 프로젝트 GET | 403 (**현재는 통과해 버리는 보안 이슈 — RED 로 작성**) | — | 🟡 P1 #1 |
+| E7 | **Admin 이 차수 종료 후에도 합/불 토글 가능 (PM 잠금 우회)** | endsAt 경과 + 중앙 총괄단 / 지부장 인증 | PATCH (APPROVED) | 200, `status=APPROVED`, audit 사유 기록 (`Admin override`) | **QA-11** | 🔴 **미구현** |
+| E8 | 지원자 목록 조회 — matchingRound/part/school/status 필터링 | SUBMITTED N건 (학교 / 파트 / 상태 mix) | GET /projects/{id}/applications?matchingRoundId=&part=&school=&status= | 각 조합별 정확한 필터링, 페이지네이션 동작 | QA-03 | ✅ (현재 status·matchingRoundId·part 만 지원 — school 필터 추가 필요시 확장) |
+| E9 | 지원자 목록 응답에 통계 메타 포함 | SUBMITTED·APPROVED·REJECTED mix | GET 동일 | 응답에 `summary` (총 지원자 / 파트별 배정 현황 / 차수별 지원율) 메타 포함 — FE 도넛/막대 그래프 데이터 | QA-03 | 🟡 응답 스키마 확장 필요 (응답 assembler 확인) |
+
+**필요 Fixture**: `ProjectApplicationFixture.submitted(formId, roundId, applicantMemberId)`
+
+---
+
+#### Flow F — `MatchingRoundFinalizationE2ETest` (PR #840 핵심)
+
+본 flow 의 검증은 `decisionDeadline + 10분` 도달 시 자동 발화 / manual override
+모두 검증해야 하므로 **스케줄러 발화를 시간으로 의존하지 말고 `AutoDecideProjectMatchingRoundUseCase`
+를 직접 호출**하는 형태로 구성합니다. (CLAUDE.md 의 "비결정적 시간/식별자는 Clock 빈으로" 규약)
+
+| # | 시나리오 (PR #840 매트릭스 기반) | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| F1 | PM 무결정 + deadline 도달 (TO=4 개발자, 지원자 8명) | 8 SUBMITTED · PM 결정 0 | UseCase.autoDecide(roundId) | APPROVED ≥ 2 (Developer 정책 ceil(TO×0.5))·나머지 REJECTED·`project_member` 행 = APPROVED 수 | — | ✅ |
+| F2 | PM 일부 결정 (TO=4, 5명, PM 1 APPROVED) | 1 APPROVED + 4 SUBMITTED | UseCase 호출 | needed=1 → SUBMITTED 풀에서 random 1명 추가 APPROVED, 최종 APPROVED=2 | — | ✅ |
+| F3 | 다중 차수 누적 (1차 1명 합격 후 2차) | 1차 종료 후 ACTIVE 멤버 1, 2차 SUBMITTED N | UseCase(2차) | quota 입력값 = 전체 TO − ACTIVE 멤버 수 (PR #840 시나리오 E) | — | ✅ |
+| F4 | Designer 정책 — 지원자 ≥2 면 최소 1 강제 | 지원자 2 + PM 미결정 | UseCase 호출 | 정확히 1명 APPROVED | — | ✅ |
+| F5 | Designer 정책 — 지원자 1 이면 자유 (자동 합격 강제 없음) | 지원자 1 + PM 미결정 | UseCase 호출 | APPROVED=0 가능 | — | ✅ |
+| F6 | 멱등성 — 같은 round 두 번 호출 | F1 결과 | UseCase 재호출 | 두 번째 호출은 no-op (`autoDecisionExecutedAt` 비교) | — | ✅ |
+| F7 | update 트랜잭션 롤백 시 scheduler 미발화 | round PATCH 후 강제 예외 | — | `afterCommit` 콜백 미실행 → in-memory task ↔ DB 일관 (PR #840 시나리오 F) | — | ✅ |
+| F8 | JVM 재시작 시 미처리 round 재등록 | 차수 created 상태 + 컨텍스트 재기동 | `@PostConstruct` 동작 | 스케줄러에 task 등록됨, deadline+10 이 과거이면 즉시 발화 (PR #840 시나리오 G) | — | ✅ |
+
+> F7/F8 은 PR #840 본문에서 가장 까다로운 시나리오로 명시되어 있어 회귀
+> 방지 차원에서 반드시 e2e 로 박아두는 것이 좋습니다.
+
+---
+
+#### Flow G — `MyProjectApplicationQueryE2ETest`
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| G1 | 본인 지원 내역 카드 정렬 (라운드 startsAt ASC → updatedAt DESC) | 동일 챌린저의 SUBMITTED 2건 + APPROVED 1건 | GET /projects/me/applications?gisuId | DRAFT 제외, 정렬 순서 검증 | — | ✅ |
+| G2 | ACTIVE 멤버이면서 application 없음 → RANDOM_MATCHING 카드 합성 | 운영진 강제 배정으로 ProjectMember.ACTIVE | 동일 호출 | 응답에 RANDOM_MATCHING 카드 1건 포함 | — | ✅ |
+| G3 | status 필터링 | SUBMITTED·APPROVED·REJECTED 혼재 | GET ?status=APPROVED | APPROVED 만 반환 | — | ✅ |
+| G4 | **PM 의 합/불 변경이 본인 지원 카드에 즉시 일치 반영** | 챌린저 SUBMITTED → PM 이 APPROVED 토글 (E1) | PM 토글 직후 챌린저 토큰으로 GET /projects/me/applications | 응답 카드의 `status=APPROVED`, `status_changed_at` 이 E1 직후 시각 (= 캐싱 / 동기화 지연 없음) | **QA-13** | ✅ |
+
+---
+
+#### Flow H — `ProjectMemberManagementE2ETest`
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| H1 | DRAFT 단계 멤버 추가/삭제 → hard delete | DRAFT + member 추가 직후 | DELETE /members/{memberId} | 200, `project_member` 행 삭제 | — | ✅ |
+| H2 | IN_PROGRESS 단계 멤버 삭제 → soft delete | IN_PROGRESS + ACTIVE 멤버 | DELETE | 200, `status=DISMISSED`, 사유 저장 | — | ✅ |
+| H3 | COMPLETED 단계 멤버 삭제 시도 → 400 | COMPLETED | DELETE | 400 | — | 🟡 (Flow I 의 종료 endpoint 필요) |
+| H4 | 소유권 양도 — 새 PO 가 PLAN 챌린저 | IN_PROGRESS + 양도 대상 PLAN 챌린저 | POST /transfer-ownership | 200, `product_owner_member_id` 변경, `product_owner_school_id` / `chapter_id` 동기화 | — | ✅ |
+| H5 | 양도 대상이 동일 기수에 이미 PO 인 경우 → 허용 (PR #843) | 양도 대상이 다른 프로젝트의 PO | POST /transfer-ownership | 200 (이전 룰은 차단) | — | ✅ |
+| H6 | 양도 대상이 PLAN 챌린저 아님 → 400 | 양도 대상 BE | 동일 호출 | 400 `PROJECT_OWNER_NOT_PLAN_CHALLENGER` | — | ✅ |
+| H7 | **운영진이 미배정 파트 빈자리에 챌린저 강제 배정** | 매칭 종료 후 파트 정원 < TO + ACTIVE 멤버 부족 + 중앙 총괄단/지부장 인증 | POST /projects/{id}/members (해당 파트의 ACTIVE 멤버 없는 챌린저) | 201, `project_member` 행 생성 (`application_id=null`, `decided_member_id=Admin`, `status=ACTIVE`), 다른 프로젝트에서 ACTIVE 인 챌린저는 후보에서 제외 | **QA-16** | 🔴 **미구현 (운영진 권한 분기)** |
+| H8 | 운영진이 H7 으로 배정한 챌린저가 다시 다른 프로젝트에 배정되지 않음 | H7 직후 | 다른 프로젝트에 H7 챌린저로 다시 POST /members | 409 또는 400 (이미 ACTIVE 멤버 보유) | QA-16 (보조) | 🔴 미구현 |
+
+---
+
+#### Flow I — `ProjectLifecycleEndE2ETest`
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| I1 | 정상 종료: IN_PROGRESS → COMPLETED + ACTIVE 멤버 일괄 COMPLETED | IN_PROGRESS + ACTIVE 멤버 N | POST `(미구현 endpoint)` /complete | `project.status=COMPLETED`, `project_member.status=COMPLETED` | — | 🔴 P1 #3 |
+| I2 | 와해: 어떤 상태든 ABORTED + 사유 기록 | IN_PROGRESS | POST `(미구현 endpoint)` /abort with reason | `project.status=ABORTED`, `status_changed_reason` 기록 | — | 🔴 P1 #3 |
+| I3 | COMPLETED / ABORTED 에서 모든 수정 액션 차단 | I1 종료 직후 | PATCH /, POST /members, PUT /part-quotas 등 | 모두 400 (도메인 가드) | — | ✅ (도메인 가드는 이미 있음, endpoint 추가 시 e2e 확인) |
+
+> I1/I2 는 endpoint 가 없어 **테스트를 먼저 RED 로 작성** → 구현 강제.
+
+---
+
+#### Flow J — Survey 폼 운영 (Project 통합 테스트로 간접 검증)
+
+| # | 시나리오 | Given | When | Then 검증 | QA | Status |
+|---|---|---|---|---|---|---|
+| J1 | PUT /application-form 3계층 diff — 섹션 추가/수정/삭제 | 폼 1개 (sec=2, q=4, opt=8) | 변형된 본문 PUT | DB 가 본문과 정확히 일치 (section/question/option 수와 orderNo) | QA-01, QA-21 | ✅ |
+| J2 | 챌린저 GET 시 본인 파트 + COMMON 만 노출 | 폼 + 정책 (DESIGN PART 섹션 1, COMMON 1) | DESIGN 챌린저로 GET | 2 섹션 반환, BE 챌린저로 호출 시 COMMON 1 + 본인 파트 0 | — | ✅ |
+| J3 | IN_PROGRESS 프로젝트에서 폼 변경 시 질문 fork (Copy-on-Write) | 응답 1건이 들어온 question | PUT 으로 동일 question 수정 | `question.parent_question_id` 설정된 신규 row 생성, 원본 `is_active=false`, 기존 응답은 원본 question 참조 유지 | — | ✅ |
+| J4 | 발행된 폼에서 질문 type 변경 시 응답 처리 | RADIO + 응답 보존 | type → SHORT_TEXT 변경 | (정책 미확정 — RED 테스트로 의도 명문화하고 P2 결정 유도) | — | 🟡 P2 |
+| J5 | 특정 파트의 '섹션 사용' 토글 — 비활성 파트 섹션은 정책에 미포함 | 폼 + DESIGN 만 PART 정책 | BE 챌린저 GET | DESIGN 섹션 미노출, COMMON 만 노출 | QA-21 | ✅ |
+| J6 | 질문 type — 주관식 / 단일 / 복수 / 파일 / 포트폴리오 모두 PUT 가능 | 5종 question_type 본문 | PUT | DB `question.type` 정확히 반영, 옵션 타입엔 `question_option` 행 존재 | QA-21 | ✅ |
+| J7 | Admin 이 프로젝트 상세 GET 시 [모집 문항 보기] 가능 — 폼 응답 정상 노출 | IN_PROGRESS + Admin 인증 | GET /projects/{id}/application-form | 200, 전체 섹션 노출 (admin 마스킹 없음) | **QA-19**, QA-20 | ✅ |
+
+---
+
+### 6.4 우선 작성 추천 순서
+
+다음은 **테스트 작성 → 구현 강제** 흐름을 고려한 추천 순서입니다. RED 로 시작하는
+항목은 테스트를 먼저 머지하면 미구현 부담이 가시화됩니다.
+
+| 순서 | 테스트 클래스 / 시나리오 | 의도 | 노션 QA 커버 |
+|---|---|---|---|
+| 1 | `ProjectDraftE2ETest` (Flow A 전체) | PR #843 회귀 방지 — 가장 가치 높음 | QA-01, QA-06, QA-25 |
+| 2 | `MatchingRoundFinalizationE2ETest` (Flow F 전체) | PR #840 의 멱등 / 롤백 / 재등록 회귀 방지 | — |
+| 3 | `ProjectApplicationDecisionE2ETest` E1~E5, E8~E9 | PM 합/불 토글 — 정상 동선 + 차수 잠금 (QA-02) | QA-02, QA-03, QA-18 |
+| 4 | Flow D-D6, E-E6 (보안 RED) | P1 #1 — `ProjectApplicationQueryController` 권한 분기 강제 | — |
+| 5 | Flow D-D7 (cancel RED) | P1 #2 — 지원 철회 endpoint + cancel() 구현 강제 | — |
+| 6 | Flow I (`ProjectLifecycleEndE2ETest` RED) | P1 #3 — complete / abort endpoint 강제 | — |
+| 7 | Flow C-C9 (1차 시작 후 PATCH 잠금 RED) | **QA-14** P2 #5 강제 | **QA-14** |
+| 8 | Flow E-E7 (Admin 토글 우회 RED) | **QA-11** P2 #6 강제 | **QA-11** |
+| 9 | Flow H-H7, H8 (운영진 강제 배정 RED) | **QA-16** P2 #7 강제 | **QA-16** |
+| 10 | Flow D-D9~D12 (응답 메타 검증) | 프로젝트 상세 응답의 `canApply` / `myApplicationId` 노출 확인 | QA-09, QA-12, QA-22, QA-23 |
+| 11 | Flow G-G4 (PM 토글 ↔ 챌린저 카드 동기화) | 실시간 일치 반영 | **QA-13** |
+| 12 | Flow J-J5~J7 (폼 PUT / GET 변형 케이스) | 발행 전 폼 편집 회귀 안전망 | QA-19, QA-20, QA-21 |
+| 13 | 잔여 (B / C 기본 / H1~H6 / J1~J4) | 일반 회귀 안전망 | QA-15 |
+
+### 6.5 구현 실행 계획 — PR 단위 분리 제안
+
+각 PR 은 **테스트 클래스 + 필요한 도메인/Adapter 변경 + Fixture 추가** 를 한 묶음으로
+머지하며, 노션 QA ID 를 PR 본문에 명시하여 추적성을 확보합니다.
+
+#### PR-1: 회귀 안전망 (PR #843 / #840 머지 직후, 동일 sprint)
+
+- **목표**: 두 PR 의 핵심 동작 회귀 방지
+- **신설 파일**
+  - `src/test/java/com/umc/product/project/e2e/ProjectDraftE2ETest.java` — Flow A 전체 (A1~A7)
+  - `src/test/java/com/umc/product/project/e2e/MatchingRoundFinalizationE2ETest.java` — Flow F 전체 (F1~F8)
+  - `src/test/java/com/umc/product/project/e2e/ProjectApplicationDecisionE2ETest.java` — E1~E5, E8 (Admin 우회 E7 제외)
+  - `src/test/java/com/umc/product/support/fixture/ProjectFixture.java`
+  - `src/test/java/com/umc/product/support/fixture/ProjectMatchingRoundFixture.java`
+  - `src/test/java/com/umc/product/support/fixture/ProjectApplicationFormFixture.java`
+  - `src/test/java/com/umc/product/support/fixture/ProjectApplicationFixture.java`
+  - `src/test/java/com/umc/product/support/fixture/ProjectPartQuotaFixture.java`
+- **변경 없음 (테스트만)**
+- **노션 QA 커버**: QA-01, QA-02, QA-03, QA-06, QA-18, QA-25
+
+#### PR-2: P1 보안 / 미구현 fix-pack (RED → GREEN 순서로 묶음 머지)
+
+- **목표**: P1 #1~#3 (Flow §4.1) 일괄 해소
+- **신설 / 변경**
+  1. **권한 분기 적용** — [ProjectApplicationQueryController](src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java) APPLY-101 / APPLY-102 에 `@CheckAccess` 적용 (코드 TODO 제거)
+  2. **지원 철회 구현**
+     - [ProjectApplication.cancel()](src/main/java/com/umc/product/project/domain/ProjectApplication.java) 본문 작성
+     - `DELETE /api/v1/projects/{projectId}/applications/me` endpoint + `CancelProjectApplicationUseCase` / Service 신설
+     - 재지원 UK 충돌 회피 — soft delete 컬럼 추가 또는 `CANCELLED` 상태 + UK 변경 마이그레이션 (정책 결정 후)
+  3. **프로젝트 종료 endpoint**
+     - `POST /api/v1/projects/{projectId}/complete`, `POST /api/v1/projects/{projectId}/abort`
+     - `CompleteProjectUseCase`, `AbortProjectUseCase` + ACTIVE 멤버 일괄 전이 부수효과
+- **신설 테스트**
+  - Flow D-D6 (보안 RED→GREEN), D-D7 (cancel)
+  - Flow I 전체 (I1, I2, I3)
+- **노션 QA 커버**: 없음 (보안 / lifecycle 은 노션 시나리오 외)
+
+#### PR-3: 노션 QA 미구현 3건 (QA-11 / QA-14 / QA-16)
+
+- **목표**: §4.2 의 P2 #5~#7 일괄 해소
+- **신설 / 변경**
+  1. **QA-14 — 1차 시작 후 차수 일정 잠금**
+     - `ProjectMatchingRound.validateReschedule(Instant now)` 추가 — chapter 의 1차 round `startsAt < now` 이면 전체 round `reschedule` 차단
+     - `ProjectErrorCode.MATCHING_ROUND_PERIOD_LOCKED` 추가
+     - `ProjectMatchingRoundCommandService.update` 진입에서 동일 chapter 의 다른 round 도 함께 호출하여 가드
+  2. **QA-11 — Admin override**
+     - `ProjectApplication.applyDecisionWithOverride(MemberRole role, ...)` 또는 별도 분기로 `MATCHING_ROUND_LOCKED` 우회
+     - `ProjectApplicationCommandService.decide` 의 `validateIsMutableAt` 호출 시 admin 권한이면 skip
+     - audit 사유에 `Admin override` 명시 필수
+  3. **QA-16 — 운영진 임의 배정**
+     - `POST /projects/{id}/members` 권한 분기 추가: `EDIT` (PO) 또는 `MANAGE` (총괄단 / 지부장)
+     - 후보 필터링 Service — `LoadProjectMemberPort.listActiveMembersByGisu` 로 다른 프로젝트 ACTIVE 멤버 제외
+     - `decided_member_id` 에 운영진 ID 기록
+- **신설 테스트**
+  - Flow C-C9, E-E7, H-H7/H8 (모두 RED → GREEN)
+- **노션 QA 커버**: **QA-11, QA-14, QA-16**
+
+#### PR-4: 회귀 안전망 확장 (선택)
+
+- **목표**: 응답 스키마 보강 + 잔여 회귀 안전망
+- **변경**
+  - Flow D-D9~D12 의 응답 메타(`canApply`, `myApplicationId`) 가 현재 응답 DTO 에 없다면 Assembler 보강
+  - Flow E-E9 의 통계 메타 (`summary` 도넛 / 막대 데이터) 응답 추가 (FE 가 별도 endpoint 로 합치는 것 보다 한 응답으로 묶는 것이 round-trip 적음)
+- **신설 테스트**
+  - Flow B / C 기본 (B1~B4, C1~C8), G4, H1~H6, J1~J7
+- **노션 QA 커버**: QA-09, QA-12, QA-13, QA-15, QA-19, QA-20, QA-21, QA-22, QA-23
+
+#### PR-5: 정책 미확정 자율 결정 (별도 ADR 동반)
+
+- §4.2 의 P2 #1~#4 (발행 후 폼 편집 정책 / cancel 후 재지원 UK / publish hook / 종료 시 멤버 전이) 를 단일 ADR 로 묶고, 결정된 항목별 후속 PR
+
+---
+
+### 6.6 작성 시 주의사항
+
+- 통합 테스트 클래스에 `@Transactional` 부여 금지 — `IntegrationTestSupport`
+  주석 참조
+- 도메인 빈을 `@MockitoBean` 으로 덮어쓰지 말 것 — 외부 시스템(메일/JWT/FCM/
+  Storage)만 허용
+- 시간 의존(Flow F, C7) 은 `Clock` 빈을 운영 코드에 두고 테스트에서 고정값
+  주입. `Thread.sleep` 으로 스케줄러 발화 기다리지 말 것
+- 자동 증가 ID 직접 비교 금지 — `isNotNull()` 또는 의미 단위(상태/관계/사유)로 검증
+- 도메인 엔티티 `new` 금지 — Fixture 또는 도메인 팩토리 메서드 (`Project.createDraft()` 등) 사용
+
+---
+
+## 7. 참고 문서
+
+- [v2.0.0 Release PR #780](https://github.com/) — Project / Survey 도메인 초기 인프라 history
+- 본 보고서 작성에 사용된 코드 위치
+  - Project 도메인: [src/main/java/com/umc/product/project/](src/main/java/com/umc/product/project/)
+  - Survey 도메인: [src/main/java/com/umc/product/survey/](src/main/java/com/umc/product/survey/)
+  - 마이그레이션: [src/main/resources/db/migration/](src/main/resources/db/migration/)
+  - 통합 테스트 베이스: [IntegrationTestSupport.java](src/test/java/com/umc/product/support/IntegrationTestSupport.java)
+  - 통합 테스트 참고 예시: [ProjectMatchingRoundControllerIntegrationTest.java](src/test/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundControllerIntegrationTest.java)
+- 외부 자료
+  - 노션 [📌 UPMS 관련 QA](https://www.notion.so/UPMS-QA-35e39ff67177804eb1d5c76e0f2fd9ca) — 25건 QA 시나리오 반영 완료 (§6.1)

--- a/docs/analysis/운영진_대시보드_KPI_구현_보고서.md
+++ b/docs/analysis/운영진_대시보드_KPI_구현_보고서.md
@@ -1,0 +1,81 @@
+# 운영진 대시보드 KPI 구현 보고서
+
+> 작성일: 2026-05-13  
+> 기준 문서: `docs/analysis/운영진_대시보드_KPI_후보_분석.md`  
+> 구현 범위: `member`, `challenger`, `organization`, `authorization`, `schedule`
+
+## 1. 범위 추출 기준
+
+기준 문서의 KPI 후보 중 현재 요청 범위에 해당하는 도메인만 구현 대상으로 삼았다.
+
+| 포함 도메인 | 반영 기준 |
+| --- | --- |
+| `member` | 신규 가입자 수, 전주 대비 증감률, 학교 기준 집계, 가입 추이 버킷 |
+| `challenger` | 활동 챌린저 수, 상태 분포, 포인트 합계, 위험군, 수료 임박 인원 |
+| `organization` | 기수, 지부, 학교, 지부-학교 매핑, 스터디 그룹 운영 현황 |
+| `authorization` | 운영진 역할 기반 대시보드 조회 스코프 |
+| `schedule` | 일정 수, 출석 필수 일정, 출석 상태 분포, 승인 대기 출석 액션 큐 |
+
+`project`, `notice`, `curriculum`, `survey`, `community`, `notification`, `audit`, `figma`, `llm`, `storage`, `term` 기반 KPI는 이번 구현에서 제외했다. 특히 기존 후보 문서에 있던 진행 중 프로젝트 수, 처리 대기 지원서 수, 매칭 차수, 미발송 공지는 응답 계약과 집계 쿼리에서 제외하고, 동일한 액션 큐 성격의 `schedule` 기반 승인 대기 출석 수로 대체했다.
+
+## 2. 구현 단계
+
+### 2.1 계약 재정의
+
+- `AdminDashboardSummaryInfo`에서 프로젝트/지원서 기반 필드를 제거했다.
+- `AdminDashboardActionQueueInfo`를 출석 승인 대기, 신규 위험군, 수료 임박 인원 중심으로 재정의했다.
+- Web Response DTO도 동일한 계약을 따르도록 수정했다.
+- Controller 테스트에는 제거된 필드가 JSON 응답에 포함되지 않는 검증을 추가했다.
+
+### 2.2 Hexagonal 구조 구현
+
+- Inbound Port: 운영진 대시보드 요약, 액션 큐, 컨텍스트, 학교별 요약, 위험군, 운영 현황 조회 UseCase를 분리했다.
+- Application Service: `AdminAnalyticsQueryService`가 Query 전용 서비스로 각 UseCase를 구현하고, `@Transactional(readOnly = true)`를 적용했다.
+- Outbound Port: 대시보드, 학교별 현황, 위험군, 운영 현황 집계 포트를 분리했다.
+- Persistence Adapter: QueryDSL 기반 집계 Repository를 어댑터 뒤에 배치해 Controller와 Repository의 직접 의존을 막았다.
+
+### 2.3 권한 스코프 적용
+
+- `ResourceType.ANALYTICS`를 추가하고 운영진 대시보드 API에 `READ` 권한을 적용했다.
+- `AdminAnalyticsScopeResolver`가 `ChallengerRole`을 기준으로 중앙, 지부, 학교, 학교 파트장 스코프를 계산한다.
+- 각 집계 Repository는 계산된 스코프의 `gisuId`, `chapterId`, `schoolId`, `part` 조건만 사용해 데이터를 필터링한다.
+
+### 2.4 KPI 집계 구현
+
+| API | 구현 KPI |
+| --- | --- |
+| `GET /api/v1/admin/dashboard/summary` | 활동 챌린저 수, 신규 가입자 수, 신규 가입자 전주 대비 증감률, 활동 학교 수, 활동 지부 수, 월간 포인트 합계, 챌린저 상태 분포 |
+| `GET /api/v1/admin/dashboard/action-queue` | 출석 승인 대기 수, 이번 주 신규 위험군 수, 수료 임박 인원 |
+| `GET /api/v1/admin/dashboard/context` | 운영진 역할 기반 대시보드 스코프 |
+| `GET /api/v1/admin/dashboard/risk-challengers` | 위험군 챌린저 목록, 누적 포인트, 최근 감점 사유/일자 |
+| `GET /api/v1/admin/dashboard/operations` | 지부-학교-파트별 챌린저 분포, 파트별 포인트 부여 현황, 일정 출석 현황, 스터디 그룹 현황, 가입 추이 버킷 |
+| `GET /api/v1/admin/schools/summary` | 학교별 활동 챌린저 수, 회장/부회장, 파트장 배치율, 평균 포인트, 위험군 수, 이번 주 신규 인원 |
+
+## 3. 테스트 기준
+
+| 검증 항목 | 기준 |
+| --- | --- |
+| Controller 계약 | 운영진 API가 `ApiResponse`를 직접 감싸지 않고 Response DTO를 반환하며, 제외 도메인 필드를 응답하지 않아야 한다. |
+| Application Service | Query UseCase별로 스코프를 계산하고 올바른 Outbound Port를 호출해야 한다. |
+| Persistence Convention | Analytics Query Repository가 `@OneToMany`를 새로 도입하지 않고, Adapter/Port 분리를 유지해야 한다. |
+| Schedule 액션 큐 | `PRESENT_PENDING`, `LATE_PENDING`, `EXCUSED_PENDING`, `ABSENT_EXCUSE_PENDING`, `LATE_EXCUSE_PENDING` 상태만 승인 대기 건수로 계산해야 한다. |
+
+## 4. 검증 결과
+
+| 명령 | 결과 |
+| --- | --- |
+| `./gradlew compileJava` | 성공 |
+| `./gradlew compileTestJava` | 성공 |
+| `./gradlew test --tests "com.umc.product.analytics.application.service.query.AdminAnalyticsScopeResolverTest" --tests "com.umc.product.analytics.application.service.query.AdminAnalyticsQueryServiceTest" --tests "com.umc.product.analytics.adapter.in.web.AdminDashboardControllerTest" --tests "com.umc.product.analytics.adapter.in.web.AdminSchoolAnalyticsControllerTest" --tests "com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsPersistenceConventionTest"` | 성공 |
+| `./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.AdminDashboardAnalyticsQueryRepositoryTest"` | 실패: Testcontainers가 Docker 클라이언트를 찾지 못해 `DockerClientProviderStrategy` 초기화에서 중단 |
+
+Repository 통합 테스트 실패는 구현 로직 실패가 아니라 현재 실행 환경의 Docker 접근 실패로 확인했다. 동일 테스트는 Testcontainers 의존성이 있으므로 Docker Desktop 또는 호환 Docker daemon이 동작하는 환경에서 재실행해야 한다.
+
+## 5. 커밋 단위
+
+구현 변경은 기능 구현과 보고서 작성의 책임을 분리해 다음 단위로 커밋한다.
+
+1. `feat: add admin analytics dashboard kpis`
+   - analytics 도메인 구현, 권한 리소스 추가, 테스트 추가
+2. `docs: add admin analytics implementation report`
+   - 구현 단계, 추출 기준, 검증 결과 보고서 반영

--- a/docs/analysis/운영진_대시보드_KPI_후보_분석.md
+++ b/docs/analysis/운영진_대시보드_KPI_후보_분석.md
@@ -1,0 +1,284 @@
+# 운영진 대시보드 KPI 후보 분석
+
+> 작성일: 2026-05-13  
+> 분석 대상: `src/main/java/com/umc/product/**/domain`, `src/main/java/com/umc/product/**/application/port/in`, `src/main/java/com/umc/product/analytics/**`  
+> 목적: 현재 백엔드 Entity와 UseCase 기준으로 운영진 대시보드에서 조회할 가치가 높은 KPI 후보를 추리고, 산출 근거와 선정 사유를 정리한다.
+
+---
+
+## 1. 요약
+
+현재 레포지토리는 이미 `analytics` 도메인에 운영진 대시보드 전용 조회 UseCase와 일부 집계 API를 보유하고 있다. 따라서 KPI는 다음 순서로 우선 적용하는 것이 합리적이다.
+
+1. **즉시 대시보드 카드/테이블로 노출 가능한 지표**
+   - `AdminDashboardSummaryInfo`, `AdminSchoolSummaryInfo`, `AdminRiskChallengerInfo`, `AdminDashboardActionQueueInfo`로 이미 응답 형태가 정의된 지표
+   - 예: 활동 챌린저 수, 신규 가입자 수, 활동 학교/지부 수, 월간 포인트 합계, 진행 중 프로젝트 수, 처리 대기 지원서 수, 학교별 위험군 수
+
+2. **운영 액션을 직접 만드는 지표**
+   - 지표가 높거나 낮을 때 운영진이 바로 개입할 수 있는 지표
+   - 예: 위험군 챌린저, 미발송 공지, 승인 대기 출석, 매칭 진행 차수, 수료 임박 인원
+
+3. **다음 이터레이션에서 확장할 추이/퍼널 지표**
+   - 별도 집계 쿼리나 어댑터 구현이 필요하지만 운영 판단 가치가 높은 지표
+   - 예: 워크북 제출/통과율, 프로젝트 지원 전환율, 공지 읽음률, FCM 발송 실패율
+
+---
+
+## 2. 코드 근거 인벤토리
+
+### 2.1 KPI 산출에 직접 쓰기 좋은 Entity
+
+| 도메인 | 주요 Entity | KPI로 활용 가능한 필드/상태 |
+| --- | --- | --- |
+| `member` | `Member`, `MemberProfile` | `createdAt`, `status`, `schoolId`, `profileImageId`, 프로필 링크 보유 여부 |
+| `challenger` | `Challenger`, `ChallengerPoint`, `ChallengerRecord` | `gisuId`, `part`, `status`, `pointValue`, `PointType`, 초대 코드 사용 여부 |
+| `organization` | `Gisu`, `Chapter`, `School`, `ChapterSchool`, `StudyGroup`, `StudyGroupMember`, `StudyGroupSchedule` | 현재 기수, 지부/학교 매핑, 스터디 그룹 수, 스터디 일정 수 |
+| `authorization` | `ChallengerRole` | 운영진 역할, 조직 스코프, 학교 파트장 담당 파트 |
+| `project` | `Project`, `ProjectApplication`, `ProjectMatchingRound`, `ProjectMember`, `ProjectPartQuota` | 프로젝트 상태, 지원서 상태, 매칭 차수 기간/단계, 파트별 TO와 합류 인원 |
+| `schedule` | `Schedule`, `ScheduleParticipant`, `ScheduleParticipantAttendance` | 일정 수, 출석 정책 여부, 출석/지각/결석/승인 대기 상태 |
+| `curriculum` | `Curriculum`, `WeeklyCurriculum`, `OriginalWorkbook`, `ChallengerWorkbook`, `MissionSubmission`, `MissionFeedback`, `WeeklyBestWorkbook` | 주차별 워크북, 배포 상태, 제출 상태, 피드백 결과, 우수 워크북 |
+| `notice` | `Notice`, `NoticeRead`, `NoticeTarget`, `NoticeVote` | 공지 발송 필요 여부, 발송 시각, 필독 여부, 읽음 기록, 투표 기간 |
+| `survey` | `Form`, `FormResponse`, `Answer` | 폼 발행 상태, 제출/임시저장 응답 수, 제출 시각 |
+| `community` | `Post`, `Comment`, `Scrap`, `Report`, `Trophy` | 게시글/댓글/스크랩/신고/트로피 활동량 |
+| `notification` | `FcmToken`, `FcmOutbox` | 활성 토큰 수, 발송 대기/성공/실패, 재시도 수 |
+| `audit` | `AuditLog` | 도메인별 운영 행위, 액션, 수행자, 대상, IP, 발생 시각 |
+| `figma`, `llm`, `storage`, `term` | `FigmaWatchedFile`, `FigmaCommentClassification`, `FileMetadata`, `TermConsent` 등 | 동기화 오류, 분류량, 업로드량, 약관 동의 현황 |
+
+대부분 Entity가 `BaseEntity`를 상속해 `createdAt`, `updatedAt`을 갖기 때문에, 일/주/월 단위 추이 집계가 가능하다.
+
+### 2.2 이미 존재하는 운영진 대시보드 UseCase
+
+| UseCase | 현재 제공 가능 지표 |
+| --- | --- |
+| `GetAdminDashboardSummaryUseCase` | 활동 챌린저 수, 신규 가입자 수/전주 대비, 활동 학교/지부 수, 월간 포인트 합계, 진행 중 프로젝트 수, 처리 대기 지원서 수, 챌린저 상태 분포 |
+| `GetAdminSchoolSummaryUseCase` | 학교별 활동 챌린저 수, 회장/부회장, 파트장 배치 비율, 평균 포인트, 위험군 수, 이번 주 신규 인원 |
+| `GetAdminRiskChallengerUseCase` | 위험군 챌린저 목록, 누적 포인트, 최근 감점 사유/일자 |
+| `GetAdminDashboardActionQueueUseCase` | 처리 대기 지원서, 진행 중 매칭 차수, 미발송 공지, 이번 주 신규 위험군, 수료 임박 인원 |
+| `GetAdminDashboardContextUseCase` | 운영진 역할 기반 데이터 스코프 |
+| `GetAdminOperationsOverviewUseCase` | 지부/학교/파트/출석/스터디/가입 추이형 운영 현황. `AdminOperationsAnalyticsPersistenceAdapter`와 `AdminOperationsAnalyticsQueryRepository`로 집계 구현이 존재한다. |
+
+---
+
+## 3. KPI 선정 기준
+
+- **운영 액션 가능성**: 지표가 이상할 때 담당 운영진이 바로 조치할 수 있어야 한다.
+- **권한 스코프 적용 가능성**: 중앙, 지부, 학교, 학교 파트장 범위로 자연스럽게 필터링되어야 한다.
+- **현재 데이터 신뢰도**: 이미 Entity 필드 또는 UseCase 응답으로 산출 가능한 지표를 우선한다.
+- **비교 가능성**: 현재 값뿐 아니라 전주/전월 대비, 기수/지부/학교/파트 비교가 가능할수록 우선순위를 높인다.
+- **N+1 회피 가능성**: FE가 목록을 모두 순회해 계산해야 하는 지표보다 서버 집계 쿼리로 산출 가능한 지표를 우선한다.
+
+---
+
+## 4. P0: 운영진 메인 대시보드에 우선 노출할 KPI
+
+### 4.1 활동 챌린저 수
+
+- **산출 기준**: 현재 기수의 `Challenger.status = ACTIVE` 수
+- **코드 근거**: `Challenger.gisuId`, `Challenger.status`, `ChallengerStatus.ACTIVE`, `GetAdminDashboardSummaryUseCase`
+- **선정 사유**: 조직 운영 규모와 현재 활성 사용자 풀을 가장 빠르게 보여주는 기본 KPI다. 지부/학교 스코프별 비교에도 적합하다.
+- **구현 상태**: `AdminDashboardSummaryInfo.activeChallengerCount`로 제공 가능
+
+### 4.2 신규 가입자 수와 전주 대비 증감률
+
+- **산출 기준**: 최근 7일 `Member.createdAt` 기준 신규 가입자 수, 직전 7일 대비 증감률
+- **코드 근거**: `Member.createdAt`, `Challenger.memberId`, `AdminDashboardSummaryInfo.newMemberCountThisWeek`, `newMemberDeltaPercent`
+- **선정 사유**: 모집/온보딩 흐름이 정상적으로 작동하는지 빠르게 판단할 수 있다. 급감 시 홍보, 초대 코드, 가입 플로우 장애를 확인해야 한다.
+- **구현 상태**: `AdminDashboardSummaryInfo`로 제공 가능
+
+### 4.3 활동 학교 수 / 활동 지부 수
+
+- **산출 기준**: 활동 챌린저가 1명 이상 있는 `schoolId`, `chapterId` distinct count
+- **코드 근거**: `Member.schoolId`, `ChapterSchool`, `Chapter`, `Challenger.status`, `AdminDashboardSummaryInfo.activeSchoolCount`, `activeChapterCount`
+- **선정 사유**: 단순 가입자 수보다 운영 커버리지 관점에서 유용하다. 특정 지부/학교의 활동 공백을 파악하는 출발점이 된다.
+- **구현 상태**: `AdminDashboardSummaryInfo`로 제공 가능
+
+### 4.4 월간 포인트 합계
+
+- **산출 기준**: 이번 달 `ChallengerPoint`의 가산/감점 합계. `pointValue`가 있으면 우선 사용하고, 없으면 `PointType.value`를 사용
+- **코드 근거**: `ChallengerPoint.pointValue`, `ChallengerPoint.type`, `PointType`, `AdminDashboardSummaryInfo.monthlyPointSum`
+- **선정 사유**: 감점 급증은 출석/과제/운영 규칙 준수에 문제가 생겼다는 신호다. 가산점과 감점을 분리해야 운영 건강도를 오해하지 않는다.
+- **구현 상태**: `AdminDashboardSummaryInfo.PointSumInfo`로 제공 가능
+
+### 4.5 챌린저 상태 분포
+
+- **산출 기준**: 현재 기수의 `ACTIVE`, `GRADUATED`, `EXPELLED`, `WITHDRAWN` count
+- **코드 근거**: `Challenger.status`, `ChallengerStatus`, `AdminDashboardSummaryInfo.challengerStatusDistribution`
+- **선정 사유**: 수료/제명/탈부 비율을 한 화면에서 비교할 수 있어 기수 운영 리스크를 조기에 파악할 수 있다.
+- **구현 상태**: `AdminDashboardSummaryInfo`로 제공 가능
+
+### 4.6 진행 중 프로젝트 수
+
+- **산출 기준**: `Project.status = IN_PROGRESS` count
+- **코드 근거**: `Project.gisuId`, `Project.chapterId`, `Project.productOwnerSchoolId`, `ProjectStatus.IN_PROGRESS`, `AdminDashboardSummaryInfo.projectInProgressCount`
+- **선정 사유**: 프로젝트 운영 규모와 현재 매칭/수행 중인 팀 수를 보여준다. 기수 말에는 완료/중단 전환 관리 지표로도 활용된다.
+- **구현 상태**: `AdminDashboardSummaryInfo`로 제공 가능
+
+### 4.7 처리 대기 지원서 수
+
+- **산출 기준**: `ProjectApplication.status = SUBMITTED` count
+- **코드 근거**: `ProjectApplication.status`, `ProjectApplicationStatus.SUBMITTED`, `ProjectApplicationForm`, `Project`, `AdminDashboardSummaryInfo.pendingApplicationCount`
+- **선정 사유**: 운영진이 즉시 처리해야 하는 업무량을 나타낸다. 대기 수가 높으면 지원자 경험과 매칭 일정이 지연된다.
+- **구현 상태**: `AdminDashboardSummaryInfo`, `AdminDashboardActionQueueInfo`로 제공 가능
+
+### 4.8 학교별 운영 현황
+
+- **산출 기준**: 학교별 활동 챌린저 수, 회장/부회장, 파트장 배치 비율, 평균 포인트, 위험군 수, 이번 주 신규 인원
+- **코드 근거**: `AdminSchoolSummaryInfo`, `Challenger`, `Member`, `School`, `ChapterSchool`, `ChallengerRole`
+- **선정 사유**: 운영진 회의에서 가장 많이 필요한 비교 테이블이다. 특히 위험군 수와 파트장 배치율은 “지금 개입할 학교”를 찾는 데 유용하다.
+- **구현 상태**: `GetAdminSchoolSummaryUseCase`, `GET /api/v1/admin/schools/summary`로 제공 가능
+
+### 4.9 위험군 챌린저 목록
+
+- **산출 기준**: 활동 챌린저 중 누적 포인트가 `riskThreshold` 이하인 대상, 최근 감점 내역 포함
+- **코드 근거**: `AdminRiskChallengerInfo`, `ChallengerPoint`, `PointType`, `GetAdminRiskChallengerUseCase`
+- **선정 사유**: KPI 카드보다 더 직접적인 액션 리스트다. 운영진이 개별 챌린저 상담, 공지, 제도 안내로 이어가기 쉽다.
+- **구현 상태**: `GET /api/v1/admin/dashboard/risk-challengers`로 제공 가능
+
+### 4.10 운영 액션 큐
+
+- **산출 기준**: 처리 대기 지원서, 진행 중 매칭 차수, 미발송 공지, 이번 주 신규 위험군, 수료 임박 인원
+- **코드 근거**: `AdminDashboardActionQueueInfo`, `ProjectApplication`, `ProjectMatchingRound`, `Notice`, `Gisu.period.endAt`, `Challenger`
+- **선정 사유**: 대시보드 첫 화면에서 “오늘 처리할 일”을 직접 보여준다. 단순 현황보다 운영 효율에 더 크게 기여한다.
+- **구현 상태**: `GetAdminDashboardActionQueueUseCase`, `GET /api/v1/admin/dashboard/action-queue`로 제공 가능
+
+---
+
+## 5. P1: 운영 현황을 더 잘 설명하는 확장 KPI
+
+### 5.1 가입 추이 버킷
+
+- **산출 기준**: `Member.createdAt` 또는 챌린저 생성 기준 일/주별 count
+- **코드 근거**: `AdminOperationsOverviewInfo.SignupBucketInfo`, `Member.createdAt`
+- **선정 사유**: 단일 “이번 주 신규”보다 모집 흐름의 상승/하락 추세를 잘 보여준다.
+- **구현 상태**: `AdminOperationsAnalyticsQueryRepository`의 `listSignupBuckets` 집계로 제공 가능
+
+### 5.2 지부-학교-파트별 챌린저 분포
+
+- **산출 기준**: 지부/학교별 전체 챌린저 수와 `ChallengerPart`별 count
+- **코드 근거**: `AdminOperationsOverviewInfo.ChapterSchoolStatusInfo`, `SchoolChallengerStatusInfo`, `Challenger.part`
+- **선정 사유**: 파트 불균형, 특정 학교의 과소/과밀 운영을 파악할 수 있다.
+- **구현 상태**: `AdminOperationsAnalyticsQueryRepository`의 `listChapterSchoolStatuses` 집계로 제공 가능
+
+### 5.3 파트별 포인트 부여 현황
+
+- **산출 기준**: 지부별/파트별 포인트 부여 건수와 합계
+- **코드 근거**: `AdminOperationsOverviewInfo.ChapterPartPointGrantStatusInfo`, `ChallengerPoint`, `Challenger.part`
+- **선정 사유**: 특정 파트에 감점이 몰리는지, 운영 기준 적용이 지부별로 편차가 큰지 확인할 수 있다.
+- **구현 상태**: `AdminOperationsAnalyticsQueryRepository`의 `listPointGrantStatuses` 집계로 제공 가능. 기간 필터가 중요하므로 기본 30일, 기수 전체 토글을 권장한다.
+
+### 5.4 일정 출석 현황
+
+- **산출 기준**: 일정 수, 출석 필수 일정 수, 출석 기록 수, `AttendanceStatus`별 count
+- **코드 근거**: `Schedule`, `ScheduleParticipant`, `ScheduleParticipantAttendance.status`, `AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo`
+- **선정 사유**: 출석 승인 대기, 지각, 결석이 많은 조직을 조기에 찾을 수 있다.
+- **구현 상태**: `AdminOperationsAnalyticsQueryRepository`의 `getScheduleAttendanceStatus` 집계로 제공 가능. 승인 대기 상태(`*_PENDING`)와 최종 상태(`PRESENT`, `LATE`, `ABSENT`, `EXCUSED`)를 분리해서 보여줘야 한다.
+
+### 5.5 스터디 그룹 운영 현황
+
+- **산출 기준**: `StudyGroup` 수, `StudyGroupSchedule` 수, 그룹별 멤버/멘토 배치 여부
+- **코드 근거**: `StudyGroup`, `StudyGroupMember`, `StudyGroupMentor`, `StudyGroupSchedule`, `GetStudyGroupUseCase`
+- **선정 사유**: UMC 운영에서 학습 그룹이 실제로 구성되고 주차별 활동이 잡히는지 확인하는 핵심 지표다.
+- **구현 상태**: `AdminOperationsAnalyticsQueryRepository`의 `getStudyGroupStatus` 집계로 그룹 수와 일정 수는 제공 가능하다. 멘토 미배정 그룹 수는 추가 집계가 필요하다.
+
+---
+
+## 6. P2: 도메인별 전문 운영 KPI 후보
+
+### 6.1 커리큘럼/워크북 KPI
+
+| KPI | 산출 기준 | 코드 근거 | 선정 사유 |
+| --- | --- | --- | --- |
+| 워크북 배포 완료율 | `OriginalWorkbookStatus.RELEASED / 전체 워크북` | `OriginalWorkbook`, `WeeklyCurriculum` | 주차별 교육 콘텐츠 배포 지연을 탐지한다. |
+| 과제 제출률 | `MissionSubmission` 제출 수 / 배포된 `ChallengerWorkbook` 수 | `ChallengerWorkbook`, `MissionSubmission` | 참여도와 학습 이탈을 측정한다. |
+| 미평가 제출 수 | `SubmissionStatus.PENDING` count | `MissionSubmission`, `ManageMissionFeedbackUseCase` | 파트장/운영진의 리뷰 병목을 보여준다. |
+| Fail/Late 비율 | `SubmissionStatus.FAIL`, `LATE` count / 제출 수 | `SubmissionStatus` | 과제 난이도나 공지 전달 문제를 조기에 발견한다. |
+| 우수 워크북 선정 수 | `WeeklyBestWorkbook` count | `WeeklyBestWorkbook` | 파트/학교별 학습 성과를 긍정 지표로 보여준다. |
+
+### 6.2 프로젝트/매칭 KPI
+
+| KPI | 산출 기준 | 코드 근거 | 선정 사유 |
+| --- | --- | --- | --- |
+| 프로젝트 상태 퍼널 | `DRAFT`, `PENDING_REVIEW`, `IN_PROGRESS`, `COMPLETED`, `ABORTED` count | `Project.status` | 프로젝트 운영 흐름과 병목 단계를 확인한다. |
+| 지원서 처리율 | `APPROVED/REJECTED` / `SUBMITTED + APPROVED + REJECTED` | `ProjectApplication.status` | 심사 지연과 운영 처리량을 측정한다. |
+| 파트별 TO 충원율 | `ProjectMember` count / `ProjectPartQuota.quota` | `ProjectPartQuota`, `ProjectMember` | 매칭 결과의 균형과 미충원 파트를 파악한다. |
+| 매칭 차수 진행률 | 현재 시각이 `startsAt~endsAt`에 포함되는 차수와 `phase` | `ProjectMatchingRound` | 매칭 일정 지연과 차수별 상태를 관리한다. |
+| 중단 프로젝트 비율 | `ProjectStatus.ABORTED / 전체 프로젝트` | `Project.status` | 프로젝트 운영 리스크를 추적한다. |
+
+### 6.3 공지/설문 KPI
+
+| KPI | 산출 기준 | 코드 근거 | 선정 사유 |
+| --- | --- | --- | --- |
+| 필독 공지 미열람 수 | `Notice.mustRead = true` 대상 중 `NoticeRead` 미존재 | `Notice`, `NoticeRead`, `NoticeTarget` | 중요한 운영 공지가 전달되지 않은 대상을 찾는다. |
+| 공지 발송 대기 수 | `shouldSendNotification = true` and `notifiedAt is null` | `Notice` | 운영진이 즉시 처리할 발송 누락을 보여준다. |
+| 공지 투표 참여율 | `NoticeVote.voteId`에 대한 제출 응답 수 / 대상자 수 | `NoticeVote`, `survey.FormResponse` | 공지 기반 의사결정 참여도를 확인한다. |
+| 설문 응답률 | `FormResponseStatus.SUBMITTED / 대상자 수` | `Form`, `FormResponse` | 운영 설문, 프로젝트 지원 폼 등의 회수율을 관리한다. |
+| 임시저장 이탈 수 | `FormResponseStatus.DRAFT` count | `FormResponse` | 폼 UX 문제나 응답 완료 독려 대상을 파악한다. |
+
+### 6.4 커뮤니티/신고 KPI
+
+| KPI | 산출 기준 | 코드 근거 | 선정 사유 |
+| --- | --- | --- | --- |
+| 게시글/댓글 생성 추이 | `Post.createdAt`, `Comment.createdAt` 기간별 count | `Post`, `Comment` | 커뮤니티 활성도를 보여준다. |
+| 스크랩/좋아요 참여율 | 스크랩/좋아요 수 / 게시글 수 | `Scrap`, `Post.likeCount`, `Comment.likeCount` | 콘텐츠 반응도를 측정한다. |
+| 신고 대기 건수 | `Report.status = PENDING` count | `Report` | 운영진 moderation 업무량을 보여준다. |
+| 트로피 발급 수 | `Trophy` 기간별 count | `Trophy`, `CreateTrophyUseCase` | 긍정적 활동 보상 현황을 보여준다. |
+
+### 6.5 시스템 운영 KPI
+
+| KPI | 산출 기준 | 코드 근거 | 선정 사유 |
+| --- | --- | --- | --- |
+| FCM 발송 실패율 | `FcmOutbox.status = FAILED` / 전체 outbox | `FcmOutbox`, `ProcessFcmOutboxUseCase` | 알림 인프라 문제를 빠르게 감지한다. |
+| FCM 활성 토큰 수 | `FcmToken.isActive = true` count | `FcmToken` | 실제 푸시 도달 가능 사용자 풀을 추정한다. |
+| Figma 동기화 실패 파일 수 | `FigmaWatchedFile.enabled = true` and `lastError not null` | `FigmaWatchedFile`, `SyncFigmaCommentsUseCase` | Figma-Discord 운영 자동화 장애를 감지한다. |
+| LLM 호출량/토큰 사용량 | `ChatCompletionResult.promptTokens`, `completionTokens` 합계 | `ChatCompleteUseCase`, `LlmMetrics` | LLM 비용과 rate limit 리스크를 추적한다. |
+| 파일 업로드량 | `FileMetadata.fileSize`, `category`, `uploadedMemberId` 기간별 합계 | `FileMetadata`, `ManageFileUseCase` | 저장소 비용과 비정상 업로드를 감시한다. |
+| 감사 로그 주요 액션 수 | `AuditLog.domain`, `action`, `actorMemberId`, `createdAt` count | `AuditLog`, `GetAuditLogUseCase` | 권한 변경, 삭제, 대량 처리 같은 민감 운영 행위를 추적한다. |
+
+---
+
+## 7. 권장 대시보드 구성
+
+### 7.1 첫 화면 KPI 카드
+
+1. 활동 챌린저 수
+2. 신규 가입자 수 및 전주 대비 증감률
+3. 활동 학교 수 / 활동 지부 수
+4. 월간 포인트 가산/감점 합계
+5. 진행 중 프로젝트 수
+6. 처리 대기 지원서 수
+
+### 7.2 운영 현황 테이블/리스트
+
+1. 학교별 운영 현황 테이블
+2. 위험군 챌린저 리스트
+3. 운영 액션 큐
+4. 챌린저 상태 분포
+
+### 7.3 다음 이터레이션 차트
+
+1. 가입 추이
+2. 지부/학교/파트별 챌린저 분포
+3. 파트별 포인트 부여 현황
+4. 일정 출석 상태 분포
+5. 커리큘럼 제출/피드백 현황
+6. 프로젝트 지원/선발 퍼널
+
+---
+
+## 8. 구현 우선순위
+
+| 우선순위 | KPI 묶음 | 이유 | 현재 상태 |
+| --- | --- | --- | --- |
+| P0 | 요약 카드, 학교별 현황, 위험군 리스트, 액션 큐 | 운영진이 매일 확인하고 즉시 조치할 수 있다. | `analytics` UseCase/Controller/일부 repository 구현 존재 |
+| P1 | 가입 추이, 파트별 분포, 포인트 추이, 출석/스터디 현황 | 운영 원인 분석과 회고에 필요하다. | `AdminOperationsOverviewInfo`와 `AdminOperationsAnalyticsQueryRepository` 구현 존재 |
+| P2 | 커리큘럼, 프로젝트 퍼널, 공지/설문, 커뮤니티, 시스템 운영 지표 | 도메인별 운영 성숙도를 높인다. | 각 도메인 Entity/UseCase는 있으나 전용 집계 API 필요 |
+
+---
+
+## 9. 주의사항
+
+- FE에서 전체 목록을 내려받아 합산하는 방식은 위험군/포인트/공지 읽음률처럼 데이터가 커지는 지표에 적합하지 않다. 서버 집계 API로 제공해야 한다.
+- 모든 지표는 `gisuId`를 기본 스코프로 삼고, 중앙/지부/학교/학교 파트장 권한에 따라 `chapterId`, `schoolId`, `responsiblePart` 필터가 자동 적용되어야 한다.
+- 신규 가입자 수는 `Member.createdAt` 기준인지, `Challenger.createdAt` 기준인지 제품 정의가 필요하다. 현재 summary 구현은 `Member.createdAt`을 사용한다.
+- 포인트 합산은 `ChallengerPoint.pointValue`와 `PointType.value`가 함께 존재하므로, 현재 analytics 구현처럼 `pointValue` 우선, 없으면 `PointType.value`를 사용하는 기준을 문서화해야 한다.
+- 운영 현황 API는 컨트롤러/서비스/어댑터/QueryDSL repository가 존재한다. FE 연결 전에는 실제 응답의 기간 필터, 권한 스코프, 대량 데이터 성능을 별도로 확인해야 한다.

--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -10,51 +10,81 @@ ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
 
-== Chapter
+== Admin dashboard
+
+=== 대시보드_action-queue_api_문서화
+operation::admin-dashboard-controller-test/대시보드_action-queue_api_문서화[snippets='http-request,http-response']
+
+=== 대시보드_context_api_응답
+operation::admin-dashboard-controller-test/대시보드_context_api_응답[snippets='http-request,http-response']
+
+=== 대시보드_operations_api_응답
+operation::admin-dashboard-controller-test/대시보드_operations_api_응답[snippets='http-request,http-response']
+
+=== 대시보드_risk-challengers_api_응답
+operation::admin-dashboard-controller-test/대시보드_risk-challengers_api_응답[snippets='http-request,http-response']
+
+=== 대시보드_summary_api_문서화
+operation::admin-dashboard-controller-test/대시보드_summary_api_문서화[snippets='http-request,http-response']
+
+== Admin school analytics
+
+=== 학교별_summary_api_문서화
+operation::admin-school-analytics-controller-test/학교별_summary_api_문서화[snippets='http-request,http-response']
+
+== Admin school query
+
+=== 학교_상세정보를_조회합니다
+operation::admin-school-query-controller-test/학교_상세정보를_조회합니다[snippets='http-request,http-response,path-parameters,response-fields']
+
+=== 학교_전체_목록을_조회합니다
+operation::admin-school-query-controller-test/학교_전체_목록을_조회합니다[snippets='http-request,http-response,response-fields']
+
+== Chapter command
 
 === 신규_지부를_생성한다
-
-operation::chapter-controller-test/신규_지부를_생성한다[snippets='http-request,http-response,request-fields']
+operation::chapter-command-controller-test/신규_지부를_생성한다[snippets='http-request,http-response,request-fields']
 
 == Chapter query
 
 === 지부_목록을_조회합니다
-
 operation::chapter-query-controller-test/지부_목록을_조회합니다[snippets='http-request,http-response,response-fields']
 
-== Gisu
+== Gisu command
+
+=== 기수를_삭제한다
+operation::gisu-command-controller-test/기수를_삭제한다[snippets='http-request,http-response,path-parameters']
+
+=== 신규_기수를_추가한다
+operation::gisu-command-controller-test/신규_기수를_추가한다[snippets='http-request,http-response,request-fields']
 
 === 현재_기수를_설정한다
-
-operation::gisu-controller-test/현재_기수를_설정한다[snippets='http-request,http-response,path-parameters']
+operation::gisu-command-controller-test/현재_기수를_설정한다[snippets='http-request,http-response,path-parameters']
 
 == Gisu query
 
-=== 기수_목록을_조회한다
+=== 기수_목록을_페이징_조회한다
+operation::gisu-query-controller-test/기수_목록을_페이징_조회한다[snippets='http-request,http-response,query-parameters,response-fields']
 
-operation::gisu-query-controller-test/기수_목록을_조회한다[snippets='http-request,http-response,response-fields']
+=== 기수_전체_목록을_조회한다
+operation::gisu-query-controller-test/기수_전체_목록을_조회한다[snippets='http-request,http-response,response-fields']
 
-== School
+=== 활성화된_기수를_조회한다
+operation::gisu-query-controller-test/활성화된_기수를_조회한다[snippets='http-request,http-response,response-fields']
+
+== School command
 
 === 총괄_신규학교를_추가한다
-
-operation::school-controller-test/총괄_신규학교를_추가한다[snippets='http-request,http-response,request-fields']
+operation::school-command-controller-test/총괄_신규학교를_추가한다[snippets='http-request,http-response,request-fields']
 
 === 총괄_학교를_일괄_삭제한다
-
-operation::school-controller-test/총괄_학교를_일괄_삭제한다[snippets='http-request,http-response,request-fields']
+operation::school-command-controller-test/총괄_학교를_일괄_삭제한다[snippets='http-request,http-response,request-fields']
 
 === 총괄_학교정보를_수정한다
+operation::school-command-controller-test/총괄_학교정보를_수정한다[snippets='http-request,http-response,path-parameters,request-fields']
 
-operation::school-controller-test/총괄_학교정보를_수정한다[snippets='http-request,http-response,path-parameters,request-fields']
+== School link query
 
-== School query
-
-=== 학교_목록을_조회합니다
-
-operation::school-query-controller-test/학교_목록을_조회합니다[snippets='http-request,http-response,query-parameters,response-fields']
-
-=== 학교_상세정보를_조회합니다
-
-operation::school-query-controller-test/학교_상세정보를_조회합니다[snippets='http-request,http-response,path-parameters,response-fields']
+=== 학교_링크를_조회합니다
+operation::school-link-query-controller-test/학교_링크를_조회합니다[snippets='http-request,http-response,path-parameters,response-fields']
 

--- a/docs/backlog/운영진_대시보드_기획안.md
+++ b/docs/backlog/운영진_대시보드_기획안.md
@@ -1,0 +1,660 @@
+# 운영진 메인 대시보드 기획안
+
+> 작성일: 2026-05-12
+> 최근 갱신: 2026-05-13 (§7.3 운영 현황 API 추가)
+> 담당: FE
+> 상태: 초안 (Draft) — §7 BE 협의용 준비 완료
+> 참조 도메인: [`src/features/challenger/`](../src/features/challenger/), [`src/features/application/`](../src/features/application/), [`src/features/matching/`](../src/features/matching/), [`src/features/project/`](../src/features/project/)
+> **BE 가 우선 읽을 섹션**: §5 권한 매트릭스 → §7 BE API 분석 → §6 MVP 범위
+
+---
+
+## 1. 배경
+
+현재 `/admin` 진입 시 [`AdminIndex`](../src/routes/admin/index.tsx) 에서 곧바로 `/admin/challenger/points` 로 리다이렉트되고 있어, 운영진이 **조직 전체 상태를 한눈에 파악할 수 있는 진입점이 없다**. 본 문서는 `/admin` 에 신규로 추가될 메인 대시보드의 정보 구조(IA) 와 위젯 구성안을 정리한다.
+
+도메인 모델은 다음 계층을 따른다.
+
+```
+기수(gisu) → 지부(chapter) → 학교(school) → 챌린저(challenger)
+                                              ├─ 파트(part): Plan / Design / Web / Android / iOS / Node.js / SpringBoot
+                                              ├─ 역할(role): 챌린저 / 학교 파트장 / 학교 회장단 / 지부장 / 중앙운영사무국 / 최고관리자
+                                              └─ 포인트(point): 가산 / 감점 (POINT_TYPE_*)
+```
+
+---
+
+## 2. 설계 원칙
+
+1. **운영진이 페이지를 열자마자 "지금 손이 가야 할 곳"이 보이도록 한다.** — 정보 나열보다 액션 가능한 시그널을 우선.
+2. **권한(`roleType`)에 따라 동일 컴포넌트에 다른 필터를 자동 주입한다.** — 중앙 = 전체 데이터, 지부장 = 본인 지부, 학교 운영진 = 본인 학교만.
+3. **이미 운영 중인 도메인 모델·API 응답을 그대로 활용한다.** — 예: `SearchChallengerOffsetResponse.partCounts` 는 그대로 차트에 투입 가능.
+4. **MVP → 점진 확장.** — 우선 가치가 높은 위젯만 먼저 만들고, 나머지는 다음 이터레이션으로 미룬다.
+
+---
+
+## 3. 정보 구조 (IA)
+
+위에서 아래로 우선순위 순.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  ①  최상단 KPI 카드 (4~6개)                                │
+├──────────────────────────────────────────────────────────┤
+│  ②  신규 가입 추이 차트   │  챌린저 상태 분포 도넛          │
+├──────────────────────────────────────────────────────────┤
+│  ③  학교/지부별 현황 테이블 (정렬·필터)                     │
+├───────────────────────────┬──────────────────────────────┤
+│  ④  파트별 분포 바차트     │  ⑤  위험군 챌린저 리스트       │
+├───────────────────────────┼──────────────────────────────┤
+│  ⑥  포인트 부여 트렌드     │  ⑦  운영 액션 큐 / 활동 피드   │
+├──────────────────────────────────────────────────────────┤
+│  ⑧  운영 현황 리포트 (조직·포인트·일정·출석·스터디·가입) │
+└───────────────────────────┴──────────────────────────────┘
+```
+
+---
+
+## 4. 위젯 상세
+
+### ① 최상단 KPI 카드
+
+운영 건강도를 한눈에 보여주는 4~6개 카드. 각 카드는 **현재 값 + 전주/전월 대비 증감**을 표기.
+
+| 카드                  | 필드 / 산출 기준                                | 비고                                 |
+| --------------------- | ----------------------------------------------- | ------------------------------------ |
+| 활동 챌린저 수        | `challengerStatus = ACTIVE` count               | 기수 필터 기본값: 현재 기수          |
+| 신규 가입자 (이번 주) | 최근 7일 신규 `member` 수                       | 전주 대비 % 변동                     |
+| 활동 학교 수          | 활동 챌린저가 1명 이상 있는 `schoolId` distinct | hover 시 지부별 분포 tooltip         |
+| 누적 부여 포인트      | 이번 달 `ChallengerPointInfo.point` 합계        | 가산 / 감점 split 표시               |
+| 매칭 진행 중 프로젝트 | `project.status = IN_PROGRESS`                  | 클릭 시 `/admin/project` 로 이동     |
+| 처리 대기 지원서      | `application.status = SUBMITTED`                | 클릭 시 `/admin/application` 로 이동 |
+
+### ② 신규 가입 추이 + 챌린저 상태 분포
+
+**(a) 신규 가입자 증감 차트**
+
+- 일별/주별 신규 챌린저 수 (스택드 바 또는 라인 차트)
+- 분기 옵션: 전체 / 지부별 / 파트별
+- 30일·90일 윈도우 토글
+
+**(b) 챌린저 상태 도넛**
+
+- `ACTIVE / GRADUATED / EXPELLED / WITHDRAWN` 비율
+- 기수 필터 적용
+- `CHALLENGER_STATUS_LABEL` 한국어 라벨 사용
+
+### ③ 학교/지부별 현황 테이블
+
+운영 회의에서 가장 많이 보는 화면. 정렬·필터 가능한 테이블.
+
+| 컬럼               | 출처 / 산출                                      |
+| ------------------ | ------------------------------------------------ |
+| 학교명             | `schoolName`                                     |
+| 소속 지부          | `chapterName`                                    |
+| 활동 챌린저 수     | challenger count where `status = ACTIVE`         |
+| 회장 / 부회장      | `SCHOOL_PRESIDENT`, `SCHOOL_VICE_PRESIDENT` 이름 |
+| 파트장 배치 비율   | `SCHOOL_PART_LEADER` 수 / 운영 중인 파트 수      |
+| 평균 포인트        | 학교 챌린저들의 `totalPoints` 평균               |
+| 경고/위험군 챌린저 | `totalPoints <= 임계치` (예: -8) 인원 수         |
+| 이번 주 신규       | 최근 7일 신규 가입 수                            |
+
+> 기본 정렬: **위험군 챌린저 수 내림차순** — "지금 손이 가야 할 학교"를 상단으로.
+
+### ④ 파트별 분포
+
+| 컬럼                  | 출처                                                                |
+| --------------------- | ------------------------------------------------------------------- |
+| 파트                  | `Part` (Plan / Design / Web / Android / iOS / Node.js / SpringBoot) |
+| 챌린저 수             | `SearchChallengerOffsetResponse.partCounts`                         |
+| 파트장 배치 학교 수   | `SCHOOL_PART_LEADER` × `responsiblePart` 집계                       |
+| 평균 포인트           | 파트별 `totalPoints` 평균                                           |
+| 베스트 워크북 수상 수 | `BEST_WORKBOOK_V2` 부여 횟수                                        |
+
+> `partCounts` 는 챌린저 검색 API 응답에 이미 포함되어 있으므로 별도 엔드포인트 추가 없이 활용 가능.
+
+### ⑤ 위험군 챌린저 리스트
+
+| 컬럼           | 출처                                |
+| -------------- | ----------------------------------- |
+| 이름           | `name`                              |
+| 학교 / 파트    | `schoolName` / `part`               |
+| 누적 포인트    | `totalPoints` (`toNumberSafe` 적용) |
+| 최근 감점 사유 | 최신 `PointType` (라벨 변환)        |
+| 최근 감점 일자 | 최신 `createdAt`                    |
+
+- 필터: `totalPoints <= 임계치` (예: -8 이하)
+- 행 클릭 → 챌린저 상세 (`/admin/challenger/points` 의 상세 패널)
+
+### ⑥ 포인트 부여 트렌드
+
+**(a) 가산 vs 감점 추이**
+
+- 최근 30일 일자별 가산/감점 합계 (스택드 바)
+- 감점이 급증하면 운영 개입 신호
+
+**(b) 포인트 타입별 분포**
+
+- `POINT_TYPE_OPTIONS` 카테고리별 부여 횟수
+- 가장 많이 부여된 가산점 Top 3 / 감점 Top 3
+
+### ⑦ 운영 액션 큐 / 활동 피드
+
+**액션 큐 (오늘 처리해야 할 일)**
+
+- 📬 처리 대기 지원서 N건
+- 🔄 진행 중인 매칭 요청 N건
+- 📢 미발송 공지 N건
+- ⚠️ 이번 주 신규 위험군 N명
+- 🎂 이번 주 수료 예정 챌린저 N명 (기수 종료 임박)
+
+**활동 피드 (선택, 다음 이터레이션)**
+
+- "OO대학교 OO님에게 `STUDY_LATE` -2점 부여 (5분 전)"
+- "OO 프로젝트 매칭 완료 (1시간 전)"
+- "신규 챌린저 N명 가입 (2시간 전)"
+
+> 감사 로그(audit log) 성격. 권한 있는 사용자에게만 노출.
+
+### ⑧ 운영 현황 리포트
+
+운영 회의와 주간 리포트에서 필요한 상세 현황을 한 번에 조회하는 API 기반 위젯. 대시보드 KPI와 달리 기간 필터(`[from, to)`)를 명시적으로 받으며, 기본 기간은 최근 30일이다.
+
+| 영역 | 필드 / 산출 기준 | 비고 |
+| ---- | ---------------- | ---- |
+| 기수·지부·학교 현황 | 지부별 학교 목록, 학교별 챌린저 총원, 파트별 인원 수 | 챌린저 총원은 해당 기수의 챌린저 전체 기준 |
+| 지부 내 파트별 상벌점 부여 현황 | `chapterId + part` 단위 `grantCount`, `pointSum` | `pointValue`가 있으면 우선 적용, 없으면 `PointType.value` 사용 |
+| 일정 및 출석 생성 현황 | 기간 내 생성된 일정 수, 출석 정책이 있는 일정 수, 출석 기록 수, 출석 상태별 수 | 일정 스코프는 작성자 학교 기준 |
+| 스터디 그룹 현황 | 기수 내 스터디 그룹 총 개수, 기간 내 스터디 그룹 일정 생성 수 | 지부/학교 스코프는 스터디 그룹 멤버 학교 기준 |
+| 기간별 신규 가입자 수 | 일자별 신규 가입자 수 | KST 날짜 버킷, `[from, to)` 기준 |
+
+> 구현 API: `GET /api/v1/admin/dashboard/operations`
+
+---
+
+## 5. 권한별 가시성 매트릭스
+
+`roleType` 을 기준으로 데이터 스코프를 분기한다.
+
+| 역할                                                                                                                           | 데이터 스코프                    |
+| ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| `SUPER_ADMIN`, `CENTRAL_PRESIDENT`, `CENTRAL_VICE_PRESIDENT`, `CENTRAL_OPERATING_TEAM_MEMBER`, `CENTRAL_EDUCATION_TEAM_MEMBER` | 전체 데이터                      |
+| `CHAPTER_PRESIDENT`                                                                                                            | 본인 지부 (`chapterId`) 데이터만 |
+| `SCHOOL_PRESIDENT`, `SCHOOL_VICE_PRESIDENT`, `SCHOOL_ETC_ADMIN`                                                                | 본인 학교 (`schoolId`) 데이터만  |
+| `SCHOOL_PART_LEADER`                                                                                                           | 본인 학교 + 담당 파트 데이터만   |
+| `CHALLENGER`                                                                                                                   | 대시보드 접근 불가               |
+
+> 동일 컴포넌트에 `roleType` 기반 필터를 자동 주입하는 식으로 처리. 라우트 가드는 별도.
+
+---
+
+## 6. MVP 범위 정의
+
+### MVP — 1차 릴리즈에 포함
+
+- ✅ ① KPI 카드 (활동 챌린저 / 신규 가입 / 대기 지원서 / 진행 매칭)
+- ✅ ③ 학교/지부별 현황 테이블
+- ✅ ⑤ 위험군 챌린저 리스트
+- ✅ ⑦ 운영 액션 큐
+- ✅ ⑧ 운영 현황 리포트 (조직·포인트·일정·출석·스터디·가입 집계)
+
+### 다음 이터레이션
+
+- ⏭ ② 신규 가입 추이 차트
+- ⏭ ② 챌린저 상태 분포 도넛
+- ⏭ ④ 파트별 분포
+- ⏭ ⑥ 포인트 부여 트렌드
+- ⏭ ⑦ 활동 피드
+
+---
+
+## 7. 백엔드 API 분석 — BE 개발자용 보고서
+
+> 본 섹션은 BE 팀이 단독으로 읽고 작업 범위를 산정할 수 있도록 작성됐다. 출처는 [`src/features/challenger/api/`](../../src/features/challenger/api/), [`src/features/auth/api/me.ts`](../../src/features/auth/api/me.ts), 그리고 각 도메인(`application`, `matching`, `project`, `notice`, `audit-log`) 의 디렉토리 구조 조사 결과(2026-05-12 시점) 다.
+
+### 7.1 현재 FE 연동 현황 한눈에 보기
+
+```
+✅ 이미 연동된 API (FE 사용 중)
+─ Challenger
+   GET    /api/v1/challenger/{id}                   챌린저 상세 + 포인트 이력
+   GET    /api/v1/challenger/search/offset          offset 페이지네이션 검색 (+ partCounts)
+   POST   /api/v1/challenger/{id}/points            포인트 부여
+   PATCH  /api/v1/challenger/{id}/part              파트 변경
+   POST   /api/v1/challenger/{id}/deactivate        챌린저 비활성화
+   DELETE /api/v1/challenger/{id}                   챌린저 삭제
+─ Member
+   GET    /api/v1/member/me                         현재 사용자 (제한된 필드 — 7.5 참조)
+   GET    /v1/member/search                         회원 검색 (페이지네이션)
+   GET    /v1/member/profile/{id}                   회원 상세 (챌린저 기록 포함)
+─ Organization
+   GET    /v1/gisu/all                              기수 전체 조회
+   GET    /v1/chapters                              지부 목록
+   GET    /v1/chapters/with-schools                 지부별 학교 목록 (gisuId 필수)
+   GET    /v1/schools/all                           학교 전체 목록
+─ Challenger Record
+   POST   /api/v1/challenger-record                 기록 생성
+   GET    /api/v1/challenger-record/code/{code}     코드로 기록 조회
+─ Audit Log
+   GET    /api/v1/admin/audit-logs                  감사 로그 조회 (필터 지원)
+
+❌ FE에서 API 클라이언트가 아직 없는 도메인 (src/features/{도메인}/api/ 부재)
+─ application, matching, project, notice, audit-log (UI는 일부 존재)
+```
+
+### 7.2 위젯 × 데이터 × API 매핑 (현재 ↔ 필요)
+
+각 위젯이 요구하는 데이터와, 이를 충족하기 위한 API 작업을 다음 4 가지로 분류한다.
+
+- **✅ 활용 가능** — 기존 API 응답을 FE에서 가공해 그대로 사용
+- **🔄 확장 필요** — 기존 엔드포인트에 파라미터/필드/정렬을 추가하면 됨 (Breaking 없음)
+- **🆕 신규 필요** — 단일 호출로는 불가능하거나 N+1 위험이 있어 신규 엔드포인트 권장
+- **⚠️ 도메인 미구현** — BE 도메인 자체가 아직 없거나 FE 클라이언트가 미연동
+
+| #   | 위젯                                             | 필요 데이터                                                                                    | 현재 상태                                                                                 | BE 작업                                                                                                                                                                                     |
+| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ①-1 | KPI: 활동 챌린저 수                              | `challengerStatus = ACTIVE` count (기수/지부/학교 스코프)                                      | 🆕 summary 집계로 제공                                                                      | `GET /api/v1/admin/dashboard/summary` 에 통합                                                                                                                                              |
+| ①-2 | KPI: 신규 가입자 (이번 주)                       | 최근 7일 신규 `member` count                                                                   | 🔄 `GET /v1/member/search` 에 `createdAt[from\|to]` 미지원                                | `GET /v1/member/search` 에 `joinedAtFrom`, `joinedAtTo` (또는 `createdAtFrom/To`) 파라미터 추가                                                                                             |
+| ①-3 | KPI: 활동 학교 수                                | 활동 챌린저 1명 이상인 `schoolId` distinct                                                     | 🆕 summary 집계로 제공                                                                      | `GET /api/v1/admin/dashboard/summary` 응답에 `activeSchoolCount` 포함                                                                                                                       |
+| ①-4 | KPI: 누적 부여 포인트 (이번 달)                  | 가산/감점 합계                                                                                 | 🆕 summary 집계로 제공                                                                      | `GET /api/v1/admin/dashboard/summary` 에 `monthlyPointSum: { positive, negative }` 포함                                                                                                      |
+| ①-5 | KPI: 매칭 진행 중 프로젝트                       | `project.status = IN_PROGRESS` count                                                           | 🆕 summary 집계로 제공                                                                      | `GET /api/v1/admin/dashboard/summary` 응답에 포함                                                                                                                                          |
+| ①-6 | KPI: 처리 대기 지원서                            | `application.status = SUBMITTED` count                                                         | 🆕 summary/action queue 집계로 제공                                                        | `GET /api/v1/admin/dashboard/summary`, `GET /api/v1/admin/dashboard/action-queue` 응답에 포함                                                                                                |
+| ②-a | 신규 가입 추이 차트                              | 일별/주별 신규 챌린저, 기수·지부·파트 분기, 30/90일 윈도우                                     | 🆕 시계열 집계 없음                                                                       | `GET /api/v1/admin/stats/signups?from&to&groupBy=DAY\|WEEK&chapterId?&part?` 신규                                                                                                           |
+| ②-b | 챌린저 상태 분포 도넛                            | `ACTIVE/GRADUATED/EXPELLED/WITHDRAWN` 비율                                                     | 🆕 summary 응답에 포함                                                                     | `GET /api/v1/admin/dashboard/summary` 의 `challengerStatusDistribution` 활용                                                                                                                 |
+| ③   | 학교/지부별 현황 테이블                          | 학교명, 지부명, 활동 챌린저 수, 회장/부회장, 파트장 비율, 평균 포인트, 위험군 수, 이번 주 신규 | 🆕 신규 집계 API로 제공                                                                    | **`GET /api/v1/admin/schools/summary?gisuId&chapterId?` 신규 (P0)** — 한 번에 학교 행 데이터 반환                                                                                            |
+| ④-1 | 파트별 분포: 챌린저 수                           | `partCounts`                                                                                   | ✅ `SearchChallengerOffsetResponse.partCounts` 그대로 활용                                | 없음 (필터 파라미터만 BE 측에서 보장)                                                                                                                                                       |
+| ④-2 | 파트별 분포: 파트장 배치 학교 수                 | `SCHOOL_PART_LEADER × responsiblePart` 집계                                                    | 🆕 현재 챌린저 상세에만 역할 있음                                                         | `GET /api/v1/admin/parts/summary?gisuId` 신규                                                                                                                                               |
+| ④-3 | 파트별 분포: 평균 포인트 / 베스트 워크북 수상 수 | 파트별 집계                                                                                    | 🆕                                                                                        | 동일 (`/api/v1/admin/parts/summary`) 응답에 포함                                                                                                                                            |
+| ⑤   | 위험군 챌린저 리스트                             | `totalPoints <= 임계치` 정렬·필터, 최근 감점 사유·일자                                         | 🆕 신규 admin API로 제공                                                                   | `GET /api/v1/admin/dashboard/risk-challengers` 에서 서버측 `riskThreshold` 필터와 `latestNegativePoint` 제공                                                                                 |
+| ⑥-a | 포인트 부여 트렌드 (가산/감점 추이)              | 일자별 가산·감점 합계 (최근 30일)                                                              | 🆕                                                                                        | `GET /api/v1/admin/stats/points/daily?from&to&gisuId?` 신규                                                                                                                                 |
+| ⑥-b | 포인트 타입별 분포                               | `POINT_TYPE_*` 별 부여 횟수, Top 3                                                             | 🆕                                                                                        | `GET /api/v1/admin/stats/points/by-type?gisuId&from&to` 신규                                                                                                                                |
+| ⑦-a | 액션 큐: 처리 대기 지원서 N건                    | application count                                                                              | 🆕 신규 action queue API로 제공                                                            | `/api/v1/admin/dashboard/action-queue` 응답                                                                                                                                                 |
+| ⑦-b | 액션 큐: 진행 중 매칭 N건                        | matching count                                                                                 | ⚠️                                                                                        | matching 도메인 상태 확인 후 결정                                                                                                                                                           |
+| ⑦-c | 액션 큐: 미발송 공지 N건                         | notice 미발송                                                                                  | ⚠️ FE 도메인 디렉토리만 존재                                                              | notice 도메인 상태 확인 후 결정                                                                                                                                                             |
+| ⑦-d | 액션 큐: 이번 주 신규 위험군 N명                 | 최근 7일 신규 가입 + `pointSum <= 임계치`                                                      | 🆕                                                                                        | `/api/v1/admin/dashboard/action-queue` 응답에 포함                                                                                                                                          |
+| ⑦-e | 액션 큐: 이번 주 수료 예정 N명                   | 현재 기수 종료 임박                                                                            | 🆕 (기수 `endAt` 필요)                                                                    | `Gisu` 응답에 `endAt` 노출 + summary 응답 포함                                                                                                                                              |
+| ⑧-1 | 운영 현황: 기수·지부·학교별 챌린저 현황          | 지부별 학교, 학교별 총원·파트별 인원 수                                                       | 🆕                                                                                        | `GET /api/v1/admin/dashboard/operations` 응답 `chapterSchoolStatuses` 에 포함                                                                                                                |
+| ⑧-2 | 운영 현황: 지부 내 파트별 상벌점 부여 현황       | `chapterId + part` 별 부여 횟수와 총점                                                        | 🆕                                                                                        | `GET /api/v1/admin/dashboard/operations` 응답 `pointGrantStatuses` 에 포함                                                                                                                   |
+| ⑧-3 | 운영 현황: 일정 및 출석 생성 현황                | 기간 내 일정 수, 출석 정책 일정 수, 출석 기록 수, 출석 상태별 수                              | 🆕                                                                                        | `GET /api/v1/admin/dashboard/operations` 응답 `scheduleAttendanceStatus` 에 포함                                                                                                             |
+| ⑧-4 | 운영 현황: 스터디 그룹 및 스터디 일정 현황       | 기수 내 스터디 그룹 총 개수, 기간 내 스터디 그룹 일정 생성 수                                 | 🆕                                                                                        | `GET /api/v1/admin/dashboard/operations` 응답 `studyGroupStatus` 에 포함                                                                                                                     |
+| ⑧-5 | 운영 현황: 기간별 신규 가입자 수                 | KST 일자별 신규 가입자 수                                                                     | 🆕                                                                                        | `GET /api/v1/admin/dashboard/operations` 응답 `signupBuckets` 에 포함                                                                                                                        |
+
+### 7.3 신규/확장 API 상세 스펙 — BE 작업 단위
+
+> **명명 규칙**: 서버 실제 prefix는 `/api/v1` 이므로 모든 신규 집계 엔드포인트는 `/api/v1/admin/...` 로 제공한다. 권한 스코프(7.5)는 BE 가 토큰에서 추출한 `roleType`+`organizationId` 기준으로 자동 필터링한다. 별도 path 분기 없음.
+
+#### 🆕 [P0] `GET /api/v1/admin/dashboard/summary`
+
+대시보드 진입 시 한 번 호출되는 핵심 집계.
+
+```
+Query Parameters
+  gisuId        string?   기본값: 현재 활성 기수 (Gisu.isActive=true)
+  chapterId     string?   CENTRAL 이상 권한에서만 의미 있음. 그 외는 BE가 무시
+  schoolId      string?   동일
+
+Response
+  {
+    activeChallengerCount: number,
+    newMemberCountThisWeek: number,
+    newMemberDeltaPercent: number,        // 전주 대비
+    activeSchoolCount: number,
+    activeChapterCount: number,
+    monthlyPointSum: {
+      positive: number,                   // 가산 합계 (이번 달)
+      negative: number,                   // 감점 합계 (이번 달, 음수)
+    },
+    projectInProgressCount: number,       // status = IN_PROGRESS
+    pendingApplicationCount: number,      // status = SUBMITTED
+    challengerStatusDistribution: {
+      ACTIVE: number,
+      GRADUATED: number,
+      EXPELLED: number,
+      WITHDRAWN: number,
+    }
+  }
+```
+
+#### 🆕 [P0] `GET /api/v1/admin/schools/summary`
+
+학교/지부별 현황 테이블의 단일 호출 엔드포인트. **위험군 챌린저 수 내림차순이 기본 정렬.**
+
+```
+Query Parameters
+  gisuId        string    필수
+  chapterId     string?
+  search        string?   학교명 부분 일치
+  riskThreshold number?   위험군 판정 임계치 (기본 -8)
+  sort          string?   "riskCount,desc" | "activeCount,desc" | "schoolName,asc"
+  page          number?
+  size          number?
+
+Response (page 형식)
+  {
+    content: [
+      {
+        schoolId: string,
+        schoolName: string,
+        chapterId: string,
+        chapterName: string,
+        activeChallengerCount: number,
+        president:      { challengerId, name } | null,   // SCHOOL_PRESIDENT
+        vicePresident:  { challengerId, name } | null,   // SCHOOL_VICE_PRESIDENT
+        partLeaderRatio: { assigned: number, totalRunningParts: number },
+        averagePointSum: number,
+        riskChallengerCount: number,                     // pointSum <= riskThreshold
+        newMemberCountThisWeek: number,
+      }
+    ],
+    page, size, totalElements, totalPages, hasNext, hasPrevious
+  }
+```
+
+#### 🆕 [P0] `GET /api/v1/admin/dashboard/risk-challengers`
+
+위험군 챌린저 위젯 전용 엔드포인트. 기존 `GET /api/v1/challenger/search/offset` 호출은 하위 호환성을 위해 변경하지 않는다.
+
+```
+Query Parameters
+  gisuId          string?
+  chapterId       string?
+  schoolId        string?
+  riskThreshold   number?      위험군 판정 임계치 (기본 -8)
+  page            number?
+  size            number?
+
+Response (page 형식)
+  {
+    content: [{
+      challengerId: string,
+      memberId: string,
+      name: string,
+      schoolName: string,
+      part: Part,
+      pointSum: number,
+      latestNegativePoint: {
+        pointType: PointType,
+        createdAt: ISO8601,
+        score: number
+      } | null
+    }],
+    page, size, totalElements, totalPages, hasNext, hasPrevious
+  }
+```
+
+#### 🔄 [선택] `GET /api/v1/challenger/search/offset` 확장
+
+기존 엔드포인트 확장은 다음 이터레이션에서 선택적으로 진행한다. 확장 시에는 기존 호출 호환을 유지하고 아래 파라미터를 추가한다.
+
+```
+추가 Query Parameters
+  status/statuses "ACTIVE"|"GRADUATED"|"EXPELLED"|"WITHDRAWN"
+  pointSumLte     number
+  pointSumGte     number
+  roleType        RoleType
+  sort            "pointSum,asc" | "pointSum,desc" | "createdAt,desc"
+
+추가 Response 필드
+  latestNegativePoint: {
+    pointType: PointType,
+    createdAt: ISO8601,
+    score: number
+  } | null
+```
+
+> ⚠️ 위험군 위젯이 FE에서 N 페이지를 끝까지 훑지 않도록 `pointSumLte` 서버측 필터가 반드시 필요하다.
+
+#### 🆕 [P0] `GET /api/v1/admin/dashboard/action-queue`
+
+운영진 액션 큐 위젯. 권한별 스코프 자동 적용.
+
+```
+Query Parameters
+  gisuId        string?
+
+Response
+  {
+    pendingApplicationCount: number,
+    inProgressMatchingCount: number,
+    unsentNoticeCount: number,
+    newRiskMemberCountThisWeek: number,
+    upcomingGraduationCount: number,    // 현재 기수 endAt 기준 D-14
+  }
+```
+
+#### 🆕 [P1] `GET /api/v1/admin/dashboard/context`
+
+권한 기반 필터 자동 주입을 위해 admin dashboard 전용 context endpoint를 제공한다. 기존 `GET /api/v1/member/me` 응답은 하위 호환성을 위해 변경하지 않는다.
+
+```
+Response
+  roleType:        RoleType
+  gisuId:          string         // 현재 활동 중인 기수
+  chapterId:       string | null  // CHAPTER_PRESIDENT 인 경우
+  schoolId:        string | null  // SCHOOL_* 인 경우
+  responsiblePart: Part | null    // SCHOOL_PART_LEADER 인 경우
+  scopeType:       "CENTRAL"|"CHAPTER"|"SCHOOL"|"SCHOOL_PART"
+```
+
+> 현재 [`src/features/auth/api/me.ts:5-14`](../../src/features/auth/api/me.ts#L5-L14) `MemberInfoResponse` 에는 `id, name, nickname, email, schoolId, schoolName, profileImageLink, status` 만 있다. 이걸로는 권한 분기 불가능.
+
+#### 🆕 [P1] `GET /api/v1/admin/dashboard/operations`
+
+운영 현황 리포트용 통합 집계 엔드포인트. 권한 스코프는 summary/action-queue와 동일하게 BE에서 자동 적용한다.
+
+```
+Query Parameters
+  gisuId        string?     기본값: 현재 활성 기수
+  from          ISO8601?    기본값: to - 30일
+  to            ISO8601?    기본값: 현재 시각
+
+Response
+  {
+    chapterSchoolStatuses: [
+      {
+        chapterId: string,
+        chapterName: string,
+        schools: [
+          {
+            schoolId: string,
+            schoolName: string,
+            totalChallengerCount: number,
+            challengerPartCounts: {
+              PLAN: number,
+              DESIGN: number,
+              WEB: number,
+              ANDROID: number,
+              IOS: number,
+              NODEJS: number,
+              SPRINGBOOT: number,
+              ADMIN: number
+            }
+          }
+        ]
+      }
+    ],
+    pointGrantStatuses: [
+      {
+        chapterId: string,
+        chapterName: string,
+        part: Part,
+        grantCount: number,
+        pointSum: number
+      }
+    ],
+    scheduleAttendanceStatus: {
+      scheduleCount: number,
+      attendanceRequiredScheduleCount: number,
+      attendanceRecordCount: number,
+      attendanceStatusCounts: {
+        PRESENT: number,
+        LATE: number,
+        ABSENT: number,
+        EXCUSED: number
+      }
+    },
+    studyGroupStatus: {
+      studyGroupCount: number,
+      studyGroupScheduleCount: number
+    },
+    signupBuckets: [
+      { date: "2026-05-13", count: 3 }
+    ]
+  }
+```
+
+집계 기준:
+
+- 기간 필터는 `[from, to)` 로 해석한다.
+- 신규 가입 버킷 날짜는 KST 기준 `LocalDate` 로 내려준다.
+- 일정 스코프는 `Schedule.authorMemberId` 의 학교가 속한 지부/학교를 기준으로 제한한다.
+- 출석 기록은 `ScheduleParticipant.attendance.status` 가 존재하고 `ScheduleParticipant.updatedAt` 이 기간 안에 있는 건을 집계한다.
+- 스터디 그룹 총 개수는 기수 기준 전체 개수이며, 지부/학교 스코프에서는 스터디 그룹 멤버의 학교로 제한한다.
+- 스터디 그룹 일정 생성 수는 `StudyGroupSchedule.createdAt` 이 기간 안에 있는 건을 집계한다.
+
+#### 🆕 [P1] `GET /v1/member/search` 확장 — 날짜 필터
+
+```
+추가 Query Parameters
+  joinedAtFrom   ISO8601    (또는 createdAtFrom)
+  joinedAtTo     ISO8601
+  groupBy        "day"|"week"|"month"?   (선택, 시계열 응답 시)
+```
+
+#### 🆕 [P1] `GET /api/v1/admin/stats/signups`
+
+```
+Query: from, to, groupBy=day|week, chapterId?, part?, gisuId?
+Response:
+  {
+    buckets: [{ date: "2026-05-12", count: 12, byPart?: { ... } }]
+  }
+```
+
+#### 🆕 [P1] `GET /api/v1/admin/stats/points/daily`
+
+```
+Query: from, to, gisuId?, chapterId?, schoolId?
+Response:
+  {
+    buckets: [
+      { date: "2026-05-12", positive: 34, negative: -12, totalGrants: 18 }
+    ]
+  }
+```
+
+#### 🆕 [P2] `GET /api/v1/admin/stats/points/by-type`
+
+```
+Query: gisuId, from, to, chapterId?, schoolId?
+Response:
+  {
+    byType: [{ pointType: "STUDY_LATE", count: 42, sum: -84 }],
+    topPositive: PointType[],   // 상위 3
+    topNegative: PointType[],
+  }
+```
+
+#### 🆕 [P2] `GET /api/v1/admin/parts/summary`
+
+```
+Query: gisuId, chapterId?
+Response:
+  {
+    parts: [
+      {
+        part: "WEB",
+        challengerCount: 87,
+        partLeaderSchoolCount: 14,
+        averagePointSum: 7.4,
+        bestWorkbookCount: 9       // BEST_WORKBOOK_V2 부여 횟수
+      }
+    ]
+  }
+```
+
+### 7.4 BE 작업 로드맵 (우선순위 정렬)
+
+| 우선순위 | 작업                                                                                                 | 의존성                                              | 예상 영향 범위           |
+| -------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------ |
+| **P0**   | `GET /api/v1/admin/dashboard/summary` 신규                                                           | application·project·matching 도메인 count 쿼리      | KPI 카드 ①-1 ~ ①-6       |
+| **P0**   | `GET /api/v1/admin/schools/summary` 신규                                                             | 챌린저·학교·기수 join 쿼리                          | 위젯 ③                   |
+| **P0**   | `GET /api/v1/admin/dashboard/risk-challengers` 신규                                                  | 챌린저·포인트 집계                                  | 위젯 ⑤                   |
+| **P0**   | `GET /api/v1/admin/dashboard/action-queue` 신규                                                      | 다수 도메인 count                                   | 위젯 ⑦                   |
+| **P1**   | `GET /api/v1/admin/dashboard/context` 신규                                                           | 운영진 역할 스코프 resolver                         | 권한 자동 필터 (전 위젯) |
+| **P1**   | `GET /api/v1/admin/dashboard/operations` 신규                                                        | 챌린저·포인트·일정·출석·스터디 그룹 집계            | 운영 현황 리포트 ⑧       |
+| **P1**   | `GET /v1/member/search` 날짜 필터 확장                                                               | 단순 where 추가                                     | KPI ①-2, 위젯 ②          |
+| **P1**   | `GET /api/v1/admin/stats/signups` 신규                                                               | 시계열 집계                                         | 위젯 ②                   |
+| **P1**   | `GET /api/v1/admin/stats/points/daily` 신규                                                          | 포인트 시계열 집계                                  | 위젯 ⑥-a                 |
+| **P2**   | `GET /api/v1/admin/stats/points/by-type` 신규                                                        | 포인트 분류 집계                                    | 위젯 ⑥-b                 |
+| **P2**   | `GET /api/v1/admin/parts/summary` 신규                                                               | 파트·역할·포인트 집계                               | 위젯 ④                   |
+
+> **MVP(§6) 기준 P0 4건 + P1 1건(`/api/v1/admin/dashboard/context`)이 완료되면 1차 릴리즈 가능.** 나머지 P1·P2 는 다음 이터레이션과 함께 추진.
+
+### 7.5 권한별 데이터 스코프 처리 — BE 책임
+
+**FE 는 동일 컴포넌트로 모든 권한을 다룬다.** 권한별 필터 자동 주입은 BE 가 토큰의 `roleType`+`organizationId` 를 기반으로 응답을 제한하는 방식으로 처리한다 (§5 매트릭스 참조).
+
+```
+권한별 자동 스코프 적용 규칙 (BE 측)
+
+  CENTRAL_*, SUPER_ADMIN
+    └─ 모든 chapterId/schoolId 허용. 클라이언트가 지정한 필터만 적용.
+
+  CHAPTER_PRESIDENT
+    └─ 토큰의 chapterId 외 다른 chapterId/schoolId 가 요청에 포함되면
+       → 403 반환
+
+  SCHOOL_PRESIDENT, SCHOOL_VICE_PRESIDENT, SCHOOL_ETC_ADMIN
+    └─ 토큰의 schoolId 밖 요청은 403 반환
+
+  SCHOOL_PART_LEADER
+    └─ 토큰의 schoolId + responsiblePart 밖 요청은 403 반환
+
+  CHALLENGER
+    └─ 대시보드 엔드포인트 전체 403
+```
+
+> **확정 정책**: 스코프 위반은 자동 덮어쓰기나 빈 결과 대신 `403` 을 반환한다. 요청 필터가 비어 있으면 서버가 사용자 권한 스코프를 자동 적용한다.
+
+### 7.6 응답 페이로드 컨벤션 — FE 측 기대치
+
+BE 가 신규 엔드포인트 작성 시 다음을 따르면 FE 통합 비용이 최소화된다.
+
+- **포인트 수치**: `pointSum`, `score` 등은 가능한 한 number 로 반환. 현재 FE 는 `toNumberSafe` 로 string/null 혼합을 방어 중이지만, 신규 엔드포인트는 number 통일을 권장.
+- **enum 직렬화**: 항상 UPPER_SNAKE 문자열로 반환 (`"ACTIVE"`, `"SCHOOL_PRESIDENT"`, `"BEST_WORKBOOK_V2"`). FE 의 `RoleType`/`ChallengerStatus`/`Part`/`PointType` 와 1:1 매핑.
+- **페이지 객체**: 기존 `SearchChallengerOffsetResponse.page` 구조 (`content, page, size, totalElements, totalPages, hasNext, hasPrevious`) 그대로 따를 것.
+- **빈 상태 vs 0**: 데이터 없음과 "값이 0" 을 구분해야 하는 KPI 카드를 위해, summary 응답에서 측정 불가능한 항목은 `null` 로, 0건인 항목은 `0` 으로 명확히 구분해 보낼 것.
+- **날짜**: 항상 ISO 8601 (UTC). 클라이언트 측에서 KST 변환.
+- **포인트 임계치(예: -8)**: BE 가 default 값을 응답이나 별도 `GET /api/v1/admin/config/thresholds` 로 노출해주면, 운영 정책 변경 시 BE 한 곳만 수정 가능. FE 하드코딩 회피.
+
+### 7.7 BE 작업 외 — FE 측에서 선행되어야 할 사항 (참고)
+
+> BE 가 모르고 있어도 무방하지만, 일정 조율 시 참고용.
+
+- 글로벌 `gisuId` 상태 (Zustand/Context). 현재 [`ProfileDropdown.tsx`](../../src/shared/ui/ProfileDropdown.tsx) 의 기수 선택은 TODO 상태.
+- `src/features/dashboard/` 도메인 신규 생성.
+- [`src/routes/admin/index.tsx`](../../src/routes/admin/index.tsx) 의 `/admin/challenger/points` 강제 리다이렉트 제거.
+
+---
+
+## 8. UX 고려 사항
+
+- **숫자 0 대 미정의 구분**: "신규 가입자 0명" 과 "데이터 없음" 을 명확히 구분. 로딩/빈 상태는 별도 디자인.
+- **포인트 수치는 `toNumberSafe`** 로 안전 변환. 백엔드가 number/string/null 혼합으로 내려줄 수 있음.
+- **기수 필터는 글로벌 컨텍스트**: 한 번 선택하면 페이지 내 모든 위젯에 적용.
+- **임계치(예: 위험군 -8점)는 상수 분리**: 운영 정책 변경 시 한 곳만 수정하도록.
+- **모바일/태블릿 대응 후순위**: 운영진은 데스크탑 사용이 기본 동선. MVP 는 데스크탑 우선.
+
+---
+
+## 9. 다음 단계
+
+1. 본 기획안 운영진 리뷰 → 위젯 확정
+2. **BE 협의 미팅** — §7.4 로드맵 기준 P0 4건 API 스펙·일정 확정
+   - 권한 스코프 위반 정책은 `403` 으로 확정됨
+   - `application` · `matching` · `project` · `notice` 도메인의 BE 측 구현 상태 점검
+   - `Gisu.endAt` 노출 여부 (수료 예정 위젯용)
+3. Figma 디자인 작업 (디자인 시스템 토큰 기반)
+4. FE 선행 작업 — 글로벌 `gisuId` 상태 도입, `/api/v1/admin/dashboard/context` 응답 기반 권한 컨텍스트 구축
+5. FE 구현 — [`src/routes/admin/index.tsx`](../src/routes/admin/index.tsx) 의 리다이렉트를 대시보드 컴포넌트로 교체, `src/features/dashboard/` 신규 도메인 추가

--- a/docs/guides/감사_로그_FE_API_가이드.md
+++ b/docs/guides/감사_로그_FE_API_가이드.md
@@ -1,0 +1,429 @@
+# 감사 로그(Audit Log) FE API 가이드
+
+> 작성일: 2026-05-12
+>
+> 본 문서는 운영진(중앙운영사무국)이 백오피스에서 감사 로그를 손쉽게 조회할 수 있도록,
+> FE 가 호출해야 할 API 와 UI 구성 시 고려할 서버측 의도를 정리한 문서입니다.
+>
+> 대상 독자: 백오피스 FE 개발자
+> 관련 도메인 패키지: [audit/](src/main/java/com/umc/product/audit)
+
+---
+
+## 0. 한눈에 보기
+
+- **무엇을 보여주는 화면인가?** 시스템 내에서 발생한 주요 상태 변경(생성/수정/삭제/승인 등)의 이력을 시간 순으로 보여주는 관리자 전용 화면입니다.
+- **누가 볼 수 있는가?** **중앙운영사무국 국원**만 조회 가능합니다.
+  ([AuditLogPermissionEvaluator.java](src/main/java/com/umc/product/audit/application/service/AuditLogPermissionEvaluator.java))
+- **데이터는 어떻게 쌓이나?** 백엔드 메서드에 붙은 `@Audited` 어노테이션이 메서드 정상 종료 후 이벤트를 발행하고, 트랜잭션 커밋 이후 **비동기로** DB 에 저장합니다.
+- **호출해야 할 엔드포인트는?** `GET /api/v1/admin/audit-logs` 단 하나입니다. 필터 파라미터로 좁혀 검색합니다.
+
+---
+
+## 1. 서버측 의도 (왜 이렇게 설계되었는가)
+
+FE 가 화면을 만들 때 다음 설계 의도를 알고 있으면 더 자연스러운 UI 를 만들 수 있어요.
+
+### 1.1 감사 로그는 "사후 기록" 이다 (Append-Only, Immutable)
+
+- 저장된 감사 로그는 **수정/삭제되지 않습니다**. `AuditLog` 엔티티는 `BaseEntity` 를 상속하지 않으며
+  쓰기 API 가 존재하지 않습니다. ([AuditLog.java](src/main/java/com/umc/product/audit/domain/AuditLog.java))
+- → FE 도 마찬가지로 **읽기 전용 화면**으로만 구성해야 합니다. "수정" / "삭제" 버튼 같은 액션 영역을 두지 마세요.
+
+### 1.2 비즈니스 트랜잭션과 분리되어 비동기로 적재된다
+
+- `@Audited` 가 붙은 메서드 → AOP 가 `AuditLogEvent` 발행 → `@TransactionalEventListener(AFTER_COMMIT)` + `@Async("auditTaskExecutor")` 로 저장.
+  ([AuditAspect.java](src/main/java/com/umc/product/audit/adapter/in/aop/AuditAspect.java),
+  [AuditLogEventListener.java](src/main/java/com/umc/product/audit/adapter/in/event/AuditLogEventListener.java))
+- 의미하는 바:
+    1. **롤백된 트랜잭션의 로그는 절대 남지 않는다** (유령 로그 방지).
+    2. 비즈니스 액션 직후 화면을 갱신해도 **수 ms 시차 뒤에 로그가 보일 수 있다**.
+- → FE 가 어떤 액션 직후 "방금 발생한 감사 로그" 를 즉시 보여주는 식의 UX 는 권장하지 않습니다.
+  필요하다면 1~2초 지연 후 재조회하거나, 사용자가 명시적으로 새로고침할 수 있게 하세요.
+
+### 1.3 필터는 "검색" 이 아니라 "좁히기" 다
+
+- 검색 파라미터는 **전부 선택(optional)** 이며, **AND 조건**으로 합쳐집니다.
+  ([AuditLogQueryRepository.java](src/main/java/com/umc/product/audit/adapter/out/persistence/AuditLogQueryRepository.java))
+- 키워드 검색(텍스트 like 검색)은 **지원하지 않습니다**. `description` 컬럼은 자유 텍스트지만
+  서버 측 `where` 절에 사용되지 않습니다.
+- → FE 는 "키워드 검색창" 보다 **필터 칩(chip)** 형태가 서버 의도에 부합합니다.
+
+### 1.4 정렬은 항상 최신순 고정
+
+- 결과는 `createdAt DESC` 로 고정 정렬되어 반환됩니다. Spring `Pageable` 의 `sort` 파라미터는 무시됩니다.
+- → FE 에서 "오래된 순으로 보기" UI 는 만들지 마세요. 굳이 필요하면 서버에 정렬 옵션 추가 요청부터.
+
+### 1.5 인덱스 설계가 곧 권장 필터 조합이다
+
+마이그레이션 ([V2026.03.12.01.00__create_audit_log.sql](src/main/resources/db/migration/V2026.03.12.01.00__create_audit_log.sql)) 에서
+다음 4 개 인덱스를 생성합니다.
+
+| 인덱스                        | 권장 필터 시나리오                                |
+|----------------------------|-------------------------------------------|
+| `(domain, action)`         | "스케줄 도메인에서 발생한 생성 이벤트만 보기"                |
+| `(target_type, target_id)` | 특정 엔티티 하나의 변경 이력 (단, 현재 API 는 미지원 — 4.6 참고) |
+| `(actor_member_id)`        | 특정 회원이 일으킨 액션 전체                          |
+| `(created_at)`             | 기간 필터, 그리고 정렬                             |
+
+→ 즉, 서버가 효율적으로 답변할 수 있는 조합은 **도메인+액션 / 행위자 / 기간** 입니다. UI 도 이 축을 기본 필터로 두는 게 가장 자연스러워요.
+
+---
+
+## 2. UI 구성 제안
+
+위의 의도에 맞춰 다음 구조를 권장합니다. 시안 그대로 구현해야 한다는 의미는 아니며, "왜 이렇게 권장하는지" 의 근거로 사용하세요.
+
+### 2.1 페이지 레이아웃
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 감사 로그                                              [새로고침]│
+├─────────────────────────────────────────────────────────────┤
+│ ┌─ 필터 영역 ────────────────────────────────────────────┐ │
+│ │ 도메인 [전체 ▼]   액션 [전체 ▼]   행위자 [회원 검색 🔍]    │ │
+│ │ 기간   [2026-05-01 00:00] ~ [2026-05-12 23:59]           │ │
+│ │                                          [초기화] [조회]   │ │
+│ └────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ 전체 N건 (page 0 / size 20)                                  │
+├──┬───────────────┬─────────┬──────────┬──────────┬─────────┤
+│  │ 시각          │ 도메인  │ 액션     │ 대상     │ 행위자   │
+├──┼───────────────┼─────────┼──────────┼──────────┼─────────┤
+│ ▶│ 05-12 14:23   │ SCHEDULE│ CREATE   │ #123     │ 홍길동   │
+│ ▶│ 05-12 14:22   │ MEMBER  │ WITHDRAW │ #88      │ (시스템) │
+│  │ ...                                                      │
+├──┴───────────────┴─────────┴──────────┴──────────┴─────────┤
+│             [◀ 이전]   1 2 3 ... 8   [다음 ▶]                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 필터 컴포넌트 권장
+
+| 필드           | 컴포넌트          | 비고                                                            |
+|--------------|---------------|---------------------------------------------------------------|
+| `domain`     | 단일 선택 드롭다운    | 옵션은 §3.4 Enum 참고. "전체" 선택 시 파라미터 미전송                          |
+| `action`     | 단일 선택 드롭다운    | 옵션은 §3.4 Enum 참고. "전체" 선택 시 파라미터 미전송                          |
+| 행위자          | 회원 검색 + 칩     | 회원 검색 모달에서 선택 후 `memberId` 만 서버에 전송. 화면에는 회원명 표시            |
+| 기간 시작/종료     | `DateTimePicker` | 로컬 시간 입력 → 서버 전송 시 **ISO-8601 UTC** (`Instant`) 로 변환          |
+| (전체 초기화)     | 보조 버튼         | 모든 파라미터를 빼고 `GET /audit-logs` 호출                              |
+
+> 💡 키워드 검색창은 두지 않는 것을 권장합니다 (§1.3).
+
+### 2.3 행 표시
+
+- **시각**: 사용자 로컬 타임존으로 변환해서 `YYYY-MM-DD HH:mm` 형식 권장. 호버 시 초 단위까지 툴팁.
+- **도메인 / 액션**: 그대로 표시하되 enum 코드(`SCHEDULE`)는 한국어 라벨로 매핑하면 가독성↑. 매핑은 FE 상수로 관리해도 충분합니다 (서버 측 한국어 라벨 API 는 아직 없음).
+- **대상(target)**: `{targetType}#{targetId}` 형태로 한 줄. 예: `Schedule#123`.
+- **행위자(actor)**:
+    - `actorMemberId` 는 **nullable** 입니다. 시스템/스케줄러/비로그인 흐름에서는 null.
+    - null 일 때는 "시스템" 으로 표시.
+    - null 아니면 회원 정보 API 로 회원명을 별도 조회하거나, 같은 페이지의 다른 행에서 캐시.
+
+### 2.4 행 펼치기 / 상세 패널
+
+`description`, `details`, `ipAddress` 는 목록에서는 자리를 많이 차지하므로 **행 펼치기(▶) 또는 옆 패널**에 두는 것을 권장합니다.
+
+- `description` — 사람이 읽도록 SpEL 로 만들어진 한 줄 설명 (예: `"일정이 생성되었습니다."`)
+- `details` — `jsonb` (현재는 빈 객체 `{}` 가 주로 들어옴). 향후 변경 전/후 값이 들어갈 수 있으므로 **JSON 뷰어**로 보여주는 게 안전합니다.
+- `ipAddress` — IPv4/IPv6 모두 가능. 그대로 표시.
+
+### 2.5 페이지네이션
+
+- Spring `Pageable` 표준 사용. **0-indexed** 입니다.
+- 기본 `size=20`. UI 에서 20 / 50 / 100 정도의 옵션을 두는 것을 권장하지만, 너무 큰 값은 막아주세요 (200 이상 비권장).
+- 응답에 `totalElements`, `totalPages`, `number`, `size` 등이 포함됩니다 (§3.2 참고).
+
+### 2.6 빈 상태 / 로딩 / 에러
+
+| 상태             | 안내 문구 예시                                                                            |
+|----------------|------------------------------------------------------------------------------------|
+| 결과 0건          | "조회 조건에 해당하는 감사 로그가 없습니다."                                                          |
+| 권한 없음 (403)    | "Audit Log 는 중앙운영사무국 국원만 조회할 수 있습니다." (서버 메시지를 그대로 사용해도 됨)                          |
+| 네트워크/서버 오류     | "조회 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."                                                  |
+
+---
+
+## 3. API 레퍼런스
+
+### 3.1 엔드포인트
+
+```
+GET /api/v1/admin/audit-logs
+```
+
+[AuditLogController.java](src/main/java/com/umc/product/audit/adapter/in/web/AuditLogController.java)
+
+- **인증**: `Authorization: Bearer {accessToken}` 필수
+- **권한**: `ResourceType.AUDIT` + `PermissionType.READ` → 중앙운영사무국 국원에게만 허용
+- Swagger 태그: `Audit | 감사 로그 조회` (`[AUDIT-001]`)
+
+### 3.2 응답 래핑
+
+모든 컨트롤러 응답은 `GlobalResponseWrapper` 를 통해 다음과 같이 래핑됩니다.
+
+**성공 응답:**
+
+```json
+{
+  "success": true,
+  "code": "COMMON200",
+  "message": "성공입니다.",
+  "result": {
+    "content": [ /* AuditLogInfo[] */ ],
+    "pageable": { /* ... */ },
+    "totalElements": 153,
+    "totalPages": 8,
+    "number": 0,
+    "size": 20,
+    "first": true,
+    "last": false,
+    "numberOfElements": 20,
+    "empty": false
+  }
+}
+```
+
+> ⚠️ 이 엔드포인트의 `result` 는 Spring `Page<T>` 직렬화 형태이며, 다른 가이드에서 자주 등장하는 커스텀 `PageResponse<T>` (`content / page / size / totalElements / totalPages / hasNext / hasPrevious`) 와 **필드명이 다릅니다**.
+> FE 에서는 `result.content`, `result.totalElements`, `result.totalPages`, `result.number` 를 사용하세요.
+
+**실패 응답:**
+
+```json
+{
+  "success": false,
+  "code": "AUTH-XXXX",
+  "message": "Audit Log는 중앙운영사무국 국원만 조회 가능합니다.",
+  "result": null
+}
+```
+
+### 3.3 Query Parameters
+
+| 파라미터            | 타입                    | 필수 | 설명                                                                          |
+|-----------------|------------------------|----|-----------------------------------------------------------------------------|
+| `domain`        | `Domain` (enum string) | N  | 발생 도메인. 예: `SCHEDULE`                                                       |
+| `action`        | `AuditAction` (enum)   | N  | 액션 종류. 예: `CREATE`, `UPDATE`                                                |
+| `actorMemberId` | `Long`                 | N  | 행위자 memberId. 시스템 액션은 항상 null 이므로 이 필터로는 검색 불가                              |
+| `from`          | `Instant` (ISO-8601)   | N  | 시작 시각 (포함, `createdAt >= from`)                                            |
+| `to`            | `Instant` (ISO-8601)   | N  | 종료 시각 (포함, `createdAt <= to`)                                              |
+| `page`          | `int`                  | N  | 0-indexed 페이지 번호. 기본값 0                                                     |
+| `size`          | `int`                  | N  | 페이지당 개수. 기본값 20                                                             |
+| `sort`          | `string`               | N  | **무시됨** — 서버에서 `createdAt DESC` 로 고정 정렬합니다                                  |
+
+> `from` / `to` 는 `Instant` 라서 반드시 **UTC 기준 ISO-8601** 로 보내야 합니다.
+> 예: `2026-05-12T00:00:00Z` 또는 `2026-05-12T09:00:00+09:00` 처럼 오프셋이 명시된 형태.
+> 단순 `2026-05-12` 같이 보내면 파싱 실패로 400 이 떨어집니다.
+
+### 3.4 주요 Enum
+
+#### `Domain`
+
+[Domain.java](src/main/java/com/umc/product/global/exception/constant/Domain.java)
+
+`COMMON`, `AUTHENTICATION`, `AUTHORIZATION`, `MEMBER`, `CHALLENGER`, `ORGANIZATION`,
+`CURRICULUM`, `SCHEDULE`, `COMMUNITY`, `NOTICE`, `FCM`, `SURVEY`, `RECRUITMENT`,
+`TERMS`, `EMAIL`, `STORAGE`, `WEBHOOK`, `AUDIT_LOG`, `PROJECT`, `FIGMA`, `LLM`
+
+> 모든 도메인이 실제로 감사 로그를 발행하는 것은 아닙니다 (현재는 `SCHEDULE` 위주). 드롭다운에는 전체 enum 을 노출해도 무방하나, "결과 0건" 빈 상태가 자주 나올 수 있다는 점을 유의하세요.
+
+#### `AuditAction`
+
+[AuditAction.java](src/main/java/com/umc/product/audit/domain/AuditAction.java)
+
+| 값          | 의미                |
+|------------|-------------------|
+| `CREATE`   | 생성                |
+| `UPDATE`   | 수정                |
+| `DELETE`   | 삭제                |
+| `APPROVE`  | 승인 (출석, 모집 지원 등)  |
+| `REJECT`   | 거절                |
+| `CHECK`    | 확인/조회 기반의 의미 있는 액션 |
+| `SUBMIT`   | 제출                |
+| `REGISTER` | 등록 (신규 가입 등)      |
+| `WITHDRAW` | 탈퇴/취소             |
+
+### 3.5 응답 본문(Result Item)
+
+[AuditLogInfo.java](src/main/java/com/umc/product/audit/application/port/in/query/dto/AuditLogInfo.java)
+
+```json
+{
+  "id": 1024,
+  "domain": "SCHEDULE",
+  "action": "CREATE",
+  "targetType": "Schedule",
+  "targetId": "123",
+  "actorMemberId": 42,
+  "description": "일정이 생성되었습니다.",
+  "details": null,
+  "ipAddress": "10.0.0.7",
+  "createdAt": "2026-05-12T05:23:11.482Z"
+}
+```
+
+필드별 노트:
+
+- `targetId` — 문자열입니다. UUID 도, 숫자 ID 도, 컴포지트 key 도 들어올 수 있어요.
+- `actorMemberId` — null 가능. UI 에서는 "시스템" 으로 표시 권장.
+- `description` — null 가능. SpEL 미설정이거나 결과가 null 인 경우.
+- `details` — null 또는 JSON 문자열. 빈 객체일 때도 있고, 미래에는 변경 사항이 들어올 수 있음 (`{"before": ..., "after": ...}` 형태가 자주 쓰이는 패턴).
+- `ipAddress` — null 가능. 비-HTTP 컨텍스트(스케줄러, 콘솔 등) 에서 발생한 액션.
+- `createdAt` — ISO-8601 UTC.
+
+---
+
+## 4. 호출 예시
+
+### 4.1 cURL — 가장 단순한 호출 (모든 도메인, 최근 20건)
+
+```bash
+curl -X GET 'https://{HOST}/api/v1/admin/audit-logs' \
+  -H 'Authorization: Bearer eyJhbGciOi...'
+```
+
+### 4.2 cURL — 특정 기간의 SCHEDULE 도메인 CREATE 만
+
+```bash
+curl -G 'https://{HOST}/api/v1/admin/audit-logs' \
+  -H 'Authorization: Bearer eyJhbGciOi...' \
+  --data-urlencode 'domain=SCHEDULE' \
+  --data-urlencode 'action=CREATE' \
+  --data-urlencode 'from=2026-05-01T00:00:00Z' \
+  --data-urlencode 'to=2026-05-12T23:59:59Z' \
+  --data-urlencode 'page=0' \
+  --data-urlencode 'size=20'
+```
+
+### 4.3 TypeScript (fetch + URLSearchParams)
+
+```ts
+type AuditLogQuery = {
+  domain?: string;        // Domain enum 문자열
+  action?: string;        // AuditAction enum 문자열
+  actorMemberId?: number;
+  from?: string;          // ISO-8601 (Instant)
+  to?: string;            // ISO-8601 (Instant)
+  page?: number;          // 0-indexed
+  size?: number;          // default 20
+};
+
+export async function searchAuditLogs(
+  query: AuditLogQuery,
+  accessToken: string,
+) {
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && v !== "") {
+      params.set(k, String(v));
+    }
+  });
+
+  const res = await fetch(
+    `/api/v1/admin/audit-logs?${params.toString()}`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+
+  if (!res.ok) {
+    // 403 (권한 없음), 401 (토큰 만료) 등은 공통 인터셉터에서 처리 권장
+    const err = await res.json().catch(() => null);
+    throw new Error(err?.message ?? `조회 실패 (${res.status})`);
+  }
+
+  const body = await res.json();
+  // body.result 는 Spring Page<AuditLogInfo>
+  return body.result as {
+    content: AuditLogInfo[];
+    totalElements: number;
+    totalPages: number;
+    number: number;
+    size: number;
+  };
+}
+```
+
+### 4.4 React Query 패턴 (참고)
+
+```ts
+const useAuditLogs = (query: AuditLogQuery) =>
+  useQuery({
+    queryKey: ["audit-logs", query],
+    queryFn: () => searchAuditLogs(query, getAccessToken()),
+    keepPreviousData: true,        // 페이지 전환 시 깜빡임 방지
+    staleTime: 10_000,             // 비동기 적재 시차 고려: 너무 짧지 않게
+  });
+```
+
+> `staleTime` 을 0 으로 두면 사용자가 빠르게 페이지를 오갈 때 비동기 적재 시차(§1.2) 때문에 같은 조건이 다르게 보일 수 있어요. 10초 정도가 무난합니다.
+
+### 4.5 자주 묻는 케이스
+
+- **특정 일정(Schedule#123) 의 이력만 보고 싶다** — 현재 API 는 `targetType` / `targetId` 필터를 지원하지 않습니다.
+  당장 필요하면 백엔드에 추가 요청을 주세요. 인덱스(§1.5)는 이미 준비되어 있습니다.
+- **description 으로 like 검색하고 싶다** — 미지원 (§1.3). 필요 시 별도 요청.
+- **CSV / Excel 내보내기** — 미지원. 임시로 페이지를 돌며 모으는 형태는 비권장 (`size` 를 크게 잡아 1회만 부르고 FE 에서 변환하는 정도가 한계).
+- **실시간 스트리밍** — 미지원. 폴링이 필요하면 30초~1분 간격 권장.
+
+---
+
+## 5. 에러 / 권한 거부 다루기
+
+| HTTP | 상황                            | 가이드                                                            |
+|------|--------------------------------|----------------------------------------------------------------|
+| 401  | 토큰 만료 / 미첨부                  | 공통 인터셉터에서 로그인 화면으로 리다이렉트                                       |
+| 403  | 중앙운영사무국 국원이 아님           | 백오피스 진입 자체를 차단하는 게 이상적. 직링크 진입 시 안내 화면 노출                       |
+| 400  | `from` / `to` 파싱 실패 등         | 입력 즉시 클라이언트에서 ISO 변환을 강제하면 거의 발생하지 않음. fallback 메시지 노출          |
+| 500  | 그 외 서버 오류                    | 재시도 버튼 + 일반 안내                                                  |
+
+권한 메시지는 컨트롤러의 `@CheckAccess(message = ...)` 로 고정되어 있어요:
+> `"Audit Log는 중앙운영사무국 국원만 조회 가능합니다."`
+이 메시지를 FE 에서 그대로 사용해도 자연스럽습니다.
+
+---
+
+## 6. 향후 확장 가능성 (FE 도 알아두면 좋은 것)
+
+지금 당장 구현되어 있진 않지만, **인덱스/데이터 모델은 이미 준비된** 항목들입니다. UI 를 만들 때 "나중에 붙기 쉬운 구조" 로 두면 좋습니다.
+
+- 대상 엔티티 단위 조회 (`targetType` / `targetId` 필터)
+- `details` 의 `before` / `after` diff 표시
+- 다중 도메인 / 다중 액션 선택 (현재는 단일)
+- 정렬 옵션 (오래된 순)
+- 백오피스 CSV 내보내기
+
+새 필터가 추가되어도 위 §2.2 의 칩(chip) 형태라면 자연스럽게 확장됩니다.
+
+---
+
+## 7. 빠른 체크리스트
+
+FE 구현 시 다음을 한 번씩 확인해주세요.
+
+- [ ] 모든 필터 파라미터는 **빈 값이면 쿼리 스트링에서 제외**한다 (서버는 null 만 인식).
+- [ ] `from` / `to` 는 **ISO-8601 + 타임존 정보** 가 포함된 문자열로 보낸다.
+- [ ] 페이지는 **0-indexed**.
+- [ ] 응답은 `result.content` 안에 배열이 있고, 페이지 정보는 `result.number / totalElements / totalPages / size`.
+- [ ] `actorMemberId` 가 null 일 수 있다 (시스템 액션).
+- [ ] `description`, `details`, `ipAddress` 가 null 일 수 있다.
+- [ ] 403 응답 메시지를 사용자에게 자연스럽게 전달한다.
+- [ ] 시간 표시는 사용자 로컬 타임존으로 변환한다.
+- [ ] 정렬은 최신순 고정이라는 점을 UI 에 반영한다 (정렬 토글 UI 없음).
+
+---
+
+## 8. 참고 파일
+
+- [AuditLogController.java](src/main/java/com/umc/product/audit/adapter/in/web/AuditLogController.java) — 엔드포인트 정의
+- [SearchAuditLogQuery.java](src/main/java/com/umc/product/audit/application/port/in/query/dto/SearchAuditLogQuery.java) — 검색 조건 DTO
+- [AuditLogInfo.java](src/main/java/com/umc/product/audit/application/port/in/query/dto/AuditLogInfo.java) — 응답 아이템 DTO
+- [AuditLog.java](src/main/java/com/umc/product/audit/domain/AuditLog.java) — 도메인 엔티티 (immutable)
+- [AuditAction.java](src/main/java/com/umc/product/audit/domain/AuditAction.java) — 액션 enum
+- [Domain.java](src/main/java/com/umc/product/global/exception/constant/Domain.java) — 도메인 enum
+- [AuditLogQueryRepository.java](src/main/java/com/umc/product/audit/adapter/out/persistence/AuditLogQueryRepository.java) — 검색 구현(QueryDSL)
+- [AuditAspect.java](src/main/java/com/umc/product/audit/adapter/in/aop/AuditAspect.java) — `@Audited` AOP
+- [AuditLogEventListener.java](src/main/java/com/umc/product/audit/adapter/in/event/AuditLogEventListener.java) — 비동기 저장 리스너
+- [AuditLogPermissionEvaluator.java](src/main/java/com/umc/product/audit/application/service/AuditLogPermissionEvaluator.java) — 권한 평가
+- [V2026.03.12.01.00__create_audit_log.sql](src/main/resources/db/migration/V2026.03.12.01.00__create_audit_log.sql) — 테이블 스키마 & 인덱스

--- a/docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-backend.md
+++ b/docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-backend.md
@@ -1,0 +1,696 @@
+# Analytics Admin Dashboard Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 운영진 메인 대시보드 MVP를 위해 `analytics` 조회 도메인과 `/api/v1/admin/...` 대시보드 API를 추가한다.
+
+**Architecture:** `analytics`는 쓰기 모델이 아니라 운영진용 read model 도메인으로 둔다. Controller는 UseCase만 호출하고, QueryService는 권한 스코프를 확정한 뒤 analytics 전용 Port를 통해 DTO projection만 조회한다. JPA Entity를 응답하거나 다른 도메인 Repository를 application/service에서 직접 주입하지 않는다.
+
+**Tech Stack:** Java 21, Spring Boot 3.5, JPA, QueryDSL, PostgreSQL, Flyway, JUnit 5, Mockito, Testcontainers
+
+---
+
+## 기준 문서와 현재 코드 차이
+
+- 기준 기획안: `docs/backlog/운영진_대시보드_기획안.md`
+- 실제 서버 URL prefix는 기존 Controller 기준 `/api/v1`이다. 기획안의 `/v1/admin/...`은 서버 코드에서는 `/api/v1/admin/...`로 구현한다.
+- 기획안의 `application.status = PENDING`은 현재 BE 모델에서는 `ProjectApplicationStatus.SUBMITTED`가 처리 대기 상태다.
+- 기획안의 `project.status IN (OPEN, IN_PROGRESS)` 중 현재 BE에는 `OPEN`이 없다. MVP의 진행 중 프로젝트는 `ProjectStatus.IN_PROGRESS`로 계산한다.
+- 하위 호환성을 위해 기존 API인 `GET /api/v1/challenger/search/offset`와 `GET /api/v1/member/me`는 변경하지 않는다.
+- 위험군 챌린저 조회와 운영진 대시보드 권한 컨텍스트는 신규 `analytics` 도메인의 admin dashboard API로 제공한다.
+
+## API 확정안
+
+### MVP P0
+
+1. `GET /api/v1/admin/dashboard/summary`
+   - Query: `gisuId?`, `chapterId?`, `schoolId?`
+   - Response: `AdminDashboardSummaryResponse`
+   - 포함: active challenger count, weekly new member count and delta, active school/chapter count, monthly point positive/negative sum, in-progress project count, submitted project application count, challenger status distribution.
+
+2. `GET /api/v1/admin/schools/summary`
+   - Query: `gisuId`, `chapterId?`, `search?`, `riskThreshold?`, `page?`, `size?`, `sort?`
+   - Response: `PageResponse<AdminSchoolSummaryResponse>`
+   - 기본 정렬: `riskChallengerCount,desc`
+
+3. `GET /api/v1/admin/dashboard/action-queue`
+   - Query: `gisuId?`, `riskThreshold?`
+   - Response: `AdminDashboardActionQueueResponse`
+   - 포함: submitted project application count, open matching round count, unsent notice count, weekly new risk challenger count, upcoming graduation challenger count.
+
+4. `GET /api/v1/admin/dashboard/risk-challengers`
+   - Query: `gisuId?`, `chapterId?`, `schoolId?`, `riskThreshold?`, `page?`, `size?`, `sort?`
+   - Response: `PageResponse<AdminRiskChallengerResponse>`
+   - 포함: name, schoolName, part, pointSum, latestNegativePoint
+   - 기존 `GET /api/v1/challenger/search/offset`는 변경하지 않는다.
+
+### P1
+
+1. `GET /api/v1/admin/dashboard/context`
+   - Response: `AdminDashboardContextResponse`
+   - `roleType`, `gisuId`, `chapterId`, `schoolId`, `responsiblePart`, `scopeType` 포함
+   - 기존 `GET /api/v1/member/me`는 변경하지 않는다.
+
+2. `GET /api/v1/admin/stats/signups`
+   - Query: `from`, `to`, `groupBy=DAY|WEEK`, `gisuId?`, `chapterId?`, `schoolId?`, `part?`
+   - Response: bucket list
+
+3. `GET /api/v1/admin/stats/points/daily`
+   - Query: `from`, `to`, `gisuId?`, `chapterId?`, `schoolId?`
+   - Response: daily positive/negative point buckets
+
+### P2
+
+1. `GET /api/v1/admin/stats/points/by-type`
+2. `GET /api/v1/admin/parts/summary`
+
+## 권한과 스코프 정책
+
+스코프 위반은 자동 덮어쓰기보다 `403`을 반환한다. 단, 요청 필터가 비어 있으면 서버가 사용자 권한 스코프를 자동 적용한다.
+
+- `SUPER_ADMIN`, `CENTRAL_*`: 요청한 `chapterId`, `schoolId`, `part` 필터 허용
+- `CHAPTER_PRESIDENT`: 본인 `chapterId` 밖 요청은 `403`
+- `SCHOOL_PRESIDENT`, `SCHOOL_VICE_PRESIDENT`, `SCHOOL_ETC_ADMIN`: 본인 `schoolId` 밖 요청은 `403`
+- `SCHOOL_PART_LEADER`: 본인 `schoolId`와 `responsiblePart` 밖 요청은 `403`
+- 일반 챌린저 또는 역할 없음: dashboard API 전체 `403`
+
+동일 사용자가 여러 역할을 가지면 요청한 `gisuId` 안에서 가장 넓은 권한을 우선한다.
+
+우선순위:
+`SUPER_ADMIN` > `CENTRAL_*` > `CHAPTER_PRESIDENT` > `SCHOOL_*` > `SCHOOL_PART_LEADER`
+
+## 패키지 구성
+
+Create:
+
+- `src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScope.java`
+- `src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScopeType.java`
+- `src/main/java/com/umc/product/analytics/domain/AdminAnalyticsSort.java`
+- `src/main/java/com/umc/product/analytics/domain/AnalyticsErrorCode.java`
+- `src/main/java/com/umc/product/analytics/domain/AnalyticsDomainException.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardSummaryUseCase.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminSchoolSummaryUseCase.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardActionQueueUseCase.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardContextUseCase.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminRiskChallengerUseCase.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardSummaryInfo.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueInfo.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardContextInfo.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerInfo.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryInfo.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardQuery.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerQuery.java`
+- `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryQuery.java`
+- `src/main/java/com/umc/product/analytics/application/port/out/LoadAdminDashboardAnalyticsPort.java`
+- `src/main/java/com/umc/product/analytics/application/port/out/LoadAdminSchoolAnalyticsPort.java`
+- `src/main/java/com/umc/product/analytics/application/port/out/LoadAdminRiskChallengerAnalyticsPort.java`
+- `src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java`
+- `src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolver.java`
+- `src/main/java/com/umc/product/analytics/application/service/evaluator/AdminAnalyticsPermissionEvaluator.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminDashboardRequest.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminRiskChallengerRequest.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminSchoolSummaryRequest.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardSummaryResponse.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardActionQueueResponse.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardContextResponse.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminRiskChallengerResponse.java`
+- `src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminSchoolSummaryResponse.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsPersistenceAdapter.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsPersistenceAdapter.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsPersistenceAdapter.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepository.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminDashboardSummaryRow.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminDashboardActionQueueRow.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminRiskChallengerRow.java`
+- `src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminSchoolSummaryRow.java`
+
+Modify:
+
+- `src/main/java/com/umc/product/authorization/domain/ResourceType.java`
+- `src/main/java/com/umc/product/challenger/application/service/ChallengerSearchService.java`
+
+Do not modify:
+
+- `src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/SearchChallengerRequest.java`
+- `src/main/java/com/umc/product/challenger/application/port/in/query/dto/SearchChallengerQuery.java`
+- `src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/SearchChallengerResponse.java`
+- `src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java`
+- `src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java`
+
+Test:
+
+- `src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolverTest.java`
+- `src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryServiceTest.java`
+- `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java`
+- `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java`
+- `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java`
+- `src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java`
+
+## 핵심 DTO 형태
+
+```java
+public record AdminDashboardQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId
+) {
+    public static AdminDashboardQuery of(Long requesterMemberId, Long gisuId, Long chapterId, Long schoolId) {
+        return new AdminDashboardQuery(requesterMemberId, gisuId, chapterId, schoolId);
+    }
+}
+```
+
+```java
+public record AdminAnalyticsScope(
+    AdminAnalyticsScopeType type,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    ChallengerPart responsiblePart,
+    ChallengerRoleType roleType
+) {
+    public boolean isCentralScope() {
+        return type == AdminAnalyticsScopeType.CENTRAL;
+    }
+}
+```
+
+```java
+public enum AdminAnalyticsScopeType {
+    CENTRAL,
+    CHAPTER,
+    SCHOOL,
+    SCHOOL_PART
+}
+```
+
+```java
+public record AdminDashboardSummaryInfo(
+    long activeChallengerCount,
+    long newMemberCountThisWeek,
+    double newMemberDeltaPercent,
+    long activeSchoolCount,
+    long activeChapterCount,
+    PointSumInfo monthlyPointSum,
+    long projectInProgressCount,
+    long pendingApplicationCount,
+    Map<ChallengerStatus, Long> challengerStatusDistribution
+) {
+    public record PointSumInfo(long positive, long negative) {
+        public static PointSumInfo of(long positive, long negative) {
+            return new PointSumInfo(positive, negative);
+        }
+    }
+}
+```
+
+```java
+public record AdminSchoolSummaryInfo(
+    Long schoolId,
+    String schoolName,
+    Long chapterId,
+    String chapterName,
+    long activeChallengerCount,
+    StaffInfo president,
+    StaffInfo vicePresident,
+    PartLeaderRatioInfo partLeaderRatio,
+    double averagePointSum,
+    long riskChallengerCount,
+    long newMemberCountThisWeek
+) {
+    public record StaffInfo(Long challengerId, String name) {
+        public static StaffInfo of(Long challengerId, String name) {
+            return new StaffInfo(challengerId, name);
+        }
+    }
+
+    public record PartLeaderRatioInfo(long assigned, long totalRunningParts) {
+        public static PartLeaderRatioInfo of(long assigned, long totalRunningParts) {
+            return new PartLeaderRatioInfo(assigned, totalRunningParts);
+        }
+    }
+}
+```
+
+## Task 1: Analytics 권한 리소스와 스코프 Resolver
+
+**Files:**
+
+- Create: `src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScope.java`
+- Create: `src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScopeType.java`
+- Create: `src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolver.java`
+- Create: `src/main/java/com/umc/product/analytics/application/service/evaluator/AdminAnalyticsPermissionEvaluator.java`
+- Modify: `src/main/java/com/umc/product/authorization/domain/ResourceType.java`
+- Test: `src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolverTest.java`
+
+- [ ] **Step 1: ResourceType에 ANALYTICS 추가**
+
+```java
+ANALYTICS("analytics", "운영진 대시보드", Set.of(PermissionType.READ)),
+```
+
+- [ ] **Step 2: AdminAnalyticsPermissionEvaluator 작성**
+
+```java
+@Component
+public class AdminAnalyticsPermissionEvaluator implements ResourcePermissionEvaluator {
+    @Override
+    public ResourceType supportedResourceType() {
+        return ResourceType.ANALYTICS;
+    }
+
+    @Override
+    public boolean evaluate(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+        if (resourcePermission.permission() != PermissionType.READ) {
+            return false;
+        }
+        return subjectAttributes.roleAttributes().stream()
+            .map(RoleAttribute::roleType)
+            .anyMatch(roleType -> roleType.isSuperAdmin()
+                || roleType.isAtLeastCentralMember()
+                || roleType == ChallengerRoleType.CHAPTER_PRESIDENT
+                || roleType.isAtLeastSchoolAdmin());
+    }
+}
+```
+
+- [ ] **Step 3: ScopeResolver의 결정 규칙 구현**
+
+`AdminAnalyticsScopeResolver.resolve(memberId, requestedGisuId, requestedChapterId, requestedSchoolId, requestedPart)`는 다음 순서로 동작한다.
+
+1. `requestedGisuId`가 없으면 기존 `GetGisuUseCase.getActiveGisu()` 또는 `GetGisuUseCase.getActiveGisuId()`로 활성 기수를 선택한다.
+2. `GetChallengerRoleUseCase.findAllByMemberId(memberId)`로 해당 기수의 역할을 필터링한다.
+3. 최고 권한을 고른다.
+4. 요청 필터가 권한 밖이면 `AnalyticsDomainException(RESOURCE_ACCESS_DENIED)`를 던진다.
+5. 필터가 비어 있으면 권한 스코프 값을 채운다.
+
+- [ ] **Step 4: ScopeResolver 단위 테스트 작성**
+
+테스트 이름:
+
+- `중앙_운영진은_요청한_지부와_학교_필터를_그대로_사용한다`
+- `지부장은_다른_지부를_요청하면_거부된다`
+- `학교_운영진은_학교_필터가_없어도_본인_학교로_스코프가_고정된다`
+- `학교_파트장은_담당_파트까지_스코프에_포함된다`
+- `운영진_역할이_없으면_대시보드_접근이_거부된다`
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.application.service.query.AdminAnalyticsScopeResolverTest"
+```
+
+Expected: 신규 테스트 PASS
+
+## Task 2: Dashboard Summary와 Action Queue API
+
+**Files:**
+
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardSummaryUseCase.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardActionQueueUseCase.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardSummaryInfo.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueInfo.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/out/LoadAdminDashboardAnalyticsPort.java`
+- Create: `src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsPersistenceAdapter.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java`
+- Test: `src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryServiceTest.java`
+- Test: `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java`
+
+- [ ] **Step 1: UseCase 인터페이스 작성**
+
+```java
+public interface GetAdminDashboardSummaryUseCase {
+    AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query);
+}
+
+public interface GetAdminDashboardActionQueueUseCase {
+    AdminDashboardActionQueueInfo getActionQueue(AdminDashboardActionQueueQuery query);
+}
+```
+
+- [ ] **Step 2: QueryService 구현**
+
+`AdminAnalyticsQueryService`는 `@Transactional(readOnly = true)`를 클래스에 붙이고 두 UseCase를 구현한다. 메서드 내부는 `scopeResolver.resolve(...)` 후 `loadAdminDashboardAnalyticsPort.getSummary(scope)` 또는 `getActionQueue(scope, riskThreshold)`만 호출한다.
+
+- [ ] **Step 3: Summary 집계 쿼리 구현**
+
+`AdminDashboardAnalyticsQueryRepository`는 Entity fetch 없이 projection만 조회한다.
+
+집계 기준:
+
+- 활동 챌린저: `challenger.status = ACTIVE`
+- 신규 회원 이번 주: `member.created_at >= weekStart`
+- 전주 대비: `prevWeekCount == 0`이면 이번 주도 0일 때 `0.0`, 이번 주가 1 이상이면 `100.0`
+- 월간 포인트: `challenger_point.created_at >= monthStart`
+- 가산/감점: `point_value`가 있으면 그 값을 우선하고 없으면 `PointType.getValue()`
+- 진행 프로젝트: `project.status = IN_PROGRESS`
+- 처리 대기 지원서: `project_application.status = SUBMITTED`
+- 상태 분포: `ACTIVE`, `GRADUATED`, `EXPELLED`, `WITHDRAWN` 모두 키를 포함하고 값이 없으면 0
+
+- [ ] **Step 4: Action Queue 집계 쿼리 구현**
+
+집계 기준:
+
+- `pendingApplicationCount`: `ProjectApplicationStatus.SUBMITTED`
+- `inProgressMatchingCount`: `startsAt <= now <= endsAt`
+- `unsentNoticeCount`: `shouldSendNotification = true and notifiedAt is null`
+- `newRiskMemberCountThisWeek`: `member.createdAt >= weekStart and pointSum <= riskThreshold`
+- `upcomingGraduationCount`: `gisu.endAt <= now + 14 days`이면 해당 스코프의 active challenger count, 아니면 0
+
+- [ ] **Step 5: Controller 작성**
+
+```java
+@RestController
+@RequestMapping("/api/v1/admin/dashboard")
+@RequiredArgsConstructor
+@Tag(name = "Admin Dashboard | 운영진 대시보드", description = "운영진 메인 대시보드 집계 API")
+public class AdminDashboardController {
+    private final GetAdminDashboardSummaryUseCase getAdminDashboardSummaryUseCase;
+    private final GetAdminDashboardActionQueueUseCase getAdminDashboardActionQueueUseCase;
+
+    @GetMapping("summary")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    AdminDashboardSummaryResponse getSummary(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminDashboardRequest request
+    ) {
+        return AdminDashboardSummaryResponse.from(
+            getAdminDashboardSummaryUseCase.getSummary(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+}
+```
+
+- [ ] **Step 6: 테스트 작성**
+
+테스트 이름:
+
+- `summary_중앙_운영진은_전체_스코프의_KPI를_조회한다`
+- `summary_학교_운영진은_본인_학교_데이터만_조회한다`
+- `actionQueue_SUBMITTED_지원서를_처리_대기로_계산한다`
+- `actionQueue_알림_요청됐지만_notifiedAt이_null인_공지수를_계산한다`
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.application.service.query.AdminAnalyticsQueryServiceTest" --tests "com.umc.product.analytics.adapter.out.persistence.AdminDashboardAnalyticsQueryRepositoryTest"
+```
+
+Expected: 신규 테스트 PASS
+
+## Task 3: 학교/지부별 현황 테이블 API
+
+**Files:**
+
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminSchoolSummaryUseCase.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryQuery.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryInfo.java`
+- Create: `src/main/java/com/umc/product/analytics/application/port/out/LoadAdminSchoolAnalyticsPort.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsPersistenceAdapter.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java`
+- Create: `src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java`
+- Test: `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java`
+
+- [ ] **Step 1: API 요청 DTO 작성**
+
+`riskThreshold` 기본값은 `-8`이다. `sort`가 없으면 `riskChallengerCount,desc`를 적용한다.
+
+허용 정렬:
+
+- `riskChallengerCount,desc`
+- `activeChallengerCount,desc`
+- `schoolName,asc`
+- `averagePointSum,asc`
+- `averagePointSum,desc`
+
+- [ ] **Step 2: 집계 쿼리 구현**
+
+한 학교 행은 다음 CTE 또는 QueryDSL equivalent로 계산한다.
+
+1. 대상 챌린저: `gisuId`, `scope`, `ACTIVE` 기준으로 challenger, member, school, chapter를 조인한다.
+2. 챌린저별 포인트 합계: `challenger_point`를 `challenger_id`로 group by 한다.
+3. 학교별 집계: active count, average point, risk count, weekly new count를 group by 한다.
+4. 회장과 부회장: `challenger_role.role_type in (SCHOOL_PRESIDENT, SCHOOL_VICE_PRESIDENT)`를 학교별로 left join 한다.
+5. 파트장 배치율: `SCHOOL_PART_LEADER`의 distinct responsiblePart 수를 `assigned`, 학교 내 active challenger distinct part 수를 `totalRunningParts`로 계산한다.
+
+- [ ] **Step 3: Controller 작성**
+
+```java
+@RestController
+@RequestMapping("/api/v1/admin/schools")
+@RequiredArgsConstructor
+public class AdminSchoolAnalyticsController {
+    private final GetAdminSchoolSummaryUseCase getAdminSchoolSummaryUseCase;
+
+    @GetMapping("summary")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    PageResponse<AdminSchoolSummaryResponse> getSchoolSummaries(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject Pageable pageable,
+        @ParameterObject AdminSchoolSummaryRequest request
+    ) {
+        return PageResponse.of(
+            getAdminSchoolSummaryUseCase.getSchoolSummaries(request.toQuery(memberPrincipal.getMemberId(), pageable)),
+            AdminSchoolSummaryResponse::from
+        );
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 작성**
+
+테스트 이름:
+
+- `학교_요약은_위험군_수_내림차순이_기본이다`
+- `지부_스코프에서는_해당_지부의_학교만_조회된다`
+- `검색어가_있으면_학교명_부분_일치만_조회된다`
+- `파트장_배치율은_배치된_파트수와_운영중인_파트수로_계산된다`
+- `포인트가_없는_챌린저는_0점으로_평균에_포함된다`
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.AdminSchoolAnalyticsQueryRepositoryTest"
+```
+
+Expected: 신규 테스트 PASS
+
+## Task 4: 위험군 챌린저 검색 확장
+
+**Files:**
+
+- Modify: `src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/SearchChallengerRequest.java`
+- Modify: `src/main/java/com/umc/product/challenger/application/port/in/query/dto/SearchChallengerQuery.java`
+- Modify: `src/main/java/com/umc/product/challenger/application/port/in/query/dto/SearchChallengerItemInfo.java`
+- Modify: `src/main/java/com/umc/product/challenger/application/port/out/SearchChallengerPort.java`
+- Modify: `src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java`
+- Modify: `src/main/java/com/umc/product/challenger/application/service/ChallengerSearchService.java`
+- Modify: `src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/SearchChallengerResponse.java`
+- Test: `src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepositoryTest.java`
+- Test: `src/test/java/com/umc/product/challenger/application/service/ChallengerSearchServiceTest.java`
+
+- [ ] **Step 1: Query DTO 확장**
+
+```java
+public record SearchChallengerQuery(
+    Long challengerId,
+    String name,
+    String nickname,
+    String keyword,
+    Long schoolId,
+    Long chapterId,
+    ChallengerPart part,
+    Long gisuId,
+    List<ChallengerStatus> statuses,
+    Double pointSumLte,
+    Double pointSumGte,
+    ChallengerRoleType roleType,
+    boolean includeLatestNegativePoint
+) {
+}
+```
+
+- [ ] **Step 2: Request DTO 확장**
+
+`status` 단건과 `statuses` 복수 요청을 모두 허용한다. 둘 다 없으면 기존 호환성을 위해 `List.of(ChallengerStatus.ACTIVE)`를 유지한다.
+
+- [ ] **Step 3: QueryRepository 확장**
+
+포인트 조건은 page content 조회 전에 적용되어야 한다. `challenger_point` 합계 subquery를 사용해 `pointSumLte`, `pointSumGte`를 DB에서 필터링한다.
+
+정렬 규칙:
+
+- `pointSum,asc`: 포인트 합계 오름차순
+- `pointSum,desc`: 포인트 합계 내림차순
+- `createdAt,desc`: 챌린저 생성일 내림차순
+- sort 미지정: 기존 `partOrder asc, gisuId desc, member.name asc`
+
+- [ ] **Step 4: latestNegativePoint 조회 추가**
+
+`includeLatestNegativePoint=true`일 때만 현재 페이지의 challengerId set을 기준으로 최신 감점 포인트를 한 번에 조회한다.
+
+감점 판정:
+
+```java
+pointValue < 0
+```
+
+응답 형태:
+
+```java
+public record LatestNegativePointInfo(
+    PointType pointType,
+    Instant createdAt,
+    double score
+) {
+    public static LatestNegativePointInfo of(PointType pointType, Instant createdAt, double score) {
+        return new LatestNegativePointInfo(pointType, createdAt, score);
+    }
+}
+```
+
+- [ ] **Step 5: 테스트 작성**
+
+테스트 이름:
+
+- `pointSumLte가_있으면_포인트_합계가_임계치_이하인_챌린저만_조회한다`
+- `pointSum_오름차순_정렬은_위험군이_먼저_나온다`
+- `includeLatestNegativePoint가_false이면_최근_감점_조회는_호출하지_않는다`
+- `includeLatestNegativePoint가_true이면_페이지_대상자의_최신_감점만_응답한다`
+- `status를_지정하지_않으면_기존처럼_ACTIVE만_조회한다`
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.challenger.adapter.out.persistence.ChallengerQueryRepositoryTest" --tests "com.umc.product.challenger.application.service.ChallengerSearchServiceTest"
+```
+
+Expected: 신규 테스트와 기존 challenger 검색 테스트 PASS
+
+## Task 5: member/me 권한 컨텍스트 확장
+
+**Files:**
+
+- Modify: `src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java`
+- Modify: `src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java`
+- Create: `src/main/java/com/umc/product/member/adapter/in/web/dto/response/PrimaryAdminScopeResponse.java`
+- Test: `src/test/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssemblerTest.java`
+
+- [ ] **Step 1: Response DTO 추가**
+
+```java
+public record PrimaryAdminScopeResponse(
+    ChallengerRoleType roleType,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    ChallengerPart responsiblePart,
+    AdminAnalyticsScopeType scopeType
+) {
+    public static PrimaryAdminScopeResponse from(AdminAnalyticsScope scope) {
+        return new PrimaryAdminScopeResponse(
+            scope.roleType(),
+            scope.gisuId(),
+            scope.chapterId(),
+            scope.schoolId(),
+            scope.responsiblePart(),
+            scope.type()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: MemberInfoResponse에 필드 추가**
+
+기존 필드는 유지하고 마지막에 `PrimaryAdminScopeResponse primaryAdminScope`를 추가한다. 운영진 역할이 없으면 `null`을 반환한다.
+
+- [ ] **Step 3: 테스트 작성**
+
+테스트 이름:
+
+- `me_응답은_기존_roles를_유지하면서_primaryAdminScope를_포함한다`
+- `운영진_역할이_없으면_primaryAdminScope는_null이다`
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssemblerTest"
+```
+
+Expected: 신규 테스트 PASS
+
+## Task 6: 문서와 RestDocs
+
+**Files:**
+
+- Create: `src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java`
+- Create: `src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java`
+- Modify: `docs/backlog/운영진_대시보드_기획안.md`
+
+- [ ] **Step 1: Controller RestDocs 테스트 작성**
+
+테스트 이름:
+
+- `대시보드_summary_API_문서화`
+- `대시보드_actionQueue_API_문서화`
+- `학교별_summary_API_문서화`
+
+- [ ] **Step 2: 기획안 BE 섹션 갱신**
+
+반영 항목:
+
+- 실제 prefix는 `/api/v1`
+- 처리 대기 지원서는 `ProjectApplicationStatus.SUBMITTED`
+- 진행 프로젝트는 `ProjectStatus.IN_PROGRESS`
+- 스코프 위반 정책은 `403`
+- 위험군 검색은 기존 challenger search 확장으로 제공
+
+- [ ] **Step 3: 문서 빌드**
+
+Run:
+
+```bash
+./gradlew asciidoctor
+```
+
+Expected: RestDocs snippets와 AsciiDoc 빌드 PASS
+
+## 검증 명령
+
+개별 작업 완료 후:
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.*"
+```
+
+전체 회귀:
+
+```bash
+./gradlew compileJava
+./gradlew compileTestJava
+./gradlew test
+```
+
+문서:
+
+```bash
+./gradlew asciidoctor
+```
+
+## 완료 기준
+
+- 운영진 권한이 없는 사용자는 모든 admin dashboard endpoint에서 `403`을 받는다.
+- 중앙 운영진, 지부장, 학교 운영진, 학교 파트장이 같은 API를 호출해도 서버가 각자 권한 범위로 집계한다.
+- 학교 요약 테이블은 N+1 없이 한 페이지를 단일 집계 쿼리로 반환한다.
+- 위험군 챌린저 리스트는 FE가 전체 페이지를 순회하지 않아도 `pointSumLte`로 서버 필터링된다.
+- 신규 API 응답은 Entity가 아니라 Response DTO만 반환한다.
+- `./gradlew compileJava`가 통과한다.
+- `./gradlew compileTestJava`가 통과한다.
+- `./gradlew test`가 통과한다.

--- a/docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-performance.md
+++ b/docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-performance.md
@@ -1,0 +1,158 @@
+# Analytics Admin Dashboard Performance Improvement Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 운영진 대시보드 MVP 구현 이후 analytics 집계 API의 인덱스, 쿼리 실행 계획, 회귀 성능을 별도 작업으로 검증하고 개선한다.
+
+**Architecture:** 기능 구현 계획과 분리된 후속 성능 작업이다. API 계약, DTO, 권한 스코프는 `2026-05-13-analytics-admin-dashboard-backend.md`의 구현 결과를 그대로 사용하고, 이 문서는 쿼리 성능과 DB 인덱스만 다룬다.
+
+**Tech Stack:** Java 21, Spring Boot 3.5, JPA, QueryDSL, PostgreSQL, Flyway, JUnit 5, Testcontainers
+
+---
+
+## 전제
+
+- 선행 문서: `docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-backend.md`
+- 선행 구현: analytics MVP API와 challenger 위험군 검색 확장이 완료되어 있어야 한다.
+- 이 작업은 기능 완료 기준에 포함하지 않는다. 별도 PR 또는 별도 커밋으로 진행한다.
+
+## 대상 API
+
+- `GET /api/v1/admin/dashboard/summary`
+- `GET /api/v1/admin/dashboard/action-queue`
+- `GET /api/v1/admin/schools/summary`
+- `GET /api/v1/challenger/search/offset?pointSumLte=...&sort=pointSum,asc`
+
+## Files
+
+- Create: `src/main/resources/db/migration/V20260513_02__add_admin_dashboard_analytics_indexes.sql`
+- Modify: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java`
+- Modify: `src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java`
+- Modify: `src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java`
+- Test: `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java`
+- Test: `src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java`
+- Test: `src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepositoryTest.java`
+
+## Task 1: 기본 인덱스 추가
+
+- [ ] **Step 1: Flyway migration 작성**
+
+```sql
+create index if not exists idx_challenger_gisu_status_part
+    on challenger (gisu_id, status, part);
+
+create index if not exists idx_challenger_member_gisu
+    on challenger (member_id, gisu_id);
+
+create index if not exists idx_member_school_created_at
+    on member (school_id, created_at);
+
+create index if not exists idx_challenger_point_challenger_created_at
+    on challenger_point (challenger_id, created_at desc);
+
+create index if not exists idx_challenger_role_gisu_role_org
+    on challenger_role (gisu_id, role_type, organization_type, organization_id);
+
+create index if not exists idx_project_gisu_status_chapter
+    on project (gisu_id, status, chapter_id);
+
+create index if not exists idx_project_application_status_submitted_at
+    on project_application (status, submitted_at);
+
+create index if not exists idx_project_matching_round_chapter_period
+    on project_matching_round (chapter_id, starts_at, ends_at, decision_deadline);
+
+create index if not exists idx_notice_notification_pending
+    on notice (should_send_notification, notified_at);
+```
+
+- [ ] **Step 2: migration 적용 테스트 실행**
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.AdminDashboardAnalyticsQueryRepositoryTest" --tests "com.umc.product.analytics.adapter.out.persistence.AdminSchoolAnalyticsQueryRepositoryTest"
+```
+
+Expected: Testcontainers PostgreSQL에서 migration 적용 후 테스트 PASS
+
+## Task 2: QueryDSL 집계 쿼리 실행 계획 점검
+
+- [ ] **Step 1: dashboard summary 쿼리의 조인 조건 확인**
+
+확인 기준:
+
+- `challenger.gisu_id`, `challenger.status` 조건이 가장 먼저 적용된다.
+- `member.school_id` 필터는 스코프가 SCHOOL 또는 SCHOOL_PART일 때만 들어간다.
+- `project.status`, `project.gisu_id`, `project.chapter_id` 조건이 index friendly하게 분리되어 있다.
+
+- [ ] **Step 2: school summary 쿼리의 group by 범위 확인**
+
+확인 기준:
+
+- page 대상 학교 목록과 row 집계를 분리한다.
+- 모든 학교를 집계한 뒤 application memory에서 paging하지 않는다.
+- `riskThreshold`는 DB query의 `having` 또는 projection 계산에 포함한다.
+
+- [ ] **Step 3: 위험군 challenger 검색의 pointSum 정렬 확인**
+
+확인 기준:
+
+- `pointSumLte`, `pointSumGte`가 전체 페이지 조회 이후 in-memory filter로 동작하지 않는다.
+- `pointSum,asc` 정렬이 DB query에 반영된다.
+- 최신 감점 조회는 현재 페이지의 challengerId set에 대해서만 1회 실행된다.
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.challenger.adapter.out.persistence.ChallengerQueryRepositoryTest"
+```
+
+Expected: 위험군 필터/정렬/최신 감점 테스트 PASS
+
+## Task 3: 성능 회귀 테스트 보강
+
+- [ ] **Step 1: 대량 fixture 기반 repository 테스트 추가**
+
+테스트 이름:
+
+- `summary_대량_데이터에서도_스코프별_집계가_정상_동작한다`
+- `schoolSummary_페이지_크기만큼만_결과를_반환한다`
+- `challengerSearch_위험군_필터는_DB에서_적용된다`
+
+- [ ] **Step 2: SQL 로그로 N+1 여부 확인**
+
+확인 기준:
+
+- dashboard summary 호출에서 school 수만큼 반복 쿼리가 발생하지 않는다.
+- school summary 한 페이지 조회에서 challenger 수만큼 반복 쿼리가 발생하지 않는다.
+- latest negative point 조회는 페이지당 1회 이하로 실행된다.
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.*" --tests "com.umc.product.challenger.adapter.out.persistence.ChallengerQueryRepositoryTest"
+```
+
+Expected: 성능 회귀 테스트 PASS
+
+## 검증 명령
+
+```bash
+./gradlew compileJava
+./gradlew compileTestJava
+./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.*" --tests "com.umc.product.challenger.adapter.out.persistence.ChallengerQueryRepositoryTest"
+```
+
+전체 회귀까지 확인할 때:
+
+```bash
+./gradlew test
+```
+
+## 완료 기준
+
+- analytics MVP 기능 문서에 성능 작업이 포함되어 있지 않다.
+- 신규 Flyway 인덱스 migration이 Testcontainers PostgreSQL에서 정상 적용된다.
+- dashboard summary, action queue, school summary, 위험군 challenger 검색 repository 테스트가 통과한다.
+- `./gradlew compileJava`가 통과한다.
+- `./gradlew compileTestJava`가 통과한다.
+- 대상 성능 회귀 테스트가 통과한다.

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/admin/dashboard")
 @RequiredArgsConstructor
-@Tag(name = "Admin Dashboard | 운영진 대시보드", description = "운영진 메인 대시보드 집계 API")
+@Tag(name = "Analytics | 운영진 종합 대시보드", description = "운영진 메인 대시보드 집계 API")
 public class AdminDashboardController {
 
     private final GetAdminDashboardSummaryUseCase getAdminDashboardSummaryUseCase;
@@ -41,7 +41,7 @@ public class AdminDashboardController {
     private final GetAdminRiskChallengerUseCase getAdminRiskChallengerUseCase;
     private final GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
 
-    @Operation(summary = "[ADMIN-DASHBOARD-001] 운영진 대시보드 요약 조회")
+    @Operation(summary = "[DASHBOARD-001] 운영진 대시보드 요약 조회")
     @GetMapping("summary")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public AdminDashboardSummaryResponse getSummary(
@@ -53,7 +53,7 @@ public class AdminDashboardController {
         );
     }
 
-    @Operation(summary = "[ADMIN-DASHBOARD-002] 운영진 대시보드 액션 큐 조회")
+    @Operation(summary = "[DASHBOARD-002] 운영진 대시보드 액션 큐 조회")
     @GetMapping("action-queue")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public AdminDashboardActionQueueResponse getActionQueue(
@@ -65,7 +65,7 @@ public class AdminDashboardController {
         );
     }
 
-    @Operation(summary = "[ADMIN-DASHBOARD-004] 운영진 대시보드 권한 컨텍스트 조회")
+    @Operation(summary = "[DASHBOARD-004] 운영진 대시보드 권한 컨텍스트 조회")
     @GetMapping("context")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public AdminDashboardContextResponse getContext(
@@ -76,7 +76,7 @@ public class AdminDashboardController {
         );
     }
 
-    @Operation(summary = "[ADMIN-DASHBOARD-005] 운영 현황 집계 조회")
+    @Operation(summary = "[DASHBOARD-005] 운영 현황 집계 조회")
     @GetMapping("operations")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public AdminOperationsOverviewResponse getOperationsOverview(
@@ -88,7 +88,7 @@ public class AdminDashboardController {
         );
     }
 
-    @Operation(summary = "[ADMIN-DASHBOARD-003] 운영진 대시보드 위험군 챌린저 조회")
+    @Operation(summary = "[DASHBOARD-003] 운영진 대시보드 위험군 챌린저 조회")
     @GetMapping("risk-challengers")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public PageResponse<AdminRiskChallengerResponse> getRiskChallengers(

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -1,0 +1,104 @@
+package com.umc.product.analytics.adapter.in.web;
+
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardActionQueueRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerRequest;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActionQueueResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardSummaryResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallengerResponse;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/dashboard")
+@RequiredArgsConstructor
+@Tag(name = "Admin Dashboard | 운영진 대시보드", description = "운영진 메인 대시보드 집계 API")
+public class AdminDashboardController {
+
+    private final GetAdminDashboardSummaryUseCase getAdminDashboardSummaryUseCase;
+    private final GetAdminDashboardActionQueueUseCase getAdminDashboardActionQueueUseCase;
+    private final GetAdminDashboardContextUseCase getAdminDashboardContextUseCase;
+    private final GetAdminRiskChallengerUseCase getAdminRiskChallengerUseCase;
+    private final GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
+
+    @Operation(summary = "[ADMIN-DASHBOARD-001] 운영진 대시보드 요약 조회")
+    @GetMapping("summary")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminDashboardSummaryResponse getSummary(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminDashboardRequest request
+    ) {
+        return AdminDashboardSummaryResponse.from(
+            getAdminDashboardSummaryUseCase.getSummary(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[ADMIN-DASHBOARD-002] 운영진 대시보드 액션 큐 조회")
+    @GetMapping("action-queue")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminDashboardActionQueueResponse getActionQueue(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminDashboardActionQueueRequest request
+    ) {
+        return AdminDashboardActionQueueResponse.from(
+            getAdminDashboardActionQueueUseCase.getActionQueue(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[ADMIN-DASHBOARD-004] 운영진 대시보드 권한 컨텍스트 조회")
+    @GetMapping("context")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminDashboardContextResponse getContext(
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
+        return AdminDashboardContextResponse.from(
+            getAdminDashboardContextUseCase.getContext(memberPrincipal.getMemberId())
+        );
+    }
+
+    @Operation(summary = "[ADMIN-DASHBOARD-005] 운영 현황 집계 조회")
+    @GetMapping("operations")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsOverviewResponse getOperationsOverview(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsOverviewRequest request
+    ) {
+        return AdminOperationsOverviewResponse.from(
+            getAdminOperationsOverviewUseCase.getOperationsOverview(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[ADMIN-DASHBOARD-003] 운영진 대시보드 위험군 챌린저 조회")
+    @GetMapping("risk-challengers")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public PageResponse<AdminRiskChallengerResponse> getRiskChallengers(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject Pageable pageable,
+        @ParameterObject AdminRiskChallengerRequest request
+    ) {
+        return PageResponse.of(
+            getAdminRiskChallengerUseCase.getRiskChallengers(request.toQuery(memberPrincipal.getMemberId(), pageable)),
+            AdminRiskChallengerResponse::from
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
@@ -9,6 +9,7 @@ import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -20,12 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/admin/schools")
 @RequiredArgsConstructor
-@Tag(name = "Admin Dashboard | 학교별 현황", description = "운영진 학교별 현황 집계 API")
+@Tag(name = "Analytics | 학교별 현황", description = "운영진 학교별 현황 집계 API")
 public class AdminSchoolAnalyticsController {
 
     private final GetAdminSchoolSummaryUseCase getAdminSchoolSummaryUseCase;
 
     @GetMapping("summary")
+    @Operation(summary = "[DASHBOARD-100] 학교별 현황 조회")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public PageResponse<AdminSchoolSummaryResponse> getSchoolSummaries(
         @CurrentMember MemberPrincipal memberPrincipal,

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
@@ -1,0 +1,40 @@
+package com.umc.product.analytics.adapter.in.web;
+
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminSchoolSummaryRequest;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminSchoolSummaryResponse;
+import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/schools")
+@RequiredArgsConstructor
+@Tag(name = "Admin Dashboard | 학교별 현황", description = "운영진 학교별 현황 집계 API")
+public class AdminSchoolAnalyticsController {
+
+    private final GetAdminSchoolSummaryUseCase getAdminSchoolSummaryUseCase;
+
+    @GetMapping("summary")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public PageResponse<AdminSchoolSummaryResponse> getSchoolSummaries(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject Pageable pageable,
+        @ParameterObject AdminSchoolSummaryRequest request
+    ) {
+        return PageResponse.of(
+            getAdminSchoolSummaryUseCase.getSchoolSummaries(request.toQuery(memberPrincipal.getMemberId(), pageable)),
+            AdminSchoolSummaryResponse::from
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminDashboardActionQueueRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminDashboardActionQueueRequest.java
@@ -1,0 +1,13 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueQuery;
+
+public record AdminDashboardActionQueueRequest(
+    Long gisuId,
+    Integer riskThreshold
+) {
+
+    public AdminDashboardActionQueueQuery toQuery(Long requesterMemberId) {
+        return AdminDashboardActionQueueQuery.of(requesterMemberId, gisuId, riskThreshold);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminDashboardRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminDashboardRequest.java
@@ -1,0 +1,14 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQuery;
+
+public record AdminDashboardRequest(
+    Long gisuId,
+    Long chapterId,
+    Long schoolId
+) {
+
+    public AdminDashboardQuery toQuery(Long requesterMemberId) {
+        return AdminDashboardQuery.of(requesterMemberId, gisuId, chapterId, schoolId);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsOverviewRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsOverviewRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import java.time.Instant;
+
+public record AdminOperationsOverviewRequest(
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public AdminOperationsOverviewQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsOverviewQuery.of(requesterMemberId, gisuId, from, to);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminRiskChallengerRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminRiskChallengerRequest.java
@@ -1,0 +1,23 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import org.springframework.data.domain.Pageable;
+
+public record AdminRiskChallengerRequest(
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    Integer riskThreshold
+) {
+
+    public AdminRiskChallengerQuery toQuery(Long requesterMemberId, Pageable pageable) {
+        return AdminRiskChallengerQuery.of(
+            requesterMemberId,
+            gisuId,
+            chapterId,
+            schoolId,
+            riskThreshold,
+            pageable
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminSchoolSummaryRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminSchoolSummaryRequest.java
@@ -1,0 +1,25 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import org.springframework.data.domain.Pageable;
+
+public record AdminSchoolSummaryRequest(
+    Long gisuId,
+    Long chapterId,
+    String search,
+    Integer riskThreshold,
+    String sort
+) {
+
+    public AdminSchoolSummaryQuery toQuery(Long requesterMemberId, Pageable pageable) {
+        return AdminSchoolSummaryQuery.of(
+            requesterMemberId,
+            gisuId,
+            chapterId,
+            search,
+            riskThreshold,
+            pageable,
+            sort
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardActionQueueResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardActionQueueResponse.java
@@ -1,0 +1,18 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+
+public record AdminDashboardActionQueueResponse(
+    long pendingAttendanceDecisionCount,
+    long newRiskMemberCountThisWeek,
+    long upcomingGraduationCount
+) {
+
+    public static AdminDashboardActionQueueResponse from(AdminDashboardActionQueueInfo info) {
+        return new AdminDashboardActionQueueResponse(
+            info.pendingAttendanceDecisionCount(),
+            info.newRiskMemberCountThisWeek(),
+            info.upcomingGraduationCount()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardContextResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardContextResponse.java
@@ -1,0 +1,27 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+
+public record AdminDashboardContextResponse(
+    ChallengerRoleType roleType,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    ChallengerPart responsiblePart,
+    AdminAnalyticsScopeType scopeType
+) {
+
+    public static AdminDashboardContextResponse from(AdminDashboardContextInfo info) {
+        return new AdminDashboardContextResponse(
+            info.roleType(),
+            info.gisuId(),
+            info.chapterId(),
+            info.schoolId(),
+            info.responsiblePart(),
+            info.scopeType()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardSummaryResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminDashboardSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.Map;
+
+public record AdminDashboardSummaryResponse(
+    long activeChallengerCount,
+    long newMemberCountThisWeek,
+    double newMemberDeltaPercent,
+    long activeSchoolCount,
+    long activeChapterCount,
+    PointSumResponse monthlyPointSum,
+    Map<ChallengerStatus, Long> challengerStatusDistribution
+) {
+
+    public static AdminDashboardSummaryResponse from(AdminDashboardSummaryInfo info) {
+        return new AdminDashboardSummaryResponse(
+            info.activeChallengerCount(),
+            info.newMemberCountThisWeek(),
+            info.newMemberDeltaPercent(),
+            info.activeSchoolCount(),
+            info.activeChapterCount(),
+            PointSumResponse.from(info.monthlyPointSum()),
+            info.challengerStatusDistribution()
+        );
+    }
+
+    public record PointSumResponse(long positive, long negative) {
+
+        public static PointSumResponse from(AdminDashboardSummaryInfo.PointSumInfo info) {
+            return new PointSumResponse(info.positive(), info.negative());
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsOverviewResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsOverviewResponse.java
@@ -1,0 +1,131 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record AdminOperationsOverviewResponse(
+    List<ChapterSchoolStatusResponse> chapterSchoolStatuses,
+    List<ChapterPartPointGrantStatusResponse> pointGrantStatuses,
+    ScheduleAttendanceStatusResponse scheduleAttendanceStatus,
+    StudyGroupStatusResponse studyGroupStatus,
+    List<SignupBucketResponse> signupBuckets
+) {
+
+    public static AdminOperationsOverviewResponse from(AdminOperationsOverviewInfo info) {
+        return new AdminOperationsOverviewResponse(
+            info.chapterSchoolStatuses().stream()
+                .map(ChapterSchoolStatusResponse::from)
+                .toList(),
+            info.pointGrantStatuses().stream()
+                .map(ChapterPartPointGrantStatusResponse::from)
+                .toList(),
+            ScheduleAttendanceStatusResponse.from(info.scheduleAttendanceStatus()),
+            StudyGroupStatusResponse.from(info.studyGroupStatus()),
+            info.signupBuckets().stream()
+                .map(SignupBucketResponse::from)
+                .toList()
+        );
+    }
+
+    public record ChapterSchoolStatusResponse(
+        Long chapterId,
+        String chapterName,
+        List<SchoolChallengerStatusResponse> schools
+    ) {
+
+        public static ChapterSchoolStatusResponse from(
+            AdminOperationsOverviewInfo.ChapterSchoolStatusInfo info
+        ) {
+            return new ChapterSchoolStatusResponse(
+                info.chapterId(),
+                info.chapterName(),
+                info.schools().stream()
+                    .map(SchoolChallengerStatusResponse::from)
+                    .toList()
+            );
+        }
+    }
+
+    public record SchoolChallengerStatusResponse(
+        Long schoolId,
+        String schoolName,
+        long totalChallengerCount,
+        Map<ChallengerPart, Long> challengerPartCounts
+    ) {
+
+        public static SchoolChallengerStatusResponse from(
+            AdminOperationsOverviewInfo.SchoolChallengerStatusInfo info
+        ) {
+            return new SchoolChallengerStatusResponse(
+                info.schoolId(),
+                info.schoolName(),
+                info.totalChallengerCount(),
+                info.challengerPartCounts()
+            );
+        }
+    }
+
+    public record ChapterPartPointGrantStatusResponse(
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        long grantCount,
+        double pointSum
+    ) {
+
+        public static ChapterPartPointGrantStatusResponse from(
+            AdminOperationsOverviewInfo.ChapterPartPointGrantStatusInfo info
+        ) {
+            return new ChapterPartPointGrantStatusResponse(
+                info.chapterId(),
+                info.chapterName(),
+                info.part(),
+                info.grantCount(),
+                info.pointSum()
+            );
+        }
+    }
+
+    public record ScheduleAttendanceStatusResponse(
+        long scheduleCount,
+        long attendanceRequiredScheduleCount,
+        long attendanceRecordCount,
+        Map<AttendanceStatus, Long> attendanceStatusCounts
+    ) {
+
+        public static ScheduleAttendanceStatusResponse from(
+            AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo info
+        ) {
+            return new ScheduleAttendanceStatusResponse(
+                info.scheduleCount(),
+                info.attendanceRequiredScheduleCount(),
+                info.attendanceRecordCount(),
+                info.attendanceStatusCounts()
+            );
+        }
+    }
+
+    public record StudyGroupStatusResponse(
+        long studyGroupCount,
+        long studyGroupScheduleCount
+    ) {
+
+        public static StudyGroupStatusResponse from(AdminOperationsOverviewInfo.StudyGroupStatusInfo info) {
+            return new StudyGroupStatusResponse(info.studyGroupCount(), info.studyGroupScheduleCount());
+        }
+    }
+
+    public record SignupBucketResponse(
+        LocalDate date,
+        long count
+    ) {
+
+        public static SignupBucketResponse from(AdminOperationsOverviewInfo.SignupBucketInfo info) {
+            return new SignupBucketResponse(info.date(), info.count());
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminRiskChallengerResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminRiskChallengerResponse.java
@@ -1,0 +1,44 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.time.Instant;
+
+public record AdminRiskChallengerResponse(
+    Long challengerId,
+    Long memberId,
+    String name,
+    String schoolName,
+    ChallengerPart part,
+    double pointSum,
+    LatestNegativePointResponse latestNegativePoint
+) {
+
+    public static AdminRiskChallengerResponse from(AdminRiskChallengerInfo info) {
+        return new AdminRiskChallengerResponse(
+            info.challengerId(),
+            info.memberId(),
+            info.name(),
+            info.schoolName(),
+            info.part(),
+            info.pointSum(),
+            LatestNegativePointResponse.from(info.latestNegativePoint())
+        );
+    }
+
+    public record LatestNegativePointResponse(
+        PointType pointType,
+        Instant createdAt,
+        double score
+    ) {
+
+        public static LatestNegativePointResponse from(AdminRiskChallengerInfo.LatestNegativePointInfo info) {
+            return info == null ? null : new LatestNegativePointResponse(
+                info.pointType(),
+                info.createdAt(),
+                info.score()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminSchoolSummaryResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminSchoolSummaryResponse.java
@@ -1,0 +1,48 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+
+public record AdminSchoolSummaryResponse(
+    Long schoolId,
+    String schoolName,
+    Long chapterId,
+    String chapterName,
+    long activeChallengerCount,
+    StaffResponse president,
+    StaffResponse vicePresident,
+    PartLeaderRatioResponse partLeaderRatio,
+    double averagePointSum,
+    long riskChallengerCount,
+    long newMemberCountThisWeek
+) {
+
+    public static AdminSchoolSummaryResponse from(AdminSchoolSummaryInfo info) {
+        return new AdminSchoolSummaryResponse(
+            info.schoolId(),
+            info.schoolName(),
+            info.chapterId(),
+            info.chapterName(),
+            info.activeChallengerCount(),
+            StaffResponse.from(info.president()),
+            StaffResponse.from(info.vicePresident()),
+            PartLeaderRatioResponse.from(info.partLeaderRatio()),
+            info.averagePointSum(),
+            info.riskChallengerCount(),
+            info.newMemberCountThisWeek()
+        );
+    }
+
+    public record StaffResponse(Long challengerId, String name) {
+
+        public static StaffResponse from(AdminSchoolSummaryInfo.StaffInfo info) {
+            return info == null ? null : new StaffResponse(info.challengerId(), info.name());
+        }
+    }
+
+    public record PartLeaderRatioResponse(long assigned, long totalRunningParts) {
+
+        public static PartLeaderRatioResponse from(AdminSchoolSummaryInfo.PartLeaderRatioInfo info) {
+            return new PartLeaderRatioResponse(info.assigned(), info.totalRunningParts());
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminDashboardAnalyticsPersistenceAdapter implements LoadAdminDashboardAnalyticsPort {
+
+    private final AdminDashboardAnalyticsQueryRepository queryRepository;
+
+    @Override
+    public AdminDashboardSummaryInfo getSummary(AdminAnalyticsScope scope) {
+        return queryRepository.getSummary(scope);
+    }
+
+    @Override
+    public AdminDashboardActionQueueInfo getActionQueue(AdminAnalyticsScope scope, int riskThreshold) {
+        return queryRepository.getActionQueue(scope, riskThreshold);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java
@@ -1,0 +1,278 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static com.umc.product.challenger.domain.QChallenger.challenger;
+import static com.umc.product.member.domain.QMember.member;
+import static com.umc.product.organization.domain.QChapter.chapter;
+import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
+import static com.umc.product.organization.domain.QGisu.gisu;
+import static com.umc.product.schedule.domain.QSchedule.schedule;
+import static com.umc.product.schedule.domain.QScheduleParticipant.scheduleParticipant;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.challenger.domain.QChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminDashboardAnalyticsQueryRepository {
+
+    private static final QChallengerPoint point = QChallengerPoint.challengerPoint;
+
+    private final JPAQueryFactory queryFactory;
+    private final Clock clock = Clock.systemUTC();
+
+    public AdminDashboardSummaryInfo getSummary(AdminAnalyticsScope scope) {
+        Instant now = Instant.now(clock);
+        Instant weekStart = now.minus(7, ChronoUnit.DAYS);
+        Instant prevWeekStart = now.minus(14, ChronoUnit.DAYS);
+        Instant monthStart = now.atZone(ZoneId.of("Asia/Seoul"))
+            .withDayOfMonth(1)
+            .truncatedTo(ChronoUnit.DAYS)
+            .toInstant();
+
+        long activeChallengerCount = countChallengers(scope, challenger.status.eq(ChallengerStatus.ACTIVE));
+        long newMemberCount = countMembers(scope, member.createdAt.goe(weekStart));
+        long prevNewMemberCount = countMembers(
+            scope,
+            member.createdAt.goe(prevWeekStart).and(member.createdAt.lt(weekStart))
+        );
+        long activeSchoolCount = countActiveSchools(scope);
+        long activeChapterCount = countActiveChapters(scope);
+        AdminDashboardSummaryInfo.PointSumInfo monthlyPointSum = monthlyPointSum(scope, monthStart);
+
+        return AdminDashboardSummaryInfo.of(
+            activeChallengerCount,
+            newMemberCount,
+            deltaPercent(newMemberCount, prevNewMemberCount),
+            activeSchoolCount,
+            activeChapterCount,
+            monthlyPointSum,
+            challengerStatusDistribution(scope)
+        );
+    }
+
+    public AdminDashboardActionQueueInfo getActionQueue(AdminAnalyticsScope scope, int riskThreshold) {
+        Instant now = Instant.now(clock);
+        Instant weekStart = now.minus(7, ChronoUnit.DAYS);
+        long pendingAttendanceDecisionCount = countPendingAttendanceDecisions(scope);
+        long newRiskMemberCountThisWeek = countNewRiskMembersThisWeek(scope, weekStart, riskThreshold);
+        long upcomingGraduationCount = isUpcomingGraduation(scope, now)
+            ? countChallengers(scope, challenger.status.eq(ChallengerStatus.ACTIVE))
+            : 0L;
+
+        return AdminDashboardActionQueueInfo.of(
+            pendingAttendanceDecisionCount,
+            newRiskMemberCountThisWeek,
+            upcomingGraduationCount
+        );
+    }
+
+    private long countChallengers(AdminAnalyticsScope scope, Predicate extraCondition) {
+        Long count = selectFromChallenger(challenger.id.countDistinct(), scope)
+            .where(extraCondition)
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private long countMembers(AdminAnalyticsScope scope, Predicate extraCondition) {
+        Long count = selectFromChallenger(member.id.countDistinct(), scope)
+            .where(extraCondition)
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private long countActiveSchools(AdminAnalyticsScope scope) {
+        Long count = selectFromChallenger(member.schoolId.countDistinct(), scope)
+            .where(challenger.status.eq(ChallengerStatus.ACTIVE))
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private long countActiveChapters(AdminAnalyticsScope scope) {
+        Long count = selectFromChallenger(chapter.id.countDistinct(), scope)
+            .where(challenger.status.eq(ChallengerStatus.ACTIVE))
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private AdminDashboardSummaryInfo.PointSumInfo monthlyPointSum(AdminAnalyticsScope scope, Instant monthStart) {
+        List<Double> scores = queryFactory
+            .select(pointScore(point))
+            .from(point)
+            .join(point.challenger, challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope)
+                .and(point.createdAt.goe(monthStart)))
+            .fetch();
+
+        long positive = 0L;
+        long negative = 0L;
+        for (Double score : scores) {
+            double value = score != null ? score : 0.0;
+            if (value > 0) {
+                positive += Math.round(value);
+            } else if (value < 0) {
+                negative += Math.round(value);
+            }
+        }
+        return AdminDashboardSummaryInfo.PointSumInfo.of(positive, negative);
+    }
+
+    private Map<ChallengerStatus, Long> challengerStatusDistribution(AdminAnalyticsScope scope) {
+        NumberExpression<Long> statusCount = challenger.id.countDistinct();
+        List<Tuple> result = selectFromChallenger(challenger.status, scope)
+            .select(challenger.status, statusCount)
+            .groupBy(challenger.status)
+            .fetch();
+
+        Map<ChallengerStatus, Long> distribution = new EnumMap<>(ChallengerStatus.class);
+        for (Tuple row : result) {
+            distribution.put(row.get(challenger.status), row.get(statusCount));
+        }
+        return distribution;
+    }
+
+    private long countPendingAttendanceDecisions(AdminAnalyticsScope scope) {
+        Long count = queryFactory
+            .select(scheduleParticipant.id.countDistinct())
+            .from(scheduleParticipant)
+            .join(scheduleParticipant.schedule, schedule)
+            .join(member).on(member.id.eq(schedule.authorMemberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(scope.gisuId())))
+            .where(scheduleScopeCondition(scope)
+                .and(scheduleParticipant.attendance.status.in(
+                    AttendanceStatus.PRESENT_PENDING,
+                    AttendanceStatus.LATE_PENDING,
+                    AttendanceStatus.EXCUSED_PENDING,
+                    AttendanceStatus.ABSENT_EXCUSE_PENDING,
+                    AttendanceStatus.LATE_EXCUSE_PENDING
+                )))
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private BooleanBuilder scheduleScopeCondition(AdminAnalyticsScope scope) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(chapter.gisu.id.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(member.schoolId.eq(scope.schoolId()));
+        }
+        return builder;
+    }
+
+    private long countNewRiskMembersThisWeek(AdminAnalyticsScope scope, Instant weekStart, int riskThreshold) {
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        return queryFactory
+            .select(challenger.id)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(point).on(point.challenger.id.eq(challenger.id))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope)
+                .and(challenger.status.eq(ChallengerStatus.ACTIVE))
+                .and(member.createdAt.goe(weekStart)))
+            .groupBy(challenger.id)
+            .having(pointSum.loe((double) riskThreshold))
+            .fetch()
+            .size();
+    }
+
+    private boolean isUpcomingGraduation(AdminAnalyticsScope scope, Instant now) {
+        Long count = queryFactory
+            .select(gisu.id.count())
+            .from(gisu)
+            .where(
+                gisu.id.eq(scope.gisuId()),
+                gisu.period.endAt.loe(now.plus(14, ChronoUnit.DAYS))
+            )
+            .fetchOne();
+        return count != null && count > 0L;
+    }
+
+    private <T> JPAQuery<T> selectFromChallenger(Expression<T> expression, AdminAnalyticsScope scope) {
+        return queryFactory
+            .select(expression)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope));
+    }
+
+    private BooleanBuilder challengerScopeCondition(AdminAnalyticsScope scope) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(challenger.gisuId.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(member.schoolId.eq(scope.schoolId()));
+        }
+        if (scope.responsiblePart() != null) {
+            builder.and(challenger.part.eq(scope.responsiblePart()));
+        }
+        return builder;
+    }
+
+    private double deltaPercent(long current, long previous) {
+        if (previous == 0L) {
+            return current == 0L ? 0.0 : 100.0;
+        }
+        return ((double) (current - previous) / previous) * 100.0;
+    }
+
+    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
+        return new CaseBuilder()
+            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
+            .otherwise(pointTypeScore(targetPoint));
+    }
+
+    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
+        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
+        for (PointType pointType : PointType.values()) {
+            if (caseBuilder == null) {
+                caseBuilder = new CaseBuilder()
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            } else {
+                caseBuilder = caseBuilder
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            }
+        }
+
+        assert caseBuilder != null;
+        return caseBuilder.otherwise(0.0);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -1,0 +1,23 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminOperationsAnalyticsPersistenceAdapter implements LoadAdminOperationsAnalyticsPort {
+
+    private final AdminOperationsAnalyticsQueryRepository queryRepository;
+
+    @Override
+    public AdminOperationsOverviewInfo getOperationsOverview(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        return queryRepository.getOperationsOverview(scope, query);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -1,0 +1,482 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.challenger.domain.QChallenger;
+import com.umc.product.challenger.domain.QChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.domain.QMember;
+import com.umc.product.organization.domain.QChapter;
+import com.umc.product.organization.domain.QChapterSchool;
+import com.umc.product.organization.domain.QSchool;
+import com.umc.product.organization.domain.QStudyGroup;
+import com.umc.product.organization.domain.QStudyGroupMember;
+import com.umc.product.organization.domain.QStudyGroupSchedule;
+import com.umc.product.schedule.domain.QSchedule;
+import com.umc.product.schedule.domain.QScheduleParticipant;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminOperationsAnalyticsQueryRepository {
+
+    private static final ZoneId DASHBOARD_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final JPAQueryFactory queryFactory;
+
+    public AdminOperationsOverviewInfo getOperationsOverview(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        return AdminOperationsOverviewInfo.of(
+            listChapterSchoolStatuses(scope),
+            listPointGrantStatuses(scope, query),
+            getScheduleAttendanceStatus(scope, query),
+            getStudyGroupStatus(scope, query),
+            listSignupBuckets(scope, query)
+        );
+    }
+
+    private List<AdminOperationsOverviewInfo.ChapterSchoolStatusInfo> listChapterSchoolStatuses(
+        AdminAnalyticsScope scope
+    ) {
+        QChapterSchool chapterSchool = new QChapterSchool("operationsChapterSchool");
+        QChapter chapter = new QChapter("operationsChapter");
+        QSchool school = new QSchool("operationsSchool");
+        QMember member = new QMember("operationsSchoolMember");
+        QChallenger challenger = new QChallenger("operationsSchoolChallenger");
+        NumberExpression<Long> challengerCount = challenger.id.countDistinct();
+
+        BooleanBuilder challengerJoinCondition = new BooleanBuilder()
+            .and(challenger.memberId.eq(member.id))
+            .and(challenger.gisuId.eq(scope.gisuId()));
+        if (scope.responsiblePart() != null) {
+            challengerJoinCondition.and(challenger.part.eq(scope.responsiblePart()));
+        }
+
+        List<Tuple> rows = queryFactory
+            .select(chapter.id, chapter.name, school.id, school.name, challenger.part, challengerCount)
+            .from(chapterSchool)
+            .join(chapterSchool.chapter, chapter)
+            .join(chapterSchool.school, school)
+            .leftJoin(member).on(member.schoolId.eq(school.id))
+            .leftJoin(challenger).on(challengerJoinCondition)
+            .where(schoolScopeCondition(scope, chapter, school))
+            .groupBy(chapter.id, chapter.name, school.id, school.name, challenger.part)
+            .orderBy(chapter.name.asc(), school.name.asc())
+            .fetch();
+
+        Map<ChapterKey, Map<SchoolKey, Map<ChallengerPart, Long>>> chapterSchoolPartCounts = new LinkedHashMap<>();
+        for (Tuple row : rows) {
+            ChapterKey chapterKey = ChapterKey.from(row, chapter);
+            SchoolKey schoolKey = SchoolKey.from(row, school);
+            ChallengerPart part = row.get(challenger.part);
+            long count = defaultLong(row.get(challengerCount));
+
+            Map<SchoolKey, Map<ChallengerPart, Long>> schoolPartCounts =
+                chapterSchoolPartCounts.computeIfAbsent(chapterKey, ignored -> new LinkedHashMap<>());
+            Map<ChallengerPart, Long> partCounts =
+                schoolPartCounts.computeIfAbsent(schoolKey, ignored -> emptyPartCounts());
+            if (part != null) {
+                partCounts.put(part, count);
+            }
+        }
+
+        return chapterSchoolPartCounts.entrySet()
+            .stream()
+            .map(chapterEntry -> AdminOperationsOverviewInfo.ChapterSchoolStatusInfo.of(
+                chapterEntry.getKey().chapterId(),
+                chapterEntry.getKey().chapterName(),
+                chapterEntry.getValue().entrySet()
+                    .stream()
+                    .map(schoolEntry -> toSchoolChallengerStatus(schoolEntry.getKey(), schoolEntry.getValue()))
+                    .toList()
+            ))
+            .toList();
+    }
+
+    private AdminOperationsOverviewInfo.SchoolChallengerStatusInfo toSchoolChallengerStatus(
+        SchoolKey school,
+        Map<ChallengerPart, Long> partCounts
+    ) {
+        long total = partCounts.values()
+            .stream()
+            .mapToLong(Long::longValue)
+            .sum();
+        return AdminOperationsOverviewInfo.SchoolChallengerStatusInfo.of(
+            school.schoolId(),
+            school.schoolName(),
+            total,
+            partCounts
+        );
+    }
+
+    private List<AdminOperationsOverviewInfo.ChapterPartPointGrantStatusInfo> listPointGrantStatuses(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        QChallengerPoint point = new QChallengerPoint("operationsPoint");
+        QChallenger challenger = new QChallenger("operationsPointChallenger");
+        QMember member = new QMember("operationsPointMember");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsPointChapterSchool");
+        QChapter chapter = new QChapter("operationsPointChapter");
+        NumberExpression<Long> grantCount = point.id.count();
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        List<Tuple> rows = queryFactory
+            .select(chapter.id, chapter.name, challenger.part, grantCount, pointSum)
+            .from(point)
+            .join(point.challenger, challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope, challenger, member, chapter)
+                .and(periodCondition(point.createdAt, query)))
+            .groupBy(chapter.id, chapter.name, challenger.part)
+            .orderBy(chapter.name.asc(), challenger.part.asc())
+            .fetch();
+
+        return rows.stream()
+            .map(row -> AdminOperationsOverviewInfo.ChapterPartPointGrantStatusInfo.of(
+                row.get(chapter.id),
+                row.get(chapter.name),
+                row.get(challenger.part),
+                defaultLong(row.get(grantCount)),
+                defaultDouble(row.get(pointSum))
+            ))
+            .toList();
+    }
+
+    private AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo getScheduleAttendanceStatus(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        QSchedule schedule = new QSchedule("operationsSchedule");
+        long scheduleCount = countSchedules(scope, query, schedule, false);
+        long attendanceRequiredScheduleCount = countSchedules(scope, query, schedule, true);
+        Map<AttendanceStatus, Long> attendanceStatusCounts = countAttendanceStatuses(scope, query);
+        long attendanceRecordCount = attendanceStatusCounts.values()
+            .stream()
+            .mapToLong(Long::longValue)
+            .sum();
+
+        return AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo.of(
+            scheduleCount,
+            attendanceRequiredScheduleCount,
+            attendanceRecordCount,
+            attendanceStatusCounts
+        );
+    }
+
+    private long countSchedules(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query,
+        QSchedule schedule,
+        boolean attendanceRequiredOnly
+    ) {
+        QMember author = new QMember("operationsScheduleAuthor");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsScheduleChapterSchool");
+        QChapter chapter = new QChapter("operationsScheduleChapter");
+        BooleanBuilder condition = scheduleScopeCondition(scope, query, schedule, author, chapter);
+        if (attendanceRequiredOnly) {
+            condition.and(schedule.policy.attendanceGraceMinutes.isNotNull());
+        }
+
+        Long count = queryFactory
+            .select(schedule.id.countDistinct())
+            .from(schedule)
+            .join(author).on(author.id.eq(schedule.authorMemberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(author.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id))
+            .where(condition)
+            .fetchOne();
+        return defaultLong(count);
+    }
+
+    private Map<AttendanceStatus, Long> countAttendanceStatuses(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        QScheduleParticipant participant = new QScheduleParticipant("operationsParticipant");
+        QSchedule schedule = new QSchedule("operationsAttendanceSchedule");
+        QMember author = new QMember("operationsAttendanceAuthor");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsAttendanceChapterSchool");
+        QChapter chapter = new QChapter("operationsAttendanceChapter");
+        NumberExpression<Long> statusCount = participant.id.count();
+
+        List<Tuple> rows = queryFactory
+            .select(participant.attendance.status, statusCount)
+            .from(participant)
+            .join(participant.schedule, schedule)
+            .join(author).on(author.id.eq(schedule.authorMemberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(author.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id))
+            .where(scheduleAuthorScopeCondition(scope, author, chapter)
+                .and(periodCondition(participant.updatedAt, query))
+                .and(participant.attendance.status.isNotNull()))
+            .groupBy(participant.attendance.status)
+            .fetch();
+
+        Map<AttendanceStatus, Long> result = new EnumMap<>(AttendanceStatus.class);
+        for (Tuple row : rows) {
+            result.put(row.get(participant.attendance.status), defaultLong(row.get(statusCount)));
+        }
+        return result;
+    }
+
+    private AdminOperationsOverviewInfo.StudyGroupStatusInfo getStudyGroupStatus(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        return AdminOperationsOverviewInfo.StudyGroupStatusInfo.of(
+            countStudyGroups(scope),
+            countStudyGroupSchedules(scope, query)
+        );
+    }
+
+    private long countStudyGroups(AdminAnalyticsScope scope) {
+        QStudyGroup studyGroup = new QStudyGroup("operationsStudyGroup");
+        JPAQuery<Long> countQuery = queryFactory
+            .select(studyGroup.id.countDistinct())
+            .from(studyGroup);
+        BooleanBuilder condition = studyGroupCondition(scope, studyGroup, countQuery);
+
+        Long count = countQuery
+            .where(condition)
+            .fetchOne();
+        return defaultLong(count);
+    }
+
+    private long countStudyGroupSchedules(AdminAnalyticsScope scope, AdminOperationsOverviewQuery query) {
+        QStudyGroupSchedule studyGroupSchedule = new QStudyGroupSchedule("operationsStudyGroupSchedule");
+        QStudyGroup studyGroup = new QStudyGroup("operationsScheduledStudyGroup");
+        JPAQuery<Long> countQuery = queryFactory
+            .select(studyGroupSchedule.id.countDistinct())
+            .from(studyGroupSchedule)
+            .join(studyGroup).on(studyGroup.id.eq(studyGroupSchedule.studyGroupId));
+        BooleanBuilder condition = studyGroupCondition(scope, studyGroup, countQuery)
+            .and(periodCondition(studyGroupSchedule.createdAt, query));
+
+        Long count = countQuery
+            .where(condition)
+            .fetchOne();
+        return defaultLong(count);
+    }
+
+    private List<AdminOperationsOverviewInfo.SignupBucketInfo> listSignupBuckets(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    ) {
+        QChallenger challenger = new QChallenger("operationsSignupChallenger");
+        QMember member = new QMember("operationsSignupMember");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsSignupChapterSchool");
+        QChapter chapter = new QChapter("operationsSignupChapter");
+
+        List<Tuple> rows = queryFactory
+            .select(member.id, member.createdAt)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope, challenger, member, chapter)
+                .and(periodCondition(member.createdAt, query)))
+            .groupBy(member.id, member.createdAt)
+            .fetch();
+
+        Map<LocalDate, Long> countsByDate = rows.stream()
+            .map(row -> row.get(member.createdAt))
+            .collect(Collectors.groupingBy(
+                createdAt -> createdAt.atZone(DASHBOARD_ZONE).toLocalDate(),
+                TreeMap::new,
+                Collectors.counting()
+            ));
+
+        return countsByDate.entrySet()
+            .stream()
+            .map(entry -> AdminOperationsOverviewInfo.SignupBucketInfo.of(entry.getKey(), entry.getValue()))
+            .toList();
+    }
+
+    private BooleanBuilder schoolScopeCondition(
+        AdminAnalyticsScope scope,
+        QChapter chapter,
+        QSchool school
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(chapter.gisu.id.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(school.id.eq(scope.schoolId()));
+        }
+        return builder;
+    }
+
+    private BooleanBuilder challengerScopeCondition(
+        AdminAnalyticsScope scope,
+        QChallenger challenger,
+        QMember member,
+        QChapter chapter
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(challenger.gisuId.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(member.schoolId.eq(scope.schoolId()));
+        }
+        if (scope.responsiblePart() != null) {
+            builder.and(challenger.part.eq(scope.responsiblePart()));
+        }
+        return builder;
+    }
+
+    private BooleanBuilder scheduleScopeCondition(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query,
+        QSchedule schedule,
+        QMember author,
+        QChapter chapter
+    ) {
+        return scheduleAuthorScopeCondition(scope, author, chapter)
+            .and(periodCondition(schedule.createdAt, query));
+    }
+
+    private BooleanBuilder scheduleAuthorScopeCondition(
+        AdminAnalyticsScope scope,
+        QMember author,
+        QChapter chapter
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(chapter.gisu.id.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(author.schoolId.eq(scope.schoolId()));
+        }
+        return builder;
+    }
+
+    private BooleanBuilder studyGroupCondition(
+        AdminAnalyticsScope scope,
+        QStudyGroup studyGroup,
+        JPAQuery<Long> query
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(studyGroup.gisuId.eq(scope.gisuId()));
+        if (scope.responsiblePart() != null) {
+            builder.and(studyGroup.part.eq(scope.responsiblePart()));
+        }
+        if (scope.chapterId() == null && scope.schoolId() == null) {
+            return builder;
+        }
+
+        QStudyGroupMember studyGroupMember = new QStudyGroupMember("operationsStudyGroupMember");
+        QMember member = new QMember("operationsStudyGroupMemberMember");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsStudyGroupChapterSchool");
+        QChapter chapter = new QChapter("operationsStudyGroupChapter");
+
+        query.leftJoin(studyGroupMember).on(studyGroupMember.studyGroup.id.eq(studyGroup.id))
+            .leftJoin(member).on(member.id.eq(studyGroupMember.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(studyGroup.gisuId)));
+
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(member.schoolId.eq(scope.schoolId()));
+        }
+        return builder;
+    }
+
+    private BooleanBuilder periodCondition(DateTimePath<Instant> path, AdminOperationsOverviewQuery query) {
+        return new BooleanBuilder()
+            .and(path.goe(query.from()))
+            .and(path.lt(query.to()));
+    }
+
+    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
+        return new CaseBuilder()
+            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
+            .otherwise(pointTypeScore(targetPoint));
+    }
+
+    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
+        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
+        for (PointType pointType : PointType.values()) {
+            if (caseBuilder == null) {
+                caseBuilder = new CaseBuilder()
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            } else {
+                caseBuilder = caseBuilder
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            }
+        }
+
+        assert caseBuilder != null;
+        return caseBuilder.otherwise(0.0);
+    }
+
+    private Map<ChallengerPart, Long> emptyPartCounts() {
+        Map<ChallengerPart, Long> counts = new EnumMap<>(ChallengerPart.class);
+        for (ChallengerPart part : ChallengerPart.values()) {
+            counts.put(part, 0L);
+        }
+        return counts;
+    }
+
+    private long defaultLong(Long value) {
+        return value != null ? value : 0L;
+    }
+
+    private double defaultDouble(Double value) {
+        return value != null ? value : 0.0;
+    }
+
+    private record ChapterKey(
+        Long chapterId,
+        String chapterName
+    ) {
+
+        private static ChapterKey from(Tuple row, QChapter chapter) {
+            return new ChapterKey(row.get(chapter.id), row.get(chapter.name));
+        }
+    }
+
+    private record SchoolKey(
+        Long schoolId,
+        String schoolName
+    ) {
+
+        private static SchoolKey from(Tuple row, QSchool school) {
+            return new SchoolKey(row.get(school.id), row.get(school.name));
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsPersistenceAdapter.java
@@ -1,0 +1,24 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminRiskChallengerAnalyticsPersistenceAdapter implements LoadAdminRiskChallengerAnalyticsPort {
+
+    private final AdminRiskChallengerAnalyticsQueryRepository queryRepository;
+
+    @Override
+    public Page<AdminRiskChallengerInfo> getRiskChallengers(
+        AdminAnalyticsScope scope,
+        AdminRiskChallengerQuery query
+    ) {
+        return queryRepository.getRiskChallengers(scope, query);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepository.java
@@ -1,0 +1,190 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static com.umc.product.challenger.domain.QChallenger.challenger;
+import static com.umc.product.member.domain.QMember.member;
+import static com.umc.product.organization.domain.QChapter.chapter;
+import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
+import static com.umc.product.organization.domain.QSchool.school;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.analytics.adapter.out.persistence.row.AdminRiskChallengerRow;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.challenger.domain.QChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminRiskChallengerAnalyticsQueryRepository {
+
+    private static final QChallengerPoint point = QChallengerPoint.challengerPoint;
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<AdminRiskChallengerInfo> getRiskChallengers(
+        AdminAnalyticsScope scope,
+        AdminRiskChallengerQuery query
+    ) {
+        List<AdminRiskChallengerRow> rows = fetchRows(scope, query);
+        long total = countRows(scope, query);
+        Map<Long, AdminRiskChallengerInfo.LatestNegativePointInfo> latestNegativePoints =
+            fetchLatestNegativePoints(rows.stream()
+                .map(AdminRiskChallengerRow::challengerId)
+                .collect(Collectors.toSet()));
+
+        List<AdminRiskChallengerInfo> content = rows.stream()
+            .map(row -> AdminRiskChallengerInfo.of(
+                row.challengerId(),
+                row.memberId(),
+                row.name(),
+                row.schoolName(),
+                row.part(),
+                row.pointSum(),
+                latestNegativePoints.get(row.challengerId())
+            ))
+            .toList();
+
+        return new PageImpl<>(content, query.pageable(), total);
+    }
+
+    private List<AdminRiskChallengerRow> fetchRows(AdminAnalyticsScope scope, AdminRiskChallengerQuery query) {
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        List<Tuple> result = queryFactory
+            .select(challenger.id, challenger.memberId, member.name, school.name, challenger.part, pointSum)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(school).on(school.id.eq(member.schoolId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .leftJoin(point).on(point.challenger.id.eq(challenger.id))
+            .where(scopeCondition(scope).and(challenger.status.eq(ChallengerStatus.ACTIVE)))
+            .groupBy(challenger.id, challenger.memberId, member.name, school.name, challenger.part)
+            .having(pointSum.loe((double) query.riskThreshold()))
+            .orderBy(pointSum.asc(), member.name.asc())
+            .offset(query.pageable().getOffset())
+            .limit(query.pageable().getPageSize())
+            .fetch();
+
+        return result.stream()
+            .map(row -> new AdminRiskChallengerRow(
+                row.get(challenger.id),
+                row.get(challenger.memberId),
+                row.get(member.name),
+                row.get(school.name),
+                row.get(challenger.part),
+                defaultDouble(row.get(pointSum))
+            ))
+            .toList();
+    }
+
+    private long countRows(AdminAnalyticsScope scope, AdminRiskChallengerQuery query) {
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        return queryFactory
+            .select(challenger.id)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .leftJoin(point).on(point.challenger.id.eq(challenger.id))
+            .where(scopeCondition(scope).and(challenger.status.eq(ChallengerStatus.ACTIVE)))
+            .groupBy(challenger.id)
+            .having(pointSum.loe((double) query.riskThreshold()))
+            .fetch()
+            .size();
+    }
+
+    private Map<Long, AdminRiskChallengerInfo.LatestNegativePointInfo> fetchLatestNegativePoints(
+        Set<Long> challengerIds
+    ) {
+        if (challengerIds.isEmpty()) {
+            return Map.of();
+        }
+
+        QChallengerPoint negativePoint = new QChallengerPoint("negativePoint");
+        NumberExpression<Double> score = pointScore(negativePoint);
+
+        List<Tuple> result = queryFactory
+            .select(negativePoint.challenger.id, negativePoint.type, negativePoint.createdAt, score)
+            .from(negativePoint)
+            .where(
+                negativePoint.challenger.id.in(challengerIds),
+                score.lt(0.0)
+            )
+            .orderBy(negativePoint.challenger.id.asc(), negativePoint.createdAt.desc(), negativePoint.id.desc())
+            .fetch();
+
+        Map<Long, AdminRiskChallengerInfo.LatestNegativePointInfo> latestNegativePoints = new HashMap<>();
+        for (Tuple row : result) {
+            Long challengerId = row.get(negativePoint.challenger.id);
+            latestNegativePoints.putIfAbsent(
+                challengerId,
+                AdminRiskChallengerInfo.LatestNegativePointInfo.of(
+                    row.get(negativePoint.type),
+                    row.get(negativePoint.createdAt),
+                    defaultDouble(row.get(score))
+                )
+            );
+        }
+        return latestNegativePoints;
+    }
+
+    private BooleanBuilder scopeCondition(AdminAnalyticsScope scope) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(challenger.gisuId.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(member.schoolId.eq(scope.schoolId()));
+        }
+        if (scope.responsiblePart() != null) {
+            builder.and(challenger.part.eq(scope.responsiblePart()));
+        }
+        return builder;
+    }
+
+    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
+        return new CaseBuilder()
+            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
+            .otherwise(pointTypeScore(targetPoint));
+    }
+
+    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
+        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
+        for (PointType pointType : PointType.values()) {
+            if (caseBuilder == null) {
+                caseBuilder = new CaseBuilder()
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            } else {
+                caseBuilder = caseBuilder
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            }
+        }
+
+        assert caseBuilder != null;
+        return caseBuilder.otherwise(0.0);
+    }
+
+    private double defaultDouble(Double value) {
+        return value != null ? value : 0.0;
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsPersistenceAdapter.java
@@ -1,0 +1,24 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminSchoolAnalyticsPersistenceAdapter implements LoadAdminSchoolAnalyticsPort {
+
+    private final AdminSchoolAnalyticsQueryRepository queryRepository;
+
+    @Override
+    public Page<AdminSchoolSummaryInfo> getSchoolSummaries(
+        AdminAnalyticsScope scope,
+        AdminSchoolSummaryQuery query
+    ) {
+        return queryRepository.getSchoolSummaries(scope, query);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java
@@ -1,0 +1,367 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static com.umc.product.authorization.domain.QChallengerRole.challengerRole;
+import static com.umc.product.challenger.domain.QChallenger.challenger;
+import static com.umc.product.member.domain.QMember.member;
+import static com.umc.product.organization.domain.QChapter.chapter;
+import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
+import static com.umc.product.organization.domain.QSchool.school;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.analytics.adapter.out.persistence.row.AdminSchoolSummaryRow;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsSort;
+import com.umc.product.challenger.domain.QChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminSchoolAnalyticsQueryRepository {
+
+    private static final QChallengerPoint point = QChallengerPoint.challengerPoint;
+
+    private final JPAQueryFactory queryFactory;
+    private final Clock clock = Clock.systemUTC();
+
+    public Page<AdminSchoolSummaryInfo> getSchoolSummaries(
+        AdminAnalyticsScope scope,
+        AdminSchoolSummaryQuery query
+    ) {
+        Instant weekStart = Instant.now(clock).minus(7, ChronoUnit.DAYS);
+        List<AdminSchoolSummaryRow> rows = fetchRows(scope, query, weekStart);
+        long total = countSchools(scope, query);
+        Set<Long> schoolIds = rows.stream().map(AdminSchoolSummaryRow::schoolId).collect(Collectors.toSet());
+        Map<Long, AdminSchoolSummaryInfo.StaffInfo> presidents = fetchStaff(schoolIds, scope.gisuId(),
+            ChallengerRoleType.SCHOOL_PRESIDENT);
+        Map<Long, AdminSchoolSummaryInfo.StaffInfo> vicePresidents = fetchStaff(schoolIds, scope.gisuId(),
+            ChallengerRoleType.SCHOOL_VICE_PRESIDENT);
+        Map<Long, Long> assignedPartCounts = fetchAssignedPartCounts(schoolIds, scope.gisuId());
+
+        List<AdminSchoolSummaryInfo> content = rows.stream()
+            .map(row -> AdminSchoolSummaryInfo.of(
+                row.schoolId(),
+                row.schoolName(),
+                row.chapterId(),
+                row.chapterName(),
+                row.activeChallengerCount(),
+                presidents.get(row.schoolId()),
+                vicePresidents.get(row.schoolId()),
+                AdminSchoolSummaryInfo.PartLeaderRatioInfo.of(
+                    assignedPartCounts.getOrDefault(row.schoolId(), 0L),
+                    row.totalRunningParts()
+                ),
+                row.averagePointSum(),
+                row.riskChallengerCount(),
+                row.newMemberCountThisWeek()
+            ))
+            .toList();
+
+        return new PageImpl<>(content, query.pageable(), total);
+    }
+
+    private List<AdminSchoolSummaryRow> fetchRows(
+        AdminAnalyticsScope scope,
+        AdminSchoolSummaryQuery query,
+        Instant weekStart
+    ) {
+        List<ChallengerSchoolMetric> metrics = fetchChallengerMetrics(scope, query);
+        List<AdminSchoolSummaryRow> rows = metrics.stream()
+            .collect(Collectors.groupingBy(ChallengerSchoolMetric::school))
+            .entrySet()
+            .stream()
+            .map(entry -> toSummaryRow(entry.getKey(), entry.getValue(), query.riskThreshold(), weekStart))
+            .sorted(rowComparator(query.sort()))
+            .toList();
+
+        return pageRows(rows, query);
+    }
+
+    private List<ChallengerSchoolMetric> fetchChallengerMetrics(
+        AdminAnalyticsScope scope,
+        AdminSchoolSummaryQuery query
+    ) {
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        List<Tuple> result = queryFactory
+            .select(
+                school.id,
+                school.name,
+                chapter.id,
+                chapter.name,
+                challenger.id,
+                challenger.part,
+                member.createdAt,
+                pointSum
+            )
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .join(school).on(school.id.eq(member.schoolId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(school.id))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .leftJoin(point).on(point.challenger.id.eq(challenger.id))
+            .where(scopeCondition(scope)
+                .and(challenger.status.eq(ChallengerStatus.ACTIVE))
+                .and(schoolNameContains(query.search())))
+            .groupBy(
+                school.id,
+                school.name,
+                chapter.id,
+                chapter.name,
+                challenger.id,
+                challenger.part,
+                member.createdAt
+            )
+            .fetch();
+
+        return result.stream()
+            .map(row -> new ChallengerSchoolMetric(
+                new SchoolSummaryKey(
+                    row.get(school.id),
+                    row.get(school.name),
+                    row.get(chapter.id),
+                    row.get(chapter.name)
+                ),
+                row.get(challenger.id),
+                row.get(challenger.part),
+                row.get(member.createdAt),
+                defaultDouble(row.get(pointSum))
+            ))
+            .toList();
+    }
+
+    private AdminSchoolSummaryRow toSummaryRow(
+        SchoolSummaryKey school,
+        List<ChallengerSchoolMetric> metrics,
+        int riskThreshold,
+        Instant weekStart
+    ) {
+        long activeChallengerCount = metrics.stream()
+            .map(ChallengerSchoolMetric::challengerId)
+            .distinct()
+            .count();
+        double averagePointSum = metrics.stream()
+            .mapToDouble(ChallengerSchoolMetric::pointSum)
+            .average()
+            .orElse(0.0);
+        long riskChallengerCount = metrics.stream()
+            .filter(metric -> metric.pointSum() <= riskThreshold)
+            .count();
+        long newMemberCountThisWeek = metrics.stream()
+            .filter(metric -> !metric.memberCreatedAt().isBefore(weekStart))
+            .count();
+        long totalRunningParts = metrics.stream()
+            .map(ChallengerSchoolMetric::part)
+            .distinct()
+            .count();
+
+        return new AdminSchoolSummaryRow(
+            school.schoolId(),
+            school.schoolName(),
+            school.chapterId(),
+            school.chapterName(),
+            activeChallengerCount,
+            averagePointSum,
+            riskChallengerCount,
+            newMemberCountThisWeek,
+            totalRunningParts
+        );
+    }
+
+    private List<AdminSchoolSummaryRow> pageRows(List<AdminSchoolSummaryRow> rows, AdminSchoolSummaryQuery query) {
+        long offset = query.pageable().getOffset();
+        if (offset >= rows.size()) {
+            return List.of();
+        }
+
+        int fromIndex = (int) offset;
+        int toIndex = Math.min(fromIndex + query.pageable().getPageSize(), rows.size());
+        return rows.subList(fromIndex, toIndex);
+    }
+
+    private long countSchools(AdminAnalyticsScope scope, AdminSchoolSummaryQuery query) {
+        Long count = queryFactory
+            .select(school.id.countDistinct())
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .join(school).on(school.id.eq(member.schoolId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(school.id))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(scopeCondition(scope)
+                .and(challenger.status.eq(ChallengerStatus.ACTIVE))
+                .and(schoolNameContains(query.search())))
+            .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    private Map<Long, AdminSchoolSummaryInfo.StaffInfo> fetchStaff(
+        Set<Long> schoolIds,
+        Long gisuId,
+        ChallengerRoleType roleType
+    ) {
+        if (schoolIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Tuple> result = queryFactory
+            .select(challengerRole.organizationId, challenger.id, member.name)
+            .from(challengerRole)
+            .join(challenger).on(challenger.id.eq(challengerRole.challengerId))
+            .join(member).on(member.id.eq(challenger.memberId))
+            .where(
+                challengerRole.gisuId.eq(gisuId),
+                challengerRole.challengerRoleType.eq(roleType),
+                challengerRole.organizationId.in(schoolIds)
+            )
+            .orderBy(challenger.id.asc())
+            .fetch();
+
+        Map<Long, AdminSchoolSummaryInfo.StaffInfo> staffBySchoolId = new HashMap<>();
+        for (Tuple row : result) {
+            staffBySchoolId.putIfAbsent(
+                row.get(challengerRole.organizationId),
+                AdminSchoolSummaryInfo.StaffInfo.of(row.get(challenger.id), row.get(member.name))
+            );
+        }
+        return staffBySchoolId;
+    }
+
+    private Map<Long, Long> fetchAssignedPartCounts(Set<Long> schoolIds, Long gisuId) {
+        if (schoolIds.isEmpty()) {
+            return Map.of();
+        }
+
+        NumberExpression<Long> assignedPartCount = challengerRole.responsiblePart.countDistinct();
+        List<Tuple> result = queryFactory
+            .select(challengerRole.organizationId, assignedPartCount)
+            .from(challengerRole)
+            .where(
+                challengerRole.gisuId.eq(gisuId),
+                challengerRole.challengerRoleType.eq(ChallengerRoleType.SCHOOL_PART_LEADER),
+                challengerRole.organizationId.in(schoolIds),
+                challengerRole.responsiblePart.isNotNull()
+            )
+            .groupBy(challengerRole.organizationId)
+            .fetch();
+
+        Map<Long, Long> countsBySchoolId = new HashMap<>();
+        for (Tuple row : result) {
+            countsBySchoolId.put(row.get(challengerRole.organizationId), row.get(assignedPartCount));
+        }
+        return countsBySchoolId;
+    }
+
+    private BooleanBuilder scopeCondition(AdminAnalyticsScope scope) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(challenger.gisuId.eq(scope.gisuId()));
+        if (scope.chapterId() != null) {
+            builder.and(chapter.id.eq(scope.chapterId()));
+        }
+        if (scope.schoolId() != null) {
+            builder.and(school.id.eq(scope.schoolId()));
+        }
+        if (scope.responsiblePart() != null) {
+            builder.and(challenger.part.eq(scope.responsiblePart()));
+        }
+        return builder;
+    }
+
+    private BooleanExpression schoolNameContains(String search) {
+        return search == null || search.isBlank()
+            ? null
+            : school.name.containsIgnoreCase(search);
+    }
+
+    private Comparator<AdminSchoolSummaryRow> rowComparator(AdminAnalyticsSort sort) {
+        return switch (sort) {
+            case ACTIVE_CHALLENGER_COUNT_DESC -> Comparator
+                .comparingLong(AdminSchoolSummaryRow::activeChallengerCount)
+                .reversed()
+                .thenComparing(AdminSchoolSummaryRow::schoolName);
+            case SCHOOL_NAME_ASC -> Comparator.comparing(AdminSchoolSummaryRow::schoolName);
+            case AVERAGE_POINT_SUM_ASC -> Comparator
+                .comparingDouble(AdminSchoolSummaryRow::averagePointSum)
+                .thenComparing(AdminSchoolSummaryRow::schoolName);
+            case AVERAGE_POINT_SUM_DESC -> Comparator
+                .comparingDouble(AdminSchoolSummaryRow::averagePointSum)
+                .reversed()
+                .thenComparing(AdminSchoolSummaryRow::schoolName);
+            case RISK_CHALLENGER_COUNT_DESC -> Comparator
+                .comparingLong(AdminSchoolSummaryRow::riskChallengerCount)
+                .reversed()
+                .thenComparing(AdminSchoolSummaryRow::schoolName);
+            default -> Comparator
+                .comparingLong(AdminSchoolSummaryRow::riskChallengerCount)
+                .reversed()
+                .thenComparing(AdminSchoolSummaryRow::schoolName);
+        };
+    }
+
+    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
+        return new CaseBuilder()
+            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
+            .otherwise(pointTypeScore(targetPoint));
+    }
+
+    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
+        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
+        for (PointType pointType : PointType.values()) {
+            if (caseBuilder == null) {
+                caseBuilder = new CaseBuilder()
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            } else {
+                caseBuilder = caseBuilder
+                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
+            }
+        }
+
+        assert caseBuilder != null;
+        return caseBuilder.otherwise(0.0);
+    }
+
+    private double defaultDouble(Double value) {
+        return value != null ? value : 0.0;
+    }
+
+    private record ChallengerSchoolMetric(
+        SchoolSummaryKey school,
+        Long challengerId,
+        ChallengerPart part,
+        Instant memberCreatedAt,
+        double pointSum
+    ) {
+    }
+
+    private record SchoolSummaryKey(
+        Long schoolId,
+        String schoolName,
+        Long chapterId,
+        String chapterName
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminRiskChallengerRow.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminRiskChallengerRow.java
@@ -1,0 +1,13 @@
+package com.umc.product.analytics.adapter.out.persistence.row;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
+public record AdminRiskChallengerRow(
+    Long challengerId,
+    Long memberId,
+    String name,
+    String schoolName,
+    ChallengerPart part,
+    double pointSum
+) {
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminSchoolSummaryRow.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/row/AdminSchoolSummaryRow.java
@@ -1,0 +1,14 @@
+package com.umc.product.analytics.adapter.out.persistence.row;
+
+public record AdminSchoolSummaryRow(
+    Long schoolId,
+    String schoolName,
+    Long chapterId,
+    String chapterName,
+    long activeChallengerCount,
+    double averagePointSum,
+    long riskChallengerCount,
+    long newMemberCountThisWeek,
+    long totalRunningParts
+) {
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardActionQueueUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardActionQueueUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueQuery;
+
+public interface GetAdminDashboardActionQueueUseCase {
+
+    AdminDashboardActionQueueInfo getActionQueue(AdminDashboardActionQueueQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardContextUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardContextUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
+
+public interface GetAdminDashboardContextUseCase {
+
+    AdminDashboardContextInfo getContext(Long requesterMemberId);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardSummaryUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminDashboardSummaryUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+
+public interface GetAdminDashboardSummaryUseCase {
+
+    AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsOverviewUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsOverviewUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+
+public interface GetAdminOperationsOverviewUseCase {
+
+    AdminOperationsOverviewInfo getOperationsOverview(AdminOperationsOverviewQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminRiskChallengerUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminRiskChallengerUseCase.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import org.springframework.data.domain.Page;
+
+public interface GetAdminRiskChallengerUseCase {
+
+    Page<AdminRiskChallengerInfo> getRiskChallengers(AdminRiskChallengerQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminSchoolSummaryUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminSchoolSummaryUseCase.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import org.springframework.data.domain.Page;
+
+public interface GetAdminSchoolSummaryUseCase {
+
+    Page<AdminSchoolSummaryInfo> getSchoolSummaries(AdminSchoolSummaryQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueInfo.java
@@ -1,0 +1,20 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+public record AdminDashboardActionQueueInfo(
+    long pendingAttendanceDecisionCount,
+    long newRiskMemberCountThisWeek,
+    long upcomingGraduationCount
+) {
+
+    public static AdminDashboardActionQueueInfo of(
+        long pendingAttendanceDecisionCount,
+        long newRiskMemberCountThisWeek,
+        long upcomingGraduationCount
+    ) {
+        return new AdminDashboardActionQueueInfo(
+            pendingAttendanceDecisionCount,
+            newRiskMemberCountThisWeek,
+            upcomingGraduationCount
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardActionQueueQuery.java
@@ -1,0 +1,16 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+public record AdminDashboardActionQueueQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    int riskThreshold
+) {
+
+    public static AdminDashboardActionQueueQuery of(Long requesterMemberId, Long gisuId, Integer riskThreshold) {
+        return new AdminDashboardActionQueueQuery(
+            requesterMemberId,
+            gisuId,
+            riskThreshold != null ? riskThreshold : -8
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardContextInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardContextInfo.java
@@ -1,0 +1,27 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+
+public record AdminDashboardContextInfo(
+    ChallengerRoleType roleType,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    ChallengerPart responsiblePart,
+    AdminAnalyticsScopeType scopeType
+) {
+
+    public static AdminDashboardContextInfo from(AdminAnalyticsScope scope) {
+        return new AdminDashboardContextInfo(
+            scope.roleType(),
+            scope.gisuId(),
+            scope.chapterId(),
+            scope.schoolId(),
+            scope.responsiblePart(),
+            scope.type()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardQuery.java
@@ -1,0 +1,13 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+public record AdminDashboardQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId
+) {
+
+    public static AdminDashboardQuery of(Long requesterMemberId, Long gisuId, Long chapterId, Long schoolId) {
+        return new AdminDashboardQuery(requesterMemberId, gisuId, chapterId, schoolId);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardSummaryInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminDashboardSummaryInfo.java
@@ -1,0 +1,55 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.EnumMap;
+import java.util.Map;
+
+public record AdminDashboardSummaryInfo(
+    long activeChallengerCount,
+    long newMemberCountThisWeek,
+    double newMemberDeltaPercent,
+    long activeSchoolCount,
+    long activeChapterCount,
+    PointSumInfo monthlyPointSum,
+    Map<ChallengerStatus, Long> challengerStatusDistribution
+) {
+
+    public static AdminDashboardSummaryInfo of(
+        long activeChallengerCount,
+        long newMemberCountThisWeek,
+        double newMemberDeltaPercent,
+        long activeSchoolCount,
+        long activeChapterCount,
+        PointSumInfo monthlyPointSum,
+        Map<ChallengerStatus, Long> challengerStatusDistribution
+    ) {
+        return new AdminDashboardSummaryInfo(
+            activeChallengerCount,
+            newMemberCountThisWeek,
+            newMemberDeltaPercent,
+            activeSchoolCount,
+            activeChapterCount,
+            monthlyPointSum,
+            normalizeStatusDistribution(challengerStatusDistribution)
+        );
+    }
+
+    public static AdminDashboardSummaryInfo empty() {
+        return of(0, 0, 0.0, 0, 0, PointSumInfo.of(0, 0), Map.of());
+    }
+
+    private static Map<ChallengerStatus, Long> normalizeStatusDistribution(Map<ChallengerStatus, Long> source) {
+        Map<ChallengerStatus, Long> distribution = new EnumMap<>(ChallengerStatus.class);
+        for (ChallengerStatus status : ChallengerStatus.values()) {
+            distribution.put(status, source.getOrDefault(status, 0L));
+        }
+        return Map.copyOf(distribution);
+    }
+
+    public record PointSumInfo(long positive, long negative) {
+
+        public static PointSumInfo of(long positive, long negative) {
+            return new PointSumInfo(positive, negative);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsOverviewInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsOverviewInfo.java
@@ -1,0 +1,130 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record AdminOperationsOverviewInfo(
+    List<ChapterSchoolStatusInfo> chapterSchoolStatuses,
+    List<ChapterPartPointGrantStatusInfo> pointGrantStatuses,
+    ScheduleAttendanceStatusInfo scheduleAttendanceStatus,
+    StudyGroupStatusInfo studyGroupStatus,
+    List<SignupBucketInfo> signupBuckets
+) {
+
+    public static AdminOperationsOverviewInfo of(
+        List<ChapterSchoolStatusInfo> chapterSchoolStatuses,
+        List<ChapterPartPointGrantStatusInfo> pointGrantStatuses,
+        ScheduleAttendanceStatusInfo scheduleAttendanceStatus,
+        StudyGroupStatusInfo studyGroupStatus,
+        List<SignupBucketInfo> signupBuckets
+    ) {
+        return new AdminOperationsOverviewInfo(
+            List.copyOf(chapterSchoolStatuses),
+            List.copyOf(pointGrantStatuses),
+            scheduleAttendanceStatus,
+            studyGroupStatus,
+            List.copyOf(signupBuckets)
+        );
+    }
+
+    public record ChapterSchoolStatusInfo(
+        Long chapterId,
+        String chapterName,
+        List<SchoolChallengerStatusInfo> schools
+    ) {
+
+        public static ChapterSchoolStatusInfo of(
+            Long chapterId,
+            String chapterName,
+            List<SchoolChallengerStatusInfo> schools
+        ) {
+            return new ChapterSchoolStatusInfo(chapterId, chapterName, List.copyOf(schools));
+        }
+    }
+
+    public record SchoolChallengerStatusInfo(
+        Long schoolId,
+        String schoolName,
+        long totalChallengerCount,
+        Map<ChallengerPart, Long> challengerPartCounts
+    ) {
+
+        public static SchoolChallengerStatusInfo of(
+            Long schoolId,
+            String schoolName,
+            long totalChallengerCount,
+            Map<ChallengerPart, Long> challengerPartCounts
+        ) {
+            return new SchoolChallengerStatusInfo(
+                schoolId,
+                schoolName,
+                totalChallengerCount,
+                Map.copyOf(challengerPartCounts)
+            );
+        }
+    }
+
+    public record ChapterPartPointGrantStatusInfo(
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        long grantCount,
+        double pointSum
+    ) {
+
+        public static ChapterPartPointGrantStatusInfo of(
+            Long chapterId,
+            String chapterName,
+            ChallengerPart part,
+            long grantCount,
+            double pointSum
+        ) {
+            return new ChapterPartPointGrantStatusInfo(chapterId, chapterName, part, grantCount, pointSum);
+        }
+    }
+
+    public record ScheduleAttendanceStatusInfo(
+        long scheduleCount,
+        long attendanceRequiredScheduleCount,
+        long attendanceRecordCount,
+        Map<AttendanceStatus, Long> attendanceStatusCounts
+    ) {
+
+        public static ScheduleAttendanceStatusInfo of(
+            long scheduleCount,
+            long attendanceRequiredScheduleCount,
+            long attendanceRecordCount,
+            Map<AttendanceStatus, Long> attendanceStatusCounts
+        ) {
+            return new ScheduleAttendanceStatusInfo(
+                scheduleCount,
+                attendanceRequiredScheduleCount,
+                attendanceRecordCount,
+                Map.copyOf(attendanceStatusCounts)
+            );
+        }
+    }
+
+    public record StudyGroupStatusInfo(
+        long studyGroupCount,
+        long studyGroupScheduleCount
+    ) {
+
+        public static StudyGroupStatusInfo of(long studyGroupCount, long studyGroupScheduleCount) {
+            return new StudyGroupStatusInfo(studyGroupCount, studyGroupScheduleCount);
+        }
+    }
+
+    public record SignupBucketInfo(
+        LocalDate date,
+        long count
+    ) {
+
+        public static SignupBucketInfo of(LocalDate date, long count) {
+            return new SignupBucketInfo(date, count);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsOverviewQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsOverviewQuery.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public record AdminOperationsOverviewQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public static AdminOperationsOverviewQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Instant from,
+        Instant to
+    ) {
+        Instant normalizedTo = to != null ? to : Instant.now();
+        Instant normalizedFrom = from != null ? from : normalizedTo.minus(30, ChronoUnit.DAYS);
+        if (!normalizedFrom.isBefore(normalizedTo)) {
+            throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_PERIOD);
+        }
+        return new AdminOperationsOverviewQuery(requesterMemberId, gisuId, normalizedFrom, normalizedTo);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerInfo.java
@@ -1,0 +1,47 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.time.Instant;
+
+public record AdminRiskChallengerInfo(
+    Long challengerId,
+    Long memberId,
+    String name,
+    String schoolName,
+    ChallengerPart part,
+    double pointSum,
+    LatestNegativePointInfo latestNegativePoint
+) {
+
+    public static AdminRiskChallengerInfo of(
+        Long challengerId,
+        Long memberId,
+        String name,
+        String schoolName,
+        ChallengerPart part,
+        double pointSum,
+        LatestNegativePointInfo latestNegativePoint
+    ) {
+        return new AdminRiskChallengerInfo(
+            challengerId,
+            memberId,
+            name,
+            schoolName,
+            part,
+            pointSum,
+            latestNegativePoint
+        );
+    }
+
+    public record LatestNegativePointInfo(
+        PointType pointType,
+        Instant createdAt,
+        double score
+    ) {
+
+        public static LatestNegativePointInfo of(PointType pointType, Instant createdAt, double score) {
+            return new LatestNegativePointInfo(pointType, createdAt, score);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminRiskChallengerQuery.java
@@ -1,0 +1,31 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import org.springframework.data.domain.Pageable;
+
+public record AdminRiskChallengerQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    int riskThreshold,
+    Pageable pageable
+) {
+
+    public static AdminRiskChallengerQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Long chapterId,
+        Long schoolId,
+        Integer riskThreshold,
+        Pageable pageable
+    ) {
+        return new AdminRiskChallengerQuery(
+            requesterMemberId,
+            gisuId,
+            chapterId,
+            schoolId,
+            riskThreshold != null ? riskThreshold : -8,
+            pageable
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryInfo.java
@@ -1,0 +1,58 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+public record AdminSchoolSummaryInfo(
+    Long schoolId,
+    String schoolName,
+    Long chapterId,
+    String chapterName,
+    long activeChallengerCount,
+    StaffInfo president,
+    StaffInfo vicePresident,
+    PartLeaderRatioInfo partLeaderRatio,
+    double averagePointSum,
+    long riskChallengerCount,
+    long newMemberCountThisWeek
+) {
+
+    public static AdminSchoolSummaryInfo of(
+        Long schoolId,
+        String schoolName,
+        Long chapterId,
+        String chapterName,
+        long activeChallengerCount,
+        StaffInfo president,
+        StaffInfo vicePresident,
+        PartLeaderRatioInfo partLeaderRatio,
+        double averagePointSum,
+        long riskChallengerCount,
+        long newMemberCountThisWeek
+    ) {
+        return new AdminSchoolSummaryInfo(
+            schoolId,
+            schoolName,
+            chapterId,
+            chapterName,
+            activeChallengerCount,
+            president,
+            vicePresident,
+            partLeaderRatio,
+            averagePointSum,
+            riskChallengerCount,
+            newMemberCountThisWeek
+        );
+    }
+
+    public record StaffInfo(Long challengerId, String name) {
+
+        public static StaffInfo of(Long challengerId, String name) {
+            return new StaffInfo(challengerId, name);
+        }
+    }
+
+    public record PartLeaderRatioInfo(long assigned, long totalRunningParts) {
+
+        public static PartLeaderRatioInfo of(long assigned, long totalRunningParts) {
+            return new PartLeaderRatioInfo(assigned, totalRunningParts);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminSchoolSummaryQuery.java
@@ -1,0 +1,35 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AdminAnalyticsSort;
+import org.springframework.data.domain.Pageable;
+
+public record AdminSchoolSummaryQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Long chapterId,
+    String search,
+    int riskThreshold,
+    Pageable pageable,
+    AdminAnalyticsSort sort
+) {
+
+    public static AdminSchoolSummaryQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Long chapterId,
+        String search,
+        Integer riskThreshold,
+        Pageable pageable,
+        String sort
+    ) {
+        return new AdminSchoolSummaryQuery(
+            requesterMemberId,
+            gisuId,
+            chapterId,
+            search,
+            riskThreshold != null ? riskThreshold : -8,
+            pageable,
+            AdminAnalyticsSort.schoolSummaryOf(sort)
+        );
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminDashboardAnalyticsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminDashboardAnalyticsPort.java
@@ -1,0 +1,12 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+
+public interface LoadAdminDashboardAnalyticsPort {
+
+    AdminDashboardSummaryInfo getSummary(AdminAnalyticsScope scope);
+
+    AdminDashboardActionQueueInfo getActionQueue(AdminAnalyticsScope scope, int riskThreshold);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAnalyticsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAnalyticsPort.java
@@ -1,0 +1,13 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+
+public interface LoadAdminOperationsAnalyticsPort {
+
+    AdminOperationsOverviewInfo getOperationsOverview(
+        AdminAnalyticsScope scope,
+        AdminOperationsOverviewQuery query
+    );
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminRiskChallengerAnalyticsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminRiskChallengerAnalyticsPort.java
@@ -1,0 +1,11 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import org.springframework.data.domain.Page;
+
+public interface LoadAdminRiskChallengerAnalyticsPort {
+
+    Page<AdminRiskChallengerInfo> getRiskChallengers(AdminAnalyticsScope scope, AdminRiskChallengerQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminSchoolAnalyticsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminSchoolAnalyticsPort.java
@@ -1,0 +1,11 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import org.springframework.data.domain.Page;
+
+public interface LoadAdminSchoolAnalyticsPort {
+
+    Page<AdminSchoolSummaryInfo> getSchoolSummaries(AdminAnalyticsScope scope, AdminSchoolSummaryQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/service/evaluator/AdminAnalyticsPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/analytics/application/service/evaluator/AdminAnalyticsPermissionEvaluator.java
@@ -1,0 +1,33 @@
+package com.umc.product.analytics.application.service.evaluator;
+
+import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminAnalyticsPermissionEvaluator implements ResourcePermissionEvaluator {
+
+    @Override
+    public ResourceType supportedResourceType() {
+        return ResourceType.ANALYTICS;
+    }
+
+    @Override
+    public boolean evaluate(SubjectAttributes subjectAttributes, ResourcePermission resourcePermission) {
+        if (resourcePermission.permission() != PermissionType.READ) {
+            return false;
+        }
+
+        return subjectAttributes.roleAttributes().stream()
+            .map(RoleAttribute::roleType)
+            .anyMatch(roleType -> roleType.isSuperAdmin()
+                || roleType.isAtLeastCentralMember()
+                || roleType == ChallengerRoleType.CHAPTER_PRESIDENT
+                || roleType.isAtLeastSchoolAdmin());
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -1,0 +1,99 @@
+package com.umc.product.analytics.application.service.query;
+
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAnalyticsQueryService implements
+    GetAdminDashboardSummaryUseCase,
+    GetAdminDashboardActionQueueUseCase,
+    GetAdminDashboardContextUseCase,
+    GetAdminSchoolSummaryUseCase,
+    GetAdminRiskChallengerUseCase,
+    GetAdminOperationsOverviewUseCase {
+
+    private final AdminAnalyticsScopeResolver scopeResolver;
+    private final LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
+    private final LoadAdminSchoolAnalyticsPort loadAdminSchoolAnalyticsPort;
+    private final LoadAdminRiskChallengerAnalyticsPort loadAdminRiskChallengerAnalyticsPort;
+    private final LoadAdminOperationsAnalyticsPort loadAdminOperationsAnalyticsPort;
+
+    @Override
+    public AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(
+            query.requesterMemberId(),
+            query.gisuId(),
+            query.chapterId(),
+            query.schoolId(),
+            null
+        );
+        return loadAdminDashboardAnalyticsPort.getSummary(scope);
+    }
+
+    @Override
+    public AdminDashboardActionQueueInfo getActionQueue(AdminDashboardActionQueueQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminDashboardAnalyticsPort.getActionQueue(scope, query.riskThreshold());
+    }
+
+    @Override
+    public AdminDashboardContextInfo getContext(Long requesterMemberId) {
+        return AdminDashboardContextInfo.from(scopeResolver.resolve(requesterMemberId, null, null, null, null));
+    }
+
+    @Override
+    public Page<AdminSchoolSummaryInfo> getSchoolSummaries(AdminSchoolSummaryQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(
+            query.requesterMemberId(),
+            query.gisuId(),
+            query.chapterId(),
+            null,
+            null
+        );
+        return loadAdminSchoolAnalyticsPort.getSchoolSummaries(scope, query);
+    }
+
+    @Override
+    public Page<AdminRiskChallengerInfo> getRiskChallengers(AdminRiskChallengerQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(
+            query.requesterMemberId(),
+            query.gisuId(),
+            query.chapterId(),
+            query.schoolId(),
+            null
+        );
+        return loadAdminRiskChallengerAnalyticsPort.getRiskChallengers(scope, query);
+    }
+
+    @Override
+    public AdminOperationsOverviewInfo getOperationsOverview(AdminOperationsOverviewQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsAnalyticsPort.getOperationsOverview(scope, query);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolver.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolver.java
@@ -1,0 +1,145 @@
+package com.umc.product.analytics.application.service.query;
+
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAnalyticsScopeResolver {
+
+    private final GetChallengerRoleUseCase getGisuChallengerRoleUseCase;
+    private final GetGisuUseCase getGisuUseCase;
+
+    public AdminAnalyticsScope resolve(
+        Long memberId,
+        Long requestedGisuId,
+        Long requestedChapterId,
+        Long requestedSchoolId,
+        ChallengerPart requestedPart
+    ) {
+        Long gisuId = requestedGisuId != null ? requestedGisuId : getGisuUseCase.getActiveGisuId();
+        ChallengerRoleInfo role = highestRole(memberId, gisuId);
+
+        ChallengerRoleType roleType = role.roleType();
+        if (roleType.isSuperAdmin() || roleType.isAtLeastCentralMember()) {
+            return AdminAnalyticsScope.of(
+                AdminAnalyticsScopeType.CENTRAL,
+                gisuId,
+                requestedChapterId,
+                requestedSchoolId,
+                requestedPart,
+                roleType
+            );
+        }
+
+        if (roleType == ChallengerRoleType.CHAPTER_PRESIDENT) {
+            Long chapterId = role.organizationId();
+            if (requestedChapterId != null && !Objects.equals(requestedChapterId, chapterId)) {
+                throwAccessDenied();
+            }
+            return AdminAnalyticsScope.of(
+                AdminAnalyticsScopeType.CHAPTER,
+                gisuId,
+                chapterId,
+                requestedSchoolId,
+                requestedPart,
+                roleType
+            );
+        }
+
+        if (roleType == ChallengerRoleType.SCHOOL_PART_LEADER) {
+            validateSchool(role.organizationId(), requestedSchoolId);
+            validatePart(role.responsiblePart(), requestedPart);
+            return AdminAnalyticsScope.of(
+                AdminAnalyticsScopeType.SCHOOL_PART,
+                gisuId,
+                null,
+                role.organizationId(),
+                role.responsiblePart(),
+                roleType
+            );
+        }
+
+        if (roleType.isAtLeastSchoolAdmin()) {
+            validateSchool(role.organizationId(), requestedSchoolId);
+            return AdminAnalyticsScope.of(
+                AdminAnalyticsScopeType.SCHOOL,
+                gisuId,
+                null,
+                role.organizationId(),
+                requestedPart,
+                roleType
+            );
+        }
+
+        throwAccessDenied();
+        throw new IllegalStateException("unreachable");
+    }
+
+    public AdminAnalyticsScope resolve(Long memberId, Long requestedGisuId) {
+        return resolve(memberId, requestedGisuId, null, null, null);
+    }
+
+    private ChallengerRoleInfo highestRole(Long memberId, Long gisuId) {
+        List<ChallengerRoleInfo> roles = getGisuChallengerRoleUseCase.findAllByMemberId(memberId).stream()
+            .filter(role -> Objects.equals(role.gisuId(), gisuId))
+            .filter(role -> priority(role.roleType()) < Integer.MAX_VALUE)
+            .sorted(Comparator.comparingInt(role -> priority(role.roleType())))
+            .toList();
+
+        if (roles.isEmpty()) {
+            throwAccessDenied();
+        }
+
+        return roles.getFirst();
+    }
+
+    private void validateSchool(Long roleSchoolId, Long requestedSchoolId) {
+        if (requestedSchoolId != null && !Objects.equals(requestedSchoolId, roleSchoolId)) {
+            throwAccessDenied();
+        }
+    }
+
+    private void validatePart(ChallengerPart responsiblePart, ChallengerPart requestedPart) {
+        if (requestedPart != null && requestedPart != responsiblePart) {
+            throwAccessDenied();
+        }
+    }
+
+    private int priority(ChallengerRoleType roleType) {
+        if (roleType.isSuperAdmin()) {
+            return 0;
+        }
+        if (roleType.isAtLeastCentralMember()) {
+            return 1;
+        }
+        if (roleType == ChallengerRoleType.CHAPTER_PRESIDENT) {
+            return 2;
+        }
+        if (roleType == ChallengerRoleType.SCHOOL_PRESIDENT
+            || roleType == ChallengerRoleType.SCHOOL_VICE_PRESIDENT
+            || roleType == ChallengerRoleType.SCHOOL_ETC_ADMIN) {
+            return 3;
+        }
+        if (roleType == ChallengerRoleType.SCHOOL_PART_LEADER) {
+            return 4;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    private void throwAccessDenied() {
+        throw new AnalyticsDomainException(AnalyticsErrorCode.RESOURCE_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScope.java
+++ b/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScope.java
@@ -1,0 +1,29 @@
+package com.umc.product.analytics.domain;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+
+public record AdminAnalyticsScope(
+    AdminAnalyticsScopeType type,
+    Long gisuId,
+    Long chapterId,
+    Long schoolId,
+    ChallengerPart responsiblePart,
+    ChallengerRoleType roleType
+) {
+
+    public static AdminAnalyticsScope of(
+        AdminAnalyticsScopeType type,
+        Long gisuId,
+        Long chapterId,
+        Long schoolId,
+        ChallengerPart responsiblePart,
+        ChallengerRoleType roleType
+    ) {
+        return new AdminAnalyticsScope(type, gisuId, chapterId, schoolId, responsiblePart, roleType);
+    }
+
+    public boolean isCentralScope() {
+        return type == AdminAnalyticsScopeType.CENTRAL;
+    }
+}

--- a/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScopeType.java
+++ b/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsScopeType.java
@@ -1,0 +1,8 @@
+package com.umc.product.analytics.domain;
+
+public enum AdminAnalyticsScopeType {
+    CENTRAL,
+    CHAPTER,
+    SCHOOL,
+    SCHOOL_PART
+}

--- a/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsSort.java
+++ b/src/main/java/com/umc/product/analytics/domain/AdminAnalyticsSort.java
@@ -1,0 +1,48 @@
+package com.umc.product.analytics.domain;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.util.Set;
+
+public enum AdminAnalyticsSort {
+    RISK_CHALLENGER_COUNT_DESC("riskChallengerCount,desc"),
+    ACTIVE_CHALLENGER_COUNT_DESC("activeChallengerCount,desc"),
+    SCHOOL_NAME_ASC("schoolName,asc"),
+    AVERAGE_POINT_SUM_ASC("averagePointSum,asc"),
+    AVERAGE_POINT_SUM_DESC("averagePointSum,desc"),
+    POINT_SUM_ASC("pointSum,asc"),
+    POINT_SUM_DESC("pointSum,desc"),
+    CREATED_AT_DESC("createdAt,desc");
+
+    private static final Set<AdminAnalyticsSort> SCHOOL_SUMMARY_SORTS = Set.of(
+        RISK_CHALLENGER_COUNT_DESC,
+        ACTIVE_CHALLENGER_COUNT_DESC,
+        SCHOOL_NAME_ASC,
+        AVERAGE_POINT_SUM_ASC,
+        AVERAGE_POINT_SUM_DESC
+    );
+
+    private final String value;
+
+    AdminAnalyticsSort(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static AdminAnalyticsSort schoolSummaryOf(String value) {
+        if (value == null || value.isBlank()) {
+            return RISK_CHALLENGER_COUNT_DESC;
+        }
+
+        for (AdminAnalyticsSort sort : SCHOOL_SUMMARY_SORTS) {
+            if (sort.value.equals(value)) {
+                return sort;
+            }
+        }
+
+        throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_SORT);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/domain/AnalyticsDomainException.java
+++ b/src/main/java/com/umc/product/analytics/domain/AnalyticsDomainException.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.domain;
+
+import com.umc.product.global.exception.BusinessException;
+import com.umc.product.global.exception.constant.Domain;
+
+public class AnalyticsDomainException extends BusinessException {
+
+    public AnalyticsDomainException(AnalyticsErrorCode errorCode) {
+        super(Domain.ANALYTICS, errorCode);
+    }
+
+    public AnalyticsDomainException(AnalyticsErrorCode errorCode, String message) {
+        super(Domain.ANALYTICS, errorCode, message);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/domain/AnalyticsErrorCode.java
+++ b/src/main/java/com/umc/product/analytics/domain/AnalyticsErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.product.analytics.domain;
+
+import com.umc.product.global.response.code.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AnalyticsErrorCode implements BaseCode {
+    RESOURCE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ANALYTICS-0001", "운영진 대시보드에 접근할 권한이 없습니다."),
+    INVALID_SORT(HttpStatus.BAD_REQUEST, "ANALYTICS-0002", "지원하지 않는 정렬 조건입니다."),
+    INVALID_PERIOD(HttpStatus.BAD_REQUEST, "ANALYTICS-0003", "조회 시작 시각은 종료 시각보다 빨라야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -65,6 +65,8 @@ public enum ResourceType {
     // 회원 관련
     MEMBER("member", "회원",
         Set.of(PermissionType.READ, PermissionType.DELETE)),
+    ANALYTICS("analytics", "운영진 대시보드",
+        Set.of(PermissionType.READ)),
     TERM("term", "약관",
         Set.of(PermissionType.WRITE)),
 

--- a/src/main/java/com/umc/product/global/exception/constant/Domain.java
+++ b/src/main/java/com/umc/product/global/exception/constant/Domain.java
@@ -26,5 +26,6 @@ public enum Domain {
     AUDIT_LOG,
     PROJECT,
     FIGMA,
-    LLM
+    LLM,
+    ANALYTICS
 }

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
@@ -1,0 +1,200 @@
+package com.umc.product.analytics.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import com.umc.product.support.RestDocsConfig;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AdminDashboardController.class)
+@Import({JacksonConfig.class, RestDocsConfig.class})
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@DisplayName("AdminDashboardController")
+class AdminDashboardControllerTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    RestDocumentationResultHandler restDocsHandler;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetAdminDashboardSummaryUseCase getAdminDashboardSummaryUseCase;
+
+    @MockitoBean
+    GetAdminDashboardActionQueueUseCase getAdminDashboardActionQueueUseCase;
+
+    @MockitoBean
+    GetAdminDashboardContextUseCase getAdminDashboardContextUseCase;
+
+    @MockitoBean
+    GetAdminRiskChallengerUseCase getAdminRiskChallengerUseCase;
+
+    @MockitoBean
+    GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("대시보드 summary API 문서화")
+    void 대시보드_summary_API_문서화() throws Exception {
+        given(getAdminDashboardSummaryUseCase.getSummary(any())).willReturn(AdminDashboardSummaryInfo.of(
+            10L,
+            2L,
+            100.0,
+            3L,
+            1L,
+            AdminDashboardSummaryInfo.PointSumInfo.of(12L, -4L),
+            Map.of()
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/dashboard/summary")
+                .param("gisuId", "7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.activeChallengerCount").value(10L))
+            .andExpect(jsonPath("$.result.pendingApplicationCount").doesNotExist())
+            .andExpect(jsonPath("$.result.projectInProgressCount").doesNotExist())
+            .andDo(restDocsHandler);
+    }
+
+    @Test
+    @DisplayName("대시보드 actionQueue API는 대상 도메인의 처리 대기 항목만 반환한다")
+    void 대시보드_actionQueue_API_문서화() throws Exception {
+        given(getAdminDashboardActionQueueUseCase.getActionQueue(any()))
+            .willReturn(AdminDashboardActionQueueInfo.of(4L, 3L, 5L));
+
+        mockMvc.perform(get("/api/v1/admin/dashboard/action-queue")
+                .param("gisuId", "7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.pendingAttendanceDecisionCount").value(4L))
+            .andExpect(jsonPath("$.result.newRiskMemberCountThisWeek").value(3L))
+            .andExpect(jsonPath("$.result.upcomingGraduationCount").value(5L))
+            .andExpect(jsonPath("$.result.pendingApplicationCount").doesNotExist())
+            .andExpect(jsonPath("$.result.unsentNoticeCount").doesNotExist())
+            .andDo(restDocsHandler);
+    }
+
+    @Test
+    @DisplayName("대시보드 context API 응답")
+    void 대시보드_context_API_응답() throws Exception {
+        given(getAdminDashboardContextUseCase.getContext(MEMBER_ID)).willReturn(new AdminDashboardContextInfo(
+            ChallengerRoleType.CENTRAL_PRESIDENT,
+            7L,
+            null,
+            null,
+            null,
+            AdminAnalyticsScopeType.CENTRAL
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/dashboard/context"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.roleType").value("CENTRAL_PRESIDENT"))
+            .andExpect(jsonPath("$.result.scopeType").value("CENTRAL"))
+            .andDo(restDocsHandler);
+    }
+
+    @Test
+    @DisplayName("대시보드 riskChallengers API 응답")
+    void 대시보드_riskChallengers_API_응답() throws Exception {
+        given(getAdminRiskChallengerUseCase.getRiskChallengers(any())).willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/admin/dashboard/risk-challengers")
+                .param("gisuId", "7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.content").isArray())
+            .andDo(restDocsHandler);
+    }
+
+    @Test
+    @DisplayName("대시보드 operations API 응답")
+    void 대시보드_operations_API_응답() throws Exception {
+        given(getAdminOperationsOverviewUseCase.getOperationsOverview(any())).willReturn(
+            AdminOperationsOverviewInfo.of(
+                java.util.List.of(AdminOperationsOverviewInfo.ChapterSchoolStatusInfo.of(
+                    10L,
+                    "중앙",
+                    java.util.List.of(AdminOperationsOverviewInfo.SchoolChallengerStatusInfo.of(
+                        20L,
+                        "가천대학교",
+                        12L,
+                        Map.of(ChallengerPart.SPRINGBOOT, 7L)
+                    ))
+                )),
+                java.util.List.of(AdminOperationsOverviewInfo.ChapterPartPointGrantStatusInfo.of(
+                    10L,
+                    "중앙",
+                    ChallengerPart.SPRINGBOOT,
+                    3L,
+                    -12.0
+                )),
+                AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo.of(
+                    5L,
+                    4L,
+                    8L,
+                    Map.of(AttendanceStatus.PRESENT, 6L)
+                ),
+                AdminOperationsOverviewInfo.StudyGroupStatusInfo.of(9L, 11L),
+                java.util.List.of(AdminOperationsOverviewInfo.SignupBucketInfo.of(LocalDate.parse("2026-05-01"), 2L))
+            )
+        );
+
+        mockMvc.perform(get("/api/v1/admin/dashboard/operations")
+                .param("gisuId", "7")
+                .param("from", "2026-05-01T00:00:00Z")
+                .param("to", "2026-05-13T00:00:00Z"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.chapterSchoolStatuses[0].chapterId").value(10L))
+            .andExpect(jsonPath("$.result.chapterSchoolStatuses[0].schools[0].challengerPartCounts.SPRINGBOOT").value(7L))
+            .andExpect(jsonPath("$.result.pointGrantStatuses[0].grantCount").value(3L))
+            .andExpect(jsonPath("$.result.scheduleAttendanceStatus.attendanceRecordCount").value(8L))
+            .andExpect(jsonPath("$.result.studyGroupStatus.studyGroupCount").value(9L))
+            .andExpect(jsonPath("$.result.signupBuckets[0].count").value(2L))
+            .andDo(restDocsHandler);
+    }
+}

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java
@@ -1,0 +1,85 @@
+package com.umc.product.analytics.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.support.RestDocsConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AdminSchoolAnalyticsController.class)
+@Import({JacksonConfig.class, RestDocsConfig.class})
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@DisplayName("AdminSchoolAnalyticsController")
+class AdminSchoolAnalyticsControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    RestDocumentationResultHandler restDocsHandler;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetAdminSchoolSummaryUseCase getAdminSchoolSummaryUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(1L).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("학교별 summary API 문서화")
+    void 학교별_summary_API_문서화() throws Exception {
+        AdminSchoolSummaryInfo info = AdminSchoolSummaryInfo.of(
+            10L,
+            "가천대학교",
+            1L,
+            "중앙",
+            20L,
+            AdminSchoolSummaryInfo.StaffInfo.of(100L, "회장"),
+            null,
+            AdminSchoolSummaryInfo.PartLeaderRatioInfo.of(3L, 6L),
+            -3.5,
+            2L,
+            4L
+        );
+        given(getAdminSchoolSummaryUseCase.getSchoolSummaries(any()))
+            .willReturn(new PageImpl<>(List.of(info), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/v1/admin/schools/summary")
+                .param("gisuId", "7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.content[0].schoolName").value("가천대학교"))
+            .andExpect(jsonPath("$.result.content[0].riskChallengerCount").value(2L))
+            .andDo(restDocsHandler);
+    }
+}

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsPersistenceConventionTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsPersistenceConventionTest.java
@@ -1,0 +1,39 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AdminAnalyticsPersistenceConvention")
+class AdminAnalyticsPersistenceConventionTest {
+
+    private static final Path ANALYTICS_PERSISTENCE_PATH = Path.of(
+        "src/main/java/com/umc/product/analytics/adapter/out/persistence"
+    );
+
+    @Test
+    @DisplayName("analytics query repository는 native SQL 대신 QueryDSL을 사용한다")
+    void analytics_query_repository는_native_SQL_대신_QueryDSL을_사용한다() throws IOException {
+        List<Path> queryRepositories = Files.list(ANALYTICS_PERSISTENCE_PATH)
+            .filter(path -> path.getFileName().toString().endsWith("AnalyticsQueryRepository.java"))
+            .toList();
+
+        assertThat(queryRepositories).hasSize(4);
+
+        for (Path queryRepository : queryRepositories) {
+            String source = Files.readString(queryRepository);
+
+            assertThat(source)
+                .as("%s", queryRepository)
+                .contains("JPAQueryFactory")
+                .doesNotContain("EntityManager")
+                .doesNotContain("createNativeQuery")
+                .doesNotContain("jakarta.persistence.Query");
+        }
+    }
+}

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
@@ -1,0 +1,196 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.ChapterSchool;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.ScheduleParticipant;
+import com.umc.product.schedule.domain.ScheduleParticipantAttendance;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import com.umc.product.schedule.domain.enums.ScheduleTag;
+import com.umc.product.support.TestContainersConfig;
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminDashboardAnalyticsQueryRepository.class})
+@DisplayName("AdminDashboardAnalyticsQueryRepository")
+class AdminDashboardAnalyticsQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    AdminDashboardAnalyticsQueryRepository sut;
+
+    private Long gisuId;
+    private Long chapterId;
+    private Long schoolAId;
+    private Long schoolBId;
+
+    @BeforeEach
+    void setUp() {
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400 * 30), true));
+        Chapter chapter = em.persist(Chapter.create(gisu, "중앙"));
+        School schoolA = em.persist(School.create("A대학교", null));
+        School schoolB = em.persist(School.create("B대학교", null));
+        em.persist(ChapterSchool.create(chapter, schoolA));
+        em.persist(ChapterSchool.create(chapter, schoolB));
+        em.flush();
+
+        gisuId = gisu.getId();
+        chapterId = chapter.getId();
+        schoolAId = schoolA.getId();
+        schoolBId = schoolB.getId();
+    }
+
+    @Test
+    @DisplayName("summary 중앙 운영진은 전체 스코프의 KPI를 조회한다")
+    void summary_중앙_운영진은_전체_스코프의_KPI를_조회한다() {
+        Challenger schoolAChallenger = persistChallenger("김서버", schoolAId, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE);
+        persistChallenger("이웹", schoolBId, ChallengerPart.WEB, ChallengerStatus.ACTIVE);
+        persistChallenger("박수료", schoolBId, ChallengerPart.DESIGN, ChallengerStatus.GRADUATED);
+        persistPoint(schoolAChallenger, PointType.BLOG_CHALLENGE, null);
+        persistPoint(schoolAChallenger, PointType.NO_WORKBOOK_MISSION, null);
+        em.flush();
+        em.clear();
+
+        AdminDashboardSummaryInfo result = sut.getSummary(centralScope());
+
+        assertThat(result.activeChallengerCount()).isEqualTo(2L);
+        assertThat(result.activeSchoolCount()).isEqualTo(2L);
+        assertThat(result.activeChapterCount()).isEqualTo(1L);
+        assertThat(result.monthlyPointSum().positive()).isEqualTo(3L);
+        assertThat(result.monthlyPointSum().negative()).isEqualTo(-4L);
+        assertThat(result.challengerStatusDistribution().get(ChallengerStatus.ACTIVE)).isEqualTo(2L);
+        assertThat(result.challengerStatusDistribution().get(ChallengerStatus.GRADUATED)).isEqualTo(1L);
+        assertThat(result.challengerStatusDistribution().get(ChallengerStatus.EXPELLED)).isZero();
+    }
+
+    @Test
+    @DisplayName("summary 학교 운영진은 본인 학교 데이터만 조회한다")
+    void summary_학교_운영진은_본인_학교_데이터만_조회한다() {
+        persistChallenger("김서버", schoolAId, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE);
+        persistChallenger("이웹", schoolBId, ChallengerPart.WEB, ChallengerStatus.ACTIVE);
+        em.flush();
+        em.clear();
+
+        AdminDashboardSummaryInfo result = sut.getSummary(schoolScope(schoolAId));
+
+        assertThat(result.activeChallengerCount()).isEqualTo(1L);
+        assertThat(result.activeSchoolCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("actionQueue 출석 승인 대기 건수를 처리 대기로 계산한다")
+    void actionQueue_출석_승인_대기_건수를_처리_대기로_계산한다() {
+        Member author = persistMember("일정작성자", schoolAId);
+        Schedule schedule = persistSchedule(author.getId());
+        persistParticipant(schedule, 101L, AttendanceStatus.PRESENT_PENDING);
+        persistParticipant(schedule, 102L, AttendanceStatus.LATE_PENDING);
+        persistParticipant(schedule, 103L, AttendanceStatus.PRESENT);
+        em.flush();
+        em.clear();
+
+        AdminDashboardActionQueueInfo result = sut.getActionQueue(centralScope(), -8);
+
+        assertThat(result.pendingAttendanceDecisionCount()).isEqualTo(2L);
+    }
+
+    private Challenger persistChallenger(
+        String name,
+        Long schoolId,
+        ChallengerPart part,
+        ChallengerStatus status
+    ) {
+        Member member = persistMember(name, schoolId);
+        Challenger challenger = em.persist(new Challenger(member.getId(), part, gisuId));
+        if (status != ChallengerStatus.ACTIVE) {
+            challenger.changeStatus(status, 999L, "테스트 상태 변경");
+        }
+        return challenger;
+    }
+
+    private Member persistMember(String name, Long schoolId) {
+        return em.persist(Member.create(name, name + "닉", name + "@example.com", schoolId, null));
+    }
+
+    private void persistPoint(Challenger challenger, PointType pointType, Integer pointValue) {
+        em.persist(ChallengerPoint.create(challenger, pointType, pointValue, "테스트 포인트"));
+    }
+
+    private Schedule persistSchedule(Long authorMemberId) {
+        Instant startsAt = Instant.now().plusSeconds(3600);
+        Instant endsAt = startsAt.plusSeconds(7200);
+        return em.persist(Schedule.builder()
+            .name("운영 일정")
+            .description("출석 승인 대기 집계 테스트")
+            .tags(Set.of(ScheduleTag.MEETING))
+            .authorMemberId(authorMemberId)
+            .startsAt(startsAt)
+            .endsAt(endsAt)
+            .policy(Schedule.createAttendancePolicy(
+                startsAt.minusSeconds(600),
+                startsAt.plusSeconds(600),
+                startsAt.plusSeconds(1200),
+                startsAt,
+                endsAt
+            ))
+            .build());
+    }
+
+    private void persistParticipant(Schedule schedule, Long memberId, AttendanceStatus status) {
+        em.persist(ScheduleParticipant.builder()
+            .schedule(schedule)
+            .memberId(memberId)
+            .attendance(ScheduleParticipantAttendance.create(null, true, null, status))
+            .build());
+    }
+
+    private AdminAnalyticsScope centralScope() {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.CENTRAL,
+            gisuId,
+            null,
+            null,
+            null,
+            ChallengerRoleType.CENTRAL_PRESIDENT
+        );
+    }
+
+    private AdminAnalyticsScope schoolScope(Long schoolId) {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.SCHOOL,
+            gisuId,
+            null,
+            schoolId,
+            null,
+            ChallengerRoleType.SCHOOL_PRESIDENT
+        );
+    }
+}

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
@@ -1,0 +1,115 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.ChapterSchool;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.TestContainersConfig;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminRiskChallengerAnalyticsQueryRepository.class})
+@DisplayName("AdminRiskChallengerAnalyticsQueryRepository")
+class AdminRiskChallengerAnalyticsQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    AdminRiskChallengerAnalyticsQueryRepository sut;
+
+    private Long gisuId;
+    private Long schoolId;
+
+    @BeforeEach
+    void setUp() {
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), true));
+        Chapter chapter = em.persist(Chapter.create(gisu, "중앙"));
+        School school = em.persist(School.create("가천대학교", null));
+        em.persist(ChapterSchool.create(chapter, school));
+        em.flush();
+        gisuId = gisu.getId();
+        schoolId = school.getId();
+    }
+
+    @Test
+    @DisplayName("pointSumLte가 있으면 포인트 합계가 임계치 이하인 챌린저만 조회한다")
+    void pointSumLte가_있으면_포인트_합계가_임계치_이하인_챌린저만_조회한다() {
+        Challenger risk = persistChallenger("위험", ChallengerPart.SPRINGBOOT);
+        Challenger safe = persistChallenger("정상", ChallengerPart.WEB);
+        persistPoint(risk, -10);
+        persistPoint(safe, -2);
+        em.flush();
+        em.clear();
+
+        Page<AdminRiskChallengerInfo> result = sut.getRiskChallengers(scope(), query(-8));
+
+        assertThat(result.getContent())
+            .extracting(AdminRiskChallengerInfo::name)
+            .containsExactly("위험");
+    }
+
+    @Test
+    @DisplayName("includeLatestNegativePoint는 페이지 대상자의 최신 감점만 응답한다")
+    void includeLatestNegativePoint는_페이지_대상자의_최신_감점만_응답한다() {
+        Challenger risk = persistChallenger("위험", ChallengerPart.SPRINGBOOT);
+        persistPoint(risk, -4);
+        persistPoint(risk, -10);
+        em.flush();
+        em.clear();
+
+        Page<AdminRiskChallengerInfo> result = sut.getRiskChallengers(scope(), query(-8));
+
+        assertThat(result.getContent().getFirst().latestNegativePoint()).isNotNull();
+        assertThat(result.getContent().getFirst().latestNegativePoint().score()).isEqualTo(-10.0);
+    }
+
+    private AdminRiskChallengerQuery query(Integer riskThreshold) {
+        return AdminRiskChallengerQuery.of(1L, gisuId, null, null, riskThreshold, PageRequest.of(0, 10));
+    }
+
+    private Challenger persistChallenger(String name, ChallengerPart part) {
+        Member member = em.persist(Member.create(name, name + "닉", name + "@example.com", schoolId, null));
+        return em.persist(new Challenger(member.getId(), part, gisuId));
+    }
+
+    private void persistPoint(Challenger challenger, int value) {
+        em.persist(ChallengerPoint.create(challenger, PointType.CUSTOM, value, "테스트"));
+    }
+
+    private AdminAnalyticsScope scope() {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.CENTRAL,
+            gisuId,
+            null,
+            null,
+            null,
+            ChallengerRoleType.CENTRAL_PRESIDENT
+        );
+    }
+}

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
@@ -1,0 +1,200 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.authorization.domain.ChallengerRole;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.ChapterSchool;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.TestContainersConfig;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminSchoolAnalyticsQueryRepository.class})
+@DisplayName("AdminSchoolAnalyticsQueryRepository")
+class AdminSchoolAnalyticsQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    AdminSchoolAnalyticsQueryRepository sut;
+
+    private Long gisuId;
+    private Long chapterAId;
+    private Long chapterBId;
+    private Long schoolAId;
+    private Long schoolBId;
+
+    @BeforeEach
+    void setUp() {
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), true));
+        Chapter chapterA = em.persist(Chapter.create(gisu, "A지부"));
+        Chapter chapterB = em.persist(Chapter.create(gisu, "B지부"));
+        School schoolA = em.persist(School.create("가천대학교", null));
+        School schoolB = em.persist(School.create("숭실대학교", null));
+        em.persist(ChapterSchool.create(chapterA, schoolA));
+        em.persist(ChapterSchool.create(chapterB, schoolB));
+        em.flush();
+
+        gisuId = gisu.getId();
+        chapterAId = chapterA.getId();
+        chapterBId = chapterB.getId();
+        schoolAId = schoolA.getId();
+        schoolBId = schoolB.getId();
+    }
+
+    @Test
+    @DisplayName("학교 요약은 위험군 수 내림차순이 기본이다")
+    void 학교_요약은_위험군_수_내림차순이_기본이다() {
+        Challenger a1 = persistChallenger("가천1", schoolAId, ChallengerPart.SPRINGBOOT);
+        Challenger a2 = persistChallenger("가천2", schoolAId, ChallengerPart.WEB);
+        Challenger b1 = persistChallenger("숭실1", schoolBId, ChallengerPart.IOS);
+        persistPoint(a1, -10);
+        persistPoint(a2, -9);
+        persistPoint(b1, -8);
+        em.flush();
+        em.clear();
+
+        Page<AdminSchoolSummaryInfo> result = sut.getSchoolSummaries(
+            centralScope(),
+            query(null, null, null)
+        );
+
+        assertThat(result.getContent())
+            .extracting(AdminSchoolSummaryInfo::schoolId)
+            .containsExactly(schoolAId, schoolBId);
+    }
+
+    @Test
+    @DisplayName("지부 스코프에서는 해당 지부의 학교만 조회된다")
+    void 지부_스코프에서는_해당_지부의_학교만_조회된다() {
+        persistChallenger("가천1", schoolAId, ChallengerPart.SPRINGBOOT);
+        persistChallenger("숭실1", schoolBId, ChallengerPart.IOS);
+        em.flush();
+        em.clear();
+
+        Page<AdminSchoolSummaryInfo> result = sut.getSchoolSummaries(
+            chapterScope(chapterAId),
+            query(chapterAId, null, null)
+        );
+
+        assertThat(result.getContent())
+            .extracting(AdminSchoolSummaryInfo::schoolId)
+            .containsExactly(schoolAId);
+    }
+
+    @Test
+    @DisplayName("검색어가 있으면 학교명 부분 일치만 조회된다")
+    void 검색어가_있으면_학교명_부분_일치만_조회된다() {
+        persistChallenger("가천1", schoolAId, ChallengerPart.SPRINGBOOT);
+        persistChallenger("숭실1", schoolBId, ChallengerPart.IOS);
+        em.flush();
+        em.clear();
+
+        Page<AdminSchoolSummaryInfo> result = sut.getSchoolSummaries(
+            centralScope(),
+            query(null, "가천", null)
+        );
+
+        assertThat(result.getContent())
+            .extracting(AdminSchoolSummaryInfo::schoolName)
+            .containsExactly("가천대학교");
+    }
+
+    @Test
+    @DisplayName("파트장 배치율은 배치된 파트수와 운영중인 파트수로 계산된다")
+    void 파트장_배치율은_배치된_파트수와_운영중인_파트수로_계산된다() {
+        Challenger leader = persistChallenger("파트장", schoolAId, ChallengerPart.SPRINGBOOT);
+        persistChallenger("웹챌", schoolAId, ChallengerPart.WEB);
+        em.persist(ChallengerRole.create(
+            leader.getId(),
+            ChallengerRoleType.SCHOOL_PART_LEADER,
+            schoolAId,
+            ChallengerPart.SPRINGBOOT,
+            gisuId
+        ));
+        em.flush();
+        em.clear();
+
+        Page<AdminSchoolSummaryInfo> result = sut.getSchoolSummaries(centralScope(), query(null, null, null));
+
+        AdminSchoolSummaryInfo.PartLeaderRatioInfo ratio = result.getContent().getFirst().partLeaderRatio();
+        assertThat(ratio.assigned()).isEqualTo(1L);
+        assertThat(ratio.totalRunningParts()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("포인트가 없는 챌린저는 0점으로 평균에 포함된다")
+    void 포인트가_없는_챌린저는_0점으로_평균에_포함된다() {
+        Challenger challenger = persistChallenger("감점", schoolAId, ChallengerPart.SPRINGBOOT);
+        persistChallenger("무점", schoolAId, ChallengerPart.WEB);
+        persistPoint(challenger, -10);
+        em.flush();
+        em.clear();
+
+        Page<AdminSchoolSummaryInfo> result = sut.getSchoolSummaries(centralScope(), query(null, null, null));
+
+        assertThat(result.getContent().getFirst().averagePointSum()).isEqualTo(-5.0);
+    }
+
+    private AdminSchoolSummaryQuery query(Long chapterId, String search, String sort) {
+        return AdminSchoolSummaryQuery.of(1L, gisuId, chapterId, search, -8, PageRequest.of(0, 10), sort);
+    }
+
+    private Challenger persistChallenger(String name, Long schoolId, ChallengerPart part) {
+        Member member = em.persist(Member.create(name, name + "닉", name + "@example.com", schoolId, null));
+        return em.persist(new Challenger(member.getId(), part, gisuId));
+    }
+
+    private void persistPoint(Challenger challenger, int value) {
+        em.persist(ChallengerPoint.create(challenger, PointType.CUSTOM, value, "테스트"));
+    }
+
+    private AdminAnalyticsScope centralScope() {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.CENTRAL,
+            gisuId,
+            null,
+            null,
+            null,
+            ChallengerRoleType.CENTRAL_PRESIDENT
+        );
+    }
+
+    private AdminAnalyticsScope chapterScope(Long chapterId) {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.CHAPTER,
+            gisuId,
+            chapterId,
+            null,
+            null,
+            ChallengerRoleType.CHAPTER_PRESIDENT
+        );
+    }
+}

--- a/src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryServiceTest.java
@@ -1,0 +1,150 @@
+package com.umc.product.analytics.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminAnalyticsQueryService")
+class AdminAnalyticsQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GISU_ID = 7L;
+
+    @Mock
+    AdminAnalyticsScopeResolver scopeResolver;
+
+    @Mock
+    LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
+
+    @Mock
+    LoadAdminSchoolAnalyticsPort loadAdminSchoolAnalyticsPort;
+
+    @Mock
+    LoadAdminRiskChallengerAnalyticsPort loadAdminRiskChallengerAnalyticsPort;
+
+    @Mock
+    LoadAdminOperationsAnalyticsPort loadAdminOperationsAnalyticsPort;
+
+    @InjectMocks
+    AdminAnalyticsQueryService sut;
+
+    @Test
+    @DisplayName("summary 중앙 운영진은 전체 스코프의 KPI를 조회한다")
+    void summary_중앙_운영진은_전체_스코프의_KPI를_조회한다() {
+        AdminDashboardQuery query = AdminDashboardQuery.of(MEMBER_ID, GISU_ID, null, null);
+        AdminAnalyticsScope scope = centralScope();
+        AdminDashboardSummaryInfo expected = AdminDashboardSummaryInfo.of(
+            10L,
+            2L,
+            100.0,
+            3L,
+            1L,
+            AdminDashboardSummaryInfo.PointSumInfo.of(12L, -4L),
+            Map.of()
+        );
+        given(scopeResolver.resolve(MEMBER_ID, GISU_ID, null, null, null)).willReturn(scope);
+        given(loadAdminDashboardAnalyticsPort.getSummary(scope)).willReturn(expected);
+
+        AdminDashboardSummaryInfo actual = sut.getSummary(query);
+
+        assertThat(actual).isEqualTo(expected);
+        then(loadAdminDashboardAnalyticsPort).should().getSummary(scope);
+    }
+
+    @Test
+    @DisplayName("summary 학교 운영진은 본인 학교 데이터만 조회한다")
+    void summary_학교_운영진은_본인_학교_데이터만_조회한다() {
+        AdminDashboardQuery query = AdminDashboardQuery.of(MEMBER_ID, GISU_ID, null, null);
+        AdminAnalyticsScope scope = AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.SCHOOL,
+            GISU_ID,
+            null,
+            30L,
+            null,
+            ChallengerRoleType.SCHOOL_PRESIDENT
+        );
+        AdminDashboardSummaryInfo expected = AdminDashboardSummaryInfo.empty();
+        given(scopeResolver.resolve(MEMBER_ID, GISU_ID, null, null, null)).willReturn(scope);
+        given(loadAdminDashboardAnalyticsPort.getSummary(scope)).willReturn(expected);
+
+        AdminDashboardSummaryInfo actual = sut.getSummary(query);
+
+        assertThat(actual).isEqualTo(expected);
+        then(loadAdminDashboardAnalyticsPort).should().getSummary(scope);
+    }
+
+    @Test
+    @DisplayName("actionQueue 출석 승인 대기와 위험군, 수료 임박 항목을 조회한다")
+    void actionQueue_출석_승인_대기와_위험군_수료_임박_항목을_조회한다() {
+        AdminDashboardActionQueueQuery query = AdminDashboardActionQueueQuery.of(MEMBER_ID, GISU_ID, -8);
+        AdminAnalyticsScope scope = centralScope();
+        AdminDashboardActionQueueInfo expected = AdminDashboardActionQueueInfo.of(4L, 3L, 2L);
+        given(scopeResolver.resolve(MEMBER_ID, GISU_ID, null, null, null)).willReturn(scope);
+        given(loadAdminDashboardAnalyticsPort.getActionQueue(scope, -8)).willReturn(expected);
+
+        AdminDashboardActionQueueInfo actual = sut.getActionQueue(query);
+
+        assertThat(actual.pendingAttendanceDecisionCount()).isEqualTo(4L);
+        assertThat(actual.newRiskMemberCountThisWeek()).isEqualTo(3L);
+        assertThat(actual.upcomingGraduationCount()).isEqualTo(2L);
+        then(loadAdminDashboardAnalyticsPort).should().getActionQueue(scope, -8);
+    }
+
+    @Test
+    @DisplayName("operationsOverview는 권한 스코프를 적용해 운영 현황을 조회한다")
+    void operationsOverview는_권한_스코프를_적용해_운영_현황을_조회한다() {
+        Instant from = Instant.parse("2026-05-01T00:00:00Z");
+        Instant to = Instant.parse("2026-05-13T00:00:00Z");
+        AdminOperationsOverviewQuery query = AdminOperationsOverviewQuery.of(MEMBER_ID, GISU_ID, from, to);
+        AdminAnalyticsScope scope = centralScope();
+        AdminOperationsOverviewInfo expected = AdminOperationsOverviewInfo.of(
+            java.util.List.of(),
+            java.util.List.of(),
+            AdminOperationsOverviewInfo.ScheduleAttendanceStatusInfo.of(3L, 2L, 8L, Map.of()),
+            AdminOperationsOverviewInfo.StudyGroupStatusInfo.of(4L, 6L),
+            java.util.List.of(AdminOperationsOverviewInfo.SignupBucketInfo.of(LocalDate.parse("2026-05-01"), 5L))
+        );
+        given(scopeResolver.resolve(MEMBER_ID, GISU_ID, null, null, null)).willReturn(scope);
+        given(loadAdminOperationsAnalyticsPort.getOperationsOverview(scope, query)).willReturn(expected);
+
+        AdminOperationsOverviewInfo actual = sut.getOperationsOverview(query);
+
+        assertThat(actual).isEqualTo(expected);
+        then(loadAdminOperationsAnalyticsPort).should().getOperationsOverview(scope, query);
+    }
+
+    private AdminAnalyticsScope centralScope() {
+        return AdminAnalyticsScope.of(
+            AdminAnalyticsScopeType.CENTRAL,
+            GISU_ID,
+            null,
+            null,
+            null,
+            ChallengerRoleType.CENTRAL_PRESIDENT
+        );
+    }
+}

--- a/src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolverTest.java
+++ b/src/test/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolverTest.java
@@ -1,0 +1,127 @@
+package com.umc.product.analytics.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import com.umc.product.analytics.domain.AdminAnalyticsScopeType;
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminAnalyticsScopeResolver")
+class AdminAnalyticsScopeResolverTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GISU_ID = 7L;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+
+    @InjectMocks
+    AdminAnalyticsScopeResolver sut;
+
+    @Test
+    @DisplayName("중앙 운영진은 요청한 지부와 학교 필터를 그대로 사용한다")
+    void 중앙_운영진은_요청한_지부와_학교_필터를_그대로_사용한다() {
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID))
+            .willReturn(List.of(role(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, null)));
+
+        AdminAnalyticsScope scope = sut.resolve(MEMBER_ID, GISU_ID, 10L, 20L, ChallengerPart.SPRINGBOOT);
+
+        assertThat(scope.type()).isEqualTo(AdminAnalyticsScopeType.CENTRAL);
+        assertThat(scope.gisuId()).isEqualTo(GISU_ID);
+        assertThat(scope.chapterId()).isEqualTo(10L);
+        assertThat(scope.schoolId()).isEqualTo(20L);
+        assertThat(scope.responsiblePart()).isEqualTo(ChallengerPart.SPRINGBOOT);
+        assertThat(scope.roleType()).isEqualTo(ChallengerRoleType.CENTRAL_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("지부장은 다른 지부를 요청하면 거부된다")
+    void 지부장은_다른_지부를_요청하면_거부된다() {
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID))
+            .willReturn(List.of(role(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, 10L, null)));
+
+        assertThatThrownBy(() -> sut.resolve(MEMBER_ID, GISU_ID, 99L, null, null))
+            .isInstanceOf(AnalyticsDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AnalyticsErrorCode.RESOURCE_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("학교 운영진은 학교 필터가 없어도 본인 학교로 스코프가 고정된다")
+    void 학교_운영진은_학교_필터가_없어도_본인_학교로_스코프가_고정된다() {
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID))
+            .willReturn(List.of(role(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, 30L, null)));
+
+        AdminAnalyticsScope scope = sut.resolve(MEMBER_ID, GISU_ID, null, null, null);
+
+        assertThat(scope.type()).isEqualTo(AdminAnalyticsScopeType.SCHOOL);
+        assertThat(scope.schoolId()).isEqualTo(30L);
+        assertThat(scope.chapterId()).isNull();
+        assertThat(scope.responsiblePart()).isNull();
+        assertThat(scope.roleType()).isEqualTo(ChallengerRoleType.SCHOOL_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("학교 파트장은 담당 파트까지 스코프에 포함된다")
+    void 학교_파트장은_담당_파트까지_스코프에_포함된다() {
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID))
+            .willReturn(List.of(
+                role(ChallengerRoleType.SCHOOL_PART_LEADER, OrganizationType.SCHOOL, 30L, ChallengerPart.ANDROID)
+            ));
+
+        AdminAnalyticsScope scope = sut.resolve(MEMBER_ID, GISU_ID, null, null, null);
+
+        assertThat(scope.type()).isEqualTo(AdminAnalyticsScopeType.SCHOOL_PART);
+        assertThat(scope.schoolId()).isEqualTo(30L);
+        assertThat(scope.responsiblePart()).isEqualTo(ChallengerPart.ANDROID);
+        assertThat(scope.roleType()).isEqualTo(ChallengerRoleType.SCHOOL_PART_LEADER);
+    }
+
+    @Test
+    @DisplayName("운영진 역할이 없으면 대시보드 접근이 거부된다")
+    void 운영진_역할이_없으면_대시보드_접근이_거부된다() {
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of());
+
+        assertThatThrownBy(() -> sut.resolve(MEMBER_ID, GISU_ID, null, null, null))
+            .isInstanceOf(AnalyticsDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AnalyticsErrorCode.RESOURCE_ACCESS_DENIED);
+    }
+
+    private ChallengerRoleInfo role(
+        ChallengerRoleType roleType,
+        OrganizationType organizationType,
+        Long organizationId,
+        ChallengerPart responsiblePart
+    ) {
+        return ChallengerRoleInfo.builder()
+            .id(1L)
+            .challengerId(100L)
+            .roleType(roleType)
+            .organizationType(organizationType)
+            .organizationId(organizationId)
+            .responsiblePart(responsiblePart)
+            .gisuId(GISU_ID)
+            .build();
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} : %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

> 제안 PR 제목: `[Feat] 운영진 대시보드 KPI 집계 API 추가`

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 백엔드 파트장이 2026-05-13 `develop` 브랜치를 기준으로 작업했어요.
- 변경 범위는 신규 `analytics` 도메인(`src/main/java/com/umc/product/analytics/**`), 권한 도메인의 `ResourceType`, 전역 예외 도메인 enum, 그리고 운영진 대시보드 관련 분석/기획 문서들이에요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: 운영진 대시보드용 신규 도메인 `analytics`를 추가하고, KPI 집계 API 6개를 새로 노출했어요.
   - `[ADMIN-DASHBOARD-001] GET /api/v1/admin/dashboard/summary` — 운영진 대시보드 요약 KPI
   - `[ADMIN-DASHBOARD-002] GET /api/v1/admin/dashboard/action-queue` — 운영자 액션 큐
   - `[ADMIN-DASHBOARD-003] GET /api/v1/admin/dashboard/risk-challengers` — 위험군 챌린저(페이지네이션)
   - `[ADMIN-DASHBOARD-004] GET /api/v1/admin/dashboard/context` — 운영자 권한 컨텍스트
   - `[ADMIN-DASHBOARD-005] GET /api/v1/admin/dashboard/operations` — 운영 현황 종합
   - `GET /api/v1/admin/schools/summary` — 학교별 현황(페이지네이션)
   - **어떻게**: Hexagonal Architecture를 그대로 따라서 `domain → application/port → application/service → adapter/in,out` 계층으로 분리했어요. 모든 UseCase는 Query 전용이라 `AdminAnalyticsQueryService`에서 `@Transactional(readOnly = true)` 로 묶었고, 영속성은 QueryDSL 기반 `*QueryRepository` 4종(`AdminDashboardAnalyticsQueryRepository`, `AdminOperationsAnalyticsQueryRepository`, `AdminRiskChallengerAnalyticsQueryRepository`, `AdminSchoolAnalyticsQueryRepository`)을 어댑터로 감싸서 구현했어요.
   - **왜**: 운영진이 한 화면에서 챌린저/학교/운영 현황을 즉시 확인할 수 있어야 한다는 [운영진 대시보드 기획안](docs/backlog/운영진_대시보드_기획안.md)의 요구사항을 만족시키기 위해서예요.

2. **무엇을**: 요청자 역할(`ChallengerRoleType`)에 따라 조회 범위를 자동으로 좁히는 `AdminAnalyticsScopeResolver`를 도입했어요.
   - **어떻게**: 중앙 운영진/슈퍼관리자는 `CENTRAL`, 지부장은 `CHAPTER`, 학교 파트장은 `SCHOOL_PART`, 그 외 학교 관리자는 `SCHOOL` 스코프로 해석하도록 했어요. 요청 파라미터가 본인 권한 밖이면 `AnalyticsErrorCode`로 401/403을 던지도록 했고, `getGisuId`가 비어 있을 때는 활성 기수(`GetGisuUseCase#getActiveGisuId`)로 대체해요.
   - **왜**: 동일한 엔드포인트를 모든 운영진이 호출하더라도 권한 단계에 맞는 데이터만 노출되도록 가드해야 했기 때문이에요.

3. **무엇을**: `ResourceType` 에 `ANALYTICS` 항목을 추가하고, 모든 신규 컨트롤러 메서드에 `@CheckAccess(resourceType = ANALYTICS, permission = READ)` 를 적용했어요.
   - **어떻게**: 권한 도메인의 기존 어노테이션 기반 가드를 재사용해서, 컨트롤러 진입 시점에 READ 권한 보유 여부를 먼저 검사하도록 만들었어요. 동시에 `global.exception.Domain` 에 분석 도메인을 추가했어요.
   - **왜**: 분석 API는 운영자만 접근 가능해야 하고, 도메인별 권한 체계를 다른 도메인과 동일한 방식으로 일관되게 유지하기 위해서예요.

4. **무엇을**: 신규 도메인에 대한 단위·통합 테스트를 7개 클래스 추가했어요.
   - **어떻게**: 컨트롤러 슬라이스 테스트(`AdminDashboardControllerTest`, `AdminSchoolAnalyticsControllerTest`), 서비스 단위 테스트(`AdminAnalyticsQueryServiceTest`, `AdminAnalyticsScopeResolverTest`), QueryDSL 레포지토리 통합 테스트(`AdminDashboardAnalyticsQueryRepositoryTest`, `AdminRiskChallengerAnalyticsQueryRepositoryTest`, `AdminSchoolAnalyticsQueryRepositoryTest`), 그리고 영속성 컨벤션 테스트(`AdminAnalyticsPersistenceConventionTest`)로 계층을 나눠 검증했어요.
   - **왜**: 집계 쿼리가 많고 권한 분기가 복잡한 도메인이라, 도입 시점부터 회귀 방지 그물망을 깔아두기 위해서예요.

5. **무엇을**: 운영진 대시보드 KPI 기획·구현·성능 보고서 및 FE 가이드를 `docs/` 에 추가했어요.
   - 추가 문서: [운영진_대시보드_KPI_구현_보고서](docs/analysis/운영진_대시보드_KPI_구현_보고서.md), [운영진_대시보드_KPI_후보_분석](docs/analysis/운영진_대시보드_KPI_후보_분석.md), [운영진_대시보드_기획안](docs/backlog/운영진_대시보드_기획안.md), [감사_로그_FE_API_가이드](docs/guides/감사_로그_FE_API_가이드.md), [analytics-admin-dashboard-backend](docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-backend.md), [analytics-admin-dashboard-performance](docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-performance.md), `docs/asciidoc/index.adoc` 갱신, `.codex/config.toml` 추가.
   - **어떻게**: KPI 후보 선정 → 기획안 → 백엔드 구현/성능 보고서 흐름으로 문서를 정리했고, REST Docs `index.adoc` 에 신규 스니펫 섹션을 연결했어요.
   - **왜**: 기획·디자인·FE 가 KPI 정의와 API 스펙을 단일 소스에서 참조할 수 있도록 하고, 향후 동일한 형태의 분석 API가 추가될 때 재사용할 표준 가이드를 남기기 위해서예요.

## 💬 리뷰 중점사항

- 권한 스코프 해석 로직(`src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsScopeResolver.java`)이 의도한 역할 매트릭스(`CENTRAL` / `CHAPTER` / `SCHOOL` / `SCHOOL_PART`)대로 동작하는지, 특히 학교 파트장이 다른 학교/파트를 조회하려 할 때 차단되는 경로를 중점으로 봐주세요.
- `ResourceType.ANALYTICS` 신규 도입에 따른 권한 매트릭스 영향(기존 권한 부여 로직과의 호환성)을 확인 부탁드려요.
- 집계 QueryDSL 4종(`AdminDashboardAnalyticsQueryRepository`, `AdminOperationsAnalyticsQueryRepository`, `AdminRiskChallengerAnalyticsQueryRepository`, `AdminSchoolAnalyticsQueryRepository`)의 fetch join/서브쿼리 사용으로 인한 N+1·실행 계획·인덱스 적합성 검토가 필요해요. 성능 측정 결과는 [analytics-admin-dashboard-performance](docs/superpowers/plans/2026-05-13-analytics-admin-dashboard-performance.md) 에 정리해 두었어요.
- `Pageable` 을 사용하는 두 엔드포인트(`risk-challengers`, `schools/summary`)에서 정렬 화이트리스트(`AdminAnalyticsSort`)가 의도한 컬럼만 허용하는지 확인 부탁드려요.
