### PR TITLE
[Feat] 일정 삭제 API 구현

### DIFF
--- a/src/main/java/com/umc/product/authorization/domain/PermissionType.java
+++ b/src/main/java/com/umc/product/authorization/domain/PermissionType.java
@@ -9,6 +9,8 @@ package com.umc.product.authorization.domain;
  * <p>
  * - DELETE: 삭제 권한
  * <p>
+ * - FORCE_DELETE: 일반 삭제 제약 조건을 우회하는 강제 삭제 권한
+ * <p>
  * - APPROVE: 승인 권한 (출석, 워크북 등)
  * <p>
  * - CHECK: 확인 권한 (공지사항 조회현황 확인)
@@ -19,6 +21,7 @@ public enum PermissionType {
     // TODO: 생성과 수정은 권한을 분리할 것 (EDIT 권한을 추가하며, 추후 Evaluator에 반영할 것)
     EDIT,       // 수정
     DELETE,     // 삭제
+    FORCE_DELETE, // 강제 삭제 (제약 조건 우회)
     APPROVE,    // 승인 (출석, 워크북 등)
     CHECK,      // 확인 (공지사항 조회현황 확인)
     MANAGE,      // 관리 (운영진 전용)

--- a/src/main/java/com/umc/product/authorization/domain/ResourceType.java
+++ b/src/main/java/com/umc/product/authorization/domain/ResourceType.java
@@ -16,7 +16,8 @@ public enum ResourceType {
 
     // Schedule 도메인
     SCHEDULE("schedule", "일정",
-        Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT, PermissionType.DELETE)),
+        Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.EDIT,
+            PermissionType.DELETE, PermissionType.FORCE_DELETE)),
     ATTENDANCE("attendance", "출석",
         Set.of(PermissionType.READ, PermissionType.WRITE, PermissionType.APPROVE)),
 

--- a/src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java
@@ -13,6 +13,7 @@ import com.umc.product.schedule.adapter.in.web.v2.dto.request.ScheduleAttendance
 import com.umc.product.schedule.adapter.in.web.v2.dto.response.ScheduleParticipantAttendanceInfoResponse;
 import com.umc.product.schedule.application.port.in.command.CreateScheduleParticipantUseCase;
 import com.umc.product.schedule.application.port.in.command.CreateScheduleUseCase;
+import com.umc.product.schedule.application.port.in.command.DeleteScheduleUseCase;
 import com.umc.product.schedule.application.port.in.command.UpdateScheduleParticipantUseCase;
 import com.umc.product.schedule.application.port.in.command.UpdateScheduleUseCase;
 import com.umc.product.schedule.application.port.in.command.dto.CreateScheduleCommand;
