### PR TITLE
[Feat] 로그인 ID 형식을 영문 소문자만 허용하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/authentication/domain/CredentialPolicy.java
+++ b/src/main/java/com/umc/product/authentication/domain/CredentialPolicy.java
@@ -14,9 +14,9 @@ import java.util.regex.Pattern;
 public final class CredentialPolicy {
 
     /**
-     * 영문 대소문자, 숫자, 점/밑줄/하이픈 5~20자. DB CHECK 제약과 일치해야 한다.
+     * 영문 소문자, 숫자, 점/밑줄/하이픈 5~20자. DB CHECK 제약과 일치해야 한다.
      */
-    public static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]{5,20}$");
+    public static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[a-z0-9._-]{5,20}$");
 
     public static final int PASSWORD_MIN_LENGTH = 8;
     public static final int PASSWORD_MAX_LENGTH = 64;

--- a/src/main/resources/db/migration/V2026.05.15.21.45__tighten_member_login_id_to_lowercase.sql
+++ b/src/main/resources/db/migration/V2026.05.15.21.45__tighten_member_login_id_to_lowercase.sql
@@ -1,0 +1,9 @@
+-- login_id 형식 정책 강화: 영문 대문자 허용을 제거하고 소문자만 허용한다.
+-- Application 계층의 CredentialPolicy.LOGIN_ID_PATTERN 과 일치해야 한다.
+
+ALTER TABLE member
+    DROP CONSTRAINT IF EXISTS member_login_id_format_check;
+
+ALTER TABLE member
+    ADD CONSTRAINT member_login_id_format_check
+        CHECK (login_id IS NULL OR login_id ~ '^[a-z0-9._-]{5,20}$');

--- a/src/test/java/com/umc/product/authentication/domain/CredentialPolicyTest.java
+++ b/src/test/java/com/umc/product/authentication/domain/CredentialPolicyTest.java
@@ -24,12 +24,12 @@ class CredentialPolicyTest {
 
         @ParameterizedTest
         @ValueSource(strings = {
-            "alice",            // 5자 영문
-            "alice01",          // 영문 + 숫자
+            "alice",            // 5자 영문 소문자
+            "alice01",          // 영문 소문자 + 숫자
             "user.name",        // 점 허용
             "user_name",        // 밑줄 허용
             "user-name",        // 하이픈 허용
-            "ABCDE12345abcde12345" // 정확히 20자 경계값
+            "abcde12345abcde12345" // 정확히 20자 경계값
         })
         @DisplayName("정상 형식의 로그인 ID 는 통과한다")
         void 정상_형식_통과(String loginId) {
@@ -44,7 +44,10 @@ class CredentialPolicyTest {
             "abcdefghij1234567890_", // 21자 초과
             "user@name",           // 허용되지 않는 특수문자
             "user name",           // 공백 포함
-            "한글닉네임"            // 비ASCII
+            "한글닉네임",          // 비ASCII
+            "Alice",               // 영문 대문자 포함 (선두)
+            "userNAME",            // 영문 대문자 포함 (중간)
+            "ABCDE"                // 영문 대문자만
         })
         @DisplayName("형식이 어긋나면 INVALID_LOGIN_ID_FORMAT 예외를 던진다")
         void 잘못된_형식이면_예외(String loginId) {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

기존 로그인 ID 형식 정책이 영문 대문자(`A-Z`)도 허용하고 있던 부분을 **영문 소문자만 허용**하도록 강화하였어요. 대소문자 혼용으로 인한 ID 충돌/혼동(예: `Alice` vs `alice`)을 사전에 차단하고, 사용자에게 일관된 ID 입력 경험을 제공하기 위함이에요.

정책 SSOT(Single Source of Truth)인 `CredentialPolicy` 와 DB CHECK 제약을 함께 갱신하여 두 계층의 정책이 어긋나지 않도록 동기화하였어요.

1. **Application 계층 (`CredentialPolicy.java`)**
   - `LOGIN_ID_PATTERN` 정규식을 `^[A-Za-z0-9._-]{5,20}$` → `^[a-z0-9._-]{5,20}$` 로 변경했어요.
   - 정책 주석(`영문 대소문자` → `영문 소문자`)을 함께 수정했어요.

2. **DB 계층 (Flyway 마이그레이션)**
   - `V2026.05.15.21.45__tighten_member_login_id_to_lowercase.sql` 을 추가하여 기존 `member_login_id_format_check` 제약을 drop 한 뒤 동일한 이름으로 소문자 한정 정규식 제약을 다시 추가하도록 하였어요.

3. **테스트 (`CredentialPolicyTest.java`)**
   - 20자 경계값 케이스를 모두 소문자(`abcde12345abcde12345`)로 교체했어요.
   - 대문자가 포함된 ID(`Alice`, `userNAME`, `ABCDE`)가 `INVALID_LOGIN_ID_FORMAT` 예외로 거부되는지 검증하는 케이스를 추가했어요.

## 💬 리뷰 중점사항

- **마이그레이션 안전성**: 새 CHECK 제약 적용 시 기존 `member.login_id` 컬럼에 대문자가 포함된 행이 존재하면 마이그레이션이 실패할 수 있어요. ID/PW 로그인 기능(#782) 이후 실제 사용자 데이터가 없다고 판단해 그대로 적용했지만, 알파/스테이징 환경에 대문자 시드 데이터가 존재한다면 사전 정리가 필요해요.
- **SSOT 동기화**: `CredentialPolicy.LOGIN_ID_PATTERN` 의 정규식과 `member_login_id_format_check` 의 정규식이 동일한지 한 번 더 검토 부탁드려요.
- **테스트 커버리지**: 대문자 거부 케이스가 `잘못된_형식이면_예외` 파라미터에 묶여 있는데, 별도의 `@Nested` 그룹으로 분리하는 편이 가독성이 좋을지 의견 부탁드려요.