### PR TITLE
[Feat] 로그인 시 ClientType를 함께 전송하도록 변경

### DIFF
--- a/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/AuthenticationController.java
@@ -12,6 +12,7 @@ import com.umc.product.authentication.application.port.in.command.dto.Authorizat
 import com.umc.product.authentication.application.port.in.command.dto.OAuthTokenLoginResult;
 import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.annotation.Public;
@@ -38,7 +39,7 @@ public class AuthenticationController implements AuthenticationControllerInterfa
     public OAuthLoginResponse googleOAuthLogin(
         @RequestBody GoogleLoginRequest request
     ) {
-        return processAccessTokenLogin(OAuthProvider.GOOGLE, request.accessToken());
+        return processAccessTokenLogin(OAuthProvider.GOOGLE, request.accessToken(), request.clientType());
     }
 
     @Override
@@ -47,7 +48,7 @@ public class AuthenticationController implements AuthenticationControllerInterfa
     public OAuthLoginResponse kakaoOAuthLogin(
         @RequestBody KakaoLoginRequest request
     ) {
-        return processAccessTokenLogin(OAuthProvider.KAKAO, request.accessToken());
+        return processAccessTokenLogin(OAuthProvider.KAKAO, request.accessToken(), request.clientType());
     }
 
     @Override
@@ -64,7 +65,7 @@ public class AuthenticationController implements AuthenticationControllerInterfa
             )
         );
 
-        return buildLoginResponse(OAuthProvider.KAKAO, result);
+        return buildLoginResponse(OAuthProvider.KAKAO, result, null, request.clientType());
     }
 
     @Override
@@ -86,34 +87,36 @@ public class AuthenticationController implements AuthenticationControllerInterfa
             );
         }
 
-        return buildLoginResponse(OAuthProvider.APPLE, result, codeResult.refreshToken());
+        return buildLoginResponse(OAuthProvider.APPLE, result, codeResult.refreshToken(), request.clientType());
     }
 
     /**
-     * Access Token 기반 OAuth 로그인 처리
+     * Access Token 기반 OAuth 로그인 처리.
+     *
+     * @param clientType 클라이언트 플랫폼. 도입 이전 클라이언트 호환을 위해 nullable.
      */
