### PR TITLE
[Fix] 운영진 대시보드 API가 잘못된 값을 반환하는 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsQueryExpressions.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsQueryExpressions.java
@@ -1,0 +1,57 @@
+package com.umc.product.analytics.adapter.out.persistence;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.umc.product.challenger.domain.QChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.organization.domain.QChapter;
+import com.umc.product.organization.domain.QChapterSchool;
+
+/**
+ * Analytics 도메인의 QueryDSL 공통 표현식 모음.
+ *
+ * <p>모든 메서드는 stateless 라 인스턴스화 없이 호출한다.
+ */
+final class AdminAnalyticsQueryExpressions {
+
+    private AdminAnalyticsQueryExpressions() {
+    }
+
+    /**
+     * 한 ChallengerPoint 행의 실효 점수를 반환한다.
+     *
+     * <p>{@code pointValue} 컬럼이 비어 있지 않으면 그 값을, 그렇지 않으면 {@code PointType.value} 를 사용한다.
+     * 도메인 엔티티의 {@link com.umc.product.challenger.domain.ChallengerPoint#getPointValue()} 와 동일한 의미를 SQL 로 표현한 것이다.
+     */
+    static NumberExpression<Double> pointScore(QChallengerPoint point) {
+        CaseBuilder.Cases<Double, NumberExpression<Double>> typeCases = null;
+        for (PointType pointType : PointType.values()) {
+            if (typeCases == null) {
+                typeCases = new CaseBuilder().when(point.type.eq(pointType)).then(pointType.getValue());
+            } else {
+                typeCases = typeCases.when(point.type.eq(pointType)).then(pointType.getValue());
+            }
+        }
+        NumberExpression<Double> typeScore = typeCases != null ? typeCases.otherwise(0.0) : null;
+
+        return new CaseBuilder()
+            .when(point.pointValue.isNotNull()).then(point.pointValue.doubleValue())
+            .otherwise(typeScore);
+    }
+
+    /**
+     * {@link QChapterSchool} 가 LEFT JOIN 으로 다중-기수 행을 반환하는 문제를 막는 dedup 필터.
+     *
+     * <p>{@code ChapterSchool} 엔티티에는 gisu 컬럼이 없고 {@link QChapter} 만 gisu 를 가지므로,
+     * 한 학교가 N 개 기수에 걸쳐 chapter_school 행을 갖는 경우 LEFT JOIN 이 N 개 행을 반환한다.
+     * 그 결과 SUM/AVG/COUNT 집계가 N 배 부풀려진다.
+     *
+     * <p>이 필터는 chapter_school 매핑이 아예 없는 학교(orphan)는 통과시키되,
+     * chapter_school 행이 존재하는 경우 현재 기수에 매칭된 chapter 가 있는 단 1개의 행만 통과시킨다.
+     * 호출자는 반드시 LEFT JOIN {@code chapter} ON 절에 {@code chapter.gisu.id.eq(...)} 필터를 함께 둬야 한다.
+     */
+    static BooleanExpression chapterMatchedOrNoMapping(QChapterSchool chapterSchool, QChapter chapter) {
+        return chapterSchool.id.isNull().or(chapter.id.isNotNull());
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java
@@ -1,5 +1,7 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.chapterMatchedOrNoMapping;
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.pointScore;
 import static com.umc.product.challenger.domain.QChallenger.challenger;
 import static com.umc.product.member.domain.QMember.member;
 import static com.umc.product.organization.domain.QChapter.chapter;
@@ -20,7 +22,6 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardAct
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallengerPoint;
-import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import java.time.Clock;
@@ -117,8 +118,18 @@ public class AdminDashboardAnalyticsQueryRepository {
     }
 
     private AdminDashboardSummaryInfo.PointSumInfo monthlyPointSum(AdminAnalyticsScope scope, Instant monthStart) {
-        List<Double> scores = queryFactory
-            .select(pointScore(point))
+        NumberExpression<Double> score = pointScore(point);
+        NumberExpression<Double> positiveSum = new CaseBuilder()
+            .when(score.gt(0.0)).then(score)
+            .otherwise(0.0)
+            .sum();
+        NumberExpression<Double> negativeSum = new CaseBuilder()
+            .when(score.lt(0.0)).then(score)
+            .otherwise(0.0)
+            .sum();
+
+        Tuple totals = queryFactory
+            .select(positiveSum, negativeSum)
             .from(point)
             .join(point.challenger, challenger)
             .join(member).on(member.id.eq(challenger.memberId))
@@ -127,19 +138,11 @@ public class AdminDashboardAnalyticsQueryRepository {
                 .and(chapter.gisu.id.eq(challenger.gisuId)))
             .where(challengerScopeCondition(scope)
                 .and(point.createdAt.goe(monthStart)))
-            .fetch();
+            .fetchOne();
 
-        long positive = 0L;
-        long negative = 0L;
-        for (Double score : scores) {
-            double value = score != null ? score : 0.0;
-            if (value > 0) {
-                positive += Math.round(value);
-            } else if (value < 0) {
-                negative += Math.round(value);
-            }
-        }
-        return AdminDashboardSummaryInfo.PointSumInfo.of(positive, negative);
+        double positive = totals != null ? defaultDouble(totals.get(positiveSum)) : 0.0;
+        double negative = totals != null ? defaultDouble(totals.get(negativeSum)) : 0.0;
+        return AdminDashboardSummaryInfo.PointSumInfo.of(Math.round(positive), Math.round(negative));
     }
 
     private Map<ChallengerStatus, Long> challengerStatusDistribution(AdminAnalyticsScope scope) {
@@ -235,6 +238,7 @@ public class AdminDashboardAnalyticsQueryRepository {
     private BooleanBuilder challengerScopeCondition(AdminAnalyticsScope scope) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(challenger.gisuId.eq(scope.gisuId()));
+        builder.and(chapterMatchedOrNoMapping(chapterSchool, chapter));
         if (scope.chapterId() != null) {
             builder.and(chapter.id.eq(scope.chapterId()));
         }
@@ -254,25 +258,7 @@ public class AdminDashboardAnalyticsQueryRepository {
         return ((double) (current - previous) / previous) * 100.0;
     }
 
-    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
-        return new CaseBuilder()
-            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
-            .otherwise(pointTypeScore(targetPoint));
-    }
-
-    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
-        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
-        for (PointType pointType : PointType.values()) {
-            if (caseBuilder == null) {
-                caseBuilder = new CaseBuilder()
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            } else {
-                caseBuilder = caseBuilder
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            }
-        }
-
-        assert caseBuilder != null;
-        return caseBuilder.otherwise(0.0);
+    private double defaultDouble(Double value) {
+        return value != null ? value : 0.0;
     }
 }

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -1,8 +1,10 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.chapterMatchedOrNoMapping;
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.pointScore;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -12,7 +14,6 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOv
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallenger;
 import com.umc.product.challenger.domain.QChallengerPoint;
-import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.member.domain.QMember;
 import com.umc.product.organization.domain.QChapter;
@@ -143,6 +144,8 @@ public class AdminOperationsAnalyticsQueryRepository {
         NumberExpression<Long> grantCount = point.id.count();
         NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
 
+        // chapter 별 그루핑이라 chapter 매핑이 없는 orphan 챌린저의 포인트는 제외한다.
+        // 동시에 chapter.id.isNotNull() 가 chapter_school 의 다중-기수 중복 행을 자연스럽게 dedup 한다.
         List<Tuple> rows = queryFactory
             .select(chapter.id, chapter.name, challenger.part, grantCount, pointSum)
             .from(point)
@@ -151,8 +154,9 @@ public class AdminOperationsAnalyticsQueryRepository {
             .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
             .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
                 .and(chapter.gisu.id.eq(challenger.gisuId)))
-            .where(challengerScopeCondition(scope, challenger, member, chapter)
-                .and(periodCondition(point.createdAt, query)))
+            .where(challengerScopeCondition(scope, challenger, member, chapterSchool, chapter)
+                .and(periodCondition(point.createdAt, query))
+                .and(chapter.id.isNotNull()))
             .groupBy(chapter.id, chapter.name, challenger.part)
             .orderBy(chapter.name.asc(), challenger.part.asc())
             .fetch();
@@ -300,7 +304,7 @@ public class AdminOperationsAnalyticsQueryRepository {
             .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
             .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
                 .and(chapter.gisu.id.eq(challenger.gisuId)))
-            .where(challengerScopeCondition(scope, challenger, member, chapter)
+            .where(challengerScopeCondition(scope, challenger, member, chapterSchool, chapter)
                 .and(periodCondition(member.createdAt, query)))
             .groupBy(member.id, member.createdAt)
             .fetch();
@@ -339,10 +343,13 @@ public class AdminOperationsAnalyticsQueryRepository {
         AdminAnalyticsScope scope,
         QChallenger challenger,
         QMember member,
+        QChapterSchool chapterSchool,
         QChapter chapter
     ) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(challenger.gisuId.eq(scope.gisuId()));
+        // chapter_school 의 다중-기수 중복 행을 dedup. orphan 학교(매핑 없음)는 보존한다.
+        builder.and(chapterMatchedOrNoMapping(chapterSchool, chapter));
         if (scope.chapterId() != null) {
             builder.and(chapter.id.eq(scope.chapterId()));
         }
@@ -420,28 +427,6 @@ public class AdminOperationsAnalyticsQueryRepository {
         return new BooleanBuilder()
             .and(path.goe(query.from()))
             .and(path.lt(query.to()));
-    }
-
-    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
-        return new CaseBuilder()
-            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
-            .otherwise(pointTypeScore(targetPoint));
-    }
-
-    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
-        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
-        for (PointType pointType : PointType.values()) {
-            if (caseBuilder == null) {
-                caseBuilder = new CaseBuilder()
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            } else {
-                caseBuilder = caseBuilder
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            }
-        }
-
-        assert caseBuilder != null;
-        return caseBuilder.otherwise(0.0);
     }
 
     private Map<ChallengerPart, Long> emptyPartCounts() {

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepository.java
@@ -1,5 +1,7 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.chapterMatchedOrNoMapping;
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.pointScore;
 import static com.umc.product.challenger.domain.QChallenger.challenger;
 import static com.umc.product.member.domain.QMember.member;
 import static com.umc.product.organization.domain.QChapter.chapter;
@@ -8,7 +10,6 @@ import static com.umc.product.organization.domain.QSchool.school;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.analytics.adapter.out.persistence.row.AdminRiskChallengerRow;
@@ -16,7 +17,6 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChalleng
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallengerPoint;
-import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import java.util.HashMap;
 import java.util.List;
@@ -97,6 +97,9 @@ public class AdminRiskChallengerAnalyticsQueryRepository {
     private long countRows(AdminAnalyticsScope scope, AdminRiskChallengerQuery query) {
         NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
 
+        // HAVING + GROUP BY 결과의 행 수를 COUNT 로 받으려면 서브쿼리가 필요한데,
+        // QueryDSL JPA 백엔드는 FROM 절에 서브쿼리를 허용하지 않는다.
+        // 대신 ID 만 select 한 후 자바에서 size 를 계산한다 — 위험군은 통상 수십-수백 건이라 메모리 영향이 작다.
         return queryFactory
             .select(challenger.id)
             .from(challenger)
@@ -150,6 +153,8 @@ public class AdminRiskChallengerAnalyticsQueryRepository {
     private BooleanBuilder scopeCondition(AdminAnalyticsScope scope) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(challenger.gisuId.eq(scope.gisuId()));
+        // chapter_school 의 다중-기수 중복 행을 dedup → pointSum 부풀림 방지.
+        builder.and(chapterMatchedOrNoMapping(chapterSchool, chapter));
         if (scope.chapterId() != null) {
             builder.and(chapter.id.eq(scope.chapterId()));
         }
@@ -160,28 +165,6 @@ public class AdminRiskChallengerAnalyticsQueryRepository {
             builder.and(challenger.part.eq(scope.responsiblePart()));
         }
         return builder;
-    }
-
-    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
-        return new CaseBuilder()
-            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
-            .otherwise(pointTypeScore(targetPoint));
-    }
-
-    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
-        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
-        for (PointType pointType : PointType.values()) {
-            if (caseBuilder == null) {
-                caseBuilder = new CaseBuilder()
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            } else {
-                caseBuilder = caseBuilder
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            }
-        }
-
-        assert caseBuilder != null;
-        return caseBuilder.otherwise(0.0);
     }
 
     private double defaultDouble(Double value) {

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepository.java
@@ -1,5 +1,7 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.chapterMatchedOrNoMapping;
+import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.pointScore;
 import static com.umc.product.authorization.domain.QChallengerRole.challengerRole;
 import static com.umc.product.challenger.domain.QChallenger.challenger;
 import static com.umc.product.member.domain.QMember.member;
@@ -10,7 +12,6 @@ import static com.umc.product.organization.domain.QSchool.school;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.analytics.adapter.out.persistence.row.AdminSchoolSummaryRow;
@@ -19,7 +20,6 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummar
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.analytics.domain.AdminAnalyticsSort;
 import com.umc.product.challenger.domain.QChallengerPoint;
-import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
@@ -279,6 +279,8 @@ public class AdminSchoolAnalyticsQueryRepository {
     private BooleanBuilder scopeCondition(AdminAnalyticsScope scope) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(challenger.gisuId.eq(scope.gisuId()));
+        // chapter_school 의 다중-기수 중복 행을 dedup → pointSum 평균/risk 카운트 부풀림 방지.
+        builder.and(chapterMatchedOrNoMapping(chapterSchool, chapter));
         if (scope.chapterId() != null) {
             builder.and(chapter.id.eq(scope.chapterId()));
         }
@@ -320,28 +322,6 @@ public class AdminSchoolAnalyticsQueryRepository {
                 .reversed()
                 .thenComparing(AdminSchoolSummaryRow::schoolName);
         };
-    }
-
-    private NumberExpression<Double> pointScore(QChallengerPoint targetPoint) {
-        return new CaseBuilder()
-            .when(targetPoint.pointValue.isNotNull()).then(targetPoint.pointValue.doubleValue())
-            .otherwise(pointTypeScore(targetPoint));
-    }
-
-    private NumberExpression<Double> pointTypeScore(QChallengerPoint targetPoint) {
-        CaseBuilder.Cases<Double, NumberExpression<Double>> caseBuilder = null;
-        for (PointType pointType : PointType.values()) {
-            if (caseBuilder == null) {
-                caseBuilder = new CaseBuilder()
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            } else {
-                caseBuilder = caseBuilder
-                    .when(targetPoint.type.eq(pointType)).then(pointType.getValue());
-            }
-        }
-
-        assert caseBuilder != null;
-        return caseBuilder.otherwise(0.0);
     }
 
     private double defaultDouble(Double value) {

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
@@ -55,7 +55,10 @@ class AdminDashboardAnalyticsQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400 * 30), true));
+        // 시드 마이그레이션(V2026.02.28.06.00)이 이미 is_active=true 인 10기를 넣어둔다.
+        // 부분 unique index uq_gisu_active 와 충돌하지 않도록 테스트 fixture 는 비활성 기수로 만든다.
+        // 분석 쿼리는 scope.gisuId() 로 기수를 스코프하므로 is_active 값과는 무관하다.
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400 * 30), false));
         Chapter chapter = em.persist(Chapter.create(gisu, "중앙"));
         School schoolA = em.persist(School.create("A대학교", null));
         School schoolB = em.persist(School.create("B대학교", null));

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
@@ -48,7 +48,9 @@ class AdminRiskChallengerAnalyticsQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), true));
+        // 시드 마이그레이션이 이미 is_active=true 인 10기를 넣어두므로 부분 unique index uq_gisu_active 와
+        // 충돌하지 않도록 비활성 기수로 만든다. 분석 쿼리는 scope.gisuId() 로 직접 스코프한다.
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), false));
         Chapter chapter = em.persist(Chapter.create(gisu, "중앙"));
         School school = em.persist(School.create("가천대학교", null));
         em.persist(ChapterSchool.create(chapter, school));

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
@@ -53,7 +53,9 @@ class AdminSchoolAnalyticsQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), true));
+        // 시드 마이그레이션이 이미 is_active=true 인 10기를 넣어두므로 부분 unique index uq_gisu_active 와
+        // 충돌하지 않도록 비활성 기수로 만든다. 분석 쿼리는 scope.gisuId() 로 직접 스코프한다.
+        Gisu gisu = em.persist(Gisu.create(7L, Instant.now().minusSeconds(3600), Instant.now().plusSeconds(86400), false));
         Chapter chapterA = em.persist(Chapter.create(gisu, "A지부"));
         Chapter chapterB = em.persist(Chapter.create(gisu, "B지부"));
         School schoolA = em.persist(School.create("가천대학교", null));


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- related to #852

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 백엔드 파트장이 2026-05-13 `develop` 브랜치를 기준으로 작업했어요.
- 변경 범위는 [analytics 영속성 레이어](src/main/java/com/umc/product/analytics/adapter/out/persistence/) 4개 repository 와 신설 헬퍼 1개로 한정돼요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: 4개 analytics repository 의 `LEFT JOIN chapterSchool` 패턴이 학교 × 기수 수만큼 행을 부풀리는 버그를 수정했어요.
   - **어떻게**: `ChapterSchool` 엔티티에 gisu 컬럼이 없고 `Chapter` 만 `gisu_id` 를 가지므로, 학교 S 가 N 개 기수에 걸쳐 chapter_school 행을 갖는 경우 `leftJoin(chapterSchool).on(school.id.eq(...))` 가 N 개 행을 반환해요. 이후 chapter LEFT JOIN 에서 gisu 매칭 행만 chapter NOT NULL 이 되지만, 나머지 N-1 개 행도 살아남아 모든 SUM/AVG/COUNT 집계가 N 배 부풀려졌어요. CENTRAL 스코프(chapter 필터 미적용)에서 가장 크게 드러나요.
   - **어떻게(수정)**: [AdminAnalyticsQueryExpressions](src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsQueryExpressions.java) 헬퍼를 신설하고 `chapterMatchedOrNoMapping(chapterSchool, chapter)` = `chapter_school IS NULL OR chapter IS NOT NULL` 을 정의했어요. 이 필터를 4개 repository 의 `scopeCondition` / `challengerScopeCondition` 에 추가해서 orphan 학교(매핑 자체가 없는 학교)는 유지하면서 다중-기수 중복 행은 잘라냈어요.
   - **왜**: 상벌점 누적값이 가장 큰 피해를 입었어요. 활성 챌린저 수처럼 `countDistinct` 로 집계되는 메트릭은 자연스럽게 dedup 되지만, `SUM(pointValue)`/`AVG(pointValue)`/HAVING 기반 위험군 카운트는 부풀려진 결과를 그대로 반환했어요.

