### PR TITLE
[Refactor] SpringEventPublisher를 DomainEventPublisher로 추상화

### DIFF
--- a/docs/adr/018-abstract-spring-event-publisher-for-future-broker.md
+++ b/docs/adr/018-abstract-spring-event-publisher-for-future-broker.md
@@ -1,0 +1,219 @@
+# ADR-018: Spring Event Publisher를 추상화하여 미래 메시지 브로커 도입을 대비한다
+
+## Status
+
+Accepted
+
+## Context
+
+UMC PRODUCT 서버는 현재 도메인 간 비동기 협력을 위해 Spring의 `ApplicationEventPublisher`와
+`@TransactionalEventListener(AFTER_COMMIT) + @Async` 조합을 사용한다. 사용 현황은 다음과 같다.
+
+- `AuditAspect`, `MemberService`, `IdPwMemberRegisterService`가 `ApplicationEventPublisher`를
+  직접 주입받아 `AuditLogEvent`를 발행한다.
+- `AuditLogEventListener`, `FcmOutboxEventListener`가
+  `@TransactionalEventListener(AFTER_COMMIT)`로 이벤트를 수신해 비동기 처리한다.
+- `notification` 도메인에는 이미 풀(폴링) 기반 outbox(`FcmOutbox*`)가 부분 구현되어 있다.
+- `ServerLifecycleAlarmListener`는 Spring lifecycle 이벤트(`ApplicationReadyEvent`)에
+  반응한다.
+
+현재 구조에는 다음 문제가 있다.
+
+1. **헥사고날 의존 방향 위반**: 응용/도메인 레이어가 Spring 인프라 API
+   (`ApplicationEventPublisher`)를 직접 참조한다. CLAUDE.md에 명시된 hexagonal
+   원칙(`application/service`는 인프라에 직접 의존하지 않음)을 깨고 있다.
+2. **이벤트 메타데이터 부재**: 이벤트에 `eventId`, `occurredAt`, `eventType` 같은 식별자/시각
+   정보가 없다. 멱등성(idempotency, 같은 이벤트가 두 번 들어와도 한 번만 처리되는 성질)을
+   보장하기 어렵고, 추적성도 떨어진다.
+3. **트랜잭션 일관성 보장 부재**: `AFTER_COMMIT` 이벤트는 in-memory 디스패치이므로 JVM이
+   비정상 종료되면 손실된다. 향후 Kafka/RabbitMQ로 옮길 때 이 문제는 더 커진다.
+4. **브로커 교체 비용**: 추상화 계층이 없어, 향후 외부 메시지 브로커(Kafka, RabbitMQ 등)를
+   도입할 때 모든 발행/수신 지점을 수정해야 한다.
+
+본 ADR은 위 문제 중 (1), (2), (4)를 1차로 해결하고, (3)은 후속 ADR로 분리하기 위한 결정을
+기록한다.
+
+## Decision
+
+우리는 Spring `ApplicationEventPublisher` 의존을 **응용 레이어의 Port Out 인터페이스로
+추상화**하기로 결정한다. 구체적인 결정은 아래와 같다.
+
+1. **Port Out 도입**: 응용 레이어에 `DomainEventPublisher` 인터페이스를 정의하고, 도메인
+   서비스/Aspect는 이 인터페이스에만 의존한다.
+2. **기본 어댑터**: `SpringDomainEventPublisher`가 Spring `ApplicationEventPublisher`로
+   위임하는 기본 구현을 제공한다.
+3. **도메인 이벤트 표준화**: 모든 도메인 이벤트는 `DomainEvent` 인터페이스를 구현하고
+   `eventId(UUID)`, `occurredAt(Instant)`, `eventType(String)` 메타데이터를 제공한다.
+4. **Listener 추상화 범위 제한 (Phase 1)**: 이번 단계에서는 Listener 측은
+   Spring `@TransactionalEventListener`를 그대로 유지한다. 브로커 도입 시 별도 bridge
+   어댑터(`adapter/in/event/Kafka*EventBridge` 등)를 추가하는 방식으로 확장한다.
+5. **단계적 진행 + PR 분리**:
+   - **Phase 1 (이 PR)**: Publisher 추상화 + 도메인 이벤트 메타데이터 표준화.
+   - **Phase 2 (별도 PR)**: `FcmOutbox` 패턴을 일반화한 `EventOutbox`로 트랜잭션 일관성 확보.
+   - **Phase 3 (브로커 도입 시점)**: Kafka/RabbitMQ 어댑터 추가.
+
+   각 Phase는 독립된 PR로 분리하여 리뷰 단위와 롤백 단위를 작게 유지한다.
+
+## Alternatives Considered
+
+### 대안 A: Phase 1만 수행 (Publisher 추상화만, outbox 없음)
+
+장점:
+- 변경 범위가 약 10개 파일로 작아 도입 비용이 낮다.
+- Listener는 변경하지 않으므로 회귀 위험이 낮다.
+- 향후 Kafka 도입 시 호출부 수정 없이 어댑터 교체만으로 전환 가능하다.
+
+단점:
+- AFTER_COMMIT 이벤트의 손실 가능성은 그대로 남는다.
+- 멱등성 처리는 추가 작업이 필요하다 (Phase 2에서 outbox와 함께 도입).
+
+선택한 이유:
+이번 PR의 목표는 헥사고날 의존 방향 정리와 메타데이터 표준화다. 트랜잭션 일관성은 별도의
+설계 트레이드오프(테이블 스키마, poller 동시성, 모니터링)가 필요하므로 분리하는 것이 안전하다.
+
+### 대안 B: Phase 1 + Phase 2를 하나의 PR로 묶기
+
+장점:
+- 한 번에 전체 그림이 완성된다.
+- 트랜잭션 일관성 문제도 동시에 해결된다.
+
+단점:
+- 변경 범위가 약 20개 파일 이상으로 커진다.
+- DB 마이그레이션(`event_outbox` 테이블 추가), 폴러 동시성 처리, 운영 메트릭까지 한 번에
+  검증해야 하므로 리뷰가 어려워진다.
+- 문제 발생 시 롤백 단위가 너무 크다.
+
+선택하지 않은 이유:
+추상화 도입과 트랜잭션 일관성 보장은 서로 다른 변경 동기다. 한 PR에 묶으면 리뷰 집중도가
+떨어지고, 한쪽에서 문제가 생겼을 때 다른 쪽까지 함께 되돌려야 한다.
+
+### 대안 C: Listener까지 한 번에 추상화 (`@EventHandler("audit.log.created")` 같은 custom annotation)
+
+장점:
+- Publisher와 Listener가 대칭적으로 추상화된다.
+- 브로커 도입 시 listener 코드도 거의 변경되지 않는다.
+
+단점:
+- Spring AOT/reflection을 다루어야 하므로 Phase 1 범위가 커진다.
+- 현재 `@TransactionalEventListener`가 잘 동작하고 있어 즉시 얻는 이득이 작다.
+- 브로커 도입 시점에는 어차피 broker별 listener 어댑터(예: `@KafkaListener`)가 필요하므로
+  중복 추상화가 된다.
+
+선택하지 않은 이유:
+Phase 1의 가치는 **응용 레이어의 인프라 의존 제거**다. Listener는 이미 `adapter/in/event/`
+패키지에 위치하므로 헥사고날 관점에서 문제가 없다. 브로커 도입 시점에 broker별 bridge
+어댑터를 추가하는 것이 더 자연스럽다.
+
+### 대안 D: 메타데이터(`eventId`, `occurredAt`)는 Phase 2에서 도입
+
+장점:
+- Phase 1 변경량이 약간 더 작아진다.
+
+단점:
+- Phase 2에서 모든 이벤트 record를 다시 수정해야 한다.
+- 그 사이 새로 추가되는 이벤트들은 메타데이터 없이 작성된다.
+- 브로커 도입 후 멱등성 처리가 무료로 따라오지 못한다.
+
+선택하지 않은 이유:
+이벤트 record 수정은 한 번에 모아두는 것이 마이그레이션 비용이 작다. 또한 `eventId`/
+`occurredAt`은 단순 record 필드 추가이므로 Phase 1에 포함해도 변경 비용이 거의 없다.
+
+## Consequences
+
+### Positive
+
+- 응용 레이어가 Spring 인프라 API에 의존하지 않으므로, 헥사고날 의존 방향이 회복된다.
+- 모든 도메인 이벤트가 식별자/시각 메타데이터를 갖게 되어 추적성이 개선된다.
+- 향후 Kafka/RabbitMQ 등 외부 브로커로 전환할 때 호출부를 수정하지 않고 어댑터 교체만으로
+  대응할 수 있다.
+- 멱등성 처리, DLQ, 재시도 정책 등 후속 기능을 도입할 때 메타데이터가 이미 준비되어 있다.
+- `FcmOutbox`처럼 부분적으로 존재하는 outbox 패턴을 Phase 2에서 일반화할 수 있는 토대가
+  마련된다.
+
+### Negative
+
+- 신규 모듈(`global/event/`)이 추가되어 패키지 수가 늘어난다.
+- 모든 이벤트 record에 `eventId`/`occurredAt` 필드를 추가해야 하므로 builder default 설정
+  또는 정적 팩토리 메서드로 자동 주입을 일관되게 처리해야 한다.
+- Phase 1만으로는 트랜잭션 일관성 문제가 해결되지 않으므로, AFTER_COMMIT 이후 JVM 비정상
+  종료 시 이벤트 손실 가능성은 그대로 남는다. (Phase 2에서 해결)
+
+### Neutral / Trade-offs
+
+- Listener는 여전히 `@TransactionalEventListener` 기반이라 broker 도입 시 Listener 측은
+  별도 bridge 어댑터를 추가해야 한다. Publisher만 추상화한 비대칭 구조다. 다만 이는
+  의도된 분할이며, broker 도입 시점에 broker별 listener를 추가하는 것이 자연스러운
+  헥사고날 패턴이다.
+- `eventId`/`occurredAt`을 record builder default로 주입하므로 명시적으로 지정하지 않으면
+  `UUID.randomUUID()` / `Instant.now()`가 들어간다. 테스트에서 이를 고정하려면 builder에
+  값을 직접 넣어야 한다.
+
+## Implementation Notes
+
+### 패키지 구조
+
+```
+src/main/java/com/umc/product/global/event/
+├── domain/
+│   └── DomainEvent.java                  # 마커 인터페이스
+├── application/port/out/
+│   └── DomainEventPublisher.java         # 포트
+└── adapter/out/
+    └── SpringDomainEventPublisher.java   # Spring 어댑터 (default)
+```
+
+### DomainEvent 인터페이스
+
+```java
+public interface DomainEvent {
+    UUID eventId();        // 멱등성 처리용 고유 식별자
+    Instant occurredAt();  // 이벤트 발생 시각
+    String eventType();    // 예: "audit.log.register", "fcm.outbox.created"
+}
+```
+
+### Phase 1 변경 범위
+
+| 영역 | 변경 내용 |
+|------|-----------|
+| 신규 (`global/event/`) | 포트, 어댑터, 마커 인터페이스 (3 파일) |
+| 수정 (`AuditLogEvent`, `FcmOutboxEvent`) | `implements DomainEvent`, 메타데이터 필드 추가 |
+| 수정 (`AuditAspect`, `MemberService`, `IdPwMemberRegisterService`) | `ApplicationEventPublisher` → `DomainEventPublisher` 교체 |
+| 미변경 | Listener (`AuditLogEventListener`, `FcmOutboxEventListener`, `ServerLifecycleAlarmListener`) |
+
+### Listener 미변경 정책
+
+Spring은 `@TransactionalEventListener`가 메서드 시그니처의 파라미터 타입(record 타입)으로
+이벤트를 라우팅한다. `DomainEventPublisher`가 내부적으로
+`ApplicationEventPublisher.publishEvent(event)`로 위임하므로, 기존 Listener는 수정 없이
+동일하게 동작한다.
+
+### 메타데이터 자동 주입
+
+이벤트 record는 Lombok `@Builder` default 또는 정적 팩토리 메서드를 통해 `eventId`와
+`occurredAt`을 자동 주입한다. 명시적으로 지정하지 않으면 다음 값이 사용된다.
+
+- `eventId`: `UUID.randomUUID()`
+- `occurredAt`: `Instant.now()`
+
+테스트에서 결정론적 값이 필요하면 builder에 직접 값을 지정한다.
+
+### 향후 Phase 2 진입 조건
+
+다음 중 하나라도 발생하면 Phase 2(EventOutbox 일반화)를 우선순위 상위로 올린다.
+
+- `AFTER_COMMIT` 이후 이벤트 손실로 인한 운영 이슈가 1회 이상 발생
+- 새로운 도메인에서 outbox 패턴이 필요한 경우 (`FcmOutbox`와 동일한 동기로)
+- 멱등성 처리가 필요한 컨슈머가 추가되는 경우
+
+### 향후 Phase 3 진입 조건
+
+- 실제 Kafka/RabbitMQ 브로커 도입이 결정되는 시점
+- 도메인 간 트래픽이 단일 JVM 처리 한계에 근접하는 시점
+
+## References
+
+- CLAUDE.md: Architecture & Domain Rules (Hexagonal Architecture)
+- `src/main/java/com/umc/product/notification/domain/FcmOutbox.java` - 기존 부분 outbox 구현
+- `src/main/java/com/umc/product/audit/adapter/in/event/AuditLogEventListener.java` - 현재
+  listener 패턴 참조

