### PR TITLE
[Feat] 프로젝트 지원서 조회 관련 API 권한 검증 적용

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -1,5 +1,8 @@
 package com.umc.product.project.adapter.in.web;
 
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
@@ -114,21 +117,34 @@ public class ProjectApplicationQueryController {
         return assembler.applicantsFor(query);
     }
 
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT_APPLICATION,
+        resourceId = "#applicationId",
+        permission = PermissionType.READ,
+        message = "지원서 상세 조회는 지원자 본인 / PO·Sub-PO / 해당 기수 Central Core / 해당 기수·지부 지부장 만 가능합니다."
+    )
     @GetMapping("/{projectId}/applications/{applicationId}")
     @Operation(
         summary = "[APPLY-102] 지원서 단건 상세 조회",
         description = """
             지원서 단건의 메타(지원자/매칭 차수/상태/시각) + 폼 구조(지원자 파트 기준 마스킹) + 제출된 답변 본문 + 첨부 파일 메타까지 한 번에 반환한다.
             <p>
-            노출 규칙:
+            권한 (L2 @CheckAccess READ):
             <ul>
-              <li>SUBMITTED/APPROVED/REJECTED -- 4종 호출자(PO/Sub-PO/지부장/CC/지원자 본인) 모두 동일 응답</li>
-              <li>DRAFT(임시저장) -- 지원자 본인만 조회 가능. 그 외 호출자에게는 404(PROJECT-0021) 로 위장하여 임시저장본의 존재 자체를 은닉</li>
+              <li>SUBMITTED/APPROVED/REJECTED -- 다음 호출자만 통과:
+                <ul>
+                  <li>지원자 본인</li>
+                  <li>해당 프로젝트의 PO</li>
+                  <li>해당 프로젝트의 Sub-PO (ACTIVE PLAN 멤버)</li>
+                  <li>해당 프로젝트 기수의 Central Core (총괄/부총괄/SUPER_ADMIN)</li>
+                  <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
+                </ul>
+              </li>
+              <li>DRAFT(임시저장) -- 지원자 본인만 통과</li>
             </ul>
+            권한 부재 시 403(AUTHORIZATION-0002) 반환.
             <p>
             정합성: path 의 projectId 와 application 의 form.project.id 가 다르면 404(PROJECT-0021) 로 위장하여 다른 프로젝트의 지원서 존재 여부를 은닉한다.
-            <p>
-            TODO: 4종 호출자(@CheckAccess) 자격 검증은 추후에 추가된다 -- 현재 이 엔드포인트는 인증된 사용자라면 누구나 호출 가능.
             """
     )
     public ProjectApplicationDetailResponse getApplicationDetail(

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -84,7 +84,15 @@ public class ProjectApplicationQueryController {
               <li>status -- 지원 상태 (SUBMITTED / APPROVED / REJECTED). 미지정 시 전체. DRAFT 입력 시 도메인 예외(APPLICATION_DRAFT_FILTER_NOT_ALLOWED) 발생.</li>
             </ul>
             <p>
-            TODO: 권한 검사 (@CheckAccess) 미적용. 운영 배포 전 PM/Sub-PO/지부장/학교장/Central Core 분기 추가 필요.
+            권한: 다음 호출자만 통과한다. 그 외에는 권한 부재를 '지원자 0건' 으로 위장하여 빈 리스트를 반환한다.
+            <ul>
+              <li>해당 프로젝트의 PO</li>
+              <li>해당 프로젝트의 보조 PM (ACTIVE PLAN 멤버)</li>
+              <li>SUPER_ADMIN</li>
+              <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
+              <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
+              <li>해당 프로젝트 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+            </ul>
             """
     )
     public List<ProjectApplicantResponse> getProjectApplicants(
@@ -96,6 +104,7 @@ public class ProjectApplicationQueryController {
         @RequestParam(required = false) ProjectApplicationStatus status
     ) {
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(memberPrincipal.getMemberId())
             .projectId(projectId)
             .matchingRoundId(matchingRoundId)
             .part(part)

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
@@ -56,8 +56,8 @@ public class ProjectApplicationResponseAssembler {
     /**
      * PM/운영진용 단일 프로젝트 지원자 목록 조회. 지원자(챌린저) 의 닉네임/실명/학교는 member 도메인을 batch 조회해 합성한다.
      * <p>
-     * TODO: 권한 검사 (@CheckAccess) 가 미적용 상태 -- 현재 일반 챌린저도 호출하면 다른 프로젝트의 지원자
-     * 실명/학교가 노출될 수 있다. 운영 배포 전 반드시 권한 추가 필요.
+     * 권한 scope 결정은 service 단({@code ProjectApplicationQueryService#searchByProject}) 에서
+     * {@code ProjectApplicationAccessScopeResolver#resolveForProjectApplicantList} 로 수행된다.
      */
     public List<ProjectApplicantResponse> applicantsFor(SearchProjectApplicationsQuery query) {
         List<ProjectApplicationCardInfo> cards = searchProjectApplicationsUseCase.searchByProject(query);

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
@@ -5,31 +5,46 @@ import java.util.List;
 /**
  * 프로젝트 지원서 목록 조회 시 적용되는 가시 범위(scope) typed value.
  * <p>
- * 권한 판정(L2 {@code ProjectApplicationPermissionEvaluator})이 단건 binary 만 다룬다면, scope 는
- * "어떤 부분집합을 보여줄지"를 표현한다. 같은 사용자라도 호출 의도(본인 지원 내역 vs PO 의 지원자 목록 vs 운영진 모니터링)에 따라
- * 다른 scope 가 적용된다.
+ * 권한 판정(L2 {@code ProjectApplicationPermissionEvaluator})이 단건 binary 만 다룬다면, scope 는 "어떤 부분집합을 보여줄지"를 표현한다. 같은 사용자라도 호출
+ * 의도(본인 지원 내역 vs PO 의 지원자 목록 vs 운영진 모니터링)에 따라 다른 scope 가 적용된다.
  */
 public sealed interface ProjectApplicationAccessScope {
 
-    /** 본인이 지원자인 지원서만 노출 (본인 지원 내역 화면). */
-    record OwnerOnly(Long memberId) implements ProjectApplicationAccessScope {}
+    /**
+     * 본인이 지원자인 지원서만 노출 (본인 지원 내역 화면).
+     */
+    record OwnerOnly(Long memberId) implements ProjectApplicationAccessScope {
+    }
 
-    /** 특정 프로젝트의 지원서만 노출 (PO/Sub-PM 의 "내 프로젝트 지원자 목록"). */
-    record ProjectScoped(Long projectId) implements ProjectApplicationAccessScope {}
+    /**
+     * 특정 프로젝트의 지원서만 (PO/Sub-PM/CC/지부장/학교장의 "이 프로젝트 지원자 목록")
+     */
+    record ProjectScoped(Long projectId) implements ProjectApplicationAccessScope {
+    }
 
     /**
      * 특정 지부들의 프로젝트 지원서 노출 (해당 기수 지부장).
      * <p>
      * 한 사용자가 동일 기수 내에서 여러 지부의 지부장을 맡는 경우를 지원하기 위해 List 로 받는다.
      */
-    record ChapterScoped(List<Long> chapterIds, Long gisuId) implements ProjectApplicationAccessScope {}
+    record ChapterScoped(List<Long> chapterIds, Long gisuId) implements ProjectApplicationAccessScope {
+    }
 
-    /** 해당 기수의 모든 지원서 (총괄단 모니터링). SUPER_ADMIN 은 gisu 무관. */
-    record AllInGisu(Long gisuId) implements ProjectApplicationAccessScope {}
+    /**
+     * 해당 기수의 모든 지원서 (총괄단 모니터링). SUPER_ADMIN 은 gisu 무관.
+     */
+    record AllInGisu(Long gisuId) implements ProjectApplicationAccessScope {
+    }
 
-    /** 글로벌 (SUPER_ADMIN). */
-    record All() implements ProjectApplicationAccessScope {}
+    /**
+     * 글로벌 (SUPER_ADMIN).
+     */
+    record All() implements ProjectApplicationAccessScope {
+    }
 
-    /** 관리 대상 0건 (권한 없음). */
-    record None() implements ProjectApplicationAccessScope {}
+    /**
+     * 관리 대상 0건 (권한 없음).
+     */
+    record None() implements ProjectApplicationAccessScope {
+    }
 }

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -64,17 +64,11 @@ public class ProjectApplicationAccessScopeResolver {
             .filter(r -> Objects.equals(r.gisuId(), project.getGisuId()))
             .toList();
 
-        if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
-            return new ProjectScoped(projectId);
-        }
-        if (rolesInGisu.stream().anyMatch(r ->
-            r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
-                && Objects.equals(r.organizationId(), project.getChapterId()))) {
-            return new ProjectScoped(projectId);
-        }
-        if (rolesInGisu.stream().anyMatch(r ->
-            r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
-                && Objects.equals(r.organizationId(), project.getProductOwnerSchoolId()))) {
+        if (rolesInGisu.stream().anyMatch(
+            r -> r.roleType().isAtLeastCentralCore() || (r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(r.organizationId(), project.getChapterId())) || (
+                r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT && Objects.equals(r.organizationId(),
+                    project.getProductOwnerSchoolId())))) {
             return new ProjectScoped(projectId);
         }
 

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -10,10 +10,7 @@ import com.umc.product.project.application.access.ProjectApplicationAccessScope.
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
-import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.exception.ProjectDomainException;
-import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +24,6 @@ import org.springframework.stereotype.Component;
 public class ProjectApplicationAccessScopeResolver {
 
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
-    private final LoadProjectPort loadProjectPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
 
     /**
@@ -48,10 +44,11 @@ public class ProjectApplicationAccessScopeResolver {
      *   <li>해당 프로젝트 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
      * </ul>
      * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리하여 권한 부재를 '지원자 0건' 으로 위장한다.
+     * <p>
+     * {@code project} 는 호출자(서비스 단)가 사전 로드한 인스턴스를 그대로 전달받는다. 동일 트랜잭션 내 중복 조회를 피하기 위함.
      */
-    public ProjectApplicationAccessScope resolveForProjectApplicantList(Long memberId, Long projectId) {
-        Project project = loadProjectPort.findById(projectId)
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    public ProjectApplicationAccessScope resolveForProjectApplicantList(Long memberId, Project project) {
+        Long projectId = project.getId();
 
         if (Objects.equals(project.getProductOwnerMemberId(), memberId)
             || loadProjectMemberPort.isActivePlanMember(projectId, memberId)) {

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -38,11 +38,18 @@ public class ProjectApplicationAccessScopeResolver {
     }
 
     /**
-     * PO/Sub-PM 의 "내 프로젝트 지원자 목록" 화면.
-     * 호출자가 부모 프로젝트의 PO 또는 보조 PM (ACTIVE PLAN 멤버) 이어야 통과.
-     * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리.
+     * 단일 프로젝트 지원자 목록(APPLY-101) 화면. 호출자가 다음 중 하나라도 만족하면 {@link ProjectScoped} 통과:
+     * <ul>
+     *   <li>해당 프로젝트의 PO</li>
+     *   <li>해당 프로젝트의 보조 PM (ACTIVE PLAN 멤버)</li>
+     *   <li>SUPER_ADMIN</li>
+     *   <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
+     *   <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
+     *   <li>해당 프로젝트 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+     * </ul>
+     * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리하여 권한 부재를 '지원자 0건' 으로 위장한다.
      */
-    public ProjectApplicationAccessScope resolveForProjectReview(Long memberId, Long projectId) {
+    public ProjectApplicationAccessScope resolveForProjectApplicantList(Long memberId, Long projectId) {
         Project project = loadProjectPort.findById(projectId)
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
 
@@ -50,6 +57,30 @@ public class ProjectApplicationAccessScopeResolver {
             || loadProjectMemberPort.isActivePlanMember(projectId, memberId)) {
             return new ProjectScoped(projectId);
         }
+
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+        if (roles.stream().anyMatch(r -> r.roleType().isSuperAdmin())) {
+            return new ProjectScoped(projectId);
+        }
+
+        List<ChallengerRoleInfo> rolesInGisu = roles.stream()
+            .filter(r -> Objects.equals(r.gisuId(), project.getGisuId()))
+            .toList();
+
+        if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
+            return new ProjectScoped(projectId);
+        }
+        if (rolesInGisu.stream().anyMatch(r ->
+            r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(r.organizationId(), project.getChapterId()))) {
+            return new ProjectScoped(projectId);
+        }
+        if (rolesInGisu.stream().anyMatch(r ->
+            r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                && Objects.equals(r.organizationId(), project.getProductOwnerSchoolId()))) {
+            return new ProjectScoped(projectId);
+        }
+
         return new None();
     }
 

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectApplicationsQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectApplicationsQuery.java
@@ -12,20 +12,23 @@ import lombok.Builder;
  * <p>
  * 임시저장(DRAFT) 지원서는 본 API 응답에 노출되지 않으므로, {@link #status} 값으로도 DRAFT 는 받지 않는다.
  *
- * @param projectId       대상 프로젝트 ID (path variable)
- * @param matchingRoundId 매칭 차수 필터 (선택). null 이면 전체 차수.
- * @param part            지원 파트 필터 (선택). null 이면 전체 파트.
- * @param status          지원 상태 필터 (선택). null 이면 SUBMITTED/APPROVED/REJECTED 전체. DRAFT(임시저장)이 들어오면 도메인 invariant 위반으로
- *                        즉시 예외를 던진다.
+ * @param requesterMemberId 요청자 Member ID. 권한 scope 결정(L1)에 사용된다.
+ * @param projectId         대상 프로젝트 ID (path variable)
+ * @param matchingRoundId   매칭 차수 필터 (선택). null 이면 전체 차수.
+ * @param part              지원 파트 필터 (선택). null 이면 전체 파트.
+ * @param status            지원 상태 필터 (선택). null 이면 SUBMITTED/APPROVED/REJECTED 전체. DRAFT(임시저장)이 들어오면 도메인 invariant 위반으로
+ *                          즉시 예외를 던진다.
  */
 @Builder
 public record SearchProjectApplicationsQuery(
+    Long requesterMemberId,
     Long projectId,
     Long matchingRoundId,
     ChallengerPart part,
     ProjectApplicationStatus status
 ) {
     public SearchProjectApplicationsQuery {
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
         Objects.requireNonNull(projectId, "projectId must not be null");
         if (status == ProjectApplicationStatus.DRAFT) {
             throw new ProjectDomainException(

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -213,13 +213,13 @@ public class ProjectApplicationQueryService
      */
     @Override
     public List<ProjectApplicationCardInfo> searchByProject(SearchProjectApplicationsQuery query) {
+        Project project = loadProjectPort.getById(query.projectId());
+
         ProjectApplicationAccessScope scope = accessScopeResolver.resolveForProjectApplicantList(
-            query.requesterMemberId(), query.projectId());
+            query.requesterMemberId(), project);
         if (scope instanceof ProjectApplicationAccessScope.None) {
             return List.of();
         }
-
-        Project project = loadProjectPort.getById(query.projectId());
 
         List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplications(
             query.projectId(),

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -3,6 +3,8 @@ package com.umc.product.project.application.service.query;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope;
+import com.umc.product.project.application.access.ProjectApplicationAccessScopeResolver;
 import com.umc.product.project.application.port.in.query.GetMyProjectApplicationsUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectApplicationDetailUseCase;
 import com.umc.product.project.application.port.in.query.SearchProjectApplicationsUseCase;
@@ -60,34 +62,13 @@ public class ProjectApplicationQueryService
     private final LoadProjectMemberPort loadProjectMemberPort;
     private final LoadProjectPort loadProjectPort;
     private final LoadProjectApplicationFormPolicyPort loadProjectApplicationFormPolicyPort;
+    private final ProjectApplicationAccessScopeResolver accessScopeResolver;
 
     // Cross-domain
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetFileUseCase getFileUseCase;
     private final GetFormUseCase getFormUseCase;
     private final GetFormResponseUseCase getFormResponseUseCase;
-
-    private static Optional<MatchingType> matchingTypeOf(ChallengerPart part) {
-        return switch (part) {
-            case DESIGN -> Optional.of(MatchingType.PLAN_DESIGN);
-            case WEB, ANDROID, IOS, NODEJS, SPRINGBOOT -> Optional.of(MatchingType.PLAN_DEVELOPER);
-            case PLAN, ADMIN -> Optional.empty();
-        };
-    }
-
-    /**
-     * application 카드와 랜덤 매칭 카드의 projectId 를 통합한 집합을 만든다 (N+1 방지용 batch 키).
-     */
-    private static Set<Long> collectProjectIds(
-        List<ProjectApplication> applications, Optional<ProjectMember> randomMatchingMember
-    ) {
-        Set<Long> projectIds = new HashSet<>();
-        for (ProjectApplication application : applications) {
-            projectIds.add(application.getApplicationForm().getProject().getId());
-        }
-        randomMatchingMember.ifPresent(member -> projectIds.add(member.getProject().getId()));
-        return projectIds;
-    }
 
     /**
      * 지원서 단건 상세 조회.
@@ -143,69 +124,12 @@ public class ProjectApplicationQueryService
         );
     }
 
-    // ==============================================================
-    //                      Helper Method
-    // ==============================================================
-
-    /**
-     * PM/운영진용 단일 프로젝트 지원자 목록 조회.
-     * <p>
-     * 흐름:
-     * <ol>
-     *   <li>프로젝트 단건 조회 (없으면 PROJECT_NOT_FOUND)</li>
-     *   <li>지원서 동적 검색 (matchingRoundId / status 필터, DRAFT 제외)</li>
-     *   <li>지원자들의 challenger.part batch 조회 (해당 기수 invariant)</li>
-     *   <li>part 필터를 in-memory 로 적용 -- challenger.part 는 ProjectApplication 컬럼이 아니므로
-     *       repository 단에서 다루지 않는다 (도메인 분리)</li>
-     *   <li>ProjectApplicationCardInfo 로 조립</li>
-     * </ol>
-     * <p>
-     * 정렬은 repository 가 phase ASC -> submittedAt ASC 로 처리하므로 이 메서드는 추가 정렬을 하지 않는다.
-     */
-    @Override
-    public List<ProjectApplicationCardInfo> searchByProject(SearchProjectApplicationsQuery query) {
-        Project project = loadProjectPort.getById(query.projectId());
-
-        List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplications(
-            query.projectId(),
-            query.matchingRoundId(),
-            query.status()
-        );
-        if (applications.isEmpty()) {
-            return List.of();
-        }
-
-        Map<Long, ChallengerPart> partsByMember = resolveApplicantParts(applications, project.getGisuId());
-
-        List<ProjectApplicationCardInfo> cards = new ArrayList<>(applications.size());
-        for (ProjectApplication application : applications) {
-            ChallengerPart applicantPart = partsByMember.get(application.getApplicantMemberId());
-            if (query.part() != null && query.part() != applicantPart) {
-                continue;
-            }
-            cards.add(ProjectApplicationCardInfo.of(application, applicantPart));
-        }
-        return cards;
-    }
-
-    /**
-     * 요청자의 챌린저 파트로부터 매칭 종류를 결정한다.
-     * <ul>
-     *   <li>해당 기수에 챌린저 레코드 없음 -> empty</li>
-     *   <li>{@code PLAN} / {@code ADMIN} -> empty (지원 대상 아님)</li>
-     *   <li>{@code DESIGN} -> {@code PLAN_DESIGN}</li>
-     *   <li>{@code WEB} / {@code ANDROID} / {@code IOS} / {@code NODEJS} / {@code SPRINGBOOT} -> {@code PLAN_DEVELOPER}</li>
-     * </ul>
-     */
-    private Optional<MatchingType> resolveMatchingType(GetMyProjectApplicationsQuery query) {
-        return getChallengerUseCase
-            .findByMemberIdAndGisuId(query.requesterMemberId(), query.gisuId())
-            .map(ChallengerInfo::part)
-            .flatMap(ProjectApplicationQueryService::matchingTypeOf);
-    }
-
-    private static String thumbnailUrlOf(Project project, Map<String, String> thumbnailLinks) {
-        return project.getThumbnailFileId() == null ? null : thumbnailLinks.get(project.getThumbnailFileId());
+    private static Optional<MatchingType> matchingTypeOf(ChallengerPart part) {
+        return switch (part) {
+            case DESIGN -> Optional.of(MatchingType.PLAN_DESIGN);
+            case WEB, ANDROID, IOS, NODEJS, SPRINGBOOT -> Optional.of(MatchingType.PLAN_DEVELOPER);
+            case PLAN, ADMIN -> Optional.empty();
+        };
     }
 
     /**
@@ -250,6 +174,92 @@ public class ProjectApplicationQueryService
         }
 
         return assembleCards(applications, randomMatchingMember, matchingType.get());
+    }
+
+    // ==============================================================
+    //                      Helper Method
+    // ==============================================================
+
+    /**
+     * application 카드와 랜덤 매칭 카드의 projectId 를 통합한 집합을 만든다 (N+1 방지용 batch 키).
+     */
+    private static Set<Long> collectProjectIds(
+        List<ProjectApplication> applications, Optional<ProjectMember> randomMatchingMember
+    ) {
+        Set<Long> projectIds = new HashSet<>();
+        for (ProjectApplication application : applications) {
+            projectIds.add(application.getApplicationForm().getProject().getId());
+        }
+        randomMatchingMember.ifPresent(member -> projectIds.add(member.getProject().getId()));
+        return projectIds;
+    }
+
+    private static String thumbnailUrlOf(Project project, Map<String, String> thumbnailLinks) {
+        return project.getThumbnailFileId() == null ? null : thumbnailLinks.get(project.getThumbnailFileId());
+    }
+
+    /**
+     * PM/운영진용 단일 프로젝트 지원자 목록 조회.
+     * <p>
+     * 흐름:
+     * <ol>
+     *   <li>권한 scope 결정 (PO/Sub-PM/SUPER_ADMIN/CC/지부장/학교장만 통과, 그 외 빈 리스트로 위장)</li>
+     *   <li>프로젝트 단건 조회 (없으면 PROJECT_NOT_FOUND)</li>
+     *   <li>지원서 동적 검색 (matchingRoundId / status 필터, DRAFT 제외)</li>
+     *   <li>지원자들의 challenger.part batch 조회 (해당 기수 invariant)</li>
+     *   <li>part 필터를 in-memory 로 적용 -- challenger.part 는 ProjectApplication 컬럼이 아니므로
+     *       repository 단에서 다루지 않는다 (도메인 분리)</li>
+     *   <li>ProjectApplicationCardInfo 로 조립</li>
+     * </ol>
+     * <p>
+     * 정렬은 repository 가 phase ASC -> submittedAt ASC 로 처리하므로 이 메서드는 추가 정렬을 하지 않는다.
+     */
+    @Override
+    public List<ProjectApplicationCardInfo> searchByProject(SearchProjectApplicationsQuery query) {
+        ProjectApplicationAccessScope scope = accessScopeResolver.resolveForProjectApplicantList(
+            query.requesterMemberId(), query.projectId());
+        if (scope instanceof ProjectApplicationAccessScope.None) {
+            return List.of();
+        }
+
+        Project project = loadProjectPort.getById(query.projectId());
+
+        List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplications(
+            query.projectId(),
+            query.matchingRoundId(),
+            query.status()
+        );
+        if (applications.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, ChallengerPart> partsByMember = resolveApplicantParts(applications, project.getGisuId());
+
+        List<ProjectApplicationCardInfo> cards = new ArrayList<>(applications.size());
+        for (ProjectApplication application : applications) {
+            ChallengerPart applicantPart = partsByMember.get(application.getApplicantMemberId());
+            if (query.part() != null && query.part() != applicantPart) {
+                continue;
+            }
+            cards.add(ProjectApplicationCardInfo.of(application, applicantPart));
+        }
+        return cards;
+    }
+
+    /**
+     * 요청자의 챌린저 파트로부터 매칭 종류를 결정한다.
+     * <ul>
+     *   <li>해당 기수에 챌린저 레코드 없음 -> empty</li>
+     *   <li>{@code PLAN} / {@code ADMIN} -> empty (지원 대상 아님)</li>
+     *   <li>{@code DESIGN} -> {@code PLAN_DESIGN}</li>
+     *   <li>{@code WEB} / {@code ANDROID} / {@code IOS} / {@code NODEJS} / {@code SPRINGBOOT} -> {@code PLAN_DEVELOPER}</li>
+     * </ul>
+     */
+    private Optional<MatchingType> resolveMatchingType(GetMyProjectApplicationsQuery query) {
+        return getChallengerUseCase
+            .findByMemberIdAndGisuId(query.requesterMemberId(), query.gisuId())
+            .map(ChallengerInfo::part)
+            .flatMap(ProjectApplicationQueryService::matchingTypeOf);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -73,13 +73,14 @@ public class ProjectApplicationQueryService
     /**
      * 지원서 단건 상세 조회.
      * <p>
+     * 권한 검사(4종 staff + 본인 / DRAFT 본인 한정)는 컨트롤러의 {@code @CheckAccess(PROJECT_APPLICATION, READ)} 가
+     * 처리하므로 본 메서드 진입 시점에는 L2 권한이 검증된 상태이다.
+     * <p>
      * 흐름:
      * <ol>
      *   <li>application fetch join 단건 로드 (form/project/matchingRound 한 번에)</li>
      *   <li>정합성 검증: application 의 form.project.id 가 path 의 projectId 와 일치해야 함.
      *       위반/미존재 모두 PROJECT_APPLICATION_NOT_FOUND 로 통일하여 다른 프로젝트의 지원서 존재 여부를 은닉</li>
-     *   <li>도메인 비즈니스 규칙: DRAFT(임시저장)은 지원자 본인만 조회 가능. PO/Sub-PO/지부장/CC 등 다른 호출자에게는
-     *       not-found 로 위장하여 임시저장본의 존재 자체를 은닉</li>
      *   <li>지원자 파트 단건 조회 (해당 기수 챌린저 invariant -- 누락 시 not-found 로 통일)</li>
      *   <li>폼 구조/정책/응답 본문/첨부 파일 raw 데이터 cross-domain 조회 (storage 만 IN 쿼리 batch)</li>
      *   <li>{@link ProjectApplicationDetailInfo#of} 가 마스킹/메타 분리/answers Map 합성까지 한 번에 처리</li>
@@ -93,10 +94,6 @@ public class ProjectApplicationQueryService
         ProjectApplicationForm applicationForm = application.getApplicationForm();
         Project project = applicationForm.getProject();
         if (!Objects.equals(project.getId(), query.projectId())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
-        }
-        if (application.isDraft()
-            && !Objects.equals(application.getApplicantMemberId(), query.requesterMemberId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
         }
 

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
@@ -216,6 +216,7 @@ class ProjectApplicationResponseAssemblerTest {
     void applicantsFor_정상_조립() {
         // given
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(100L)
             .projectId(1L).build();
         ProjectApplicationCardInfo card = applicantCardOf(55L, 200L, ChallengerPart.WEB);
 
@@ -247,6 +248,7 @@ class ProjectApplicationResponseAssemblerTest {
     void applicantsFor_빈_리스트() {
         // given
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(100L)
             .projectId(1L).build();
         given(searchProjectApplicationsUseCase.searchByProject(query))
             .willReturn(List.of());
@@ -264,6 +266,7 @@ class ProjectApplicationResponseAssemblerTest {
     void applicantsFor_member_누락_시_null() {
         // given
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(100L)
             .projectId(1L).build();
         ProjectApplicationCardInfo card = applicantCardOf(55L, 200L, ChallengerPart.WEB);
 

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -1,7 +1,6 @@
 package com.umc.product.project.application.access;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
@@ -11,11 +10,8 @@ import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.None;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
-import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.exception.ProjectDomainException;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,14 +36,12 @@ class ProjectApplicationAccessScopeResolverTest {
     @Mock
     GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock
-    LoadProjectPort loadProjectPort;
-    @Mock
     LoadProjectMemberPort loadProjectMemberPort;
 
     @InjectMocks
     ProjectApplicationAccessScopeResolver sut;
 
-    // --- 프로젝트 미존재 ---
+    // --- PO / Sub-PM (프로젝트 단위 권한) ---
 
     private static Project project(Long ownerMemberId, Long gisuId, Long chapterId, Long schoolId) {
         Project p = newInstance(Project.class);
@@ -59,8 +53,6 @@ class ProjectApplicationAccessScopeResolverTest {
         return p;
     }
 
-    // --- PO / Sub-PM (프로젝트 단위 권한) ---
-
     private static <T> T newInstance(Class<T> clazz) {
         try {
             var constructor = clazz.getDeclaredConstructor();
@@ -70,6 +62,8 @@ class ProjectApplicationAccessScopeResolverTest {
             throw new RuntimeException(e);
         }
     }
+
+    // --- SUPER_ADMIN (기수 무관) ---
 
     private static ChallengerRoleInfo roleInfo(
         ChallengerRoleType type, OrganizationType orgType, Long orgId, Long gisuId
@@ -85,28 +79,16 @@ class ProjectApplicationAccessScopeResolverTest {
             .build();
     }
 
-    // --- SUPER_ADMIN (기수 무관) ---
-
-    @Test
-    @DisplayName("projectApplicantList_프로젝트가_없으면_PROJECT_NOT_FOUND_던진다")
-    void projectApplicantList_프로젝트_미존재() {
-        given(loadProjectPort.findById(PROJECT_ID)).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID))
-            .isInstanceOf(ProjectDomainException.class);
-    }
-
     // --- Central Core (총괄 / 부총괄) ---
 
     @Test
     @DisplayName("projectApplicantList_PO_본인이면_ProjectScoped")
     void projectApplicantList_PO_통과() {
         // PO == 호출자 -- short-circuit 으로 isActivePlanMember 미호출
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(MEMBER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(MEMBER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
         assertThat(((ProjectScoped) scope).projectId()).isEqualTo(PROJECT_ID);
@@ -115,12 +97,11 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_Sub_PM_이면_ProjectScoped")
     void projectApplicantList_SubPM_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(true);
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -128,8 +109,7 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_SUPER_ADMIN_이면_기수_무관_ProjectScoped")
     void projectApplicantList_SUPER_ADMIN_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         // 역할 레코드의 gisuId 가 프로젝트 기수와 다르더라도 통과해야 함
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
@@ -137,7 +117,7 @@ class ProjectApplicationAccessScopeResolverTest {
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -145,15 +125,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_같은_기수_총괄이면_ProjectScoped")
     void projectApplicantList_총괄_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -163,15 +142,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_같은_기수_부총괄도_ProjectScoped")
     void projectApplicantList_부총괄_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CENTRAL_VICE_PRESIDENT, OrganizationType.CENTRAL, null, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -179,15 +157,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_타_기수_총괄이면_None")
     void projectApplicantList_타기수_총괄_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, OTHER_GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -196,15 +173,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @DisplayName("projectApplicantList_중앙_운영국원은_권한_없음_None")
     void projectApplicantList_운영국원_거부() {
         // CENTRAL_OPERATING_TEAM_MEMBER 는 isAtLeastCentralCore() 미포함 -> 거부
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, OrganizationType.CENTRAL, null, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -214,15 +190,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_같은_기수_지부의_지부장이면_ProjectScoped")
     void projectApplicantList_지부장_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, CHAPTER_ID, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -230,15 +205,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_타_지부_지부장이면_None")
     void projectApplicantList_타지부_지부장_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, OTHER_CHAPTER_ID, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -246,15 +220,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_타_기수_지부장이면_None")
     void projectApplicantList_타기수_지부장_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, CHAPTER_ID, OTHER_GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -262,15 +235,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_같은_기수_학교의_회장이면_ProjectScoped")
     void projectApplicantList_학교회장_통과() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
@@ -281,15 +253,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @DisplayName("projectApplicantList_학교_부회장은_권한_없음_None")
     void projectApplicantList_학교_부회장_거부() {
         // SCHOOL_VICE_PRESIDENT 는 명시적으로 제외됨 (회장만 통과)
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -299,15 +270,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_타_학교_회장이면_None")
     void projectApplicantList_타학교_회장_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -315,15 +285,14 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_타_기수_학교_회장이면_None")
     void projectApplicantList_타기수_학교회장_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, OTHER_GISU_ID)
         ));
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }
@@ -331,13 +300,12 @@ class ProjectApplicationAccessScopeResolverTest {
     @Test
     @DisplayName("projectApplicantList_역할이_없는_일반_챌린저면_None")
     void projectApplicantList_일반_챌린저_거부() {
-        given(loadProjectPort.findById(PROJECT_ID))
-            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of());
 
         ProjectApplicationAccessScope scope =
-            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
     }

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -1,0 +1,344 @@
+package com.umc.product.project.application.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.None;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplicationAccessScopeResolverTest {
+
+    private static final Long PROJECT_ID = 100L;
+    private static final Long MEMBER_ID = 10L;
+    private static final Long OWNER_ID = 99L;
+    private static final Long GISU_ID = 1L;
+    private static final Long CHAPTER_ID = 5L;
+    private static final Long SCHOOL_ID = 7L;
+    private static final Long OTHER_GISU_ID = 999L;
+    private static final Long OTHER_CHAPTER_ID = 888L;
+    private static final Long OTHER_SCHOOL_ID = 777L;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock
+    LoadProjectPort loadProjectPort;
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+
+    @InjectMocks
+    ProjectApplicationAccessScopeResolver sut;
+
+    // --- 프로젝트 미존재 ---
+
+    private static Project project(Long ownerMemberId, Long gisuId, Long chapterId, Long schoolId) {
+        Project p = newInstance(Project.class);
+        ReflectionTestUtils.setField(p, "id", PROJECT_ID);
+        ReflectionTestUtils.setField(p, "productOwnerMemberId", ownerMemberId);
+        ReflectionTestUtils.setField(p, "gisuId", gisuId);
+        ReflectionTestUtils.setField(p, "chapterId", chapterId);
+        ReflectionTestUtils.setField(p, "productOwnerSchoolId", schoolId);
+        return p;
+    }
+
+    // --- PO / Sub-PM (프로젝트 단위 권한) ---
+
+    private static <T> T newInstance(Class<T> clazz) {
+        try {
+            var constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ChallengerRoleInfo roleInfo(
+        ChallengerRoleType type, OrganizationType orgType, Long orgId, Long gisuId
+    ) {
+        return ChallengerRoleInfo.builder()
+            .id(1L)
+            .challengerId(1L)
+            .roleType(type)
+            .organizationType(orgType)
+            .organizationId(orgId)
+            .responsiblePart(null)
+            .gisuId(gisuId)
+            .build();
+    }
+
+    // --- SUPER_ADMIN (기수 무관) ---
+
+    @Test
+    @DisplayName("projectApplicantList_프로젝트가_없으면_PROJECT_NOT_FOUND_던진다")
+    void projectApplicantList_프로젝트_미존재() {
+        given(loadProjectPort.findById(PROJECT_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    // --- Central Core (총괄 / 부총괄) ---
+
+    @Test
+    @DisplayName("projectApplicantList_PO_본인이면_ProjectScoped")
+    void projectApplicantList_PO_통과() {
+        // PO == 호출자 -- short-circuit 으로 isActivePlanMember 미호출
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(MEMBER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+        assertThat(((ProjectScoped) scope).projectId()).isEqualTo(PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_Sub_PM_이면_ProjectScoped")
+    void projectApplicantList_SubPM_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(true);
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_SUPER_ADMIN_이면_기수_무관_ProjectScoped")
+    void projectApplicantList_SUPER_ADMIN_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        // 역할 레코드의 gisuId 가 프로젝트 기수와 다르더라도 통과해야 함
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SUPER_ADMIN, OrganizationType.CENTRAL, null, OTHER_GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_같은_기수_총괄이면_ProjectScoped")
+    void projectApplicantList_총괄_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    // --- 지부장 ---
+
+    @Test
+    @DisplayName("projectApplicantList_같은_기수_부총괄도_ProjectScoped")
+    void projectApplicantList_부총괄_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CENTRAL_VICE_PRESIDENT, OrganizationType.CENTRAL, null, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_타_기수_총괄이면_None")
+    void projectApplicantList_타기수_총괄_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, OTHER_GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_중앙_운영국원은_권한_없음_None")
+    void projectApplicantList_운영국원_거부() {
+        // CENTRAL_OPERATING_TEAM_MEMBER 는 isAtLeastCentralCore() 미포함 -> 거부
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, OrganizationType.CENTRAL, null, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    // --- 학교 회장 (SCHOOL_PRESIDENT 만 통과, 부회장 제외) ---
+
+    @Test
+    @DisplayName("projectApplicantList_같은_기수_지부의_지부장이면_ProjectScoped")
+    void projectApplicantList_지부장_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, CHAPTER_ID, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_타_지부_지부장이면_None")
+    void projectApplicantList_타지부_지부장_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, OTHER_CHAPTER_ID, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_타_기수_지부장이면_None")
+    void projectApplicantList_타기수_지부장_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, CHAPTER_ID, OTHER_GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_같은_기수_학교의_회장이면_ProjectScoped")
+    void projectApplicantList_학교회장_통과() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
+    }
+
+    // --- 권한 없음 (역할 0건) ---
+
+    @Test
+    @DisplayName("projectApplicantList_학교_부회장은_권한_없음_None")
+    void projectApplicantList_학교_부회장_거부() {
+        // SCHOOL_VICE_PRESIDENT 는 명시적으로 제외됨 (회장만 통과)
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    // --- helpers ---
+
+    @Test
+    @DisplayName("projectApplicantList_타_학교_회장이면_None")
+    void projectApplicantList_타학교_회장_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_타_기수_학교_회장이면_None")
+    void projectApplicantList_타기수_학교회장_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, OTHER_GISU_ID)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_역할이_없는_일반_챌린저면_None")
+    void projectApplicantList_일반_챌린저_거부() {
+        given(loadProjectPort.findById(PROJECT_ID))
+            .willReturn(Optional.of(project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID)));
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of());
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, PROJECT_ID);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -608,9 +608,12 @@ class ProjectApplicationQueryServiceTest {
     @DisplayName("searchByProject_권한_scope_가_None_이면_빈_리스트_위장")
     void searchByProject_권한_없음_빈_리스트() {
         // given
+        Project project = createProject(1L, "프로젝트A", null, 99L);
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
             .requesterMemberId(REQUESTER_ID).projectId(1L).build();
-        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+
+        given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
             .willReturn(new ProjectApplicationAccessScope.None());
 
         // when
@@ -630,9 +633,9 @@ class ProjectApplicationQueryServiceTest {
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
             .requesterMemberId(REQUESTER_ID).projectId(1L).build();
 
-        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
-            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of());
 
@@ -658,9 +661,9 @@ class ProjectApplicationQueryServiceTest {
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
             .requesterMemberId(REQUESTER_ID).projectId(1L).build();
 
-        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
-            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of(application));
         given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(eq(Set.of(200L)), eq(GISU_ID)))
@@ -699,9 +702,9 @@ class ProjectApplicationQueryServiceTest {
             .part(ChallengerPart.WEB)
             .build();
 
-        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
-            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of(webApp, androidApp));
         given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), eq(GISU_ID)))
@@ -731,9 +734,9 @@ class ProjectApplicationQueryServiceTest {
             .status(ProjectApplicationStatus.APPROVED)
             .build();
 
-        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
-            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectApplicationPort.searchProjectApplications(
             1L, 7L, ProjectApplicationStatus.APPROVED))
             .willReturn(List.of());

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.access.ProjectApplicationAccessScope;
+import com.umc.product.project.application.access.ProjectApplicationAccessScopeResolver;
 import com.umc.product.project.application.port.in.query.dto.GetMyProjectApplicationsQuery;
 import com.umc.product.project.application.port.in.query.dto.GetProjectApplicationDetailQuery;
 import com.umc.product.project.application.port.in.query.dto.ManagedProjectApplicationCardStatus;
@@ -86,6 +88,8 @@ class ProjectApplicationQueryServiceTest {
     GetFormUseCase getFormUseCase;
     @Mock
     GetFormResponseUseCase getFormResponseUseCase;
+    @Mock
+    ProjectApplicationAccessScopeResolver accessScopeResolver;
     @InjectMocks
     ProjectApplicationQueryService sut;
 
@@ -593,10 +597,29 @@ class ProjectApplicationQueryServiceTest {
     void searchByProject_DRAFT_필터_금지() {
         // given & when & then -- Query record compact constructor 에서 차단된다
         assertThatThrownBy(() -> SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
             .projectId(1L)
             .status(ProjectApplicationStatus.DRAFT)
             .build())
             .isInstanceOf(ProjectDomainException.class);
+    }
+
+    @Test
+    @DisplayName("searchByProject_권한_scope_가_None_이면_빈_리스트_위장")
+    void searchByProject_권한_없음_빈_리스트() {
+        // given
+        SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(REQUESTER_ID).projectId(1L).build();
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+            .willReturn(new ProjectApplicationAccessScope.None());
+
+        // when
+        List<ProjectApplicationCardInfo> result = sut.searchByProject(query);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(loadProjectApplicationPort, never())
+            .searchProjectApplications(any(), any(), any());
     }
 
     @Test
@@ -605,8 +628,10 @@ class ProjectApplicationQueryServiceTest {
         // given
         Project project = createProject(1L, "프로젝트A", null, 99L);
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
-            .projectId(1L).build();
+            .requesterMemberId(REQUESTER_ID).projectId(1L).build();
 
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of());
@@ -631,8 +656,10 @@ class ProjectApplicationQueryServiceTest {
             55L, project, round, 200L, ProjectApplicationStatus.APPROVED);
 
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
-            .projectId(1L).build();
+            .requesterMemberId(REQUESTER_ID).projectId(1L).build();
 
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of(application));
@@ -667,10 +694,13 @@ class ProjectApplicationQueryServiceTest {
             56L, project, round, 201L, ProjectApplicationStatus.SUBMITTED);
 
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
             .projectId(1L)
             .part(ChallengerPart.WEB)
             .build();
 
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(loadProjectApplicationPort.searchProjectApplications(1L, null, null))
             .willReturn(List.of(webApp, androidApp));
@@ -695,11 +725,14 @@ class ProjectApplicationQueryServiceTest {
         // given
         Project project = createProject(1L, "프로젝트A", null, 99L);
         SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
             .projectId(1L)
             .matchingRoundId(7L)
             .status(ProjectApplicationStatus.APPROVED)
             .build();
 
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, 1L))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(loadProjectApplicationPort.searchProjectApplications(
             1L, 7L, ProjectApplicationStatus.APPROVED))

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -923,26 +923,9 @@ class ProjectApplicationQueryServiceTest {
         assertThat(result.filesByFileId().get("f-abc").originalFileName()).isEqualTo("포트폴리오.pdf");
     }
 
-    @Test
-    @DisplayName("getDetail_DRAFT_상태인데_지원자_본인이_아니면_NOT_FOUND_위장")
-    void getDetail_DRAFT_타인_차단() {
-        // given - 지원자 본인은 200L, 호출자는 300L (다른 챌린저/운영진)
-        Project project = createProject(1L, "프로젝트A", null, 99L);
-        ProjectMatchingRound round = createMatchingRound(
-            7L, MatchingType.PLAN_DESIGN, MatchingPhase.FIRST);
-        ProjectApplication application = createApplicationWithFormResponse(
-            55L, project, round, 200L, ProjectApplicationStatus.DRAFT, 123L);
-
-        GetProjectApplicationDetailQuery query = detailQuery(1L, 55L, 300L);
-        given(loadProjectApplicationPort.findByIdWithDetails(55L))
-            .willReturn(Optional.of(application));
-
-        // when & then
-        assertThatThrownBy(() -> sut.getDetail(query))
-            .isInstanceOf(ProjectDomainException.class)
-            .hasFieldOrPropertyWithValue("baseCode", ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
-        verify(getChallengerUseCase, never()).findByMemberIdAndGisuId(any(), any());
-    }
+    // DRAFT 본인 한정 위반(타인 차단) 케이스는 컨트롤러의 @CheckAccess (L2 evaluator.canRead) 가
+    // 처리하므로 service 단위 테스트에서는 다루지 않는다. 해당 분기 검증은
+    // ProjectApplicationPermissionEvaluatorTest 의 READ는_DRAFT_지원서를_PO여도_거부 등에서 보장.
 
     @Test
     @DisplayName("getDetail_DRAFT_상태이지만_지원자_본인_호출이면_정상_조회")


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #842 

## 🚀 작업 내용

ProjectApplicationQueryController 의 3개 API (APPLY-004 / 101 / 102) 에 대해 권한 검증을 적용했습니다.

### APPLY-004 GET /me/applications - 변경 없음
> 변경 사항이 없습니다.
#### 이유
1.  `loadProjectApplicationPort.searchMyApplications(requesterMemberId, gisuId, ...)` 의 첫 인자가
   SQL `WHERE applicant_member_id = :requesterMemberId` 로 그대로 들어가고 있습니다.
2.  `@CurrentMember` 가 사용자의 인증을 이미 보장합니다.
3. 챌린저 자격 분기는 service 가 이미 처리하고 있습니다. description 의 "챌린저가 아니거나 PLAN/ADMIN
  이면 빈 리스트" 는 `resolveMatchingType` 이 empty 를 반환할 때 빈 리스트로 끊는 로직으로
  충족됩니다.
4. `@CheckAccess(PROJECT_APPLICATION, READ)` (resourceId 없이) 을 붙이면 evaluator 의
  resourceId == null -> true 분기로 빠져 무조건 통과하기 때문에 실제로는 no-op 이므로 적용할 필요가 없습니다.

---

###  APPLY-101 GET /{projectId}/applications - L1 (Resolver) 적용
> L1 (Resolver)를 적용하였습니다.
#### 이유
`@CheckAccess` 단건 binary 모델과는 의미가 안 맞습니다 (evaluator 의 `canRead` 는 `applicationId`
  단건 기준이지 `projectId` 가 아니라서, `resourceId="#projectId"` 로 넣으면 엉뚱한 `application` 을
   load 합니다). 그래서 L1를 확장하여 적용했습니다.

#### 변경 사항
> 기존 `resolveForProjectReview` 는 PO/Sub-PM 만 다루어 description 이 요구하는 5종
  호출자(PO/Sub-PM/SUPER_ADMIN/CC/지부장/학교장) 를 못 받았습니다. 따라서 아래처럼 확장하였습니다.

**Resolver** - `ProjectApplicationAccessScopeResolver`
  - 기존 `resolveForProjectReview` -> `resolveForProjectApplicantList` 로 리네임 +
  확장
  - 5종 호출자 모두 `ProjectScoped(projectId)` 통과, 그 외 `None()` 반환
  - 매칭 키:
    - **PO**: `project.productOwnerMemberId == memberId`
    - **Sub-PM**: `loadProjectMemberPort.isActivePlanMember(projectId, memberId)`
    - **SUPER_ADMIN**: `role` 의 `isSuperAdmin()` (기수 무관)
    - **Central Core**: `role.gisuId == project.gisuId AND isAtLeastCentralCore()`
    - **지부장**: `role.gisuId == project.gisuId AND role.organizationId == project.chapterId`
    - **학교 회장**: `
role.gisuId == project.gisuId AND role.organizationId ==
  project.productOwnerSchoolId
` (SCHOOL_PRESIDENT 한정, 부회장 제외)

---

 ### APPLY-102 GET /{projectId}/applications/{applicationId} - L2 (@CheckAccess) 적용
> L2 (@CheckAccess)를 적용하였습니다.

#### 이유
단건 by `applicationId API. evaluator` 의 `canRead` 가 description 의 호출자 룰과 일치합니다. - 지원자 본인 / DRAFT 본인 한정 / SUBMITTED+ 4종 staff (PO/Sub-PM/CC/지부장).


## 💬 리뷰 중점사항

- 현재 코드 기준으로 `APPLY-101 `(단일 프로젝트에 대한 지원자 목록 조회) -> 학교 회장 가능, `APPLY-102`(단건 지원서 상세) -> 학교 회장 불가능인데 이게 맞나요?
- 노션에는 교내 부회장에 대한 언급이 없어서 권한 코드에서 뺐는데 (회장단이 아닌 회장만 가능하도록) 이것도 맞는지 확인 부탁드립니다.