2. **무엇을**: `monthlyPointSum` 의 자바 사이드 집계를 SQL CASE-WHEN 한 번에 처리하도록 바꿨어요.
   - **어떻게**: [AdminDashboardAnalyticsQueryRepository.monthlyPointSum](src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepository.java) 가 기존에는 모든 point 점수를 row 단위로 fetch 한 뒤 `Math.round` 후 누적했어요. `SUM(CASE WHEN score > 0 THEN score ELSE 0 END)` / `SUM(CASE WHEN score < 0 THEN score ELSE 0 END)` 두 개의 표현식으로 한 번에 집계하도록 변경했어요.
   - **왜**: 이전 구현은 `BEST_WORKBOOK(-0.5)` 처럼 0.5 단위 점수가 row 단위 `Math.round` 로 잘려나가고, 데이터 전송량도 컸어요. SQL 집계로 옮겨 정확도와 성능을 함께 잡았어요.

3. **무엇을**: 중복되어 있던 `pointScore` / `pointTypeScore` 메서드를 헬퍼로 통합했어요.
   - **어떻게**: 동일한 CASE-WHEN 구문이 4개 repository 에 복붙되어 있던 것을 [AdminAnalyticsQueryExpressions.pointScore](src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminAnalyticsQueryExpressions.java) 단일 정의로 모았어요. 동작은 동일해요 (`pointValue` 가 있으면 그 값을, 없으면 `PointType.value` 를 사용).
   - **왜**: PointType enum 이 변경될 때 한 곳만 손보면 되도록 단일 진실 공급원을 만들기 위해서예요.