--- a/src/main/java/com/umc/product/audit/adapter/in/aop/AuditAspect.java
+++ b/src/main/java/com/umc/product/audit/adapter/in/aop/AuditAspect.java
@@ -2,6 +2,7 @@ package com.umc.product.audit.adapter.in.aop;
 
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditLogEvent;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.security.MemberPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -11,7 +12,6 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.expression.MethodBasedEvaluationContext;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.ParameterNameDiscoverer;
@@ -35,7 +35,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class AuditAspect {
 
-    private final ApplicationEventPublisher eventPublisher;
+    private final DomainEventPublisher eventPublisher;
     private final ExpressionParser parser = new SpelExpressionParser();
     private final ParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
 
@@ -60,7 +60,7 @@ public class AuditAspect {
                 .ipAddress(ipAddress)
                 .build();
 
-            eventPublisher.publishEvent(event);
+            eventPublisher.publish(event);
         } catch (Exception e) {
             log.error("감사 로그 이벤트 발행 중 오류: method={}, error={}",
                 joinPoint.getSignature().toShortString(), e.getMessage(), e);

--- a/src/main/java/com/umc/product/audit/domain/AuditLogEvent.java
+++ b/src/main/java/com/umc/product/audit/domain/AuditLogEvent.java
@@ -1,16 +1,24 @@
 package com.umc.product.audit.domain;
 
+import com.umc.product.global.event.domain.DomainEvent;
 import com.umc.product.global.exception.constant.Domain;
+import java.time.Instant;
 import java.util.Map;
+import java.util.UUID;
 import lombok.Builder;
 
 /**
  * 감사 로그 이벤트
  * <p>
  * AOP Aspect 또는 서비스에서 직접 발행하여 비동기로 감사 로그를 저장합니다.
+ * <p>
+ * {@code eventId}와 {@code occurredAt}을 명시하지 않으면 각각 {@link UUID#randomUUID()}와
+ * {@link Instant#now()}로 자동 채워집니다.
  */
 @Builder
 public record AuditLogEvent(
+    UUID eventId,
+    Instant occurredAt,
     Domain domain,
     AuditAction action,
     String targetType,
@@ -19,5 +27,19 @@ public record AuditLogEvent(
     String description,
     Map<String, Object> details,
     String ipAddress
-) {
+) implements DomainEvent {
+
+    public AuditLogEvent {
+        if (eventId == null) {
+            eventId = UUID.randomUUID();
+        }
+        if (occurredAt == null) {
+            occurredAt = Instant.now();
+        }
+    }
+
+    @Override
+    public String eventType() {
+        return "audit.log." + action.name().toLowerCase();
+    }
 }

--- a/src/main/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisher.java
+++ b/src/main/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisher.java
@@ -24,6 +24,10 @@ public class SpringDomainEventPublisher implements DomainEventPublisher {
         delegate.publishEvent(event);
     }
 
+    /**
+     * 컬렉션의 순회 순서대로 위임한다. 도중 이벤트 발행이 예외를 던지면 이후 이벤트는
+     * 발행되지 않고 예외가 호출자에게 전파된다 (fail-fast). 원자성은 보장하지 않는다.
+     */
     @Override
     public void publishAll(Collection<? extends DomainEvent> events) {
         events.forEach(delegate::publishEvent);

--- a/src/main/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisher.java
+++ b/src/main/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisher.java
@@ -1,0 +1,31 @@
+package com.umc.product.global.event.adapter.out;
+
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
+import com.umc.product.global.event.domain.DomainEvent;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring {@link ApplicationEventPublisher}로 위임하는 기본 어댑터.
+ * <p>
+ * 발행된 이벤트는 Spring 컨테이너 내부에서 디스패치되므로, 동일 JVM 내 리스너만 수신할 수 있다.
+ * 외부 브로커(Kafka, RabbitMQ 등) 도입 시점에는 동일 포트를 구현하는 다른 어댑터로 교체한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SpringDomainEventPublisher implements DomainEventPublisher {
+
+    private final ApplicationEventPublisher delegate;
+
+    @Override
+    public void publish(DomainEvent event) {
+        delegate.publishEvent(event);
+    }
+
+    @Override
+    public void publishAll(Collection<? extends DomainEvent> events) {
+        events.forEach(delegate::publishEvent);
+    }
+}

--- a/src/main/java/com/umc/product/global/event/application/port/out/DomainEventPublisher.java
+++ b/src/main/java/com/umc/product/global/event/application/port/out/DomainEventPublisher.java
@@ -1,0 +1,28 @@
+package com.umc.product.global.event.application.port.out;
+
+import com.umc.product.global.event.domain.DomainEvent;
+import java.util.Collection;
+
+/**
+ * 도메인 이벤트 발행을 위한 Port Out.
+ * <p>
+ * 응용 레이어와 도메인 레이어는 Spring {@code ApplicationEventPublisher} 같은 인프라 API에
+ * 직접 의존하지 않고, 이 인터페이스에만 의존한다. 실제 발행 메커니즘은 어댑터 구현체가 담당한다.
+ * <p>
+ * 향후 Kafka, RabbitMQ 등 외부 메시지 브로커 도입 시 새 어댑터를 추가하는 방식으로 확장한다.
+ */
+public interface DomainEventPublisher {
+
+    /**
+     * 단일 도메인 이벤트를 발행한다.
+     */
+    void publish(DomainEvent event);
+
+    /**
+     * 여러 도메인 이벤트를 일괄 발행한다.
+     * <p>
+     * 발행 순서는 입력 컬렉션의 순회 순서를 따른다. 트랜잭션 경계나 원자성은 어댑터 구현체가
+     * 정의한다.
+     */
+    void publishAll(Collection<? extends DomainEvent> events);
+}

--- a/src/main/java/com/umc/product/global/event/domain/DomainEvent.java
+++ b/src/main/java/com/umc/product/global/event/domain/DomainEvent.java
@@ -1,0 +1,24 @@
+package com.umc.product.global.event.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 모든 도메인 이벤트가 구현해야 하는 마커 인터페이스.
+ * <p>
+ * 메타데이터는 다음 용도를 가진다.
+ * <ul>
+ *     <li>{@code eventId} — 멱등성 처리를 위한 고유 식별자.</li>
+ *     <li>{@code occurredAt} — 이벤트가 발생한 시각.</li>
+ *     <li>{@code eventType} — 이벤트 종류를 식별하는 문자열 (예: "audit.log.register").
+ *         향후 브로커 도입 시 topic/queue 라우팅 키로 사용된다.</li>
+ * </ul>
+ */
+public interface DomainEvent {
+
+    UUID eventId();
+
+    Instant occurredAt();
+
+    String eventType();
+}

--- a/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
+++ b/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
@@ -4,6 +4,7 @@ import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.audit.domain.AuditLogEvent;
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.RegisterCredentialByEmailCommand;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
 import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
@@ -12,7 +13,6 @@ import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -31,7 +31,7 @@ public class EmailMemberRegisterService implements RegisterEmailMemberUseCase {
     private final CredentialAuthenticationUseCase credentialAuthenticationUseCase;
     private final GetSchoolUseCase getSchoolUseCase;
 
-    private final ApplicationEventPublisher eventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -49,7 +49,7 @@ public class EmailMemberRegisterService implements RegisterEmailMemberUseCase {
             + "소속 " + command.nickname() + "/" + command.name()
             + " 님이 회원 가입하셨습니다.";
 
-        eventPublisher.publishEvent(
+        eventPublisher.publish(
             AuditLogEvent.builder()
                 .domain(Domain.MEMBER)
                 .action(AuditAction.REGISTER)

--- a/src/main/java/com/umc/product/member/application/service/MemberService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberService.java
@@ -7,6 +7,7 @@ import com.umc.product.authentication.application.port.in.command.dto.LinkOAuthC
 import com.umc.product.authentication.application.port.in.command.dto.UnlinkOAuthCommand;
 import com.umc.product.authentication.application.port.in.query.GetMemberOAuthUseCase;
 import com.umc.product.authentication.application.port.in.query.dto.MemberOAuthInfo;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
 import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
@@ -26,7 +27,6 @@ import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCa
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +44,7 @@ public class MemberService implements ManageMemberUseCase, RegisterOAuthMemberUs
     private final ManageTermAgreementUseCase manageTermAgreementUseCase;
     private final GetSchoolUseCase getSchoolUseCase;
 
-    private final ApplicationEventPublisher eventPublisher;
+    private final DomainEventPublisher eventPublisher;
     private final SendWebhookAlarmUseCase sendWebhookAlarmUseCase;
 
     @Override
@@ -86,7 +86,7 @@ public class MemberService implements ManageMemberUseCase, RegisterOAuthMemberUs
                 .build()
         );
 
-        eventPublisher.publishEvent(
+        eventPublisher.publish(
             AuditLogEvent.builder()
                 .domain(Domain.MEMBER)
                 .action(AuditAction.REGISTER)
@@ -176,7 +176,7 @@ public class MemberService implements ManageMemberUseCase, RegisterOAuthMemberUs
 
         saveMemberPort.delete(memberToDelete);
 
-        eventPublisher.publishEvent(
+        eventPublisher.publish(
             AuditLogEvent.builder()
                 .domain(Domain.MEMBER)
                 .action(AuditAction.WITHDRAW)

--- a/src/main/java/com/umc/product/notification/domain/FcmOutboxEvent.java
+++ b/src/main/java/com/umc/product/notification/domain/FcmOutboxEvent.java
@@ -1,4 +1,23 @@
 package com.umc.product.notification.domain;
 
-public record FcmOutboxEvent() {
+import com.umc.product.global.event.domain.DomainEvent;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * FCM outbox에 신규 항목이 적재되었음을 알리는 트리거 이벤트.
+ * <p>
+ * 페이로드는 의도적으로 비워둔다. 수신자({@code FcmOutboxEventListener})는 이벤트 자체를
+ * 트리거로만 사용하고, 실제 outbox 항목은 polling으로 직접 읽어 처리한다.
+ */
+public record FcmOutboxEvent(UUID eventId, Instant occurredAt) implements DomainEvent {
+
+    public static FcmOutboxEvent create() {
+        return new FcmOutboxEvent(UUID.randomUUID(), Instant.now());
+    }
+
+    @Override
+    public String eventType() {
+        return "fcm.outbox.created";
+    }
 }

--- a/src/test/java/com/umc/product/audit/domain/AuditLogEventTest.java
+++ b/src/test/java/com/umc/product/audit/domain/AuditLogEventTest.java
@@ -1,0 +1,76 @@
+package com.umc.product.audit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.global.exception.constant.Domain;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuditLogEventTest {
+
+    @Test
+    @DisplayName("eventId와 occurredAt을 지정하지 않으면 기본값이 자동 주입된다")
+    void 메타데이터_미지정시_기본값_자동주입() {
+        // given
+        Instant before = Instant.now();
+
+        // when
+        AuditLogEvent event = AuditLogEvent.builder()
+            .domain(Domain.MEMBER)
+            .action(AuditAction.REGISTER)
+            .targetType("Member")
+            .targetId("1")
+            .build();
+
+        // then
+        Instant after = Instant.now();
+        assertThat(event.eventId()).isNotNull();
+        assertThat(event.occurredAt()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("eventId와 occurredAt을 명시하면 그 값이 그대로 유지된다")
+    void 메타데이터_명시시_값_유지() {
+        // given
+        UUID givenId = UUID.randomUUID();
+        Instant givenInstant = Instant.parse("2026-01-01T00:00:00Z");
+
+        // when
+        AuditLogEvent event = AuditLogEvent.builder()
+            .eventId(givenId)
+            .occurredAt(givenInstant)
+            .domain(Domain.MEMBER)
+            .action(AuditAction.REGISTER)
+            .targetType("Member")
+            .targetId("1")
+            .build();
+
+        // then
+        assertThat(event.eventId()).isEqualTo(givenId);
+        assertThat(event.occurredAt()).isEqualTo(givenInstant);
+    }
+
+    @Test
+    @DisplayName("eventType은 'audit.log.<action>' 형식으로 생성된다")
+    void eventType은_action_기반으로_생성() {
+        // given
+        AuditLogEvent registerEvent = AuditLogEvent.builder()
+            .domain(Domain.MEMBER)
+            .action(AuditAction.REGISTER)
+            .targetType("Member")
+            .targetId("1")
+            .build();
+        AuditLogEvent withdrawEvent = AuditLogEvent.builder()
+            .domain(Domain.MEMBER)
+            .action(AuditAction.WITHDRAW)
+            .targetType("Member")
+            .targetId("1")
+            .build();
+
+        // then
+        assertThat(registerEvent.eventType()).isEqualTo("audit.log.register");
+        assertThat(withdrawEvent.eventType()).isEqualTo("audit.log.withdraw");
+    }
+}

--- a/src/test/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisherTest.java
+++ b/src/test/java/com/umc/product/global/event/adapter/out/SpringDomainEventPublisherTest.java
@@ -1,0 +1,71 @@
+package com.umc.product.global.event.adapter.out;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.umc.product.global.event.domain.DomainEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class SpringDomainEventPublisherTest {
+
+    @Mock
+    private ApplicationEventPublisher delegate;
+
+    @InjectMocks
+    private SpringDomainEventPublisher publisher;
+
+    @Test
+    @DisplayName("publish는 ApplicationEventPublisher로 위임된다")
+    void publish_위임_성공() {
+        // given
+        DomainEvent event = new TestEvent(UUID.randomUUID(), Instant.now(), "test.created");
+
+        // when
+        publisher.publish(event);
+
+        // then
+        verify(delegate, times(1)).publishEvent(event);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    @DisplayName("publishAll은 입력 컬렉션 순서대로 모든 이벤트를 위임한다")
+    void publishAll_순서대로_위임_성공() {
+        // given
+        DomainEvent first = new TestEvent(UUID.randomUUID(), Instant.now(), "test.first");
+        DomainEvent second = new TestEvent(UUID.randomUUID(), Instant.now(), "test.second");
+
+        // when
+        publisher.publishAll(List.of(first, second));
+
+        // then
+        verify(delegate).publishEvent(first);
+        verify(delegate).publishEvent(second);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    @DisplayName("publishAll에 빈 컬렉션이 주어지면 위임 없이 정상 종료된다")
+    void publishAll_빈_컬렉션_정상_종료() {
+        // when
+        publisher.publishAll(List.of());
+
+        // then
+        verifyNoMoreInteractions(delegate);
+    }
+
+    private record TestEvent(UUID eventId, Instant occurredAt, String eventType)
+        implements DomainEvent {
+    }
+}

--- a/src/test/java/com/umc/product/notification/domain/FcmOutboxEventTest.java
+++ b/src/test/java/com/umc/product/notification/domain/FcmOutboxEventTest.java
@@ -1,0 +1,45 @@
+package com.umc.product.notification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FcmOutboxEventTest {
+
+    @Test
+    @DisplayName("create는 매번 새로운 인스턴스와 새로운 eventId를 반환한다")
+    void create는_매번_새_인스턴스_반환() {
+        // when
+        FcmOutboxEvent first = FcmOutboxEvent.create();
+        FcmOutboxEvent second = FcmOutboxEvent.create();
+
+        // then
+        assertThat(first.eventId()).isNotEqualTo(second.eventId());
+    }
+
+    @Test
+    @DisplayName("create로 생성된 이벤트의 occurredAt은 호출 시점 근처여야 한다")
+    void create는_호출_시점에_occurredAt_설정() {
+        // given
+        Instant before = Instant.now();
+
+        // when
+        FcmOutboxEvent event = FcmOutboxEvent.create();
+
+        // then
+        Instant after = Instant.now();
+        assertThat(event.occurredAt()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("eventType은 'fcm.outbox.created'이다")
+    void eventType은_고정값() {
+        // when
+        FcmOutboxEvent event = FcmOutboxEvent.create();
+
+        // then
+        assertThat(event.eventType()).isEqualTo("fcm.outbox.created");
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- related to 이벤트 기반 비동기 처리 추상화 작업

## 🚀 작업 내용

[ADR-018](./docs/adr/018-abstract-spring-event-publisher-for-future-broker.md)에 기록한 결정사항에 따라, 응용 레이어가 Spring `ApplicationEventPublisher`에 직접 의존하던 구조를 Port Out 인터페이스로 추상화했어요. 향후 Kafka, RabbitMQ 등 외부 메시지 브로커를 도입할 때 호출부를 수정하지 않고 어댑터만 교체해도 되도록 만드는 것이 목표예요.

### 1. 신규 추상화 계층 추가 (`global/event/`)

헥사고날 구조에 맞추어 도메인/응용/어댑터 레이어를 분리했어요.

- `domain/DomainEvent` — 모든 도메인 이벤트가 구현해야 하는 마커 인터페이스예요. `eventId(UUID)`, `occurredAt(Instant)`, `eventType(String)` 메타데이터를 제공해요. 향후 멱등성 처리와 브로커 라우팅 키 용도로 쓰일 거예요.
- `application/port/out/DomainEventPublisher` — `publish` / `publishAll` 두 메서드를 가진 Port Out이에요. 응용/도메인 레이어는 이 인터페이스만 의존해요.
- `adapter/out/SpringDomainEventPublisher` — 기본 어댑터예요. 내부적으로 `ApplicationEventPublisher`로 위임하므로 기존 `@TransactionalEventListener` 동작은 변하지 않아요. `publishAll`은 fail-fast로 동작한다는 점을 JavaDoc에 명시했어요.

### 2. 기존 도메인 이벤트를 `DomainEvent`로 표준화

- `AuditLogEvent`와 `FcmOutboxEvent`가 `DomainEvent`를 구현하도록 수정했어요.
- `AuditLogEvent`는 record compact constructor에서 `eventId`/`occurredAt`이 null이면 `UUID.randomUUID()` / `Instant.now()`로 자동 채워주도록 했어요. 호출부는 변경 없이 그대로 동작해요.
- `FcmOutboxEvent`는 빈 record였는데 정적 팩토리 `FcmOutboxEvent.create()`를 통해서만 생성하도록 했어요. (참고로 현재 발행되는 곳이 없는 dead code인데, 제거 결정은 별도 ADR로 미루고 일관성 유지를 위해 마이그레이션만 진행했어요.)

### 3. 발행부 마이그레이션

`ApplicationEventPublisher`를 직접 주입받던 3곳을 `DomainEventPublisher`로 교체했어요.

- `MemberService` (회원가입/탈퇴 시 감사 로그 이벤트 발행)
- `IdPwMemberRegisterService` (ID/PW 회원가입 시 감사 로그 이벤트 발행)
- `AuditAspect` (`@Audited` AOP에서 감사 로그 이벤트 발행)

리스너 측(`AuditLogEventListener`, `FcmOutboxEventListener`)은 변경하지 않았어요. Spring이 record 타입 기반으로 라우팅하므로 기존 `@TransactionalEventListener(AFTER_COMMIT)` 동작이 그대로 유지돼요.

### 4. 테스트 추가

- `SpringDomainEventPublisherTest` — `ApplicationEventPublisher` 위임 검증 (3 tests)
- `AuditLogEventTest` — 메타데이터 자동 주입 / 명시 시 유지 / `eventType` 생성 검증 (3 tests)
- `FcmOutboxEventTest` — 정적 팩토리 동작 검증 (3 tests)

모두 통과 확인했어요 (`./gradlew test` 기준 0 failures / 0 errors).

### 5. NOT in scope (이번 PR에 포함하지 않은 것)

- **Phase 2 (EventOutbox 일반화)**: AFTER_COMMIT 이벤트가 JVM 비정상 종료 시 손실되는 문제는 별도 PR에서 outbox 패턴 일반화로 해결할 예정이에요. 현재 `notification` 도메인의 `FcmOutbox` 패턴을 `global/event/`로 일반화하는 방향이에요.
- **Listener 추상화**: 이번에는 publisher만 추상화했어요. 향후 broker 도입 시점에 broker별 bridge 어댑터(`@KafkaListener` 등)를 추가하는 형태로 확장할 거예요. 자세한 트레이드오프는 [ADR-018](./docs/adr/018-abstract-spring-event-publisher-for-future-broker.md#alternatives-considered)에 정리해두었어요.
- **`ServerLifecycleAlarmListener`**: Spring lifecycle 이벤트(`ApplicationReadyEvent`)에 반응하는 코드라 추상화 대상에서 제외했어요.

## 💬 리뷰 중점사항

1. **헥사고날 의존 방향**: `global/event/` 신규 패키지가 `domain` → `application/port/out` ← `adapter/out` 방향을 잘 따르는지 봐주세요. 응용 서비스에서 Spring 인프라 API 직접 참조를 제거하는 것이 핵심 목적이에요.
2. **`AuditLogEvent`의 record + `@Builder` + compact constructor 조합**: Lombok `@Builder`로 생성된 인스턴스에도 compact constructor의 메타데이터 자동 주입이 동작하도록 했어요. 테스트에서 검증했지만 한 번 더 봐주시면 좋겠어요.
3. **`SpringDomainEventPublisher.publishAll`의 fail-fast 동작**: 중간 이벤트 발행이 예외를 던지면 이후 이벤트는 발행되지 않고 예외가 호출자에게 전파돼요. JavaDoc에 명시했고, 이는 의도된 동작이에요. 추후 Outbox 어댑터에서는 별도 원자성 보장 정책을 적용할 예정이에요.
4. **`FcmOutboxEvent` 처리**: 일관성 유지를 위해 `DomainEvent`로 마이그레이션했지만, 실제로는 어디서도 발행되지 않는 dead code예요. 제거 결정은 별도 ADR로 진행할 예정이에요 (`docs/analysis/notification-fcm-current-state.md` 참고).

---

📎 참고 문서: [ADR-018: Spring Event Publisher를 추상화하여 미래 메시지 브로커 도입을 대비한다](./docs/adr/018-abstract-spring-event-publisher-for-future-broker.md)