### PR TITLE
[Feat] 이메일 발송 목적별 분기, Event 기반 변경, 발송 빈도 제한, Orphan 제거 스케쥴러 도입

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionScheduler.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionScheduler.java
@@ -1,0 +1,38 @@
+package com.umc.product.authentication.adapter.in.scheduler;
+
+import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * email_verification 의 만료된 세션을 주기적으로 정리하는 회수 잡.
+ * <p>
+ * 만료 직후 즉시 삭제하지 않고 일정 기간(retention) 을 두어 운영 디버깅 가능 시점을 확보한다.
+ * 기본값은 매일 03:00 (Asia/Seoul), retention 7 일.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationRetentionScheduler {
+
+    private static final Duration RETENTION = Duration.ofDays(7);
+
+    private final DeleteEmailVerificationPort deleteEmailVerificationPort;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void purge() {
+        Instant threshold = Instant.now().minus(RETENTION);
+        int deleted = deleteEmailVerificationPort.deleteExpiredBefore(threshold);
+        if (deleted > 0) {
+            log.info("email_verification 회수 완료: threshold={}, deleted={}", threshold, deleted);
+        } else {
+            log.debug("email_verification 회수: 보존 기간 초과 행 없음. threshold={}", threshold);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
@@ -46,7 +46,7 @@ public class EmailAuthenticationController {
             .validateEmailVerificationSession(
                 ValidateEmailVerificationSessionCommand
                     .builder()
-                    .sessionId(request.emailVerificationId().toString())
+                    .sessionId(request.emailVerificationId())
                     .code(request.verificationCode())
                     .build()
             );
@@ -78,7 +78,7 @@ public class EmailAuthenticationController {
 
         return SendEmailVerificationResponse
             .builder()
-            .emailVerificationId(sessionId.toString())
+            .emailVerificationId(sessionId)
             .build();
     }
 

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/response/SendEmailVerificationResponse.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/response/SendEmailVerificationResponse.java
@@ -4,6 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record SendEmailVerificationResponse(
-    String emailVerificationId
+    Long emailVerificationId
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationJpaRepository.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationJpaRepository.java
@@ -1,7 +1,15 @@
 package com.umc.product.authentication.adapter.out.persistence;
 
 import com.umc.product.authentication.domain.EmailVerification;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM EmailVerification ev WHERE ev.expiresAt < :threshold")
+    int deleteByExpiresAtBefore(@Param("threshold") Instant threshold);
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.umc.product.authentication.application.port.out.SaveEmailVerification
 import com.umc.product.authentication.domain.EmailVerification;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +28,11 @@ public class EmailVerificationPersistenceAdapter implements LoadEmailVerificatio
         return emailVerificationQueryRepository.findByToken(token)
             .orElseThrow(() -> new AuthenticationDomainException(
                 AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION));
+    }
+
+    @Override
+    public Optional<EmailVerification> findLatestSentByEmail(String email) {
+        return emailVerificationQueryRepository.findLatestSentByEmail(email);
     }
 
     @Override

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
@@ -1,17 +1,20 @@
 package com.umc.product.authentication.adapter.out.persistence;
 
+import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
 import com.umc.product.authentication.domain.EmailVerification;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import java.time.Instant;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class EmailVerificationPersistenceAdapter implements LoadEmailVerificationPort, SaveEmailVerificationPort {
+public class EmailVerificationPersistenceAdapter implements
+    LoadEmailVerificationPort, SaveEmailVerificationPort, DeleteEmailVerificationPort {
 
     private final EmailVerificationJpaRepository emailVerificationJpaRepository;
     private final EmailVerificationQueryRepository emailVerificationQueryRepository;
@@ -31,5 +34,10 @@ public class EmailVerificationPersistenceAdapter implements LoadEmailVerificatio
     @Override
     public EmailVerification save(EmailVerification emailVerification) {
         return emailVerificationJpaRepository.save(emailVerification);
+    }
+
+    @Override
+    public int deleteExpiredBefore(Instant threshold) {
+        return emailVerificationJpaRepository.deleteByExpiresAtBefore(threshold);
     }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapter.java
@@ -24,13 +24,6 @@ public class EmailVerificationPersistenceAdapter implements LoadEmailVerificatio
     }
 
     @Override
-    public EmailVerification getByToken(String token) {
-        return emailVerificationQueryRepository.findByToken(token)
-            .orElseThrow(() -> new AuthenticationDomainException(
-                AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION));
-    }
-
-    @Override
     public Optional<EmailVerification> findLatestSentByEmail(String email) {
         return emailVerificationQueryRepository.findLatestSentByEmail(email);
     }

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
@@ -22,15 +22,6 @@ public class EmailVerificationQueryRepository {
         );
     }
 
-    public Optional<EmailVerification> findByToken(String token) {
-        return Optional.ofNullable(
-            jpaQueryFactory
-                .selectFrom(emailVerification)
-                .where(emailVerification.token.eq(token))
-                .fetchOne()
-        );
-    }
-
     public Optional<EmailVerification> findLatestSentByEmail(String email) {
         return Optional.ofNullable(
             jpaQueryFactory

--- a/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationQueryRepository.java
@@ -30,4 +30,18 @@ public class EmailVerificationQueryRepository {
                 .fetchOne()
         );
     }
+
+    public Optional<EmailVerification> findLatestSentByEmail(String email) {
+        return Optional.ofNullable(
+            jpaQueryFactory
+                .selectFrom(emailVerification)
+                .where(
+                    emailVerification.email.eq(email),
+                    emailVerification.lastSentAt.isNotNull()
+                )
+                .orderBy(emailVerification.lastSentAt.desc())
+                .limit(1)
+                .fetchOne()
+        );
+    }
 }

--- a/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
+++ b/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
@@ -1,0 +1,16 @@
+package com.umc.product.authentication.application.event;
+
+/**
+ * 이메일 인증 세션 생성/재발급 후, 메일 발송이 필요할 때 트랜잭션 commit 직후
+ * 비동기로 메일을 보내기 위해 발행되는 애플리케이션 이벤트.
+ * <p>
+ * SMTP 호출이 트랜잭션 내부에서 일어나면 메일 서버 응답이 느릴 때 DB 커넥션을 길게
+ * 점유하고, 발송 실패가 세션 롤백을 유발해 사용자가 처음부터 다시 인증해야 하는
+ * 문제가 있었다. AFTER_COMMIT 단계로 분리해 양쪽 부작용을 끊는다.
+ */
+public record SendVerificationEmailEvent(
+    String email,
+    String verificationCode,
+    String verificationLink
+) {
+}

--- a/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
+++ b/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
@@ -10,7 +10,6 @@ package com.umc.product.authentication.application.event;
  */
 public record SendVerificationEmailEvent(
     String email,
-    String verificationCode,
-    String verificationLink
+    String verificationCode
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEventListener.java
+++ b/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEventListener.java
@@ -26,7 +26,6 @@ public class SendVerificationEmailEventListener {
             SendVerificationEmailCommand.builder()
                 .to(event.email())
                 .verificationCode(event.verificationCode())
-                .verificationLink(event.verificationLink())
                 .build()
         );
     }

--- a/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEventListener.java
+++ b/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEventListener.java
@@ -1,0 +1,33 @@
+package com.umc.product.authentication.application.event;
+
+import com.umc.product.notification.application.port.in.SendEmailUseCase;
+import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * {@link SendVerificationEmailEvent} 를 받아 트랜잭션 commit 직후 실제 메일 발송을 트리거한다.
+ * <p>
+ * SendEmailUseCase 구현이 자체적으로 @Async 비동기 처리를 수행하므로, 이 리스너는 큐잉 역할만 한다.
+ * 트랜잭션이 롤백되면 발송 이벤트도 함께 사라져, 세션이 영속화되지 않은 상태에서 메일이 나가는
+ * 일을 막는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SendVerificationEmailEventListener {
+
+    private final SendEmailUseCase sendEmailUseCase;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(SendVerificationEmailEvent event) {
+        sendEmailUseCase.sendVerificationEmail(
+            SendVerificationEmailCommand.builder()
+                .to(event.email())
+                .verificationCode(event.verificationCode())
+                .verificationLink(event.verificationLink())
+                .build()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/ValidateEmailVerificationSessionCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/ValidateEmailVerificationSessionCommand.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 @Builder
 public record ValidateEmailVerificationSessionCommand(
     String sessionId,
-    String code,
-    String token
+    String code
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/ValidateEmailVerificationSessionCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/ValidateEmailVerificationSessionCommand.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ValidateEmailVerificationSessionCommand(
-    String sessionId,
+    Long sessionId,
     String code
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/application/port/out/DeleteEmailVerificationPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/DeleteEmailVerificationPort.java
@@ -1,0 +1,13 @@
+package com.umc.product.authentication.application.port.out;
+
+import java.time.Instant;
+
+public interface DeleteEmailVerificationPort {
+
+    /**
+     * expires_at 이 주어진 시각보다 이전인 레코드를 일괄 삭제한다.
+     *
+     * @return 삭제된 행 수
+     */
+    int deleteExpiredBefore(Instant threshold);
+}

--- a/src/main/java/com/umc/product/authentication/application/port/out/LoadEmailVerificationPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/LoadEmailVerificationPort.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 public interface LoadEmailVerificationPort {
     EmailVerification getById(Long id);
 
-    EmailVerification getByToken(String token);
-
     /**
      * 주어진 email 에 대해 실제로 발송이 일어난 가장 최근 세션을 조회한다.
      * throttle 검사 용도로, last_sent_at IS NOT NULL 인 레코드만 대상으로 한다.

--- a/src/main/java/com/umc/product/authentication/application/port/out/LoadEmailVerificationPort.java
+++ b/src/main/java/com/umc/product/authentication/application/port/out/LoadEmailVerificationPort.java
@@ -1,9 +1,16 @@
 package com.umc.product.authentication.application.port.out;
 
 import com.umc.product.authentication.domain.EmailVerification;
+import java.util.Optional;
 
 public interface LoadEmailVerificationPort {
     EmailVerification getById(Long id);
 
     EmailVerification getByToken(String token);
+
+    /**
+     * 주어진 email 에 대해 실제로 발송이 일어난 가장 최근 세션을 조회한다.
+     * throttle 검사 용도로, last_sent_at IS NOT NULL 인 레코드만 대상으로 한다.
+     */
+    Optional<EmailVerification> findLatestSentByEmail(String email);
 }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -27,6 +27,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthenticationService implements ManageAuthenticationUseCase {
 
+    /**
+     * 6자리 인증 코드 생성에 사용하는 보안 난수 생성기. JVM 단위 단일 인스턴스로 재사용한다.
+     */
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     private final LoadEmailVerificationPort loadEmailVerificationPort;
     private final SaveEmailVerificationPort saveEmailVerificationPort;
     private final JwtTokenProvider jwtTokenProvider;
@@ -136,9 +141,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
             throw new AuthenticationDomainException(AuthenticationErrorCode.NO_EMAIL_VERIFICATION_METHOD_GIVEN);
         }
 
-        EmailVerification emailVerification = loadEmailVerificationPort.getById(
-            Long.valueOf(command.sessionId())
-        );
+        EmailVerification emailVerification = loadEmailVerificationPort.getById(command.sessionId());
 
         // verifyCode 가 실패해도 attempt_count 증가/세션 무효화는 영속되어야 하므로
         // AuthenticationDomainException 에 대해서는 트랜잭션을 롤백하지 않는다.
@@ -159,8 +162,6 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     }
 
     private String generateRandomCode() {
-        SecureRandom random = new SecureRandom();
-
-        return String.valueOf(random.nextInt(900000) + 100000);
+        return String.valueOf(RANDOM.nextInt(900000) + 100000);
     }
 }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -18,11 +18,9 @@ import java.security.SecureRandom;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
@@ -34,8 +32,6 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     private final JwtTokenProvider jwtTokenProvider;
     private final GetMemberCredentialUseCase getMemberCredentialUseCase;
     private final ApplicationEventPublisher eventPublisher;
-    @Value("${app.base-url}")
-    private String serverUrl;
 
     // TODO: EmailSendUseCase와 구분할 필요가 있습니다.
     @Override
@@ -109,7 +105,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
         if (shouldSendEmail) {
             emailVerification.markSent();
-            publishSendEmailEvent(email, code, token);
+            publishSendEmailEvent(email, code);
         }
 
         return sessionId;
@@ -130,49 +126,36 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         emailVerification.regenerate(newCode, newToken);
         emailVerification.markSent();
 
-        publishSendEmailEvent(emailVerification.getEmail(), newCode, newToken);
+        publishSendEmailEvent(emailVerification.getEmail(), newCode);
     }
 
     @Override
     @Transactional(noRollbackFor = AuthenticationDomainException.class)
     public String validateEmailVerificationSession(ValidateEmailVerificationSessionCommand command) {
-        // code가 주어지면 토큰이 우선 순위
-        if (command.code() != null) {
-            EmailVerification emailVerification = loadEmailVerificationPort.getById(
-                Long.valueOf(command.sessionId())
-            );
-
-            // verifyCode 가 실패해도 attempt_count 증가/세션 무효화는 영속되어야 하므로
-            // AuthenticationDomainException 에 대해서는 트랜잭션을 롤백하지 않는다.
-            emailVerification.verifyCode(command.code());
-
-            return jwtTokenProvider.createEmailVerificationToken(
-                emailVerification.getEmail(),
-                emailVerification.getPurpose()
-            );
+        if (command.code() == null) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.NO_EMAIL_VERIFICATION_METHOD_GIVEN);
         }
 
-        if (command.token() != null) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.UNSUPPORTED_EMAIL_VERIFICATION_METHOD);
-        }
+        EmailVerification emailVerification = loadEmailVerificationPort.getById(
+            Long.valueOf(command.sessionId())
+        );
 
-        throw new AuthenticationDomainException(AuthenticationErrorCode.NO_EMAIL_VERIFICATION_METHOD_GIVEN);
+        // verifyCode 가 실패해도 attempt_count 증가/세션 무효화는 영속되어야 하므로
+        // AuthenticationDomainException 에 대해서는 트랜잭션을 롤백하지 않는다.
+        emailVerification.verifyCode(command.code());
+
+        return jwtTokenProvider.createEmailVerificationToken(
+            emailVerification.getEmail(),
+            emailVerification.getPurpose()
+        );
     }
 
     /**
      * 실제 SMTP 호출을 트랜잭션 commit 이후로 미루기 위해 이벤트를 발행한다.
      * AFTER_COMMIT 단계에서 SendVerificationEmailEventListener 가 메일을 발송한다.
      */
-    private void publishSendEmailEvent(String email, String code, String token) {
-        String emailVerificationPath = "/api/v1/auth/email-verification/token";
-
-        String verificationLink = UriComponentsBuilder
-            .fromUriString(serverUrl)
-            .path(emailVerificationPath)
-            .queryParam("token", token)
-            .toUriString();
-
-        eventPublisher.publishEvent(new SendVerificationEmailEvent(email, code, verificationLink));
+    private void publishSendEmailEvent(String email, String code) {
+        eventPublisher.publishEvent(new SendVerificationEmailEvent(email, code));
     }
 
     private String generateRandomCode() {

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -85,6 +85,16 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
             }
         };
 
+        // 실제로 메일이 나갈 경우에만 throttle 을 검사한다. silent skip 으로 발송하지 않는 경로는
+        // 메일 폭주 위험이 없으므로 throttle 대상이 아니다.
+        if (shouldSendEmail) {
+            loadEmailVerificationPort.findLatestSentByEmail(email)
+                .filter(EmailVerification::isSendThrottled)
+                .ifPresent(latest -> {
+                    throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+                });
+        }
+
         String code = generateRandomCode();
         String token = UUID.randomUUID().toString();
 
@@ -98,6 +108,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         Long sessionId = saveEmailVerificationPort.save(emailVerification).getId();
 
         if (shouldSendEmail) {
+            emailVerification.markSent();
             publishSendEmailEvent(email, code, token);
         }
 
@@ -109,10 +120,15 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     public void resendEmailVerification(Long sessionId) {
         EmailVerification emailVerification = loadEmailVerificationPort.getById(sessionId);
 
+        if (emailVerification.isSendThrottled()) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+        }
+
         String newCode = generateRandomCode();
         String newToken = UUID.randomUUID().toString();
 
         emailVerification.regenerate(newCode, newToken);
+        emailVerification.markSent();
 
         publishSendEmailEvent(emailVerification.getEmail(), newCode, newToken);
     }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -12,16 +12,19 @@ import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.notification.application.port.in.SendEmailUseCase;
 import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
 import java.security.SecureRandom;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthenticationService implements ManageAuthenticationUseCase {
@@ -30,6 +33,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     private final LoadEmailVerificationPort loadEmailVerificationPort;
     private final SaveEmailVerificationPort saveEmailVerificationPort;
     private final JwtTokenProvider jwtTokenProvider;
+    private final GetMemberCredentialUseCase getMemberCredentialUseCase;
     @Value("${app.base-url}")
     private String serverUrl;
 
@@ -59,6 +63,28 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         // DTO 단계 검증을 통과해도, Service 진입 시 도메인 SSOT 인 CredentialPolicy 로 한번 더 검증한다.
         CredentialPolicy.validateEmail(email);
 
+        // purpose 별 가입 여부 분기 검증.
+        // - REGISTER: 이미 가입된 이메일이면 인증 진행 자체를 차단 (가입 마지막 단계의 UNIQUE 충돌로 인한
+        //   "인증 다 했는데 실패" UX 방지). 회원가입 흐름에서는 이미 가입 여부 노출이 자연스러움.
+        // - PASSWORD_RESET: 미가입 / 자격증명 미등록 이메일에 대해서는 user enumeration 방어를 위해
+        //   응답은 동일하게 내려보내되 실제 메일 발송만 건너뛴다. 후속 reset 흐름에서도 INVALID_LOGIN_CREDENTIAL
+        //   단일 메시지로 응답하므로 끝까지 가입 여부가 노출되지 않는다.
+        boolean shouldSendEmail = switch (purpose) {
+            case REGISTER -> {
+                if (getMemberCredentialUseCase.existsByEmail(email)) {
+                    throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
+                }
+                yield true;
+            }
+            case PASSWORD_RESET -> {
+                boolean hasCredential = getMemberCredentialUseCase.findCredentialByEmail(email).isPresent();
+                if (!hasCredential) {
+                    log.info("PASSWORD_RESET 발송 요청이지만 가입/자격증명 미존재 — 발송 건너뜀 (enumeration 방어)");
+                }
+                yield hasCredential;
+            }
+        };
+
         String code = generateRandomCode();
         String token = UUID.randomUUID().toString();
 
@@ -71,7 +97,9 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
         Long sessionId = saveEmailVerificationPort.save(emailVerification).getId();
 
-        sendVerificationEmail(email, code, token);
+        if (shouldSendEmail) {
+            sendVerificationEmail(email, code, token);
+        }
 
         return sessionId;
     }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -1,5 +1,6 @@
 package com.umc.product.authentication.application.service;
 
+import com.umc.product.authentication.application.event.SendVerificationEmailEvent;
 import com.umc.product.authentication.application.port.in.command.ManageAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.NewTokens;
 import com.umc.product.authentication.application.port.in.command.dto.RenewAccessTokenCommand;
@@ -13,13 +14,12 @@ import com.umc.product.authentication.domain.exception.AuthenticationDomainExcep
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
-import com.umc.product.notification.application.port.in.SendEmailUseCase;
-import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
 import java.security.SecureRandom;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -29,11 +29,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class AuthenticationService implements ManageAuthenticationUseCase {
 
-    private final SendEmailUseCase sendEmailUseCase;
     private final LoadEmailVerificationPort loadEmailVerificationPort;
     private final SaveEmailVerificationPort saveEmailVerificationPort;
     private final JwtTokenProvider jwtTokenProvider;
     private final GetMemberCredentialUseCase getMemberCredentialUseCase;
+    private final ApplicationEventPublisher eventPublisher;
     @Value("${app.base-url}")
     private String serverUrl;
 
@@ -98,7 +98,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         Long sessionId = saveEmailVerificationPort.save(emailVerification).getId();
 
         if (shouldSendEmail) {
-            sendVerificationEmail(email, code, token);
+            publishSendEmailEvent(email, code, token);
         }
 
         return sessionId;
@@ -114,7 +114,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
         emailVerification.regenerate(newCode, newToken);
 
-        sendVerificationEmail(emailVerification.getEmail(), newCode, newToken);
+        publishSendEmailEvent(emailVerification.getEmail(), newCode, newToken);
     }
 
     @Override
@@ -143,7 +143,11 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         throw new AuthenticationDomainException(AuthenticationErrorCode.NO_EMAIL_VERIFICATION_METHOD_GIVEN);
     }
 
-    private void sendVerificationEmail(String email, String code, String token) {
+    /**
+     * 실제 SMTP 호출을 트랜잭션 commit 이후로 미루기 위해 이벤트를 발행한다.
+     * AFTER_COMMIT 단계에서 SendVerificationEmailEventListener 가 메일을 발송한다.
+     */
+    private void publishSendEmailEvent(String email, String code, String token) {
         String emailVerificationPath = "/api/v1/auth/email-verification/token";
 
         String verificationLink = UriComponentsBuilder
@@ -152,13 +156,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
             .queryParam("token", token)
             .toUriString();
 
-        sendEmailUseCase.sendVerificationEmail(
-            SendVerificationEmailCommand.builder()
-                .to(email)
-                .verificationCode(code)
-                .verificationLink(verificationLink)
-                .build()
-        );
+        eventPublisher.publishEvent(new SendVerificationEmailEvent(email, code, verificationLink));
     }
 
     private String generateRandomCode() {

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -24,6 +24,11 @@ import lombok.NoArgsConstructor;
 public class EmailVerification extends BaseEntity {
 
     /**
+     * 인증 세션의 유효 기간 (초). 발급 / 재발급 시 expires_at = now + 이 값.
+     */
+    public static final long SESSION_VALIDITY_SECONDS = 10 * 60;
+
+    /**
      * 인증 코드 brute-force 방어를 위한 최대 시도 횟수. 초과 시 세션을 즉시 무효화한다.
      */
     public static final int MAX_ATTEMPT_COUNT = 5;
@@ -93,7 +98,7 @@ public class EmailVerification extends BaseEntity {
         this.token = token;
         this.code = code;
         this.purpose = purpose;
-        this.expiresAt = Instant.now().plusSeconds(10 * 60); // 10분 후 만료
+        this.expiresAt = Instant.now().plusSeconds(SESSION_VALIDITY_SECONDS); // 10분 후 만료
         this.isVerified = false;
         this.attemptCount = 0;
     }
@@ -167,7 +172,7 @@ public class EmailVerification extends BaseEntity {
 
         this.code = newCode;
         this.token = newToken;
-        this.expiresAt = Instant.now().plusSeconds(10 * 60);
+        this.expiresAt = Instant.now().plusSeconds(SESSION_VALIDITY_SECONDS);
         this.attemptCount = 0;
     }
 

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -141,15 +141,6 @@ public class EmailVerification extends BaseEntity {
         throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
     }
 
-    public void verifyToken() {
-        if (!isExpired()) {
-            setVerified("TOKEN");
-            return;
-        }
-
-        throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
-    }
-
     public void regenerate(String newCode, String newToken) {
         if (this.isVerified) {
             throw new AuthenticationDomainException(AuthenticationErrorCode.ALREADY_VERIFIED_EMAIL);

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -120,8 +120,27 @@ public class EmailVerification extends BaseEntity {
         this.lastSentAt = Instant.now();
     }
 
+    /**
+     * 인증 코드 검증.
+     * <p>
+     * 사용자 열거 / 코드 탐색 방어를 위해 다음 실패 케이스는 외부에 모두 동일한
+     * INVALID_EMAIL_VERIFICATION 응답으로 수렴시킨다:
+     * <ul>
+     *   <li>이미 검증 완료된 세션의 재시도 (verifiedAt / verifiedBy 덮어쓰기 방지 가드)</li>
+     *   <li>임계치 초과로 무효화된 세션의 추가 시도 (attempt_count 더 이상 증가시키지 않음)</li>
+     *   <li>만료된 세션</li>
+     *   <li>코드 불일치</li>
+     * </ul>
+     * 운영 디버깅에서 상태 구분이 필요하면 attemptCount / isVerified / expiresAt /
+     * lastSentAt 으로 사후 분석한다.
+     */
     public void verifyCode(String code) {
-        // 임계치 초과로 이미 무효화된 세션은 즉시 거부 (시도 횟수도 더 이상 증가시키지 않음)
+        // 1. 이미 검증 완료된 세션: 부수효과 없이 즉시 거부 (verifiedAt 덮어쓰기 방지)
+        if (this.isVerified) {
+            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+
+        // 2. 임계치 초과로 무효화된 세션: 시도 횟수도 더 이상 증가시키지 않고 즉시 거부
         if (this.attemptCount >= MAX_ATTEMPT_COUNT) {
             throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
         }

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -28,6 +28,11 @@ public class EmailVerification extends BaseEntity {
      */
     public static final int MAX_ATTEMPT_COUNT = 5;
 
+    /**
+     * 같은 이메일 / 같은 세션에 대한 연속 발송 간 최소 간격(초). 메일 폭주 방어.
+     */
+    public static final long MIN_SEND_INTERVAL_SECONDS = 60;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -74,6 +79,13 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "attempt_count", nullable = false)
     private int attemptCount;
 
+    /**
+     * 마지막으로 메일을 실제로 발송한 시각. throttle 검사에 사용한다.
+     * silent skip (예: PASSWORD_RESET 미가입) 인 경우에는 갱신하지 않는다.
+     */
+    @Column(name = "last_sent_at")
+    private Instant lastSentAt;
+
 
     @Builder
     public EmailVerification(String email, String token, String code, EmailVerificationPurpose purpose) {
@@ -88,6 +100,24 @@ public class EmailVerification extends BaseEntity {
 
     public boolean isExpired() {
         return Instant.now().isAfter(this.expiresAt);
+    }
+
+    /**
+     * 마지막 실제 발송 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
+     * lastSentAt 이 null 이면 (아직 실제로 발송된 적이 없음) 즉시 발송 가능하다.
+     */
+    public boolean isSendThrottled() {
+        if (this.lastSentAt == null) {
+            return false;
+        }
+        return Instant.now().isBefore(this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+    }
+
+    /**
+     * 실제 메일 발송이 트리거된 시점을 기록한다. AFTER_COMMIT 이벤트 발행 직전에 호출된다.
+     */
+    public void markSent() {
+        this.lastSentAt = Instant.now();
     }
 
     public void verifyCode(String code) {

--- a/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
@@ -50,6 +50,8 @@ public enum AuthenticationErrorCode implements BaseCode {
         "이미 인증이 완료된 이메일 인증 세션입니다."),
     EMAIL_VERIFICATION_SESSION_EXPIRED(HttpStatus.BAD_REQUEST, "AUTHENTICATION-0018",
         "만료된 이메일 인증 세션입니다. 새로운 인증을 요청해주세요."),
+    EMAIL_VERIFICATION_THROTTLED(HttpStatus.TOO_MANY_REQUESTS, "AUTHENTICATION-0027",
+        "이메일 인증 발송 빈도가 너무 잦습니다. 잠시 후 다시 시도해주세요."),
 
     // ID/PW 자격증명 관련 에러
     LOGIN_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTHENTICATION-0019", "이미 사용 중인 로그인 ID입니다."),

--- a/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/AuthenticationErrorCode.java
@@ -24,8 +24,6 @@ public enum AuthenticationErrorCode implements BaseCode {
         "잘못된 이메일 요청 인증입니다."),
     INVALID_EMAIL_VERIFICATION(HttpStatus.UNAUTHORIZED, "AUTHENTICATION-0004",
         "이메일 인증 정보가 일치하지 않습니다."),
-    UNSUPPORTED_EMAIL_VERIFICATION_METHOD(HttpStatus.BAD_REQUEST, "AUTHENTICATION-0005",
-        "지원하지 않는 이메일 인증 방식입니다."),
 
     // OAUTH 관련 에러
     OAUTH_SUCCESS_BUT_NO_MEMBER(HttpStatus.NOT_FOUND, "AUTHENTICATION-0006",

--- a/src/main/java/com/umc/product/notification/application/port/in/dto/SendVerificationEmailCommand.java
+++ b/src/main/java/com/umc/product/notification/application/port/in/dto/SendVerificationEmailCommand.java
@@ -4,8 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record SendVerificationEmailCommand(
-        String to,
-        String verificationCode,
-        String verificationLink // 추후 인증을 위해서 추가
+    String to,
+    String verificationCode
 ) {
 }

--- a/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
+++ b/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
@@ -43,7 +43,6 @@ public class SendEmailService implements SendEmailUseCase {
             // Thymeleaf 템플릿 렌더링
             Context context = new Context();
             context.setVariable("verificationToken", command.verificationCode());
-//            context.setVariable("verificationLink", command.verificationLink());
 
             String htmlContent = templateEngine.process("email/verification", context);
             helper.setText(htmlContent, true);

--- a/src/main/resources/db/migration/V2026.05.17.21.45__add_last_sent_at_to_email_verification.sql
+++ b/src/main/resources/db/migration/V2026.05.17.21.45__add_last_sent_at_to_email_verification.sql
@@ -1,0 +1,9 @@
+-- 이메일 인증 발송 빈도 throttle 을 위한 마지막 발송 시각 컬럼을 추가한다.
+-- 새 세션 생성 시점에 동일 이메일의 직전 발송으로부터 60초 이상 경과했는지 검사한다.
+-- 기존 레코드의 last_sent_at 은 created_at 으로 백필해 합리적인 기본값을 부여한다.
+ALTER TABLE email_verification
+    ADD COLUMN last_sent_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE email_verification
+SET last_sent_at = created_at
+WHERE last_sent_at IS NULL;

--- a/src/main/resources/db/migration/V2026.05.17.22.00__add_expires_at_index_to_email_verification.sql
+++ b/src/main/resources/db/migration/V2026.05.17.22.00__add_expires_at_index_to_email_verification.sql
@@ -1,0 +1,4 @@
+-- 만료 세션 정리 잡과 만료 검사 쿼리의 효율을 위해 expires_at 인덱스를 추가한다.
+-- PostgreSQL CONCURRENTLY 옵션은 Flyway 트랜잭션과 충돌하므로 사용하지 않는다.
+CREATE INDEX IF NOT EXISTS idx_email_verification_expires_at
+    ON email_verification (expires_at);

--- a/src/test/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionSchedulerTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionSchedulerTest.java
@@ -1,0 +1,55 @@
+package com.umc.product.authentication.adapter.in.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * EmailVerificationRetentionScheduler 단위 테스트.
+ * <p>
+ * 매일 03:00 cron 발동 자체는 Spring 환경 책임이므로 단위 테스트에서는 purge() 메서드가
+ * deletePort 에 적절한 threshold (현재 - retention) 를 위임하는지만 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationRetentionSchedulerTest {
+
+    @Mock
+    DeleteEmailVerificationPort deleteEmailVerificationPort;
+
+    @InjectMocks
+    EmailVerificationRetentionScheduler scheduler;
+
+    @Test
+    @DisplayName("purge 호출 시 현재 - 7일 이전 만료 레코드 삭제를 위임한다")
+    void retention_threshold_위임() {
+        // given
+        Instant before = Instant.now();
+        given(deleteEmailVerificationPort.deleteExpiredBefore(any(Instant.class))).willReturn(3);
+
+        // when
+        scheduler.purge();
+
+        // then
+        Instant after = Instant.now();
+        ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
+        then(deleteEmailVerificationPort).should().deleteExpiredBefore(captor.capture());
+        Instant threshold = captor.getValue();
+        // retention 7일 ± 약간의 호출 지연을 허용
+        assertThat(threshold).isBetween(
+            before.minus(Duration.ofDays(7)).minusSeconds(1),
+            after.minus(Duration.ofDays(7)).plusSeconds(1)
+        );
+    }
+}

--- a/src/test/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/out/persistence/EmailVerificationPersistenceAdapterTest.java
@@ -78,36 +78,4 @@ class EmailVerificationPersistenceAdapterTest {
                 .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
         }
     }
-
-    @Nested
-    @DisplayName("getByToken")
-    class GetByToken {
-
-        @Test
-        @DisplayName("존재하면 엔티티를 반환한다")
-        void 존재_시_엔티티_반환() {
-            // given
-            EmailVerification session = newSession();
-            given(queryRepository.findByToken(TOKEN)).willReturn(Optional.of(session));
-
-            // when
-            EmailVerification result = adapter.getByToken(TOKEN);
-
-            // then
-            assertThat(result).isSameAs(session);
-        }
-
-        @Test
-        @DisplayName("미존재 시 INVALID_EMAIL_VERIFICATION 예외를 던진다")
-        void 미존재_시_예외() {
-            // given
-            given(queryRepository.findByToken(TOKEN)).willReturn(Optional.empty());
-
-            // when / then
-            assertThatThrownBy(() -> adapter.getByToken(TOKEN))
-                .isInstanceOf(AuthenticationDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
-        }
-    }
 }

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -16,8 +16,11 @@ import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
 import com.umc.product.notification.application.port.in.SendEmailUseCase;
 import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -56,6 +59,9 @@ class AuthenticationServiceTest {
     @Mock
     JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    GetMemberCredentialUseCase getMemberCredentialUseCase;
+
     @InjectMocks
     AuthenticationService service;
 
@@ -90,10 +96,11 @@ class AuthenticationServiceTest {
         }
 
         @Test
-        @DisplayName("정상 이메일이면 세션을 저장하고 인증 메일을 발송한다")
-        void 정상_세션_생성() {
+        @DisplayName("REGISTER + 미가입 이메일이면 세션을 저장하고 인증 메일을 발송한다")
+        void REGISTER_정상_세션_생성() {
             // given
             ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
+            given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(false);
             EmailVerification persisted = newSession(EmailVerificationPurpose.REGISTER);
             ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
             given(saveEmailVerificationPort.save(any(EmailVerification.class))).willReturn(persisted);
@@ -105,6 +112,61 @@ class AuthenticationServiceTest {
             assertThat(sessionId).isEqualTo(SESSION_ID);
             then(sendEmailUseCase).should()
                 .sendVerificationEmail(any(SendVerificationEmailCommand.class));
+        }
+
+        @Test
+        @DisplayName("REGISTER + 이미 가입된 이메일이면 EMAIL_ALREADY_EXISTS 예외를 던지고 저장/발송하지 않는다")
+        void REGISTER_중복_이메일_거부() {
+            // given
+            given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(true);
+
+            // when / then
+            assertThatThrownBy(() ->
+                service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.REGISTER))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
+
+            then(saveEmailVerificationPort).should(never()).save(any());
+            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
+        }
+
+        @Test
+        @DisplayName("PASSWORD_RESET + 자격증명 존재하면 세션을 저장하고 인증 메일을 발송한다")
+        void PASSWORD_RESET_정상_세션_생성() {
+            // given
+            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
+            given(getMemberCredentialUseCase.findCredentialByEmail(EMAIL))
+                .willReturn(Optional.of(new MemberCredentialInfo(1L, "encoded-password")));
+            EmailVerification persisted = newSession(EmailVerificationPurpose.PASSWORD_RESET);
+            ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
+            given(saveEmailVerificationPort.save(any(EmailVerification.class))).willReturn(persisted);
+
+            // when
+            Long sessionId = service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+
+            // then
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            then(sendEmailUseCase).should()
+                .sendVerificationEmail(any(SendVerificationEmailCommand.class));
+        }
+
+        @Test
+        @DisplayName("PASSWORD_RESET + 자격증명 미존재면 세션은 저장하되 메일은 발송하지 않는다 (enumeration 방어)")
+        void PASSWORD_RESET_미가입_silent() {
+            // given
+            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
+            given(getMemberCredentialUseCase.findCredentialByEmail(EMAIL)).willReturn(Optional.empty());
+            EmailVerification persisted = newSession(EmailVerificationPurpose.PASSWORD_RESET);
+            ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
+            given(saveEmailVerificationPort.save(any(EmailVerification.class))).willReturn(persisted);
+
+            // when
+            Long sessionId = service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+
+            // then: 응답은 정상이지만 메일은 발송되지 않음 (이메일 열거 방어)
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
         }
     }
 

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -183,7 +183,7 @@ class AuthenticationServiceTest {
 
             ValidateEmailVerificationSessionCommand command =
                 ValidateEmailVerificationSessionCommand.builder()
-                    .sessionId(SESSION_ID.toString())
+                    .sessionId(SESSION_ID)
                     .code(CODE)
                     .build();
 
@@ -206,7 +206,7 @@ class AuthenticationServiceTest {
 
             ValidateEmailVerificationSessionCommand command =
                 ValidateEmailVerificationSessionCommand.builder()
-                    .sessionId(SESSION_ID.toString())
+                    .sessionId(SESSION_ID)
                     .code("000000")
                     .build();
 

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -81,9 +81,7 @@ class AuthenticationServiceTest {
         @Test
         @DisplayName("잘못된 이메일 형식이면 INVALID_EMAIL_FORMAT 예외를 던지고 저장/이벤트 발행하지 않는다")
         void 잘못된_이메일_거부() {
-            // given: ReflectionTestUtils 로 @Value 주입 우회 (test 컨텍스트 없이도 동작하도록)
-            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
-
+            // given
             // when / then
             assertThatThrownBy(() -> service.createEmailVerificationSession("not-an-email",
                 EmailVerificationPurpose.REGISTER))
@@ -99,7 +97,6 @@ class AuthenticationServiceTest {
         @DisplayName("REGISTER + 미가입 이메일이면 세션을 저장하고 메일 발송 이벤트를 발행한다")
         void REGISTER_정상_세션_생성() {
             // given
-            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
             given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(false);
             EmailVerification persisted = newSession(EmailVerificationPurpose.REGISTER);
             ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
@@ -134,7 +131,6 @@ class AuthenticationServiceTest {
         @DisplayName("PASSWORD_RESET + 자격증명 존재하면 세션을 저장하고 메일 발송 이벤트를 발행한다")
         void PASSWORD_RESET_정상_세션_생성() {
             // given
-            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
             given(getMemberCredentialUseCase.findCredentialByEmail(EMAIL))
                 .willReturn(Optional.of(new MemberCredentialInfo(1L, "encoded-password")));
             EmailVerification persisted = newSession(EmailVerificationPurpose.PASSWORD_RESET);
@@ -150,10 +146,30 @@ class AuthenticationServiceTest {
         }
 
         @Test
+        @DisplayName("직전 발송으로부터 60초 이내면 EMAIL_VERIFICATION_THROTTLED 예외로 거부한다")
+        void throttle_위반_거부() {
+            // given
+            given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(false);
+            EmailVerification recent = newSession(EmailVerificationPurpose.REGISTER);
+            recent.markSent(); // 직전 발송
+            given(loadEmailVerificationPort.findLatestSentByEmail(EMAIL))
+                .willReturn(java.util.Optional.of(recent));
+
+            // when / then
+            assertThatThrownBy(() ->
+                service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.REGISTER))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+
+            then(saveEmailVerificationPort).should(never()).save(any());
+            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
+        }
+
+        @Test
         @DisplayName("PASSWORD_RESET + 자격증명 미존재면 세션은 저장하되 이벤트는 발행하지 않는다 (enumeration 방어)")
         void PASSWORD_RESET_미가입_silent() {
             // given
-            ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
             given(getMemberCredentialUseCase.findCredentialByEmail(EMAIL)).willReturn(Optional.empty());
             EmailVerification persisted = newSession(EmailVerificationPurpose.PASSWORD_RESET);
             ReflectionTestUtils.setField(persisted, "id", SESSION_ID);

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import com.umc.product.authentication.application.event.SendVerificationEmailEvent;
 import com.umc.product.authentication.application.port.in.command.dto.ValidateEmailVerificationSessionCommand;
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
 import com.umc.product.authentication.application.port.out.SaveEmailVerificationPort;
@@ -18,9 +19,8 @@ import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
-import com.umc.product.notification.application.port.in.SendEmailUseCase;
-import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,9 +48,6 @@ class AuthenticationServiceTest {
     private static final String ISSUED_TOKEN = "issued.jwt.token";
 
     @Mock
-    SendEmailUseCase sendEmailUseCase;
-
-    @Mock
     LoadEmailVerificationPort loadEmailVerificationPort;
 
     @Mock
@@ -61,6 +58,9 @@ class AuthenticationServiceTest {
 
     @Mock
     GetMemberCredentialUseCase getMemberCredentialUseCase;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     AuthenticationService service;
@@ -79,7 +79,7 @@ class AuthenticationServiceTest {
     class CreateSession {
 
         @Test
-        @DisplayName("잘못된 이메일 형식이면 INVALID_EMAIL_FORMAT 예외를 던지고 저장/발송하지 않는다")
+        @DisplayName("잘못된 이메일 형식이면 INVALID_EMAIL_FORMAT 예외를 던지고 저장/이벤트 발행하지 않는다")
         void 잘못된_이메일_거부() {
             // given: ReflectionTestUtils 로 @Value 주입 우회 (test 컨텍스트 없이도 동작하도록)
             ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
@@ -92,11 +92,11 @@ class AuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_FORMAT);
 
             then(saveEmailVerificationPort).should(never()).save(any());
-            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
+            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
         }
 
         @Test
-        @DisplayName("REGISTER + 미가입 이메일이면 세션을 저장하고 인증 메일을 발송한다")
+        @DisplayName("REGISTER + 미가입 이메일이면 세션을 저장하고 메일 발송 이벤트를 발행한다")
         void REGISTER_정상_세션_생성() {
             // given
             ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
@@ -110,12 +110,11 @@ class AuthenticationServiceTest {
 
             // then
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(sendEmailUseCase).should()
-                .sendVerificationEmail(any(SendVerificationEmailCommand.class));
+            then(eventPublisher).should().publishEvent(any(SendVerificationEmailEvent.class));
         }
 
         @Test
-        @DisplayName("REGISTER + 이미 가입된 이메일이면 EMAIL_ALREADY_EXISTS 예외를 던지고 저장/발송하지 않는다")
+        @DisplayName("REGISTER + 이미 가입된 이메일이면 EMAIL_ALREADY_EXISTS 예외, 저장/이벤트 발행 모두 차단")
         void REGISTER_중복_이메일_거부() {
             // given
             given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(true);
@@ -128,11 +127,11 @@ class AuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
 
             then(saveEmailVerificationPort).should(never()).save(any());
-            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
+            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
         }
 
         @Test
-        @DisplayName("PASSWORD_RESET + 자격증명 존재하면 세션을 저장하고 인증 메일을 발송한다")
+        @DisplayName("PASSWORD_RESET + 자격증명 존재하면 세션을 저장하고 메일 발송 이벤트를 발행한다")
         void PASSWORD_RESET_정상_세션_생성() {
             // given
             ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
@@ -147,12 +146,11 @@ class AuthenticationServiceTest {
 
             // then
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(sendEmailUseCase).should()
-                .sendVerificationEmail(any(SendVerificationEmailCommand.class));
+            then(eventPublisher).should().publishEvent(any(SendVerificationEmailEvent.class));
         }
 
         @Test
-        @DisplayName("PASSWORD_RESET + 자격증명 미존재면 세션은 저장하되 메일은 발송하지 않는다 (enumeration 방어)")
+        @DisplayName("PASSWORD_RESET + 자격증명 미존재면 세션은 저장하되 이벤트는 발행하지 않는다 (enumeration 방어)")
         void PASSWORD_RESET_미가입_silent() {
             // given
             ReflectionTestUtils.setField(service, "serverUrl", "https://example.com");
@@ -164,9 +162,9 @@ class AuthenticationServiceTest {
             // when
             Long sessionId = service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
 
-            // then: 응답은 정상이지만 메일은 발송되지 않음 (이메일 열거 방어)
+            // then: 응답은 정상이지만 메일 이벤트는 발행되지 않음 (이메일 열거 방어)
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(sendEmailUseCase).should(never()).sendVerificationEmail(any());
+            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
         }
     }
 

--- a/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
+++ b/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
@@ -111,6 +111,24 @@ class EmailVerificationTest {
         }
 
         @Test
+        @DisplayName("이미 검증된 세션에 재호출하면 verifiedAt 을 덮어쓰지 않고 INVALID_EMAIL_VERIFICATION 으로 거부한다")
+        void 이미_검증된_세션_재호출_거부() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            session.verifyCode(CODE);
+            java.time.Instant firstVerifiedAt = session.getVerifiedAt();
+            int countBefore = session.getAttemptCount();
+
+            // when / then
+            assertThatThrownBy(() -> session.verifyCode(CODE))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+            assertThat(session.getVerifiedAt()).isEqualTo(firstVerifiedAt);
+            assertThat(session.getAttemptCount()).isEqualTo(countBefore);
+        }
+
+        @Test
         @DisplayName("임계치 도달 후에는 정답을 입력해도 검증되지 않으며 attemptCount 가 더 이상 증가하지 않는다")
         void 임계치_도달_후_정답도_거부() {
             // given

--- a/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
+++ b/src/test/java/com/umc/product/authentication/domain/EmailVerificationTest.java
@@ -5,9 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * EmailVerification 도메인 단위 테스트.
@@ -146,6 +148,46 @@ class EmailVerificationTest {
                 .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
             assertThat(session.getAttemptCount()).isEqualTo(countBefore);
             assertThat(session.isVerified()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isSendThrottled / markSent")
+    class Throttle {
+
+        @Test
+        @DisplayName("lastSentAt 이 null 이면 throttle 대상이 아니다")
+        void 미발송_세션은_throttle_아님() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+
+            // then
+            assertThat(session.isSendThrottled()).isFalse();
+            assertThat(session.getLastSentAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("markSent 직후 60초 미만 경과 시 throttle 위반")
+        void markSent_직후_throttle() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            session.markSent();
+
+            // then
+            assertThat(session.isSendThrottled()).isTrue();
+            assertThat(session.getLastSentAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("lastSentAt 이 60초 이전이면 throttle 해제")
+        void 일정시간_경과시_throttle_해제() {
+            // given
+            EmailVerification session = newSession(EmailVerificationPurpose.REGISTER);
+            ReflectionTestUtils.setField(session, "lastSentAt",
+                Instant.now().minusSeconds(EmailVerification.MIN_SEND_INTERVAL_SECONDS + 1));
+
+            // then
+            assertThat(session.isSendThrottled()).isFalse();
         }
     }
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치: `kyeoungwoon/email-verification-hotfix` (stacked PR)
- [x] PR 제목 컨벤션 준수
- [x] PR1(#878) 머지 후 base 가 `develop` 으로 자동 전환되면 머지 진행 예정

## 🔥 연관 이슈

이메일 인증 코드 리뷰 결과의 P2/P3 항목을 묶은 도메인 정비 PR 입니다. PR1(#878, 핫픽스) 위에 쌓은 stacked PR 이며, PR1 머지 후 진행해주세요.

## 🚀 작업 내용

### 1. send API 에 purpose 별 가입 여부 분기 검증 (`feat`)

- **REGISTER + 이미 가입**: `EMAIL_ALREADY_EXISTS` 예외로 즉시 거부. 가입 마지막 단계의 UNIQUE 충돌로 인한 "인증 다 했는데 실패" UX 방지.
- **PASSWORD_RESET + 미가입/자격증명 미존재**: 응답은 정상으로 내려보내되 실제 메일 발송만 건너뜀. user enumeration 방어 (후속 reset 단계도 `INVALID_LOGIN_CREDENTIAL` 단일 메시지로 응답하므로 끝까지 가입 여부가 외부에 노출되지 않음).
- `AuthenticationService` 가 `Member.GetMemberCredentialUseCase` 를 주입받아 cross-domain UseCase 호출 원칙 준수.

### 2. 이메일 발송을 ApplicationEvent + AFTER_COMMIT 으로 분리 (`refactor`)

- `SendVerificationEmailEvent` 도메인 이벤트 도입
- `SendVerificationEmailEventListener` 가 `@TransactionalEventListener(phase = AFTER_COMMIT)` 로 실제 SMTP 호출 위임
- 세션 영속화 트랜잭션 내부에서 SMTP 호출이 일어나던 구조 제거 → 발송 실패가 세션 롤백을 일으키지 않음, DB 커넥션 점유 시간 단축
- 트랜잭션 롤백 시 이벤트도 함께 사라져 "세션 미영속 + 메일 발송" 상태 방지

### 3. 발송 빈도 throttle 추가 — 60초, DB 기반 (`feat`)

- `email_verification.last_sent_at` 컬럼 추가 (Flyway, 기존 row 는 `created_at` 으로 백필)
- `EmailVerification.MIN_SEND_INTERVAL_SECONDS(60)` 상수, `isSendThrottled()` / `markSent()` 도메인 메서드
- `LoadEmailVerificationPort.findLatestSentByEmail`: 같은 이메일에 대한 직전 실제 발송 세션 조회
- `createEmailVerificationSession`: 실제 발송 직전에 throttle 검사. PASSWORD_RESET silent skip 경로는 메일 폭주 위험이 없어 검사 대상에서 제외.
- `resendEmailVerification`: 동일 세션 재발송 시 throttle 검사
- `AUTHENTICATION-0027 EMAIL_VERIFICATION_THROTTLED` 신규 에러 코드 (HTTP 429)

### 4. 미사용 매직 링크 흐름 코드 제거 (`refactor`)

`/api/v1/auth/email-verification/token?token=...` 링크를 메일로 발송하지만 대응 컨트롤러가 없어 클릭 시 404 가 떨어지던 죽은 코드를 제거합니다. 메일 본문의 `verificationLink` 도 thymeleaf 템플릿에서 주석 처리되어 있었습니다.

- `EmailVerification.verifyToken()` 제거
- `LoadEmailVerificationPort.getByToken()` + `Adapter` + `QueryRepository.findByToken` 모두 제거
- `ValidateEmailVerificationSessionCommand.token` 필드 제거 (요청 DTO 에서 받지 않으므로 항상 null)
- `AuthenticationService` token 분기 / `UNSUPPORTED_EMAIL_VERIFICATION_METHOD` 처리 / `serverUrl @Value` 제거
- `AuthenticationErrorCode.UNSUPPORTED_EMAIL_VERIFICATION_METHOD` enum 제거
- `SendVerificationEmailEvent` / `SendVerificationEmailCommand` 의 `verificationLink` 필드 제거 + `SendEmailService` 주석 정리
- 관련 어댑터 테스트(`GetByToken` nested) 제거
- `email_verification.token` 컬럼 자체는 운영 데이터 보호를 위해 보존 (별도 cleanup PR 에서 처리 예정)

### 5. verifyCode 에 이미 검증된 세션 가드 추가 (`refactor`)

- 이미 `isVerified=true` 인 세션에 재호출 시 `setVerified` 가 재실행되어 `verifiedAt` 이 덮어써지던 문제 가드
- 사용자 열거 / 코드 탐색 방어 의도를 도메인 메서드 javadoc 에 명시: 검증 완료 / 임계치 초과 / 만료 / 코드 불일치 모두 외부에 동일 `INVALID_EMAIL_VERIFICATION` 응답
- 운영 디버깅은 `attemptCount`, `isVerified`, `expiresAt`, `lastSentAt` 조합으로 사후 분석

### 6. 만료 세션 정리 스케줄러 + `expires_at` 인덱스 (`feat`)

- `DeleteEmailVerificationPort` + Adapter / JpaRepository `@Modifying @Query`
- `EmailVerificationRetentionScheduler`: 매일 03:00 (Asia/Seoul) cron, retention 7 일
- Flyway: `CREATE INDEX idx_email_verification_expires_at`

### 7. P3 잡다한 정리 (`chore`)

- `EmailVerification.SESSION_VALIDITY_SECONDS` 상수로 만료 시간 매직 넘버 제거
- `AuthenticationService.RANDOM` 을 `static final SecureRandom` 으로 재사용
- `ValidateEmailVerificationSessionCommand.sessionId` 를 `Long` 으로 변경 → Controller 의 `.toString()` 왕복 제거
- `SendEmailVerificationResponse.emailVerificationId` 도 `Long` 으로 통일

### 8. 단위 테스트 추가 (`test`)

- `EmailVerificationTest`: 이미 검증된 세션 재호출 거부 / `isSendThrottled` & `markSent` 동작
- `AuthenticationServiceTest`: throttle 위반 시 저장/이벤트 발행 차단
- `EmailVerificationRetentionSchedulerTest`: retention 7 일 threshold 위임 확인
- 인증 패키지 전체 67개 테스트 통과

## 💬 리뷰 중점사항

1. **PASSWORD_RESET 미가입 silent skip 정책**: enumeration 방어를 위해 응답은 200 OK + 메일 미발송 방식. audit 권고의 "명시적 거부"와 다른 선택입니다. 보안 일관성을 위해 silent 를 택했고, 후속 reset 흐름의 `INVALID_LOGIN_CREDENTIAL` 단일 메시지 정책과도 정합합니다.
2. **AFTER_COMMIT 이벤트 패턴**: 기존에 다른 도메인에서 동일 패턴을 사용하는지 / 트랜잭션 propagation 가 추가로 검토할 필요가 없는지 확인 부탁드립니다.
3. **throttle 60초**: 도메인 상수입니다. 운영 중 조정 필요성이 있으면 별도 PR 에서 `@Value` 외부화 검토.
4. **email_verification.token 컬럼 보존**: 매직 링크 코드는 제거했으나 DB 컬럼 자체는 운영 데이터 보호 차원에서 남겼습니다. 후속 cleanup PR 에서 컬럼도 함께 정리 가능합니다.
5. **만료 세션 정리 스케줄러**: 매일 03:00 (Asia/Seoul) cron. 운영 환경의 서버 시간대와 일치하는지 / retention 7일이 적절한지 확인 부탁드립니다.
6. **base 브랜치 변경**: PR1(#878) 머지 후 GitHub 에서 자동으로 base 가 `develop` 으로 전환될 예정입니다. 그 시점에 PR 본문 / 변경 사항을 다시 확인해주세요.