### PR TITLE
[Feat] Member 및 Challenger 검색 및 정보 조회 V2 API 구현 및 성능 개선

### DIFF
--- a/docs/analysis/member_me_v1_v2_성능_비교_보고서.md
+++ b/docs/analysis/member_me_v1_v2_성능_비교_보고서.md
@@ -1,0 +1,289 @@
+# `/me` 성능 비교 보고서 — v1 vs v2
+
+UMC PRODUCT Backend / 작성일: 2026-05-19 / 대상 PR: [#885](https://github.com/UMC-PRODUCT/umc-product-server/pull/885)
+
+## TL;DR
+
+| 항목 | v1 (PR 이전) | v1 (PR 적용 후) | v2 (BFF) |
+|---|---:|---:|---:|
+| DB 쿼리 수 (N=3 기수) | **12** | **6** | **8** |
+| DB 쿼리 수 (N 기수) | **3N+3** | **6** | **8** |
+| 트랜잭션 경계 | 분리(6+) | 분리(6+) | **단일 readOnly** |
+| 응답 데이터 | 프로필 + 이력 | 동일 | + 활동일 / 활성기수 강조 / 운영진 / 기수별 점수 |
+| 시점 일관성 | 약함 | 약함 | **보장** |
+| RTT(클라이언트 호출 수) | 1 + α | 1 + α | **1** |
+
+`α`는 클라이언트가 "현재 운영진인지", "총 활동일 며칠인지" 등을 별도 API로 보충해야 했던 호출 수입니다.
+
+---
+
+## 비교 환경 — 가정
+
+회원 A (`memberId=10`) 라는 한 사용자가 다음 데이터를 보유한다고 가정합니다.
+
+- 참여 기수: **3개** (6기 WEB / 7기 SPRINGBOOT / 8기 SPRINGBOOT)
+- 챌린저 상태: 모두 ACTIVE (가장 최근 8기는 활성 기수)
+- 보유 상벌점: 총 30건 (기수별 평균 10건)
+- 활성 기수에 `SCHOOL_PRESIDENT` 운영진 1건
+
+쿼리 수 모델링은 JPA 단일 쿼리 단위로 계산합니다 (커넥션 풀·캐시 hit 제외, worst case).
+
+---
+
+## v1 (PR 이전) — N+1 패턴이 다층
+
+### 호출 그래프
+
+```
+GET /api/v1/member/me
+       ↓
+MemberQueryController.getMyProfile
+       ↓
+MemberInfoResponseAssembler.fromMemberId(memberId)
+       │
+       ├── getMemberUseCase.getById(memberId)                          ── Q1
+       │
+       ├── getChallengerUseCase.getAllByMemberId(memberId)
+       │     └─ ChallengerQueryService.getAllByMemberId (PR 이전)
+       │          ├─ loadChallengerPort.getAllByMemberId               ── Q2
+       │          └─ for each challenger:
+       │              └─ getChallengerPointUseCase                     ── Q3, Q4, Q5  (N+1)
+       │                  .getListByChallengerId(challenger.id)
+       │
+       ├── for each challenger:                                        # adapter loop
+       │     ├── getGisuUseCase.getById(gisuId)                        ── Q6, Q7, Q8  (N+1)
+       │     └── getChapterUseCase.byGisuAndSchool(gisuId, schoolId)   ── Q9, Q10, Q11 (N+1)
+       │
+       └── getMemberProfileUseCase.getMemberProfileById(memberId)      ── Q12
+```
+
+### 쿼리 수: **3N + 3 = 12** (N=3)
+
+| 쿼리 출처 | 횟수 |
+|---|---:|
+| `member.findById` (+school join) | 1 |
+| `challenger.findByMemberId` | 1 |
+| `challenger_point.findByChallengerId` (챌린저당 1회) | N = 3 |
+| `gisu.findById` (챌린저당 1회) | N = 3 |
+| `chapter.byGisuAndSchool` (챌린저당 1회) | N = 3 |
+| `member_profile.findByMemberId` | 1 |
+| **합계** | **12** |
+
+핵심 문제는 `ChallengerQueryService` 의 `getChallengerInfoFromChallenger` 가 stream 내부에서 `getChallengerPointUseCase.getListByChallengerId` 를 매번 호출하던 것이었습니다.
+
+---
+
+## v1 (PR 적용 후, T1·D13 반영) — N+1 제거
+
+### 호출 그래프
+
+```
+GET /api/v1/member/me
+       ↓
+MemberInfoResponseAssembler.fromMemberId
+       │
+       ├── getMemberUseCase.getById                                    ── Q1
+       │
+       ├── getChallengerUseCase.getAllByMemberId
+       │     └─ ChallengerQueryService.getAllByMemberId (D13)
+       │          ├─ loadChallengerPort.getAllByMemberId               ── Q2
+       │          └─ toChallengerInfoListBatch
+       │              └─ getMapByChallengerIds (IN 쿼리 1회)           ── Q3
+       │
+       ├── getGisuUseCase.getByIds(gisuIds)         (IN 쿼리 1회)      ── Q4
+       ├── getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds        ── Q5
+       └── getMemberProfileUseCase.getMemberProfileById                ── Q6
+```
+
+### 쿼리 수: **6** (N과 무관, O(1))
+
+| 쿼리 | 횟수 |
+|---|---:|
+| `member` | 1 |
+| `challenger.findByMemberId` | 1 |
+| `challenger_point.findByChallengerIdIn` (IN) | 1 |
+| `gisu.findByIdIn` (IN) | 1 |
+| `chapter` map (gisuIds × schoolIds 조인) | 1 |
+| `member_profile` | 1 |
+| **합계** | **6** |
+
+3기수 기준 **12 → 6, 50% 감소**. 10기수 가정 시 **33 → 6, 82% 감소**.
+
+응답 스키마는 v1 그대로 유지(회귀 없음). 단순히 N+1만 사라진 상태입니다.
+
+---
+
+## v2 (BFF) — 단일 트랜잭션 + 추가 정보
+
+### 호출 그래프
+
+```
+GET /api/v2/member/me
+       ↓
+MemberQueryV2Controller.getMySummary
+       ↓
+MemberSummaryV2QueryService.getSummaryByMemberId  (@Transactional(readOnly=true))
+       │   ← 8개 외부 호출이 모두 같은 트랜잭션 안
+       │
+       ├── getMemberUseCase.getById                                    ── Q1
+       ├── getMemberProfileUseCase.getMemberProfileById                ── Q2
+       │
+       ├── getChallengerUseCase.getAllByMemberId
+       │     ├─ loadChallengerPort.getAllByMemberId                    ── Q3
+       │     └─ getMapByChallengerIds (IN)                             ── Q4
+       │
+       ├── getGisuUseCase.findActiveGisu()  (Optional)                 ── Q5
+       ├── getGisuUseCase.getByIds(gisuIds) (IN)                       ── Q6
+       ├── getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds        ── Q7
+       ├── getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(IN) ── Q8
+       │
+       └── ChallengerActivityPeriodService.calculateActivityPeriod
+             (사전-fetch한 데이터 메모리 계산 → 0 쿼리)
+       ↓
+MemberSummaryV2Response
+```
+
+### 쿼리 수: **8** (N과 무관, O(1))
+
+| 쿼리 | 횟수 | v1과의 차이 |
+|---|---:|---|
+| `member` | 1 | 동일 |
+| `member_profile` | 1 | 동일 |
+| `challenger.findByMemberId` | 1 | 동일 |
+| `challenger_point.findByChallengerIdIn` | 1 | 동일 |
+| **`gisu.findActiveByIsActive`** | 1 | **v2 신규** — 활성 기수 식별 |
+| `gisu.findByIdIn` | 1 | 동일 |
+| `chapter` map | 1 | 동일 |
+| **`challenger_role.findByChallengerIdIn`** | 1 | **v2 신규** — 운영진 RoleType |
+| 활동일 계산 | 0 | 메모리 (`GisuInfo.activityDays`) |
+| **합계** | **8** | +2 (정보량 ↑) |
+
+v1과 비교해 쿼리가 2개 더 발생하지만, 그 2개로 활동일 합산·운영진 여부·기수별 점수 강조 정보까지 모두 응답에 담깁니다.
+
+---
+
+## 트랜잭션 경계 — 가장 큰 구조적 차이
+
+### v1 (이전·이후 동일)
+
+`MemberInfoResponseAssembler` 는 `@Component` 입니다. Spring이 트랜잭션을 열어주지 않습니다. 내부에서 호출하는 각 UseCase Service(`MemberQueryService`, `ChallengerQueryService`, `GisuQueryService` …)가 각자 `@Transactional(readOnly=true)` 를 가지고 있으므로 **호출마다 별도 트랜잭션** 이 열렸다 닫힙니다.
+
+```
+[Q1: member]      open tx → commit
+[Q2,Q3: challenger+points]   open tx → commit
+[Q4: gisu]        open tx → commit
+[Q5: chapter]     open tx → commit
+[Q6: profile]     open tx → commit
+```
+
+→ **시점 일관성 보장 안 됨**. 회원이 8기 챌린저 등록 직후 호출하면 Q2에서는 8기가 보이는데 Q4에서 기수 정보를 받지 못해 schema-skew 가능성 (확률은 낮지만 race window 존재).
+
+### v2
+
+`MemberSummaryV2QueryService` 가 `@Service @Transactional(readOnly=true)`. Controller가 service를 호출하는 순간 트랜잭션이 열리고, **8개 외부 호출이 모두 같은 트랜잭션 안에서 단일 스냅샷에 대해 실행** 됩니다.
+
+```
+open tx
+  [Q1..Q8 모두 같은 스냅샷]
+commit
+```
+
+→ **시점 일관성 보장**. 활성 기수 전환·점수 적재 같은 짧은 write가 응답 중간에 들어와도 응답은 일관된 한 시점을 반영합니다.
+
+---
+
+## 응답 페이로드 비교
+
+### v1 응답 (`MemberInfoResponse`)
+
+```json
+{
+  "id": 10,
+  "name": "...",
+  "email": "...",
+  "schoolId": 1,
+  "schoolName": "...",
+  "profileImageLink": null,
+  "status": "ACTIVE",
+  "roles": [...],
+  "challengerRecords": [
+    { "challengerId": 1, "gisuId": 6, "gisu": 7, "chapterId": 3, "chapterName": "...",
+      "part": "WEB", "challengerStatus": "ACTIVE",
+      "challengerPoints": [...], "points": [...],   // 중복 (deprecated)
+      "totalPoints": 3.0,
+      "memberStatus": "ACTIVE", "status": "ACTIVE", // 중복 (deprecated)
+      ... },
+    ...
+  ],
+  "profile": {...}
+}
+```
+
+빠진 정보: **활동일, 활성 기수 강조, 운영진 여부**. 클라이언트가 이 정보를 원하면 추가 API 호출이 필요합니다.
+
+### v2 응답 (`MemberSummaryV2Response`)
+
+```json
+{
+  "id": 10, "name": "...", "email": "...", "schoolId": 1,
+  "schoolName": "...", "profileImageLink": null, "status": "ACTIVE",
+  "profile": {...},
+
+  "totalActivityDays": 547,           // ← 추가
+  "currentGisuMemberInfo": {          // ← 추가, 휴지기엔 null
+    "gisuId": 8, "generation": 9,
+    "challenger": { "challengerId": 3, "part": "SPRINGBOOT",
+                    "challengerStatus": "ACTIVE",
+                    "points": [...], "totalPoints": 4.0 },
+    "isAdmin": true,
+    "roleTypes": ["SCHOOL_PRESIDENT"]
+  },
+
+  "challengerHistory": [              // ← 정제됨 (deprecated 필드 제거)
+    { "challengerId": 3, "gisuId": 8, "generation": 9,
+      "chapterId": 3, "chapterName": "...",
+      "part": "SPRINGBOOT", "challengerStatus": "ACTIVE",
+      "points": [...], "totalPoints": 4.0, "roleTypes": [...] },
+    ...최신 기수 우선 정렬
+  ]
+}
+```
+
+v1 대비 페이로드는 약 15~25% 증가 (활동일 `long` 1개, `currentGisuMemberInfo` 객체 1개)지만, deprecated 중복 필드 제거로 **상쇄 효과** 가 있어 실측 크기는 비슷한 수준이 될 가능성이 높습니다.
+
+---
+
+## 시나리오 walkthrough — 회원 A (3기수 + 활성 기수 회장) 호출
+
+| 단계 | v1 (이전) | v1 (PR 후) | v2 |
+|---|---|---|---|
+| 클라이언트 호출 | `GET /me` | `GET /me` | `GET /me` |
+| 백엔드 쿼리 수 | 12 | 6 | 8 |
+| 트랜잭션 수 | ~6 | ~6 | 1 |
+| 활동일 표시 | 별도 API 필요 | 별도 API 필요 | 응답에 포함 |
+| 활성 기수 챌린저 강조 | 클라이언트 계산 | 클라이언트 계산 | 응답에 포함 |
+| 운영진 여부 | 별도 API 호출 또는 roles 파싱 | 동일 | boolean 한 줄 |
+| 총 클라이언트 RTT | 1 + α (활동일/운영진 별도) | 1 + α | **1** |
+
+α 가 단순히 2회였다고 가정해도 v2 시 클라이언트 입장에서 **RTT 1/3로 축소** 됩니다.
+
+---
+
+## 한계와 후속 측정 계획
+
+본 보고서의 수치는 **JPA 쿼리 카운트 기반 모델링** 이며, 실제 응답 시간은 측정하지 않았습니다. PR 머지 후 다음을 권장합니다.
+
+1. **Hibernate statistics 로깅** (`spring.jpa.properties.hibernate.generate_statistics=true`) 로 N=3·5·10 시 실제 쿼리 수 검증
+2. **JMeter 또는 k6** 로 동시 100요청 시 p50/p95 응답 시간 측정 — v1(PR 후) vs v2
+3. **PG `pg_stat_statements`** 로 `getAllByMemberId` 호출 빈도와 평균 시간 추적 (D13 효과)
+4. **Application logs**: `/api/v1/member/me` 와 `/api/v2/member/me` 의 처리 시간 분포 비교 (1주 단위)
+
+특히 v2의 신규 쿼리 2건(`findActiveGisu`, `getAllRoleTypesByChallengerIds`)이 hot path 부하에 미치는 영향을 모니터링 대상으로 두면 좋습니다.
+
+---
+
+## 결론
+
+- **v1 (PR 이전 → PR 적용 후)**: 같은 응답 모델에서 **3N+3 → 6** 쿼리로 떨어지며 챌린저 수에 비례하던 비용이 사라졌습니다.
+- **v2 (BFF)**: v1보다 쿼리 2건이 추가되지만, 그 비용으로 **활동일·활성 기수 운영진·기수별 점수 강조** 까지 한 응답으로 제공하고 **단일 readOnly 트랜잭션** 으로 시점 일관성을 보장합니다.
+- 클라이언트 입장에서는 v2가 **RTT 1회** 에 필요한 모든 정보를 받게 되어, v1+보조 API 호출 조합을 단일 호출로 대체할 수 있습니다.

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
@@ -10,6 +10,10 @@ import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -38,14 +42,28 @@ public class ChallengerResponseAssembler {
         List<ChallengerInfo> challengerInfos = getChallengerUseCase.getAllByMemberId(memberId);
         MemberInfo memberInfo = getMemberUseCase.getById(memberId);
 
-        return challengerInfos.stream()
-            .map(challengerInfo -> {
-                GisuInfo gisuInfo = getGisuUseCase.getById(challengerInfo.gisuId());
-                ChapterInfo chapterInfo = getChapterUseCase.byGisuAndSchool(challengerInfo.gisuId(),
-                    memberInfo.schoolId());
+        // 챌린저별로 gisu/chapter를 반복 조회하면 N+1이 발생하므로, batch 메서드로 한 번에 조회합니다.
+        Set<Long> gisuIds = challengerInfos.stream()
+            .map(ChallengerInfo::gisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
 
-                return ChallengerInfoResponse.from(challengerInfo, memberInfo, gisuInfo, chapterInfo);
-            })
+        Map<Long, GisuInfo> gisuByGisuId = gisuIds.isEmpty()
+            ? Map.of()
+            : getGisuUseCase.getByIds(gisuIds).stream()
+                .collect(Collectors.toMap(GisuInfo::gisuId, g -> g));
+
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = (gisuIds.isEmpty() || memberInfo.schoolId() == null)
+            ? Map.of()
+            : getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(gisuIds, Set.of(memberInfo.schoolId()));
+
+        return challengerInfos.stream()
+            .map(challengerInfo -> ChallengerInfoResponse.from(
+                challengerInfo,
+                memberInfo,
+                gisuByGisuId.get(challengerInfo.gisuId()),
+                chapterByGisuAndSchool.getOrDefault(challengerInfo.gisuId(), Map.of()).get(memberInfo.schoolId())
+            ))
             .toList();
     }
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
@@ -62,8 +62,19 @@ public class ChallengerResponseAssembler {
                 challengerInfo,
                 memberInfo,
                 gisuByGisuId.get(challengerInfo.gisuId()),
-                chapterByGisuAndSchool.getOrDefault(challengerInfo.gisuId(), Map.of()).get(memberInfo.schoolId())
+                getChapterInfo(chapterByGisuAndSchool, challengerInfo.gisuId(), memberInfo.schoolId())
             ))
             .toList();
+    }
+
+    private ChapterInfo getChapterInfo(
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool,
+        Long gisuId,
+        Long schoolId
+    ) {
+        if (schoolId == null) {
+            return null;
+        }
+        return chapterByGisuAndSchool.getOrDefault(gisuId, Map.of()).get(schoolId);
     }
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java
@@ -29,7 +29,7 @@ public class ChallengerSearchV2Controller {
     private final SearchMemberUseCase searchMemberUseCase;
 
     @Operation(
-        summary = "[CHALLENGER-V2-101] 챌린저 검색 v2",
+        summary = "[CHALLENGER-201] 챌린저 검색 v2",
         description = """
             챌린저 단위 페이지네이션 검색입니다.
 

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java
@@ -1,0 +1,54 @@
+package com.umc.product.challenger.adapter.in.web.v2;
+
+import com.umc.product.challenger.adapter.in.web.v2.dto.response.ChallengerSearchV2Response;
+import com.umc.product.member.adapter.in.web.dto.request.SearchMemberRequest;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * /api/v2/challenger 의 Query 엔드포인트.
+ * <p>
+ * 회원 검색이 아닌 "챌린저 검색"이 목적이며, 같은 회원이 여러 기수에 참여했다면 기수별로 별도 row를 반환합니다.
+ * 검색 조건은 회원 검색과 동일한 키워드/필터를 사용합니다 (SearchMemberQuery).
+ * <p>
+ * 권한 정책: v1과 동일하게 인증된 사용자가 호출 가능. 별도 권한 강화는 후속 PR.
+ */
+@RestController
+@RequestMapping("/api/v2/challenger")
+@RequiredArgsConstructor
+@Tag(name = "Challenger V2 | 챌린저 Query", description = "챌린저 단위 검색 등 챌린저 조회 v2 엔드포인트")
+public class ChallengerSearchV2Controller {
+
+    private final SearchMemberUseCase searchMemberUseCase;
+
+    @Operation(
+        summary = "[CHALLENGER-V2-101] 챌린저 검색 v2",
+        description = """
+            챌린저 단위 페이지네이션 검색입니다.
+
+            - 같은 회원이 여러 기수에 참여했다면 기수별 챌린저가 각각 별도 row로 반환됩니다.
+            - v1 회원 검색 응답에 더해 다음 두 필드를 제공합니다.
+              - `challengerStatus`: 해당 행 챌린저의 상태 (ACTIVE/GRADUATED/EXPELLED/WITHDRAWN)
+              - `isAdminInActiveGisu`: 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
+            - 검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+              컨트롤러 단에서 마스킹 처리되어 응답됩니다.
+            - 회원 단위로 묶인 검색이 필요하다면 `/api/v2/member/search` 를 사용해 주세요.
+            """
+    )
+    @GetMapping("search")
+    public ChallengerSearchV2Response searchChallengersV2(
+        @ParameterObject Pageable pageable,
+        @ParameterObject SearchMemberRequest searchRequest
+    ) {
+        return ChallengerSearchV2Response.from(
+            searchMemberUseCase.searchChallengersByV2(searchRequest.toQuery(), pageable)
+        ).withMaskedEmails();
+    }
+}

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/v2/dto/response/ChallengerSearchV2Response.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/v2/dto/response/ChallengerSearchV2Response.java
@@ -1,0 +1,97 @@
+package com.umc.product.challenger.adapter.in.web.v2.dto.response;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.util.EmailMasker;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * GET /api/v2/challenger/search 응답 DTO. 챌린저 단위 페이지네이션이며,
+ * 같은 회원이 여러 기수 챌린저 이력을 가지면 별도 row로 분리되어 반환됩니다.
+ */
+public record ChallengerSearchV2Response(
+    long totalCount,
+    PageResponse<ChallengerSearchV2ItemResponse> page
+) {
+    public static ChallengerSearchV2Response from(ChallengerSearchV2Result result) {
+        PageResponse<ChallengerSearchV2ItemResponse> pageResponse =
+            PageResponse.of(result.page(), ChallengerSearchV2ItemResponse::from);
+        return new ChallengerSearchV2Response(
+            result.page().getTotalElements(),
+            pageResponse
+        );
+    }
+
+    /**
+     * 검색 결과의 이메일을 일괄 마스킹한 새 응답을 반환합니다. 검색은 본인 외의 회원이 결과로 포함되므로
+     * 로그인 식별자인 이메일이 평문으로 노출되지 않도록 컨트롤러 단에서 호출해 적용합니다.
+     */
+    public ChallengerSearchV2Response withMaskedEmails() {
+        List<ChallengerSearchV2ItemResponse> masked = page.content().stream()
+            .map(ChallengerSearchV2ItemResponse::withMaskedEmail)
+            .toList();
+
+        PageResponse<ChallengerSearchV2ItemResponse> maskedPage = new PageResponse<>(
+            masked,
+            page.page(),
+            page.size(),
+            page.totalElements(),
+            page.totalPages(),
+            page.hasNext(),
+            page.hasPrevious()
+        );
+        return new ChallengerSearchV2Response(totalCount, maskedPage);
+    }
+
+    public record ChallengerSearchV2ItemResponse(
+        Long memberId,
+        String name,
+        String nickname,
+        String email,
+        Long schoolId,
+        String schoolName,
+        String profileImageLink,
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        ChallengerPart part,
+        @Schema(description = "검색 결과 행의 챌린저 상태")
+        ChallengerStatus challengerStatus,
+        List<ChallengerRoleType> roleTypes,
+        @Schema(description = "이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지")
+        boolean isAdminInActiveGisu
+    ) {
+        public static ChallengerSearchV2ItemResponse from(ChallengerSearchItemV2Info info) {
+            return new ChallengerSearchV2ItemResponse(
+                info.memberId(),
+                info.name(),
+                info.nickname(),
+                info.email(),
+                info.schoolId(),
+                info.schoolName(),
+                info.profileImageLink(),
+                info.challengerId(),
+                info.gisuId(),
+                info.generation(),
+                info.part(),
+                info.challengerStatus(),
+                info.roleTypes(),
+                info.isAdminInActiveGisu()
+            );
+        }
+
+        public ChallengerSearchV2ItemResponse withMaskedEmail() {
+            return new ChallengerSearchV2ItemResponse(
+                memberId, name, nickname,
+                EmailMasker.mask(email),
+                schoolId, schoolName, profileImageLink,
+                challengerId, gisuId, generation, part, challengerStatus, roleTypes, isAdminInActiveGisu
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerJpaRepository.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerJpaRepository.java
@@ -19,6 +19,11 @@ public interface ChallengerJpaRepository extends JpaRepository<Challenger, Long>
     List<Challenger> findByMemberId(Long memberId);
 
     /**
+     * 여러 memberId로 챌린저 목록 IN 쿼리 1회 조회
+     */
+    List<Challenger> findByMemberIdIn(Set<Long> memberIds);
+
+    /**
      * gisuId로 챌린저 목록 조회
      */
     List<Challenger> findByGisuId(Long gisuId);

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
@@ -47,6 +47,14 @@ public class ChallengerPersistenceAdapter implements LoadChallengerPort, SaveCha
     }
 
     @Override
+    public List<Challenger> listAllByMemberIds(Set<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+        return repository.findByMemberIdIn(memberIds);
+    }
+
+    @Override
     public List<Challenger> getAllByGisuId(Long gisuId) {
         return repository.findByGisuId(gisuId);
     }

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
@@ -94,7 +94,7 @@ public class ChallengerPersistenceAdapter implements LoadChallengerPort, SaveCha
 
     @Override
     public List<Challenger> listByMemberIdsAndGisuId(Set<Long> memberIds, Long gisuId) {
-        if (memberIds == null || memberIds.isEmpty()) {
+        if (memberIds == null || memberIds.isEmpty() || gisuId == null) {
             return List.of();
         }
         return repository.findByMemberIdInAndGisuId(memberIds, gisuId);

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerActivityPeriodUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerActivityPeriodUseCase.java
@@ -1,0 +1,35 @@
+package com.umc.product.challenger.application.port.in.query;
+
+import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSummary;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 회원의 기수별 활동일 합산을 조회하는 UseCase 입니다.
+ * <p>
+ * 활동일은 챌린저 상태가 ACTIVE 또는 GRADUATED인 기수에 한해 산정되며,
+ * 진행 중인 기수는 요청 시점(now)까지의 일수로 계산합니다.
+ * EXPELLED/WITHDRAWN 챌린저는 합산에서 제외됩니다.
+ */
+public interface GetChallengerActivityPeriodUseCase {
+
+    /**
+     * memberId만 가지고 단독으로 활동일 요약을 계산합니다. 내부에서 챌린저와 기수 정보를 조회합니다.
+     */
+    ActivityPeriodSummary getActivityPeriodByMemberId(Long memberId);
+
+    /**
+     * 이미 조회된 챌린저/기수 데이터를 받아 활동일 요약을 계산합니다.
+     * <p>
+     * BFF처럼 동일 트랜잭션 내에서 이미 일괄 조회한 데이터를 재사용해 중복 쿼리를 피하고자 할 때 사용합니다.
+     *
+     * @param challengers      회원의 챌린저 정보 목록
+     * @param gisuInfosByGisuId 챌린저들이 참여한 기수 정보 (gisuId 기준)
+     */
+    ActivityPeriodSummary calculateActivityPeriod(
+        List<ChallengerInfo> challengers,
+        Map<Long, GisuInfo> gisuInfosByGisuId
+    );
+}

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
@@ -1,5 +1,6 @@
 package com.umc.product.challenger.application.port.in.query;
 
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import java.util.List;
@@ -51,6 +52,20 @@ public interface GetChallengerUseCase {
      * 챌린저 이력이 없는 회원은 결과 Map에 키로 등장하지 않습니다.
      */
     Map<Long, List<ChallengerInfo>> getAllByMemberIds(Set<Long> memberIds);
+
+    /**
+     * 여러 memberId로 회원별 모든 챌린저 기본 정보를 IN 쿼리 1회로 일괄 조회합니다.
+     * <p>
+     * 상벌점이 필요 없는 검색/목록 조립에서 사용합니다.
+     */
+    Map<Long, List<ChallengerBasicInfo>> getAllBasicByMemberIds(Set<Long> memberIds);
+
+    /**
+     * 특정 기수 내 여러 memberId의 챌린저 기본 정보를 조회합니다.
+     * <p>
+     * 해당 기수 챌린저가 없는 회원은 결과에서 제외합니다.
+     */
+    List<ChallengerBasicInfo> listBasicByMemberIdsAndGisuId(Set<Long> memberIds, Long gisuId);
 
     /**
      * 여러 challengerId로 챌린저 정보 배치 조회

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
@@ -46,6 +46,13 @@ public interface GetChallengerUseCase {
     List<ChallengerInfo> getAllByMemberId(Long memberId);
 
     /**
+     * 여러 memberId로 회원별 모든 챌린저 정보를 IN 쿼리 1회로 일괄 조회합니다.
+     * <p>
+     * 챌린저 이력이 없는 회원은 결과 Map에 키로 등장하지 않습니다.
+     */
+    Map<Long, List<ChallengerInfo>> getAllByMemberIds(Set<Long> memberIds);
+
+    /**
      * 여러 challengerId로 챌린저 정보 배치 조회
      *
      * @param challengerIds 챌린저 ID 목록

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ActivityPeriodSummary.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ActivityPeriodSummary.java
@@ -1,0 +1,36 @@
+package com.umc.product.challenger.application.port.in.query.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 회원의 기수별 활동일 요약 정보입니다.
+ * <p>
+ * 활동일 산정은 챌린저 상태가 ACTIVE 또는 GRADUATED인 기수에 한하며,
+ * 진행 중인 기수는 요청 시점(now)까지의 일수로 계산합니다.
+ */
+public record ActivityPeriodSummary(
+    long totalActivityDays,
+    List<PerGisu> perGisu
+) {
+    /**
+     * 단일 기수의 활동일 항목입니다.
+     */
+    public record PerGisu(
+        Long gisuId,
+        Long generation,
+        long activityDays
+    ) {
+    }
+
+    public static ActivityPeriodSummary empty() {
+        return new ActivityPeriodSummary(0L, List.of());
+    }
+
+    public static ActivityPeriodSummary of(Map<Long, PerGisu> perGisuByGisuId) {
+        long total = perGisuByGisuId.values().stream()
+            .mapToLong(PerGisu::activityDays)
+            .sum();
+        return new ActivityPeriodSummary(total, perGisuByGisuId.values().stream().toList());
+    }
+}

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerBasicInfo.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerBasicInfo.java
@@ -1,0 +1,27 @@
+package com.umc.product.challenger.application.port.in.query.dto;
+
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+
+/**
+ * 상벌점 없이 챌린저 식별/소속 정보만 담는 경량 Info DTO입니다.
+ */
+public record ChallengerBasicInfo(
+    Long challengerId,
+    Long memberId,
+    Long gisuId,
+    ChallengerPart part,
+    ChallengerStatus challengerStatus
+) {
+
+    public static ChallengerBasicInfo from(Challenger challenger) {
+        return new ChallengerBasicInfo(
+            challenger.getId(),
+            challenger.getMemberId(),
+            challenger.getGisuId(),
+            challenger.getPart(),
+            challenger.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
+++ b/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
@@ -28,6 +28,13 @@ public interface LoadChallengerPort {
     List<Challenger> getAllByMemberId(Long memberId);
 
     /**
+     * 여러 memberId로 챌린저 목록 조회 (IN 쿼리 1회).
+     * <p>
+     * 회원이 챌린저 이력이 없을 수도 있으므로 누락된 memberId가 있어도 예외를 던지지 않습니다.
+     */
+    List<Challenger> listAllByMemberIds(Set<Long> memberIds);
+
+    /**
      * gisuId로 챌린저 목록 조회
      */
     List<Challenger> getAllByGisuId(Long gisuId);

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerActivityPeriodService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerActivityPeriodService.java
@@ -1,0 +1,77 @@
+package com.umc.product.challenger.application.service;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerActivityPeriodUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSummary;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengerActivityPeriodService implements GetChallengerActivityPeriodUseCase {
+
+    private static final Set<ChallengerStatus> COUNTED_STATUSES =
+        Set.of(ChallengerStatus.ACTIVE, ChallengerStatus.GRADUATED);
+
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetGisuUseCase getGisuUseCase;
+
+    @Override
+    public ActivityPeriodSummary getActivityPeriodByMemberId(Long memberId) {
+        List<ChallengerInfo> challengers = getChallengerUseCase.getAllByMemberId(memberId);
+        if (challengers.isEmpty()) {
+            return ActivityPeriodSummary.empty();
+        }
+
+        Set<Long> gisuIds = challengers.stream()
+            .map(ChallengerInfo::gisuId)
+            .collect(Collectors.toSet());
+
+        Map<Long, GisuInfo> gisuInfoByGisuId = getGisuUseCase.getByIds(gisuIds).stream()
+            .collect(Collectors.toMap(GisuInfo::gisuId, g -> g));
+
+        return calculateActivityPeriod(challengers, gisuInfoByGisuId);
+    }
+
+    @Override
+    public ActivityPeriodSummary calculateActivityPeriod(
+        List<ChallengerInfo> challengers,
+        Map<Long, GisuInfo> gisuInfosByGisuId
+    ) {
+        if (challengers == null || challengers.isEmpty()) {
+            return ActivityPeriodSummary.empty();
+        }
+
+        Instant now = Instant.now();
+        Map<Long, ActivityPeriodSummary.PerGisu> perGisu = new LinkedHashMap<>();
+
+        challengers.stream()
+            .filter(c -> COUNTED_STATUSES.contains(c.challengerStatus()))
+            .map(ChallengerInfo::gisuId)
+            .distinct()
+            .map(gisuInfosByGisuId::get)
+            .filter(Objects::nonNull)
+            .sorted((a, b) -> Long.compare(
+                a.generation() == null ? 0L : a.generation(),
+                b.generation() == null ? 0L : b.generation()))
+            .forEach(gisu -> perGisu.put(
+                gisu.gisuId(),
+                new ActivityPeriodSummary.PerGisu(gisu.gisuId(), gisu.generation(), gisu.activityDays(now))
+            ));
+
+        return ActivityPeriodSummary.of(perGisu);
+    }
+}

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
@@ -79,6 +79,20 @@ public class ChallengerQueryService implements GetChallengerUseCase {
     }
 
     @Override
+    public Map<Long, List<ChallengerInfo>> getAllByMemberIds(Set<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Challenger> challengers = loadChallengerPort.listAllByMemberIds(memberIds);
+        if (challengers.isEmpty()) {
+            return Map.of();
+        }
+        List<ChallengerInfo> infos = toChallengerInfoListBatch(challengers);
+        return infos.stream()
+            .collect(Collectors.groupingBy(ChallengerInfo::memberId));
+    }
+
+    @Override
     public ChallengerInfoWithStatus getLatestActiveChallengerByMemberId(Long memberId) {
         Challenger challenger = loadChallengerPort.findTopByMemberIdOrderByCreatedAtDesc(memberId);
         if (challenger.getStatus() == ChallengerStatus.WITHDRAWN

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
@@ -2,6 +2,7 @@ package com.umc.product.challenger.application.service;
 
 import com.umc.product.challenger.application.port.in.query.GetChallengerPointUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerPointInfo;
@@ -90,6 +91,27 @@ public class ChallengerQueryService implements GetChallengerUseCase {
         List<ChallengerInfo> infos = toChallengerInfoListBatch(challengers);
         return infos.stream()
             .collect(Collectors.groupingBy(ChallengerInfo::memberId));
+    }
+
+    @Override
+    public Map<Long, List<ChallengerBasicInfo>> getAllBasicByMemberIds(Set<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Challenger> challengers = loadChallengerPort.listAllByMemberIds(memberIds);
+        if (challengers.isEmpty()) {
+            return Map.of();
+        }
+        return challengers.stream()
+            .map(ChallengerBasicInfo::from)
+            .collect(Collectors.groupingBy(ChallengerBasicInfo::memberId));
+    }
+
+    @Override
+    public List<ChallengerBasicInfo> listBasicByMemberIdsAndGisuId(Set<Long> memberIds, Long gisuId) {
+        return loadChallengerPort.listByMemberIdsAndGisuId(memberIds, gisuId).stream()
+            .map(ChallengerBasicInfo::from)
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
@@ -73,10 +73,9 @@ public class ChallengerQueryService implements GetChallengerUseCase {
 
     @Override
     public List<ChallengerInfo> getAllByMemberId(Long memberId) {
-        List<Challenger> challengers = loadChallengerPort.getAllByMemberId(memberId);
-        return challengers.stream()
-            .map(this::getChallengerInfoFromChallenger)
-            .toList();
+        // 챌린저별로 상벌점을 따로 조회하면 N(챌린저 수) 만큼 쿼리가 발생하므로,
+        // IN 쿼리 1회로 일괄 조회하는 batch 헬퍼를 사용합니다.
+        return toChallengerInfoListBatch(loadChallengerPort.getAllByMemberId(memberId));
     }
 
     @Override

--- a/src/main/java/com/umc/product/global/util/EmailMasker.java
+++ b/src/main/java/com/umc/product/global/util/EmailMasker.java
@@ -1,0 +1,43 @@
+package com.umc.product.global.util;
+
+/**
+ * 외부에 노출되는 응답에서 이메일을 부분 마스킹하기 위한 유틸리티입니다.
+ * <p>
+ * 이메일은 로그인 식별자이므로 검색 결과 등 본인 외 응답에는 원문을 그대로 노출하지 않고,
+ * 로컬 파트의 앞부분 일부만 남기고 가립니다. 도메인 파트는 그대로 둡니다.
+ * <p>
+ * 마스킹 규칙:
+ * <p>
+ * - 로컬 파트 길이 1: `a@domain` (가릴 글자 없음 — 원문 유지)
+ * <p>
+ * - 로컬 파트 길이 2~3: 앞 1글자 + 나머지 `*` (예: `ab@x` → `a*@x`)
+ * <p>
+ * - 로컬 파트 길이 4 이상: 앞 3글자 + 나머지 `*` (예: `donggukcd200@x` → `don*********@x`)
+ */
+public final class EmailMasker {
+
+    private EmailMasker() {
+    }
+
+    public static String mask(String email) {
+        if (email == null || email.isBlank()) {
+            return email;
+        }
+
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            // '@'가 없거나 로컬 파트가 비어있는 비정상 입력은 방어적으로 원문을 그대로 둡니다.
+            return email;
+        }
+
+        String local = email.substring(0, at);
+        String domain = email.substring(at);
+
+        int keep = local.length() <= 3 ? 1 : 3;
+        if (local.length() <= keep) {
+            return email;
+        }
+
+        return local.substring(0, keep) + "*".repeat(local.length() - keep) + domain;
+    }
+}

--- a/src/main/java/com/umc/product/global/util/EmailMasker.java
+++ b/src/main/java/com/umc/product/global/util/EmailMasker.java
@@ -12,7 +12,7 @@ package com.umc.product.global.util;
  * <p>
  * - 로컬 파트 길이 2~3: 앞 1글자 + 나머지 `*` (예: `ab@x` → `a*@x`)
  * <p>
- * - 로컬 파트 길이 4 이상: 앞 3글자 + 나머지 `*` (예: `donggukcd200@x` → `don*********@x`)
+ * - 로컬 파트 길이 4 이상: 앞 3글자 + 나머지 `*` (예: `university@x` → `uni*******@x`)
  */
 public final class EmailMasker {
 

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java
@@ -47,7 +47,12 @@ public class MemberQueryController {
         return assembler.fromMemberId(memberPrincipal.getMemberId());
     }
 
-    @Operation(summary = "[MEMBER-103] 회원 검색", description = "이름, 닉네임, 이메일, 학교명으로 검색, 기수/파트/지부/학교별 필터링")
+    @Operation(summary = "[MEMBER-103] 회원 검색", description = """
+        이름, 닉네임, 이메일, 학교명으로 검색하며 기수/파트/지부/학교별 필터링을 지원합니다.
+
+        검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+        컨트롤러 단에서 마스킹 처리되어 응답됩니다.
+        """)
     @GetMapping("search")
     SearchMemberResponse searchMembers(
         @ParameterObject Pageable pageable,
@@ -55,7 +60,7 @@ public class MemberQueryController {
     ) {
         return SearchMemberResponse.from(
             searchMemberUseCase.searchBy(searchRequest.toQuery(), pageable)
-        );
+        ).withMaskedEmails();
     }
 
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
@@ -2,6 +2,7 @@ package com.umc.product.member.adapter.in.web.assembler;
 
 import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
 import com.umc.product.member.application.port.in.query.GetMemberProfileUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -12,6 +13,10 @@ import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -28,18 +33,31 @@ public class MemberInfoResponseAssembler {
     public MemberInfoResponse fromMemberId(Long memberId) {
         MemberInfo memberInfo = getMemberUseCase.getById(memberId);
 
-        // TODO: member에서 challenger에 너무 깊게 들어온 기분인데 일단 너무 졸려서 그냥 냅둘께요
-        List<ChallengerInfoResponse> challengerInfoResponses =
-            getChallengerUseCase.getAllByMemberId(memberId)
-                .stream()
-                .map(info -> {
-                    GisuInfo gisuInfo = getGisuUseCase.getById(info.gisuId());
-                    ChapterInfo chapterInfo = getChapterUseCase.byGisuAndSchool(info.gisuId(),
-                        memberInfo.schoolId());
+        // 챌린저 별로 gisu/chapter를 매번 조회하면 N+1이 발생하므로, 두 도메인의 batch 메서드로 한 번에 조회합니다.
+        List<ChallengerInfo> challengerInfos = getChallengerUseCase.getAllByMemberId(memberId);
 
-                    return ChallengerInfoResponse.from(info, memberInfo, gisuInfo, chapterInfo);
-                })
-                .toList();
+        Set<Long> gisuIds = challengerInfos.stream()
+            .map(ChallengerInfo::gisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        Map<Long, GisuInfo> gisuByGisuId = gisuIds.isEmpty()
+            ? Map.of()
+            : getGisuUseCase.getByIds(gisuIds).stream()
+                .collect(Collectors.toMap(GisuInfo::gisuId, g -> g));
+
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = (gisuIds.isEmpty() || memberInfo.schoolId() == null)
+            ? Map.of()
+            : getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(gisuIds, Set.of(memberInfo.schoolId()));
+
+        List<ChallengerInfoResponse> challengerInfoResponses = challengerInfos.stream()
+            .map(info -> ChallengerInfoResponse.from(
+                info,
+                memberInfo,
+                gisuByGisuId.get(info.gisuId()),
+                chapterByGisuAndSchool.getOrDefault(info.gisuId(), Map.of()).get(memberInfo.schoolId())
+            ))
+            .toList();
 
         MemberProfileInfo memberProfileInfo = getMemberProfileUseCase.getMemberProfileById(memberId);
 

--- a/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/assembler/MemberInfoResponseAssembler.java
@@ -55,7 +55,7 @@ public class MemberInfoResponseAssembler {
                 info,
                 memberInfo,
                 gisuByGisuId.get(info.gisuId()),
-                chapterByGisuAndSchool.getOrDefault(info.gisuId(), Map.of()).get(memberInfo.schoolId())
+                getChapterInfo(chapterByGisuAndSchool, info.gisuId(), memberInfo.schoolId())
             ))
             .toList();
 
@@ -66,5 +66,16 @@ public class MemberInfoResponseAssembler {
 
     public MemberInfoResponse fromMemberIdToPublic(Long memberId) {
         return fromMemberId(memberId).toPublic();
+    }
+
+    private ChapterInfo getChapterInfo(
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool,
+        Long gisuId,
+        Long schoolId
+    ) {
+        if (schoolId == null) {
+            return null;
+        }
+        return chapterByGisuAndSchool.getOrDefault(gisuId, Map.of()).get(schoolId);
     }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/response/SearchMemberResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/response/SearchMemberResponse.java
@@ -3,6 +3,7 @@ package com.umc.product.member.adapter.in.web.dto.response;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.util.EmailMasker;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
 import java.util.List;
@@ -18,6 +19,27 @@ public record SearchMemberResponse(
             result.page().getTotalElements(),
             pageResponse
         );
+    }
+
+    /**
+     * 검색 결과의 이메일을 일괄 마스킹한 새 응답을 반환합니다. 검색은 본인 외의 회원이 결과로 포함되므로
+     * 로그인 식별자인 이메일이 평문으로 노출되지 않도록 컨트롤러 단에서 호출해 적용합니다.
+     */
+    public SearchMemberResponse withMaskedEmails() {
+        List<SearchMemberItemResponse> masked = page.content().stream()
+            .map(SearchMemberItemResponse::withMaskedEmail)
+            .toList();
+
+        PageResponse<SearchMemberItemResponse> maskedPage = new PageResponse<>(
+            masked,
+            page.page(),
+            page.size(),
+            page.totalElements(),
+            page.totalPages(),
+            page.hasNext(),
+            page.hasPrevious()
+        );
+        return new SearchMemberResponse(totalCount, maskedPage);
     }
 
     public record SearchMemberItemResponse(
@@ -48,6 +70,15 @@ public record SearchMemberResponse(
                 info.gisu(),
                 info.part(),
                 info.roleTypes()
+            );
+        }
+
+        public SearchMemberItemResponse withMaskedEmail() {
+            return new SearchMemberItemResponse(
+                memberId, name, nickname,
+                EmailMasker.mask(email),
+                schoolId, schoolName, profileImageLink,
+                challengerId, gisuId, gisu, part, roleTypes
             );
         }
     }

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
@@ -43,12 +43,12 @@ public class MemberQueryV2Controller {
 
             - 기본 프로필 및 소셜 링크
             - 모든 참여 기수의 활동 기간을 합산한 `totalActivityDays`
-            - `currentGisuMembership`
+            - `currentGisuMemberInfo`
               - 활성 기수 정보 (gisuId, generation)
               - 활성 기수에 ACTIVE 상태인 챌린저 신분 (없으면 null)
               - 활성 기수에 운영진 ChallengerRole 하나라도 보유 여부 (`isAdmin`)
               - 보유 운영진 RoleType 목록
-              - 휴지기에는 `currentGisuMembership = null`
+              - 휴지기에는 `currentGisuMemberInfo = null`
             - `challengerHistory` : 모든 기수의 챌린저 이력 (최신 기수 우선). 기수별 상벌점 포함.
             """
     )
@@ -62,9 +62,10 @@ public class MemberQueryV2Controller {
     @Operation(
         summary = "[MEMBER-202] 회원 검색 v2",
         description = """
-            v1 검색 응답에 추가로 다음 두 필드를 제공합니다.
+            회원 단위 검색 결과를 반환합니다.
 
-            - `challengerStatus` : 해당 행 챌린저의 상태 (ACTIVE/GRADUATED/EXPELLED/WITHDRAWN)
+            - `currentChallenger` : 활성 기수 챌린저 우선, 없으면 최신 기수 챌린저
+            - `challengerRecords` : 회원이 보유한 모든 챌린저 이력 요약
             - `isAdminInActiveGisu` : 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
 
             검색 조건/필터는 v1과 동일합니다.

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
@@ -1,0 +1,82 @@
+package com.umc.product.member.adapter.in.web.v2;
+
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.member.adapter.in.web.dto.request.SearchMemberRequest;
+import com.umc.product.member.adapter.in.web.v2.dto.response.MemberSummaryV2Response;
+import com.umc.product.member.adapter.in.web.v2.dto.response.SearchMemberV2Response;
+import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * /api/v2/member 의 Query 엔드포인트.
+ * <p>
+ * BFF 패턴으로, 프로필/활성 기수 멤버십/활동일/이력/상벌점을 한 호출에 제공합니다.
+ * <p>
+ * 권한 정책:
+ * <p>
+ * - /me : 인증된 사용자 본인 정보 (인증 필터로 보호, @CheckAccess 불필요)
+ * <p>
+ * - /search : v1과 동일 정책. 별도 권한 어노테이션 없음 (v1 회귀 방지). 권한 강화는 별도 PR.
+ */
+@RestController
+@RequestMapping("/api/v2/member")
+@RequiredArgsConstructor
+@Tag(name = "Member V2 | 회원 Query", description = "BFF 패턴으로 회원 정보를 한 번에 조회합니다.")
+public class MemberQueryV2Controller {
+
+    private final GetMemberSummaryV2UseCase getMemberSummaryV2UseCase;
+    private final SearchMemberUseCase searchMemberUseCase;
+
+    @Operation(
+        summary = "[MEMBER-V2-101] 내 종합 정보 조회",
+        description = """
+            현재 로그인한 사용자의 통합 정보를 반환합니다.
+
+            - 기본 프로필 및 소셜 링크
+            - 모든 참여 기수의 활동 기간을 합산한 `totalActivityDays`
+            - `currentGisuMembership`
+              - 활성 기수 정보 (gisuId, generation)
+              - 활성 기수에 ACTIVE 상태인 챌린저 신분 (없으면 null)
+              - 활성 기수에 운영진 ChallengerRole 하나라도 보유 여부 (`isAdmin`)
+              - 보유 운영진 RoleType 목록
+              - 휴지기에는 `currentGisuMembership = null`
+            - `challengerHistory` : 모든 기수의 챌린저 이력 (최신 기수 우선). 기수별 상벌점 포함.
+            """
+    )
+    @GetMapping("me")
+    public MemberSummaryV2Response getMySummary(@CurrentMember MemberPrincipal memberPrincipal) {
+        return MemberSummaryV2Response.from(
+            getMemberSummaryV2UseCase.getSummaryByMemberId(memberPrincipal.getMemberId())
+        );
+    }
+
+    @Operation(
+        summary = "[MEMBER-V2-102] 회원 검색 v2",
+        description = """
+            v1 검색 응답에 추가로 다음 두 필드를 제공합니다.
+
+            - `challengerStatus` : 해당 행 챌린저의 상태 (ACTIVE/GRADUATED/EXPELLED/WITHDRAWN)
+            - `isAdminInActiveGisu` : 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
+
+            검색 조건/필터는 v1과 동일합니다.
+            """
+    )
+    @GetMapping("search")
+    public SearchMemberV2Response searchMembersV2(
+        @ParameterObject Pageable pageable,
+        @ParameterObject SearchMemberRequest searchRequest
+    ) {
+        return SearchMemberV2Response.from(
+            searchMemberUseCase.searchByV2(searchRequest.toQuery(), pageable)
+        );
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
@@ -68,6 +68,9 @@ public class MemberQueryV2Controller {
             - `isAdminInActiveGisu` : 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
 
             검색 조건/필터는 v1과 동일합니다.
+
+            검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+            컨트롤러 단에서 마스킹 처리되어 응답됩니다.
             """
     )
     @GetMapping("search")
@@ -77,6 +80,6 @@ public class MemberQueryV2Controller {
     ) {
         return SearchMemberV2Response.from(
             searchMemberUseCase.searchByV2(searchRequest.toQuery(), pageable)
-        );
+        ).withMaskedEmails();
     }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java
@@ -30,14 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v2/member")
 @RequiredArgsConstructor
-@Tag(name = "Member V2 | 회원 Query", description = "BFF 패턴으로 회원 정보를 한 번에 조회합니다.")
+@Tag(name = "Member V2 | 회원 Query", description = "BFF 패턴이 적용되었습니다.")
 public class MemberQueryV2Controller {
 
     private final GetMemberSummaryV2UseCase getMemberSummaryV2UseCase;
     private final SearchMemberUseCase searchMemberUseCase;
 
     @Operation(
-        summary = "[MEMBER-V2-101] 내 종합 정보 조회",
+        summary = "[MEMBER-201] 내 종합 정보 조회",
         description = """
             현재 로그인한 사용자의 통합 정보를 반환합니다.
 
@@ -60,7 +60,7 @@ public class MemberQueryV2Controller {
     }
 
     @Operation(
-        summary = "[MEMBER-V2-102] 회원 검색 v2",
+        summary = "[MEMBER-202] 회원 검색 v2",
         description = """
             v1 검색 응답에 추가로 다음 두 필드를 제공합니다.
 

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
@@ -19,19 +19,23 @@ import java.util.List;
  */
 public record MemberSummaryV2Response(
     Long id,
+
     String name,
     String nickname,
+
     String email,
+
     Long schoolId,
     String schoolName,
     String profileImageLink,
     MemberStatus status,
     MemberProfileInfo profile,
-    @Schema(description = "ACTIVE/GRADUATED 챌린저로 활동한 총 일수의 합산")
+
+    @Schema(description = "챌린저로 활동한 총 일수")
     long totalActivityDays,
-    @Schema(description = "현재 활성 기수의 멤버십 스냅샷. 휴지기에는 null", nullable = true)
-    CurrentGisuMembership currentGisuMembership,
-    @Schema(description = "회원이 가진 모든 챌린저 이력. 최신 기수가 먼저")
+    @Schema(description = "현재 활성 기수에 대한 챌린저 정보", nullable = true)
+    CurrentGisuMemberInfo currentGisuMemberInfo,
+    @Schema(description = "모든 챌린저 기록 (최신 기수 우선)")
     List<ChallengerHistoryV2> challengerHistory
 ) {
 
@@ -50,22 +54,25 @@ public record MemberSummaryV2Response(
             m.status(),
             p,
             info.totalActivityDays(),
-            info.currentGisuMembership() == null ? null : CurrentGisuMembership.from(info.currentGisuMembership()),
+            info.currentGisuMembership() == null ? null : CurrentGisuMemberInfo.from(info.currentGisuMembership()),
             info.challengerHistory().stream().map(ChallengerHistoryV2::from).toList()
         );
     }
 
-    public record CurrentGisuMembership(
+    public record CurrentGisuMemberInfo(
         Long gisuId,
         Long generation,
+
         @Schema(description = "활성 기수에서 현재 ACTIVE 상태인 챌린저 신분. ACTIVE가 아니면 null", nullable = true)
         ActiveChallenger challenger,
+
         @Schema(description = "활성 기수에 운영진 ChallengerRole이 하나라도 존재하는지")
         boolean isAdmin,
+        @Schema(description = "활성 기수에 가지고 있는 역할 목록")
         List<ChallengerRoleType> roleTypes
     ) {
-        public static CurrentGisuMembership from(MemberSummaryV2Info.CurrentGisuMembership info) {
-            return new CurrentGisuMembership(
+        public static CurrentGisuMemberInfo from(MemberSummaryV2Info.CurrentGisuMembership info) {
+            return new CurrentGisuMemberInfo(
                 info.gisuId(),
                 info.generation(),
                 info.challenger() == null ? null : ActiveChallenger.from(info.challenger()),
@@ -97,11 +104,14 @@ public record MemberSummaryV2Response(
         Long challengerId,
         Long gisuId,
         Long generation,
+
         Long chapterId,
         String chapterName,
+
         ChallengerPart part,
         ChallengerStatus challengerStatus,
         List<ChallengerPointInfo> points,
+
         Double totalPoints,
         List<ChallengerRoleType> roleTypes
     ) {

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
@@ -1,0 +1,123 @@
+package com.umc.product.member.adapter.in.web.v2.dto.response;
+
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerPointInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * GET /api/v2/member/me 응답 DTO.
+ * <p>
+ * BFF 응답이며 한 호출로 프로필/활성 기수 멤버십/활동일/챌린저 이력을 모두 제공합니다.
+ * v1 ChallengerInfoResponse의 호환 중복 필드(status/memberStatus, challengerPoints/points 등)는 v2에 도입하지 않습니다.
+ */
+public record MemberSummaryV2Response(
+    Long id,
+    String name,
+    String nickname,
+    String email,
+    Long schoolId,
+    String schoolName,
+    String profileImageLink,
+    MemberStatus status,
+    MemberProfileInfo profile,
+    @Schema(description = "ACTIVE/GRADUATED 챌린저로 활동한 총 일수의 합산")
+    long totalActivityDays,
+    @Schema(description = "현재 활성 기수의 멤버십 스냅샷. 휴지기에는 null", nullable = true)
+    CurrentGisuMembership currentGisuMembership,
+    @Schema(description = "회원이 가진 모든 챌린저 이력. 최신 기수가 먼저")
+    List<ChallengerHistoryV2> challengerHistory
+) {
+
+    public static MemberSummaryV2Response from(MemberSummaryV2Info info) {
+        MemberInfo m = info.member();
+        MemberProfileInfo p = info.profile();
+
+        return new MemberSummaryV2Response(
+            m.id(),
+            m.name(),
+            m.nickname(),
+            m.email(),
+            m.schoolId(),
+            m.schoolName(),
+            m.profileImageLink(),
+            m.status(),
+            p,
+            info.totalActivityDays(),
+            info.currentGisuMembership() == null ? null : CurrentGisuMembership.from(info.currentGisuMembership()),
+            info.challengerHistory().stream().map(ChallengerHistoryV2::from).toList()
+        );
+    }
+
+    public record CurrentGisuMembership(
+        Long gisuId,
+        Long generation,
+        @Schema(description = "활성 기수에서 현재 ACTIVE 상태인 챌린저 신분. ACTIVE가 아니면 null", nullable = true)
+        ActiveChallenger challenger,
+        @Schema(description = "활성 기수에 운영진 ChallengerRole이 하나라도 존재하는지")
+        boolean isAdmin,
+        List<ChallengerRoleType> roleTypes
+    ) {
+        public static CurrentGisuMembership from(MemberSummaryV2Info.CurrentGisuMembership info) {
+            return new CurrentGisuMembership(
+                info.gisuId(),
+                info.generation(),
+                info.challenger() == null ? null : ActiveChallenger.from(info.challenger()),
+                info.isAdmin(),
+                info.roleTypes()
+            );
+        }
+    }
+
+    public record ActiveChallenger(
+        Long challengerId,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus,
+        List<ChallengerPointInfo> points,
+        Double totalPoints
+    ) {
+        public static ActiveChallenger from(MemberSummaryV2Info.ActiveChallenger info) {
+            return new ActiveChallenger(
+                info.challengerId(),
+                info.part(),
+                info.challengerStatus(),
+                info.points(),
+                info.totalPoints()
+            );
+        }
+    }
+
+    public record ChallengerHistoryV2(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus,
+        List<ChallengerPointInfo> points,
+        Double totalPoints,
+        List<ChallengerRoleType> roleTypes
+    ) {
+        public static ChallengerHistoryV2 from(MemberSummaryV2Info.ChallengerHistoryItem info) {
+            return new ChallengerHistoryV2(
+                info.challengerId(),
+                info.gisuId(),
+                info.generation(),
+                info.chapterId(),
+                info.chapterName(),
+                info.part(),
+                info.challengerStatus(),
+                info.points(),
+                info.totalPoints(),
+                info.roleTypes()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
@@ -4,6 +4,7 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.util.EmailMasker;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,17 +26,42 @@ public record SearchMemberV2Response(
         );
     }
 
+    /**
+     * 검색 결과의 이메일을 일괄 마스킹한 새 응답을 반환합니다. 검색은 본인 외의 회원이 결과로 포함되므로
+     * 로그인 식별자인 이메일이 평문으로 노출되지 않도록 컨트롤러 단에서 호출해 적용합니다.
+     */
+    public SearchMemberV2Response withMaskedEmails() {
+        List<SearchMemberV2ItemResponse> masked = page.content().stream()
+            .map(SearchMemberV2ItemResponse::withMaskedEmail)
+            .toList();
+
+        PageResponse<SearchMemberV2ItemResponse> maskedPage = new PageResponse<>(
+            masked,
+            page.page(),
+            page.size(),
+            page.totalElements(),
+            page.totalPages(),
+            page.hasNext(),
+            page.hasPrevious()
+        );
+        return new SearchMemberV2Response(totalCount, maskedPage);
+    }
+
     public record SearchMemberV2ItemResponse(
         Long memberId,
+
         String name,
         String nickname,
+
         String email,
         Long schoolId,
         String schoolName,
+
         String profileImageLink,
         Long challengerId,
+
         Long gisuId,
-        Long gisu,
+        Long generation,
         ChallengerPart part,
         @Schema(description = "검색 결과 행의 챌린저 상태")
         ChallengerStatus challengerStatus,
@@ -59,6 +85,15 @@ public record SearchMemberV2Response(
                 info.challengerStatus(),
                 info.roleTypes(),
                 info.isAdminInActiveGisu()
+            );
+        }
+
+        public SearchMemberV2ItemResponse withMaskedEmail() {
+            return new SearchMemberV2ItemResponse(
+                memberId, name, nickname,
+                EmailMasker.mask(email),
+                schoolId, schoolName, profileImageLink,
+                challengerId, gisuId, generation, part, challengerStatus, roleTypes, isAdminInActiveGisu
             );
         }
     }

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
@@ -61,11 +61,11 @@ public record SearchMemberV2Response(
         String schoolName,
         String profileImageLink,
         @Schema(description = "대표 챌린저. 활성 기수 챌린저 우선, 없으면 최신 기수", nullable = true)
-        PrimaryChallengerResponse primaryChallenger,
+        CurrentChallengerResponse currentChallenger,
         @Schema(description = "이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지")
         boolean isAdminInActiveGisu,
         @Schema(description = "회원이 보유한 모든 챌린저 이력 요약 (최신 기수 우선)")
-        List<ParticipationResponse> participations
+        List<ChallengerRecordResponse> challengerRecords
     ) {
         public static SearchMemberV2ItemResponse from(SearchMemberItemV2Info info) {
             return new SearchMemberV2ItemResponse(
@@ -76,9 +76,9 @@ public record SearchMemberV2Response(
                 info.schoolId(),
                 info.schoolName(),
                 info.profileImageLink(),
-                info.primaryChallenger() == null ? null : PrimaryChallengerResponse.from(info.primaryChallenger()),
+                info.primaryChallenger() == null ? null : CurrentChallengerResponse.from(info.primaryChallenger()),
                 info.isAdminInActiveGisu(),
-                info.participations().stream().map(ParticipationResponse::from).toList()
+                info.participations().stream().map(ChallengerRecordResponse::from).toList()
             );
         }
 
@@ -87,20 +87,20 @@ public record SearchMemberV2Response(
                 memberId, name, nickname,
                 EmailMasker.mask(email),
                 schoolId, schoolName, profileImageLink,
-                primaryChallenger, isAdminInActiveGisu, participations
+                currentChallenger, isAdminInActiveGisu, challengerRecords
             );
         }
     }
 
-    public record PrimaryChallengerResponse(
+    public record CurrentChallengerResponse(
         Long challengerId,
         Long gisuId,
         Long generation,
         ChallengerPart part,
         ChallengerStatus challengerStatus
     ) {
-        public static PrimaryChallengerResponse from(PrimaryChallenger info) {
-            return new PrimaryChallengerResponse(
+        public static CurrentChallengerResponse from(PrimaryChallenger info) {
+            return new CurrentChallengerResponse(
                 info.challengerId(),
                 info.gisuId(),
                 info.generation(),
@@ -110,15 +110,15 @@ public record SearchMemberV2Response(
         }
     }
 
-    public record ParticipationResponse(
+    public record ChallengerRecordResponse(
         Long challengerId,
         Long gisuId,
         Long generation,
         ChallengerPart part,
         ChallengerStatus challengerStatus
     ) {
-        public static ParticipationResponse from(Participation info) {
-            return new ParticipationResponse(
+        public static ChallengerRecordResponse from(Participation info) {
+            return new ChallengerRecordResponse(
                 info.challengerId(),
                 info.gisuId(),
                 info.generation(),

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
@@ -1,0 +1,65 @@
+package com.umc.product.member.adapter.in.web.v2.dto.response;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * GET /api/v2/member/search 응답 DTO. v1 필드에 더해 챌린저 상태와 활성 기수 운영진 여부를 추가합니다.
+ */
+public record SearchMemberV2Response(
+    long totalCount,
+    PageResponse<SearchMemberV2ItemResponse> page
+) {
+    public static SearchMemberV2Response from(SearchMemberV2Result result) {
+        PageResponse<SearchMemberV2ItemResponse> pageResponse =
+            PageResponse.of(result.page(), SearchMemberV2ItemResponse::from);
+        return new SearchMemberV2Response(
+            result.page().getTotalElements(),
+            pageResponse
+        );
+    }
+
+    public record SearchMemberV2ItemResponse(
+        Long memberId,
+        String name,
+        String nickname,
+        String email,
+        Long schoolId,
+        String schoolName,
+        String profileImageLink,
+        Long challengerId,
+        Long gisuId,
+        Long gisu,
+        ChallengerPart part,
+        @Schema(description = "검색 결과 행의 챌린저 상태")
+        ChallengerStatus challengerStatus,
+        List<ChallengerRoleType> roleTypes,
+        @Schema(description = "이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지")
+        boolean isAdminInActiveGisu
+    ) {
+        public static SearchMemberV2ItemResponse from(SearchMemberItemV2Info info) {
+            return new SearchMemberV2ItemResponse(
+                info.memberId(),
+                info.name(),
+                info.nickname(),
+                info.email(),
+                info.schoolId(),
+                info.schoolName(),
+                info.profileImageLink(),
+                info.challengerId(),
+                info.gisuId(),
+                info.gisu(),
+                info.part(),
+                info.challengerStatus(),
+                info.roleTypes(),
+                info.isAdminInActiveGisu()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/SearchMemberV2Response.java
@@ -1,17 +1,22 @@
 package com.umc.product.member.adapter.in.web.v2.dto.response;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.global.util.EmailMasker;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.Participation;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.PrimaryChallenger;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 /**
- * GET /api/v2/member/search 응답 DTO. v1 필드에 더해 챌린저 상태와 활성 기수 운영진 여부를 추가합니다.
+ * GET /api/v2/member/search 응답 DTO.
+ * <p>
+ * 회원 1명당 1개 항목으로 반환되며, 같은 회원이 여러 기수 챌린저 이력을 가져도 별도 row로 분리되지 않습니다.
+ * 대표 챌린저(primaryChallenger)는 활성 기수 챌린저를 우선 선택하고, 없으면 가장 최신 기수의 챌린저로 선택됩니다.
+ * 참여 기수 요약(participations)을 함께 제공해 검색 결과 식별을 돕습니다.
  */
 public record SearchMemberV2Response(
     long totalCount,
@@ -49,25 +54,18 @@ public record SearchMemberV2Response(
 
     public record SearchMemberV2ItemResponse(
         Long memberId,
-
         String name,
         String nickname,
-
         String email,
         Long schoolId,
         String schoolName,
-
         String profileImageLink,
-        Long challengerId,
-
-        Long gisuId,
-        Long generation,
-        ChallengerPart part,
-        @Schema(description = "검색 결과 행의 챌린저 상태")
-        ChallengerStatus challengerStatus,
-        List<ChallengerRoleType> roleTypes,
+        @Schema(description = "대표 챌린저. 활성 기수 챌린저 우선, 없으면 최신 기수", nullable = true)
+        PrimaryChallengerResponse primaryChallenger,
         @Schema(description = "이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지")
-        boolean isAdminInActiveGisu
+        boolean isAdminInActiveGisu,
+        @Schema(description = "회원이 보유한 모든 챌린저 이력 요약 (최신 기수 우선)")
+        List<ParticipationResponse> participations
     ) {
         public static SearchMemberV2ItemResponse from(SearchMemberItemV2Info info) {
             return new SearchMemberV2ItemResponse(
@@ -78,13 +76,9 @@ public record SearchMemberV2Response(
                 info.schoolId(),
                 info.schoolName(),
                 info.profileImageLink(),
-                info.challengerId(),
-                info.gisuId(),
-                info.gisu(),
-                info.part(),
-                info.challengerStatus(),
-                info.roleTypes(),
-                info.isAdminInActiveGisu()
+                info.primaryChallenger() == null ? null : PrimaryChallengerResponse.from(info.primaryChallenger()),
+                info.isAdminInActiveGisu(),
+                info.participations().stream().map(ParticipationResponse::from).toList()
             );
         }
 
@@ -93,7 +87,43 @@ public record SearchMemberV2Response(
                 memberId, name, nickname,
                 EmailMasker.mask(email),
                 schoolId, schoolName, profileImageLink,
-                challengerId, gisuId, generation, part, challengerStatus, roleTypes, isAdminInActiveGisu
+                primaryChallenger, isAdminInActiveGisu, participations
+            );
+        }
+    }
+
+    public record PrimaryChallengerResponse(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus
+    ) {
+        public static PrimaryChallengerResponse from(PrimaryChallenger info) {
+            return new PrimaryChallengerResponse(
+                info.challengerId(),
+                info.gisuId(),
+                info.generation(),
+                info.part(),
+                info.challengerStatus()
+            );
+        }
+    }
+
+    public record ParticipationResponse(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus
+    ) {
+        public static ParticipationResponse from(Participation info) {
+            return new ParticipationResponse(
+                info.challengerId(),
+                info.gisuId(),
+                info.generation(),
+                info.part(),
+                info.challengerStatus()
             );
         }
     }

--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -104,6 +104,11 @@ public class MemberPersistenceAdapter implements LoadMemberPort, SaveMemberPort,
     }
 
     @Override
+    public Page<Long> searchMemberIds(SearchMemberQuery query, Pageable pageable) {
+        return memberQueryRepository.searchMemberIdsBy(query, pageable);
+    }
+
+    @Override
     public List<Long> findAllIdsCursor(Long lastId, Pageable pageable) {
         return memberJpaRepository.findIdsCursor(lastId, pageable);
     }

--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
@@ -50,7 +50,7 @@ public class MemberQueryRepository {
     }
 
     /**
-     * 검색 로직
+     * 검색 로직 (v1) — 챌린저 단위 row.
      */
     public Page<Challenger> searchBy(SearchMemberQuery query, Pageable pageable) {
         QChallenger challenger = QChallenger.challenger;
@@ -69,6 +69,38 @@ public class MemberQueryRepository {
 
         Long total = queryFactory
             .select(challenger.count())
+            .from(challenger)
+            .join(member).on(challenger.memberId.eq(member.id))
+            .where(condition)
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    /**
+     * 검색 로직 (v2) — 회원 단위 distinct memberId.
+     * <p>
+     * 같은 회원이 여러 챌린저 이력을 가져도 1개 row로만 반환됩니다.
+     * gisuId/part 같은 챌린저 필터는 "회원이 한 번이라도 그 조건을 만족하는 챌린저를 가졌는가"로 매칭됩니다.
+     */
+    public Page<Long> searchMemberIdsBy(SearchMemberQuery query, Pageable pageable) {
+        QChallenger challenger = QChallenger.challenger;
+        QMember member = QMember.member;
+
+        BooleanBuilder condition = buildSearchCondition(query, challenger, member);
+
+        List<Long> content = queryFactory
+            .selectDistinct(member.id)
+            .from(challenger)
+            .join(member).on(challenger.memberId.eq(member.id))
+            .where(condition)
+            .orderBy(member.schoolId.asc(), member.name.asc(), member.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = queryFactory
+            .select(member.id.countDistinct())
             .from(challenger)
             .join(member).on(challenger.memberId.eq(member.id))
             .where(condition)

--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
@@ -1,6 +1,7 @@
 package com.umc.product.member.adapter.out.persistence;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -89,8 +90,13 @@ public class MemberQueryRepository {
 
         BooleanBuilder condition = buildSearchCondition(query, challenger, member);
 
-        List<Long> content = queryFactory
-            .selectDistinct(member.id)
+        // PostgreSQL은 SELECT DISTINCT 사용 시 ORDER BY 표현식이 SELECT 목록에 포함되어 있어야 합니다.
+        // member 테이블의 컬럼은 같은 member.id 행에서 항상 동일한 값을 가지므로,
+        // (id, schoolId, name) 묶음에 distinct를 걸어도 결과는 member.id 단위 distinct와 동일하면서
+        // 표준 SQL 규칙도 만족합니다.
+        List<Tuple> rows = queryFactory
+            .select(member.id, member.schoolId, member.name)
+            .distinct()
             .from(challenger)
             .join(member).on(challenger.memberId.eq(member.id))
             .where(condition)
@@ -98,6 +104,10 @@ public class MemberQueryRepository {
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
+
+        List<Long> content = rows.stream()
+            .map(t -> t.get(member.id))
+            .toList();
 
         Long total = queryFactory
             .select(member.id.countDistinct())

--- a/src/main/java/com/umc/product/member/application/port/in/query/GetMemberSummaryV2UseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/GetMemberSummaryV2UseCase.java
@@ -1,0 +1,12 @@
+package com.umc.product.member.application.port.in.query;
+
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+
+/**
+ * /api/v2/member/me BFF UseCase.
+ * <p>
+ * 활성 기수 멤버십, 챌린저 이력, 활동일 합산, 기수별 상벌점 등을 한 응답으로 제공합니다.
+ */
+public interface GetMemberSummaryV2UseCase {
+    MemberSummaryV2Info getSummaryByMemberId(Long memberId);
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
@@ -1,5 +1,6 @@
 package com.umc.product.member.application.port.in.query;
 
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
@@ -10,7 +11,14 @@ public interface SearchMemberUseCase {
     SearchMemberResult searchBy(SearchMemberQuery query, Pageable pageable);
 
     /**
-     * v2 검색: v1 필드에 더해 챌린저 상태와 현재 활성 기수 운영진 여부를 포함합니다.
+     * v2 회원 검색 — 같은 회원의 여러 기수 챌린저 이력은 1개 row로 묶입니다.
+     * primaryChallenger와 participations 요약을 함께 제공합니다.
      */
     SearchMemberV2Result searchByV2(SearchMemberQuery query, Pageable pageable);
+
+    /**
+     * v2 챌린저 검색 — 챌린저 단위 페이지네이션. 같은 회원의 여러 기수 챌린저 이력은
+     * 각각 별도 row로 반환됩니다. v1 검색 응답 + challengerStatus + isAdminInActiveGisu 필드를 포함합니다.
+     */
+    ChallengerSearchV2Result searchChallengersByV2(SearchMemberQuery query, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
@@ -2,9 +2,15 @@ package com.umc.product.member.application.port.in.query;
 
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import org.springframework.data.domain.Pageable;
 
 public interface SearchMemberUseCase {
 
     SearchMemberResult searchBy(SearchMemberQuery query, Pageable pageable);
+
+    /**
+     * v2 검색: v1 필드에 더해 챌린저 상태와 현재 활성 기수 운영진 여부를 포함합니다.
+     */
+    SearchMemberV2Result searchByV2(SearchMemberQuery query, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
@@ -12,7 +12,7 @@ public interface SearchMemberUseCase {
 
     /**
      * v2 회원 검색 — 같은 회원의 여러 기수 챌린저 이력은 1개 row로 묶입니다.
-     * primaryChallenger와 participations 요약을 함께 제공합니다.
+     * currentChallenger와 challengerRecords 요약을 함께 제공합니다.
      */
     SearchMemberV2Result searchByV2(SearchMemberQuery query, Pageable pageable);
 

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/ChallengerSearchItemV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/ChallengerSearchItemV2Info.java
@@ -1,0 +1,30 @@
+package com.umc.product.member.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.List;
+
+/**
+ * /api/v2/challenger/search 응답의 항목 단위 정보입니다.
+ * <p>
+ * 챌린저 1개당 1개 항목으로, 같은 회원이 여러 기수 챌린저 이력을 가지면 여러 row로 분리되어 반환됩니다.
+ * 검색의 주체가 "챌린저"라는 의미에 부합하는 응답 형태입니다.
+ */
+public record ChallengerSearchItemV2Info(
+    Long memberId,
+    String name,
+    String nickname,
+    String email,
+    Long schoolId,
+    String schoolName,
+    String profileImageLink,
+    Long challengerId,
+    Long gisuId,
+    Long generation,
+    ChallengerPart part,
+    ChallengerStatus challengerStatus,
+    List<ChallengerRoleType> roleTypes,
+    boolean isAdminInActiveGisu
+) {
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/ChallengerSearchV2Result.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/ChallengerSearchV2Result.java
@@ -1,0 +1,6 @@
+package com.umc.product.member.application.port.in.query.dto;
+
+import org.springframework.data.domain.Page;
+
+public record ChallengerSearchV2Result(Page<ChallengerSearchItemV2Info> page) {
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
@@ -1,0 +1,82 @@
+package com.umc.product.member.application.port.in.query.dto;
+
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerPointInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * /api/v2/member/me 응답에 사용되는 BFF Info DTO 입니다. 어댑터의 Response 매핑은 단순 위임만 합니다.
+ */
+public record MemberSummaryV2Info(
+    MemberInfo member,
+    MemberProfileInfo profile,
+    long totalActivityDays,
+    CurrentGisuMembership currentGisuMembership,
+    List<ChallengerHistoryItem> challengerHistory
+) {
+
+    /**
+     * 현재 활성 기수에 한정된 멤버십 스냅샷.
+     * <p>
+     * - 휴지기에는 null
+     * - challenger는 활성 기수에 ACTIVE 챌린저 레코드가 있는 경우에만 set
+     * - isAdmin은 활성 기수의 challengerRole 레코드 존재 여부 (status 무관)
+     */
+    public record CurrentGisuMembership(
+        Long gisuId,
+        Long generation,
+        ActiveChallenger challenger,
+        boolean isAdmin,
+        List<ChallengerRoleType> roleTypes
+    ) {
+    }
+
+    public record ActiveChallenger(
+        Long challengerId,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus,
+        List<ChallengerPointInfo> points,
+        Double totalPoints
+    ) {
+    }
+
+    public record ChallengerHistoryItem(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus,
+        List<ChallengerPointInfo> points,
+        Double totalPoints,
+        List<ChallengerRoleType> roleTypes
+    ) {
+        public static ChallengerHistoryItem of(
+            ChallengerInfo challenger,
+            GisuInfo gisu,
+            ChapterInfo chapter,
+            Map<Long, List<ChallengerRoleType>> roleTypesByChallengerId
+        ) {
+            return new ChallengerHistoryItem(
+                challenger.challengerId(),
+                gisu != null ? gisu.gisuId() : challenger.gisuId(),
+                gisu != null ? gisu.generation() : null,
+                chapter != null ? chapter.id() : null,
+                chapter != null ? chapter.name() : null,
+                challenger.part(),
+                challenger.challengerStatus(),
+                challenger.challengerPoints() == null ? List.of() : challenger.challengerPoints(),
+                challenger.totalPoints() == null ? 0.0 : challenger.totalPoints(),
+                roleTypesByChallengerId.getOrDefault(challenger.challengerId(), List.of())
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberItemV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberItemV2Info.java
@@ -1,0 +1,29 @@
+package com.umc.product.member.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.List;
+
+/**
+ * /api/v2/member/search 응답의 항목 단위 정보입니다.
+ * <p>
+ * v1의 SearchMemberItemInfo에 추가로 challengerStatus, isAdminInActiveGisu 두 필드가 포함됩니다.
+ */
+public record SearchMemberItemV2Info(
+    Long memberId,
+    String name,
+    String nickname,
+    String email,
+    Long schoolId,
+    String schoolName,
+    String profileImageLink,
+    Long challengerId,
+    Long gisuId,
+    Long gisu,
+    ChallengerPart part,
+    ChallengerStatus challengerStatus,
+    List<ChallengerRoleType> roleTypes,
+    boolean isAdminInActiveGisu
+) {
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberItemV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberItemV2Info.java
@@ -1,14 +1,14 @@
 package com.umc.product.member.application.port.in.query.dto;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import java.util.List;
 
 /**
  * /api/v2/member/search 응답의 항목 단위 정보입니다.
  * <p>
- * v1의 SearchMemberItemInfo에 추가로 challengerStatus, isAdminInActiveGisu 두 필드가 포함됩니다.
+ * 회원 1명당 1개 항목이며, 같은 회원이 여러 기수 챌린저 이력을 가져도 별도 row로 분리되지 않습니다.
+ * 대표 챌린저는 활성 기수 챌린저 우선, 없으면 가장 최신 기수의 챌린저로 선택됩니다.
  */
 public record SearchMemberItemV2Info(
     Long memberId,
@@ -18,12 +18,32 @@ public record SearchMemberItemV2Info(
     Long schoolId,
     String schoolName,
     String profileImageLink,
-    Long challengerId,
-    Long gisuId,
-    Long gisu,
-    ChallengerPart part,
-    ChallengerStatus challengerStatus,
-    List<ChallengerRoleType> roleTypes,
-    boolean isAdminInActiveGisu
+    PrimaryChallenger primaryChallenger,
+    boolean isAdminInActiveGisu,
+    List<Participation> participations
 ) {
+
+    /**
+     * 검색 결과 화면에 한 줄로 보여줄 대표 챌린저 정보.
+     */
+    public record PrimaryChallenger(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus
+    ) {
+    }
+
+    /**
+     * 회원이 보유한 챌린저 이력의 가벼운 요약. 검색 결과에서 회원 식별을 돕기 위해 함께 노출됩니다.
+     */
+    public record Participation(
+        Long challengerId,
+        Long gisuId,
+        Long generation,
+        ChallengerPart part,
+        ChallengerStatus challengerStatus
+    ) {
+    }
 }

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberV2Result.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/SearchMemberV2Result.java
@@ -1,0 +1,6 @@
+package com.umc.product.member.application.port.in.query.dto;
+
+import org.springframework.data.domain.Page;
+
+public record SearchMemberV2Result(Page<SearchMemberItemV2Info> page) {
+}

--- a/src/main/java/com/umc/product/member/application/port/out/SearchMemberPort.java
+++ b/src/main/java/com/umc/product/member/application/port/out/SearchMemberPort.java
@@ -7,5 +7,13 @@ import org.springframework.data.domain.Pageable;
 
 public interface SearchMemberPort {
 
+    /**
+     * 챌린저 단위 검색 (v1). 같은 회원의 여러 기수 챌린저가 각각 별도 row로 반환됩니다.
+     */
     Page<Challenger> search(SearchMemberQuery query, Pageable pageable);
+
+    /**
+     * 회원 단위 검색 (v2). 같은 회원이 여러 챌린저 이력을 가지더라도 1개 row(memberId)로만 반환합니다.
+     */
+    Page<Long> searchMemberIds(SearchMemberQuery query, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
@@ -1,6 +1,8 @@
 package com.umc.product.member.application.service;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -8,15 +10,19 @@ import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.Participation;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.PrimaryChallenger;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import com.umc.product.member.application.port.out.SearchMemberPort;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +39,7 @@ public class MemberSearchService implements SearchMemberUseCase {
     private final SearchMemberPort searchMemberPort;
 
     private final GetMemberUseCase getMemberUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final GetGisuUseCase getGisuUseCase;
 
@@ -54,30 +61,46 @@ public class MemberSearchService implements SearchMemberUseCase {
 
     @Override
     public SearchMemberV2Result searchByV2(SearchMemberQuery query, Pageable pageable) {
-        Page<Challenger> challengers = searchMemberPort.search(query, pageable);
-        List<Challenger> content = challengers.getContent();
+        Page<Long> memberIdPage = searchMemberPort.searchMemberIds(query, pageable);
+        List<Long> memberIds = memberIdPage.getContent();
 
-        Map<Long, MemberInfo> memberProfiles = loadMemberProfiles(content);
-        Map<Long, List<ChallengerRoleType>> roleTypes = loadRoleTypes(content);
-        Map<Long, Long> gisuGenerationMap = loadGisuGenerationMap(content);
+        if (memberIds.isEmpty()) {
+            return new SearchMemberV2Result(memberIdPage.map(id -> null));
+        }
 
-        // 현재 활성 기수 정보를 한 번만 조회합니다. 휴지기에는 isAdminInActiveGisu가 항상 false가 됩니다.
-        Long activeGisuId = getGisuUseCase.findActiveGisu()
-            .map(GisuInfo::gisuId)
-            .orElse(null);
+        Set<Long> memberIdSet = Set.copyOf(memberIds);
 
-        // 검색 결과에 포함된 회원들의 활성 기수 운영진 챌린저 ID 집합을 미리 계산합니다.
-        Set<Long> adminChallengerIdsInActiveGisu =
-            collectAdminChallengerIdsInActiveGisu(content, activeGisuId);
+        // 회원 정보 batch 로딩
+        Map<Long, MemberInfo> memberInfoMap = getMemberUseCase.findAllByIds(memberIdSet);
 
-        Page<SearchMemberItemV2Info> items = challengers.map(challenger -> toItemInfoV2(
-            challenger, memberProfiles, roleTypes, gisuGenerationMap, adminChallengerIdsInActiveGisu
+        // 회원별 모든 챌린저 batch 로딩 (IN 쿼리 1회)
+        Map<Long, List<ChallengerInfo>> challengersByMemberId =
+            getChallengerUseCase.getAllByMemberIds(memberIdSet);
+
+        // 활성 기수 한 번 조회 (휴지기에는 Optional.empty)
+        Optional<GisuInfo> activeGisuOpt = getGisuUseCase.findActiveGisu();
+        Long activeGisuId = activeGisuOpt.map(GisuInfo::gisuId).orElse(null);
+
+        // 모든 챌린저의 gisuId를 모아 generation 매핑 일괄 조회
+        Map<Long, Long> generationByGisuId = loadGenerationMap(challengersByMemberId);
+
+        // 활성 기수에 속한 챌린저들의 운영진 RoleType 일괄 조회 → 회원 단위 isAdminInActiveGisu 산출
+        Set<Long> memberIdsWithAdminInActiveGisu =
+            computeMembersWithAdminInActiveGisu(challengersByMemberId, activeGisuId);
+
+        Page<SearchMemberItemV2Info> items = memberIdPage.map(memberId -> toItemV2Info(
+            memberId,
+            memberInfoMap,
+            challengersByMemberId.getOrDefault(memberId, List.of()),
+            generationByGisuId,
+            activeGisuId,
+            memberIdsWithAdminInActiveGisu.contains(memberId)
         ));
 
         return new SearchMemberV2Result(items);
     }
 
-    // ======= PRIVATE =========
+    // ======= PRIVATE — v1 helpers =========
 
     private SearchMemberItemInfo toItemInfo(
         Challenger challenger,
@@ -100,33 +123,6 @@ public class MemberSearchService implements SearchMemberUseCase {
             gisuGenerationMap.get(challenger.getGisuId()),
             challenger.getPart(),
             roleTypes.getOrDefault(challenger.getId(), List.of())
-        );
-    }
-
-    private SearchMemberItemV2Info toItemInfoV2(
-        Challenger challenger,
-        Map<Long, MemberInfo> memberProfiles,
-        Map<Long, List<ChallengerRoleType>> roleTypes,
-        Map<Long, Long> gisuGenerationMap,
-        Set<Long> adminChallengerIdsInActiveGisu
-    ) {
-        MemberInfo profile = memberProfiles.get(challenger.getMemberId());
-
-        return new SearchMemberItemV2Info(
-            challenger.getMemberId(),
-            profile != null ? profile.name() : null,
-            profile != null ? profile.nickname() : null,
-            profile != null ? profile.email() : null,
-            profile != null ? profile.schoolId() : null,
-            profile != null ? profile.schoolName() : null,
-            profile != null ? profile.profileImageLink() : null,
-            challenger.getId(),
-            challenger.getGisuId(),
-            gisuGenerationMap.get(challenger.getGisuId()),
-            challenger.getPart(),
-            challenger.getStatus(),
-            roleTypes.getOrDefault(challenger.getId(), List.of()),
-            adminChallengerIdsInActiveGisu.contains(challenger.getId())
         );
     }
 
@@ -169,52 +165,121 @@ public class MemberSearchService implements SearchMemberUseCase {
             .collect(Collectors.toMap(GisuInfo::gisuId, GisuInfo::generation));
     }
 
-    /**
-     * 검색 결과로 노출된 회원들 가운데 활성 기수에 운영진 기록이 있는 챌린저 ID 집합을 구합니다.
-     * <p>
-     * 활성 기수에 매칭되는 검색 결과의 챌린저 ID 중 ChallengerRole이 존재하는 ID만 모읍니다.
-     * 다른 기수의 챌린저 행이라도, 같은 회원이 활성 기수에 운영진을 보유하면 true가 되도록
-     * 회원 단위로도 한 번 더 확장합니다.
-     */
-    private Set<Long> collectAdminChallengerIdsInActiveGisu(
-        List<Challenger> content,
+    // ======= PRIVATE — v2 helpers =========
+
+    private Map<Long, Long> loadGenerationMap(Map<Long, List<ChallengerInfo>> challengersByMemberId) {
+        Set<Long> gisuIds = challengersByMemberId.values().stream()
+            .flatMap(List::stream)
+            .map(ChallengerInfo::gisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        if (gisuIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return getGisuUseCase.getByIds(gisuIds).stream()
+            .collect(Collectors.toMap(GisuInfo::gisuId, GisuInfo::generation));
+    }
+
+    private Set<Long> computeMembersWithAdminInActiveGisu(
+        Map<Long, List<ChallengerInfo>> challengersByMemberId,
         Long activeGisuId
     ) {
-        if (activeGisuId == null || content.isEmpty()) {
+        if (activeGisuId == null) {
             return Set.of();
         }
 
-        Set<Long> memberIdsWithAdminInActiveGisu = collectMemberIdsWithAdminInActiveGisu(content, activeGisuId);
-
-        return content.stream()
-            .filter(c -> memberIdsWithAdminInActiveGisu.contains(c.getMemberId()))
-            .map(Challenger::getId)
-            .collect(Collectors.toSet());
-    }
-
-    private Set<Long> collectMemberIdsWithAdminInActiveGisu(List<Challenger> content, Long activeGisuId) {
-        // 활성 기수의 챌린저 행만 추려서 그 챌린저 ID로 운영진 보유 여부를 일괄 조회합니다.
-        Set<Long> activeGisuChallengerIds = content.stream()
-            .filter(c -> Objects.equals(c.getGisuId(), activeGisuId))
-            .map(Challenger::getId)
+        Set<Long> activeGisuChallengerIds = challengersByMemberId.values().stream()
+            .flatMap(List::stream)
+            .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
+            .map(ChallengerInfo::challengerId)
             .collect(Collectors.toSet());
 
         if (activeGisuChallengerIds.isEmpty()) {
             return Set.of();
         }
 
-        Map<Long, List<ChallengerRoleType>> activeGisuRoleTypes =
+        Map<Long, List<ChallengerRoleType>> rolesByChallengerId =
             getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(activeGisuChallengerIds);
 
-        // 운영진 보유 챌린저의 memberId를 모읍니다.
-        Set<Long> adminChallengerIds = activeGisuRoleTypes.entrySet().stream()
+        Set<Long> adminChallengerIds = rolesByChallengerId.entrySet().stream()
             .filter(e -> !e.getValue().isEmpty())
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
 
-        return content.stream()
-            .filter(c -> adminChallengerIds.contains(c.getId()))
-            .map(Challenger::getMemberId)
+        return challengersByMemberId.entrySet().stream()
+            .filter(e -> e.getValue().stream()
+                .anyMatch(c -> adminChallengerIds.contains(c.challengerId())))
+            .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
+    }
+
+    private SearchMemberItemV2Info toItemV2Info(
+        Long memberId,
+        Map<Long, MemberInfo> memberInfoMap,
+        List<ChallengerInfo> myChallengers,
+        Map<Long, Long> generationByGisuId,
+        Long activeGisuId,
+        boolean isAdminInActiveGisu
+    ) {
+        MemberInfo m = memberInfoMap.get(memberId);
+
+        PrimaryChallenger primary = selectPrimaryChallenger(myChallengers, generationByGisuId, activeGisuId);
+        List<Participation> participations = myChallengers.stream()
+            .sorted(Comparator
+                .comparing((ChallengerInfo c) -> generationByGisuId.getOrDefault(c.gisuId(), 0L)).reversed()
+                .thenComparing(ChallengerInfo::challengerId))
+            .map(c -> new Participation(
+                c.challengerId(),
+                c.gisuId(),
+                generationByGisuId.get(c.gisuId()),
+                c.part(),
+                c.challengerStatus()
+            ))
+            .toList();
+
+        return new SearchMemberItemV2Info(
+            memberId,
+            m != null ? m.name() : null,
+            m != null ? m.nickname() : null,
+            m != null ? m.email() : null,
+            m != null ? m.schoolId() : null,
+            m != null ? m.schoolName() : null,
+            m != null ? m.profileImageLink() : null,
+            primary,
+            isAdminInActiveGisu,
+            participations
+        );
+    }
+
+    /**
+     * 활성 기수 챌린저가 있으면 그것을, 없으면 가장 최신 기수의 챌린저를 대표로 선택합니다.
+     */
+    private PrimaryChallenger selectPrimaryChallenger(
+        List<ChallengerInfo> challengers,
+        Map<Long, Long> generationByGisuId,
+        Long activeGisuId
+    ) {
+        if (challengers.isEmpty()) {
+            return null;
+        }
+
+        Optional<ChallengerInfo> active = activeGisuId == null ? Optional.empty()
+            : challengers.stream()
+                .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
+                .findFirst();
+
+        ChallengerInfo picked = active.orElseGet(() -> challengers.stream()
+            .max(Comparator.comparing(c -> generationByGisuId.getOrDefault(c.gisuId(), 0L)))
+            .orElseThrow());
+
+        return new PrimaryChallenger(
+            picked.challengerId(),
+            picked.gisuId(),
+            generationByGisuId.get(picked.gisuId()),
+            picked.part(),
+            picked.challengerStatus()
+        );
     }
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
@@ -7,8 +7,10 @@ import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import com.umc.product.member.application.port.out.SearchMemberPort;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
@@ -50,6 +52,31 @@ public class MemberSearchService implements SearchMemberUseCase {
         return new SearchMemberResult(items);
     }
 
+    @Override
+    public SearchMemberV2Result searchByV2(SearchMemberQuery query, Pageable pageable) {
+        Page<Challenger> challengers = searchMemberPort.search(query, pageable);
+        List<Challenger> content = challengers.getContent();
+
+        Map<Long, MemberInfo> memberProfiles = loadMemberProfiles(content);
+        Map<Long, List<ChallengerRoleType>> roleTypes = loadRoleTypes(content);
+        Map<Long, Long> gisuGenerationMap = loadGisuGenerationMap(content);
+
+        // 현재 활성 기수 정보를 한 번만 조회합니다. 휴지기에는 isAdminInActiveGisu가 항상 false가 됩니다.
+        Long activeGisuId = getGisuUseCase.findActiveGisu()
+            .map(GisuInfo::gisuId)
+            .orElse(null);
+
+        // 검색 결과에 포함된 회원들의 활성 기수 운영진 챌린저 ID 집합을 미리 계산합니다.
+        Set<Long> adminChallengerIdsInActiveGisu =
+            collectAdminChallengerIdsInActiveGisu(content, activeGisuId);
+
+        Page<SearchMemberItemV2Info> items = challengers.map(challenger -> toItemInfoV2(
+            challenger, memberProfiles, roleTypes, gisuGenerationMap, adminChallengerIdsInActiveGisu
+        ));
+
+        return new SearchMemberV2Result(items);
+    }
+
     // ======= PRIVATE =========
 
     private SearchMemberItemInfo toItemInfo(
@@ -73,6 +100,33 @@ public class MemberSearchService implements SearchMemberUseCase {
             gisuGenerationMap.get(challenger.getGisuId()),
             challenger.getPart(),
             roleTypes.getOrDefault(challenger.getId(), List.of())
+        );
+    }
+
+    private SearchMemberItemV2Info toItemInfoV2(
+        Challenger challenger,
+        Map<Long, MemberInfo> memberProfiles,
+        Map<Long, List<ChallengerRoleType>> roleTypes,
+        Map<Long, Long> gisuGenerationMap,
+        Set<Long> adminChallengerIdsInActiveGisu
+    ) {
+        MemberInfo profile = memberProfiles.get(challenger.getMemberId());
+
+        return new SearchMemberItemV2Info(
+            challenger.getMemberId(),
+            profile != null ? profile.name() : null,
+            profile != null ? profile.nickname() : null,
+            profile != null ? profile.email() : null,
+            profile != null ? profile.schoolId() : null,
+            profile != null ? profile.schoolName() : null,
+            profile != null ? profile.profileImageLink() : null,
+            challenger.getId(),
+            challenger.getGisuId(),
+            gisuGenerationMap.get(challenger.getGisuId()),
+            challenger.getPart(),
+            challenger.getStatus(),
+            roleTypes.getOrDefault(challenger.getId(), List.of()),
+            adminChallengerIdsInActiveGisu.contains(challenger.getId())
         );
     }
 
@@ -113,5 +167,54 @@ public class MemberSearchService implements SearchMemberUseCase {
 
         return getGisuUseCase.getByIds(gisuIds).stream()
             .collect(Collectors.toMap(GisuInfo::gisuId, GisuInfo::generation));
+    }
+
+    /**
+     * 검색 결과로 노출된 회원들 가운데 활성 기수에 운영진 기록이 있는 챌린저 ID 집합을 구합니다.
+     * <p>
+     * 활성 기수에 매칭되는 검색 결과의 챌린저 ID 중 ChallengerRole이 존재하는 ID만 모읍니다.
+     * 다른 기수의 챌린저 행이라도, 같은 회원이 활성 기수에 운영진을 보유하면 true가 되도록
+     * 회원 단위로도 한 번 더 확장합니다.
+     */
+    private Set<Long> collectAdminChallengerIdsInActiveGisu(
+        List<Challenger> content,
+        Long activeGisuId
+    ) {
+        if (activeGisuId == null || content.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<Long> memberIdsWithAdminInActiveGisu = collectMemberIdsWithAdminInActiveGisu(content, activeGisuId);
+
+        return content.stream()
+            .filter(c -> memberIdsWithAdminInActiveGisu.contains(c.getMemberId()))
+            .map(Challenger::getId)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Long> collectMemberIdsWithAdminInActiveGisu(List<Challenger> content, Long activeGisuId) {
+        // 활성 기수의 챌린저 행만 추려서 그 챌린저 ID로 운영진 보유 여부를 일괄 조회합니다.
+        Set<Long> activeGisuChallengerIds = content.stream()
+            .filter(c -> Objects.equals(c.getGisuId(), activeGisuId))
+            .map(Challenger::getId)
+            .collect(Collectors.toSet());
+
+        if (activeGisuChallengerIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<Long, List<ChallengerRoleType>> activeGisuRoleTypes =
+            getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(activeGisuChallengerIds);
+
+        // 운영진 보유 챌린저의 memberId를 모읍니다.
+        Set<Long> adminChallengerIds = activeGisuRoleTypes.entrySet().stream()
+            .filter(e -> !e.getValue().isEmpty())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+
+        return content.stream()
+            .filter(c -> adminChallengerIds.contains(c.getId()))
+            .map(Challenger::getMemberId)
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
@@ -2,6 +2,7 @@ package com.umc.product.member.application.service;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -74,8 +75,10 @@ public class MemberSearchService implements SearchMemberUseCase {
         Long activeGisuId = getGisuUseCase.findActiveGisu()
             .map(GisuInfo::gisuId)
             .orElse(null);
+        Map<Long, ChallengerBasicInfo> activeGisuChallengerByMemberId =
+            loadActiveGisuChallengerByMemberId(content, activeGisuId);
         Set<Long> adminChallengerIdsInActiveGisu =
-            collectAdminChallengerIdsInActiveGisu(content, activeGisuId);
+            collectAdminChallengerIdsInActiveGisu(content, roleTypes, activeGisuChallengerByMemberId);
 
         Page<ChallengerSearchItemV2Info> items = challengers.map(challenger ->
             toChallengerSearchItemV2(challenger, memberProfiles, roleTypes, gisuGenerationMap,
@@ -100,8 +103,8 @@ public class MemberSearchService implements SearchMemberUseCase {
         Map<Long, MemberInfo> memberInfoMap = getMemberUseCase.findAllByIds(memberIdSet);
 
         // 회원별 모든 챌린저 batch 로딩 (IN 쿼리 1회)
-        Map<Long, List<ChallengerInfo>> challengersByMemberId =
-            getChallengerUseCase.getAllByMemberIds(memberIdSet);
+        Map<Long, List<ChallengerBasicInfo>> challengersByMemberId =
+            getChallengerUseCase.getAllBasicByMemberIds(memberIdSet);
 
         // 활성 기수 한 번 조회 (휴지기에는 Optional.empty)
         Optional<GisuInfo> activeGisuOpt = getGisuUseCase.findActiveGisu();
@@ -197,34 +200,54 @@ public class MemberSearchService implements SearchMemberUseCase {
      * 검색 결과 챌린저 행들 가운데, 같은 회원이 활성 기수에 운영진 ChallengerRole을 보유하면
      * 그 회원이 가진 모든 챌린저 행에 대해 isAdminInActiveGisu=true가 되도록 챌린저 ID 집합을 만듭니다.
      */
-    private Set<Long> collectAdminChallengerIdsInActiveGisu(
+    private Map<Long, ChallengerBasicInfo> loadActiveGisuChallengerByMemberId(
         List<Challenger> content,
         Long activeGisuId
     ) {
         if (activeGisuId == null || content.isEmpty()) {
-            return Set.of();
+            return Map.of();
         }
 
-        Set<Long> activeGisuChallengerIds = content.stream()
-            .filter(c -> Objects.equals(c.getGisuId(), activeGisuId))
-            .map(Challenger::getId)
-            .collect(Collectors.toSet());
-
-        if (activeGisuChallengerIds.isEmpty()) {
-            return Set.of();
-        }
-
-        Map<Long, List<ChallengerRoleType>> activeGisuRoleTypes =
-            getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(activeGisuChallengerIds);
-
-        Set<Long> adminChallengerIds = activeGisuRoleTypes.entrySet().stream()
-            .filter(e -> !e.getValue().isEmpty())
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toSet());
-
-        Set<Long> adminMemberIds = content.stream()
-            .filter(c -> adminChallengerIds.contains(c.getId()))
+        Set<Long> memberIds = content.stream()
             .map(Challenger::getMemberId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        if (memberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return getChallengerUseCase.listBasicByMemberIdsAndGisuId(memberIds, activeGisuId).stream()
+            .collect(Collectors.toMap(ChallengerBasicInfo::memberId, c -> c, (a, b) -> a));
+    }
+
+    private Set<Long> collectAdminChallengerIdsInActiveGisu(
+        List<Challenger> content,
+        Map<Long, List<ChallengerRoleType>> roleTypes,
+        Map<Long, ChallengerBasicInfo> activeGisuChallengerByMemberId
+    ) {
+        if (content.isEmpty() || activeGisuChallengerByMemberId.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<Long> activeGisuChallengerIds = activeGisuChallengerByMemberId.values().stream()
+            .map(ChallengerBasicInfo::challengerId)
+            .collect(Collectors.toSet());
+
+        Set<Long> missingRoleChallengerIds = activeGisuChallengerIds.stream()
+            .filter(challengerId -> !roleTypes.containsKey(challengerId))
+            .collect(Collectors.toSet());
+
+        Map<Long, List<ChallengerRoleType>> missingRoleTypes = missingRoleChallengerIds.isEmpty()
+            ? Map.of()
+            : getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(missingRoleChallengerIds);
+
+        Set<Long> adminMemberIds = activeGisuChallengerByMemberId.values().stream()
+            .filter(c -> !roleTypes.getOrDefault(
+                c.challengerId(),
+                missingRoleTypes.getOrDefault(c.challengerId(), List.of())
+            ).isEmpty())
+            .map(ChallengerBasicInfo::memberId)
             .collect(Collectors.toSet());
 
         return content.stream()
@@ -262,10 +285,10 @@ public class MemberSearchService implements SearchMemberUseCase {
 
     // ======= PRIVATE — member search v2 helpers =========
 
-    private Map<Long, Long> loadGenerationMap(Map<Long, List<ChallengerInfo>> challengersByMemberId) {
+    private Map<Long, Long> loadGenerationMap(Map<Long, List<ChallengerBasicInfo>> challengersByMemberId) {
         Set<Long> gisuIds = challengersByMemberId.values().stream()
             .flatMap(List::stream)
-            .map(ChallengerInfo::gisuId)
+            .map(ChallengerBasicInfo::gisuId)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
 
@@ -278,7 +301,7 @@ public class MemberSearchService implements SearchMemberUseCase {
     }
 
     private Set<Long> computeMembersWithAdminInActiveGisu(
-        Map<Long, List<ChallengerInfo>> challengersByMemberId,
+        Map<Long, List<ChallengerBasicInfo>> challengersByMemberId,
         Long activeGisuId
     ) {
         if (activeGisuId == null) {
@@ -288,7 +311,7 @@ public class MemberSearchService implements SearchMemberUseCase {
         Set<Long> activeGisuChallengerIds = challengersByMemberId.values().stream()
             .flatMap(List::stream)
             .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
-            .map(ChallengerInfo::challengerId)
+            .map(ChallengerBasicInfo::challengerId)
             .collect(Collectors.toSet());
 
         if (activeGisuChallengerIds.isEmpty()) {
@@ -313,7 +336,7 @@ public class MemberSearchService implements SearchMemberUseCase {
     private SearchMemberItemV2Info toItemV2Info(
         Long memberId,
         Map<Long, MemberInfo> memberInfoMap,
-        List<ChallengerInfo> myChallengers,
+        List<ChallengerBasicInfo> myChallengers,
         Map<Long, Long> generationByGisuId,
         Long activeGisuId,
         boolean isAdminInActiveGisu
@@ -323,8 +346,8 @@ public class MemberSearchService implements SearchMemberUseCase {
         PrimaryChallenger primary = selectPrimaryChallenger(myChallengers, generationByGisuId, activeGisuId);
         List<Participation> participations = myChallengers.stream()
             .sorted(Comparator
-                .comparing((ChallengerInfo c) -> generationByGisuId.getOrDefault(c.gisuId(), 0L)).reversed()
-                .thenComparing(ChallengerInfo::challengerId))
+                .comparing((ChallengerBasicInfo c) -> generationByGisuId.getOrDefault(c.gisuId(), 0L)).reversed()
+                .thenComparing(ChallengerBasicInfo::challengerId))
             .map(c -> new Participation(
                 c.challengerId(),
                 c.gisuId(),
@@ -352,7 +375,7 @@ public class MemberSearchService implements SearchMemberUseCase {
      * 활성 기수 챌린저가 있으면 그것을, 없으면 가장 최신 기수의 챌린저를 대표로 선택합니다.
      */
     private PrimaryChallenger selectPrimaryChallenger(
-        List<ChallengerInfo> challengers,
+        List<ChallengerBasicInfo> challengers,
         Map<Long, Long> generationByGisuId,
         Long activeGisuId
     ) {
@@ -360,12 +383,12 @@ public class MemberSearchService implements SearchMemberUseCase {
             return null;
         }
 
-        Optional<ChallengerInfo> active = activeGisuId == null ? Optional.empty()
+        Optional<ChallengerBasicInfo> active = activeGisuId == null ? Optional.empty()
             : challengers.stream()
                 .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
                 .findFirst();
 
-        ChallengerInfo picked = active.orElseGet(() -> challengers.stream()
+        ChallengerBasicInfo picked = active.orElseGet(() -> challengers.stream()
             .max(Comparator.comparing(c -> generationByGisuId.getOrDefault(c.gisuId(), 0L)))
             .orElseThrow());
 

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
@@ -7,6 +7,8 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
@@ -57,6 +59,30 @@ public class MemberSearchService implements SearchMemberUseCase {
         );
 
         return new SearchMemberResult(items);
+    }
+
+    @Override
+    public ChallengerSearchV2Result searchChallengersByV2(SearchMemberQuery query, Pageable pageable) {
+        Page<Challenger> challengers = searchMemberPort.search(query, pageable);
+        List<Challenger> content = challengers.getContent();
+
+        Map<Long, MemberInfo> memberProfiles = loadMemberProfiles(content);
+        Map<Long, List<ChallengerRoleType>> roleTypes = loadRoleTypes(content);
+        Map<Long, Long> gisuGenerationMap = loadGisuGenerationMap(content);
+
+        // 활성 기수 + 해당 회원이 활성 기수에 운영진 ChallengerRole을 보유하는지 회원 단위로 산출
+        Long activeGisuId = getGisuUseCase.findActiveGisu()
+            .map(GisuInfo::gisuId)
+            .orElse(null);
+        Set<Long> adminChallengerIdsInActiveGisu =
+            collectAdminChallengerIdsInActiveGisu(content, activeGisuId);
+
+        Page<ChallengerSearchItemV2Info> items = challengers.map(challenger ->
+            toChallengerSearchItemV2(challenger, memberProfiles, roleTypes, gisuGenerationMap,
+                adminChallengerIdsInActiveGisu)
+        );
+
+        return new ChallengerSearchV2Result(items);
     }
 
     @Override
@@ -165,7 +191,76 @@ public class MemberSearchService implements SearchMemberUseCase {
             .collect(Collectors.toMap(GisuInfo::gisuId, GisuInfo::generation));
     }
 
-    // ======= PRIVATE — v2 helpers =========
+    // ======= PRIVATE — challenger search v2 helpers =========
+
+    /**
+     * 검색 결과 챌린저 행들 가운데, 같은 회원이 활성 기수에 운영진 ChallengerRole을 보유하면
+     * 그 회원이 가진 모든 챌린저 행에 대해 isAdminInActiveGisu=true가 되도록 챌린저 ID 집합을 만듭니다.
+     */
+    private Set<Long> collectAdminChallengerIdsInActiveGisu(
+        List<Challenger> content,
+        Long activeGisuId
+    ) {
+        if (activeGisuId == null || content.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<Long> activeGisuChallengerIds = content.stream()
+            .filter(c -> Objects.equals(c.getGisuId(), activeGisuId))
+            .map(Challenger::getId)
+            .collect(Collectors.toSet());
+
+        if (activeGisuChallengerIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<Long, List<ChallengerRoleType>> activeGisuRoleTypes =
+            getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(activeGisuChallengerIds);
+
+        Set<Long> adminChallengerIds = activeGisuRoleTypes.entrySet().stream()
+            .filter(e -> !e.getValue().isEmpty())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+
+        Set<Long> adminMemberIds = content.stream()
+            .filter(c -> adminChallengerIds.contains(c.getId()))
+            .map(Challenger::getMemberId)
+            .collect(Collectors.toSet());
+
+        return content.stream()
+            .filter(c -> adminMemberIds.contains(c.getMemberId()))
+            .map(Challenger::getId)
+            .collect(Collectors.toSet());
+    }
+
+    private ChallengerSearchItemV2Info toChallengerSearchItemV2(
+        Challenger challenger,
+        Map<Long, MemberInfo> memberProfiles,
+        Map<Long, List<ChallengerRoleType>> roleTypes,
+        Map<Long, Long> gisuGenerationMap,
+        Set<Long> adminChallengerIdsInActiveGisu
+    ) {
+        MemberInfo profile = memberProfiles.get(challenger.getMemberId());
+
+        return new ChallengerSearchItemV2Info(
+            challenger.getMemberId(),
+            profile != null ? profile.name() : null,
+            profile != null ? profile.nickname() : null,
+            profile != null ? profile.email() : null,
+            profile != null ? profile.schoolId() : null,
+            profile != null ? profile.schoolName() : null,
+            profile != null ? profile.profileImageLink() : null,
+            challenger.getId(),
+            challenger.getGisuId(),
+            gisuGenerationMap.get(challenger.getGisuId()),
+            challenger.getPart(),
+            challenger.getStatus(),
+            roleTypes.getOrDefault(challenger.getId(), List.of()),
+            adminChallengerIdsInActiveGisu.contains(challenger.getId())
+        );
+    }
+
+    // ======= PRIVATE — member search v2 helpers =========
 
     private Map<Long, Long> loadGenerationMap(Map<Long, List<ChallengerInfo>> challengersByMemberId) {
         Set<Long> gisuIds = challengersByMemberId.values().stream()

--- a/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
@@ -1,0 +1,169 @@
+package com.umc.product.member.application.service;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerActivityPeriodUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSummary;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.member.application.port.in.query.GetMemberProfileUseCase;
+import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info.ActiveChallenger;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info.ChallengerHistoryItem;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info.CurrentGisuMembership;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * /api/v2/member/me BFF UseCase 구현체.
+ * <p>
+ * 모든 외부 도메인 조회를 단일 readOnly 트랜잭션 안에서 수행해 응답 시점 일관성을 보장합니다.
+ * 챌린저 수와 무관하게 외부 호출 수가 O(1)이 되도록 batch 로딩 패턴을 사용합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
+
+    private final GetMemberUseCase getMemberUseCase;
+    private final GetMemberProfileUseCase getMemberProfileUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetGisuUseCase getGisuUseCase;
+    private final GetChapterUseCase getChapterUseCase;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChallengerActivityPeriodUseCase getChallengerActivityPeriodUseCase;
+
+    @Override
+    public MemberSummaryV2Info getSummaryByMemberId(Long memberId) {
+        MemberInfo memberInfo = getMemberUseCase.getById(memberId);
+        MemberProfileInfo profileInfo = getMemberProfileUseCase.getMemberProfileById(memberId);
+
+        // 챌린저 + 점수 일괄 로딩 (D13에서 batch로 교체됨)
+        List<ChallengerInfo> challengers = getChallengerUseCase.getAllByMemberId(memberId);
+
+        Set<Long> gisuIds = challengers.stream()
+            .map(ChallengerInfo::gisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        Set<Long> challengerIds = challengers.stream()
+            .map(ChallengerInfo::challengerId)
+            .collect(Collectors.toSet());
+
+        // 활성 기수: 휴지기에는 Optional.empty()
+        Optional<GisuInfo> activeGisuOpt = getGisuUseCase.findActiveGisu();
+
+        // 기수/지부/역할/활동일 일괄 조회
+        Map<Long, GisuInfo> gisuByGisuId = gisuIds.isEmpty()
+            ? Map.of()
+            : getGisuUseCase.getByIds(gisuIds).stream()
+                .collect(Collectors.toMap(GisuInfo::gisuId, g -> g));
+
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = loadChapterMap(memberInfo, gisuIds);
+
+        Map<Long, List<ChallengerRoleType>> roleTypesByChallengerId = challengerIds.isEmpty()
+            ? Map.of()
+            : getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(challengerIds);
+
+        ActivityPeriodSummary activitySummary =
+            getChallengerActivityPeriodUseCase.calculateActivityPeriod(challengers, gisuByGisuId);
+
+        // 현재 활성 기수 멤버십 조립
+        CurrentGisuMembership currentMembership = activeGisuOpt
+            .map(activeGisu -> buildCurrentMembership(activeGisu, challengers, roleTypesByChallengerId))
+            .orElse(null);
+
+        // 챌린저 이력 (기수 내림차순)
+        List<ChallengerHistoryItem> history = challengers.stream()
+            .sorted((a, b) -> {
+                Long genA = Optional.ofNullable(gisuByGisuId.get(a.gisuId()))
+                    .map(GisuInfo::generation).orElse(0L);
+                Long genB = Optional.ofNullable(gisuByGisuId.get(b.gisuId()))
+                    .map(GisuInfo::generation).orElse(0L);
+                return Long.compare(genB, genA);
+            })
+            .map(c -> ChallengerHistoryItem.of(
+                c,
+                gisuByGisuId.get(c.gisuId()),
+                chapterByGisuAndSchool.getOrDefault(c.gisuId(), Map.of()).get(memberInfo.schoolId()),
+                roleTypesByChallengerId
+            ))
+            .toList();
+
+        return new MemberSummaryV2Info(
+            memberInfo,
+            profileInfo,
+            activitySummary.totalActivityDays(),
+            currentMembership,
+            history
+        );
+    }
+
+    private Map<Long, Map<Long, ChapterInfo>> loadChapterMap(MemberInfo memberInfo, Set<Long> gisuIds) {
+        if (gisuIds.isEmpty() || memberInfo.schoolId() == null) {
+            return Map.of();
+        }
+        return getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(
+            gisuIds,
+            Set.of(memberInfo.schoolId())
+        );
+    }
+
+    private CurrentGisuMembership buildCurrentMembership(
+        GisuInfo activeGisu,
+        List<ChallengerInfo> challengers,
+        Map<Long, List<ChallengerRoleType>> roleTypesByChallengerId
+    ) {
+        Long activeGisuId = activeGisu.gisuId();
+
+        // 활성 기수 챌린저 중 ACTIVE 상태인 레코드를 찾습니다 (D11).
+        Optional<ChallengerInfo> activeChallengerOpt = challengers.stream()
+            .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
+            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
+            .findFirst();
+
+        // 활성 기수에 속한 챌린저 행(상태 불문)의 역할 타입을 모두 모읍니다.
+        // 활성 기수에 챌린저 레코드는 없고 운영진 기록만 있는 케이스를 위해 빈 챌린저도 포함되는 식으로 처리.
+        List<ChallengerRoleType> roleTypes = challengers.stream()
+            .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
+            .flatMap(c -> roleTypesByChallengerId.getOrDefault(c.challengerId(), List.of()).stream())
+            .distinct()
+            .sorted()
+            .toList();
+
+        ActiveChallenger activeChallenger = activeChallengerOpt
+            .map(c -> new ActiveChallenger(
+                c.challengerId(),
+                c.part(),
+                c.challengerStatus(),
+                c.challengerPoints() == null ? Collections.emptyList() : c.challengerPoints(),
+                c.totalPoints() == null ? 0.0 : c.totalPoints()
+            ))
+            .orElse(null);
+
+        return new CurrentGisuMembership(
+            activeGisu.gisuId(),
+            activeGisu.generation(),
+            activeChallenger,
+            !roleTypes.isEmpty(),
+            roleTypes
+        );
+    }
+}

--- a/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
@@ -102,7 +102,7 @@ public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
             .map(c -> ChallengerHistoryItem.of(
                 c,
                 gisuByGisuId.get(c.gisuId()),
-                chapterByGisuAndSchool.getOrDefault(c.gisuId(), Map.of()).get(memberInfo.schoolId()),
+                getChapterInfo(chapterByGisuAndSchool, c.gisuId(), memberInfo.schoolId()),
                 roleTypesByChallengerId
             ))
             .toList();
@@ -126,6 +126,17 @@ public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
         );
     }
 
+    private ChapterInfo getChapterInfo(
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool,
+        Long gisuId,
+        Long schoolId
+    ) {
+        if (schoolId == null) {
+            return null;
+        }
+        return chapterByGisuAndSchool.getOrDefault(gisuId, Map.of()).get(schoolId);
+    }
+
     private CurrentGisuMembership buildCurrentMembership(
         GisuInfo activeGisu,
         List<ChallengerInfo> challengers,
@@ -140,7 +151,6 @@ public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
             .findFirst();
 
         // 활성 기수에 속한 챌린저 행(상태 불문)의 역할 타입을 모두 모읍니다.
-        // 활성 기수에 챌린저 레코드는 없고 운영진 기록만 있는 케이스를 위해 빈 챌린저도 포함되는 식으로 처리.
         List<ChallengerRoleType> roleTypes = challengers.stream()
             .filter(c -> Objects.equals(c.gisuId(), activeGisuId))
             .flatMap(c -> roleTypesByChallengerId.getOrDefault(c.challengerId(), List.of()).stream())

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/gisu/GisuPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/gisu/GisuPersistenceAdapter.java
@@ -28,6 +28,11 @@ public class GisuPersistenceAdapter implements SaveGisuPort, LoadGisuPort {
     }
 
     @Override
+    public Optional<Gisu> findActiveGisuOptional() {
+        return gisuJpaRepository.findByIsActiveTrue();
+    }
+
+    @Override
     public Optional<Gisu> findActiveGisuWithLock() {
         return gisuJpaRepository.findActiveWithLock();
     }

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/gisu/GisuPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/gisu/GisuPersistenceAdapter.java
@@ -22,13 +22,13 @@ public class GisuPersistenceAdapter implements SaveGisuPort, LoadGisuPort {
     private final GisuJpaRepository gisuJpaRepository;
     private final GisuQueryRepository gisuQueryRepository;
 
-    public Gisu findActiveGisu() {
+    public Gisu getActiveGisu() {
         return gisuJpaRepository.findByIsActiveTrue().orElseThrow(
             () -> new OrganizationDomainException(OrganizationErrorCode.GISU_IS_ACTIVE_NOT_FOUND));
     }
 
     @Override
-    public Optional<Gisu> findActiveGisuOptional() {
+    public Optional<Gisu> findActiveGisu() {
         return gisuJpaRepository.findByIsActiveTrue();
     }
 
@@ -38,13 +38,13 @@ public class GisuPersistenceAdapter implements SaveGisuPort, LoadGisuPort {
     }
 
     @Override
-    public Gisu findById(Long gisuId) {
+    public Gisu getById(Long gisuId) {
         return gisuJpaRepository.findById(gisuId).orElseThrow(
             () -> new OrganizationDomainException(OrganizationErrorCode.GISU_NOT_FOUND));
     }
 
     @Override
-    public List<Gisu> findByIds(Set<Long> gisuIds) {
+    public List<Gisu> listByIds(Set<Long> gisuIds) {
         return gisuJpaRepository.findByIdIn(gisuIds);
     }
 

--- a/src/main/java/com/umc/product/organization/application/port/in/query/GetGisuUseCase.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/GetGisuUseCase.java
@@ -4,6 +4,7 @@ import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuNameInfo;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,11 @@ public interface GetGisuUseCase {
     Long getActiveGisuId();
 
     GisuInfo getActiveGisu();
+
+    /**
+     * 활성 기수가 존재하지 않을 수 있는 시점(휴지기 등)에 사용합니다.
+     */
+    Optional<GisuInfo> findActiveGisu();
 
     GisuInfo getGisuByDate(Instant targetDate);
 }

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/gisu/GisuInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/gisu/GisuInfo.java
@@ -1,7 +1,7 @@
 package com.umc.product.organization.application.port.in.query.dto.gisu;
 
 import com.umc.product.organization.domain.Gisu;
-import java.time.Duration;
+import com.umc.product.organization.domain.GisuActivityDays;
 import java.time.Instant;
 
 public record GisuInfo(
@@ -25,10 +25,6 @@ public record GisuInfo(
      * 주어진 시점(now) 기준의 활동일을 반환합니다. {@link Gisu#activityDays(Instant)}와 동일한 규칙을 따릅니다.
      */
     public long activityDays(Instant now) {
-        if (now.isBefore(startAt)) {
-            return 0L;
-        }
-        Instant effectiveEnd = now.isBefore(endAt) ? now : endAt;
-        return Duration.between(startAt, effectiveEnd).toDays();
+        return GisuActivityDays.calculate(startAt, endAt, now);
     }
 }

--- a/src/main/java/com/umc/product/organization/application/port/in/query/dto/gisu/GisuInfo.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/dto/gisu/GisuInfo.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.application.port.in.query.dto.gisu;
 
 import com.umc.product.organization.domain.Gisu;
+import java.time.Duration;
 import java.time.Instant;
 
 public record GisuInfo(
@@ -18,5 +19,16 @@ public record GisuInfo(
             gisu.getEndAt(),
             gisu.isActive()
         );
+    }
+
+    /**
+     * 주어진 시점(now) 기준의 활동일을 반환합니다. {@link Gisu#activityDays(Instant)}와 동일한 규칙을 따릅니다.
+     */
+    public long activityDays(Instant now) {
+        if (now.isBefore(startAt)) {
+            return 0L;
+        }
+        Instant effectiveEnd = now.isBefore(endAt) ? now : endAt;
+        return Duration.between(startAt, effectiveEnd).toDays();
     }
 }

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadGisuPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadGisuPort.java
@@ -12,6 +12,11 @@ public interface LoadGisuPort {
 
     Gisu findActiveGisu();
 
+    /**
+     * 활성 기수가 없을 수도 있는 경우(휴지기 등)에 사용합니다.
+     */
+    Optional<Gisu> findActiveGisuOptional();
+
     Optional<Gisu> findActiveGisuWithLock();
 
     Gisu findById(Long gisuId);

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadGisuPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadGisuPort.java
@@ -10,18 +10,18 @@ import org.springframework.data.domain.Pageable;
 
 public interface LoadGisuPort {
 
-    Gisu findActiveGisu();
+    Gisu getActiveGisu();
 
     /**
      * 활성 기수가 없을 수도 있는 경우(휴지기 등)에 사용합니다.
      */
-    Optional<Gisu> findActiveGisuOptional();
+    Optional<Gisu> findActiveGisu();
 
     Optional<Gisu> findActiveGisuWithLock();
 
-    Gisu findById(Long gisuId);
+    Gisu getById(Long gisuId);
 
-    List<Gisu> findByIds(Set<Long> gisuIds);
+    List<Gisu> listByIds(Set<Long> gisuIds);
 
     List<Gisu> findAll();
 

--- a/src/main/java/com/umc/product/organization/application/port/service/command/ChapterService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/command/ChapterService.java
@@ -36,7 +36,7 @@ public class ChapterService implements ManageChapterUseCase {
 
     @Override
     public Long create(CreateChapterCommand command) {
-        Gisu gisu = loadGisuPort.findById(command.gisuId());
+        Gisu gisu = loadGisuPort.getById(command.gisuId());
         validateChapterNameNotDuplicated(command.gisuId(), command.name());
 
         Chapter chapter = Chapter.create(gisu, command.name());

--- a/src/main/java/com/umc/product/organization/application/port/service/command/GisuService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/command/GisuService.java
@@ -34,7 +34,7 @@ public class GisuService implements ManageGisuUseCase {
 
     @Override
     public void deleteGisu(Long gisuId) {
-        Gisu gisu = loadGisuPort.findById(gisuId);
+        Gisu gisu = loadGisuPort.getById(gisuId);
         if (loadChapterPort.existsByGisuId(gisuId)) {
             throw new OrganizationDomainException(OrganizationErrorCode.GISU_HAS_ASSOCIATED_CHAPTERS);
         }
@@ -55,7 +55,7 @@ public class GisuService implements ManageGisuUseCase {
         oldActiveGisuOptional.ifPresent(Gisu::inactive);
 
         // 새로운 기수를 활성화
-        Gisu newGisu = loadGisuPort.findById(gisuId);
+        Gisu newGisu = loadGisuPort.getById(gisuId);
         newGisu.active();
     }
 

--- a/src/main/java/com/umc/product/organization/application/port/service/command/StudyGroupCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/command/StudyGroupCommandService.java
@@ -45,7 +45,7 @@ public class StudyGroupCommandService implements ManageStudyGroupUseCase {
     @Override
     public void create(CreateStudyGroupCommand command) {
         // 생성하고자 하는 기수에 스터디를 생성
-        Gisu gisu = loadGisuPort.findById(command.gisuId());
+        Gisu gisu = loadGisuPort.getById(command.gisuId());
         validateNoPartStudyConflict(gisu.getId(), command.part(), command.memberIds());
 
         // 스터디 그룹 먼저 생성

--- a/src/main/java/com/umc/product/organization/application/port/service/query/GisuQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/GisuQueryService.java
@@ -45,29 +45,29 @@ public class GisuQueryService implements GetGisuUseCase {
 
     @Override
     public GisuInfo getById(Long gisuId) {
-        return GisuInfo.from(loadGisuPort.findById(gisuId));
+        return GisuInfo.from(loadGisuPort.getById(gisuId));
     }
 
     @Override
     public List<GisuInfo> getByIds(Set<Long> gisuIds) {
-        return loadGisuPort.findByIds(gisuIds).stream()
+        return loadGisuPort.listByIds(gisuIds).stream()
             .map(GisuInfo::from)
             .toList();
     }
 
     @Override
     public Long getActiveGisuId() {
-        return loadGisuPort.findActiveGisu().getId();
+        return loadGisuPort.getActiveGisu().getId();
     }
 
     @Override
     public GisuInfo getActiveGisu() {
-        return GisuInfo.from(loadGisuPort.findActiveGisu());
+        return GisuInfo.from(loadGisuPort.getActiveGisu());
     }
 
     @Override
     public Optional<GisuInfo> findActiveGisu() {
-        return loadGisuPort.findActiveGisuOptional().map(GisuInfo::from);
+        return loadGisuPort.findActiveGisu().map(GisuInfo::from);
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/application/port/service/query/GisuQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/GisuQueryService.java
@@ -8,6 +8,7 @@ import com.umc.product.organization.exception.OrganizationDomainException;
 import com.umc.product.organization.exception.OrganizationErrorCode;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -62,6 +63,11 @@ public class GisuQueryService implements GetGisuUseCase {
     @Override
     public GisuInfo getActiveGisu() {
         return GisuInfo.from(loadGisuPort.findActiveGisu());
+    }
+
+    @Override
+    public Optional<GisuInfo> findActiveGisu() {
+        return loadGisuPort.findActiveGisuOptional().map(GisuInfo::from);
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/domain/Gisu.java
+++ b/src/main/java/com/umc/product/organization/domain/Gisu.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Duration;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -58,5 +59,26 @@ public class Gisu extends BaseEntity {
 
     public void inactive() {
         this.isActive = false;
+    }
+
+    /**
+     * 주어진 시점(now)을 기준으로 이 기수에서의 활동일 수를 계산합니다.
+     * <p>
+     * - now < startAt : 0 (아직 시작 전)
+     * <p>
+     * - startAt ≤ now < endAt : now - startAt (진행 중인 기수는 현재까지)
+     * <p>
+     * - now ≥ endAt : endAt - startAt (종료된 기수는 전체 기간)
+     */
+    public long activityDays(Instant now) {
+        Instant start = getStartAt();
+        Instant end = getEndAt();
+
+        if (now.isBefore(start)) {
+            return 0L;
+        }
+
+        Instant effectiveEnd = now.isBefore(end) ? now : end;
+        return Duration.between(start, effectiveEnd).toDays();
     }
 }

--- a/src/main/java/com/umc/product/organization/domain/Gisu.java
+++ b/src/main/java/com/umc/product/organization/domain/Gisu.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.Duration;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -73,12 +72,6 @@ public class Gisu extends BaseEntity {
     public long activityDays(Instant now) {
         Instant start = getStartAt();
         Instant end = getEndAt();
-
-        if (now.isBefore(start)) {
-            return 0L;
-        }
-
-        Instant effectiveEnd = now.isBefore(end) ? now : end;
-        return Duration.between(start, effectiveEnd).toDays();
+        return GisuActivityDays.calculate(start, end, now);
     }
 }

--- a/src/main/java/com/umc/product/organization/domain/GisuActivityDays.java
+++ b/src/main/java/com/umc/product/organization/domain/GisuActivityDays.java
@@ -1,0 +1,19 @@
+package com.umc.product.organization.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public final class GisuActivityDays {
+
+    private GisuActivityDays() {
+    }
+
+    public static long calculate(Instant startAt, Instant endAt, Instant now) {
+        if (now.isBefore(startAt)) {
+            return 0L;
+        }
+
+        Instant effectiveEnd = now.isBefore(endAt) ? now : endAt;
+        return Duration.between(startAt, effectiveEnd).toDays();
+    }
+}

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerActivityPeriodServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerActivityPeriodServiceTest.java
@@ -1,0 +1,173 @@
+package com.umc.product.challenger.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSummary;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChallengerActivityPeriodService — 활동일 합산 로직")
+class ChallengerActivityPeriodServiceTest {
+
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+
+    @InjectMocks
+    ChallengerActivityPeriodService service;
+
+    private ChallengerInfo challenger(Long id, Long gisuId, ChallengerStatus status) {
+        return ChallengerInfo.builder()
+            .challengerId(id)
+            .memberId(100L)
+            .gisuId(gisuId)
+            .part(ChallengerPart.SPRINGBOOT)
+            .challengerPoints(List.of())
+            .totalPoints(0.0)
+            .challengerStatus(status)
+            .build();
+    }
+
+    private GisuInfo gisu(Long gisuId, Long generation, Instant startAt, Instant endAt) {
+        return new GisuInfo(gisuId, generation, startAt, endAt, false);
+    }
+
+    @Test
+    void ACTIVE와_GRADUATED_챌린저의_기수만_합산한다() {
+        Instant farPast = Instant.now().minus(400, ChronoUnit.DAYS);
+        Instant past = Instant.now().minus(200, ChronoUnit.DAYS);
+        Instant pastEnd = Instant.now().minus(50, ChronoUnit.DAYS);
+
+        List<ChallengerInfo> challengers = List.of(
+            challenger(1L, 10L, ChallengerStatus.GRADUATED),
+            challenger(2L, 11L, ChallengerStatus.ACTIVE),
+            challenger(3L, 12L, ChallengerStatus.EXPELLED),
+            challenger(4L, 13L, ChallengerStatus.WITHDRAWN)
+        );
+
+        Map<Long, GisuInfo> gisus = Map.of(
+            10L, gisu(10L, 6L, farPast, past),
+            11L, gisu(11L, 7L, past, pastEnd),
+            12L, gisu(12L, 8L, farPast, past),
+            13L, gisu(13L, 9L, past, pastEnd)
+        );
+
+        ActivityPeriodSummary summary = service.calculateActivityPeriod(challengers, gisus);
+
+        assertThat(summary.perGisu()).hasSize(2);
+        assertThat(summary.perGisu())
+            .extracting(ActivityPeriodSummary.PerGisu::gisuId)
+            .containsExactlyInAnyOrder(10L, 11L);
+        assertThat(summary.totalActivityDays()).isGreaterThan(0L);
+    }
+
+    @Test
+    void 챌린저가_없으면_빈_요약을_반환한다() {
+        ActivityPeriodSummary summary = service.calculateActivityPeriod(List.of(), Map.of());
+
+        assertThat(summary.totalActivityDays()).isZero();
+        assertThat(summary.perGisu()).isEmpty();
+    }
+
+    @Test
+    void EXPELLED_WITHDRAWN만_있으면_0일을_반환한다() {
+        Instant past = Instant.now().minus(100, ChronoUnit.DAYS);
+        Instant pastEnd = Instant.now().minus(10, ChronoUnit.DAYS);
+
+        List<ChallengerInfo> challengers = List.of(
+            challenger(1L, 10L, ChallengerStatus.EXPELLED),
+            challenger(2L, 11L, ChallengerStatus.WITHDRAWN)
+        );
+
+        Map<Long, GisuInfo> gisus = Map.of(
+            10L, gisu(10L, 6L, past, pastEnd),
+            11L, gisu(11L, 7L, past, pastEnd)
+        );
+
+        ActivityPeriodSummary summary = service.calculateActivityPeriod(challengers, gisus);
+
+        assertThat(summary.totalActivityDays()).isZero();
+        assertThat(summary.perGisu()).isEmpty();
+    }
+
+    @Test
+    void 진행중인_기수는_now까지의_일수만_포함한다() {
+        Instant startOfActive = Instant.now().minus(30, ChronoUnit.DAYS);
+        Instant futureEnd = Instant.now().plus(120, ChronoUnit.DAYS);
+
+        List<ChallengerInfo> challengers = List.of(
+            challenger(1L, 10L, ChallengerStatus.ACTIVE)
+        );
+
+        Map<Long, GisuInfo> gisus = Map.of(
+            10L, gisu(10L, 8L, startOfActive, futureEnd)
+        );
+
+        ActivityPeriodSummary summary = service.calculateActivityPeriod(challengers, gisus);
+
+        // 가까운 시각(현재)이라 정확한 일수보다는 범위를 검증
+        assertThat(summary.totalActivityDays()).isBetween(29L, 31L);
+    }
+
+    @Test
+    void 종료된_기수는_전체_기간을_합산한다() {
+        Instant start = Instant.now().minus(200, ChronoUnit.DAYS);
+        Instant end = Instant.now().minus(20, ChronoUnit.DAYS);
+
+        List<ChallengerInfo> challengers = List.of(
+            challenger(1L, 10L, ChallengerStatus.GRADUATED)
+        );
+
+        Map<Long, GisuInfo> gisus = Map.of(
+            10L, gisu(10L, 7L, start, end)
+        );
+
+        ActivityPeriodSummary summary = service.calculateActivityPeriod(challengers, gisus);
+
+        assertThat(summary.totalActivityDays()).isEqualTo(ChronoUnit.DAYS.between(start, end));
+    }
+
+    @Test
+    void getActivityPeriodByMemberId는_내부에서_챌린저와_기수를_조회한다() {
+        Instant start = Instant.now().minus(100, ChronoUnit.DAYS);
+        Instant end = Instant.now().minus(10, ChronoUnit.DAYS);
+
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of(
+            challenger(1L, 10L, ChallengerStatus.GRADUATED)
+        ));
+        given(getGisuUseCase.getByIds(java.util.Set.of(10L)))
+            .willReturn(List.of(gisu(10L, 7L, start, end)));
+
+        ActivityPeriodSummary summary = service.getActivityPeriodByMemberId(100L);
+
+        assertThat(summary.totalActivityDays()).isEqualTo(ChronoUnit.DAYS.between(start, end));
+    }
+
+    @Test
+    void getActivityPeriodByMemberId는_챌린저_0건이면_빈_요약을_반환한다() {
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of());
+
+        ActivityPeriodSummary summary = service.getActivityPeriodByMemberId(100L);
+
+        assertThat(summary.totalActivityDays()).isZero();
+        assertThat(summary.perGisu()).isEmpty();
+    }
+}

--- a/src/test/java/com/umc/product/global/util/EmailMaskerTest.java
+++ b/src/test/java/com/umc/product/global/util/EmailMaskerTest.java
@@ -1,0 +1,64 @@
+package com.umc.product.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EmailMasker — 이메일 마스킹 유틸")
+class EmailMaskerTest {
+
+    @Test
+    void null_입력은_null을_반환한다() {
+        assertThat(EmailMasker.mask(null)).isNull();
+    }
+
+    @Test
+    void 빈_문자열은_그대로_반환한다() {
+        assertThat(EmailMasker.mask("")).isEqualTo("");
+        assertThat(EmailMasker.mask("   ")).isEqualTo("   ");
+    }
+
+    @Test
+    void 골뱅이가_없는_입력은_원문_그대로_반환한다() {
+        // 비정상 입력에 대한 방어 — 마스킹 시도하지 않습니다.
+        assertThat(EmailMasker.mask("notAnEmail")).isEqualTo("notAnEmail");
+    }
+
+    @Test
+    void 로컬_파트가_비어있으면_원문_그대로_반환한다() {
+        assertThat(EmailMasker.mask("@domain.com")).isEqualTo("@domain.com");
+    }
+
+    @Test
+    void 로컬_파트_길이_1은_그대로_반환한다() {
+        assertThat(EmailMasker.mask("a@umc.com")).isEqualTo("a@umc.com");
+    }
+
+    @Test
+    void 로컬_파트_길이_2는_앞_1글자만_남기고_마스킹한다() {
+        assertThat(EmailMasker.mask("ab@umc.com")).isEqualTo("a*@umc.com");
+    }
+
+    @Test
+    void 로컬_파트_길이_3은_앞_1글자만_남기고_마스킹한다() {
+        assertThat(EmailMasker.mask("abc@umc.com")).isEqualTo("a**@umc.com");
+    }
+
+    @Test
+    void 로컬_파트_길이_4는_앞_3글자만_남기고_마스킹한다() {
+        assertThat(EmailMasker.mask("abcd@umc.com")).isEqualTo("abc*@umc.com");
+    }
+
+    @Test
+    void 로컬_파트가_긴_경우_앞_3글자만_남기고_마스킹한다() {
+        assertThat(EmailMasker.mask("donggukcd200@gmail.com"))
+            .isEqualTo("don*********@gmail.com");
+    }
+
+    @Test
+    void 도메인은_절대_마스킹되지_않는다() {
+        String masked = EmailMasker.mask("longlocalpart@hanyang.ac.kr");
+        assertThat(masked).endsWith("@hanyang.ac.kr");
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/ChallengerSearchV2Test.java
+++ b/src/test/java/com/umc/product/member/application/service/ChallengerSearchV2Test.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -74,6 +75,10 @@ class ChallengerSearchV2Test {
         return new GisuInfo(gisuId, generation, Instant.now(), Instant.now().plusSeconds(100), active);
     }
 
+    private ChallengerBasicInfo basic(Long id, Long memberId, ChallengerPart part, Long gisuId) {
+        return new ChallengerBasicInfo(id, memberId, gisuId, part, ChallengerStatus.ACTIVE);
+    }
+
     @Test
     void 챌린저_단위_검색은_같은_회원이라도_여러_row로_반환된다() {
         Pageable pageable = PageRequest.of(0, 10);
@@ -117,6 +122,9 @@ class ChallengerSearchV2Test {
         ));
         given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(gisu(activeGisuId, 9L, true)));
         given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(activeGisuId, 9L, true)));
+        given(getChallengerUseCase.listBasicByMemberIdsAndGisuId(anySet(), any())).willReturn(List.of(
+            basic(1L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId)
+        ));
 
         ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
             new SearchMemberQuery(null, null, null, null, null), pageable
@@ -145,6 +153,9 @@ class ChallengerSearchV2Test {
             gisu(7L, 8L, false), gisu(activeGisuId, 9L, true)
         ));
         given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(activeGisuId, 9L, true)));
+        given(getChallengerUseCase.listBasicByMemberIdsAndGisuId(anySet(), any())).willReturn(List.of(
+            basic(2L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId)
+        ));
 
         ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
             new SearchMemberQuery(null, null, null, null, null), pageable
@@ -154,5 +165,30 @@ class ChallengerSearchV2Test {
         // 두 행 모두 isAdminInActiveGisu=true (회원 단위로 확장)
         assertThat(content).extracting(ChallengerSearchItemV2Info::isAdminInActiveGisu)
             .containsExactly(true, true);
+    }
+
+    @Test
+    void 활성기수_행이_현재_페이지에_없어도_활성기수_운영진이면_isAdminInActiveGisu_true이다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Long activeGisuId = 8L;
+        Challenger past = challenger(1L, 10L, ChallengerPart.WEB, 7L);
+        Page<Challenger> page = new PageImpl<>(List.of(past), pageable, 1);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "운영진")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet()))
+            .willReturn(Map.of())
+            .willReturn(Map.of(2L, List.of(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(gisu(7L, 8L, false)));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(activeGisuId, 9L, true)));
+        given(getChallengerUseCase.listBasicByMemberIdsAndGisuId(anySet(), any())).willReturn(List.of(
+            basic(2L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId)
+        ));
+
+        ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        assertThat(result.page().getContent().get(0).isAdminInActiveGisu()).isTrue();
     }
 }

--- a/src/test/java/com/umc/product/member/application/service/ChallengerSearchV2Test.java
+++ b/src/test/java/com/umc/product/member/application/service/ChallengerSearchV2Test.java
@@ -1,0 +1,158 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+import com.umc.product.member.application.port.out.SearchMemberPort;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberSearchService.searchChallengersByV2 — 챌린저 단위 v2 검색")
+class ChallengerSearchV2Test {
+
+    @Mock SearchMemberPort searchMemberPort;
+    @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetChallengerUseCase getChallengerUseCase;
+    @Mock GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock GetGisuUseCase getGisuUseCase;
+
+    @InjectMocks MemberSearchService memberSearchService;
+
+    private Challenger challenger(Long id, Long memberId, ChallengerPart part, Long gisuId) {
+        Challenger c = Challenger.builder()
+            .memberId(memberId)
+            .part(part)
+            .gisuId(gisuId)
+            .build();
+        ReflectionTestUtils.setField(c, "id", id);
+        return c;
+    }
+
+    private MemberInfo profile(Long id, String name) {
+        return MemberInfo.builder()
+            .id(id)
+            .name(name)
+            .nickname(name)
+            .email("test@test.com")
+            .schoolId(1L)
+            .schoolName("학교")
+            .status(MemberStatus.ACTIVE)
+            .build();
+    }
+
+    private GisuInfo gisu(Long gisuId, Long generation, boolean active) {
+        return new GisuInfo(gisuId, generation, Instant.now(), Instant.now().plusSeconds(100), active);
+    }
+
+    @Test
+    void 챌린저_단위_검색은_같은_회원이라도_여러_row로_반환된다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Challenger c1 = challenger(1L, 10L, ChallengerPart.WEB, 6L);
+        Challenger c2 = challenger(2L, 10L, ChallengerPart.SPRINGBOOT, 7L);
+        Challenger c3 = challenger(3L, 10L, ChallengerPart.SPRINGBOOT, 8L);
+        Page<Challenger> page = new PageImpl<>(List.of(c1, c2, c3), pageable, 3);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "홍길동")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            gisu(6L, 7L, false), gisu(7L, 8L, false), gisu(8L, 9L, true)
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+
+        ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        List<ChallengerSearchItemV2Info> content = result.page().getContent();
+        // 같은 회원이지만 챌린저 3개라 3개 row
+        assertThat(content).hasSize(3);
+        assertThat(content).extracting(ChallengerSearchItemV2Info::memberId)
+            .containsExactly(10L, 10L, 10L);
+        assertThat(content).extracting(ChallengerSearchItemV2Info::challengerId)
+            .containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    void challengerStatus와_isAdminInActiveGisu가_매핑된다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Long activeGisuId = 8L;
+        Challenger activeRow = challenger(1L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
+        Page<Challenger> page = new PageImpl<>(List.of(activeRow), pageable, 1);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "운영진")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
+            1L, List.of(ChallengerRoleType.SCHOOL_PRESIDENT)
+        ));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(gisu(activeGisuId, 9L, true)));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(activeGisuId, 9L, true)));
+
+        ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        ChallengerSearchItemV2Info item = result.page().getContent().get(0);
+        assertThat(item.challengerStatus()).isEqualTo(ChallengerStatus.ACTIVE);
+        assertThat(item.roleTypes()).containsExactly(ChallengerRoleType.SCHOOL_PRESIDENT);
+        assertThat(item.isAdminInActiveGisu()).isTrue();
+    }
+
+    @Test
+    void 같은_회원의_과거_기수_행도_활성기수_운영진이면_isAdminInActiveGisu_true이다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Long activeGisuId = 8L;
+        Challenger past = challenger(1L, 10L, ChallengerPart.WEB, 7L);
+        Challenger active = challenger(2L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
+        Page<Challenger> page = new PageImpl<>(List.of(past, active), pageable, 2);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "운영진")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
+            2L, List.of(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)
+        ));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            gisu(7L, 8L, false), gisu(activeGisuId, 9L, true)
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(activeGisuId, 9L, true)));
+
+        ChallengerSearchV2Result result = memberSearchService.searchChallengersByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        List<ChallengerSearchItemV2Info> content = result.page().getContent();
+        // 두 행 모두 isAdminInActiveGisu=true (회원 단위로 확장)
+        assertThat(content).extracting(ChallengerSearchItemV2Info::isAdminInActiveGisu)
+            .containsExactly(true, true);
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
@@ -59,16 +59,14 @@ class MemberSearchServiceV2Test {
             .build();
     }
 
-    private ChallengerInfo challenger(Long id, Long memberId, Long gisuId, ChallengerPart part, ChallengerStatus status) {
-        return ChallengerInfo.builder()
-            .challengerId(id)
-            .memberId(memberId)
-            .gisuId(gisuId)
-            .part(part)
-            .challengerPoints(List.of())
-            .totalPoints(0.0)
-            .challengerStatus(status)
-            .build();
+    private ChallengerBasicInfo challenger(
+        Long id,
+        Long memberId,
+        Long gisuId,
+        ChallengerPart part,
+        ChallengerStatus status
+    ) {
+        return new ChallengerBasicInfo(id, memberId, gisuId, part, status);
     }
 
     private GisuInfo gisu(Long gisuId, Long generation, boolean active) {
@@ -83,7 +81,7 @@ class MemberSearchServiceV2Test {
 
         given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
         given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "홍길동")));
-        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+        given(getChallengerUseCase.getAllBasicByMemberIds(anySet())).willReturn(Map.of(
             10L, List.of(
                 challenger(101L, 10L, 6L, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
                 challenger(102L, 10L, 7L, ChallengerPart.SPRINGBOOT, ChallengerStatus.GRADUATED),
@@ -120,7 +118,7 @@ class MemberSearchServiceV2Test {
 
         given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
         given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "졸업자")));
-        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+        given(getChallengerUseCase.getAllBasicByMemberIds(anySet())).willReturn(Map.of(
             10L, List.of(
                 challenger(101L, 10L, 6L, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
                 challenger(102L, 10L, 7L, ChallengerPart.SPRINGBOOT, ChallengerStatus.GRADUATED)
@@ -151,7 +149,7 @@ class MemberSearchServiceV2Test {
 
         given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
         given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "운영진")));
-        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+        given(getChallengerUseCase.getAllBasicByMemberIds(anySet())).willReturn(Map.of(
             10L, List.of(
                 challenger(101L, 10L, 8L, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE)
             )
@@ -175,7 +173,7 @@ class MemberSearchServiceV2Test {
 
         given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
         given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "회원")));
-        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+        given(getChallengerUseCase.getAllBasicByMemberIds(anySet())).willReturn(Map.of(
             10L, List.of(challenger(101L, 10L, 7L, ChallengerPart.WEB, ChallengerStatus.GRADUATED))
         ));
         given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty()); // 휴지기

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
@@ -6,7 +6,8 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
-import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
@@ -33,31 +34,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("MemberSearchService.searchByV2 — v2 검색")
+@DisplayName("MemberSearchService.searchByV2 — 회원 단위 v2 검색")
 class MemberSearchServiceV2Test {
 
     @Mock SearchMemberPort searchMemberPort;
     @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetChallengerUseCase getChallengerUseCase;
     @Mock GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock GetGisuUseCase getGisuUseCase;
 
     @InjectMocks MemberSearchService memberSearchService;
 
-    private Challenger createChallenger(Long id, Long memberId, ChallengerPart part, Long gisuId) {
-        Challenger c = Challenger.builder()
-            .memberId(memberId)
-            .part(part)
-            .gisuId(gisuId)
-            .build();
-        ReflectionTestUtils.setField(c, "id", id);
-        // status는 builder가 ACTIVE로 기본 세팅하므로 별도 ReflectionTestUtils 호출은 불요
-        return c;
-    }
-
-    private MemberInfo createProfile(Long id, String name) {
+    private MemberInfo profile(Long id, String name) {
         return MemberInfo.builder()
             .id(id)
             .name(name)
@@ -69,51 +59,78 @@ class MemberSearchServiceV2Test {
             .build();
     }
 
+    private ChallengerInfo challenger(Long id, Long memberId, Long gisuId, ChallengerPart part, ChallengerStatus status) {
+        return ChallengerInfo.builder()
+            .challengerId(id)
+            .memberId(memberId)
+            .gisuId(gisuId)
+            .part(part)
+            .challengerPoints(List.of())
+            .totalPoints(0.0)
+            .challengerStatus(status)
+            .build();
+    }
+
+    private GisuInfo gisu(Long gisuId, Long generation, boolean active) {
+        return new GisuInfo(gisuId, generation, Instant.now(), Instant.now().plusSeconds(100), active);
+    }
+
     @Test
-    void v2_검색은_challengerStatus를_매핑한다() {
+    void 같은_회원의_여러_기수_챌린저는_하나의_row로_묶여_반환된다() {
+        // given: memberId=10 한 명이 3개 기수 챌린저 보유, 검색 결과 = 회원 1명
         Pageable pageable = PageRequest.of(0, 10);
+        Page<Long> memberIdPage = new PageImpl<>(List.of(10L), pageable, 1);
 
-        Challenger c1 = createChallenger(1L, 10L, ChallengerPart.WEB, 7L);
-        Page<Challenger> page = new PageImpl<>(List.of(c1), pageable, 1);
-
-        given(searchMemberPort.search(any(), any())).willReturn(page);
-        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "홍길동")));
-        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
-        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
-            new GisuInfo(7L, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "홍길동")));
+        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+            10L, List.of(
+                challenger(101L, 10L, 6L, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
+                challenger(102L, 10L, 7L, ChallengerPart.SPRINGBOOT, ChallengerStatus.GRADUATED),
+                challenger(103L, 10L, 8L, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE)
+            )
         ));
-        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(8L, 9L, true)));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            gisu(6L, 7L, false),
+            gisu(7L, 8L, false),
+            gisu(8L, 9L, true)
+        ));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
 
+        // when
         SearchMemberV2Result result = memberSearchService.searchByV2(
             new SearchMemberQuery(null, null, null, null, null), pageable
         );
 
+        // then: 회원 1명 = row 1개, participations에 3개 챌린저 요약
         List<SearchMemberItemV2Info> content = result.page().getContent();
         assertThat(content).hasSize(1);
-        assertThat(content.get(0).challengerStatus()).isEqualTo(ChallengerStatus.ACTIVE);
-        // 활성 기수 정보가 없으므로(휴지기) isAdminInActiveGisu는 항상 false
-        assertThat(content.get(0).isAdminInActiveGisu()).isFalse();
+        assertThat(content.get(0).memberId()).isEqualTo(10L);
+        assertThat(content.get(0).participations()).hasSize(3);
+        // primaryChallenger는 활성 기수(8L) 챌린저인 103번
+        assertThat(content.get(0).primaryChallenger().challengerId()).isEqualTo(103L);
+        assertThat(content.get(0).primaryChallenger().gisuId()).isEqualTo(8L);
     }
 
     @Test
-    void 활성기수_챌린저가_운영진이면_isAdminInActiveGisu가_true다() {
+    void 활성_기수_챌린저가_없으면_가장_최신_기수_챌린저가_대표로_선택된다() {
         Pageable pageable = PageRequest.of(0, 10);
+        Page<Long> memberIdPage = new PageImpl<>(List.of(10L), pageable, 1);
 
-        Long activeGisuId = 7L;
-        Challenger activeRow = createChallenger(1L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
-        Page<Challenger> page = new PageImpl<>(List.of(activeRow), pageable, 1);
-
-        given(searchMemberPort.search(any(), any())).willReturn(page);
-        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "운영진")));
-        // 검색결과 전체 운영진 매핑 (toItemInfoV2가 한 번, collectAdmin이 한 번 더 호출됨)
-        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
-            1L, List.of(ChallengerRoleType.SCHOOL_PRESIDENT)
+        given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "졸업자")));
+        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+            10L, List.of(
+                challenger(101L, 10L, 6L, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
+                challenger(102L, 10L, 7L, ChallengerPart.SPRINGBOOT, ChallengerStatus.GRADUATED)
+            )
         ));
+        // 활성 기수가 9L이지만 이 회원은 9L 챌린저가 없음 → 활성 기수 챌린저 부재로 운영진 조회가 호출되지 않음
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(9L, 10L, true)));
         given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
-            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
-        ));
-        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(
-            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+            gisu(6L, 7L, false),
+            gisu(7L, 8L, false)
         ));
 
         SearchMemberV2Result result = memberSearchService.searchByV2(
@@ -121,39 +138,67 @@ class MemberSearchServiceV2Test {
         );
 
         SearchMemberItemV2Info item = result.page().getContent().get(0);
-        assertThat(item.isAdminInActiveGisu()).isTrue();
-        assertThat(item.roleTypes()).containsExactly(ChallengerRoleType.SCHOOL_PRESIDENT);
+        // 가장 큰 generation(8) 챌린저가 대표 = 102L
+        assertThat(item.primaryChallenger().challengerId()).isEqualTo(102L);
+        assertThat(item.primaryChallenger().generation()).isEqualTo(8L);
+        assertThat(item.isAdminInActiveGisu()).isFalse();
     }
 
     @Test
-    void 다른_기수_챌린저_행이지만_같은_회원이_활성기수에_운영진이면_isAdminInActiveGisu_true() {
+    void 활성_기수_챌린저가_운영진이면_isAdminInActiveGisu가_true다() {
         Pageable pageable = PageRequest.of(0, 10);
+        Page<Long> memberIdPage = new PageImpl<>(List.of(10L), pageable, 1);
 
-        Long activeGisuId = 7L;
-        Challenger pastRow = createChallenger(1L, 10L, ChallengerPart.WEB, 6L); // 과거 기수 행
-        Challenger activeRow = createChallenger(2L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
-        Page<Challenger> page = new PageImpl<>(List.of(pastRow, activeRow), pageable, 2);
-
-        given(searchMemberPort.search(any(), any())).willReturn(page);
-        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "운영진")));
-        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
-            2L, List.of(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)
+        given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "운영진")));
+        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+            10L, List.of(
+                challenger(101L, 10L, 8L, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE)
+            )
         ));
-        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
-            new GisuInfo(6L, 7L, Instant.now().minusSeconds(1000), Instant.now().minusSeconds(500), false),
-            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
-        ));
-        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(
-            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
-        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(8L, 9L, true)));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(gisu(8L, 9L, true)));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet()))
+            .willReturn(Map.of(101L, List.of(ChallengerRoleType.SCHOOL_PRESIDENT)));
 
         SearchMemberV2Result result = memberSearchService.searchByV2(
             new SearchMemberQuery(null, null, null, null, null), pageable
         );
 
-        List<SearchMemberItemV2Info> content = result.page().getContent();
-        // 두 행 모두 isAdminInActiveGisu=true (회원 단위로 확장)
-        assertThat(content).extracting(SearchMemberItemV2Info::isAdminInActiveGisu)
-            .containsExactly(true, true);
+        assertThat(result.page().getContent().get(0).isAdminInActiveGisu()).isTrue();
+    }
+
+    @Test
+    void 휴지기에는_isAdminInActiveGisu가_항상_false이다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Long> memberIdPage = new PageImpl<>(List.of(10L), pageable, 1);
+
+        given(searchMemberPort.searchMemberIds(any(), any())).willReturn(memberIdPage);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, profile(10L, "회원")));
+        given(getChallengerUseCase.getAllByMemberIds(anySet())).willReturn(Map.of(
+            10L, List.of(challenger(101L, 10L, 7L, ChallengerPart.WEB, ChallengerStatus.GRADUATED))
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty()); // 휴지기
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(gisu(7L, 8L, false)));
+
+        SearchMemberV2Result result = memberSearchService.searchByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        assertThat(result.page().getContent().get(0).isAdminInActiveGisu()).isFalse();
+    }
+
+    @Test
+    void 검색결과가_비어있으면_빈_페이지를_반환한다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Long> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        given(searchMemberPort.searchMemberIds(any(), any())).willReturn(emptyPage);
+
+        SearchMemberV2Result result = memberSearchService.searchByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        assertThat(result.page().getContent()).isEmpty();
+        assertThat(result.page().getTotalElements()).isZero();
     }
 }

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchServiceV2Test.java
@@ -1,0 +1,159 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
+import com.umc.product.member.application.port.out.SearchMemberPort;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberSearchService.searchByV2 — v2 검색")
+class MemberSearchServiceV2Test {
+
+    @Mock SearchMemberPort searchMemberPort;
+    @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock GetGisuUseCase getGisuUseCase;
+
+    @InjectMocks MemberSearchService memberSearchService;
+
+    private Challenger createChallenger(Long id, Long memberId, ChallengerPart part, Long gisuId) {
+        Challenger c = Challenger.builder()
+            .memberId(memberId)
+            .part(part)
+            .gisuId(gisuId)
+            .build();
+        ReflectionTestUtils.setField(c, "id", id);
+        // status는 builder가 ACTIVE로 기본 세팅하므로 별도 ReflectionTestUtils 호출은 불요
+        return c;
+    }
+
+    private MemberInfo createProfile(Long id, String name) {
+        return MemberInfo.builder()
+            .id(id)
+            .name(name)
+            .nickname(name)
+            .email("test@test.com")
+            .schoolId(1L)
+            .schoolName("학교")
+            .status(MemberStatus.ACTIVE)
+            .build();
+    }
+
+    @Test
+    void v2_검색은_challengerStatus를_매핑한다() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Challenger c1 = createChallenger(1L, 10L, ChallengerPart.WEB, 7L);
+        Page<Challenger> page = new PageImpl<>(List.of(c1), pageable, 1);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "홍길동")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            new GisuInfo(7L, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+
+        SearchMemberV2Result result = memberSearchService.searchByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        List<SearchMemberItemV2Info> content = result.page().getContent();
+        assertThat(content).hasSize(1);
+        assertThat(content.get(0).challengerStatus()).isEqualTo(ChallengerStatus.ACTIVE);
+        // 활성 기수 정보가 없으므로(휴지기) isAdminInActiveGisu는 항상 false
+        assertThat(content.get(0).isAdminInActiveGisu()).isFalse();
+    }
+
+    @Test
+    void 활성기수_챌린저가_운영진이면_isAdminInActiveGisu가_true다() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Long activeGisuId = 7L;
+        Challenger activeRow = createChallenger(1L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
+        Page<Challenger> page = new PageImpl<>(List.of(activeRow), pageable, 1);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "운영진")));
+        // 검색결과 전체 운영진 매핑 (toItemInfoV2가 한 번, collectAdmin이 한 번 더 호출됨)
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
+            1L, List.of(ChallengerRoleType.SCHOOL_PRESIDENT)
+        ));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(
+            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        ));
+
+        SearchMemberV2Result result = memberSearchService.searchByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        SearchMemberItemV2Info item = result.page().getContent().get(0);
+        assertThat(item.isAdminInActiveGisu()).isTrue();
+        assertThat(item.roleTypes()).containsExactly(ChallengerRoleType.SCHOOL_PRESIDENT);
+    }
+
+    @Test
+    void 다른_기수_챌린저_행이지만_같은_회원이_활성기수에_운영진이면_isAdminInActiveGisu_true() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Long activeGisuId = 7L;
+        Challenger pastRow = createChallenger(1L, 10L, ChallengerPart.WEB, 6L); // 과거 기수 행
+        Challenger activeRow = createChallenger(2L, 10L, ChallengerPart.SPRINGBOOT, activeGisuId);
+        Page<Challenger> page = new PageImpl<>(List.of(pastRow, activeRow), pageable, 2);
+
+        given(searchMemberPort.search(any(), any())).willReturn(page);
+        given(getMemberUseCase.findAllByIds(anySet())).willReturn(Map.of(10L, createProfile(10L, "운영진")));
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of(
+            2L, List.of(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)
+        ));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(
+            new GisuInfo(6L, 7L, Instant.now().minusSeconds(1000), Instant.now().minusSeconds(500), false),
+            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        ));
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(
+            new GisuInfo(activeGisuId, 8L, Instant.now(), Instant.now().plusSeconds(100), true)
+        ));
+
+        SearchMemberV2Result result = memberSearchService.searchByV2(
+            new SearchMemberQuery(null, null, null, null, null), pageable
+        );
+
+        List<SearchMemberItemV2Info> content = result.page().getContent();
+        // 두 행 모두 isAdminInActiveGisu=true (회원 단위로 확장)
+        assertThat(content).extracting(SearchMemberItemV2Info::isAdminInActiveGisu)
+            .containsExactly(true, true);
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
@@ -1,0 +1,205 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerActivityPeriodUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSummary;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.GetMemberProfileUseCase;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberSummaryV2QueryService — BFF 조립")
+class MemberSummaryV2QueryServiceTest {
+
+    @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetMemberProfileUseCase getMemberProfileUseCase;
+    @Mock GetChallengerUseCase getChallengerUseCase;
+    @Mock GetGisuUseCase getGisuUseCase;
+    @Mock GetChapterUseCase getChapterUseCase;
+    @Mock GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock GetChallengerActivityPeriodUseCase getChallengerActivityPeriodUseCase;
+
+    @InjectMocks MemberSummaryV2QueryService service;
+
+    private MemberInfo member() {
+        return MemberInfo.builder()
+            .id(100L)
+            .name("홍길동")
+            .nickname("hong")
+            .email("umc@hanyang.ac.kr")
+            .schoolId(1L)
+            .schoolName("한양대 ERICA")
+            .profileImageLink(null)
+            .status(MemberStatus.ACTIVE)
+            .roles(List.of())
+            .build();
+    }
+
+    private MemberProfileInfo profile() {
+        return MemberProfileInfo.builder().build();
+    }
+
+    private ChallengerInfo challenger(Long id, Long gisuId, ChallengerStatus status) {
+        return ChallengerInfo.builder()
+            .challengerId(id)
+            .memberId(100L)
+            .gisuId(gisuId)
+            .part(ChallengerPart.SPRINGBOOT)
+            .challengerPoints(List.of())
+            .totalPoints(0.0)
+            .challengerStatus(status)
+            .build();
+    }
+
+    private GisuInfo gisu(Long gisuId, Long generation) {
+        Instant start = Instant.now().minus(60, ChronoUnit.DAYS);
+        Instant end = Instant.now().plus(120, ChronoUnit.DAYS);
+        return new GisuInfo(gisuId, generation, start, end, true);
+    }
+
+    @Test
+    void 활성기수에_ACTIVE_챌린저와_운영진_기록이_있으면_그_정보가_세팅된다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        ChallengerInfo activeChallenger = challenger(11L, 7L, ChallengerStatus.ACTIVE);
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of(activeChallenger));
+
+        GisuInfo activeGisu = gisu(7L, 8L);
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(activeGisu));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(activeGisu));
+
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(anySet(), anySet()))
+            .willReturn(Map.of(7L, Map.of(1L, new ChapterInfo(200L, "서울지부"))));
+
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet()))
+            .willReturn(Map.of(11L, List.of(ChallengerRoleType.SCHOOL_PRESIDENT)));
+
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(45L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.totalActivityDays()).isEqualTo(45L);
+        assertThat(info.currentGisuMembership()).isNotNull();
+        assertThat(info.currentGisuMembership().gisuId()).isEqualTo(7L);
+        assertThat(info.currentGisuMembership().challenger()).isNotNull();
+        assertThat(info.currentGisuMembership().challenger().challengerId()).isEqualTo(11L);
+        assertThat(info.currentGisuMembership().isAdmin()).isTrue();
+        assertThat(info.currentGisuMembership().roleTypes())
+            .containsExactly(ChallengerRoleType.SCHOOL_PRESIDENT);
+        assertThat(info.challengerHistory()).hasSize(1);
+    }
+
+    @Test
+    void 활성기수가_없으면_currentGisuMembership은_null이다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        ChallengerInfo prevChallenger = challenger(5L, 6L, ChallengerStatus.GRADUATED);
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of(prevChallenger));
+
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+
+        Instant start = Instant.now().minus(300, ChronoUnit.DAYS);
+        Instant end = Instant.now().minus(120, ChronoUnit.DAYS);
+        GisuInfo oldGisu = new GisuInfo(6L, 7L, start, end, false);
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(oldGisu));
+
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(anySet(), anySet()))
+            .willReturn(Map.of(6L, Map.of(1L, new ChapterInfo(200L, "서울지부"))));
+
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
+
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(180L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.currentGisuMembership()).isNull();
+        assertThat(info.totalActivityDays()).isEqualTo(180L);
+        assertThat(info.challengerHistory()).hasSize(1);
+    }
+
+    @Test
+    void 활성기수_챌린저가_EXPELLED면_challenger는_null이고_isAdmin은_운영진_기록을_따른다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        ChallengerInfo expelled = challenger(11L, 7L, ChallengerStatus.EXPELLED);
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of(expelled));
+
+        GisuInfo activeGisu = gisu(7L, 8L);
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(activeGisu));
+        given(getGisuUseCase.getByIds(anySet())).willReturn(List.of(activeGisu));
+
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(anySet(), anySet()))
+            .willReturn(Map.of(7L, Map.of(1L, new ChapterInfo(200L, "서울지부"))));
+
+        // 활성 기수에 운영진 기록이 없음
+        given(getChallengerRoleUseCase.getAllRoleTypesByChallengerIds(anySet())).willReturn(Map.of());
+
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(0L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.currentGisuMembership()).isNotNull();
+        assertThat(info.currentGisuMembership().challenger()).isNull();
+        assertThat(info.currentGisuMembership().isAdmin()).isFalse();
+        assertThat(info.totalActivityDays()).isZero();
+    }
+
+    @Test
+    void 챌린저_이력이_없는_신규_회원도_정상_응답된다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of());
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.of(gisu(7L, 8L)));
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(0L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.challengerHistory()).isEmpty();
+        assertThat(info.totalActivityDays()).isZero();
+        // 활성 기수가 있어도, 본인 챌린저/운영진 기록이 없으면 isAdmin=false + challenger=null
+        assertThat(info.currentGisuMembership()).isNotNull();
+        assertThat(info.currentGisuMembership().challenger()).isNull();
+        assertThat(info.currentGisuMembership().isAdmin()).isFalse();
+        assertThat(info.currentGisuMembership().roleTypes()).isEmpty();
+    }
+}

--- a/src/test/java/com/umc/product/organization/domain/GisuActivityDaysTest.java
+++ b/src/test/java/com/umc/product/organization/domain/GisuActivityDaysTest.java
@@ -1,0 +1,78 @@
+package com.umc.product.organization.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Gisu.activityDays 도메인 메서드")
+class GisuActivityDaysTest {
+
+    private static final Instant START = Instant.parse("2026-03-01T00:00:00Z");
+    private static final Instant END = Instant.parse("2026-09-01T00:00:00Z");
+
+    private Gisu createGisu() {
+        return Gisu.create(7L, START, END, true);
+    }
+
+    @Test
+    void now가_시작일_이전이면_0일을_반환한다() {
+        Gisu gisu = createGisu();
+        Instant before = START.minus(10, ChronoUnit.DAYS);
+
+        long days = gisu.activityDays(before);
+
+        assertThat(days).isZero();
+    }
+
+    @Test
+    void now가_시작일_직전_경계이면_0일을_반환한다() {
+        Gisu gisu = createGisu();
+
+        long days = gisu.activityDays(START.minusNanos(1));
+
+        assertThat(days).isZero();
+    }
+
+    @Test
+    void now가_시작일_정각이면_0일을_반환한다() {
+        Gisu gisu = createGisu();
+
+        long days = gisu.activityDays(START);
+
+        assertThat(days).isZero();
+    }
+
+    @Test
+    void 진행중인_기수는_now까지의_일수를_반환한다() {
+        Gisu gisu = createGisu();
+        Instant midway = START.plus(45, ChronoUnit.DAYS);
+
+        long days = gisu.activityDays(midway);
+
+        assertThat(days).isEqualTo(45L);
+    }
+
+    @Test
+    void 종료된_기수는_전체_기간을_반환한다() {
+        Gisu gisu = createGisu();
+        Instant afterEnd = END.plus(30, ChronoUnit.DAYS);
+
+        long days = gisu.activityDays(afterEnd);
+
+        long expected = ChronoUnit.DAYS.between(START, END);
+        assertThat(days).isEqualTo(expected);
+    }
+
+    @Test
+    void now가_정확히_종료일이면_전체_기간을_반환한다() {
+        Gisu gisu = createGisu();
+
+        long days = gisu.activityDays(END);
+
+        long expected = ChronoUnit.DAYS.between(START, END);
+        assertThat(days).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요.

## 🔥 연관 이슈

- resolves #(이슈 번호 추후 첨부)

## 🚀 작업 내용

### 누가/언제 — 본 PR로 어디까지

프로덕트팀 채널의 회원 도메인 BFF 도입 논의에 따라, 회원 정보 화면 한 호출에 필요한 데이터를 모두 모아 내려주는 v2 API들을 추가했어요. 동시에 v1 회원 조회 응답에 있던 N+1, 검색 응답의 이메일 평문 노출, 그리고 검색 시 같은 회원이 여러 row로 보이던 UX 문제까지 같은 PR에서 정리했어요.

### 무엇을

1. **`GET /api/v2/member/me` 신설** — BFF 단일 엔드포인트
   - 기본 프로필 + 소셜 링크 (`MemberInfo`, `MemberProfileInfo`)
   - **`totalActivityDays`**: 모든 참여 기수의 활동 기간을 `Instant.now()` 기준으로 합산
     - `ChallengerStatus`가 `ACTIVE` 또는 `GRADUATED`인 기수만 합산
     - 진행 중인 기수는 `min(now, gisu.endAt) - gisu.startAt`
   - **`currentGisuMemberInfo`** (휴지기에는 `null`)
     - `gisuId`, `generation` — 활성 기수 정보
     - `challenger` — 활성 기수의 **ACTIVE** 챌린저 신분 (없으면 `null`)
     - `isAdmin` — 활성 기수에 `ChallengerRole` 레코드가 하나라도 있는지
     - `roleTypes` — 보유한 운영진 RoleType 전체
   - **`challengerHistory`** — 모든 기수 챌린저 이력 (`generation` 내림차순). 기수별 `points[]`, `totalPoints` 포함.

2. **`GET /api/v2/member/search` 신설 — 회원 단위 검색**
   - 같은 회원이 여러 기수 챌린저 이력을 가져도 **1개 row**로만 반환됩니다.
   - 응답: 회원 기본 정보 + `primaryChallenger` (활성 기수 우선 > 최신 기수) + `isAdminInActiveGisu` boolean + `participations` 챌린저 이력 요약 리스트.
   - Repository에서 `selectDistinct(member.id)` + `member.id.countDistinct()`로 회원 단위 페이지네이션.
   - 정렬: `member.schoolId asc, member.name asc, member.id asc`.

3. **`GET /api/v2/challenger/search` 신설 — 챌린저 단위 검색**
   - 같은 회원이 여러 기수에 참여했다면 **기수별 챌린저가 각각 별도 row**로 반환됩니다.
   - v1 검색 응답 필드 + `challengerStatus` + `isAdminInActiveGisu`(회원 단위로 확장).
   - 검색 조건은 회원 검색과 동일한 키워드/필터 사용 (`SearchMemberQuery`).
   - 컨트롤러는 challenger 도메인에 두되 service는 member 도메인의 `SearchMemberUseCase`를 호출 (cross-domain UseCase 호출 패턴).

4. **검색 응답 이메일 마스킹 — v1·v2 양쪽 모두 적용**
   - 본인 외 회원이 결과에 포함되므로 로그인 식별자인 이메일은 컨트롤러 단에서 마스킹.
   - `global/util/EmailMasker`: 로컬 파트 길이에 따라 앞 1~3글자만 남기고 나머지 `*`. 도메인은 그대로.
   - `SearchMemberResponse.withMaskedEmails()`, `SearchMemberV2Response.withMaskedEmails()`, `ChallengerSearchV2Response.withMaskedEmails()` 각각 추가. v1·v2 컨트롤러가 직접 호출.
   - `/me`는 본인 정보 응답이므로 마스킹 대상에서 제외.
   - 예: `donggukcd200@gmail.com` → `don*********@gmail.com`

5. **`Gisu` 도메인에 `activityDays(Instant now)` 추가**
   - now < startAt → 0
   - startAt ≤ now < endAt → `Duration.between(startAt, now).toDays()`
   - now ≥ endAt → 전체 기수 기간
   - `GisuInfo`에도 동일 헬퍼 추가 (record 위에서 직접 호출 가능)

6. **`GetGisuUseCase.findActiveGisu(): Optional<GisuInfo>` 시그니처 추가**
   - 휴지기에 예외 대신 `Optional.empty()` 반환

7. **`GetChallengerActivityPeriodUseCase` + `ChallengerActivityPeriodService` 신설** (challenger 도메인)
   - `getActivityPeriodByMemberId(memberId)` — 단독 호출용 (내부에서 chal/gisu 조회)
   - `calculateActivityPeriod(challengers, gisuInfosByGisuId)` — BFF가 사전-fetch한 데이터로 계산 (중복 쿼리 회피)

8. **`ChallengerQueryService.getAllByMemberId` N+1 해소**
   - 기존: stream 내부에서 `getListByChallengerId` 챌린저당 1회 호출 → 4 기수면 점수 쿼리 4회
   - 변경: 같은 파일에 이미 존재하던 `toChallengerInfoListBatch`(IN 쿼리 1회)로 교체
   - 호출처 영향: `MemberInfoResponseAssembler`, `ChallengerResponseAssembler`, `AuthorizationService`, `CommunityPostPermissionEvaluator`, `CommunityCommentPermissionEvaluator`, `ScheduleCapabilitiesService` — 결과 형태 동일, 성능만 개선

9. **`GetChallengerUseCase.getAllByMemberIds(Set<Long>)` batch 신설** (회원 검색 v2용)
   - 회원별 모든 챌린저를 IN 쿼리 1회로 일괄 조회

10. **v1 N+1 해소 (T1)**
    - `MemberInfoResponseAssembler.fromMemberId` — gisu/chapter 챌린저당 호출 → batch 1회
    - `ChallengerResponseAssembler.fromMemberId` — 동일하게 batch 처리

### 왜 (의사결정, /plan-eng-review + outside voice + 추가 결정)

| # | 결정 | 채택 이유 |
|---|---|---|
| D1 | Hybrid 배치 (도메인 계산은 UseCase, 조립은 application Service) | CLAUDE.md "NO God Services", CQRS 명확. 단일 readOnly 트랜잭션이 필요해 BFF 조립을 application Service로 끌어올림 |
| D2 | 활동일 = `ACTIVE` + `GRADUATED`만 합산 | EXPELLED/WITHDRAWN은 멤버십이 공식 종료 → 활동일 의미와 부합. `leftAt` 컬럼 도입 전의 보수적 근사 |
| D3 | 기수별 합산 + 활성 기수 강조. 전체 누적 X | 상벌점은 기수 생명주기와 함께. 전체 누적은 운영 의미 없음 |
| D4 | search v2 = `challengerStatus` + `isAdminInActiveGisu(boolean)` | 검색은 식별 화면. 활동일/점수는 클릭→/me에서 |
| D5 | `findActiveGisu(): Optional<GisuInfo>` UseCase 시그니처 신설 | 휴지기 정상 응답 |
| D6 | `currentGisuMemberInfo` 중첩 객체 + `isAdmin`/`roleTypes` 같이 제공 | 그룹 의미 명확. 휴지기 = 객체 자체 null로 한 줄 분기 |
| D7 | 단일 `/api/v2/member/me` 엔드포인트 | BFF 원칙. RTT 1회 + 시점 일관성 |
| D8 | `Gisu.activityDays(Instant)` 도메인 + `GetChallengerActivityPeriodUseCase` | 도메인 경계와 일치. 호출자가 데이터를 사전-fetch해 중복 쿼리 회피 가능 |
| D9 | `MemberSummaryV2Response` 단일 파일 + inner record | 기존 `SearchMemberResponse` 관례와 일치 |
| D10 | v2 전용 `ChallengerHistoryV2` inner record | v1 `ChallengerInfoResponse`의 호환용 중복 필드를 v2에 전염시키지 않음 |
| D11 | `currentGisuMemberInfo.challenger`는 ACTIVE일 때만 세팅 | 제명/탈퇴자가 "현재 챌린저"로 표시되는 오류 방지 |
| D12 | 회원 단위 search v2와 챌린저 단위 search v2를 별도 endpoint로 분리 | v1 검색이 챌린저 단위 row라 같은 회원이 여러 번 노출되던 UX 문제 → "회원을 찾는 검색"(`/api/v2/member/search`)과 "챌린저 행을 찾는 검색"(`/api/v2/challenger/search`)을 의미별로 분리 |
| D13 | `ChallengerQueryService.getAllByMemberId` 같은 PR에서 batch 패턴으로 | 같은 파일에 이미 batch 헬퍼 존재. v1 성능도 동시 개선 |
| 추가 | v1·v2 search 응답 이메일 마스킹 | 이메일이 로그인 식별자라 평문 노출은 credential stuffing·피싱 표적화 위험 |

### 외부 시각(Outside Voice) 검증 & 반영

1. **활동일 D2/D8 모순 (P1)**
   - 지적: GRADUATED 챌린저는 `gisu.endAt`까지 활동일을 받음 → 졸업 후 휴지기간이 활동일에 산입될 수 있음
   - 대응: 본 PR은 `leftAt` 컬럼 도입 전의 보수적 근사임을 명시. 정확한 추적은 별도 PR (NOT in scope)

2. **D5 시그니처 충돌 (P1)**
   - 지적: Port의 기존 `findActiveGisu()`(throw)와 UseCase의 새 `findActiveGisu(): Optional` 같은 이름
   - 대응: Port의 컨벤션 위반 메서드명을 같이 정리해 `getActiveGisu(): Gisu` (throw) + `findActiveGisu(): Optional<Gisu>`로 통일

3. **D13 회귀 영향 (P1)**
   - 지적: `getAllByMemberId` batch 교체가 권한 평가(`AuthorizationService`) 등 hot path에 영향
   - 대응: 호출처 6곳 모두 확인. 4곳은 `.isEmpty()`만, 2곳은 결과 형태 동일하며 점수 추가 로드돼도 사용 안 함. 영향 없음

4. **D8 시그니처 모호함 (P2)**
   - 지적: `summarize(memberId)`로 표기되면 BFF 호출 시 chal/gisu 중복 fetch 위험
   - 대응: 두 시그니처로 분리. `getActivityPeriodByMemberId(memberId)`(단독) + `calculateActivityPeriod(challengers, gisus)`(사전-fetch). BFF는 후자 사용

5. **트랜잭션 경계 (P2)**
   - 지적: Assembler를 `@Component`로 두면 8개 UseCase가 8개 분리된 트랜잭션
   - 대응: BFF 조립 로직을 `MemberSummaryV2QueryService`(`@Service` + `@Transactional(readOnly=true)`)로 이동

6. **F9 누락 — GRADUATED 운영진 케이스 (P2)**
   - 지적: 실패 모드에 "활성 기수에 GRADUATED + 운영진" 케이스 누락
   - 대응: D11 정의로 `challenger=null` + `isAdmin=true` 처리. 단위 테스트 포함

### 어떻게 — 데이터 흐름

```
GET /api/v2/member/me
       ↓
[MemberQueryV2Controller]
       ↓
[MemberSummaryV2QueryService] (@Transactional readOnly)
       ├── GetMemberUseCase.getById
       ├── GetMemberProfileUseCase
       ├── GetChallengerUseCase.getAllByMemberId (D13 batch)
       ├── GetGisuUseCase.findActiveGisu() ── Optional<GisuInfo>
       ├── GetGisuUseCase.getByIds(gisuIds) ← batch
       ├── GetChapterUseCase.getChapterMapByGisuIdsAndSchoolIds ← batch
       ├── GetChallengerRoleUseCase.getAllRoleTypesByChallengerIds ← batch
       └── GetChallengerActivityPeriodUseCase.calculateActivityPeriod(challengers, gisuMap)
       ↓
MemberSummaryV2Response

GET /api/v2/member/search   (회원 단위)
       ↓
SearchMemberPort.searchMemberIds → Page<Long>
       ↓
GetMemberUseCase.findAllByIds + GetChallengerUseCase.getAllByMemberIds (batch)
+ GetGisuUseCase.getByIds + 활성기수 운영진 산출
       ↓ .withMaskedEmails()
회원 1명 = row 1개 + primaryChallenger + participations

GET /api/v2/challenger/search   (챌린저 단위)
       ↓
SearchMemberPort.search → Page<Challenger>
       ↓ v1 동일 로직 + challengerStatus + isAdminInActiveGisu(회원 단위 확장)
       ↓ .withMaskedEmails()
챌린저 1개 = row 1개
```

### NOT in scope

- `ChallengerInfoResponse` deprecated 중복 필드 제거 — 호환성 영향. 별도 PR.
- `Challenger.leftAt` 컬럼 추가 — 활동일 정확도 향상. 별도 PR.
- v1 `/api/v1/member/me`, `/api/v1/member/search`의 deprecation — v2 안정화 후.
- v1·v2 `/search` 권한 강화 (`@CheckAccess` 등) — 정책 합의 필요.
- HTTP cache header, ETag.

## 💬 리뷰 중점사항

1. **D2 활동일 의미 가정**: GRADUATED 챌린저는 `gisu.endAt`까지를 활동일로 봅니다. 정확한 추적은 후속 `leftAt` PR로.
2. **D11 ACTIVE 챌린저만 currentGisuMemberInfo.challenger 세팅**: 활성 기수에 EXPELLED/WITHDRAWN 챌린저 레코드가 있어도 `challenger=null`. 클라이언트가 history에서 상태 확인 필요.
3. **검색 endpoint 분리 (D12)**: `/api/v2/member/search`(회원 단위) ↔ `/api/v2/challenger/search`(챌린저 단위). 검색 의도별로 분리되어 같은 회원이 여러 번 노출되는 v1 문제가 회원 단위 쪽에서 해소됨.
4. **`isAdminInActiveGisu` 회원 단위 확장**: 두 검색 모두 다른 기수 행이라도 같은 회원이 활성 기수에 운영진 기록 있으면 `true`. 검색 UX 의도 확인 부탁.
5. **이메일 마스킹 규칙**: 로컬 길이 1은 원문 유지, 2~3은 앞 1글자 + `*`, 4 이상은 앞 3글자 + `*`. 도메인은 그대로.
6. **N+1 해소 hot path 영향**: 권한 평가 등에서 `getAllByMemberId` 호출 시 점수가 추가로 IN 쿼리 1번 실행돼요. 기능 영향 없지만 성능 모니터링 권장.