### PR TITLE
[Refactor] 이메일 발송 이벤트를 추상화된 DomainEvent로 통합

### DIFF
--- a/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
+++ b/src/main/java/com/umc/product/authentication/application/event/SendVerificationEmailEvent.java
@@ -1,15 +1,43 @@
 package com.umc.product.authentication.application.event;
 
+import com.umc.product.global.event.domain.DomainEvent;
+import java.time.Instant;
+import java.util.UUID;
+
 /**
  * 이메일 인증 세션 생성/재발급 후, 메일 발송이 필요할 때 트랜잭션 commit 직후
- * 비동기로 메일을 보내기 위해 발행되는 애플리케이션 이벤트.
+ * 비동기로 메일을 보내기 위해 발행되는 도메인 이벤트.
  * <p>
  * SMTP 호출이 트랜잭션 내부에서 일어나면 메일 서버 응답이 느릴 때 DB 커넥션을 길게
  * 점유하고, 발송 실패가 세션 롤백을 유발해 사용자가 처음부터 다시 인증해야 하는
  * 문제가 있었다. AFTER_COMMIT 단계로 분리해 양쪽 부작용을 끊는다.
+ * <p>
+ * {@code eventId}와 {@code occurredAt}을 명시하지 않으면 각각 {@link UUID#randomUUID()}와
+ * {@link Instant#now()}로 자동 채워진다. 응용 레이어에서는 {@link #of(String, String)}
+ * 정적 팩토리를 사용한다.
  */
 public record SendVerificationEmailEvent(
+    UUID eventId,
+    Instant occurredAt,
     String email,
     String verificationCode
-) {
+) implements DomainEvent {
+
+    public SendVerificationEmailEvent {
+        if (eventId == null) {
+            eventId = UUID.randomUUID();
+        }
+        if (occurredAt == null) {
+            occurredAt = Instant.now();
+        }
+    }
+
+    public static SendVerificationEmailEvent of(String email, String verificationCode) {
+        return new SendVerificationEmailEvent(null, null, email, verificationCode);
+    }
+
+    @Override
+    public String eventType() {
+        return "authentication.email.verification.requested";
+    }
 }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -12,13 +12,13 @@ import com.umc.product.authentication.domain.EmailVerification;
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import java.security.SecureRandom;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +36,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     private final SaveEmailVerificationPort saveEmailVerificationPort;
     private final JwtTokenProvider jwtTokenProvider;
     private final GetMemberCredentialUseCase getMemberCredentialUseCase;
-    private final ApplicationEventPublisher eventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     // TODO: EmailSendUseCase와 구분할 필요가 있습니다.
     @Override
