### PR TITLE
[Refactor] 프로젝트 목록 조회 배치를 통한 성능 개선

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -47,6 +47,13 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     }
 
     @Override
+    public Map<Long, List<ProjectMember>> listByProjectIdsAndPartGroupedByProjectId(
+        Collection<Long> projectIds, ChallengerPart part
+    ) {
+        return queryRepository.listByProjectIdsAndPartGroupedByProjectId(projectIds, part);
+    }
+
+    @Override
     public Map<ChallengerPart, Long> countByProjectIdGroupByPart(Long projectId) {
         List<Object[]> rows = repository.countByProjectIdGroupByPartRaw(projectId, ProjectMemberStatus.ACTIVE);
 

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
@@ -8,6 +8,7 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -68,6 +69,40 @@ public class ProjectMemberQueryRepository {
             .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    /**
+     * 여러 프로젝트의 특정 파트 ACTIVE 멤버를 한 번에 조회해 projectId 기준으로 그룹핑한다.
+     * <p>
+     * {@code projectMember.project.id} projection 으로 FK 만 추출하여, 호출자가 {@code member.getProject().getId()} 로 lazy
+     * 프록시에 접근하지 않도록 한다.
+     *
+     * @return projectId -> 멤버 목록 맵. 해당 파트 멤버가 없는 프로젝트는 엔트리 없음.
+     */
+    public Map<Long, List<ProjectMember>> listByProjectIdsAndPartGroupedByProjectId(
+        Collection<Long> projectIds, ChallengerPart part
+    ) {
+        if (projectIds == null || projectIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Tuple> rows = queryFactory
+            .select(projectMember.project.id, projectMember)
+            .from(projectMember)
+            .where(
+                projectMember.project.id.in(projectIds),
+                projectMember.part.eq(part),
+                projectMember.status.eq(ProjectMemberStatus.ACTIVE)
+            )
+            .fetch();
+
+        Map<Long, List<ProjectMember>> result = new HashMap<>();
+        for (Tuple row : rows) {
+            Long projectId = row.get(projectMember.project.id);
+            ProjectMember member = row.get(projectMember);
+            result.computeIfAbsent(projectId, k -> new ArrayList<>()).add(member);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -24,6 +24,14 @@ public interface LoadProjectMemberPort {
     List<ProjectMember> listByProjectIdAndPart(Long projectId, ChallengerPart part);
 
     /**
+     * 여러 프로젝트의 특정 파트 ACTIVE 멤버를 한 번에 조회해 projectId 기준 Map 으로 반환합니다 (N+1 방지).
+     *
+     * @return projectId -> 멤버 목록 맵. 해당 파트 멤버가 없는 프로젝트는 엔트리 없음.
+     */
+    Map<Long, List<ProjectMember>> listByProjectIdsAndPartGroupedByProjectId(
+        Collection<Long> projectIds, ChallengerPart part);
+
+    /**
      * 특정 프로젝트의 파트별 활성 멤버 수를 집계합니다. {@code PartQuotaInfo.currentCount} 계산에 사용됩니다.
      *
      * @return 파트 → 인원수 맵. 활성 멤버가 없는 파트는 0 또는 엔트리 없음

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -28,8 +28,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -86,20 +89,15 @@ public class ProjectQueryService implements
             .statuses(new ArrayList<>(requested))
             .pageable(query.pageable())
             .build();
-        return applyScope(scope, base).map(this::toProjectInfo);
+        return toProjectInfoPage(applyScope(scope, base));
     }
 
     @Override
     public Page<ProjectInfo> search(SearchProjectQuery query, Long memberId) {
-        // TODO: N+1 — 페이지당 (3 × size + 1) 쿼리. batch 메서드 추가 필요:
-        //  LoadProjectMemberPort.listByProjectIdsAndPart(Set<Long>, ChallengerPart)
-        //  LoadProjectMemberPort.countByProjectIdsGroupByPart(Set<Long>)
-        //  LoadProjectPartQuotaPort.listByProjectIds(Set<Long>)
         Set<ProjectStatus> requestedStatuses = new HashSet<>(query.statuses());
         ProjectAccessScope scope = scopeResolver.resolveForPublicSearch(
             memberId, query.gisuId(), requestedStatuses);
-        return applyScope(scope, query)
-            .map(this::toProjectInfo);
+        return toProjectInfoPage(applyScope(scope, query));
     }
 
     /**
@@ -121,6 +119,87 @@ public class ProjectQueryService implements
             case None() ->
                 new PageImpl<>(List.of(), query.pageable(), 0L);
         };
+    }
+
+    /**
+     * Project 페이지를 ProjectInfo 페이지로 배치 조립합니다.
+     * <p>
+     * coPM/파트별 TO/파일 URL 을 페이지 단위 IN 쿼리로 한 번에 조회해 N+1 을 방지합니다.
+     */
+    private Page<ProjectInfo> toProjectInfoPage(Page<Project> page) {
+        List<Project> projects = page.getContent();
+        if (projects.isEmpty()) {
+            return new PageImpl<>(List.of(), page.getPageable(), page.getTotalElements());
+        }
+
+        Set<Long> projectIds = projects.stream()
+            .map(Project::getId)
+            .collect(Collectors.toSet());
+
+        Map<Long, List<ProjectMember>> planMembersByProject =
+            loadProjectMemberPort.listByProjectIdsAndPartGroupedByProjectId(projectIds, ChallengerPart.PLAN);
+        Map<Long, List<ProjectPartQuota>> quotasByProject =
+            loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(projectIds);
+        Map<Long, Map<ChallengerPart, Long>> memberCountsByProject =
+            loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(projectIds);
+        Map<String, String> fileLinks = resolveFileLinks(projects);
+
+        return page.map(project -> assembleProjectInfo(
+            project,
+            planMembersByProject.getOrDefault(project.getId(), List.of()),
+            quotasByProject.getOrDefault(project.getId(), List.of()),
+            memberCountsByProject.getOrDefault(project.getId(), Map.of()),
+            fileLinks
+        ));
+    }
+
+    /**
+     * 미리 배치 조회한 결과로 단일 Project 의 ProjectInfo 를 조립합니다.
+     */
+    private ProjectInfo assembleProjectInfo(
+        Project project,
+        List<ProjectMember> planMembers,
+        List<ProjectPartQuota> quotas,
+        Map<ChallengerPart, Long> currentCounts,
+        Map<String, String> fileLinks
+    ) {
+        List<Long> coPmMemberIds = planMembers.stream()
+            .map(ProjectMember::getMemberId)
+            .filter(memberId -> !memberId.equals(project.getProductOwnerMemberId()))
+            .toList();
+
+        List<ProjectPartQuotaInfo> partQuotas = quotas.stream()
+            .map(q -> ProjectPartQuotaInfo.of(
+                q.getPart(),
+                q.getQuota(),
+                currentCounts.getOrDefault(q.getPart(), 0L)
+            ))
+            .toList();
+
+        return ProjectInfo.from(
+            project,
+            coPmMemberIds,
+            partQuotas,
+            resolveLink(fileLinks, project.getThumbnailFileId()),
+            resolveLink(fileLinks, project.getLogoFileId())
+        );
+    }
+
+    /**
+     * 여러 프로젝트의 썸네일/로고 파일 ID → CDN URL을 일괄 조회합니다.
+     */
+    private Map<String, String> resolveFileLinks(List<Project> projects) {
+        List<String> fileIds = projects.stream()
+            .flatMap(p -> Stream.of(p.getThumbnailFileId(), p.getLogoFileId()))
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+        if (fileIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return getFileUseCase.getFileLinks(fileIds);
     }
 
     /**

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -3,7 +3,10 @@ package com.umc.product.project.application.service.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.access.ProjectAccessScope;
@@ -157,9 +160,12 @@ class ProjectQueryServiceTest {
             .willReturn(new ProjectAccessScope.PublicOnly());
         given(loadProjectPort.search(any(SearchProjectQuery.class)))
             .willReturn(new PageImpl<>(List.of(project), pageable, 1));
-        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
-            .willReturn(List.of());
-        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of());
+        given(loadProjectMemberPort.listByProjectIdsAndPartGroupedByProjectId(anySet(), eq(ChallengerPart.PLAN)))
+            .willReturn(Map.of());
+        given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(anySet()))
+            .willReturn(Map.of());
+        given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(anySet()))
+            .willReturn(Map.of());
         given(getFileUseCase.getFileLinks(List.of("thumb-1")))
             .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
 
@@ -170,6 +176,47 @@ class ProjectQueryServiceTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).id()).isEqualTo(1L);
+    }
+
+    @Test
+    void search_여러_프로젝트_배치_조립() {
+        // given
+        Project p1 = createProject(1L, ProjectStatus.IN_PROGRESS);
+        Project p2 = createProject(2L, ProjectStatus.IN_PROGRESS);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            1L, null, null, null, null, null, pageable);
+
+        given(scopeResolver.resolveForPublicSearch(any(), any(), anySet()))
+            .willReturn(new ProjectAccessScope.PublicOnly());
+        given(loadProjectPort.search(any(SearchProjectQuery.class)))
+            .willReturn(new PageImpl<>(List.of(p1, p2), pageable, 2));
+        given(loadProjectMemberPort.listByProjectIdsAndPartGroupedByProjectId(anySet(), eq(ChallengerPart.PLAN)))
+            .willReturn(Map.of(1L, List.of(createProjectMember(20L))));
+        given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(anySet()))
+            .willReturn(Map.of(2L, List.of(createPartQuota(2L, ChallengerPart.WEB, 3))));
+        given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(anySet()))
+            .willReturn(Map.of(2L, Map.of(ChallengerPart.WEB, 2L)));
+        given(getFileUseCase.getFileLinks(List.of("thumb-1")))
+            .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
+
+        // when
+        Page<ProjectInfo> result = sut.search(query, 99L);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+
+        ProjectInfo first = result.getContent().get(0);
+        assertThat(first.id()).isEqualTo(1L);
+        assertThat(first.coProductOwnerMemberIds()).containsExactly(20L);
+        assertThat(first.partQuotas()).isEmpty();
+
+        ProjectInfo second = result.getContent().get(1);
+        assertThat(second.id()).isEqualTo(2L);
+        assertThat(second.coProductOwnerMemberIds()).isEmpty();
+        assertThat(second.partQuotas()).hasSize(1);
+        assertThat(second.partQuotas().get(0).part()).isEqualTo(ChallengerPart.WEB);
+        assertThat(second.partQuotas().get(0).currentCount()).isEqualTo(2);
     }
 
     @Test
@@ -190,6 +237,7 @@ class ProjectQueryServiceTest {
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
+        verify(loadProjectMemberPort, never()).listByProjectIdsAndPartGroupedByProjectId(anySet(), any());
     }
 
     @Test
@@ -205,9 +253,12 @@ class ProjectQueryServiceTest {
                     ProjectStatus.COMPLETED, ProjectStatus.ABORTED)));
         given(loadProjectPort.search(any(SearchProjectQuery.class)))
             .willReturn(new PageImpl<>(List.of(project), pageable, 1));
-        given(loadProjectMemberPort.listByProjectIdAndPart(1L, ChallengerPart.PLAN))
-            .willReturn(List.of());
-        given(loadProjectPartQuotaPort.listByProjectId(1L)).willReturn(List.of());
+        given(loadProjectMemberPort.listByProjectIdsAndPartGroupedByProjectId(anySet(), eq(ChallengerPart.PLAN)))
+            .willReturn(Map.of());
+        given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(anySet()))
+            .willReturn(Map.of());
+        given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(anySet()))
+            .willReturn(Map.of());
         given(getFileUseCase.getFileLinks(List.of("thumb-1")))
             .willReturn(Map.of("thumb-1", "https://cdn.example.com/thumb-1"));
 
@@ -229,6 +280,7 @@ class ProjectQueryServiceTest {
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
+        verify(loadProjectMemberPort, never()).listByProjectIdsAndPartGroupedByProjectId(anySet(), any());
     }
 
     // ========== Helper Methods ==========


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요.

## 🔥 연관 이슈

- resolves #865

## 🚀 작업 내용

프로젝트 목록 조회(PROJECT-001) / 관리 목록 조회(PROJECT-006) API의 N+1 쿼리를 제거했습니다.

기존 `ProjectQueryService.search()` / `searchManaged()` 는 페이지 결과를 `.map(this::toProjectInfo)` 로 변환하면서, 프로젝트 1건마다 4개의 추가 쿼리(coPM 멤버 / 파트 정원 / 파트별 인원 / 파일 URL)를 실행했습니다. `size=20` 기준 페이지 1회 조회에 약 82개 쿼리가 발생했습니다.

페이지 단위 배치 조회로 전환했습니다.

1. `LoadProjectMemberPort.listByProjectIdsAndPartGroupedByProjectId` 신규 추가 — 여러 프로젝트의 PLAN 파트 멤버를 IN 쿼리 1회로 조회
2. 기존 배치 메서드 활용 — `listByProjectIdsGroupedByProjectId`(파트 정원), `countByProjectIdsGroupByProjectIdAndPart`(파트별 활성 인원)
3. 페이지 전체 썸네일/로고 파일 ID를 모아 `getFileLinks` 1회 호출
4. `toProjectInfoPage` / `assembleProjectInfo` 로 미리 조회한 결과를 메모리에서 조립

## 💬 리뷰 중점사항

- 검색 쿼리 자체의 상관 서브쿼리 개선·인덱스 보강은 본 PR 범위 밖이며 별도 작업으로 진행 예정입니다.
