### PR TITLE
[Fix] Local 환경에서도 Query 관련 메트릭을 로그에서 조회할 수 있도록 수정

### DIFF
--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -144,6 +144,14 @@ public class LoggingInterceptor implements HandlerInterceptor {
                 MDC.put(MDC_CLIENT_IP, clientIp);
             }
 
+            // 로컬 콘솔 패턴은 MDC 키를 렌더링하지 않으므로 (traceId 만 노출),
+            // 메시지 본문에 핵심 메트릭을 함께 실어 로컬에서도 한 줄로 가시화한다.
+            // JSON 어펜더(CONSOLE_JSON / LOKI)는 <mdc/> 프로바이더로 동일 값을 별도 필드로 직렬화한다.
+            String summary = String.format(
+                "%s status=%d durationMs=%d queryCount=%d queryTimeMs=%d",
+                EVENT_REQUEST_COMPLETED, response.getStatus(), durationMs, queryCount, queryTimeMs
+            );
+
             if (ex != null) {
                 // ADR-016 §민감 필드 정책: throwable 을 log.error 에 넘기면 JSON layout 의
                 // <stackTrace> 프로바이더가 전체 스택을 직렬화하고, 예외 메시지에 토큰 / 사용자
@@ -151,9 +159,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
                 // 메타 (exception 클래스명) 만 MDC 로 남기고, 스택 자체는 전역 예외 핸들러 /
                 // 컨트롤러 등 책임 지점의 로그에 맡긴다.
                 MDC.put(MDC_EXCEPTION, ex.getClass().getSimpleName());
-                log.error(EVENT_REQUEST_COMPLETED);
+                log.error(summary);
             } else {
-                log.info(EVENT_REQUEST_COMPLETED);
+                log.info(summary);
             }
         } finally {
             // ThreadLocal 누수 방지: 조기 반환 / try 블록 내 예외 경로 모두에서

--- a/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
@@ -201,9 +201,12 @@ class LoggingInterceptorTest {
     }
 
     private Map<String, String> findEventMdc(String message) {
+        // api_request_completed 메시지는 로컬 콘솔 가시화를 위해 본문 뒤에
+        // " status=... durationMs=... queryCount=... queryTimeMs=..." 가 따라붙으므로
+        // startsWith 로 매칭한다. (event MDC 키는 별도로 검증한다)
         List<ILoggingEvent> events = listAppender.list;
         for (ILoggingEvent event : events) {
-            if (message.equals(event.getMessage())) {
+            if (event.getMessage() != null && event.getMessage().startsWith(message)) {
                 return event.getMDCPropertyMap();
             }
         }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- related to #846

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 백엔드 파트장이 2026-05-13 `develop` 브랜치를 기준으로 작업했어요.
- 변경 범위는 `LoggingInterceptor` 와 그 테스트(`LoggingInterceptorTest`) 두 파일이에요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: `api_request_completed` 로그의 메시지 본문에 `status` / `durationMs` / `queryCount` / `queryTimeMs` 를 함께 실어 로컬 콘솔에서도 한 줄로 노출되도록 수정했어요.
   - **어떻게**: [LoggingInterceptor.java](src/main/java/com/umc/product/global/config/LoggingInterceptor.java) 의 `log.info(EVENT_REQUEST_COMPLETED)` / `log.error(EVENT_REQUEST_COMPLETED)` 호출을 `String.format` 으로 조립한 `summary` 문자열을 넘기도록 바꿨어요. 기존 MDC 푸시 로직은 그대로 두어 JSON 어펜더 측 출력 스키마는 유지했어요.
   - **왜**: 로컬 프로필이 사용하는 `LOCAL_CONSOLE_LOG_PATTERN` 은 `traceId` 외의 MDC 키를 렌더링하지 않아서, P6Spy + `QueryStatsHolder` 가 정상적으로 카운트를 누적하고 있음에도 로컬 디버깅 시 `queryCount` / `queryTimeMs` 가 보이지 않는 이슈가 있었어요. JSON stdout / Loki 환경에서는 `<mdc/>` 프로바이더로 같은 값이 별도 필드로 직렬화되므로 영향이 없어요.

2. **무엇을**: 테스트 헬퍼 `findEventMdc` 의 메시지 매칭을 `equals` → `startsWith` 로 바꿨어요.
   - **어떻게**: 위 변경으로 `api_request_completed` 뒤에 메트릭 문자열이 따라붙기 때문에 prefix 매칭으로 갱신하고, `event` MDC 키 검증은 기존대로 유지했어요.
   - **왜**: 메시지 본문 변경에 따른 회귀를 막기 위해서예요. ([LoggingInterceptorTest.java](src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java))

## 💬 리뷰 중점사항

- 메시지 본문에 메트릭이 추가되면서 Grafana / Loki LogQL 의 `event` 필터(`| json | event=\"api_request_completed\"`)와 numeric 필드(`unwrap durationMs` 등)는 모두 MDC 기반이라 호환이 유지돼요. 혹시 메시지 텍스트(`{message=\"api_request_completed\"}`)로 grep 하는 쿼리가 있는지 확인 부탁드려요.
- 로컬 콘솔에서 `api_request_completed status=200 durationMs=15 queryCount=3 queryTimeMs=2` 형태로 한 줄에 보이는지 검증 부탁드려요.
- 기존 `LoggingInterceptorTest` 가 모두 통과해요(`./gradlew test --tests "com.umc.product.global.config.LoggingInterceptorTest"`).