### PR TITLE
[Feat] 프로젝트 EDIT 권한 평가 일원화 및 운영진 대상으로 허용하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -95,7 +95,7 @@ public class ProjectCommandController {
     @PostMapping("/{projectId}/submit")
     @Operation(
         summary = "[PROJECT-107] 프로젝트 제출",
-        description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다. 작성자 PM만 호출 가능."
+        description = "DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다. 작성자(creator)만 호출 가능."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -104,12 +104,10 @@ public class ProjectCommandController {
         message = "프로젝트 제출 권한이 없습니다."
     )
     public ProjectStatusResponse submit(
-        @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId
     ) {
         submitProjectUseCase.submit(SubmitProjectCommand.builder()
             .projectId(projectId)
-            .requesterMemberId(memberPrincipal.getMemberId())
             .build());
         return ProjectStatusResponse.of(projectId, ProjectStatus.PENDING_REVIEW);
     }
@@ -117,7 +115,7 @@ public class ProjectCommandController {
     @PostMapping("/{projectId}/transfer-ownership")
     @Operation(
         summary = "[PROJECT-104] 프로젝트 소유권 양도",
-        description = "메인 PM을 다른 PLAN 파트 챌린저에게 양도합니다. 현재 PM만 호출 가능. 종료 상태에서는 호출 불가."
+        description = "메인 PM을 다른 PLAN 파트 챌린저에게 양도합니다. 현재 PM 또는 운영진이 호출 가능. 종료 상태에서는 호출 불가."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -126,12 +124,11 @@ public class ProjectCommandController {
         message = "프로젝트 소유권 양도 권한이 없습니다."
     )
     public ProjectStatusResponse transferOwnership(
-        @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId,
         @Valid @RequestBody TransferProjectOwnershipRequest request
     ) {
         ProjectStatus status = transferProjectOwnershipUseCase.transfer(
-            request.toCommand(projectId, memberPrincipal.getMemberId()));
+            request.toCommand(projectId));
         return ProjectStatusResponse.of(projectId, status);
     }
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/TransferProjectOwnershipRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/TransferProjectOwnershipRequest.java
@@ -14,10 +14,9 @@ public record TransferProjectOwnershipRequest(
     @Size(max = 200, message = "사유는 200자 이하여야 합니다")
     String reason
 ) {
-    public TransferProjectOwnershipCommand toCommand(Long projectId, Long requesterMemberId) {
+    public TransferProjectOwnershipCommand toCommand(Long projectId) {
         return TransferProjectOwnershipCommand.builder()
             .projectId(projectId)
-            .requesterMemberId(requesterMemberId)
             .newOwnerMemberId(newOwnerMemberId)
             .reason(reason)
             .build();

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -9,9 +9,9 @@ public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 
     boolean existsByProductOwnerMemberIdAndGisuId(Long productOwnerMemberId, Long gisuId);
 
-    Optional<Project> findByCreatedByMemberIdAndGisuIdAndStatus(
-        Long createdByMemberId, Long gisuId, ProjectStatus status);
+    Optional<Project> findByCreatorMemberIdAndGisuIdAndStatus(
+        Long creatorMemberId, Long gisuId, ProjectStatus status);
 
-    boolean existsByCreatedByMemberIdAndGisuIdAndStatus(
-        Long createdByMemberId, Long gisuId, ProjectStatus status);
+    boolean existsByCreatorMemberIdAndGisuIdAndStatus(
+        Long creatorMemberId, Long gisuId, ProjectStatus status);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -38,13 +38,13 @@ public class ProjectPersistenceAdapter implements LoadProjectPort, SaveProjectPo
 
     @Override
     public Optional<Project> findDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId) {
-        return jpaRepository.findByCreatedByMemberIdAndGisuIdAndStatus(
+        return jpaRepository.findByCreatorMemberIdAndGisuIdAndStatus(
             creatorMemberId, gisuId, ProjectStatus.DRAFT);
     }
 
     @Override
     public boolean existsDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId) {
-        return jpaRepository.existsByCreatedByMemberIdAndGisuIdAndStatus(
+        return jpaRepository.existsByCreatorMemberIdAndGisuIdAndStatus(
             creatorMemberId, gisuId, ProjectStatus.DRAFT);
     }
 

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectCommand.java
@@ -11,11 +11,9 @@ import lombok.Builder;
  */
 @Builder
 public record SubmitProjectCommand(
-    Long projectId,
-    Long requesterMemberId
+    Long projectId
 ) {
     public SubmitProjectCommand {
         Objects.requireNonNull(projectId, "projectId must not be null");
-        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
     }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/TransferProjectOwnershipCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/TransferProjectOwnershipCommand.java
@@ -9,13 +9,11 @@ import lombok.Builder;
 @Builder
 public record TransferProjectOwnershipCommand(
     Long projectId,
-    Long requesterMemberId,
     Long newOwnerMemberId,
     String reason
 ) {
     public TransferProjectOwnershipCommand {
         Objects.requireNonNull(projectId, "projectId must not be null");
-        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
         Objects.requireNonNull(newOwnerMemberId, "newOwnerMemberId must not be null");
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -153,10 +153,6 @@ public class ProjectCommandService implements
     public void submit(SubmitProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
 
-        if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
-        }
-
         if (!loadProjectApplicationFormPort.existsByProjectId(project.getId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_SUBMIT_VALIDATION_FAILED);
         }
@@ -167,10 +163,6 @@ public class ProjectCommandService implements
     @Override
     public ProjectStatus transfer(TransferProjectOwnershipCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
-
-        if (!project.getProductOwnerMemberId().equals(command.requesterMemberId())) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
-        }
 
         ChallengerInfo newOwner = getChallengerUseCase.getByMemberIdAndGisuId(
             command.newOwnerMemberId(), project.getGisuId()

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -8,7 +8,6 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.util.Objects;
@@ -84,30 +83,26 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
     }
 
     /**
-     * 단건 EDIT 분기.
+     * 단건 EDIT 분기. EDIT 을 쓰는 모든 액션(기본정보 수정 · 제출 · 소유권 양도 · 팀원 추가/제거)의
+     * "누가" 를 여기서 일원화해 판정한다.
      * <ul>
-     *   <li>PO: DRAFT / PENDING_REVIEW / IN_PROGRESS 단계 모두 허용</li>
-     *   <li>Creator (운영진이 만든 경우): DRAFT 단계만 허용 (작성 보조). 제출 후엔 PO 만 관리.</li>
-     *   <li>그 외: 거부. 외부 운영진 분기 없음 — 정책상 기본정보 수정은 PO 전용.</li>
+     *   <li>DRAFT: creator 만 — 임시저장 단계는 작성자의 작업 공간.</li>
+     *   <li>PENDING_REVIEW / IN_PROGRESS: PO 또는 운영진(해당 기수 총괄단 / 본인 지부장).</li>
      *   <li>COMPLETED / ABORTED: 절대 차단 (도메인 레벨 가드 {@code Project#validateMutable} 와 정합)</li>
      * </ul>
      */
     private boolean canEdit(SubjectAttributes subject, ResourcePermission permission) {
         Project project = loadProject(permission);
-        if (isOwner(subject, project)) {
-            return switch (project.getStatus()) {
-                case DRAFT, PENDING_REVIEW, IN_PROGRESS -> true;
-                case COMPLETED, ABORTED -> false;
-            };
-        }
-        if (project.getStatus() == ProjectStatus.DRAFT && isCreator(subject, project)) {
-            return true;
-        }
-        return false;
+        return switch (project.getStatus()) {
+            case DRAFT -> isCreator(subject, project);
+            case PENDING_REVIEW, IN_PROGRESS ->
+                isOwner(subject, project) || isProjectAdmin(subject, project);
+            case COMPLETED, ABORTED -> false;
+        };
     }
 
     private boolean isCreator(SubjectAttributes subject, Project project) {
-        return Objects.equals(subject.memberId(), project.getCreatedByMemberId());
+        return Objects.equals(subject.memberId(), project.getCreatorMemberId());
     }
 
     /**
@@ -119,11 +114,18 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
     private boolean canManage(SubjectAttributes subject, ResourcePermission permission) {
         Project project = loadProject(permission);
         return switch (project.getStatus()) {
-            case PENDING_REVIEW, IN_PROGRESS ->
-                isCentralCoreInGisu(subject, project.getGisuId())
-                    || isChapterPresidentOf(subject, project.getChapterId(), project.getGisuId());
+            case PENDING_REVIEW, IN_PROGRESS -> isProjectAdmin(subject, project);
             case DRAFT, COMPLETED, ABORTED -> false;
         };
+    }
+
+    /**
+     * 해당 프로젝트에 대한 운영진 권한 보유 여부. 해당 기수 총괄단(SUPER_ADMIN 은 글로벌)
+     * 또는 해당 프로젝트 지부의 지부장(해당 기수)이면 true.
+     */
+    private boolean isProjectAdmin(SubjectAttributes subject, Project project) {
+        return isCentralCoreInGisu(subject, project.getGisuId())
+            || isChapterPresidentOf(subject, project.getChapterId(), project.getGisuId());
     }
 
     private boolean isChapterPresidentOf(SubjectAttributes subject, Long chapterId, Long gisuId) {

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -72,7 +72,7 @@ public class Project extends BaseEntity {
      * {@code productOwnerMemberId} 와 다를 수 있다. DRAFT 단계 EDIT 권한 분기 + audit 용도.
      */
     @Column(nullable = false, name = "created_by_member_id")
-    private Long createdByMemberId;
+    private Long creatorMemberId;
 
     private Long statusChangedByMemberId; // 프로젝트 상태를 변경한 멤버의 ID입니다. (예: ABORTED로 변경한 멤버)
     private String statusChangedReason; // 프로젝트 상태를 변경한 이유입니다. (예: ABORTED로 변경한 이유)
@@ -99,7 +99,7 @@ public class Project extends BaseEntity {
         String thumbnailFileId,
         Long productOwnerMemberId,
         Long productOwnerSchoolId,
-        Long createdByMemberId
+        Long creatorMemberId
     ) {
         this.gisuId = gisuId;
         this.chapterId = chapterId;
@@ -111,7 +111,7 @@ public class Project extends BaseEntity {
         this.thumbnailFileId = thumbnailFileId;
         this.productOwnerMemberId = productOwnerMemberId;
         this.productOwnerSchoolId = productOwnerSchoolId;
-        this.createdByMemberId = createdByMemberId;
+        this.creatorMemberId = creatorMemberId;
     }
 
     /**
@@ -122,7 +122,7 @@ public class Project extends BaseEntity {
      * @param chapterId            프로젝트가 속한 지부 ID (PO의 소속 지부에서 결정)
      * @param productOwnerMemberId PO Member ID (PLAN 파트 챌린저여야 함)
      * @param productOwnerSchoolId PO 의 학교 ID 비정규화 (학교 운영진 scope 및 학교 필터에서 사용)
-     * @param createdByMemberId    호출자(생성자) Member ID. PM 본인 등록 시엔 PO 와 동일,
+     * @param creatorMemberId      호출자(생성자) Member ID. PM 본인 등록 시엔 PO 와 동일,
      *                             운영진이 다른 챌린저를 PO 로 지정한 경우엔 다름.
      * @return DRAFT 상태의 프로젝트
      */
@@ -131,14 +131,14 @@ public class Project extends BaseEntity {
         Long chapterId,
         Long productOwnerMemberId,
         Long productOwnerSchoolId,
-        Long createdByMemberId
+        Long creatorMemberId
     ) {
         return Project.builder()
             .gisuId(gisuId)
             .chapterId(chapterId)
             .productOwnerMemberId(productOwnerMemberId)
             .productOwnerSchoolId(productOwnerSchoolId)
-            .createdByMemberId(createdByMemberId)
+            .creatorMemberId(creatorMemberId)
             .status(ProjectStatus.DRAFT)
             .build();
     }

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
@@ -106,7 +106,7 @@ class ProjectApplicationFormPersistenceAdapterTest {
         ReflectionTestUtils.setField(project, "name", name);
         ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
         ReflectionTestUtils.setField(project, "productOwnerSchoolId", 1L);
-        ReflectionTestUtils.setField(project, "createdByMemberId", ownerId);
+        ReflectionTestUtils.setField(project, "creatorMemberId", ownerId);
         em.persist(project);
         return project;
     }

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
@@ -132,7 +132,7 @@ class ProjectApplicationFormPolicyPersistenceAdapterTest {
         ReflectionTestUtils.setField(project, "name", name);
         ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
         ReflectionTestUtils.setField(project, "productOwnerSchoolId", 1L);
-        ReflectionTestUtils.setField(project, "createdByMemberId", ownerId);
+        ReflectionTestUtils.setField(project, "creatorMemberId", ownerId);
         em.persist(project);
         return project;
     }

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -412,7 +412,7 @@ class ProjectQueryRepositoryTest {
         ReflectionTestUtils.setField(project, "name", name);
         ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
         ReflectionTestUtils.setField(project, "productOwnerSchoolId", ownerSchoolId);
-        ReflectionTestUtils.setField(project, "createdByMemberId", ownerId);
+        ReflectionTestUtils.setField(project, "creatorMemberId", ownerId);
         em.persist(project);
         return project;
     }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -789,7 +789,7 @@ class ProjectApplicationFormCommandServiceTest {
         ReflectionTestUtils.setField(project, "status", status);
         ReflectionTestUtils.setField(project, "name", name);
         ReflectionTestUtils.setField(project, "productOwnerMemberId", 99L);
-        ReflectionTestUtils.setField(project, "createdByMemberId", 99L);
+        ReflectionTestUtils.setField(project, "creatorMemberId", 99L);
         return project;
     }
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -453,24 +453,9 @@ class ProjectCommandServiceTest {
 
             sut.submit(SubmitProjectCommand.builder()
                 .projectId(1L)
-                .requesterMemberId(100L)
                 .build());
 
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.PENDING_REVIEW);
-        }
-
-        @Test
-        void 작성자가_아니면_예외() {
-            Project project = createProject(ProjectStatus.DRAFT);
-            given(loadProjectPort.getById(1L)).willReturn(project);
-
-            assertThatThrownBy(() -> sut.submit(SubmitProjectCommand.builder()
-                .projectId(1L)
-                .requesterMemberId(999L)
-                .build()))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
 
         @Test
@@ -482,7 +467,6 @@ class ProjectCommandServiceTest {
 
             assertThatThrownBy(() -> sut.submit(SubmitProjectCommand.builder()
                 .projectId(1L)
-                .requesterMemberId(100L)
                 .build()))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
@@ -502,22 +486,11 @@ class ProjectCommandServiceTest {
             given(getMemberUseCase.getById(200L)).willReturn(memberInfo(8L));
             given(getChapterUseCase.byGisuAndSchool(1L, 8L)).willReturn(new ChapterInfo(3L, "인천"));
 
-            sut.transfer(transferCommand(100L, 200L));
+            sut.transfer(transferCommand(200L));
 
             assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
             assertThat(project.getProductOwnerSchoolId()).isEqualTo(8L);
             assertThat(project.getChapterId()).isEqualTo(3L);
-        }
-
-        @Test
-        void 현재_PM이_아니면_예외() {
-            Project project = createProject(ProjectStatus.DRAFT);
-            given(loadProjectPort.getById(1L)).willReturn(project);
-
-            assertThatThrownBy(() -> sut.transfer(transferCommand(999L, 200L)))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
 
         @Test
@@ -527,7 +500,7 @@ class ProjectCommandServiceTest {
             given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
                 .willReturn(challengerInfo(200L, ChallengerPart.WEB));
 
-            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
+            assertThatThrownBy(() -> sut.transfer(transferCommand(200L)))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_OWNER_NOT_PLAN_CHALLENGER);
@@ -540,7 +513,7 @@ class ProjectCommandServiceTest {
             given(getChallengerUseCase.getByMemberIdAndGisuId(200L, 1L))
                 .willReturn(challengerInfo(200L, ChallengerPart.PLAN));
 
-            assertThatThrownBy(() -> sut.transfer(transferCommand(100L, 200L)))
+            assertThatThrownBy(() -> sut.transfer(transferCommand(200L)))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
@@ -557,16 +530,15 @@ class ProjectCommandServiceTest {
             given(getMemberUseCase.getById(200L)).willReturn(memberInfo(8L));
             given(getChapterUseCase.byGisuAndSchool(1L, 8L)).willReturn(new ChapterInfo(3L, "인천"));
 
-            sut.transfer(transferCommand(100L, 200L));
+            sut.transfer(transferCommand(200L));
 
             assertThat(project.getProductOwnerMemberId()).isEqualTo(200L);
             then(loadProjectPort).should(never()).existsByOwnerAndGisu(any(), any());
         }
 
-        private TransferProjectOwnershipCommand transferCommand(Long requester, Long newOwner) {
+        private TransferProjectOwnershipCommand transferCommand(Long newOwner) {
             return TransferProjectOwnershipCommand.builder()
                 .projectId(1L)
-                .requesterMemberId(requester)
                 .newOwnerMemberId(newOwner)
                 .build();
         }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
@@ -220,7 +220,7 @@ class ProjectMemberCommandServiceTest {
             ReflectionTestUtils.setField(p, "gisuId", 1L);
             ReflectionTestUtils.setField(p, "chapterId", 1L);
             ReflectionTestUtils.setField(p, "productOwnerMemberId", 99L);
-            ReflectionTestUtils.setField(p, "createdByMemberId", 99L);
+            ReflectionTestUtils.setField(p, "creatorMemberId", 99L);
             return p;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandServiceTest.java
@@ -172,7 +172,7 @@ class ProjectPartQuotaCommandServiceTest {
             ReflectionTestUtils.setField(p, "chapterId", 1L);
             ReflectionTestUtils.setField(p, "productOwnerMemberId", 100L);
             ReflectionTestUtils.setField(p, "productOwnerSchoolId", 7L);
-            ReflectionTestUtils.setField(p, "createdByMemberId", 100L);
+            ReflectionTestUtils.setField(p, "creatorMemberId", 100L);
             return p;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -450,7 +450,7 @@ class ProjectApplicationPermissionEvaluatorTest {
             Project project = constructor.newInstance();
             ReflectionTestUtils.setField(project, "id", id);
             ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
-            ReflectionTestUtils.setField(project, "createdByMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "creatorMemberId", ownerMemberId);
             ReflectionTestUtils.setField(project, "status", status);
             ReflectionTestUtils.setField(project, "gisuId", PROJECT_GISU_ID);
             ReflectionTestUtils.setField(project, "chapterId", PROJECT_CHAPTER_ID);

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -363,7 +363,7 @@ class ProjectPermissionEvaluatorTest {
     }
 
     @Test
-    void EDIT은_PENDING_REVIEW에서_중앙총괄도_거부() {
+    void EDIT은_PENDING_REVIEW에서_중앙총괄_허용() {
         Long projectId = 100L;
         given(loadProjectPort.findById(projectId))
             .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
@@ -371,7 +371,7 @@ class ProjectPermissionEvaluatorTest {
         SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
         ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
 
-        assertThat(sut.evaluate(subject, permission)).isFalse();
+        assertThat(sut.evaluate(subject, permission)).isTrue();
     }
 
     @Test
@@ -388,7 +388,7 @@ class ProjectPermissionEvaluatorTest {
     }
 
     @Test
-    void EDIT은_IN_PROGRESS에서_중앙총괄도_거부() {
+    void EDIT은_IN_PROGRESS에서_중앙총괄_허용() {
         Long projectId = 100L;
         given(loadProjectPort.findById(projectId))
             .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.IN_PROGRESS)));
@@ -396,11 +396,11 @@ class ProjectPermissionEvaluatorTest {
         SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
         ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
 
-        assertThat(sut.evaluate(subject, permission)).isFalse();
+        assertThat(sut.evaluate(subject, permission)).isTrue();
     }
 
     @Test
-    void EDIT은_PENDING_REVIEW에서_지부장도_거부() {
+    void EDIT은_PENDING_REVIEW에서_본인_지부장_허용() {
         Long projectId = 100L;
         given(loadProjectPort.findById(projectId))
             .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
@@ -409,7 +409,7 @@ class ProjectPermissionEvaluatorTest {
             List.of(chapterPresidentRole(1L, 1L)));
         ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
 
-        assertThat(sut.evaluate(subject, permission)).isFalse();
+        assertThat(sut.evaluate(subject, permission)).isTrue();
     }
 
     @Test
@@ -418,7 +418,7 @@ class ProjectPermissionEvaluatorTest {
         Long creatorId = 20L;
         Long projectId = 100L;
         Project p = project(projectId, ownerId, ProjectStatus.DRAFT);
-        ReflectionTestUtils.setField(p, "createdByMemberId", creatorId);
+        ReflectionTestUtils.setField(p, "creatorMemberId", creatorId);
         given(loadProjectPort.findById(projectId)).willReturn(Optional.of(p));
 
         SubjectAttributes subject = subjectWith(creatorId, List.of(), List.of());
@@ -433,7 +433,7 @@ class ProjectPermissionEvaluatorTest {
         Long creatorId = 20L;
         Long projectId = 100L;
         Project p = project(projectId, ownerId, ProjectStatus.PENDING_REVIEW);
-        ReflectionTestUtils.setField(p, "createdByMemberId", creatorId);
+        ReflectionTestUtils.setField(p, "creatorMemberId", creatorId);
         given(loadProjectPort.findById(projectId)).willReturn(Optional.of(p));
 
         SubjectAttributes subject = subjectWith(creatorId, List.of(), List.of());
@@ -503,6 +503,84 @@ class ProjectPermissionEvaluatorTest {
 
         assertThatThrownBy(() -> sut.evaluate(subject, permission))
             .isInstanceOf(ProjectDomainException.class);
+    }
+
+    @Test
+    void EDIT은_DRAFT에서_PO라도_creator가_아니면_거부() {
+        Long ownerId = 10L;
+        Long creatorId = 20L;
+        Long projectId = 100L;
+        Project p = project(projectId, ownerId, ProjectStatus.DRAFT);
+        ReflectionTestUtils.setField(p, "creatorMemberId", creatorId);
+        given(loadProjectPort.findById(projectId)).willReturn(Optional.of(p));
+
+        SubjectAttributes subject = subjectWith(ownerId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_IN_PROGRESS에서_본인_지부장_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.IN_PROGRESS)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(),
+            List.of(chapterPresidentRole(1L, 1L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void EDIT은_PENDING_REVIEW에서_다른_지부의_지부장_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(),
+            List.of(chapterPresidentRole(2L, 1L)));   // 본 프로젝트의 chapterId=1
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_PENDING_REVIEW에서_이전_기수_중앙총괄_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRoleInGisu(99L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_PENDING_REVIEW에서_이전_기수_지부장_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(),
+            List.of(chapterPresidentRole(1L, 99L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void EDIT은_ABORTED에서_운영진도_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.ABORTED)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.EDIT);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
     }
 
     // --- MANAGE (publish/abort/complete 등 운영진 전용 상태 전이) ---
@@ -693,7 +771,7 @@ class ProjectPermissionEvaluatorTest {
             Project project = constructor.newInstance();
             ReflectionTestUtils.setField(project, "id", id);
             ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
-            ReflectionTestUtils.setField(project, "createdByMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "creatorMemberId", ownerMemberId);
             ReflectionTestUtils.setField(project, "status", status);
             ReflectionTestUtils.setField(project, "gisuId", 1L);
             ReflectionTestUtils.setField(project, "chapterId", 1L);

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationFormQueryServiceTest.java
@@ -302,7 +302,7 @@ class ProjectApplicationFormQueryServiceTest {
         ReflectionTestUtils.setField(project, "status", ProjectStatus.IN_PROGRESS);
         ReflectionTestUtils.setField(project, "name", "Triple");
         ReflectionTestUtils.setField(project, "productOwnerMemberId", PM_MEMBER_ID);
-        ReflectionTestUtils.setField(project, "createdByMemberId", PM_MEMBER_ID);
+        ReflectionTestUtils.setField(project, "creatorMemberId", PM_MEMBER_ID);
         return project;
     }
 

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -250,7 +250,7 @@ class ProjectQueryServiceTest {
         ReflectionTestUtils.setField(project, "description", "테스트 설명");
         ReflectionTestUtils.setField(project, "thumbnailFileId", "thumb-1");
         ReflectionTestUtils.setField(project, "productOwnerMemberId", 10L);
-        ReflectionTestUtils.setField(project, "createdByMemberId", 10L);
+        ReflectionTestUtils.setField(project, "creatorMemberId", 10L);
         return project;
     }
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #866

## 🚀 작업 내용

프로젝트 EDIT 액션의 권한 판정을 `ProjectPermissionEvaluator.canEdit` 한 곳으로 일원화하고, 운영진에게 개방했습니다.

**1. `canEdit` 권한 정책 재정의**
EDIT 을 공유하는 5개 액션(기본정보 수정 · 제출 · 소유권 양도 · 팀원 추가/제거)의 권한을 상태 기준으로 일원화했어요.

| 프로젝트 상태 | 허용 주체 |
|---|---|
| DRAFT | creator 만 (임시저장은 작성자의 작업 공간) |
| PENDING_REVIEW / IN_PROGRESS | PO 또는 운영진(해당 기수 총괄단 / 본인 지부장) |
| COMPLETED / ABORTED | 차단 |

**2. 서비스 계층 PO 체크 제거**
- `ProjectCommandService.submit()` / `transfer()` 에서 `productOwnerMemberId` 검사를 제거했어요. 
  -  ->권한은 `@CheckAccess(EDIT)` → `canEdit` 가 단독으로 담당하도록 했어요.

**테스트**
- `ProjectPermissionEvaluatorTest`: 구 정책("PO 전용")을 검증하던 EDIT 테스트 3개를 새 정책에 맞게 반전하고, 운영진 케이스 6개를 추가했습니다.
- `ProjectCommandServiceTest`: 권한 검증이 서비스 책임에서 빠지면서, 해당 단위 테스트 2개를 제거했습니다. (커버리지는 `ProjectPermissionEvaluatorTest` 로 이동)
- 프로젝트 테스트 458개 전부 통과를 확인했습니다.

## 💬 리뷰 중점사항
