### PR TITLE
[Fix] 회원 검색 키워드에서 닉네임 검색 누락 수정

### DIFF
--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
@@ -110,6 +110,7 @@ public class MemberQueryRepository {
             .exists();
 
         return member.name.containsIgnoreCase(keyword)
+            .or(member.nickname.containsIgnoreCase(keyword))
             .or(member.email.containsIgnoreCase(keyword))
             .or(schoolNameExists);
     }

--- a/src/test/java/com/umc/product/member/application/port/in/query/SearchMemberUseCaseTest.java
+++ b/src/test/java/com/umc/product/member/application/port/in/query/SearchMemberUseCaseTest.java
@@ -209,6 +209,29 @@ class SearchMemberUseCaseTest extends UseCaseTestSupport {
         }
 
         @Test
+        void 닉네임으로_검색한다() {
+            // given
+            Member member1 = saveMember("홍길동", "hong123", "hong@test.com", school1.getId());
+            Member member2 = saveMember("김철수", "kim456", "kim@test.com", school1.getId());
+            saveChallengerPort.save(
+                Challenger.builder().memberId(member1.getId()).part(ChallengerPart.PLAN).gisuId(gisu7.getId())
+                    .build());
+            saveChallengerPort.save(
+                Challenger.builder().memberId(member2.getId()).part(ChallengerPart.WEB).gisuId(gisu7.getId())
+                    .build());
+
+            SearchMemberQuery query = new SearchMemberQuery("hong123", null, null, null, null);
+            PageRequest pageable = PageRequest.of(0, 10);
+
+            // when
+            SearchMemberResult result = searchMemberUseCase.searchBy(query, pageable);
+
+            // then
+            assertThat(result.page().getContent()).hasSize(1);
+            assertThat(result.page().getContent().get(0).nickname()).isEqualTo("hong123");
+        }
+
+        @Test
         void 검색_결과가_없으면_빈_페이지를_반환한다() {
             // given
             Member member = saveMember("홍길동", "hong", "hong@test.com", school1.getId());


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 서버 파트가 2026-05-16에 `main` 브랜치를 기준으로 작업했어요.
- 변경 범위는 `member` 도메인의 persistence 레이어(`MemberQueryRepository`)와 통합 테스트(`SearchMemberUseCaseTest`)예요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: `GET /api/v1/member/search` 엔드포인트에서 키워드로 닉네임 검색이 되지 않던 버그를 수정했어요.
   - **어떻게**: `MemberQueryRepository.keywordContains()` 메서드의 QueryDSL 조건에 `member.nickname.containsIgnoreCase(keyword)` 를 추가했어요.
   - **왜**: Swagger 명세(`@Operation description`)에는 "이름, 닉네임, 이메일, 학교명으로 검색"이라고 명시되어 있었으나, 실제 쿼리 조건에서 `nickname` 이 누락되어 닉네임으로 검색 시 항상 빈 결과가 반환되고 있었어요.

2. **무엇을**: 닉네임 검색에 대한 통합 테스트 케이스를 추가했어요.
   - **어떻게**: `SearchMemberUseCaseTest`의 `KeywordSearch` 중첩 클래스에 `닉네임으로_검색한다()` 테스트를 추가하여 실제 DB에서 닉네임 검색이 동작함을 검증해요.
   - **왜**: 기존에 이름, 이메일, 학교명 검색 테스트는 있었으나 닉네임 검색 테스트가 없어서 버그가 조기에 발견되지 않았어요.

## 💬 리뷰 중점사항

- `keywordContains()` 의 검색 조건 순서가 `name → nickname → email → schoolName` 으로 변경됐어요. 기능상 차이는 없으나 순서 의도가 맞는지 확인 부탁드려요.