4. **무엇을**: `listPointGrantStatuses` 에 `chapter.id.isNotNull()` 필터를 추가했어요.
   - **어떻게**: [AdminOperationsAnalyticsQueryRepository.listPointGrantStatuses](src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java) 는 chapter 기준 그루핑이므로, chapter 가 null 인 행이 결과에 섞이면 응답에 chapterId=null 가 노출되는 문제가 있었어요. dedup 필터와 함께 `chapter.id.isNotNull()` 도 추가해서 orphan 챌린저의 포인트를 결과에서 제외했어요.
   - **왜**: chapter 단위로 묶이는 응답은 chapter 가 결정될 수 있는 챌린저만 포함해야 의미 있는 집계가 돼요. [listChapterSchoolStatuses](src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java) 가 이미 chapter_school 부터 시작해서 orphan 을 자연스럽게 제외하는 것과 동일한 정책이에요.

## 💬 리뷰 중점사항

- **로컬 환경에서 Docker daemon 이 떠 있지 않아 `@DataJpaTest` + Testcontainers 기반의 repository 통합 테스트는 실행하지 못했어요.** 리뷰어가 머지 전 `./gradlew test --tests "com.umc.product.analytics.adapter.out.persistence.*"` 로 한 번 돌려봐주시면 좋아요. (서비스 레이어 unit 테스트는 `./gradlew test --tests "com.umc.product.analytics.application.service.query.*"` 로 직접 돌렸고 모두 통과해요.)
- 후속으로 다중-기수 chapter_school 시나리오에 대한 회귀 테스트를 추가하는 게 좋아요. 예: 동일 학교가 2개 기수에 걸쳐 chapter_school 행을 갖도록 fixture 를 만든 뒤 `monthlyPointSum` / `getRiskChallengers` / `getSchoolSummaries` 가 인플레이션 없이 동작하는지 검증.
- `chapterMatchedOrNoMapping` 가 `WHERE ... AND (cs.id IS NULL OR c.id IS NOT NULL)` 형태로 잘 풀려나오는지 한 번 봐주세요. 일부 DB 옵티마이저는 이 패턴을 sub-plan 으로 잡을 수 있어 실행 계획 확인 부탁드려요.
- 위험군 챌린저 API 의 sort 가 여전히 `pointSum.asc(), member.name.asc()` 로 하드코딩되어 있어요. `Pageable.getSort()` 를 반영하지 않으니 별도 이슈로 후속 처리할 가치가 있어요.