-    private OAuthLoginResponse processAccessTokenLogin(OAuthProvider provider, String token) {
+    private OAuthLoginResponse processAccessTokenLogin(OAuthProvider provider, String token, ClientType clientType) {
         OAuthTokenLoginResult result = oAuthAuthenticationUseCase.accessTokenLogin(
             new AccessTokenLoginCommand(provider, token)
         );
 
-        return buildLoginResponse(provider, result);
+        return buildLoginResponse(provider, result, null, clientType);
     }
 
     /**
-     * OAuthTokenLoginResult를 기반으로 OAuthLoginResponse를 생성합니다.
+     * OAuthTokenLoginResult 를 기반으로 OAuthLoginResponse 를 생성합니다.
+     *
+     * @param clientType 클라이언트 플랫폼. nullable — null 인 경우 AT claim 에 포함되지 않으며
+     *                   다운스트림 통계에서는 "UNKNOWN" 으로 집계된다.
      */
-    private OAuthLoginResponse buildLoginResponse(OAuthProvider provider, OAuthTokenLoginResult result) {
-        return buildLoginResponse(provider, result, null);
-    }
-
     private OAuthLoginResponse buildLoginResponse(OAuthProvider provider, OAuthTokenLoginResult result,
-                                                  String appleRefreshToken) {
+                                                  String appleRefreshToken, ClientType clientType) {
         if (result.isExistingMember()) {
             // 기존 회원: JWT 발급
             String accessToken = jwtTokenProvider.createAccessToken(
                 result.memberId(),
-                Collections.emptyList()
+                Collections.emptyList(),
+                clientType
             );
             String refreshToken = jwtTokenProvider.createRefreshToken(result.memberId());
 

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
@@ -96,7 +96,8 @@ public class CredentialAuthenticationController {
     @Public
     @PostMapping("/login/email")
     @Operation(summary = "[LOGIN-006] 이메일/PW 로그인",
-        description = "email/password 로 인증하여 AccessToken/RefreshToken 을 발급받습니다.")
+        description = "email/password 로 인증하여 AccessToken/RefreshToken 을 발급받습니다. "
+            + "clientType(ANDROID, IOS, WEB)을 함께 전달하면 AccessToken claim 으로 반영됩니다.")
     public IdPwLoginResponse loginByEmail(
         @Valid @RequestBody LoginByEmailRequest request
     ) {

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java
@@ -5,9 +5,9 @@ import com.umc.product.authentication.adapter.in.web.dto.request.LoginByEmailReq
 import com.umc.product.authentication.adapter.in.web.dto.request.RegisterCredentialRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.ResetPasswordByEmailRequest;
 import com.umc.product.authentication.adapter.in.web.dto.response.EmailAvailabilityResponse;
-import com.umc.product.authentication.adapter.in.web.dto.response.IdPwLoginResponse;
+import com.umc.product.authentication.adapter.in.web.dto.response.LocalLoginResponse;
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
-import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
+import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
 import com.umc.product.authentication.application.port.in.query.CheckCredentialAvailabilityUseCase;
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -98,10 +98,10 @@ public class CredentialAuthenticationController {
     @Operation(summary = "[LOGIN-006] 이메일/PW 로그인",
         description = "email/password 로 인증하여 AccessToken/RefreshToken 을 발급받습니다. "
             + "clientType(ANDROID, IOS, WEB)을 함께 전달하면 AccessToken claim 으로 반영됩니다.")
-    public IdPwLoginResponse loginByEmail(
+    public LocalLoginResponse loginByEmail(
         @Valid @RequestBody LoginByEmailRequest request
     ) {
-        IdPwLoginResult result = credentialAuthenticationUseCase.loginByEmail(request.toCommand());
-        return IdPwLoginResponse.from(result);
+        LocalLoginResult result = credentialAuthenticationUseCase.loginByEmail(request.toCommand());
+        return LocalLoginResponse.from(result);
     }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/GoogleLoginRequest.java
@@ -1,6 +1,13 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
+import com.umc.product.common.domain.enums.ClientType;
+
 public record GoogleLoginRequest(
-    String accessToken
+    String accessToken,
+
+    // 클라이언트 플랫폼(ANDROID/IOS/WEB). 트래픽 분포 분석을 위해 AT claim 으로 흘려보낸다.
+    // 도입 이전 클라이언트 호환을 위해 nullable. 누락 시 AT claim 자체가 생략되며
+    // 다운스트림 (MDC / 통계) 에서는 "UNKNOWN" 으로 집계된다.
+    ClientType clientType
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoCodeLoginRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoCodeLoginRequest.java
@@ -1,5 +1,6 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
+import com.umc.product.common.domain.enums.ClientType;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -11,6 +12,11 @@ import jakarta.validation.constraints.NotBlank;
  */
 public record KakaoCodeLoginRequest(
     @NotBlank String authorizationCode,
-    @NotBlank String redirectUri
+    @NotBlank String redirectUri,
+
+    // 클라이언트 플랫폼(ANDROID/IOS/WEB). 트래픽 분포 분석을 위해 AT claim 으로 흘려보낸다.
+    // 도입 이전 클라이언트 호환을 위해 nullable. 누락 시 AT claim 자체가 생략되며
+    // 다운스트림 (MDC / 통계) 에서는 "UNKNOWN" 으로 집계된다.
+    ClientType clientType
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/KakaoLoginRequest.java
@@ -1,6 +1,13 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
+import com.umc.product.common.domain.enums.ClientType;
+
 public record KakaoLoginRequest(
-    String accessToken
+    String accessToken,
+
+    // 클라이언트 플랫폼(ANDROID/IOS/WEB). 트래픽 분포 분석을 위해 AT claim 으로 흘려보낸다.
+    // 도입 이전 클라이언트 호환을 위해 nullable. 누락 시 AT claim 자체가 생략되며
+    // 다운스트림 (MDC / 통계) 에서는 "UNKNOWN" 으로 집계된다.
+    ClientType clientType
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/LoginByEmailRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/LoginByEmailRequest.java
@@ -1,18 +1,23 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
 import com.umc.product.authentication.application.port.in.command.dto.LoginByEmailCommand;
+import com.umc.product.common.domain.enums.ClientType;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginByEmailRequest(
     @NotBlank String email,
-    @NotBlank String password
+    @NotBlank String password,
+
+    // 클라이언트 플랫폼(ANDROID/IOS/WEB). 트래픽 분포 분석을 위해 AT claim 으로 흘려보낸다.
+    // 도입 이전 클라이언트 호환을 위해 nullable. 누락 시 다운스트림(MDC / 통계)에서는 "UNKNOWN" 으로 집계된다.
+    ClientType clientType
 ) {
     public LoginByEmailCommand toCommand() {
-        return LoginByEmailCommand.of(this.email, this.password);
+        return LoginByEmailCommand.of(this.email, this.password, this.clientType);
     }
 
     @Override
     public String toString() {
-        return "LoginByEmailRequest[email=" + email + ", password=***]";
+        return "LoginByEmailRequest[email=" + email + ", password=***, clientType=" + clientType + "]";
     }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/response/LocalLoginResponse.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/response/LocalLoginResponse.java
@@ -1,16 +1,16 @@
 package com.umc.product.authentication.adapter.in.web.dto.response;
 
-import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
+import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
 import lombok.Builder;
 
 @Builder
-public record IdPwLoginResponse(
+public record LocalLoginResponse(
     Long memberId,
     String accessToken,
     String refreshToken
 ) {
-    public static IdPwLoginResponse from(IdPwLoginResult result) {
-        return IdPwLoginResponse.builder()
+    public static LocalLoginResponse from(LocalLoginResult result) {
+        return LocalLoginResponse.builder()
             .memberId(result.memberId())
             .accessToken(result.accessToken())
             .refreshToken(result.refreshToken())

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/CredentialAuthenticationUseCase.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/CredentialAuthenticationUseCase.java
@@ -1,7 +1,7 @@
 package com.umc.product.authentication.application.port.in.command;
 
 import com.umc.product.authentication.application.port.in.command.dto.ChangePasswordCommand;
-import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
+import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
 import com.umc.product.authentication.application.port.in.command.dto.LoginByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.RegisterCredentialByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.ResetPasswordByEmailCommand;
@@ -38,5 +38,5 @@ public interface CredentialAuthenticationUseCase {
      * 이메일/PW 로그인. 성공 시 JWT 토큰 쌍을 발급하며,
      * 해시 파라미터가 갱신 대상이면 transparent rehash 를 수행한다.
      */
-    IdPwLoginResult loginByEmail(LoginByEmailCommand command);
+    LocalLoginResult loginByEmail(LoginByEmailCommand command);
 }

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LocalLoginResult.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LocalLoginResult.java
@@ -6,7 +6,7 @@ import lombok.Builder;
  * ID/PW 로그인 성공 결과. JWT 발급은 Service 가 담당하며 본 DTO 는 그 결과만 운반한다.
  */
 @Builder
-public record IdPwLoginResult(
+public record LocalLoginResult(
     Long memberId,
     String accessToken,
     String refreshToken

--- a/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LoginByEmailCommand.java
+++ b/src/main/java/com/umc/product/authentication/application/port/in/command/dto/LoginByEmailCommand.java
@@ -1,5 +1,7 @@
 package com.umc.product.authentication.application.port.in.command.dto;
 
+import com.umc.product.common.domain.enums.ClientType;
+
 /**
  * 이메일/PW 로그인 커맨드.
  * <p>
@@ -8,14 +10,19 @@ package com.umc.product.authentication.application.port.in.command.dto;
  */
 public record LoginByEmailCommand(
     String email,
-    String rawPassword
+    String rawPassword,
+    ClientType clientType
 ) {
     public static LoginByEmailCommand of(String email, String rawPassword) {
-        return new LoginByEmailCommand(email, rawPassword);
+        return of(email, rawPassword, null);
+    }
+
+    public static LoginByEmailCommand of(String email, String rawPassword, ClientType clientType) {
+        return new LoginByEmailCommand(email, rawPassword, clientType);
     }
 
     @Override
     public String toString() {
-        return "LoginByEmailCommand[email=" + email + ", rawPassword=***]";
+        return "LoginByEmailCommand[email=" + email + ", rawPassword=***, clientType=" + clientType + "]";
     }
 }

--- a/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
@@ -110,7 +110,11 @@ public class CredentialAuthenticationService implements CredentialAuthentication
 
         // 4) 토큰 발급
         Long memberId = credential.memberId();
-        String accessToken = jwtTokenProvider.createAccessToken(memberId, Collections.emptyList());
+        String accessToken = jwtTokenProvider.createAccessToken(
+            memberId,
+            Collections.emptyList(),
+            command.clientType()
+        );
         String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
 
         return IdPwLoginResult.builder()

--- a/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
@@ -2,7 +2,7 @@ package com.umc.product.authentication.application.service;
 
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.ChangePasswordCommand;
-import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
+import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
 import com.umc.product.authentication.application.port.in.command.dto.LoginByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.RegisterCredentialByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.ResetPasswordByEmailCommand;
@@ -88,7 +88,7 @@ public class CredentialAuthenticationService implements CredentialAuthentication
 
     @Override
     @Transactional(readOnly = true)
-    public IdPwLoginResult loginByEmail(LoginByEmailCommand command) {
+    public LocalLoginResult loginByEmail(LoginByEmailCommand command) {
         // 1) 자격증명 조회: 부재 / 실패 모두 동일 메시지로 처리하여 사용자 열거 공격을 방지한다.
         Optional<MemberCredentialInfo> credentialOpt =
             getMemberCredentialUseCase.findCredentialByEmail(command.email());
@@ -117,7 +117,7 @@ public class CredentialAuthenticationService implements CredentialAuthentication
         );
         String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
 
-        return IdPwLoginResult.builder()
+        return LocalLoginResult.builder()
             .memberId(memberId)
             .accessToken(accessToken)
             .refreshToken(refreshToken)

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -51,6 +51,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
     private static final String EVENT_REQUEST_STARTED = "api_request_started";
     private static final String EVENT_REQUEST_COMPLETED = "api_request_completed";
+    private static final String UNKNOWN = "UNKNOWN";
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -65,6 +66,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
         MDC.put(MDC_METHOD, request.getMethod());
         MDC.put(MDC_PATH, request.getRequestURI());
+        MDC.put(MDC_CLIENT_TYPE, UNKNOWN);
 
         // Micrometer Tracing 이 채워 둔 traceId 를 FE 디버깅용으로 응답 헤더에 노출.
         // 별도 requestId UUID 는 발급하지 않는다 (FE 호환성 — X-Trace-Id 가 이미 사용 중).
@@ -74,8 +76,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
         }
 
         // 인증된 사용자라면 memberId / clientType 을 MDC 에 등록.
-        // 익명 사용자 또는 도입 이전 발급 토큰은 키를 비워둔다 —
-        // Loki 에서 `memberId is null` / `clientType is null` 로 식별 가능.
+        // clientType 이 없으면 UNKNOWN 으로 남겨 메트릭에서 누락 트래픽을 집계할 수 있게 한다.
         putMemberContextToMdcIfAuthenticated();
 
         // ADR-016 §MDC 키 표준: api_request_completed 와 동일하게 event 필드를 채워
@@ -97,9 +98,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
      *
      * <p>서비스 도메인 명명을 그대로 사용 (`userId` 가 아니라 `memberId`).
      *
-     * <p>{@code clientType} 은 OAuth 로그인 시 클라이언트가 선택적으로 전달한 플랫폼 정보를
-     * AT claim 으로 받아온 값이다. 도입 이전 발급 토큰 / 비-OAuth 경로 토큰의 경우 null 이며,
-     * 이 때는 MDC 키 자체를 비워두어 Loki/대시보드에서 미설정 트래픽을 구분 집계할 수 있게 한다.
+     * <p>{@code clientType} 은 로그인 시 클라이언트가 선택적으로 전달한 플랫폼 정보를
+     * AT claim 으로 받아온 값이다. 도입 이전 발급 토큰 / 누락된 클라이언트는 UNKNOWN 으로 남겨
+     * Loki/대시보드에서 미설정 트래픽을 구분 집계할 수 있게 한다.
      *
      * <p>Filter 가 아니라 Interceptor 에서 채우는 이유:
      * <ul>

--- a/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
+++ b/src/main/java/com/umc/product/global/config/LoggingInterceptor.java
@@ -36,6 +36,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
     // ===== MDC keys (ADR-016 §MDC 키 표준) =====
     private static final String MDC_MEMBER_ID = "memberId";
+    private static final String MDC_CLIENT_TYPE = "clientType";
     private static final String MDC_METHOD = "method";
     private static final String MDC_PATH = "path";
     private static final String MDC_URI_TEMPLATE = "uriTemplate";
@@ -72,9 +73,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
             response.setHeader(TRACE_ID_HEADER, traceId);
         }
 
-        // 인증된 사용자라면 memberId 를 MDC 에 등록.
-        // 익명 사용자는 비워둔다 — Loki 에서 `memberId is null` 로 익명 트래픽을 식별한다.
-        putMemberIdToMdcIfAuthenticated();
+        // 인증된 사용자라면 memberId / clientType 을 MDC 에 등록.
+        // 익명 사용자 또는 도입 이전 발급 토큰은 키를 비워둔다 —
+        // Loki 에서 `memberId is null` / `clientType is null` 로 식별 가능.
+        putMemberContextToMdcIfAuthenticated();
 
         // ADR-016 §MDC 키 표준: api_request_completed 와 동일하게 event 필드를 채워
         // LogQL `| json | event="api_request_started"` 필터링이 가능하도록 한다.
@@ -90,9 +92,14 @@ public class LoggingInterceptor implements HandlerInterceptor {
     }
 
     /**
-     * SecurityContextHolder 에서 인증된 {@link MemberPrincipal} 을 조회해 MDC {@code memberId} 를 채운다.
+     * SecurityContextHolder 에서 인증된 {@link MemberPrincipal} 을 조회해
+     * MDC {@code memberId} 와 {@code clientType} 을 채운다.
      *
      * <p>서비스 도메인 명명을 그대로 사용 (`userId` 가 아니라 `memberId`).
+     *
+     * <p>{@code clientType} 은 OAuth 로그인 시 클라이언트가 선택적으로 전달한 플랫폼 정보를
+     * AT claim 으로 받아온 값이다. 도입 이전 발급 토큰 / 비-OAuth 경로 토큰의 경우 null 이며,
+     * 이 때는 MDC 키 자체를 비워두어 Loki/대시보드에서 미설정 트래픽을 구분 집계할 수 있게 한다.
      *
      * <p>Filter 가 아니라 Interceptor 에서 채우는 이유:
      * <ul>
@@ -100,13 +107,16 @@ public class LoggingInterceptor implements HandlerInterceptor {
      *     <li>인증 책임은 Filter, 로그 컨텍스트 책임은 Interceptor 로 분리된다.</li>
      * </ul>
      */
-    private void putMemberIdToMdcIfAuthenticated() {
+    private void putMemberContextToMdcIfAuthenticated() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             return;
         }
         if (authentication.getPrincipal() instanceof MemberPrincipal memberPrincipal) {
             MDC.put(MDC_MEMBER_ID, String.valueOf(memberPrincipal.getMemberId()));
+            if (memberPrincipal.getClientType() != null) {
+                MDC.put(MDC_CLIENT_TYPE, memberPrincipal.getClientType().name());
+            }
         }
     }
 

--- a/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 if (jwtTokenProvider.validateAccessToken(token)) {
                     Long memberId = jwtTokenProvider.parseAccessToken(token);
                     List<String> roles = jwtTokenProvider.getRolesFromAccessToken(token);
-                    // clientType 은 도입 이전 토큰이나 비-OAuth 경로로 발급된 토큰에서는 null 일 수 있다.
+                    // clientType 은 도입 이전 토큰이나 claim 누락 토큰에서는 null 일 수 있다.
                     ClientType clientType = jwtTokenProvider.getClientTypeFromAccessToken(token);
 
                     // ADR-016: 모든 요청은 LoggingInterceptor 가 api_request_completed JSON 라인에

--- a/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/product/global/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.umc.product.global.security;
 
 
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.common.domain.enums.ClientType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,13 +39,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 if (jwtTokenProvider.validateAccessToken(token)) {
                     Long memberId = jwtTokenProvider.parseAccessToken(token);
                     List<String> roles = jwtTokenProvider.getRolesFromAccessToken(token);
+                    // clientType 은 도입 이전 토큰이나 비-OAuth 경로로 발급된 토큰에서는 null 일 수 있다.
+                    ClientType clientType = jwtTokenProvider.getClientTypeFromAccessToken(token);
 
                     // ADR-016: 모든 요청은 LoggingInterceptor 가 api_request_completed JSON 라인에
                     // userId(=memberId) 를 MDC 로 포함하므로 인증 한 줄 텍스트 로그는 중복이다.
                     // 토큰 검증 흐름 디버깅이 필요한 경우에만 보이도록 DEBUG 로 강등.
                     log.debug("JWT authenticated: memberId={}", memberId);
 
-                    MemberPrincipal memberPrincipal = new MemberPrincipal(memberId);
+                    MemberPrincipal memberPrincipal = new MemberPrincipal(memberId, clientType);
 
                     List<SimpleGrantedAuthority> authorities = roles.stream()
                         .map(role -> new SimpleGrantedAuthority("ROLE_" + role))

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.umc.product.global.security;
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth"; // 권한 정보를 저장할 키
+    private static final String CLIENT_TYPE_KEY = "clientType"; // 클라이언트 플랫폼(ANDROID/IOS/WEB) 정보를 저장할 키
     private final SecretKey accessTokenSecret;
     private final SecretKey refreshTokenSecret;
     private final SecretKey oAuthVerificationTokenSecret;
@@ -97,17 +99,31 @@ public class JwtTokenProvider {
      * AccessToken 생성 메소드
      */
     public String createAccessToken(Long memberId, List<String> roles) {
+        return createAccessToken(memberId, roles, (ClientType) null);
+    }
+
+    /**
+     * AccessToken 생성 메소드 (clientType 포함)
+     * <p>
+     * clientType 은 트래픽 분포 분석용 optional claim. null 인 경우 claim 자체를 추가하지 않으며,
+     * 다운스트림(MDC, 통계)에서는 미설정으로 간주된다.
+     */
+    public String createAccessToken(Long memberId, List<String> roles, ClientType clientType) {
         Date now = new Date();
         Date validityDate = new Date(now.getTime() + accessTokenValidityInMilliseconds);
 
-        return Jwts.builder()
+        var builder = Jwts.builder()
             .subject(String.valueOf(memberId)) // 사용자 식별자 (ID)
             .claim(AUTHORITIES_KEY, roles)     // 권한 정보 저장
             .issuedAt(now)
             .expiration(validityDate)
-            .signWith(accessTokenSecret)
-            .compact()
-            ;
+            .signWith(accessTokenSecret);
+
+        if (clientType != null) {
+            builder.claim(CLIENT_TYPE_KEY, clientType.name());
+        }
+
+        return builder.compact();
     }
 
     public String createAccessToken(Long memberId, List<String> roles, Long expiresInSeconds) {
@@ -147,6 +163,28 @@ public class JwtTokenProvider {
             return (List<String>) roles;
         }
         return Collections.emptyList();
+    }
+
+    /**
+     * AccessToken 에서 clientType claim 을 추출한다.
+     * <p>
+     * 도입 이전에 발급된 토큰 / 비-OAuth 로그인 경로로 발급된 토큰에는 claim 이 존재하지 않으므로,
+     * 그 경우엔 {@code null} 을 반환한다. 호출자는 null-safe 하게 다루어야 하며 (예: MDC 미기록,
+     * 통계에서 "UNKNOWN" 으로 집계), 절대 예외를 던지지 않는다.
+     */
+    public ClientType getClientTypeFromAccessToken(String token) {
+        Claims claims = parseClaims(token, accessTokenSecret);
+        String clientTypeStr = claims.get(CLIENT_TYPE_KEY, String.class);
+        if (clientTypeStr == null) {
+            return null;
+        }
+        try {
+            return ClientType.valueOf(clientTypeStr);
+        } catch (IllegalArgumentException e) {
+            // 알 수 없는 enum 값이 들어와도 통계 집계가 깨지지 않도록 null 처리.
+            log.warn("AccessToken 의 clientType claim 값을 해석할 수 없습니다: {}", clientTypeStr);
+            return null;
+        }
     }
 
     public boolean validateAccessToken(String token) {

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -106,7 +106,7 @@ public class JwtTokenProvider {
      * AccessToken 생성 메소드 (clientType 포함)
      * <p>
      * clientType 은 트래픽 분포 분석용 optional claim. null 인 경우 claim 자체를 추가하지 않으며,
-     * 다운스트림(MDC, 통계)에서는 미설정으로 간주된다.
+     * 다운스트림(MDC, 통계)에서는 UNKNOWN 으로 집계된다.
      */
     public String createAccessToken(Long memberId, List<String> roles, ClientType clientType) {
         Date now = new Date();
@@ -168,9 +168,9 @@ public class JwtTokenProvider {
     /**
      * AccessToken 에서 clientType claim 을 추출한다.
      * <p>
-     * 도입 이전에 발급된 토큰 / 비-OAuth 로그인 경로로 발급된 토큰에는 claim 이 존재하지 않으므로,
-     * 그 경우엔 {@code null} 을 반환한다. 호출자는 null-safe 하게 다루어야 하며 (예: MDC 미기록,
-     * 통계에서 "UNKNOWN" 으로 집계), 절대 예외를 던지지 않는다.
+     * 도입 이전에 발급된 토큰 / clientType 미전달 로그인 경로로 발급된 토큰에는 claim 이 존재하지 않으므로,
+     * 그 경우엔 {@code null} 을 반환한다. 호출자는 null-safe 하게 다루어야 하며
+     * 통계에서는 "UNKNOWN" 으로 집계한다. 절대 예외를 던지지 않는다.
      */
     public ClientType getClientTypeFromAccessToken(String token) {
         Claims claims = parseClaims(token, accessTokenSecret);

--- a/src/main/java/com/umc/product/global/security/MemberPrincipal.java
+++ b/src/main/java/com/umc/product/global/security/MemberPrincipal.java
@@ -1,5 +1,6 @@
 package com.umc.product.global.security;
 
+import com.umc.product.common.domain.enums.ClientType;
 import java.util.Collection;
 import java.util.Collections;
 import lombok.Builder;
@@ -11,9 +12,18 @@ public class MemberPrincipal {
 
     private final Long memberId;
 
+    // AT claim 으로 전달된 클라이언트 플랫폼. 도입 이전 토큰 / 비-OAuth 발급 토큰은 null.
+    // 통계/로그 컨텍스트용 메타데이터이며, 인가 결정에는 영향을 주지 않는다.
+    private final ClientType clientType;
+
     @Builder
-    public MemberPrincipal(Long memberId) {
+    public MemberPrincipal(Long memberId, ClientType clientType) {
         this.memberId = memberId;
+        this.clientType = clientType;
+    }
+
+    public MemberPrincipal(Long memberId) {
+        this(memberId, null);
     }
 
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -24,6 +34,7 @@ public class MemberPrincipal {
     public String toString() {
         return "MemberPrincipal{" +
                 "memberId=" + memberId +
+                ", clientType=" + clientType +
                 '}';
     }
 }

--- a/src/main/java/com/umc/product/global/security/MemberPrincipal.java
+++ b/src/main/java/com/umc/product/global/security/MemberPrincipal.java
@@ -12,7 +12,7 @@ public class MemberPrincipal {
 
     private final Long memberId;
 
-    // AT claim 으로 전달된 클라이언트 플랫폼. 도입 이전 토큰 / 비-OAuth 발급 토큰은 null.
+    // AT claim 으로 전달된 클라이언트 플랫폼. 도입 이전 토큰 / claim 누락 토큰은 null.
     // 통계/로그 컨텍스트용 메타데이터이며, 인가 결정에는 영향을 주지 않는다.
     private final ClientType clientType;
 

--- a/src/test/java/com/umc/product/authentication/adapter/in/web/dto/request/LoginByEmailRequestTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/in/web/dto/request/LoginByEmailRequestTest.java
@@ -1,0 +1,33 @@
+package com.umc.product.authentication.adapter.in.web.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.authentication.application.port.in.command.dto.LoginByEmailCommand;
+import com.umc.product.common.domain.enums.ClientType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoginByEmailRequestTest {
+
+    private static final String EMAIL = "alice@example.com";
+    private static final String RAW_PASSWORD = "Strong-Pw-2026";
+
+    @Test
+    @DisplayName("이메일/PW 로그인 요청의 clientType 을 커맨드로 전달한다")
+    void clientType_커맨드_전달() {
+        // given
+        LoginByEmailRequest request = new LoginByEmailRequest(
+            EMAIL,
+            RAW_PASSWORD,
+            ClientType.ANDROID
+        );
+
+        // when
+        LoginByEmailCommand command = request.toCommand();
+
+        // then
+        assertThat(command.email()).isEqualTo(EMAIL);
+        assertThat(command.rawPassword()).isEqualTo(RAW_PASSWORD);
+        assertThat(command.clientType()).isEqualTo(ClientType.ANDROID);
+    }
+}

--- a/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.umc.product.authentication.application.port.in.command.dto.ChangePasswordCommand;
-import com.umc.product.authentication.application.port.in.command.dto.IdPwLoginResult;
+import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
 import com.umc.product.authentication.application.port.in.command.dto.LoginByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.RegisterCredentialByEmailCommand;
 import com.umc.product.authentication.application.port.in.command.dto.ResetPasswordByEmailCommand;
@@ -223,7 +223,7 @@ class CredentialAuthenticationServiceTest {
             given(jwtTokenProvider.createRefreshToken(MEMBER_ID)).willReturn("refresh-token");
 
             // when
-            IdPwLoginResult result = service.loginByEmail(
+            LocalLoginResult result = service.loginByEmail(
                 LoginByEmailCommand.of(EMAIL, RAW_PASSWORD, ClientType.IOS)
             );
 

--- a/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
@@ -18,6 +18,7 @@ import com.umc.product.authentication.application.port.in.command.dto.RegisterCr
 import com.umc.product.authentication.application.port.in.command.dto.ResetPasswordByEmailCommand;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
@@ -210,23 +211,27 @@ class CredentialAuthenticationServiceTest {
     class LoginByEmail {
 
         @Test
-        @DisplayName("정상 로그인 시 토큰을 발급하고, 별도 트랜잭션의 rehashService.rehashIfNeeded 를 호출한다")
-        void 로그인_성공_rehash호출_확인() {
+        @DisplayName("정상 로그인 시 clientType 을 포함해 토큰을 발급하고, 별도 트랜잭션의 rehashService.rehashIfNeeded 를 호출한다")
+        void 로그인_성공_clientType_토큰_발급_rehash호출_확인() {
             // given
             MemberCredentialInfo credential = new MemberCredentialInfo(MEMBER_ID, ENCODED_PASSWORD);
             given(getMemberCredentialUseCase.findCredentialByEmail(EMAIL))
                 .willReturn(Optional.of(credential));
             given(passwordEncoder.matches(RAW_PASSWORD, ENCODED_PASSWORD)).willReturn(true);
-            given(jwtTokenProvider.createAccessToken(eq(MEMBER_ID), anyList())).willReturn("access-token");
+            given(jwtTokenProvider.createAccessToken(eq(MEMBER_ID), anyList(), eq(ClientType.IOS)))
+                .willReturn("access-token");
             given(jwtTokenProvider.createRefreshToken(MEMBER_ID)).willReturn("refresh-token");
 
             // when
-            IdPwLoginResult result = service.loginByEmail(LoginByEmailCommand.of(EMAIL, RAW_PASSWORD));
+            IdPwLoginResult result = service.loginByEmail(
+                LoginByEmailCommand.of(EMAIL, RAW_PASSWORD, ClientType.IOS)
+            );
 
             // then
             assertThat(result.memberId()).isEqualTo(MEMBER_ID);
             assertThat(result.accessToken()).isEqualTo("access-token");
             assertThat(result.refreshToken()).isEqualTo("refresh-token");
+            then(jwtTokenProvider).should().createAccessToken(eq(MEMBER_ID), anyList(), eq(ClientType.IOS));
             then(rehashService).should().rehashIfNeeded(credential, RAW_PASSWORD);
         }
 
@@ -246,6 +251,7 @@ class CredentialAuthenticationServiceTest {
             // 매칭/토큰 발급은 호출되지 않아야 한다
             then(passwordEncoder).should(never()).matches(anyString(), anyString());
             then(jwtTokenProvider).should(never()).createAccessToken(anyLong(), anyList());
+            then(jwtTokenProvider).should(never()).createAccessToken(anyLong(), anyList(), any(ClientType.class));
         }
 
         @Test
@@ -264,6 +270,7 @@ class CredentialAuthenticationServiceTest {
                 .isEqualTo(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL);
 
             then(jwtTokenProvider).should(never()).createAccessToken(anyLong(), anyList());
+            then(jwtTokenProvider).should(never()).createAccessToken(anyLong(), anyList(), any(ClientType.class));
             then(manageMemberCredentialUseCase).should(never()).changePassword(any());
         }
     }

--- a/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/config/LoggingInterceptorTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.global.security.MemberPrincipal;
 import java.util.Collections;
 import java.util.List;
@@ -147,8 +148,8 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    @DisplayName("인증된 MemberPrincipal 이 있으면 memberId 가 MDC 에 채워진다")
-    void preHandle_인증된_사용자_memberId_MDC_등록() {
+    @DisplayName("인증된 MemberPrincipal 의 clientType 이 없으면 MDC clientType 을 UNKNOWN 으로 채운다")
+    void preHandle_인증된_사용자_clientType_UNKNOWN_등록() {
         // given
         MemberPrincipal principal = new MemberPrincipal(42L);
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
@@ -164,8 +165,30 @@ class LoggingInterceptorTest {
 
         // then
         assertThat(MDC.get("memberId")).isEqualTo("42");
+        assertThat(MDC.get("clientType")).isEqualTo("UNKNOWN");
         // 서비스 도메인 명명을 사용하므로 userId 는 사용하지 않는다
         assertThat(MDC.get("userId")).isNull();
+    }
+
+    @Test
+    @DisplayName("인증된 MemberPrincipal 의 clientType 이 있으면 해당 값을 MDC 에 채운다")
+    void preHandle_인증된_사용자_clientType_MDC_등록() {
+        // given
+        MemberPrincipal principal = new MemberPrincipal(42L, ClientType.IOS);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+            principal, null, Collections.emptyList()
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/forms/123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        interceptor.preHandle(request, response, new Object());
+
+        // then
+        assertThat(MDC.get("memberId")).isEqualTo("42");
+        assertThat(MDC.get("clientType")).isEqualTo("IOS");
     }
 
     @Test
@@ -180,6 +203,7 @@ class LoggingInterceptorTest {
 
         // then
         assertThat(MDC.get("memberId")).isNull();
+        assertThat(MDC.get("clientType")).isEqualTo("UNKNOWN");
     }
 
     @Test


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 누가 · 언제 · 어디서

- 백엔드 파트원이 2026-05-19 `develop` 브랜치를 기준으로 작업했어요.
- 변경 범위는 `authentication` 도메인의 OAuth 로그인 어댑터(`src/main/java/com/umc/product/authentication/adapter/in/web`)와 글로벌 보안/로깅 모듈(`src/main/java/com/umc/product/global/security`, `src/main/java/com/umc/product/global/config`)이에요.

### 무엇을 · 어떻게 · 왜

1. **무엇을**: Google / Kakao / Kakao Authorization Code 로그인 요청에 옵셔널 `clientType` 필드를 추가했어요. (Apple은 이전부터 필수였고 그대로 유지돼요.)
   - **어떻게**: 기존 `com.umc.product.common.domain.enums.ClientType` (ANDROID / IOS / WEB) enum 을 그대로 재사용했고, `GoogleLoginRequest` · `KakaoLoginRequest` · `KakaoCodeLoginRequest` record 에 nullable 필드로 추가했어요.
   - **왜**: 일일 API 트래픽이 어느 플랫폼에서 발생하는지 분포를 분석하기 위해서예요. 옵셔널로 둔 이유는 도입 이전 버전의 클라이언트가 갱신 전까지도 기존처럼 로그인할 수 있어야 하기 때문이에요.

2. **무엇을**: `JwtTokenProvider` 에 `clientType` claim 발급/파싱 로직을 추가했어요.
   - **어떻게**: `createAccessToken(memberId, roles, ClientType)` 오버로드를 추가하고, `clientType` 이 `null` 이면 claim 자체를 생략하도록 했어요. `getClientTypeFromAccessToken(token)` 은 claim 부재 / 알 수 없는 enum 값을 모두 `null` 로 처리해서 절대 예외를 던지지 않아요. 기존 두 시그니처는 그대로 보존해서 회원가입 완료 등 다른 호출자가 깨지지 않게 했어요.
   - **왜**: AT claim 으로 흘려보내면 매 요청마다 클라이언트가 헤더를 다시 보낼 필요 없이 인증 흐름이 자동으로 디바이스 컨텍스트를 전파할 수 있어요. JWT 서명 덕분에 위변조도 어려워요.

3. **무엇을**: `JwtAuthenticationFilter` → `MemberPrincipal` → `LoggingInterceptor` 로 이어지는 인증/로깅 파이프라인에 `clientType` 을 흘려보냈어요.
   - **어떻게**: `MemberPrincipal` 에 nullable `clientType` 필드를 추가하고 기존 `new MemberPrincipal(memberId)` 생성자도 보존했어요. `JwtAuthenticationFilter` 에서 AT claim 을 파싱해 Principal 에 주입하고, `LoggingInterceptor` 의 `putMemberContextToMdcIfAuthenticated()` 에서 MDC `clientType` 키를 채워요. `clientType` 이 `null` 인 경우 MDC 키 자체를 비워두어 Loki 에서 `clientType is null` 로 미설정 트래픽을 식별할 수 있어요.
   - **왜**: 매 요청 로그(`api_request_completed`) 에 디바이스 라벨이 자동으로 붙어야 LogQL / PromQL 로 일일 디바이스 분포 집계가 가능해요. ADR-016 의 MDC 키 표준을 그대로 따라서 `memberId` 와 동일한 null 정책을 유지했어요.

4. **무엇을**: 통계 집계 측면에서 도입 이전에 발급된 AT 도 안전하게 처리되도록 null-safe 흐름을 일관되게 적용했어요.
   - **어떻게**: 토큰 생성(claim 생략) → 토큰 파싱(`null` 반환) → Principal(`null` 보존) → MDC(키 미설정) 네 단계 모두에서 `null` 을 정상 흐름으로 간주해요.
   - **왜**: 배포 시점에 활성화돼 있는 1시간 만료 AT 가 모두 만료될 때까지는 claim 이 없는 토큰이 섞여 들어와요. 그 트래픽도 통계 쿼리에서 미설정 버킷으로 자연스럽게 잡혀야 대시보드가 깨지지 않아요.

## 💬 리뷰 중점사항

- 인증/보안 흐름 변경이에요. JWT claim 추가가 토큰 검증·서명·MDC 라이프사이클에 영향을 주지 않는지 확인 부탁드려요.
- 클라이언트 영향도: Apple 로그인은 기존 `clientType` 필수 동작이 그대로 유지돼요. Google / Kakao / Kakao Code 는 옵셔널이라 기존 클라이언트가 갱신 없이도 동작해요. 클라 안내 메시지는 별도로 공유 예정이에요.
- `JwtTokenProvider.getClientTypeFromAccessToken` 이 claim 부재 / 알 수 없는 enum 값을 모두 `null` 로 흡수해요. 통계 집계 외에 인가 결정에는 일절 사용하지 않으므로 null-safety 정책으로 충분하다고 판단했어요. 의견 주시면 좋아요.
- ADR-016 MDC 키 표준에 `clientType` 키가 추가됐어요. 기존 `memberId` 와 동일한 null 정책(미인증/도입 이전 토큰은 키를 비움)이라 ADR 본문 갱신은 필요하지 않다고 봤는데, 별도 ADR 보강이 필요한지 확인 부탁드려요.