### PR TITLE
[Docs] Event Outbox 도입 관련 ADR 문서 작성

### DIFF
--- a/docs/adr/019-introduce-transactional-event-outbox.md
+++ b/docs/adr/019-introduce-transactional-event-outbox.md
@@ -1,0 +1,384 @@
+# ADR-019: 이벤트 손실 방지를 위한 Transactional Event Outbox 도입
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR-018](./018-abstract-spring-event-publisher-for-future-broker.md)에서 Spring
+`ApplicationEventPublisher` 의존을 `DomainEventPublisher` Port Out으로 추상화했다 (Phase 1).
+이 단계는 헥사고날 의존 방향 정리와 도메인 이벤트 메타데이터(`eventId`, `occurredAt`,
+`eventType`) 표준화에 집중했고, 발행 메커니즘 자체는 여전히 Spring의
+`@TransactionalEventListener(AFTER_COMMIT) + @Async` 조합이다.
+
+### 현재 메커니즘의 위험
+
+`@TransactionalEventListener(AFTER_COMMIT)`로 발행된 이벤트는 **JVM 메모리 안에서만 디스패치**된다.
+비즈니스 트랜잭션이 commit된 직후 listener가 비동기 처리를 마치기 전에 JVM이 비정상 종료되면
+이벤트가 영구 손실된다. 구체적 시나리오:
+
+- **회원가입**: `member` INSERT는 commit됐는데, `AuditLogEvent` listener가 `audit_log` INSERT를
+  하기 전에 JVM kill → 가입은 완료됐는데 감사 로그 누락. 컴플라이언스/포렌식 추적 실패.
+- **이메일 인증**: `email_verification` INSERT는 commit됐는데, `SendVerificationEmailEvent`
+  listener가 SMTP 호출 전에 JVM kill → 사용자는 세션 ID를 받았지만 메일은 영영 안 옴 →
+  "인증 코드 어디 갔어요?" CS 발생, 재시도 불가.
+- **향후 도메인 확장**: 결제 완료 → 알림 발송, 회원 탈퇴 → 외부 시스템 정리 등 이벤트 손실이
+  실제 사용자 피해로 이어지는 시나리오가 도메인 확장과 함께 증가한다.
+
+### 분산 시스템의 근본 제약
+
+이는 흔히 **Dual-Write Problem**이라 부르는 분산 시스템의 근본 제약이다. "DB 변경 + 외부 시스템
+알림"을 같이 해야 할 때 두 작업이 서로 다른 트랜잭션 경계에 속하면 원자성을 보장할 수 없다.
+분산 트랜잭션(XA/2PC)이 이론적 해법이지만 외부 broker(Kafka 등)가 제대로 지원하지 않거나
+성능 페널티가 크다.
+
+### 무엇이 Phase 2 결정을 가속하는가
+
+1. 위 시나리오들이 도메인 확장과 함께 빈도가 증가한다.
+2. ADR-018에서 도입한 `DomainEventPublisher` 추상화가 어댑터 교체만으로 메커니즘 전환을 가능하게 만들었다.
+3. 향후 Kafka/RabbitMQ 도입 시 outbox는 broker로 가는 "안전한 다리" 역할을 한다. 미리 도입하면
+   broker 전환이 점진적이 된다.
+
+### ADR-018 표현 보정
+
+ADR-018 본문에 "Phase 2는 `FcmOutbox` 패턴을 일반화한다"라고 적었으나 이는 부정확하다.
+`FcmOutbox`(현재 dead code)는 Firebase **토픽 subscribe/unsubscribe API 호출의 트랜잭션-안전
+분리**를 목적으로 만들어진 단일 용도 outbox다. Phase 2의 EventOutbox는 **모든 도메인 이벤트의
+보장된 전달**이 목적이라 도메인이 다르다. 메커니즘(DB 테이블 + poller + 상태 머신)은 비슷하지만
+재사용/일반화 관계가 아니다. EventOutbox는 별도 신규 메커니즘으로 도입하며, FcmOutbox는
+[ADR-020](./020-remove-fcm-outbox-dead-code.md)에 따라 별도 정리한다.
+
+## Decision
+
+우리는 다음 구조의 **Transactional Event Outbox**를 도입하기로 결정한다.
+
+```
+┌──────────────────────────────────────────┐
+│  비즈니스 트랜잭션 (단일 PostgreSQL)      │
+│  ──────────────────────────────────────  │
+│  BEGIN                                   │
+│    INSERT INTO members (...)             │  ← 비즈니스 변경
+│    INSERT INTO event_outbox (...)        │  ← 이벤트 영속화
+│  COMMIT                                  │  ← 둘 다 원자적
+└──────────────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────────────┐
+│  EventOutboxPoller (@Scheduled)          │
+│  ──────────────────────────────────────  │
+│  LOOP:                                   │
+│    SELECT * FROM event_outbox            │
+│      WHERE status = 'PENDING'            │
+│        AND next_attempt_at <= now()      │
+│      ORDER BY id                         │
+│      FOR UPDATE SKIP LOCKED              │
+│      LIMIT N;                            │
+│    for each row:                         │
+│      → 역직렬화 → ApplicationEventPublisher │
+│        .publishEvent(event)              │
+│      → 기존 @TransactionalEventListener  │
+│        listener 가 받아 처리              │
+│      → 성공: status = 'PUBLISHED'        │
+│      → 실패: attempts++, next_attempt_at │
+│              지수 백오프 적용              │
+└──────────────────────────────────────────┘
+```
+
+### 구체적 결정 항목
+
+1. **신규 어댑터 추가**: `global/event/adapter/out/OutboxDomainEventPublisher`가
+   `DomainEventPublisher`를 구현한다. `publish(event)` 호출 시 외부 큐에 보내지 않고 outbox
+   테이블에 INSERT만 수행한다.
+2. **기존 어댑터(`SpringDomainEventPublisher`)는 유지한다.** 두 어댑터 중 어느 쪽을 활성화할지는
+   `app.event-outbox.enabled` feature flag로 선택한다. 점진 롤아웃 + 즉시 롤백 가능.
+3. **Listener 코드는 변경하지 않는다.** Poller가 outbox row를 처리할 때 내부적으로 Spring
+   `ApplicationEventPublisher.publishEvent(event)`로 디스패치하므로, 기존 `@TransactionalEventListener`
+   리스너들이 그대로 받아 처리한다. 단, `AFTER_COMMIT` 단계 의미가 더 이상 필요하지 않으므로
+   `@EventListener`로 점진 단순화 가능 (별도 후속 작업).
+4. **트랜잭션 동작 변경**: 발행 시점이 "비즈니스 commit 직후"가 아닌 "비즈니스 commit과 동시에
+   outbox INSERT 영속화 + poller 다음 주기에 처리"가 된다. 즉 발행 가시성에 **poller 주기만큼
+   지연**이 생긴다 (초기 설정 5초).
+5. **멱등성**: outbox row와 발행 이벤트는 `eventId(UUID)`로 1:1 대응된다. Phase 3 broker 도입
+   시점에 consumer가 `eventId` 기반 dedup으로 exactly-once-effect를 달성할 수 있다.
+6. **단계적 적용**: SendVerificationEmailEvent부터 우선 적용 (가장 임팩트 큼). AuditLogEvent,
+   FcmOutboxEvent(살아있다면)는 검증 후 합류.
+
+## Alternatives Considered
+
+### 대안 A: Phase 1만 유지하고 outbox는 broker 도입 시점까지 미루기
+
+장점:
+- 추가 인프라/스키마 변경 불필요. 코드베이스 단순함 유지.
+
+단점:
+- 이벤트 손실 시나리오는 그대로 잔존.
+- Kafka 등 broker를 직접 도입할 때 outbox와 broker 변경을 한꺼번에 해야 함 → 변경 폭과 리스크 증가.
+
+선택하지 않은 이유:
+이벤트 손실 시나리오 중 일부(예: 이메일 인증 메일 누락)는 broker 없이도 사용자 피해를
+일으킨다. broker 도입은 시기상조이지만 outbox는 broker와 무관한 단독 가치가 있다.
+
+### 대안 B: Spring Modulith의 `event_publication` 메커니즘 사용
+
+[Spring Modulith](https://spring.io/projects/spring-modulith)는 Spring 팀이 공식 지원하는
+모듈러 모놀리스 라이브러리로, `@ApplicationModuleListener` + `event_publication` 테이블 기반
+outbox를 기본 제공한다.
+
+장점:
+- 구현 비용 없음. 의존성 추가로 즉시 활용 가능.
+- Spring 공식 메인테넌스 → 장기적으로 안정.
+- 우리가 직접 만들려는 메커니즘과 거의 동일한 구조.
+
+단점:
+- Spring Modulith의 모듈 경계 검증, `ApplicationModuleListener` 어노테이션 등 부가 기능까지
+  도입해야 함. 우리 헥사고날 구조와 미묘하게 충돌할 수 있음.
+- `DomainEventPublisher` Port Out 추상화와 어떻게 결합할지 추가 설계 필요.
+- 버전 안정성: 1.x 초기 (2024-).
+
+선택하지 않은 이유:
+첫 도입에서는 의존성과 추상화 결합 방식을 검토할 시간이 필요하다. 우리가 직접 만드는 outbox는
+약 200~300 라인 수준이고, 기존 `DomainEventPublisher` 추상화에 자연스럽게 어댑터로 들어맞는다.
+단, **운영 6개월 후 Spring Modulith로 마이그레이션할 가능성은 열어둔다** — 추상화 덕분에 어댑터
+교체로 가능하다.
+
+### 대안 C: Debezium CDC 도입
+
+[Debezium](https://debezium.io/)은 DB의 transaction log (PostgreSQL WAL)를 직접 읽어 Kafka로
+publish하는 CDC 도구다. Outbox 테이블 변경을 자동으로 broker로 routing할 수 있다.
+
+장점:
+- Push 기반이라 latency 압도적으로 낮음 (수 ms~).
+- Poller 코드 불필요.
+- 업계 표준급 도구.
+
+단점:
+- Kafka Connect 인프라 운영 부담.
+- broker(Kafka) 도입이 선행 조건. 우리는 아직 broker 없음.
+- 학습 곡선.
+
+선택하지 않은 이유:
+broker 도입 전이라 Debezium의 본 가치를 활용할 수 없다. Phase 3 broker 도입 시점에 다시 검토.
+지금 도입한 단순 poller는 broker 도입 시점에 Debezium으로 교체하기 용이하다 (outbox 테이블
+스키마는 그대로, 디스패치 메커니즘만 교체).
+
+### 대안 D: Redis 기반 outbox
+
+Redis에 outbox queue를 두고 비즈니스 트랜잭션 commit 후 Redis에 push.
+
+장점:
+- 처리량 높음. Latency 낮음.
+
+단점:
+- **트랜잭션 일관성 보장 불가**. PostgreSQL 트랜잭션과 Redis 쓰기는 서로 다른 시스템 →
+  outbox 패턴이 풀려는 dual-write 문제를 그대로 재현.
+- Redis 데이터 유실 위험 (메모리 기반, 영속화 옵션은 디스크지만 fsync 지연 가능).
+- Redis 운영 부담 추가.
+
+선택하지 않은 이유:
+outbox 패턴의 본질은 "비즈니스 데이터와 같은 트랜잭션에서 영속화"인데 Redis는 이를 만족하지
+못한다. Redis는 Phase 3에서 broker 또는 분산 락 용도로 별도 검토 가능 (이 경우는 outbox 자체가
+아닌 broker 또는 보조 인프라).
+
+### 대안 E: Event Sourcing 도입
+
+도메인 상태를 "이벤트 시퀀스"로 저장하는 근본적 모델 전환 (Axon Framework, EventStoreDB 등).
+
+장점:
+- 감사 추적, 시간 여행, 복잡한 도메인 모델링에 강함.
+- 이벤트가 곧 진실이므로 dual-write 문제 자체가 사라짐.
+
+단점:
+- 도메인 모델 전면 재설계 필요.
+- 학습 곡선 매우 큼. 팀 전체 합의 필요.
+- 대부분 도메인은 CRUD가 적절하고 event sourcing은 과도.
+
+선택하지 않은 이유:
+범위와 비용이 outbox 도입과 비교 불가능하게 크다. 현재 우리 도메인(회원/감사/알림)은 CRUD로
+충분히 표현되고, event sourcing의 강점(시간 여행, 도메인 복잡도)을 필요로 하지 않는다.
+
+## Consequences
+
+### Positive
+
+- **이벤트 손실 방지**: 비즈니스 commit과 이벤트 영속화가 같은 트랜잭션이므로 JVM 비정상
+  종료에도 이벤트는 outbox에 남아 재시작 후 처리된다.
+- **자동 재시도**: SMTP 일시 장애 등 일시적 실패가 자동 복구된다. `attempts` 컬럼과
+  지수 백오프 정책으로 영구 실패와 일시 실패가 자연스럽게 구분된다.
+- **At-least-once 전달 보장**: 분산 시스템에서 현실적인 최상의 보장이다.
+- **멱등성 hooks**: `eventId(UUID)`가 영속화되므로 consumer가 dedup 가능. Phase 3에서
+  exactly-once-effect 달성의 토대.
+- **점진적 broker 전환**: Phase 3에서 KafkaRelay가 outbox를 폴링하도록 어댑터만 추가하면 됨.
+  큰 마이그레이션 없음.
+- **운영 가시성**: outbox 테이블 자체가 "처리 중인 이벤트의 단일 진실의 원천(SSOT)"이라
+  Prometheus 메트릭(PENDING 적체, FAILED 수) 추출이 직관적이다.
+
+### Negative
+
+- **지연 추가**: 발행 시점이 "commit 직후 즉시"가 아닌 "다음 poller 주기"가 된다 (초기 5초).
+  대부분 use case는 영향 없지만, 즉시 발행이 필요한 use case가 있다면 별도 설계 필요.
+- **DB 테이블 hot path**: `event_outbox` INSERT/SELECT/UPDATE가 빈번해진다. Index 설계와
+  cleanup 정책이 필수.
+- **운영 부담 추가**: poller 모니터링, 누적 row 정리 job, FAILED row 알람 등.
+- **트랜잭션 동작 변경**: 기존 `AFTER_COMMIT` 의미가 약간 달라진다. 일부 listener가 commit과
+  발행 사이의 즉시성에 의존한다면 회귀 가능 (현재 listener들은 모두 비동기/지연 허용이라 안전).
+- **DB 크기 증가**: 처리된 이벤트가 정리 전까지 쌓인다. cleanup 정책이 없으면 무한 증가.
+
+### Neutral / Trade-offs
+
+- **Exactly-once는 여전히 환상**: outbox는 at-least-once를 보장할 뿐이고, exactly-once는
+  consumer 측 멱등성으로만 흉내낼 수 있다. 분산 시스템의 근본 제약이다.
+- **`@TransactionalEventListener(AFTER_COMMIT)`의 진화**: outbox 도입 후 listener의
+  `AFTER_COMMIT` phase가 사실상 불필요해진다 (poller가 commit 이후의 상태에서만 row를 읽으니까).
+  단순화 가능하지만 호환성 유지를 위해 즉시 제거하지 않는다.
+- **Spring Modulith 도입 미루기**: 직접 구현이 200~300 라인 수준이라 비용이 작지만, 장기적으로
+  Spring 공식 메커니즘으로 교체할 의향은 유지한다.
+- **Phase 3 broker 도입 시 어댑터 교체 vs poller 교체**: 향후 Kafka 도입 시 두 가지 길이 있다.
+  (a) OutboxDomainEventPublisher는 그대로 두고 KafkaRelay를 poller로 교체, (b) Debezium
+  도입해서 outbox 변경을 자동 Kafka publish. 시기에 따라 선택.
+
+## Implementation Notes
+
+### 패키지 구조 (Phase 2 신규)
+
+```
+src/main/java/com/umc/product/global/event/
+├── domain/
+│   ├── DomainEvent.java                       # (기존, ADR-018)
+│   └── EventOutbox.java                       # (신규) outbox 엔티티
+├── application/
+│   ├── port/out/
+│   │   ├── DomainEventPublisher.java          # (기존, ADR-018)
+│   │   ├── LoadEventOutboxPort.java           # (신규)
+│   │   └── SaveEventOutboxPort.java           # (신규)
+│   └── service/
+│       └── EventOutboxRelayService.java       # (신규) poller가 호출
+└── adapter/
+    ├── in/scheduler/
+    │   └── EventOutboxPoller.java             # (신규)
+    └── out/
+        ├── SpringDomainEventPublisher.java    # (기존, ADR-018)
+        ├── OutboxDomainEventPublisher.java    # (신규) 기본 어댑터
+        └── persistence/
+            ├── EventOutboxPersistenceAdapter.java
+            └── EventOutboxJpaRepository.java
+```
+
+### Flyway 마이그레이션
+
+```sql
+-- V2026.NN.NN.NN.NN__create_event_outbox.sql
+CREATE TABLE event_outbox (
+    id              BIGSERIAL PRIMARY KEY,
+    event_id        UUID NOT NULL,
+    event_type      VARCHAR(150) NOT NULL,
+    payload         JSONB NOT NULL,
+    occurred_at     TIMESTAMPTZ NOT NULL,
+    status          VARCHAR(20) NOT NULL,    -- PENDING | PUBLISHED | FAILED
+    attempts        INT NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 멱등성을 위한 UNIQUE: 같은 eventId가 두 번 들어오지 않음
+CREATE UNIQUE INDEX uix_event_outbox_event_id ON event_outbox(event_id);
+
+-- 폴링 효율을 위한 partial index
+CREATE INDEX ix_event_outbox_pending ON event_outbox(next_attempt_at, id)
+  WHERE status = 'PENDING';
+
+-- 모니터링/cleanup용
+CREATE INDEX ix_event_outbox_status_published_at ON event_outbox(status, published_at);
+```
+
+### Poller 동시성
+
+멀티 인스턴스 환경(여러 JVM이 동시에 poller 동작)에서는 다음 둘 중 하나로 race를 방지한다:
+
+- (선호) `SELECT ... FOR UPDATE SKIP LOCKED` — PostgreSQL이 row 단위로 자연스럽게 분배.
+- (대안) Redisson `RLock` 기반 leader election — poller가 한 인스턴스에서만 동작.
+
+초기 도입은 `SKIP LOCKED`로 충분. 적체가 보이면 leader election 추가 검토.
+
+### 직렬화 / 역직렬화
+
+- Jackson 기반 JSON 직렬화. `DomainEvent` 마커 인터페이스에 `@JsonTypeInfo(use = NAME, property = "_type")` 추가
+  검토 (단, 기존 구현 영향을 최소화하기 위해 별도 `EventEnvelope` record로 감싸는 방식이 더
+  안전할 수 있음. PR 시점에 결정).
+- Listener 측은 직렬화/역직렬화를 신경 쓰지 않도록 envelope 처리 책임을
+  `OutboxDomainEventPublisher`와 poller에 한정한다.
+
+### 백오프 정책
+
+- 첫 실패: 즉시 재시도 (5초 후 poller 다음 주기).
+- 이후 실패: `2^attempts * 5s` 백오프 (5s, 10s, 20s, 40s, ...).
+- `attempts >= 10` 도달 시 `FAILED` 상태로 마킹하고 알람.
+- 운영 중 정책 변경이 잦을 것이므로 상수가 아닌 `app.event-outbox.*` 프로퍼티로 노출.
+
+### Cleanup 정책
+
+- PUBLISHED row는 24시간 후 별도 Scheduler가 DELETE (또는 archive 테이블로 이관).
+- FAILED row는 영구 보존 (운영자 수동 처리 대상).
+- 정책은 `app.event-outbox.cleanup.*` 프로퍼티로 조정.
+
+### Feature Flag 및 롤아웃
+
+```yaml
+app:
+  event-outbox:
+    enabled: false        # 초기 false (SpringDomainEventPublisher 활성)
+    poll-interval-ms: 5000
+    batch-size: 100
+    max-attempts: 10
+    cleanup:
+      published-retention-hours: 24
+      run-interval-minutes: 60
+```
+
+`enabled=true` 전환 전 사전 단계:
+
+1. DB 마이그레이션 적용 (테이블 생성). 어댑터 동작 미변경.
+2. 운영 환경에서 `enabled=false` 상태로 배포 → 회귀 없음 확인.
+3. 통합 테스트에서만 `enabled=true`로 동작 검증.
+4. 운영에서 `enabled=true` 전환. Prometheus 메트릭으로 PENDING 적체 감시.
+5. 회귀 시 즉시 `enabled=false` 롤백 가능.
+
+### 모니터링 메트릭 (Prometheus)
+
+- `event_outbox_pending_total{event_type}`
+- `event_outbox_failed_total{event_type}`
+- `event_outbox_publish_duration_seconds{event_type}` (히스토그램)
+- `event_outbox_poll_lag_seconds` (가장 오래된 PENDING의 `now() - occurred_at`)
+
+### Phase 2 PR 분할 전략 (참고)
+
+1. PR 1: outbox 엔티티 + 마이그레이션 + 포트 정의 (실제 동작 없음, 인프라만)
+2. PR 2: `OutboxDomainEventPublisher` + poller + relay service (feature flag off)
+3. PR 3: cleanup 스케줄러 + 모니터링 메트릭
+4. PR 4: feature flag on 전환 + 운영 가이드 문서
+
+각 PR은 독립적 머지 + 롤백 가능하도록 설계한다.
+
+### 진입 / 진출 조건
+
+**Phase 2 진입 조건** (이 ADR 머지 후):
+- [ADR-020](./020-remove-fcm-outbox-dead-code.md)에 따라 `FcmOutbox` dead code 정리 선행 권장
+  (이름/스키마 충돌 방지).
+
+**Phase 3(외부 broker 도입) 진입 조건**:
+- 다음 중 하나가 충족될 때 검토.
+  - 도메인 간 트래픽이 단일 JVM 처리 한계 근접.
+  - 외부 시스템(검색 색인, 분석 파이프라인 등)이 도메인 이벤트를 소비할 필요 발생.
+  - Outbox 테이블 부하가 운영 부담이 될 때 Debezium 검토.
+
+## References
+
+- [ADR-018: Spring Event Publisher 추상화](./018-abstract-spring-event-publisher-for-future-broker.md)
+- [ADR-020: FcmOutbox dead code 정리](./020-remove-fcm-outbox-dead-code.md)
+- Microservices.io: Transactional Outbox Pattern (Chris Richardson)
+- Confluent: "Reliable Microservices Data Exchange With the Outbox Pattern"
+- Spring Modulith: `event_publication` 메커니즘 (Spring 공식)
+- Debezium: Outbox Event Router (CDC 기반 outbox 자동화)
+- `docs/analysis/notification-fcm-current-state.md` (FcmOutbox 분석)

--- a/docs/adr/020-remove-fcm-outbox-dead-code.md
+++ b/docs/adr/020-remove-fcm-outbox-dead-code.md
@@ -1,0 +1,272 @@
+# ADR-020: notification 도메인의 deprecated FCM Outbox / Topic 코드 일괄 제거
+
+## Status
+
+Accepted
+
+## Context
+
+`notification` 도메인은 한때 Firebase Cloud Messaging의 토픽(topic) 구독 모델을 사용했고,
+이 토픽 subscribe/unsubscribe API 호출의 트랜잭션-안전 분리를 위해 `FcmOutbox` 메커니즘을
+도입했다. 2026-03~2026-04 사이에 알림 모델이 **"토픽 구독" → "토큰 직접 발송"**으로 전환되면서
+다음 두 영역이 동시에 dead path가 되었다.
+
+### 토픽 모델 폐기 시점
+
+마이그레이션 타임라인:
+
+| 시점         | 마이그레이션                                              | 의미                |
+|------------|----------------------------------------------------|-------------------|
+| 2026-03-06 | `V2026.03.06.00.00__create_fcm_outbox.sql`         | outbox 테이블 도입     |
+| 2026-03-17 | `V2026.03.17.00.00__create_fcm_token_topic.sql`    | 토픽 매핑 도입          |
+| 2026-04-18 | `V2026.04.18.00.00__alter_fcm_token_multi_device.sql` | 멀티 디바이스 전환        |
+| **2026-04-23** | **`V2026.04.23.23.50__drop_fcm_token_topic.sql`** | **토픽 매핑 폐기**     |
+
+토픽 폐기와 함께 토픽 API 호출 자체가 사라졌고, outbox가 보호할 외부 호출도 함께 사라졌다.
+
+### 현재 dead code 목록
+
+[docs/analysis/notification-fcm-current-state.md](../analysis/notification-fcm-current-state.md)의
+분석을 따른다.
+
+**도메인/응용 레이어**
+
+- `notification/domain/FcmOutbox.java` — 엔티티 (모든 row가 무의미한 상태)
+- `notification/domain/FcmOutboxEvent.java` — **빈 record, 발행하는 코드 없음**
+- `notification/domain/FcmOutboxEventType.java` — `FCM_SUBSCRIBE` / `FCM_UNSUBSCRIBE` 두 값, 사용처 없음
+- `notification/domain/FcmOutboxStatus.java` — `PENDING` / `PROCESSED` / `FAILED`, 활성 path 없음
+- `notification/application/service/FcmOutboxService.java` — PENDING을 즉시 FAILED로 마킹하는 stub
+- `notification/application/port/in/ProcessFcmOutboxUseCase.java` — 위 stub의 인터페이스
+- `notification/application/port/out/LoadFcmOutboxPort.java`, `SaveFcmOutboxPort.java`
+- `notification/adapter/out/persistentce/FcmOutboxPersistenceAdapter.java`,
+  `FcmOutboxJpaRepository.java`
+- `notification/adapter/in/scheduler/FcmOutboxScheduler.java` — 빈 테이블만 polling
+- `notification/adapter/in/event/FcmOutboxEventListener.java` — `FcmOutboxEvent` 발행 없으니
+  호출되지 않음
+
+**토픽 관련**
+
+- `notification/application/service/FcmTopicService.java` — `log.warn("[DEPRECATED] ...")`만 남는
+  no-op stub
+- `notification/application/port/in/ManageFcmTopicUseCase.java` — `@Deprecated(forRemoval = true)`
+- 컨트롤러 deprecated endpoints:
+  - `DELETE /api/v1/notification/fcm/topics/legacy`
+  - `resubscribeAllMemberLegacyTopics` 관련 endpoint
+
+**설정**
+
+- `app.fcm.outbox-interval-ms` 프로퍼티
+
+**DB 스키마**
+
+- `fcm_outbox` 테이블 (현재 row가 있을 수 있으나 모두 의미 없음)
+
+### 정리해야 하는 이유
+
+1. **인지 부담**: 신규 개발자가 코드베이스를 탐색할 때 outbox/topic 코드를 보고 "왜 있는지"
+   추적하는 시간 손실.
+2. **이름 충돌 위험**: [ADR-019](./019-introduce-transactional-event-outbox.md)의
+   `EventOutbox`가 도입되면 `FcmOutbox`와 이름 유사성으로 인한 혼동 가능성. 같은 PR에서 두
+   메커니즘이 공존하면 리뷰가 어려워진다.
+3. **마이그레이션 부담**: `fcm_outbox` 테이블은 향후 DB 백업/복구/스키마 dump에 계속 포함된다.
+4. **Spring Bean 등록 부담**: `@Component`로 등록된 dead bean들이 ApplicationContext에 남아 있다.
+
+### 정리 결정의 risk
+
+이 ADR이 다루어야 할 risk:
+
+- **외부 클라이언트가 deprecated endpoint를 여전히 호출**할 가능성. 호출 결과가 no-op이지만
+  HTTP 404로 바뀌면 클라이언트 측 에러 핸들링이 필요할 수 있음. 사전 로그 분석 필수.
+- **`fcm_outbox` 테이블 row가 운영 환경에 남아있을 가능성**. 모두 FAILED 상태로 추정되지만
+  실제 행 수와 상태 확인 필수.
+
+## Decision
+
+우리는 `notification` 도메인의 deprecated FCM Outbox / Topic 관련 코드를 **단일 PR로 일괄 제거**
+하기로 결정한다.
+
+### 제거 대상
+
+위 "현재 dead code 목록" 전체.
+
+### 마이그레이션 전략
+
+1. **사전 확인**:
+   - 운영 환경 로그에서 `DELETE /topics/legacy` 등 deprecated endpoint 호출 빈도 최근 30일 분석.
+     호출이 없거나 무시 가능한 수준이면 제거. 의미 있는 호출이 있다면 클라이언트 팀과 합의 후 진행.
+   - `SELECT count(*), status FROM fcm_outbox GROUP BY status;` 실행하여 잔존 row 상태 확인.
+2. **Flyway 마이그레이션**: `V2026.NN.NN.NN.NN__drop_fcm_outbox.sql`로 `fcm_outbox` 테이블 DROP.
+3. **Java 코드 일괄 삭제**: 위 "현재 dead code 목록"의 모든 파일 제거.
+4. **테스트 영향 확인**: `FcmOutboxServiceTest`, `FcmOutboxEventTest` 등 관련 테스트 동시 제거.
+   다른 테스트에서 dead code를 import하는지 grep으로 전수 확인.
+5. **`FcmController` 정리**: deprecated endpoint 메서드 제거. 남는 endpoint(`PUT /token`)만 유지.
+6. **`FcmProperties` 정리**: `outbox-interval-ms` 사용처 없어지므로 `application-*.yaml`에서
+   해당 키 제거.
+
+### 진행 순서
+
+`ADR-019`(EventOutbox 도입) 구현보다 **선행 권장**. 이름 충돌과 리뷰 혼동을 줄이기 위함.
+
+## Alternatives Considered
+
+### 대안 A: 그대로 유지 (현 상태)
+
+장점:
+- 변경 없음. risk 0.
+
+단점:
+- 모든 dead code 단점이 누적된다 (인지 부담, 이름 충돌, 마이그레이션 부담).
+- `@Deprecated(forRemoval = true)`가 이미 붙어 있는데 실제 제거를 하지 않는 모순.
+
+선택하지 않은 이유:
+이미 5주 이상 dead path였고, EventOutbox 도입을 앞두고 정리하지 않으면 두 outbox 메커니즘이
+공존하는 어색한 상태가 길어진다.
+
+### 대안 B: `@Deprecated` 마킹만 유지하고 제거는 더 미루기
+
+장점:
+- 외부 클라이언트 호환성 유지.
+
+단점:
+- 이미 일부는 `forRemoval = true` 상태인데 그 약속을 지키지 않는 셈.
+- 새 개발자/AI 에이전트가 deprecated 코드를 활성 path로 오인할 위험.
+
+선택하지 않은 이유:
+사전 로그 분석에서 외부 호출이 없다면 미룰 이유가 없다. 호출이 있다면 그건 별개 협의 사항.
+
+### 대안 C: 단계적 제거 (Java 코드 먼저, 테이블은 뒤에)
+
+장점:
+- 운영 안전성 (테이블이 살아있으면 rollback 가능).
+
+단점:
+- 두 번의 PR / 두 번의 리뷰 비용.
+- Spring JPA에서 엔티티 클래스를 제거하면 Flyway validation이 실패할 수 있음 (`fcm_outbox`가
+  엔티티 매핑 없이 DB에 남아있는 상태). 추가 설정 필요.
+
+선택하지 않은 이유:
+JPA 엔티티-테이블 매핑 정합성 때문에 단계 분리가 오히려 복잡해진다. 단일 PR로 일괄 처리하는
+것이 더 안전하다.
+
+### 대안 D: `FcmOutbox`를 `EventOutbox`의 기반으로 재활용
+
+장점:
+- 기존 마이그레이션과 인프라 활용.
+
+단점:
+- 두 outbox의 목적이 다름. `FcmOutbox`는 Firebase 토픽 API 호출 보호용, `EventOutbox`는
+  도메인 이벤트 전달용. 스키마 호환성 없음 (`FcmOutbox.event_type`은 enum 두 개, EventOutbox는
+  자유 문자열; payload 컬럼 의미 다름).
+- 재활용하려면 마이그레이션으로 스키마 변경이 필요한데, 결국 새 테이블 만드는 것과 비용이 같음.
+- 의미론적 혼란 가중.
+
+선택하지 않은 이유:
+ADR-018의 "FcmOutbox 일반화" 표현이 잘못된 것과 같은 이유. 두 outbox는 다른 도메인이다.
+별도 신규 + 기존 일괄 정리가 가장 깔끔.
+
+## Consequences
+
+### Positive
+
+- 코드베이스에서 dead code 약 10개 파일 + 1개 테이블 + 1개 프로퍼티 제거.
+- ADR-019의 `EventOutbox` 도입 시 이름 충돌 / 인지 충돌 없음.
+- Spring ApplicationContext에서 dead bean 4개 제거 (`FcmOutboxService`, `FcmOutboxScheduler`,
+  `FcmOutboxEventListener`, `FcmTopicService`).
+- DB 백업/복구/스키마 dump에서 무의미 데이터 제거.
+- `@Deprecated(forRemoval = true)` 약속 이행.
+
+### Negative
+
+- Flyway 마이그레이션 추가 (DROP TABLE). 운영 환경에서 잔존 row가 있다면 영구 삭제.
+- 외부 클라이언트가 deprecated endpoint를 호출 중이라면 404 응답으로 전환 (사전 분석 필수).
+- Git history에서 dead code 컨텍스트를 찾으려면 commit 검색이 필요해짐 (대안: ADR 보관).
+
+### Neutral / Trade-offs
+
+- **잔존 row의 의미**: `fcm_outbox` row가 운영에 남아있더라도 처리하는 코드가 stub이라
+  실효적 영향 없음. 백업 1회 후 drop이 안전.
+- **외부 호출 0 가정 깨질 경우**: 사전 분석에서 호출이 발견되면 이 ADR을 보류하고 클라이언트
+  팀과 협의 후 단계적 deprecation 일정 별도 합의.
+
+## Implementation Notes
+
+### 사전 확인 체크리스트 (PR 만들기 전)
+
+- [ ] 운영 환경 nginx/Spring 로그에서 최근 30일간 다음 endpoint 호출 0건 확인:
+  - `DELETE /api/v1/notification/fcm/topics/legacy`
+  - `resubscribeAllMemberLegacyTopics` 관련 path
+- [ ] `SELECT count(*), status, max(created_at) FROM fcm_outbox GROUP BY status;` 결과 확인
+  (모두 FAILED 또는 PROCESSED, 최근 30일 신규 row 없음 검증).
+- [ ] `application-*.yaml` 전체에서 `app.fcm.outbox-interval-ms` 사용처 grep.
+- [ ] 다른 도메인 코드에서 `FcmOutbox*` 또는 `ManageFcmTopicUseCase` import 여부 grep
+  (현 분석에서는 0건이지만 PR 시점 재확인).
+
+### Flyway 마이그레이션
+
+```sql
+-- V2026.NN.NN.NN.NN__drop_fcm_outbox.sql
+DROP TABLE IF EXISTS fcm_outbox;
+```
+
+기존 마이그레이션(`create_fcm_outbox.sql`, `create_fcm_token_topic.sql`,
+`drop_fcm_token_topic.sql`)은 **삭제하지 않는다.** Flyway 히스토리는 보존한다.
+
+### 제거 파일 일람
+
+```
+src/main/java/com/umc/product/notification/
+  domain/
+    FcmOutbox.java
+    FcmOutboxEvent.java
+    FcmOutboxEventType.java
+    FcmOutboxStatus.java
+  application/
+    port/in/
+      ProcessFcmOutboxUseCase.java
+      ManageFcmTopicUseCase.java
+    port/out/
+      LoadFcmOutboxPort.java
+      SaveFcmOutboxPort.java
+    service/
+      FcmOutboxService.java
+      FcmTopicService.java
+  adapter/
+    in/
+      scheduler/FcmOutboxScheduler.java
+      event/FcmOutboxEventListener.java
+    out/persistentce/
+      FcmOutboxPersistenceAdapter.java
+      FcmOutboxJpaRepository.java
+
+src/test/java/com/umc/product/notification/
+  application/service/FcmOutboxServiceTest.java
+  domain/FcmOutboxEventTest.java   ← ADR-018 작업에서 추가된 테스트, 같이 제거
+```
+
+`FcmController`의 deprecated endpoint 메서드만 제거하고 클래스 자체는 유지.
+
+### 검증 절차
+
+1. `./gradlew compileJava compileTestJava` — 컴파일 통과
+2. `./gradlew test` — 전 테스트 통과
+3. Spring Boot 기동 확인 (Bean 등록 누락 없음)
+4. PR 본문에 다음 정보 첨부:
+   - 사전 분석 결과 (endpoint 호출 빈도, 잔존 row 수)
+   - 마이그레이션 SQL
+   - 제거된 파일 수
+
+### ADR-018, ADR-019와의 관계
+
+- ADR-018에서 `FcmOutboxEvent`를 `DomainEvent`로 마이그레이션한 작업은 일관성 유지를 위한
+  잠정 조치였다. 이 ADR로 해당 record 자체가 제거된다.
+- ADR-019의 `EventOutbox` 신규 도입은 이 ADR 정리 후에 진행해야 이름/스키마 충돌이 없다.
+
+## References
+
+- [ADR-018: Spring Event Publisher 추상화](./018-abstract-spring-event-publisher-for-future-broker.md)
+- [ADR-019: Transactional Event Outbox 도입](./019-introduce-transactional-event-outbox.md)
+- [notification 도메인 분석 보고서](../analysis/notification-fcm-current-state.md)
+- Flyway 히스토리:
+  - `V2026.03.06.00.00__create_fcm_outbox.sql`
+  - `V2026.03.17.00.00__create_fcm_token_topic.sql`
+  - `V2026.04.23.23.50__drop_fcm_token_topic.sql`


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- follow-up to #880 ([Refactor] SpringEventPublisher를 DomainEventPublisher로 추상화)
- related to #883 (#879 의미론적 충돌 follow-up)

## 🚀 작업 내용

ADR-018에서 결정한 Phase 1 추상화 위에 올라갈 Phase 2 작업의 의사결정을 ADR로 정리했어요. 실제 구현은 별도 PR로 진행할 예정이고, 이번 PR은 **문서/결정만** 포함해요.

### 1. ADR-019: Transactional Event Outbox 도입

**핵심 결정**: 현재 `@TransactionalEventListener(AFTER_COMMIT)` 패턴이 JVM 비정상 종료 시 이벤트를 손실하는 문제를 해결하기 위해, 비즈니스 트랜잭션과 같은 DB 트랜잭션 안에 이벤트를 영속화하는 outbox 패턴을 도입해요.

주요 내용:
- **문제 정의**: Dual-Write Problem과 구체적 손실 시나리오(이메일 인증 메일 누락, 감사 로그 누락) 명시
- **해결 구조**: `OutboxDomainEventPublisher` 어댑터 + `event_outbox` 테이블 + `EventOutboxPoller` 스케줄러
- **5가지 대안 평가**: Phase 1 유지 / Spring Modulith / Debezium CDC / Redis outbox / Event Sourcing 각각의 장단점과 우리 시스템에 적합한지 판단
- **Implementation Notes**: 테이블 스키마, 인덱스, 백오프 정책, cleanup 정책, feature flag 기반 점진 롤아웃, Prometheus 메트릭, PR 분할 전략(4개 PR)까지 명시
- **ADR-018 표현 보정**: ADR-018에 "FcmOutbox 패턴을 일반화"라고 적은 부분이 부정확했음을 명시. 두 outbox는 도메인이 다르고 EventOutbox는 별도 신규 메커니즘이에요.

### 2. ADR-020: FcmOutbox dead code 일괄 제거

**핵심 결정**: notification 도메인의 deprecated FCM Outbox/Topic 관련 코드 약 10개 파일과 `fcm_outbox` 테이블을 일괄 제거해요. ADR-019의 EventOutbox 구현 **전**에 선행 진행하는 것을 권장해요(이름 충돌 방지).

주요 내용:
- **근거**: `docs/analysis/notification-fcm-current-state.md` 분석 인용. FCM 알림 모델이 "토픽 구독" → "토큰 직접 발송"으로 전환되면서 outbox가 보호하던 토픽 API 호출 자체가 사라짐 (2026-04-23 토픽 매핑 폐기 마이그레이션 기준)
- **제거 대상 일람**: 도메인 4개 + 응용 6개 + 어댑터 4개 + 테스트 2개 파일, 컨트롤러 deprecated endpoint, `app.fcm.outbox-interval-ms` 프로퍼티
- **4가지 대안 평가**: 유지 / `@Deprecated` 마킹만 유지 / 단계적 제거 / `EventOutbox` 기반으로 재활용 각각에 대한 검토와 거부 이유
- **사전 확인 체크리스트**: 운영 로그에서 deprecated endpoint 호출 빈도 확인, 잔존 row 수 확인 등 안전장치 명시
- **Implementation Notes**: 제거 대상 파일 정확한 경로, 마이그레이션 SQL, 검증 절차

### 3. ADR 간 의존 관계 명시

각 ADR이 서로를 인용하도록 작성했어요.

- ADR-019의 진입 조건: ADR-020 선행 권장 (이름 충돌 방지)
- ADR-020 결정의 동기: ADR-019의 `EventOutbox` 도입을 깔끔하게 준비

## 💬 리뷰 중점사항

1. **Phase 2 결정 자체의 적절성**: 이벤트 손실이 실제 운영 risk로 받아들여지는지, 지금이 도입 시점인지에 대한 합의가 핵심이에요. (ADR-019 Context 섹션)
2. **EventOutbox 구현 PR 분할 전략**: ADR-019에 4개 PR로 분할하는 전략을 적어두었어요. 합리적인지, 더 잘게 쪼개거나 합쳐야 할지 의견 부탁드려요.
3. **ADR-020의 사전 확인 항목**: 운영 로그 분석과 잔존 row 확인은 PR 만들기 전 필수 단계예요. 누락된 확인 항목이 있는지 봐주세요.
4. **Spring Modulith 대안**: 당장 도입하지 않기로 했지만 6개월 후 마이그레이션 가능성을 열어두었어요. 이 부분의 판단에 동의하시는지 확인 부탁드려요.

## 다음 단계 (이 PR 머지 후)

1. ADR-020 구현 PR (FCM dead code 정리, 사전 분석 포함)
2. ADR-019 구현 PR #1 (outbox 엔티티 + 마이그레이션 + 포트 정의)
3. ADR-019 구현 PR #2 (`OutboxDomainEventPublisher` + poller + relay service, feature flag off)
4. ADR-019 구현 PR #3 (cleanup 스케줄러 + 모니터링 메트릭)
5. ADR-019 구현 PR #4 (feature flag on 전환 + 운영 가이드 문서)

---

📎 관련 문서
- [ADR-018](./docs/adr/018-abstract-spring-event-publisher-for-future-broker.md): Phase 1 추상화
- [ADR-019](./docs/adr/019-introduce-transactional-event-outbox.md): Phase 2 EventOutbox 도입 (이 PR)
- [ADR-020](./docs/adr/020-remove-fcm-outbox-dead-code.md): FCM Outbox dead code 정리 (이 PR)
- [notification 도메인 분석](./docs/analysis/notification-fcm-current-state.md)