@@ -158,7 +158,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
      * AFTER_COMMIT 단계에서 SendVerificationEmailEventListener 가 메일을 발송한다.
      */
     private void publishSendEmailEvent(String email, String code) {
-        eventPublisher.publishEvent(new SendVerificationEmailEvent(email, code));
+        eventPublisher.publish(SendVerificationEmailEvent.of(email, code));
     }
 
     private String generateRandomCode() {

--- a/src/test/java/com/umc/product/authentication/application/event/SendVerificationEmailEventTest.java
+++ b/src/test/java/com/umc/product/authentication/application/event/SendVerificationEmailEventTest.java
@@ -1,0 +1,66 @@
+package com.umc.product.authentication.application.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SendVerificationEmailEventTest {
+
+    @Test
+    @DisplayName("of 정적 팩토리는 eventId와 occurredAt을 자동 주입한다")
+    void of_메타데이터_자동주입() {
+        // given
+        Instant before = Instant.now();
+
+        // when
+        SendVerificationEmailEvent event = SendVerificationEmailEvent.of("user@example.com", "123456");
+
+        // then
+        Instant after = Instant.now();
+        assertThat(event.eventId()).isNotNull();
+        assertThat(event.occurredAt()).isBetween(before, after);
+        assertThat(event.email()).isEqualTo("user@example.com");
+        assertThat(event.verificationCode()).isEqualTo("123456");
+    }
+
+    @Test
+    @DisplayName("of 정적 팩토리는 매번 새로운 eventId를 반환한다")
+    void of는_매번_새_eventId_반환() {
+        // when
+        SendVerificationEmailEvent first = SendVerificationEmailEvent.of("a@example.com", "111111");
+        SendVerificationEmailEvent second = SendVerificationEmailEvent.of("a@example.com", "111111");
+
+        // then
+        assertThat(first.eventId()).isNotEqualTo(second.eventId());
+    }
+
+    @Test
+    @DisplayName("eventId와 occurredAt을 명시하면 그 값이 그대로 유지된다")
+    void 메타데이터_명시시_값_유지() {
+        // given
+        UUID givenId = UUID.randomUUID();
+        Instant givenInstant = Instant.parse("2026-01-01T00:00:00Z");
+
+        // when
+        SendVerificationEmailEvent event = new SendVerificationEmailEvent(
+            givenId, givenInstant, "user@example.com", "654321"
+        );
+
+        // then
+        assertThat(event.eventId()).isEqualTo(givenId);
+        assertThat(event.occurredAt()).isEqualTo(givenInstant);
+    }
+
+    @Test
+    @DisplayName("eventType은 'authentication.email.verification.requested'이다")
+    void eventType은_고정값() {
+        // when
+        SendVerificationEmailEvent event = SendVerificationEmailEvent.of("user@example.com", "123456");
+
+        // then
+        assertThat(event.eventType()).isEqualTo("authentication.email.verification.requested");
+    }
+}

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -16,11 +16,11 @@ import com.umc.product.authentication.domain.EmailVerification;
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
 import java.util.Optional;
-import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ class AuthenticationServiceTest {
     GetMemberCredentialUseCase getMemberCredentialUseCase;
 
     @Mock
-    ApplicationEventPublisher eventPublisher;
+    DomainEventPublisher eventPublisher;
 
     @InjectMocks
     AuthenticationService service;
@@ -90,7 +90,7 @@ class AuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_FORMAT);
 
             then(saveEmailVerificationPort).should(never()).save(any());
-            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should(never()).publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test
@@ -107,7 +107,7 @@ class AuthenticationServiceTest {
 
             // then
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(eventPublisher).should().publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should().publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test
@@ -124,7 +124,7 @@ class AuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
 
             then(saveEmailVerificationPort).should(never()).save(any());
-            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should(never()).publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test
@@ -142,7 +142,7 @@ class AuthenticationServiceTest {
 
             // then
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(eventPublisher).should().publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should().publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test
@@ -163,7 +163,7 @@ class AuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
 
             then(saveEmailVerificationPort).should(never()).save(any());
-            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should(never()).publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test
@@ -180,7 +180,7 @@ class AuthenticationServiceTest {
 
             // then: 응답은 정상이지만 메일 이벤트는 발행되지 않음 (이메일 열거 방어)
             assertThat(sessionId).isEqualTo(SESSION_ID);
-            then(eventPublisher).should(never()).publishEvent(any(SendVerificationEmailEvent.class));
+            then(eventPublisher).should(never()).publish(any(SendVerificationEmailEvent.class));
         }
     }
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- follow-up to #880 ([Refactor] SpringEventPublisher를 DomainEventPublisher로 추상화)
- merge-coincident with #879 ([Feat] 이메일 발송 목적별 분기, Event 기반 변경, 발송 빈도 제한, Orphan 제거 스케쥴러 도입)

## 🚀 작업 내용

#880이 머지되어 develop에 `DomainEventPublisher` 추상화가 들어왔는데, 같은 시점에 머지된 #879에서 추가한 `SendVerificationEmailEvent`와 `AuthenticationService`가 여전히 Spring `ApplicationEventPublisher`를 직접 사용하고 있었어요. Git 텍스트 머지가 이 의미론적 충돌(semantic conflict)을 잡지 못해서, 일관성을 회복하기 위한 후속 작업을 진행했어요.

### 1. `SendVerificationEmailEvent`를 `DomainEvent`로 표준화

`AuditLogEvent` / `FcmOutboxEvent`와 동일한 패턴으로 정리했어요.

- `eventId(UUID)`, `occurredAt(Instant)` 메타데이터 필드 추가
- record compact constructor에서 null이면 `UUID.randomUUID()` / `Instant.now()`로 자동 채워주도록 처리
- 정적 팩토리 `SendVerificationEmailEvent.of(email, code)` 도입 (CLAUDE.md "응용 레이어 외부에서 `new` 금지" 컨벤션 준수)
- `eventType()`은 `"authentication.email.verification.requested"` 반환

### 2. `AuthenticationService` 마이그레이션

- `ApplicationEventPublisher` 의존을 `DomainEventPublisher`로 교체
- `publishSendEmailEvent()` 내부의 `eventPublisher.publishEvent(new SendVerificationEmailEvent(email, code))`를 `eventPublisher.publish(SendVerificationEmailEvent.of(email, code))`로 변경

리스너 측(`SendVerificationEmailEventListener`)은 변경하지 않았어요. Spring이 record 타입 기반으로 라우팅하므로 기존 `@TransactionalEventListener(AFTER_COMMIT)` 동작이 그대로 유지돼요.

### 3. 테스트

- **신규**: `SendVerificationEmailEventTest` — `of()` 정적 팩토리의 메타데이터 자동 주입, 매번 새 `eventId` 생성, 직접 생성자 값 유지, `eventType` 형식 검증 (4 tests)
- **마이그레이션**: `AuthenticationServiceTest` — `@Mock ApplicationEventPublisher` → `@Mock DomainEventPublisher`로 교체, `publishEvent(...)` 호출 검증을 `publish(...)`로 변경 (8 tests)

`./gradlew test` 기준 관련 21개 테스트 (이벤트 추상화 9 + 이번 신규 4 + AuthenticationService 8) 모두 통과 확인했어요.

### 4. NOT in scope

- **추가 발견 위치 없음**: `grep -r "ApplicationEventPublisher" src/main/java`로 전수 조사한 결과, 응용/도메인 레이어에서 Spring `ApplicationEventPublisher`를 직접 의존하는 코드는 이제 0건이에요. (어댑터인 `SpringDomainEventPublisher`만 정상적으로 의존)
- **Phase 2 (EventOutbox 일반화)**: 여전히 별도 PR에서 진행할 예정이에요 (#880의 NOT in scope와 동일).

## 💬 리뷰 중점사항

1. **의미론적 일관성**: `SendVerificationEmailEvent`가 `AuditLogEvent` / `FcmOutboxEvent`와 동일한 record + compact constructor + `DomainEvent` 패턴을 따르는지 봐주세요.
2. **`SendVerificationEmailEvent.of(...)` 정적 팩토리**: CLAUDE.md의 "응용 레이어에서 `new` 금지" 원칙에 맞게 호출부(`AuthenticationService`)에서 정적 팩토리를 사용하도록 했어요. 파라미터 2개라 `of` 명명 컨벤션에도 맞아요.
3. **테스트 mock 교체**: `AuthenticationServiceTest`의 `@Mock` 타입을 `DomainEventPublisher`로 바꾸면서 verify 메서드명도 `publishEvent` → `publish`로 함께 수정했어요. 기존 테스트 8개의 동작 의도는 그대로예요 (NPE는 mock 타입 불일치 때문이었음).

---

📎 참고 문서: [ADR-018: Spring Event Publisher를 추상화하여 미래 메시지 브로커 도입을 대비한다](./docs/adr/018-abstract-spring-event-publisher-for-future-broker.md)