@@ -29,6 +30,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +46,7 @@ public class ScheduleCommandV2Controller {
 
     private final CreateScheduleUseCase createScheduleUseCase;
     private final UpdateScheduleUseCase updateScheduleUseCase;
+    private final DeleteScheduleUseCase deleteScheduleUseCase;
 
     private final CreateScheduleParticipantUseCase createScheduleParticipantAttendanceUseCase;
     private final UpdateScheduleParticipantUseCase updateScheduleParticipantUseCase;
@@ -172,6 +175,81 @@ public class ScheduleCommandV2Controller {
         EditScheduleCommand command = request.toCommand(scheduleId, memberPrincipal.getMemberId());
 
         return updateScheduleUseCase.update(command);
+    }
+
+    @CheckAccess(
+        resourceType = ResourceType.SCHEDULE,
+        resourceId = "#scheduleId",
+        permission = PermissionType.DELETE,
+        message = "'생성자 본인' 또는 '해당 일정 기수의 최고 운영 관리자'만 가능합니다."
+    )
+    @Operation(summary = "[SCHEDULE-C006] 일정 삭제", description = """
+        일정을 삭제합니다.
+
+        - 일정에 연결된 모든 참여자(ScheduleParticipant) 정보도 함께 삭제됩니다.
+        - 일정 참여자 중 출석 기록(`attendance.status`)이 존재하는 사용자가 한 명이라도 있는 경우 삭제할 수 없습니다.
+          (이 경우, 강제 삭제 API를 사용해야 합니다.)
+
+        삭제 가능 권한:
+        - 일정 생성자 본인
+        - 해당 일정이 진행되는 기수의 최고 운영 관리자(`SUPER_ADMIN`)
+        """
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = """
+            SCHEDULE-0033 : 출석 기록이 존재하는 일정은 삭제할 수 없습니다.
+            """,
+            content = @Content
+        ),
+        @ApiResponse(responseCode = "403", description = """
+            AUTHORIZATION-0002 : 해당 리소스에 접근할 권한이 없습니다.
+            """,
+            content = @Content
+        ),
+        @ApiResponse(responseCode = "404", description = """
+            SCHEDULE-0009 : 일정을 찾을 수 없습니다.
+            """,
+            content = @Content
+        )
+    })
+    @DeleteMapping("/{scheduleId}")
+    public void delete(@PathVariable Long scheduleId) {
+        deleteScheduleUseCase.delete(scheduleId);
+    }
+
+    @CheckAccess(
+        resourceType = ResourceType.SCHEDULE,
+        resourceId = "#scheduleId",
+        permission = PermissionType.FORCE_DELETE,
+        message = "'해당 일정 기수의 최고 운영 관리자'만 가능합니다."
+    )
+    @Operation(summary = "[SCHEDULE-C007] 일정 강제 삭제", description = """
+        출석 기록 존재 여부와 관계 없이 일정을 강제로 삭제합니다.
+
+        - 일정에 연결된 모든 참여자(ScheduleParticipant) 정보도 함께 삭제됩니다.
+        - 출석 기록이 있는 일정 또한 삭제 가능합니다.
+
+        강제 삭제 가능 권한:
+        - 해당 일정이 진행되는 기수의 최고 운영 관리자(`SUPER_ADMIN`)
+        """
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "403", description = """
+            AUTHORIZATION-0002 : 해당 리소스에 접근할 권한이 없습니다.
+            """,
+            content = @Content
+        ),
+        @ApiResponse(responseCode = "404", description = """
+            SCHEDULE-0009 : 일정을 찾을 수 없습니다.
+            """,
+            content = @Content
+        )
+    })
+    @DeleteMapping("/{scheduleId}/force")
+    public void forceDelete(@PathVariable Long scheduleId) {
+        deleteScheduleUseCase.forceDelete(scheduleId);
     }
 
     // ========================= 출석 관련 =========================

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantPersistenceAdapter.java
@@ -76,4 +76,9 @@ public class ScheduleParticipantPersistenceAdapter implements
     public Set<Long> findScheduleIdsByMemberId(Long memberId) {
         return scheduleParticipantQueryRepository.findScheduleIdsByMemberId(memberId);
     }
+
+    @Override
+    public boolean existsAttendanceStatusByScheduleId(Long scheduleId) {
+        return scheduleParticipantQueryRepository.existsAttendanceStatusByScheduleId(scheduleId);
+    }
 }

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantPersistenceAdapter.java
@@ -39,6 +39,11 @@ public class ScheduleParticipantPersistenceAdapter implements
         scheduleParticipantJpaRepository.deleteAll(participants);
     }
 
+    @Override
+    public void deleteByScheduleId(Long scheduleId) {
+        scheduleParticipantQueryRepository.deleteByScheduleId(scheduleId);
+    }
+
     // ======== LoadScheduleParticipantPort =======
     @Override
     public List<ScheduleParticipant> findAllByScheduleId(Long scheduleId) {

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantQueryRepository.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantQueryRepository.java
@@ -142,4 +142,16 @@ public class ScheduleParticipantQueryRepository {
             .fetchFirst();
         return fetchOne != null;
     }
+
+    /**
+     * 특정 일정에 속한 모든 ScheduleParticipant를 단일 DELETE 쿼리로 벌크 삭제
+     *
+     * @return 삭제된 행의 개수
+     */
+    public long deleteByScheduleId(Long scheduleId) {
+        return queryFactory
+            .delete(scheduleParticipant)
+            .where(scheduleParticipant.schedule.id.eq(scheduleId))
+            .execute();
+    }
 }

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantQueryRepository.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleParticipantQueryRepository.java
@@ -127,4 +127,19 @@ public class ScheduleParticipantQueryRepository {
                 .fetch()
         );
     }
+
+    /**
+     * 일정에 속한 참여자 중 attendance.status가 not null인 기록이 하나라도 존재하는지 확인
+     */
+    public boolean existsAttendanceStatusByScheduleId(Long scheduleId) {
+        Integer fetchOne = queryFactory
+            .selectOne()
+            .from(scheduleParticipant)
+            .where(
+                scheduleParticipant.schedule.id.eq(scheduleId),
+                scheduleParticipant.attendance.status.isNotNull()
+            )
+            .fetchFirst();
+        return fetchOne != null;
+    }
 }

