### PR TITLE
[Feat] 이메일 인증 시 보안 강화

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
@@ -9,6 +9,7 @@ import com.umc.product.authentication.adapter.in.web.dto.response.IdPwLoginRespo
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
 import com.umc.product.authentication.application.port.in.query.CheckCredentialAvailabilityUseCase;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
@@ -74,7 +75,10 @@ public class CredentialAuthenticationController {
     public void resetPasswordByEmail(
         @Valid @RequestBody ResetPasswordByEmailRequest request
     ) {
-        String email = jwtTokenProvider.parseEmailVerificationToken(request.emailVerificationToken());
+        String email = jwtTokenProvider.parseEmailVerificationToken(
+            request.emailVerificationToken(),
+            EmailVerificationPurpose.PASSWORD_RESET
+        );
         credentialAuthenticationUseCase.resetPasswordByEmail(request.toCommand(email));
     }
 

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
@@ -13,6 +13,7 @@ import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.annotation.Public;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,13 +62,19 @@ public class EmailAuthenticationController {
             인증을 요청하는 이메일로 인증 코드를 발송합니다.
 
             이메일 인증코드는 6자리의 숫자로만 구성되어 있습니다.
+
+            purpose 는 회원가입(REGISTER) 또는 비밀번호 초기화(PASSWORD_RESET) 중 하나여야 하며,
+            cross-purpose 공격 방어를 위해 세션 단위로 고정됩니다.
             """)
     @PostMapping("email-verification")
     @Public
     public SendEmailVerificationResponse sendEmailVerification(
-        @RequestBody SendEmailVerificationRequest request
+        @Valid @RequestBody SendEmailVerificationRequest request
     ) {
-        Long sessionId = manageAuthenticationUseCase.createEmailVerificationSession(request.email());
+        Long sessionId = manageAuthenticationUseCase.createEmailVerificationSession(
+            request.email(),
+            request.purpose()
+        );
 
         return SendEmailVerificationResponse
             .builder()

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
@@ -1,6 +1,16 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import jakarta.validation.constraints.NotNull;
+
 public record SendEmailVerificationRequest(
-    String email
+    String email,
+
+    /**
+     * 인증 세션 용도. 회원가입(REGISTER) / 비밀번호 초기화(PASSWORD_RESET).
+     * cross-purpose 공격 방어를 위해 세션 단위로 고정한다.
+     */
+    @NotNull
+    EmailVerificationPurpose purpose
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
@@ -1,9 +1,15 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SendEmailVerificationRequest(
+    @NotBlank
+    @Email
+    @Size(max = 100)
     String email,
 
     /**

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
@@ -3,6 +3,8 @@ package com.umc.product.authentication.adapter.out.persistence;
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
 import com.umc.product.authentication.domain.EmailVerification;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,12 +17,16 @@ public class EmailVerificationPersistenceAdapter implements LoadEmailVerificatio
 
     @Override
     public EmailVerification getById(Long id) {
-        return emailVerificationQueryRepository.findById(id);
+        return emailVerificationQueryRepository.findById(id)
+            .orElseThrow(() -> new AuthenticationDomainException(
+                AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION));
     }
 
     @Override
     public EmailVerification getByToken(String token) {
-        return emailVerificationQueryRepository.findByToken(token);
+        return emailVerificationQueryRepository.findByToken(token)
+            .orElseThrow(() -> new AuthenticationDomainException(
+                AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION));
     }
 
     @Override

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
@@ -4,6 +4,7 @@ import static com.umc.product.authentication.domain.QEmailVerification.emailVeri
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.authentication.domain.EmailVerification;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,17 +13,21 @@ import org.springframework.stereotype.Repository;
 public class EmailVerificationQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
-    EmailVerification findById(Long id) {
-        return jpaQueryFactory
-            .selectFrom(emailVerification)
-            .where(emailVerification.id.eq(id))
-            .fetchOne();
+    public Optional<EmailVerification> findById(Long id) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .selectFrom(emailVerification)
+                .where(emailVerification.id.eq(id))
+                .fetchOne()
+        );
     }
 
-    EmailVerification findByToken(String token) {
-        return jpaQueryFactory
-            .selectFrom(emailVerification)
-            .where(emailVerification.token.eq(token))
-            .fetchOne();
+    public Optional<EmailVerification> findByToken(String token) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .selectFrom(emailVerification)
+                .where(emailVerification.token.eq(token))
+                .fetchOne()
+        );
     }
 }

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/ManageAuthenticationUseCase.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/ManageAuthenticationUseCase.java
@@ -3,6 +3,7 @@ package com.umc.product.authentication.application.port.in.command;
 import com.umc.product.authentication.application.port.in.command.dto.NewTokens;
 import com.umc.product.authentication.application.port.in.command.dto.RenewAccessTokenCommand;
 import com.umc.product.authentication.application.port.in.command.dto.ValidateEmailVerificationSessionCommand;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 
 public interface ManageAuthenticationUseCase {
     /**
@@ -12,8 +13,11 @@ public interface ManageAuthenticationUseCase {
 
     /**
      * 새로운 이메일 인증 세션을 생성합니다. (발송까지)
+     * <p>
+     * 세션 용도(purpose) 는 발급 시점에 고정되며, 이후 검증으로 발급되는
+     * emailVerificationToken 의 purpose claim 으로 그대로 이어진다.
      */
-    Long createEmailVerificationSession(String email);
+    Long createEmailVerificationSession(String email, EmailVerificationPurpose purpose);
 
     /**
      * 기존 이메일 인증 세션의 인증 코드를 재발급하고 이메일을 재전송합니다.

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -90,7 +90,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = AuthenticationDomainException.class)
     public String validateEmailVerificationSession(ValidateEmailVerificationSessionCommand command) {
         // code가 주어지면 토큰이 우선 순위
         if (command.code() != null) {
@@ -98,6 +98,8 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
                 Long.valueOf(command.sessionId())
             );
 
+            // verifyCode 가 실패해도 attempt_count 증가/세션 무효화는 영속되어야 하므로
+            // AuthenticationDomainException 에 대해서는 트랜잭션을 롤백하지 않는다.
             emailVerification.verifyCode(command.code());
 
             return jwtTokenProvider.createEmailVerificationToken(

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -6,6 +6,7 @@ import com.umc.product.authentication.application.port.in.command.dto.RenewAcces
 import com.umc.product.authentication.application.port.in.command.dto.ValidateEmailVerificationSessionCommand;
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
+import com.umc.product.authentication.domain.CredentialPolicy;
 import com.umc.product.authentication.domain.EmailVerification;
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
@@ -55,6 +56,9 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     @Override
     @Transactional
     public Long createEmailVerificationSession(String email, EmailVerificationPurpose purpose) {
+        // DTO 단계 검증을 통과해도, Service 진입 시 도메인 SSOT 인 CredentialPolicy 로 한번 더 검증한다.
+        CredentialPolicy.validateEmail(email);
+
         String code = generateRandomCode();
         String token = UUID.randomUUID().toString();
 

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -7,6 +7,7 @@ import com.umc.product.authentication.application.port.in.command.dto.ValidateEm
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
 import com.umc.product.authentication.domain.EmailVerification;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -53,7 +54,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
     @Override
     @Transactional
-    public Long createEmailVerificationSession(String email) {
+    public Long createEmailVerificationSession(String email, EmailVerificationPurpose purpose) {
         String code = generateRandomCode();
         String token = UUID.randomUUID().toString();
 
@@ -61,6 +62,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
             .email(email)
             .code(code)
             .token(token)
+            .purpose(purpose)
             .build();
 
         Long sessionId = saveEmailVerificationPort.save(emailVerification).getId();
@@ -94,7 +96,10 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
             emailVerification.verifyCode(command.code());
 
-            return jwtTokenProvider.createEmailVerificationToken(emailVerification.getEmail());
+            return jwtTokenProvider.createEmailVerificationToken(
+                emailVerification.getEmail(),
+                emailVerification.getPurpose()
+            );
         }
 
         if (command.token() != null) {

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -22,6 +22,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailVerification extends BaseEntity {
+
+    /**
+     * 인증 코드 brute-force 방어를 위한 최대 시도 횟수. 초과 시 세션을 즉시 무효화한다.
+     */
+    public static final int MAX_ATTEMPT_COUNT = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,6 +67,13 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "purpose", nullable = false, length = 20)
     private EmailVerificationPurpose purpose;
 
+    /**
+     * 인증 코드 검증 시도 횟수. MAX_ATTEMPT_COUNT 도달 시 즉시 만료(세션 무효화)한다.
+     * regenerate 시 0 으로 초기화한다.
+     */
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
 
     @Builder
     public EmailVerification(String email, String token, String code, EmailVerificationPurpose purpose) {
@@ -70,6 +83,7 @@ public class EmailVerification extends BaseEntity {
         this.purpose = purpose;
         this.expiresAt = Instant.now().plusSeconds(10 * 60); // 10분 후 만료
         this.isVerified = false;
+        this.attemptCount = 0;
     }
 
     public boolean isExpired() {
@@ -77,9 +91,21 @@ public class EmailVerification extends BaseEntity {
     }
 
     public void verifyCode(String code) {
+        // 임계치 초과로 이미 무효화된 세션은 즉시 거부 (시도 횟수도 더 이상 증가시키지 않음)
+        if (this.attemptCount >= MAX_ATTEMPT_COUNT) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+
+        this.attemptCount++;
+
         if (this.code.equals(code) && !isExpired()) {
             setVerified("CODE");
             return;
+        }
+
+        // 이번 시도로 임계치에 도달했다면 즉시 세션 만료시켜 후속 시도를 차단한다.
+        if (this.attemptCount >= MAX_ATTEMPT_COUNT) {
+            this.expiresAt = Instant.now();
         }
 
         throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
@@ -102,6 +128,7 @@ public class EmailVerification extends BaseEntity {
         this.code = newCode;
         this.token = newToken;
         this.expiresAt = Instant.now().plusSeconds(10 * 60);
+        this.attemptCount = 0;
     }
 
     private void setVerified(String method) {

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -5,6 +5,8 @@ import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -52,12 +54,20 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
 
+    /**
+     * 인증 세션의 용도 (REGISTER / PASSWORD_RESET). cross-purpose 공격 방어를 위해 세션 단위로 고정한다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose", nullable = false, length = 20)
+    private EmailVerificationPurpose purpose;
+
 
     @Builder
-    public EmailVerification(String email, String token, String code) {
+    public EmailVerification(String email, String token, String code, EmailVerificationPurpose purpose) {
         this.email = email;
         this.token = token;
         this.code = code;
+        this.purpose = purpose;
         this.expiresAt = Instant.now().plusSeconds(10 * 60); // 10분 후 만료
         this.isVerified = false;
     }

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerificationPurpose.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerificationPurpose.java
@@ -1,0 +1,19 @@
+package com.umc.product.authentication.domain;
+
+/**
+ * 이메일 인증 세션 및 emailVerificationToken 의 용도를 구분한다.
+ * <p>
+ * 회원가입용과 비밀번호 초기화용 토큰을 분리해, 한 흐름에서 발급된 토큰이
+ * 다른 흐름에 재사용되지 않도록 한다 (cross-purpose 공격 방어).
+ */
+public enum EmailVerificationPurpose {
+    /**
+     * 신규 회원가입을 위한 이메일 인증.
+     */
+    REGISTER,
+
+    /**
+     * 가입된 회원의 비밀번호 초기화를 위한 이메일 인증.
+     */
+    PASSWORD_RESET
+}

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.umc.product.global.security;
 
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.OAuthProvider;
@@ -74,14 +75,18 @@ public class JwtTokenProvider {
 
     /**
      * emailVerificationToken 발급
+     * <p>
+     * purpose claim 으로 회원가입(REGISTER) 과 비밀번호 초기화(PASSWORD_RESET) 흐름을 구분한다.
+     * 한 흐름에서 발급된 토큰이 다른 흐름에 재사용되지 않도록, 파싱 시 expectedPurpose 와 비교한다.
      */
-    public String createEmailVerificationToken(String email) {
+    public String createEmailVerificationToken(String email, EmailVerificationPurpose purpose) {
         Date now = new Date();
         Date validityDate = new Date(now.getTime() + verificationTokenValidityInMilliseconds); // 10분 유효
 
         return Jwts.builder()
             .subject("EMAIL_VERIFICATION")
             .claim("email", email)
+            .claim("purpose", purpose.name())
             .issuedAt(now)
             .expiration(validityDate)
             .signWith(emailVerificationTokenSecret)
@@ -215,11 +220,20 @@ public class JwtTokenProvider {
 
     /**
      * emailVerificationToken 파싱 및 검증
+     * <p>
+     * 토큰의 purpose claim 이 expectedPurpose 와 일치하지 않으면 INVALID_EMAIL_VERIFICATION 예외를 던진다.
+     * 예) 회원가입(REGISTER) 흐름에서 발급된 토큰을 비밀번호 초기화에 사용하려는 cross-purpose 공격 방어.
      */
-    public String parseEmailVerificationToken(String token) {
+    public String parseEmailVerificationToken(String token, EmailVerificationPurpose expectedPurpose) {
         validateToken(token, emailVerificationTokenSecret);
 
         Claims claims = parseClaims(token, emailVerificationTokenSecret);
+
+        String purposeClaim = claims.get("purpose", String.class);
+        if (purposeClaim == null || !purposeClaim.equals(expectedPurpose.name())) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+
         return claims.get("email", String.class);
     }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -1,5 +1,6 @@
 package com.umc.product.member.adapter.in.web;
 
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -70,7 +71,10 @@ public class MemberCommandController {
     )
     RegisterResponse registerMemberByOAuth(@RequestBody OAuthRegisterMemberRequest request) {
         OAuthVerificationClaims claims = jwtTokenProvider.parseOAuthVerificationToken(request.oAuthVerificationToken());
-        String email = jwtTokenProvider.parseEmailVerificationToken(request.emailVerificationToken());
+        String email = jwtTokenProvider.parseEmailVerificationToken(
+            request.emailVerificationToken(),
+            EmailVerificationPurpose.REGISTER
+        );
 
         OAuthRegisterMemberCommand command = OAuthRegisterMemberCommand
             .builder()
@@ -108,7 +112,10 @@ public class MemberCommandController {
         content = "'회원 ID: ' + #result.memberId + '\n닉네임/이름: ' + #request.nickname + '/' + #request.name + '\n학교: ' + #request.schoolId"
     )
     RegisterResponse registerMemberByEmail(@Valid @RequestBody EmailRegisterMemberRequest request) {
-        String email = jwtTokenProvider.parseEmailVerificationToken(request.emailVerificationToken());
+        String email = jwtTokenProvider.parseEmailVerificationToken(
+            request.emailVerificationToken(),
+            EmailVerificationPurpose.REGISTER
+        );
 
         Long createdMemberId = registerEmailMemberUseCase.register(request.toCommand(email));
 

--- a/src/main/java/com/umc/product/test/controller/TestController.java
+++ b/src/main/java/com/umc/product/test/controller/TestController.java
@@ -4,6 +4,7 @@ import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authentication.adapter.out.external.AppleOAuthProperties;
 import com.umc.product.authentication.adapter.out.external.AppleTokenVerifier;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import com.umc.product.global.exception.constant.Domain;
@@ -176,8 +177,11 @@ public class TestController {
     @Operation(summary = "[TEST-009] EmailVerificationToken 발급")
     @Public
     @GetMapping("/token/email")
-    public String getEmailVerification(@RequestParam String email) {
-        return jwtTokenProvider.createEmailVerificationToken(email);
+    public String getEmailVerification(
+        @RequestParam String email,
+        @RequestParam(required = false, defaultValue = "REGISTER") EmailVerificationPurpose purpose
+    ) {
+        return jwtTokenProvider.createEmailVerificationToken(email, purpose);
     }
 
     @Operation(summary = "[TEST-010] oAuthVerificationToken 발급")

--- a/src/main/resources/db/migration/V2026.05.17.21.00__add_purpose_to_email_verification.sql
+++ b/src/main/resources/db/migration/V2026.05.17.21.00__add_purpose_to_email_verification.sql
@@ -1,0 +1,9 @@
+-- email_verification 세션에 용도(purpose) 구분 컬럼을 추가한다.
+-- 회원가입(REGISTER) 과 비밀번호 초기화(PASSWORD_RESET) 흐름의 cross-purpose 공격을 방어한다.
+-- 기존 레코드는 회원가입 인증에 해당하므로 REGISTER 로 기본값을 부여한다.
+ALTER TABLE email_verification
+    ADD COLUMN purpose VARCHAR(20) NOT NULL DEFAULT 'REGISTER';
+
+ALTER TABLE email_verification
+    ADD CONSTRAINT email_verification_purpose_check
+        CHECK (purpose IN ('REGISTER', 'PASSWORD_RESET'));

--- a/src/main/resources/db/migration/V2026.05.17.21.30__add_attempt_count_to_email_verification.sql
+++ b/src/main/resources/db/migration/V2026.05.17.21.30__add_attempt_count_to_email_verification.sql
@@ -1,0 +1,4 @@
+-- 이메일 인증 코드 brute-force 방어를 위한 시도 횟수 컬럼을 추가한다.
+-- 임계치(5회) 초과 시 도메인 레이어에서 세션을 무효화한다.
+ALTER TABLE email_verification
+    ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;

--- a/src/test/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapterTest.java
@@ -1,0 +1,113 @@
+package com.umc.product.authentication.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authentication.domain.EmailVerification;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * EmailVerificationPersistenceAdapter 단위 테스트.
+ * <p>
+ * CLAUDE.md 의 get[By] 시멘틱(없으면 예외) 을 충족하는지, QueryRepository 의 Optional 빈 결과를
+ * 도메인 예외로 변환하는지 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationPersistenceAdapterTest {
+
+    private static final Long SESSION_ID = 100L;
+    private static final String TOKEN = "11111111-1111-1111-1111-111111111111";
+
+    @Mock
+    EmailVerificationJpaRepository jpaRepository;
+
+    @Mock
+    EmailVerificationQueryRepository queryRepository;
+
+    @InjectMocks
+    EmailVerificationPersistenceAdapter adapter;
+
+    private EmailVerification newSession() {
+        return EmailVerification.builder()
+            .email("alice@example.com")
+            .code("123456")
+            .token(TOKEN)
+            .purpose(EmailVerificationPurpose.REGISTER)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("getById")
+    class GetById {
+
+        @Test
+        @DisplayName("존재하면 엔티티를 반환한다")
+        void 존재_시_엔티티_반환() {
+            // given
+            EmailVerification session = newSession();
+            given(queryRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+            // when
+            EmailVerification result = adapter.getById(SESSION_ID);
+
+            // then
+            assertThat(result).isSameAs(session);
+        }
+
+        @Test
+        @DisplayName("미존재 시 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+        void 미존재_시_예외() {
+            // given
+            given(queryRepository.findById(SESSION_ID)).willReturn(Optional.empty());
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getById(SESSION_ID))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+    }
+
+    @Nested
+    @DisplayName("getByToken")
+    class GetByToken {
+
+        @Test
+        @DisplayName("존재하면 엔티티를 반환한다")
+        void 존재_시_엔티티_반환() {
+            // given
+            EmailVerification session = newSession();
+            given(queryRepository.findByToken(TOKEN)).willReturn(Optional.of(session));
+
+            // when
+            EmailVerification result = adapter.getByToken(TOKEN);
+
+            // then
+            assertThat(result).isSameAs(session);
+        }
+
+        @Test
+        @DisplayName("미존재 시 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+        void 미존재_시_예외() {
+            // given
+            given(queryRepository.findByToken(TOKEN)).willReturn(Optional.empty());
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getByToken(TOKEN))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -1,0 +1,163 @@
+package com.umc.product.authentication.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authentication.application.port.in.command.dto.ValidateEmailVerificationSessionCommand;
+import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
+import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
+import com.umc.product.authentication.domain.EmailVerification;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.notification.application.port.in.SendEmailUseCase;
+import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * AuthenticationService 단위 테스트.
+ * <p>
+ * 이메일 인증 핫픽스 (C1~C4) 의 서비스 계층 동작을 검증한다:
+ * - send 시 이메일 형식 검증 (CredentialPolicy)
+ * - validate 시 세션 purpose 가 토큰 purpose 로 그대로 이어지는지
+ * - validate 시 코드 불일치 → 도메인 예외 그대로 전달 (트랜잭션은 noRollbackFor 로 attempt_count 보존)
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceTest {
+
+    private static final String EMAIL = "alice@example.com";
+    private static final Long SESSION_ID = 100L;
+    private static final String CODE = "123456";
+    private static final String TOKEN = "22222222-2222-2222-2222-222222222222";
+    private static final String ISSUED_TOKEN = "issued.jwt.token";
+
+    @Mock
+    SendEmailUseCase sendEmailUseCase;
+
+    @Mock
+    LoadEmailVerificationPort loadEmailVerificationPort;
+
+    @Mock
+    SaveEmailVerificationPort saveEmailVerificationPort;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    AuthenticationService service;
+
+    private EmailVerification newSession(EmailVerificationPurpose purpose) {
+        return EmailVerification.builder()
+            .email(EMAIL)
+            .code(CODE)
+            .token(TOKEN)
+            .purpose(purpose)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("createEmailVerificationSession")
+    class CreateSession {
+
+        @Test
+        @DisplayName("잘못된 이메일 형식이면 INVALID_EMAIL_FORMAT 예외를 던지고 저장/발송하지 않는다")
+        void 잘못된_이메일_거부() {
+            // given: ReflectionTestUtils 로 @Value 주입 우회 (test 컨텍스트 없이도 동작하도록)
+            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
+
+            // when / then
+            assertThatThrownBy(() -> service.createEmailVerificationSession("not-an-email",
+                EmailVerificationPurpose.REGISTER))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_FORMAT);
+
+            then(saveEmailVerificationPort).should(never()).save(any());
+            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
+        }
+
+        @Test
+        @DisplayName("정상 이메일이면 세션을 저장하고 인증 메일을 발송한다")
+        void 정상_세션_생성() {
+            // given
+            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
+            EmailVerification persisted = newSession(EmailVerificationPurpose.REGISTER);
+            ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
+            given(saveEmailVerificationPort.save(any(EmailVerification.class))).willReturn(persisted);
+
+            // when
+            Long sessionId = service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.REGISTER);
+
+            // then
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            then(sendEmailUseCase).should()
+                .sendVerificationEmail(any(SendVerificationEmailCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("validateEmailVerificationSession")
+    class ValidateSession {
+
+        @Test
+        @DisplayName("정답 코드 검증 시 세션의 purpose 로 emailVerificationToken 을 발급한다")
+        void 검증_성공_시_purpose_그대로_발급() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.PASSWORD_RESET);
+            given(loadEmailVerificationPort.getById(SESSION_ID)).willReturn(session);
+            given(jwtTokenProvider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.PASSWORD_RESET))
+                .willReturn(ISSUED_TOKEN);
+
+            ValidateEmailVerificationSessionCommand command =
+                ValidateEmailVerificationSessionCommand.builder()
+                    .sessionId(SESSION_ID.toString())
+                    .code(CODE)
+                    .build();
+
+            // when
+            String issued = service.validateEmailVerificationSession(command);
+
+            // then
+            assertThat(issued).isEqualTo(ISSUED_TOKEN);
+            assertThat(session.isVerified()).isTrue();
+            then(jwtTokenProvider).should()
+                .createEmailVerificationToken(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+        }
+
+        @Test
+        @DisplayName("틀린 코드면 INVALID_EMAIL_VERIFICATION 예외를 던지고 토큰을 발급하지 않는다")
+        void 틀린_코드_시_토큰_미발급() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            given(loadEmailVerificationPort.getById(SESSION_ID)).willReturn(session);
+
+            ValidateEmailVerificationSessionCommand command =
+                ValidateEmailVerificationSessionCommand.builder()
+                    .sessionId(SESSION_ID.toString())
+                    .code("000000")
+                    .build();
+
+            // when / then
+            assertThatThrownBy(() -> service.validateEmailVerificationSession(command))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+
+            then(jwtTokenProvider).should(never()).createEmailVerificationToken(anyString(), any());
+            assertThat(session.getAttemptCount()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
+++ b/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
@@ -1,0 +1,170 @@
+package com.umc.product.authentication.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EmailVerification 도메인 단위 테스트.
+ * <p>
+ * verifyCode 의 brute-force 방어(시도 횟수 / 임계치 초과 시 즉시 만료), regenerate 의 초기화,
+ * purpose 영속을 검증한다.
+ */
+class EmailVerificationTest {
+
+    private static final String EMAIL = "alice@example.com";
+    private static final String CODE = "123456";
+    private static final String TOKEN = "00000000-0000-0000-0000-000000000000";
+
+    private EmailVerification newSession(EmailVerificationPurpose purpose) {
+        return EmailVerification.builder()
+            .email(EMAIL)
+            .code(CODE)
+            .token(TOKEN)
+            .purpose(purpose)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("새 세션 생성")
+    class Create {
+
+        @Test
+        @DisplayName("attemptCount 는 0 으로, isVerified 는 false 로 시작한다")
+        void 초기_상태_검증() {
+            // given / when
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+
+            // then
+            assertThat(session.getAttemptCount()).isZero();
+            assertThat(session.isVerified()).isFalse();
+            assertThat(session.getPurpose()).isEqualTo(EmailVerificationPurpose.REGISTER);
+            assertThat(session.getEmail()).isEqualTo(EMAIL);
+        }
+
+        @Test
+        @DisplayName("purpose 는 빌더에 전달된 값으로 고정된다")
+        void purpose_고정() {
+            // given / when
+            EmailVerification session = newSession(EmailVerificationPurpose.PASSWORD_RESET);
+
+            // then
+            assertThat(session.getPurpose()).isEqualTo(EmailVerificationPurpose.PASSWORD_RESET);
+        }
+    }
+
+    @Nested
+    @DisplayName("verifyCode")
+    class VerifyCode {
+
+        @Test
+        @DisplayName("올바른 코드와 미만료 상태이면 검증 성공한다")
+        void 정상_검증_성공() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+
+            // when
+            session.verifyCode(CODE);
+
+            // then
+            assertThat(session.isVerified()).isTrue();
+            assertThat(session.getVerifiedAt()).isNotNull();
+            assertThat(session.getVerifiedBy()).isEqualTo("CODE");
+            assertThat(session.getAttemptCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("틀린 코드면 attemptCount 가 1 증가하고 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+        void 틀린_코드_시도_횟수_증가() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+
+            // when / then
+            assertThatThrownBy(() -> session.verifyCode("000000"))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+            assertThat(session.getAttemptCount()).isEqualTo(1);
+            assertThat(session.isVerified()).isFalse();
+        }
+
+        @Test
+        @DisplayName("MAX_ATTEMPT_COUNT 회 실패 시 세션이 즉시 만료된다")
+        void 임계치_도달_시_세션_무효화() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+
+            // when: 5회 연속 실패
+            for (int i = 0; i < EmailVerification.MAX_ATTEMPT_COUNT; i++) {
+                assertThatThrownBy(() -> session.verifyCode("000000"))
+                    .isInstanceOf(AuthenticationDomainException.class);
+            }
+
+            // then
+            assertThat(session.getAttemptCount()).isEqualTo(EmailVerification.MAX_ATTEMPT_COUNT);
+            assertThat(session.isExpired()).isTrue();
+        }
+
+        @Test
+        @DisplayName("임계치 도달 후에는 정답을 입력해도 검증되지 않으며 attemptCount 가 더 이상 증가하지 않는다")
+        void 임계치_도달_후_정답도_거부() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            for (int i = 0; i < EmailVerification.MAX_ATTEMPT_COUNT; i++) {
+                assertThatThrownBy(() -> session.verifyCode("000000"))
+                    .isInstanceOf(AuthenticationDomainException.class);
+            }
+            int countBefore = session.getAttemptCount();
+
+            // when / then
+            assertThatThrownBy(() -> session.verifyCode(CODE))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+            assertThat(session.getAttemptCount()).isEqualTo(countBefore);
+            assertThat(session.isVerified()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("regenerate")
+    class Regenerate {
+
+        @Test
+        @DisplayName("코드 재발급 시 attemptCount 가 0 으로 초기화된다")
+        void 재발급_시_attemptCount_초기화() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            assertThatThrownBy(() -> session.verifyCode("000000"))
+                .isInstanceOf(AuthenticationDomainException.class);
+            assertThat(session.getAttemptCount()).isEqualTo(1);
+
+            // when
+            session.regenerate("999999", "new-token");
+
+            // then
+            assertThat(session.getAttemptCount()).isZero();
+            assertThat(session.getCode()).isEqualTo("999999");
+            assertThat(session.getToken()).isEqualTo("new-token");
+        }
+
+        @Test
+        @DisplayName("이미 검증된 세션은 ALREADY_VERIFIED_EMAIL 예외로 재발급 불가")
+        void 검증_완료_세션_재발급_금지() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            session.verifyCode(CODE);
+
+            // when / then
+            assertThatThrownBy(() -> session.regenerate("999999", "new-token"))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.ALREADY_VERIFIED_EMAIL);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/security/JwtTokenProviderEmailVerificationTest.java
+++ b/src/test/java/com/umc/product/global/security/JwtTokenProviderEmailVerificationTest.java
@@ -1,0 +1,98 @@
+package com.umc.product.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JwtTokenProvider 의 emailVerificationToken purpose claim 검증 단위 테스트.
+ * <p>
+ * 회원가입(REGISTER) 흐름에서 발급된 토큰이 비밀번호 초기화(PASSWORD_RESET) 에 재사용되지
+ * 않도록, 발급 시 purpose 를 claim 으로 심고 파싱 시 expectedPurpose 와 일치해야만
+ * 통과시키는 동작을 검증한다.
+ */
+class JwtTokenProviderEmailVerificationTest {
+
+    private static final String EMAIL = "alice@example.com";
+    private static final String ACCESS_TOKEN_SECRET = "test-access-token-secret-must-be-long-enough-for-hmac-sha256";
+    private static final String REFRESH_TOKEN_SECRET = "test-refresh-token-secret-must-be-long-enough-for-hmac-sha256";
+    private static final String OAUTH_VERIFICATION_TOKEN_SECRET =
+        "test-oauth-verification-token-secret-must-be-long-enough-for-hmac-sha256";
+    private static final String EMAIL_VERIFICATION_TOKEN_SECRET =
+        "test-email-verification-token-secret-must-be-long-enough-for-hmac-sha256";
+
+    private JwtTokenProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new JwtTokenProvider(
+            ACCESS_TOKEN_SECRET,
+            REFRESH_TOKEN_SECRET,
+            OAUTH_VERIFICATION_TOKEN_SECRET,
+            EMAIL_VERIFICATION_TOKEN_SECRET,
+            3600L,
+            3600L,
+            600L
+        );
+    }
+
+    @Test
+    @DisplayName("REGISTER 로 발급한 토큰은 REGISTER 로 파싱 시 이메일을 반환한다")
+    void purpose_일치_REGISTER_정상_파싱() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.REGISTER);
+
+        // when
+        String parsedEmail = provider.parseEmailVerificationToken(token, EmailVerificationPurpose.REGISTER);
+
+        // then
+        assertThat(parsedEmail).isEqualTo(EMAIL);
+    }
+
+    @Test
+    @DisplayName("PASSWORD_RESET 로 발급한 토큰은 PASSWORD_RESET 로 파싱 시 이메일을 반환한다")
+    void purpose_일치_PASSWORD_RESET_정상_파싱() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+
+        // when
+        String parsedEmail = provider.parseEmailVerificationToken(token, EmailVerificationPurpose.PASSWORD_RESET);
+
+        // then
+        assertThat(parsedEmail).isEqualTo(EMAIL);
+    }
+
+    @Test
+    @DisplayName("REGISTER 토큰을 PASSWORD_RESET 로 파싱하면 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+    void cross_purpose_REGISTER_to_RESET_거부() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.REGISTER);
+
+        // when / then
+        assertThatThrownBy(() ->
+            provider.parseEmailVerificationToken(token, EmailVerificationPurpose.PASSWORD_RESET))
+            .isInstanceOf(AuthenticationDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+    }
+
+    @Test
+    @DisplayName("PASSWORD_RESET 토큰을 REGISTER 로 파싱하면 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+    void cross_purpose_RESET_to_REGISTER_거부() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+
+        // when / then
+        assertThatThrownBy(() ->
+            provider.parseEmailVerificationToken(token, EmailVerificationPurpose.REGISTER))
+            .isInstanceOf(AuthenticationDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치: `develop`
- [x] PR 제목 컨벤션 준수

## 🔥 연관 이슈

이메일 인증 흐름에 대한 코드 리뷰에서 P1으로 분류된 보안/신뢰성 이슈 4건을 묶어 핫픽스로 진행합니다. (이슈 번호가 따로 발급되지 않은 내부 진단 결과 기반)

## 🚀 작업 내용

이메일 인증 흐름에서 운영상 위험이 큰 P1 항목 4건을 한 PR로 묶어 즉시 조치합니다. P2/P3 의 도메인 정비 작업은 별도 PR(`kyeoungwoon/email-verification-refactor` 예정) 으로 분리합니다.

### 1. `get` 메서드 null 반환 가드 + Optional 시멘틱 정합화 (`fix`)

- `EmailVerificationQueryRepository` 가 `fetchOne()` 결과를 그대로 반환해 미존재 시 `null` 이 흘러가던 문제 → `Optional<EmailVerification>` 으로 시그니처 변경
- `EmailVerificationPersistenceAdapter` 의 `getById` / `getByToken` 에서 미존재 시 `AuthenticationDomainException(INVALID_EMAIL_VERIFICATION)` 으로 전환
- `CLAUDE.md` 의 `get[By]` 시멘틱(존재해야 함, 없으면 예외) 정합화

### 2. emailVerificationToken 에 `purpose` claim 추가 — cross-purpose 공격 방어 (`feat`)

- 회원가입(`REGISTER`) 흐름에서 발급된 토큰이 비밀번호 초기화(`PASSWORD_RESET`) 에 재사용될 수 있던 문제를 해결합니다.
- `EmailVerificationPurpose` enum 도입 + `email_verification.purpose` 컬럼 추가 (Flyway 마이그레이션, 기본값 `REGISTER`, CHECK 제약)
- send-API 단계에서 purpose 를 받아 **세션에 영속화** — 클라이언트가 verify-code 시점에 purpose 를 임의로 바꿔 토큰을 위조하지 못하도록 함
- `JwtTokenProvider.createEmailVerificationToken(email, purpose)` / `parseEmailVerificationToken(token, expectedPurpose)` 시그니처 변경. 불일치 시 `INVALID_EMAIL_VERIFICATION` 예외.
- 호출부 명시적 purpose 전달:
  - `MemberCommandController` (`/register`, `/register/oauth`, `/register/email`) → `REGISTER`
  - `CredentialAuthenticationController` (`/password/reset`) → `PASSWORD_RESET`
  - `TestController` (`/test/token/email`) → 쿼리 파라미터로 `purpose` (기본 `REGISTER`)

### 3. send 이메일 인증 요청 형식 검증 추가 (`feat`)

- `SendEmailVerificationRequest.email` 에 `@NotBlank @Email @Size(max=100)` 추가, 컨트롤러에 `@Valid` 적용
- `AuthenticationService.createEmailVerificationSession` 진입 시 도메인 SSOT 인 `CredentialPolicy.validateEmail` 추가 호출 (DTO 우회 시점 방어)

### 4. 인증 코드 brute-force 방어 — `attempt_count` 도입 (`feat`)

- 6자리 숫자 코드(100만 조합)에 무제한 시도가 허용되던 문제 해결
- `email_verification.attempt_count` 컬럼 추가 (Flyway, 기본값 0)
- `EmailVerification.MAX_ATTEMPT_COUNT = 5` 도입, 임계치 도달 시 `expiresAt = now()` 로 즉시 세션 무효화
- 이미 무효화된 세션 재호출은 카운트를 더 올리지 않고 즉시 거부 (불필요한 DB write 방지)
- `regenerate` 시 `attempt_count` 0 으로 초기화
- `validateEmailVerificationSession` 에 `noRollbackFor = AuthenticationDomainException` 설정 — 검증 실패 시에도 `attempt_count` / `expiresAt` 변경분이 보존되어야 brute-force 방어가 유효하기 때문

### 5. 단위 테스트 추가 (`test`)

- `EmailVerificationTest`: 초기 상태, verifyCode 정상/실패/임계치 도달/초과 후 거부, regenerate 시 attemptCount 초기화, 검증 완료 세션 재발급 금지
- `JwtTokenProviderEmailVerificationTest`: purpose claim 라운드트립 및 cross-purpose 거부 양방향
- `EmailVerificationPersistenceAdapterTest`: getById/getByToken 미존재 시 예외 변환
- `AuthenticationServiceTest`: send 시 잘못된 이메일 거부, 검증 성공 시 세션 purpose 가 토큰 발급에 그대로 전달

총 20개 테스트 모두 통과 확인했습니다.

### 후속 작업 (별도 PR 예정)

P2/P3 의 도메인 정비 트랙은 다음 PR(`kyeoungwoon/email-verification-refactor`) 로 진행합니다:
- send-API purpose 에 따른 가입 여부 분기 검증 (REGISTER 미가입 / PASSWORD_RESET 가입 강제)
- `@TransactionalEventListener(AFTER_COMMIT)` 기반 이메일 발송 분리
- 발송 빈도 throttle (DB 기반, 60초)
- 미사용 매직 링크 코드 제거
- `verifyCode` 의 `verifiedAt` 덮어쓰기 가드
- 만료 세션 정리 스케줄러 + `expires_at` 인덱스
- P3 잡다한 정리 (만료 시간 `@Value`, SecureRandom static, Long.parseLong 등)

## 💬 리뷰 중점사항

1. **API 호환성 (BREAKING)**: `POST /api/v1/auth/email-verification` 의 `purpose` 가 **필수 파라미터**로 변경됩니다. 모바일/웹 클라이언트가 동일 타이밍에 업데이트되는지 확인 부탁드립니다. (회원가입은 `REGISTER`, 비밀번호 초기화는 `PASSWORD_RESET` 전송 필요)
2. **`noRollbackFor` 적용**: `validateEmailVerificationSession` 에서 `AuthenticationDomainException` 발생 시 트랜잭션이 롤백되지 않도록 했습니다. brute-force 방어를 위한 의도된 동작이지만, 다른 도메인 예외가 추가될 경우 의도치 않은 부분 커밋이 발생할 수 있어 한 번 더 검토 부탁드립니다.
3. **Flyway 마이그레이션 2개** (`...add_purpose_to_email_verification.sql`, `...add_attempt_count_to_email_verification.sql`): 기존 레코드는 `purpose='REGISTER'`, `attempt_count=0` 으로 백필됩니다. 운영 데이터에 회원가입 외 흐름의 잔존 세션이 없는지 확인 부탁드립니다.
4. **임계치 5회**: 도메인 상수로 두었으며, 필요 시 PR2 의 P3 정리에서 `@Value` 로 외부화하겠습니다.