--- a/src/main/java/com/umc/product/schedule/application/port/in/command/DeleteScheduleUseCase.java
+++ b/src/main/java/com/umc/product/schedule/application/port/in/command/DeleteScheduleUseCase.java
@@ -1,0 +1,20 @@
+package com.umc.product.schedule.application.port.in.command;
+
+public interface DeleteScheduleUseCase {
+
+    /**
+     * 일정을 삭제합니다.
+     * <p>
+     * 일정에 연결된 ScheduleParticipant 중 attendance.status가 하나라도 존재한다면 삭제가 불가능하며, 예외가 발생합니다.
+     * <p>
+     * 일정에 연결된 모든 ScheduleParticipant도 함께 삭제됩니다.
+     */
+    void delete(Long scheduleId);
+
+    /**
+     * 일정을 강제로 삭제합니다.
+     * <p>
+     * 출석 기록 존재 여부와 관계 없이 삭제 가능하며, 일정에 연결된 모든 ScheduleParticipant도 함께 삭제됩니다.
+     */
+    void forceDelete(Long scheduleId);
+}

--- a/src/main/java/com/umc/product/schedule/application/port/out/DeleteScheduleParticipantPort.java
+++ b/src/main/java/com/umc/product/schedule/application/port/out/DeleteScheduleParticipantPort.java
@@ -6,4 +6,9 @@ import java.util.List;
 public interface DeleteScheduleParticipantPort {
 
     void deleteAll(List<ScheduleParticipant> participants);
+
+    /**
+     * 특정 일정에 속한 모든 ScheduleParticipant를 단일 벌크 쿼리로 삭제합니다.
+     */
+    void deleteByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/umc/product/schedule/application/port/out/LoadScheduleParticipantPort.java
+++ b/src/main/java/com/umc/product/schedule/application/port/out/LoadScheduleParticipantPort.java
@@ -32,4 +32,9 @@ public interface LoadScheduleParticipantPort {
      * @return 일정 ID 목록
      */
     Set<Long> findScheduleIdsByMemberId(Long memberId);
+
+    /**
+     * 일정에 속한 참여자 중 attendance.status가 존재(not null)하는 기록이 하나라도 있는지 확인합니다.
+     */
+    boolean existsAttendanceStatusByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
@@ -10,11 +10,13 @@ import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import com.umc.product.schedule.application.port.in.command.CreateScheduleUseCase;
+import com.umc.product.schedule.application.port.in.command.DeleteScheduleUseCase;
 import com.umc.product.schedule.application.port.in.command.UpdateScheduleUseCase;
 import com.umc.product.schedule.application.port.in.command.dto.CreateScheduleCommand;
 import com.umc.product.schedule.application.port.in.command.dto.EditScheduleCommand;
 import com.umc.product.schedule.application.port.in.query.dto.ScheduleCapabilitiesInfo;
 import com.umc.product.schedule.application.port.out.DeleteScheduleParticipantPort;
+import com.umc.product.schedule.application.port.out.DeleteSchedulePort;
 import com.umc.product.schedule.application.port.out.LoadScheduleParticipantPort;
 import com.umc.product.schedule.application.port.out.LoadSchedulePort;
 import com.umc.product.schedule.application.port.out.SaveScheduleParticipantPort;
@@ -40,10 +42,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ScheduleCommandService implements CreateScheduleUseCase, UpdateScheduleUseCase {
+public class ScheduleCommandService implements CreateScheduleUseCase, UpdateScheduleUseCase, DeleteScheduleUseCase {
 
     private final SaveSchedulePort saveSchedulePort;
     private final LoadSchedulePort loadSchedulePort;
+    private final DeleteSchedulePort deleteSchedulePort;
 
     private final SaveScheduleParticipantPort saveScheduleParticipantPort;
     private final DeleteScheduleParticipantPort deleteScheduleParticipantPort;
@@ -208,7 +211,55 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
         return schedule.getId();
     }
 
+    // 일정 삭제
+    // 출석 기록이 존재하면 삭제 불가
+    @Audited(
+        domain = Domain.SCHEDULE,
+        action = AuditAction.DELETE,
+        targetType = "Schedule",
+        targetId = "#scheduleId",
+        description = "'일정이 삭제되었습니다.'"
+    )
+    @Override
+    public void delete(Long scheduleId) {
+        Schedule schedule = loadSchedulePort.findById(scheduleId)
+            .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+        if (loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(scheduleId)) {
+            throw new ScheduleDomainException(ScheduleErrorCode.SCHEDULE_HAS_ATTENDANCE_RECORD);
+        }
+
+        deleteScheduleWithParticipants(schedule);
+    }
+
+    // 일정 강제 삭제
+    // 출석 기록이 존재해도 삭제 가능
+    @Audited(
+        domain = Domain.SCHEDULE,
+        action = AuditAction.DELETE,
+        targetType = "Schedule",
+        targetId = "#scheduleId",
+        description = "'일정이 강제 삭제되었습니다.'"
+    )
+    @Override
+    public void forceDelete(Long scheduleId) {
+        Schedule schedule = loadSchedulePort.findById(scheduleId)
+            .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+        deleteScheduleWithParticipants(schedule);
+    }
+
     // ============================== Helper Methods ==============================
+
+    // 일정에 연결된 모든 ScheduleParticipant 및 Schedule을 삭제
+    private void deleteScheduleWithParticipants(Schedule schedule) {
+        List<ScheduleParticipant> participants = loadScheduleParticipantPort.findAllByScheduleId(schedule.getId());
+        if (!participants.isEmpty()) {
+            deleteScheduleParticipantPort.deleteAll(participants);
+        }
+        deleteSchedulePort.delete(schedule.getId());
+    }
+
 
     // command로부터 policy 생성
     private AttendancePolicy createPolicyFromCommand(EditScheduleCommand command, Schedule schedule) {

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
@@ -252,11 +252,9 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
     // ============================== Helper Methods ==============================
 
     // 일정에 연결된 모든 ScheduleParticipant 및 Schedule을 삭제
+    // 참여자는 단일 벌크 DELETE 쿼리로 삭제하여, 대규모 일정에서도 메모리/네트워크 부하를 최소화
     private void deleteScheduleWithParticipants(Schedule schedule) {
-        List<ScheduleParticipant> participants = loadScheduleParticipantPort.findAllByScheduleId(schedule.getId());
-        if (!participants.isEmpty()) {
-            deleteScheduleParticipantPort.deleteAll(participants);
-        }
+        deleteScheduleParticipantPort.deleteByScheduleId(schedule.getId());
         deleteSchedulePort.delete(schedule.getId());
     }
 

--- a/src/main/java/com/umc/product/schedule/application/service/evaluator/SchedulePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/schedule/application/service/evaluator/SchedulePermissionEvaluator.java
@@ -54,11 +54,7 @@ public class SchedulePermissionEvaluator implements ResourcePermissionEvaluator 
                 .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
             // 해당 일정의 기수에서 최고 운영 관리자 권한이 있다면 즉시 통과
-            Long targetGisuId = getGisuUseCase.getGisuByDate(schedule.getStartsAt()).gisuId();
-            boolean isAdmin = subjectAttributes.roleAttributes().stream()
-                .filter(role -> role.gisuId().equals(targetGisuId))
-                .anyMatch(role -> role.roleType().isSuperAdmin());
-            if (isAdmin) {
+            if (isSuperAdminOfScheduleGisu(subjectAttributes, schedule)) {
                 return true;
             }
 
@@ -66,6 +62,27 @@ public class SchedulePermissionEvaluator implements ResourcePermissionEvaluator 
             return schedule.getAuthorMemberId().equals(memberId);
         }
 
+        // FORCE_DELETE (일정 강제 삭제)
+        // '해당 일정 기수의 최고 운영 관리자'만 가능 (생성자 본인은 불가)
+        if (permission == PermissionType.FORCE_DELETE) {
+
+            if (resourcePermission.resourceId() == null) {
+                return false;
+            }
+
+            Schedule schedule = loadSchedulePort.findById(resourcePermission.getResourceIdAsLong())
+                .orElseThrow(() -> new ScheduleDomainException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+            return isSuperAdminOfScheduleGisu(subjectAttributes, schedule);
+        }
+
         return false;
+    }
+
+    private boolean isSuperAdminOfScheduleGisu(SubjectAttributes subjectAttributes, Schedule schedule) {
+        Long targetGisuId = getGisuUseCase.getGisuByDate(schedule.getStartsAt()).gisuId();
+        return subjectAttributes.roleAttributes().stream()
+            .filter(role -> role.gisuId().equals(targetGisuId))
+            .anyMatch(role -> role.roleType().isSuperAdmin());
     }
 }

--- a/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/umc/product/schedule/domain/exception/ScheduleErrorCode.java
@@ -63,6 +63,9 @@ public enum ScheduleErrorCode implements BaseCode {
 
     INVALID_MEMBER_INVITE(HttpStatus.BAD_REQUEST, "SCHEDULE-0032", "초대하려는 참여자에 유효하지 않은 사용자가 포함되어 있습니다."),
 
+    SCHEDULE_HAS_ATTENDANCE_RECORD(HttpStatus.BAD_REQUEST, "SCHEDULE-0033",
+        "출석 기록이 존재하는 일정은 삭제할 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/umc/product/schedule/application/service/command/ScheduleCommandServiceDeleteTest.java
+++ b/src/test/java/com/umc/product/schedule/application/service/command/ScheduleCommandServiceDeleteTest.java
@@ -1,0 +1,224 @@
+package com.umc.product.schedule.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.schedule.application.port.out.DeleteScheduleParticipantPort;
+import com.umc.product.schedule.application.port.out.DeleteSchedulePort;
+import com.umc.product.schedule.application.port.out.LoadScheduleParticipantPort;
+import com.umc.product.schedule.application.port.out.LoadSchedulePort;
+import com.umc.product.schedule.application.port.out.SaveScheduleParticipantPort;
+import com.umc.product.schedule.application.port.out.SaveSchedulePort;
+import com.umc.product.schedule.application.service.query.ScheduleCapabilitiesService;
+import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.ScheduleParticipant;
+import com.umc.product.schedule.domain.exception.ScheduleDomainException;
+import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScheduleCommandService 일정 삭제")
+class ScheduleCommandServiceDeleteTest {
+
+    private static final Long SCHEDULE_ID = 100L;
+    @Mock
+    SaveSchedulePort saveSchedulePort;
+    @Mock
+    LoadSchedulePort loadSchedulePort;
+    @Mock
+    DeleteSchedulePort deleteSchedulePort;
+    @Mock
+    SaveScheduleParticipantPort saveScheduleParticipantPort;
+    @Mock
+    DeleteScheduleParticipantPort deleteScheduleParticipantPort;
+    @Mock
+    LoadScheduleParticipantPort loadScheduleParticipantPort;
+    @Mock
+    ScheduleCapabilitiesService capabilitiesService;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+    @InjectMocks
+    ScheduleCommandService sut;
+
+    private Schedule scheduleStub() {
+        Schedule schedule = new Schedule() {
+        };
+        ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
+        ReflectionTestUtils.setField(schedule, "authorMemberId", 10L);
+        return schedule;
+    }
+
+    private ScheduleParticipant participantStub(Long memberId) {
+        ScheduleParticipant participant = new ScheduleParticipant() {
+        };
+        ReflectionTestUtils.setField(participant, "memberId", memberId);
+        return participant;
+    }
+
+    @Nested
+    @DisplayName("delete - 일반 삭제")
+    class delete {
+
+        @Test
+        @DisplayName("일정과 모든 참여자를 함께 삭제한다")
+        void 일정과_모든_참여자를_함께_삭제한다() {
+            // given
+            Schedule schedule = scheduleStub();
+            List<ScheduleParticipant> participants = List.of(
+                participantStub(1L),
+                participantStub(2L)
+            );
+
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+            given(loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(SCHEDULE_ID))
+                .willReturn(false);
+            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
+                .willReturn(participants);
+
+            // when
+            sut.delete(SCHEDULE_ID);
+
+            // then
+            then(deleteScheduleParticipantPort).should().deleteAll(participants);
+            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
+        }
+
+        @Test
+        @DisplayName("참여자가 없는 일정도 정상 삭제된다")
+        void 참여자가_없는_일정도_정상_삭제된다() {
+            // given
+            Schedule schedule = scheduleStub();
+
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+            given(loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(SCHEDULE_ID))
+                .willReturn(false);
+            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
+                .willReturn(List.of());
+
+            // when
+            sut.delete(SCHEDULE_ID);
+
+            // then
+            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
+        }
+
+        @Test
+        @DisplayName("출석 기록이 존재하면 SCHEDULE-0033 예외가 발생한다")
+        void 출석_기록이_존재하면_삭제_불가() {
+            // given
+            Schedule schedule = scheduleStub();
+
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+            given(loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(SCHEDULE_ID))
+                .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> sut.delete(SCHEDULE_ID))
+                .isInstanceOf(ScheduleDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ScheduleErrorCode.SCHEDULE_HAS_ATTENDANCE_RECORD);
+
+            then(deleteSchedulePort).should(never()).delete(anyLong());
+            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 일정 삭제 시 SCHEDULE_NOT_FOUND 예외가 발생한다")
+        void 존재하지_않는_일정_삭제_시_예외() {
+            // given
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.delete(SCHEDULE_ID))
+                .isInstanceOf(ScheduleDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ScheduleErrorCode.SCHEDULE_NOT_FOUND);
+
+            then(deleteSchedulePort).should(never()).delete(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("forceDelete - 강제 삭제")
+    class forceDelete {
+
+        @Test
+        @DisplayName("출석 기록 존재 여부와 무관하게 일정과 참여자를 함께 삭제한다")
+        void 출석_기록_존재_여부와_무관하게_삭제된다() {
+            // given
+            Schedule schedule = scheduleStub();
+            List<ScheduleParticipant> participants = List.of(
+                participantStub(1L),
+                participantStub(2L)
+            );
+
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
+                .willReturn(participants);
+
+            // when
+            sut.forceDelete(SCHEDULE_ID);
+
+            // then
+            then(loadScheduleParticipantPort).should(never())
+                .existsAttendanceStatusByScheduleId(any());
+            then(deleteScheduleParticipantPort).should().deleteAll(participants);
+            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
+        }
+
+        @Test
+        @DisplayName("참여자가 없으면 일정만 삭제된다")
+        void 참여자가_없으면_일정만_삭제된다() {
+            // given
+            Schedule schedule = scheduleStub();
+
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
+                .willReturn(List.of());
+
+            // when
+            sut.forceDelete(SCHEDULE_ID);
+
+            // then
+            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 일정 강제 삭제 시 SCHEDULE_NOT_FOUND 예외가 발생한다")
+        void 존재하지_않는_일정_강제_삭제_시_예외() {
+            // given
+            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sut.forceDelete(SCHEDULE_ID))
+                .isInstanceOf(ScheduleDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ScheduleErrorCode.SCHEDULE_NOT_FOUND);
+
+            then(deleteSchedulePort).should(never()).delete(anyLong());
+        }
+    }
+}

--- a/src/test/java/com/umc/product/schedule/application/service/command/ScheduleCommandServiceDeleteTest.java
+++ b/src/test/java/com/umc/product/schedule/application/service/command/ScheduleCommandServiceDeleteTest.java
@@ -2,7 +2,6 @@ package com.umc.product.schedule.application.service.command;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -19,10 +18,8 @@ import com.umc.product.schedule.application.port.out.SaveScheduleParticipantPort
 import com.umc.product.schedule.application.port.out.SaveSchedulePort;
 import com.umc.product.schedule.application.service.query.ScheduleCapabilitiesService;
 import com.umc.product.schedule.domain.Schedule;
-import com.umc.product.schedule.domain.ScheduleParticipant;
 import com.umc.product.schedule.domain.exception.ScheduleDomainException;
 import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -69,58 +66,25 @@ class ScheduleCommandServiceDeleteTest {
         return schedule;
     }
 
-    private ScheduleParticipant participantStub(Long memberId) {
-        ScheduleParticipant participant = new ScheduleParticipant() {
-        };
-        ReflectionTestUtils.setField(participant, "memberId", memberId);
-        return participant;
-    }
-
     @Nested
     @DisplayName("delete - 일반 삭제")
     class delete {
 
         @Test
-        @DisplayName("일정과 모든 참여자를 함께 삭제한다")
-        void 일정과_모든_참여자를_함께_삭제한다() {
-            // given
-            Schedule schedule = scheduleStub();
-            List<ScheduleParticipant> participants = List.of(
-                participantStub(1L),
-                participantStub(2L)
-            );
-
-            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
-            given(loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(SCHEDULE_ID))
-                .willReturn(false);
-            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
-                .willReturn(participants);
-
-            // when
-            sut.delete(SCHEDULE_ID);
-
-            // then
-            then(deleteScheduleParticipantPort).should().deleteAll(participants);
-            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
-        }
-
-        @Test
-        @DisplayName("참여자가 없는 일정도 정상 삭제된다")
-        void 참여자가_없는_일정도_정상_삭제된다() {
+        @DisplayName("일정과 모든 참여자를 단일 벌크 쿼리로 함께 삭제한다")
+        void 일정과_모든_참여자를_벌크_쿼리로_함께_삭제한다() {
             // given
             Schedule schedule = scheduleStub();
 
             given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
             given(loadScheduleParticipantPort.existsAttendanceStatusByScheduleId(SCHEDULE_ID))
                 .willReturn(false);
-            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
-                .willReturn(List.of());
 
             // when
             sut.delete(SCHEDULE_ID);
 
             // then
-            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+            then(deleteScheduleParticipantPort).should().deleteByScheduleId(SCHEDULE_ID);
             then(deleteSchedulePort).should().delete(SCHEDULE_ID);
         }
 
@@ -141,7 +105,7 @@ class ScheduleCommandServiceDeleteTest {
                 .isEqualTo(ScheduleErrorCode.SCHEDULE_HAS_ATTENDANCE_RECORD);
 
             then(deleteSchedulePort).should(never()).delete(anyLong());
-            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+            then(deleteScheduleParticipantPort).should(never()).deleteByScheduleId(anyLong());
         }
 
         @Test
@@ -157,6 +121,7 @@ class ScheduleCommandServiceDeleteTest {
                 .isEqualTo(ScheduleErrorCode.SCHEDULE_NOT_FOUND);
 
             then(deleteSchedulePort).should(never()).delete(anyLong());
+            then(deleteScheduleParticipantPort).should(never()).deleteByScheduleId(anyLong());
         }
     }
 
@@ -165,18 +130,12 @@ class ScheduleCommandServiceDeleteTest {
     class forceDelete {
 
         @Test
-        @DisplayName("출석 기록 존재 여부와 무관하게 일정과 참여자를 함께 삭제한다")
-        void 출석_기록_존재_여부와_무관하게_삭제된다() {
+        @DisplayName("출석 기록 존재 여부와 무관하게 일정과 참여자를 단일 벌크 쿼리로 함께 삭제한다")
+        void 출석_기록_존재_여부와_무관하게_벌크_삭제된다() {
             // given
             Schedule schedule = scheduleStub();
-            List<ScheduleParticipant> participants = List.of(
-                participantStub(1L),
-                participantStub(2L)
-            );
 
             given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
-            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
-                .willReturn(participants);
 
             // when
             sut.forceDelete(SCHEDULE_ID);
@@ -184,25 +143,7 @@ class ScheduleCommandServiceDeleteTest {
             // then
             then(loadScheduleParticipantPort).should(never())
                 .existsAttendanceStatusByScheduleId(any());
-            then(deleteScheduleParticipantPort).should().deleteAll(participants);
-            then(deleteSchedulePort).should().delete(SCHEDULE_ID);
-        }
-
-        @Test
-        @DisplayName("참여자가 없으면 일정만 삭제된다")
-        void 참여자가_없으면_일정만_삭제된다() {
-            // given
-            Schedule schedule = scheduleStub();
-
-            given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
-            given(loadScheduleParticipantPort.findAllByScheduleId(SCHEDULE_ID))
-                .willReturn(List.of());
-
-            // when
-            sut.forceDelete(SCHEDULE_ID);
-
-            // then
-            then(deleteScheduleParticipantPort).should(never()).deleteAll(anyList());
+            then(deleteScheduleParticipantPort).should().deleteByScheduleId(SCHEDULE_ID);
             then(deleteSchedulePort).should().delete(SCHEDULE_ID);
         }
 
@@ -219,6 +160,7 @@ class ScheduleCommandServiceDeleteTest {
                 .isEqualTo(ScheduleErrorCode.SCHEDULE_NOT_FOUND);
 
             then(deleteSchedulePort).should(never()).delete(anyLong());
+            then(deleteScheduleParticipantPort).should(never()).deleteByScheduleId(anyLong());
         }
     }
 }

--- a/src/test/java/com/umc/product/schedule/application/service/evaluator/SchedulePermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/schedule/application/service/evaluator/SchedulePermissionEvaluatorTest.java
@@ -1,0 +1,229 @@
+package com.umc.product.schedule.application.service.evaluator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
+import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.authorization.domain.SubjectAttributes.GisuChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import com.umc.product.schedule.application.port.out.LoadSchedulePort;
+import com.umc.product.schedule.domain.Schedule;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SchedulePermissionEvaluator")
+class SchedulePermissionEvaluatorTest {
+
+    private static final Long SCHEDULE_ID = 100L;
+    private static final Long AUTHOR_MEMBER_ID = 10L;
+    private static final Long SCHEDULE_GISU_ID = 1L;
+    private static final Long OTHER_GISU_ID = 99L;
+    @Mock
+    LoadSchedulePort loadSchedulePort;
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+    @InjectMocks
+    SchedulePermissionEvaluator sut;
+
+    @Test
+    @DisplayName("supportedResourceType은 SCHEDULE을 반환한다")
+    void supportedResourceType은_SCHEDULE을_반환한다() {
+        assertThat(sut.supportedResourceType()).isEqualTo(ResourceType.SCHEDULE);
+    }
+
+    private void givenScheduleAndGisu() {
+        Schedule schedule = schedule();
+        given(loadSchedulePort.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+        given(getGisuUseCase.getGisuByDate(schedule.getStartsAt()))
+            .willReturn(new GisuInfo(SCHEDULE_GISU_ID, 9L, null, null, true));
+    }
+
+    private Schedule schedule() {
+        Schedule schedule = new Schedule() {
+        };
+        ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
+        ReflectionTestUtils.setField(schedule, "authorMemberId", AUTHOR_MEMBER_ID);
+        ReflectionTestUtils.setField(schedule, "startsAt", Instant.parse("2026-05-13T10:00:00Z"));
+        return schedule;
+    }
+
+    // --- helpers ---
+
+    private SubjectAttributes subjectWith(Long memberId, List<RoleAttribute> roles) {
+        return SubjectAttributes.builder()
+            .memberId(memberId)
+            .schoolId(1L)
+            .gisuChallengerInfos(List.<GisuChallengerInfo>of())
+            .roleAttributes(roles)
+            .build();
+    }
+
+    private RoleAttribute superAdminRoleInGisu(Long gisuId) {
+        return new RoleAttribute(
+            ChallengerRoleType.SUPER_ADMIN,
+            OrganizationType.CENTRAL,
+            null, null, gisuId
+        );
+    }
+
+    private RoleAttribute centralCoreRoleInGisu(Long gisuId) {
+        return new RoleAttribute(
+            ChallengerRoleType.CENTRAL_PRESIDENT,
+            OrganizationType.CENTRAL,
+            null, null, gisuId
+        );
+    }
+
+    @Nested
+    @DisplayName("DELETE - 일반 삭제 권한")
+    class delete {
+
+        @Test
+        @DisplayName("일정 생성자 본인이면 허용")
+        void 생성자_본인_허용() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(AUTHOR_MEMBER_ID, List.of());
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isTrue();
+        }
+
+        @Test
+        @DisplayName("해당 일정 기수의 SUPER_ADMIN이면 허용")
+        void 해당_기수_SUPER_ADMIN_허용() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(superAdminRoleInGisu(SCHEDULE_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isTrue();
+        }
+
+        @Test
+        @DisplayName("생성자도 아니고 해당 기수 SUPER_ADMIN도 아니면 거부")
+        void 생성자_아니고_SUPER_ADMIN_아니면_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L, List.of());
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 기수의 SUPER_ADMIN이면 거부")
+        void 다른_기수_SUPER_ADMIN_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(superAdminRoleInGisu(OTHER_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+
+        @Test
+        @DisplayName("해당 기수의 중앙총괄(SUPER_ADMIN 아님)은 생성자가 아니면 거부")
+        void 해당_기수_중앙총괄은_생성자_아니면_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(centralCoreRoleInGisu(SCHEDULE_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("FORCE_DELETE - 강제 삭제 권한")
+    class forceDelete {
+
+        @Test
+        @DisplayName("해당 일정 기수의 SUPER_ADMIN이면 허용")
+        void 해당_기수_SUPER_ADMIN_허용() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(superAdminRoleInGisu(SCHEDULE_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.FORCE_DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isTrue();
+        }
+
+        @Test
+        @DisplayName("일정 생성자 본인이라도 SUPER_ADMIN이 아니면 거부")
+        void 생성자_본인이라도_SUPER_ADMIN_아니면_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(AUTHOR_MEMBER_ID, List.of());
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.FORCE_DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 기수의 SUPER_ADMIN이면 거부")
+        void 다른_기수_SUPER_ADMIN_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(superAdminRoleInGisu(OTHER_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.FORCE_DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+
+        @Test
+        @DisplayName("해당 기수 중앙총괄(SUPER_ADMIN 아님)이면 거부")
+        void 해당_기수_중앙총괄_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L,
+                List.of(centralCoreRoleInGisu(SCHEDULE_GISU_ID)));
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.FORCE_DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+
+        @Test
+        @DisplayName("아무 역할도 없는 사용자는 거부")
+        void 일반_사용자_거부() {
+            givenScheduleAndGisu();
+
+            SubjectAttributes subject = subjectWith(20L, List.of());
+            ResourcePermission permission = ResourcePermission.of(
+                ResourceType.SCHEDULE, SCHEDULE_ID, PermissionType.FORCE_DELETE);
+
+            assertThat(sut.evaluate(subject, permission)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #790 

## 🚀 작업 내용

1. **SCHEDULE-C006 (일정 삭제)** : 일정 생성자 본인, 해당 일정 기수 `SUPER_ADMIN`만 가능. 출석 기록이 하나라도 있으면 삭제 불가능.
2. **SCHEDULE-C007 (강제 삭제**) : 해당 일정 기수 `SUPER_ADMIN`만 가능. 출석 기록 검사 없이 삭제 진행
3. 관련 테스트코드 작성

두 API 모두  `Schedule` + 모든 `ScheduleParticipant`를 함께 삭제합니다.

## 💬 리뷰 중점사항

1. `PermissionType`에 `SUPER_ADMIN` 전용 `FORCE_DELETE`을 추가했는데 이 부분에 대한 리뷰어 분들의 생각이 궁금합니다. 강제 삭제 기능은 일정 뿐만 아니라 공지나 커뮤니티 등등 앞으로 범용적으로 쓰일 수 있을 거 같아 이렇게 분리했는데, 그냥 `MANAGE`나 다른 방법으로 하는 게 나을지요?

