### PR TITLE
[Perf] Layered Build 및 캐시를 통한 Docker 이미지 빌드 성능 최적화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@
 # ------------------------------------------------------------------
 SPRING_APPLICATION_NAME=x-umc-product
 SPRING_PROFILES_ACTIVE=local
-APP_BASE_URL=http://localhost:8080
 APP_ENVIRONMENT=local
 
 # 로컬 개발자/인스턴스 식별자. 미설정 시 USER/USERNAME/HOSTNAME fallback 사용.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
             ${{ steps.ecr-login.outputs.registry }}/umc-product-server:${{ steps.set-env.outputs.lower_environment }}-latest
 
           platforms: linux/amd64,linux/arm64
-          # 캐시는 추후 빌드 성능 최적화를 통해 개선, 현재는 네트워크 비용이 더 많이 들어서 비활성화 합니다.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: 📝 PR Comment & Commit Status
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,6 +173,12 @@ springBoot {
     buildInfo()
 }
 
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+    layered {
+        enabled.set(true)
+    }
+}
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:deprecation")
     options.generatedSourceOutputDirectory.set(querydslDir)

--- a/docker/app/dockerfile
+++ b/docker/app/dockerfile
@@ -3,7 +3,11 @@ WORKDIR /builder
 
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} application.jar
+
+# Spring Boot 3.5.x 기준
+# jarmode=tools extract --layers는 최종 실행용 application.jar를 포함한 layer들을 만든다.
 RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
+
 
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
@@ -11,29 +15,26 @@ WORKDIR /app
 LABEL maintainer="UMC PRODUCT SERVER TEAM"
 LABEL description="UMC PRODUCT Official SpringBoot Backend Server"
 
-# curl 설치 (헬스체크용) + non-root 유저 생성
 RUN apk add --no-cache curl && \
     addgroup -S spring && \
     adduser -S spring -G spring && \
     mkdir -p /app/logs && \
     chown -R spring:spring /app
 
-# Spring Boot layered jar를 Docker layer로 분리
+# Spring Boot layer 순서대로 복사
+# dependencies: 외부 라이브러리
+# spring-boot-loader: Spring Boot 실행 로더 관련 파일
+# snapshot-dependencies: SNAPSHOT 의존성
+# application: 실제 애플리케이션 jar/application 파일
 COPY --from=builder --chown=spring:spring /builder/extracted/dependencies/ ./
 COPY --from=builder --chown=spring:spring /builder/extracted/spring-boot-loader/ ./
 COPY --from=builder --chown=spring:spring /builder/extracted/snapshot-dependencies/ ./
 COPY --from=builder --chown=spring:spring /builder/extracted/application/ ./
 
-# 로그 디렉토리 생성 및 권한 설정
-RUN mkdir -p /app/logs && chown -R spring:spring /app/logs
-
-# Switch to non-root user
 USER spring:spring
 
-# Expose application port
 EXPOSE 8080
 
-# JVM options
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
                -XX:MaxRAMPercentage=75.0 \
                -XX:+UseG1GC \
@@ -43,8 +44,9 @@ ENV JAVA_OPTS="-XX:+UseContainerSupport \
                -Duser.timezone=Asia/Seoul \
                -Djava.security.egd=file:/dev/./urandom"
 
-# Use exec form with sh -c so JAVA_OPTS is expanded and signals forwarded
+# Spring Boot 3.5 + jarmode=tools extract --layers 방식에서는
+# 최종 이미지 안의 application.jar를 실행한다.
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar application.jar"]
 
-# Optional healthcheck (uncomment if actuator/health endpoint exists)
-# HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8080/actuator/health || exit 1
+# HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+#   CMD curl -f http://localhost:8080/actuator/health || exit 1

--- a/docker/app/dockerfile
+++ b/docker/app/dockerfile
@@ -1,4 +1,11 @@
-FROM amazoncorretto:21-alpine
+FROM eclipse-temurin:21-jre-alpine AS builder
+WORKDIR /builder
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} application.jar
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
 LABEL maintainer="UMC PRODUCT SERVER TEAM"
@@ -11,9 +18,11 @@ RUN apk add --no-cache curl && \
     mkdir -p /app/logs && \
     chown -R spring:spring /app
 
-# 이미 build된 jar 파일을 docker 안으로 복사
-COPY --chown=spring:spring build/libs/*.jar app.jar
-RUN chmod 444 app.jar
+# Spring Boot layered jar를 Docker layer로 분리
+COPY --from=builder --chown=spring:spring /builder/extracted/dependencies/ ./
+COPY --from=builder --chown=spring:spring /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder --chown=spring:spring /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder --chown=spring:spring /builder/extracted/application/ ./
 
 # 로그 디렉토리 생성 및 권한 설정
 RUN mkdir -p /app/logs && chown -R spring:spring /app/logs
@@ -35,7 +44,7 @@ ENV JAVA_OPTS="-XX:+UseContainerSupport \
                -Djava.security.egd=file:/dev/./urandom"
 
 # Use exec form with sh -c so JAVA_OPTS is expanded and signals forwarded
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar application.jar"]
 
 # Optional healthcheck (uncomment if actuator/health endpoint exists)
 # HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8080/actuator/health || exit 1

--- a/docs/analysis/boot-and-build-optimization-phase1-plan.md
+++ b/docs/analysis/boot-and-build-optimization-phase1-plan.md
@@ -19,7 +19,7 @@
    - `hibernate.temp.use_jdbc_metadata_defaults=false`를 설정한다.
 
 3. local profile lazy initialization
-   - `application-local.yml`을 추가한다.
+   - `application.yml` 안에 `local` profile document를 추가한다.
    - 기본 active profile이 `local`이므로 로컬 개발 부팅만 지연 초기화한다.
    - prod/dev/test 프로필에 전파하지 않는다.
 
@@ -28,7 +28,7 @@
    - Dockerfile에서 Spring Boot `tools` jarmode로 layer를 추출한다.
    - `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application`을 별도 Docker layer로 복사한다.
 
-5. Runtime base image JDK에서 JRE로 전환
+5. Runtime base image Corretto JDK에서 Temurin JRE로 전환
    - `amazoncorretto:21-alpine`에서 프로젝트의 개발용 Dockerfile이 이미 사용하는 `eclipse-temurin:21-jre-alpine`로 바꾼다.
    - runtime container에는 javac/jlink가 필요 없다는 전제다.
 
@@ -60,7 +60,7 @@ plan review
 application.yml tuning
   |
   v
-application-local.yml lazy init
+application.yml local profile lazy init
   |
   v
 bootJar layered config
@@ -88,6 +88,112 @@ compile/build verification
 | Spring AI starter 제거 | 위험 | 현재 source가 provider별 model class에 직접 의존한다. 단순 dependency 제거는 compile 실패 가능성이 크다. | 보류 |
 | 단일 플랫폼 전환 | 위험 | 운영/개발 배포 아키텍처 확인이 없다. | 보류 |
 
+## 추가 판단: Corretto에서 Temurin/JRE 전환 영향
+
+### 변경 범위
+
+이번 변경은 GitHub Actions에서 컴파일/테스트에 쓰는 JDK 자체를 바꾸는 변경이 아니다. `.github/workflows/ci.yml`의 `actions/setup-java@v4`는 계속 `distribution: 'corretto'`를 사용한다. 바뀐 것은 운영 Docker 이미지의 런타임 베이스 이미지다.
+
+| 구분 | 변경 전 | 변경 후 | 영향 범위 |
+|---|---|---|---|
+| CI compile/test JDK | Corretto 21 | Corretto 21 | 변경 없음 |
+| Docker builder stage | 없음 | `eclipse-temurin:21-jre-alpine` | Spring Boot jar layer 추출 실행 |
+| Docker runtime stage | `amazoncorretto:21-alpine` | `eclipse-temurin:21-jre-alpine` | 운영 컨테이너 Java 런타임 |
+| Java major version | 21 | 21 | 변경 없음 |
+| 패키징 | JDK 포함 이미지 | JRE 이미지 | JDK 도구 제거 |
+
+따라서 이 변경은 "Java 21 런타임 배포판 변경 + JDK에서 JRE로 축소"에 가깝다. Eclipse Temurin은 Docker Official Image로 제공되는 OpenJDK 빌드이며 Java SE TCK-tested 런타임으로 문서화되어 있다. Amazon Corretto도 OpenJDK 기반 TCK 인증 배포판이다. 두 이미지 모두 Java 21 기준의 표준 JVM 동작을 제공하므로, 애플리케이션 코드가 Java 표준 API와 일반 Spring Boot 런타임에만 의존한다면 기능 영향은 낮다.
+
+### 영향 없음으로 판단한 근거
+
+- 애플리케이션 빌드와 테스트는 여전히 Corretto 21에서 수행되므로 compile classpath, annotation processing, QueryDSL Q클래스 생성에는 영향이 없다.
+- 런타임 컨테이너에서 `javac`, `jlink`, `jcmd`, `jmap`, `ToolProvider.getSystemJavaCompiler`, attach API 같은 JDK 도구를 호출하는 코드나 스크립트가 확인되지 않았다.
+- 기존 운영 이미지도 Alpine 기반이고 변경 후 이미지도 Alpine 기반이므로 libc 계열 전환(glibc ↔ musl) 리스크가 새로 생기지 않는다.
+- `eclipse-temurin:21-jre-alpine` 공식 이미지 태그는 `amd64`, `arm64v8`를 지원하므로 현재 `linux/amd64,linux/arm64` 멀티 플랫폼 빌드 범위와 맞는다.
+- Spring Boot `tools` jarmode layer 추출은 JDK 컴파일러가 아니라 `java` 런타임으로 실행되므로 JRE 이미지에서도 동작한다.
+
+### 남는 리스크
+
+- JDK 도구가 사라진다. 운영 컨테이너 안에서 `jcmd`, `jmap`, `jstack`, `jfr` CLI로 즉석 진단하는 운영 절차가 있다면 별도 디버그 이미지나 외부 수집 절차가 필요하다.
+- `-XX:+HeapDumpOnOutOfMemoryError` 자체는 JRE에서도 동작하지만, 생성된 heap dump를 컨테이너 내부에서 바로 분석하는 도구는 없다.
+- 보고서의 장기 후보인 CRaC는 Corretto/JDK 배포판 선택과 직접 관련될 수 있으므로, Phase 2 이후 CRaC를 실제 적용할 때는 Temurin JRE 유지 여부를 다시 결정해야 한다.
+- 벤더별 JVM 패치와 기본 CA/JVM 파일 구성 차이는 0이 아니다. 배포 전 최소 1회 `docker run` smoke test와 dev/staging 기동 확인이 필요하다.
+
+### 로컬 검증 메모
+
+- `java -version` 로컬 런타임: Temurin 21.0.11.
+- `java -Djarmode=tools -jar ... extract --layers`로 layer 추출을 확인했다.
+- 추출 결과의 주요 크기: `dependencies/lib` 약 175MB, application jar 약 4MB, `snapshot-dependencies` 0MB.
+- Dockerfile과 동일하게 `dependencies`와 `application` layer를 한 디렉터리에 배치한 뒤 `java -jar`를 실행했을 때 `UmcProductApplication` 기동 로그까지 도달했다. 이후 실패 원인은 layer/런타임 문제가 아니라 로컬 환경 변수 `MAIL_HOST` 미설정이었다.
+- 현재 환경에서는 Docker socket 권한 문제로 실제 `docker build`는 아직 로컬 검증하지 못했다.
+
+### 참고 문서
+
+- [Eclipse Temurin Docker Official Image](https://hub.docker.com/_/eclipse-temurin)
+- [Docker official-images eclipse-temurin tag manifest](https://github.com/docker-library/official-images/blob/master/library/eclipse-temurin)
+- [Amazon Corretto 21 Docker image guide](https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/docker-install.html)
+
+## Docker build cache 적용 효과
+
+### 적용 위치
+
+`.github/workflows/ci.yml`의 `docker/build-push-action@v6`에 다음 옵션을 추가했다.
+
+```yaml
+cache-from: type=gha
+cache-to: type=gha,mode=max
+```
+
+GitHub hosted runner에서 `docker/build-push-action`을 사용할 때 `type=gha` 캐시의 URL과 토큰은 액션이 자동으로 채운다. 현재 워크플로는 이미 `docker/setup-buildx-action@v3`를 사용하고 있어 BuildKit 기반 cache import/export 경로와 맞는다.
+
+### 어떤 부분에 작용하는가
+
+1. Gradle 빌드에는 직접 작용하지 않는다.
+   - `compileJava`, `test`, `bootJar`는 Docker build 전에 실행된다.
+   - 이 구간은 기존 `actions/setup-java@v4`의 `cache: gradle`이 담당한다.
+
+2. Dockerfile stage와 image layer에 작용한다.
+   - BuildKit이 이전 workflow run의 cache record를 `cache-from: type=gha`로 가져온다.
+   - 빌드가 끝나면 다음 run에서 재사용할 cache record와 layer를 `cache-to: type=gha,mode=max`로 저장한다.
+   - `mode=max`는 final image layer뿐 아니라 중간 stage cache까지 가능한 넓게 저장하므로, `builder` stage의 layer 추출 단계와 runtime stage의 COPY 단계도 캐시 후보가 된다.
+
+3. Spring Boot layered jar와 결합해 큰 의존성 layer를 안정화한다.
+   - 현재 추출 기준으로 `dependencies/lib`가 약 175MB이고 application jar가 약 4MB다.
+   - 일반적인 애플리케이션 코드 변경에서는 의존성 layer 내용이 그대로이고 application layer만 바뀐다.
+   - 이 경우 ECR push/pull 및 BuildKit cache export에서 큰 의존성 layer를 다시 전송하지 않는 효과가 난다.
+
+4. 멀티 플랫폼 빌드에서 플랫폼별로 따로 작용한다.
+   - 현재 `linux/amd64,linux/arm64`를 모두 빌드한다.
+   - base image pull, `apk add curl`, 유저/권한 설정, layer COPY 결과는 플랫폼별 cache key를 가진다.
+   - 특히 ARM64 빌드는 GitHub runner에서 QEMU 에뮬레이션 비용이 붙을 수 있어, cache hit 시 절감 체감이 더 크다.
+
+### 기대값
+
+정량 baseline이 아직 없으므로 아래 값은 현재 Dockerfile 구조와 layer 크기 기준의 기대 범위다.
+
+| 시나리오 | cache hit 범위 | 기대 효과 |
+|---|---|---|
+| 최초 적용 직후 cold build | 거의 없음 | cache export 때문에 오히려 소폭 증가 가능 |
+| 같은 커밋 재실행 또는 Docker 입력이 동일한 재시도 | base/apk/extract/final copy 대부분 hit | 기존 보고서의 **5~10분 단축** 기대가 가장 잘 맞는 구간 |
+| 일반 소스 변경, 의존성 변경 없음 | base/apk/final dependency layer 재사용, application layer만 갱신 | **1~3분 단축** 기대. ECR push가 병목이면 더 커질 수 있음 |
+| `build.gradle.kts` 또는 의존성 변경 | dependency layer invalidation | 해당 run 효과 제한적. 다음 run부터 다시 warm cache |
+| Dockerfile 또는 base image 변경 | 관련 step 이후 invalidation | cache 효과 제한적. 변경 후 새 cache 형성 |
+
+중요한 제한은 현재 Dockerfile이 host에서 만들어진 fat jar 전체를 `builder` stage에 `application.jar`로 복사한다는 점이다. 애플리케이션 코드만 바뀌어도 jar 파일 digest가 바뀌므로 `RUN java -Djarmode=tools ... extract` 단계는 다시 실행될 수 있다. 즉, 이번 cache 적용은 "Gradle 빌드 자체를 생략"하거나 "모든 소스 변경에서 layer 추출을 생략"하는 최적화가 아니라, Docker/BuildKit layer 재사용과 registry 전송량 감소를 통해 CI 후반부를 줄이는 최적화다.
+
+### 관찰해야 할 지표
+
+- `docker/build-push-action` 로그의 `importing cache manifest from gha`, `CACHED`, `exporting cache` 출력
+- `docker buildx` step 전체 시간과 push 시간
+- GitHub Actions cache 사용량 및 eviction 여부
+- ECR에 실제 push된 layer 수와 크기
+- 같은 커밋 재실행, 소스만 변경, 의존성 변경 케이스를 분리한 평균 시간
+
+### 참고 문서
+
+- [Docker Docs: GitHub Actions cache backend](https://docs.docker.com/build/cache/backends/gha/)
+- [Docker Docs: Cache management with GitHub Actions](https://docs.docker.com/build/ci/github-actions/cache/)
+
 ## 검증 계획
 
 1. `./gradlew compileJava`
@@ -98,5 +204,5 @@ compile/build verification
 ## 잔여 리스크
 
 - Docker daemon 또는 registry 접근이 없는 환경에서는 Dockerfile 검증이 로컬에서 제한될 수 있다.
-- `application-local.yml` 도입으로 로컬에서는 일부 bean 설정 오류가 첫 호출 시점으로 미뤄질 수 있다.
+- `application.yml`의 `local` profile lazy initialization으로 로컬에서는 일부 bean 설정 오류가 첫 호출 시점으로 미뤄질 수 있다.
 - GHA cache 비용/효율은 실제 Actions 로그에서 cache hit/miss를 확인해야 한다.

--- a/docs/analysis/boot-and-build-optimization-phase1-plan.md
+++ b/docs/analysis/boot-and-build-optimization-phase1-plan.md
@@ -14,7 +14,7 @@
    - 운영에서 시작 직후 burst 트래픽을 우선해야 하면 환경 변수로 즉시 원복 가능하다.
 
 2. Hibernate JDBC metadata 접근 차단
-   - PostGIS dialect를 명시한다.
+   - Hibernate 6의 공간 타입 지원이 통합된 PostgreSQL dialect를 명시한다.
    - `hibernate.boot.allow_jdbc_metadata_access=false`를 설정한다.
    - `hibernate.temp.use_jdbc_metadata_defaults=false`를 설정한다.
 
@@ -80,7 +80,7 @@ compile/build verification
 | 항목 | 판단 | 이유 | 결정 |
 |---|---|---|---|
 | Hikari 기본값 축소 | 적합 | 환경 변수로 되돌릴 수 있고 변경 범위가 작다. 첫 요청 burst 지연만 확인하면 된다. | 진행 |
-| Hibernate metadata 차단 | 적합 | PostGIS dialect 존재를 로컬 Gradle cache의 `hibernate-spatial-6.6.39.Final.jar`에서 확인했다. | 진행 |
+| Hibernate metadata 차단 | 적합 | Hibernate Spatial 6.6.39에서 `PostgisPG10Dialect`는 deprecated 호환 클래스라 `org.hibernate.dialect.PostgreSQLDialect`를 사용한다. | 진행 |
 | local lazy init | 적합 | 운영 프로필이 아니라 로컬 DX에만 영향을 준다. | 진행 |
 | layered jar Dockerfile | 적합 | Spring Boot 3.5 공식 Dockerfile 가이드의 `-Djarmode=tools ... extract --layers` 흐름과 일치한다. | 진행 |
 | JRE 전환 | 적합 | runtime container에서 JDK toolchain은 쓰지 않는다. `amazoncorretto:21-alpine-jre` 태그는 존재하지 않아 기존 dev Dockerfile과 같은 Temurin JRE Alpine을 사용한다. | 진행 |

--- a/docs/analysis/boot-and-build-optimization-phase1-plan.md
+++ b/docs/analysis/boot-and-build-optimization-phase1-plan.md
@@ -1,0 +1,102 @@
+# 부팅 및 Docker 빌드 최적화 Phase 1 실행 계획
+
+## 목표
+
+`docs/analysis/boot-and-build-optimization-report.md`의 Phase 1 항목 중 Low risk로 즉시 검증 가능한 변경을 먼저 적용한다. 부팅 시간과 Docker 이미지 빌드 시간을 줄이되, provider 전환이나 운영 인프라 아키텍처처럼 외부 결정이 필요한 항목은 코드 변경에서 분리한다.
+
+## 범위
+
+### 이번 PR에서 적용
+
+1. Hikari 초기 커넥션 확보 비용 축소
+   - `HIKARI_MIN_IDLE` 기본값을 `10`에서 `2`로 낮춘다.
+   - `HIKARI_INITIALIZATION_FAIL_TIMEOUT` 기본값을 `-1`로 둔다.
+   - 운영에서 시작 직후 burst 트래픽을 우선해야 하면 환경 변수로 즉시 원복 가능하다.
+
+2. Hibernate JDBC metadata 접근 차단
+   - PostGIS dialect를 명시한다.
+   - `hibernate.boot.allow_jdbc_metadata_access=false`를 설정한다.
+   - `hibernate.temp.use_jdbc_metadata_defaults=false`를 설정한다.
+
+3. local profile lazy initialization
+   - `application-local.yml`을 추가한다.
+   - 기본 active profile이 `local`이므로 로컬 개발 부팅만 지연 초기화한다.
+   - prod/dev/test 프로필에 전파하지 않는다.
+
+4. Spring Boot layered jar 기반 Docker 이미지
+   - `bootJar` layered archive 생성을 명시한다.
+   - Dockerfile에서 Spring Boot `tools` jarmode로 layer를 추출한다.
+   - `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application`을 별도 Docker layer로 복사한다.
+
+5. Runtime base image JDK에서 JRE로 전환
+   - `amazoncorretto:21-alpine`에서 프로젝트의 개발용 Dockerfile이 이미 사용하는 `eclipse-temurin:21-jre-alpine`로 바꾼다.
+   - runtime container에는 javac/jlink가 필요 없다는 전제다.
+
+6. GitHub Actions Docker layer cache 활성화
+   - `docker/build-push-action@v6`에 `cache-from: type=gha`, `cache-to: type=gha,mode=max`를 추가한다.
+   - layered jar 이후 적용하므로 fat jar 단일 레이어 캐시보다 cache 효율이 높다.
+
+### 이번 PR에서 보류
+
+1. Spring AI multi starter 제거
+   - 현재 adapter 클래스가 `OpenAiChatModel`, `VertexAiGeminiChatModel`, `GoogleGenAiChatModel`을 직접 import한다.
+   - dependency를 단순 제거하면 compile classpath가 깨진다.
+   - provider별 source set, module 분리, 또는 adapter 추상화 재설계가 필요하므로 Phase 1에서 바로 제거하지 않는다.
+
+2. `linux/amd64` 단일 플랫폼 전환
+   - 현재 CI는 `linux/amd64,linux/arm64`를 모두 빌드한다.
+   - ECS/Fargate, on-premise dev, ARM host 사용 여부 확인 전 축소하면 배포 가능성을 깨뜨릴 수 있다.
+   - 인프라 아키텍처 확인 후 별도 PR로 결정한다.
+
+## 실행 순서
+
+```text
+report copy
+  |
+  v
+plan review
+  |
+  v
+application.yml tuning
+  |
+  v
+application-local.yml lazy init
+  |
+  v
+bootJar layered config
+  |
+  v
+Dockerfile layer extraction + JRE
+  |
+  v
+GHA docker cache
+  |
+  v
+compile/build verification
+```
+
+## Eng Review
+
+| 항목 | 판단 | 이유 | 결정 |
+|---|---|---|---|
+| Hikari 기본값 축소 | 적합 | 환경 변수로 되돌릴 수 있고 변경 범위가 작다. 첫 요청 burst 지연만 확인하면 된다. | 진행 |
+| Hibernate metadata 차단 | 적합 | PostGIS dialect 존재를 로컬 Gradle cache의 `hibernate-spatial-6.6.39.Final.jar`에서 확인했다. | 진행 |
+| local lazy init | 적합 | 운영 프로필이 아니라 로컬 DX에만 영향을 준다. | 진행 |
+| layered jar Dockerfile | 적합 | Spring Boot 3.5 공식 Dockerfile 가이드의 `-Djarmode=tools ... extract --layers` 흐름과 일치한다. | 진행 |
+| JRE 전환 | 적합 | runtime container에서 JDK toolchain은 쓰지 않는다. `amazoncorretto:21-alpine-jre` 태그는 존재하지 않아 기존 dev Dockerfile과 같은 Temurin JRE Alpine을 사용한다. | 진행 |
+| GHA cache | 적합 | layered jar 이후 적용하면 캐시 폭발 위험이 낮다. GHA 10GB 한도는 추후 summary에서 관찰한다. | 진행 |
+| Spring AI starter 제거 | 위험 | 현재 source가 provider별 model class에 직접 의존한다. 단순 dependency 제거는 compile 실패 가능성이 크다. | 보류 |
+| 단일 플랫폼 전환 | 위험 | 운영/개발 배포 아키텍처 확인이 없다. | 보류 |
+
+## 검증 계획
+
+1. `./gradlew compileJava`
+2. `./gradlew bootJar`
+3. `docker build -f docker/app/dockerfile .`
+4. 가능하면 `docker run --rm ...`으로 `java -jar application.jar` layout 기동 확인
+
+## 잔여 리스크
+
+- Docker daemon 또는 registry 접근이 없는 환경에서는 Dockerfile 검증이 로컬에서 제한될 수 있다.
+- `application-local.yml` 도입으로 로컬에서는 일부 bean 설정 오류가 첫 호출 시점으로 미뤄질 수 있다.
+- GHA cache 비용/효율은 실제 Actions 로그에서 cache hit/miss를 확인해야 한다.

--- a/docs/analysis/boot-and-build-optimization-report.md
+++ b/docs/analysis/boot-and-build-optimization-report.md
@@ -1,0 +1,366 @@
+## TL;DR
+
+UMC PRODUCT 백엔드의 **SpringBoot 부팅 시간**과 **Docker 빌드 시간**을 단축하기 위한 현황 분석 및 최적화 방안 정리 보고서입니다. 현재 두 영역 모두 정량 측정값이 없어 우선 baseline 확보를 권장하며, 즉시 적용 가능한 P1 항목만 반영해도 **부팅 시간 약 4~10초 단축**, **Docker 빌드/배포 시간 약 5~15분 단축**이 기대됩니다.
+
+- 부팅 P1: Spring AI 다중 starter 정리, Hikari `minimum-idle` 축소, Hibernate JDBC metadata 차단, `lazy-initialization`(local 한정)
+- Docker P1: Layered Jar 도입, GHA Docker layer 캐시 활성화, 베이스 이미지 JDK→JRE 전환, 멀티 플랫폼 빌드 범위 재검토
+
+---
+
+## 1. 배경 및 목적
+
+- 현재 부팅 시간과 Docker 빌드 시간 모두 **측정 hook이 없어 추세 추적이 불가능**한 상태입니다.
+- 의존성 규모 증가(73개 JPA 엔티티, 1,518개 Java 파일, Spring AI 3종 starter, OTel/Sentry/Loki 등)와 Spring Boot 3.5 / Java 21 도입으로 **새로운 최적화 옵션(AppCDS, CRaC, Layered Jar 등)이 활용 가능**해졌습니다.
+- 본 보고서는 현황을 정량적으로 진단하고 기법별 기대 효과/난이도/리스크를 정리하여, **우선순위 기반 단계적 개선 로드맵**을 제시합니다. 구현은 별도 PR에서 진행합니다.
+
+---
+
+## 2. SpringBoot 부팅 시간 최적화
+
+### 2.1 현황 분석
+
+#### 2.1.1 기본 정보
+- Spring Boot 버전: **3.5.9** (`build.gradle.kts:3`)
+- Java 버전: **21** (`build.gradle.kts:15`)
+- 주요 starter (10종): `web`, `validation`, `aop`, `actuator`, `security`, `data-jpa`, `mail`, `thymeleaf`, `cache`, `docker-compose` (`build.gradle.kts:56-156`)
+- 주요 외부 라이브러리: QueryDSL 5.1.0, jjwt 0.12.5, Flyway + PostGIS, p6spy 1.10.0, springdoc-openapi 2.8.17, AWS SDK v2 BOM, Google Cloud Storage, Firebase Admin SDK 9.7.1, **Spring AI 1.1.5 (OpenAI + VertexAI Gemini + Google GenAI 3종 동시 starter)**, micrometer-tracing-bridge-otel + OTLP exporter + Loki4j + Sentry + logstash-encoder, Caffeine, datafaker, BouncyCastle, hibernate-spatial/JTS
+
+#### 2.1.2 부팅 시간에 영향을 미치는 요소
+- `@SpringBootApplication` 위치: `src/main/java/com/umc/product/UmcProductApplication.java:7` → base package `com.umc.product` 전체(Java 소스 1,518개)를 component scan + `@ConfigurationPropertiesScan`
+- JPA Entity 수: **73개**
+- `@Configuration` 수: **약 28개**, `@EnableXxx` 7종 (`@EnableWebSecurity`, `@EnableMethodSecurity`, `@EnableScheduling`, `@EnableJpaAuditing`, `@EnableAsync`, …)
+- `@ConditionalOn*` 빈: 약 16개 (주로 LLM/storage/webhook adapter)
+- Flyway migration 수: **71개** (`src/main/resources/db/migration/V2026.*.sql`)
+- Hikari 설정 (`application.yml:64-75`): `maximum-pool-size=10`, `minimum-idle=10` → 부팅 시 10개 connection 즉시 확보
+- `spring.jpa.open-in-view: false` (`application.yml:88`) — 이미 적용됨
+- `ddl-auto: validate` (`application.yml:87`) — 73개 엔티티 metadata 검증
+- `hibernate.boot.allow_jdbc_metadata_access`, `temp.use_jdbc_metadata_defaults` 모두 **미설정**
+- AOT/Native, Lazy init: **미적용**
+- p6spy: 운영 환경 포함 모든 환경에서 활성화 (`build.gradle.kts:110`, `P6SpyConfig.java:11`)
+- Actuator: `health,info,metrics,prometheus,tracing` 5종 노출 (`application.yml:237`), tracing sampling 1.0
+- Spring AI 3종 starter 동시 의존: 실제로는 단일 `LLM_PROVIDER` 사용 (`build.gradle.kts:151-153`, `application.yml:127-154`)
+
+#### 2.1.3 현재 측정값
+- 로컬 부팅 시간: **미측정**
+- CI 부팅 시간: **미측정** (`.github/workflows/ci.yml`, `cd.yml` 모두 health 대기 없음)
+- Dockerfile 헬스체크: 주석 처리 (`docker/app/Dockerfile:41`)
+
+### 2.2 최적화 방안
+
+#### 2.2.1 Spring AI 멀티 provider starter 정리 — P1
+- **현황**: 동시 의존 3종 (`build.gradle.kts:151-153`). 실제 활성 provider는 `LLM_PROVIDER` 단일 값으로 결정. 미사용 starter도 `ChatModel`, `RetryTemplate`, WebClient/HTTP client, JSON parser 자동구성이 부팅 단계에서 평가됨.
+- **기대 효과**: starter 1~2개 제거 시 **-1.0~2.5초** (각 starter 자동구성 ≈ 300~800ms × 2~3, ChatClient/HttpClient init 포함).
+- **적용 난이도**: Low
+- **리스크**: provider 전환 시 빌드/배포 분리 또는 `@SpringBootApplication(exclude={...})` 누락 위험.
+- **우선순위**: **P1**
+
+#### 2.2.2 Hikari `minimum-idle` 축소 + `initialization-fail-timeout` 조정 — P1
+- **현황**: `application.yml:67-68` `maximum-pool-size=10`, `minimum-idle=10` 동일 설정. 부팅 시 10개 connection 동기 확보. PostgreSQL 핸드셰이크 한 번 ≈ 30~80ms (PostGIS 활성화 보정 포함) → 직렬화 시 +0.3~0.8초.
+- **기대 효과**: `minimum-idle=2` + `initialization-fail-timeout=-1`로 변경 시 **-0.3~0.7초**. 트래픽 도달 시 lazy 확보.
+- **적용 난이도**: Low
+- **리스크**: 첫 요청 burst 시 connection 확보 지연 (~50ms × N). 대규모 트래픽 직후 시작에는 부적합 — staging 우선 검증.
+- **우선순위**: **P1** (특히 local/dev)
+
+#### 2.2.3 Hibernate JDBC metadata 호출 차단 — P1
+- **현황**: `application.yml:83-94`에서 `hibernate.boot.allow_jdbc_metadata_access`, `hibernate.temp.use_jdbc_metadata_defaults` 모두 **미설정**. dialect 자동 판별을 위해 부팅 시 JDBC connection을 열고 metadata 1회 round-trip. PostgreSQL 18 + JTS extension lookup 포함 시 +0.3~0.6초.
+- **기대 효과**: `spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false` + `hibernate.temp.use_jdbc_metadata_defaults=false` 설정 시 **-0.3~0.6초**. dialect는 `org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect`로 명시.
+- **적용 난이도**: Low (dialect 명시 한 줄 추가)
+- **리스크**: PostgreSQL 버전 업그레이드 시 dialect 갱신 누락 가능.
+- **우선순위**: **P1**
+
+#### 2.2.4 `spring.main.lazy-initialization=true` (local 한정) — P1
+- **현황**: 미설정. 28개 `@Configuration` × 평균 1.6 `@Bean` + 다수 `@Service/@Repository/@Component` 모두 즉시 초기화.
+- **기대 효과**: `local` profile 한정 활성화 시 **-2~5초** (개발 hot-reload 사이클의 체감 효과 큼).
+- **적용 난이도**: Low — `application-local.yml`에 `spring.main.lazy-initialization: true`
+- **리스크**: 부팅 중에만 발견되는 mis-config가 첫 요청까지 미루어짐. **prod 활성화 금지** (첫 요청 P99 spike).
+- **우선순위**: **P1** (DX 개선)
+
+#### 2.2.5 Flyway prod 분리 실행 — P2
+- **현황**: `application.yml:77-81` `spring.flyway.enabled=true`로 매 부팅마다 71개 migration의 checksum 비교. 평균 10ms/migration × 71 ≈ 0.5~1초.
+- **기대 효과**: prod 한정으로 별도 migration job (`java -jar app.jar --spring.profiles.active=migration`)으로 분리 시 **-0.5~1초** + 다중 인스턴스 동시 부팅 시 schema_history lock 경합 제거.
+- **적용 난이도**: Med (CD 워크플로 step 추가)
+- **리스크**: 마이그레이션 실패 시 배포 차단 흐름 재설계 필요.
+- **우선순위**: **P2**
+
+#### 2.2.6 Actuator/Tracing 옵션 정리 — P2
+- **현황**: `application.yml:237-279` — Prometheus + OTLP 양쪽 export 동시 활성, tracing sampling=1.0, `MeterRegistry`가 jvm/process/http/jdbc/tomcat/hikaricp/logback/cache 모두 활성.
+- **기대 효과**: MeterRegistry/MeterBinder 등록만으로 +0.3~0.6초 소비 추정. 미사용 항목(`cache`/`logback` 카운터) trim 시 **-0.1~0.3초**. Prometheus + OTLP 중복 → 한쪽으로 통합 시 추가 -0.1초.
+- **적용 난이도**: Low
+- **리스크**: 관측 데이터 누락 — Grafana dashboard와 동기 필요.
+- **우선순위**: **P2**
+
+#### 2.2.7 p6spy 운영 환경 비활성화 — P2
+- **현황**: `build.gradle.kts:110` `p6spy-spring-boot-starter`가 `implementation`으로 포함 → 모든 환경에서 DataSource가 P6DataSource로 wrapping. `P6SpyConfig.java:11` `@PostConstruct` 항상 실행.
+- **기대 효과**: prod에서 비활성화 시 DataSource proxy 초기화 + per-query reflection wrapping 제거. 부팅 **-0.1~0.3초**, 운영 query latency **5~10% 개선** (보너스).
+- **적용 난이도**: Low (`decorator.datasource.p6spy.enable-logging: false` + `decorator.datasource.enabled: false` 프로필 분기)
+- **리스크**: prod 쿼리 로깅 필요 시 대체 수단 마련 — 이미 OTel tracing으로 SQL span 수집 가능.
+- **우선순위**: **P2**
+
+#### 2.2.8 AppCDS / Class Data Sharing — P2
+- **현황**: Dockerfile (`docker/app/Dockerfile:28-35`) JVM 옵션에 CDS 관련 플래그 **없음**.
+- **기대 효과**: Spring Boot 3.3+ 의 `-Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=app.jsa` 한 번 실행 후 `-XX:SharedArchiveFile=app.jsa`로 부팅 → 클래스 로딩 시간 30~40% 단축. 1,500+ Java 파일 + 다량 라이브러리 환경에서 전체 부팅 **-2~4초** 추정.
+- **적용 난이도**: Med (Dockerfile multi-stage에서 jsa 생성 → runtime stage에 복사)
+- **리스크**: 의존성 변동 시 jsa 재생성 필요. 잘못된 jsa로 부팅 시 silent corruption 가능 → CI 검증 추가 필요.
+- **우선순위**: **P2** (운영 환경 효과 가장 큼)
+
+#### 2.2.9 CRaC (Coordinated Restore at Checkpoint) — P3
+- **현황**: Spring Boot 3.5 + Corretto 21에서 지원 가능. 현재 미적용.
+- **기대 효과**: 체크포인트 복원 부팅 ≈ 200~500ms (95%+ 감소 가능).
+- **적용 난이도**: High (Corretto CRaC build + 체크포인트 권한 + DB connection drop/restore handler 모든 stateful bean에 `Resource` 구현)
+- **리스크**: 외부 client 다수(S3, Firebase, OTel exporter, Loki4j, Sentry, Spring AI WebClient 등) → 체크포인트 시 모두 disconnect/restore 필요. 운영 안정화까지 1~2달.
+- **우선순위**: **P3**
+
+#### 2.2.10 GraalVM Native Image — P3
+- **현황**: 플러그인 미적용. QueryDSL annotation processor, p6spy bytecode proxy, hibernate-spatial JTS reflection, AWS SDK / Firebase / Spring AI 등 reflection-heavy library 다수.
+- **기대 효과**: 부팅 <500ms + 메모리 사용 50~70% 감소.
+- **적용 난이도**: High — reflection hint 다량 필요. Spring AI 3종 starter는 reflection hint 부족 가능성 큼.
+- **리스크**: 빌드 시간 10배↑, 디버깅 어려움. 현 시점 ROI 낮음.
+- **우선순위**: **P3**
+
+#### 2.2.11 Component Scan 범위 명시 — P3
+- **현황**: `UmcProductApplication.java:7` `@SpringBootApplication` 기본 = base package `com.umc.product` 전체.
+- **기대 효과**: `scanBasePackages={...}` 명시 시 **-0.1~0.3초** (체감 작음).
+- **적용 난이도**: Med (도메인 추가 시 list 갱신 필요)
+- **리스크**: 누락 시 빈 미등록 → 운영 사고. 헥사고날 구조상 효과 미미.
+- **우선순위**: **P3**
+
+#### 2.2.12 dev/local 한정 `-XX:TieredStopAtLevel=1` — P3
+- **현황**: 미적용.
+- **기대 효과**: local/dev 부팅 시 **-1~2초** (C1 only). steady-state TPS 감소.
+- **적용 난이도**: Low
+- **리스크**: **prod 적용 금지**.
+- **우선순위**: **P3**
+
+#### 2.2.13 가상 스레드 (참고) — P3
+- **현황**: Java 21 사용 중. `spring.threads.virtual.enabled` 미설정.
+- **기대 효과**: 부팅 시간 직접 영향은 거의 없음 (-0.05초 미만).
+- **리스크**: JPA/blocking I/O 다수 → virtual thread pinning 가능성. 별도 트랙으로 검증.
+- **우선순위**: **P3**
+
+#### 2.2.14 이미 적용된 항목
+- `spring.jpa.open-in-view: false` (`application.yml:88`)
+- `server.shutdown: graceful` (`application.yml:9`)
+- QueryDSL Q클래스 compile-time 생성 (`build.gradle.kts:182`)
+- `springdoc-openapi` 기본 비활성화 (`application.yml:175,198` `enabled=false`)
+
+### 2.3 부팅 시간 최적화 요약표
+
+| 우선순위 | 기법 | 기대 효과 | 난이도 |
+|---|---|---|---|
+| P1 | Spring AI 멀티 starter 정리 | -1.0~2.5초 | Low |
+| P1 | Hikari `minimum-idle` 축소 | -0.3~0.7초 | Low |
+| P1 | Hibernate JDBC metadata 차단 | -0.3~0.6초 | Low |
+| P1 | `lazy-initialization` (local) | -2~5초 (DX) | Low |
+| P2 | Flyway 분리 실행 (prod) | -0.5~1초 | Med |
+| P2 | Actuator/Tracing 옵션 정리 | -0.1~0.4초 | Low |
+| P2 | p6spy prod 비활성화 | -0.1~0.3초 + 쿼리 ↑5~10% | Low |
+| P2 | AppCDS / Class Data Sharing | -2~4초 | Med |
+| P3 | CRaC | -90%+ (수십 초 → 0.x초) | High |
+| P3 | GraalVM Native Image | 부팅 <0.5초 | High |
+| P3 | ComponentScan 범위 명시 | -0.1~0.3초 | Med |
+| P3 | `TieredStopAtLevel=1` (dev) | -1~2초 (dev) | Low |
+| P3 | 가상 스레드 | 부팅 영향 미미 | Low |
+
+**누적 P1+P2 적용 예상**: **-4~10초** (현재 부팅 시간 미측정이라 비율로는 ~30~50% 단축 추정).
+
+---
+
+## 3. Docker 빌드 시간 최적화
+
+### 3.1 현황 분석
+
+#### 3.1.1 Docker 빌드 환경
+- Dockerfile 위치: `docker/app/dockerfile` (운영), `docker/dev/dockerfile` (개발용, 현재 미사용 추정)
+- 베이스 이미지: `amazoncorretto:21-alpine` (`docker/app/dockerfile:1`) — JDK 포함 (~330MB)
+- Multi-stage: **미사용** (CI에서 host의 `bootJar` 산출물만 COPY)
+- Layered jar: **미적용** (`build.gradle.kts`에 `bootJar { layered { } }` 블록 없음)
+- BuildKit: CI에서 `docker/setup-buildx-action@v3` 적용 (`.github/workflows/ci.yml:152-153`)
+- Docker plugin (Jib/bootBuildImage): **미적용**
+
+#### 3.1.2 현재 Dockerfile 요약
+```dockerfile
+# docker/app/dockerfile - 단일 stage, 사전 빌드된 fat jar 복사 방식
+FROM amazoncorretto:21-alpine
+WORKDIR /app
+RUN apk add --no-cache curl && addgroup -S spring && adduser -S spring -G spring && \
+    mkdir -p /app/logs && chown -R spring:spring /app
+COPY --chown=spring:spring build/libs/*.jar app.jar  # CI의 bootJar 산출물 의존
+RUN chmod 444 app.jar
+USER spring:spring
+EXPOSE 8080
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 ..."
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]
+```
+
+#### 3.1.3 CI에서의 빌드
+- 워크플로 파일: `.github/workflows/ci.yml` (`cd.yml`, `cd-ecr.yml`이 `workflow_call`로 재사용)
+- 캐시 전략
+  - Gradle: `actions/setup-java@v4`의 `cache: gradle` 적용 (`.github/workflows/ci.yml:118`)
+  - Docker layer: **비활성화** — `.github/workflows/ci.yml:195` 주석 `"캐시는 추후 빌드 성능 최적화를 통해 개선, 현재는 네트워크 비용이 더 많이 들어서 비활성화 합니다."`
+- 빌드 단계: `compileJava` → `test` → `bootJar` → QEMU/Buildx setup → `docker/build-push-action@v6` 멀티 플랫폼 빌드 (`linux/amd64,linux/arm64`, `.github/workflows/ci.yml:194`)
+
+#### 3.1.4 현재 측정값
+- 로컬/CI 빌드 시간: **측정값 부재**
+- 이미지 크기: 측정값 부재 (베이스 `amazoncorretto:21-alpine`만 약 330MB)
+
+### 3.2 최적화 방안
+
+#### 3.2.1 Spring Boot Layered Jar + Dockerfile 분리 COPY — P1
+- **현황**: 미적용. `build.gradle.kts:1-7`의 Spring Boot plugin은 있으나 `bootJar { layered { enabled = true } }` 블록 부재. `docker/app/dockerfile:15`에서 fat jar 단일 레이어 COPY.
+- **기대 효과**: 의존성(`dependencies`, `snapshot-dependencies`, `spring-boot-loader`)과 `application` 클래스 분리 시 **재빌드에서 application 레이어(~5MB)만 갱신**. 일반 소스 변경 PR에서 push/pull 시간 60~80% 감소. ECR push 시 변경 레이어만 업로드되어 CI 후반부 **1~3분 단축** 예상.
+- **적용 난이도**: Low (Gradle 1줄 + Dockerfile 4~5줄 재구성)
+- **리스크**: 거의 없음. `JarLauncher` 메인 클래스 변경 필요 (`org.springframework.boot.loader.launch.JarLauncher`).
+- **우선순위**: **P1**
+
+#### 3.2.2 Multi-stage 빌드로 일원화 — P2
+- **현황**: 미적용. CI에서 `bootJar`를 호스트에서 실행 후 `docker/app/dockerfile:15`로 산출물만 COPY. 로컬에서 `docker build .` 단독 실행 불가.
+- **기대 효과**: Dockerfile 단독 빌드 가능성 확보(DX 개선), CI 단계 통합 시 Gradle 캐시 마운트 활용 가능. 3.2.3과 결합 시 시너지.
+- **적용 난이도**: Med (현 워크플로의 `bootJar` 스텝 제거 + 빌드 컨텍스트 정비)
+- **리스크**: 빌드가 도커 컨텍스트로 이동하므로 캐시 없이 사용하면 오히려 느려질 수 있음 — 3.2.3과 함께 적용 권장.
+- **우선순위**: **P2**
+
+#### 3.2.3 BuildKit `--mount=type=cache`로 Gradle 캐시 마운트 — P2
+- **현황**: 미적용. CI는 host-level `actions/setup-java@v4` Gradle 캐시만 활용.
+- **기대 효과**: Multi-stage와 결합 시 `~/.gradle/caches`, `~/.gradle/wrapper` 영속 캐시 → 의존성 미변경 빌드에서 **2~5분 절감**.
+- **적용 난이도**: Med (3.2.2 선행 필요)
+- **리스크**: BuildKit 캐시는 GHA hosted runner 재시작 시 휘발 → `cache-to=type=gha`와 함께 사용해야 효과.
+- **우선순위**: **P2**
+
+#### 3.2.4 GitHub Actions Docker layer 캐시 (gha cache) — P1
+- **현황**: 미적용. `.github/workflows/ci.yml:179-194`의 `docker/build-push-action@v6`에 `cache-from`/`cache-to` 옵션 부재. `.github/workflows/ci.yml:195`에 비활성화 사유 주석.
+- **기대 효과**: `cache-from: type=gha, cache-to: type=gha,mode=max` 추가 시 의존성 레이어 재사용 → 멀티 플랫폼(amd64+arm64) 빌드에서 **5~10분 단축** 예상. 현재 ARM 에뮬레이션 비용까지 캐시 가능.
+- **적용 난이도**: Low (워크플로 2줄 추가)
+- **리스크**: GHA 캐시 10GB 한도 — Layered jar(3.2.1) 없이 적용 시 fat jar 전체가 캐시되어 빠르게 한도 초과. **3.2.1 선행 권장**.
+- **우선순위**: **P1**
+
+#### 3.2.5 ECR Registry 캐시 (`cache-from=type=registry`) — P2
+- **현황**: 미적용. ECR 로그인은 되어 있으나(`.github/workflows/ci.yml:169-176`) 캐시 참조 미설정.
+- **기대 효과**: ECR에 캐시 매니페스트 저장 → CI runner 간 캐시 공유. GHA 캐시 10GB 한도와 무관. PR/main 캐시 분리 시 ARM 빌드 추가 단축.
+- **적용 난이도**: Low (ECR repo 1개 추가 + 워크플로 2줄)
+- **리스크**: 매 빌드마다 캐시 매니페스트 push/pull 발생 → 네트워크 비용 증가. `.github/workflows/ci.yml:195`의 비용 우려 재검토 필요.
+- **우선순위**: **P2**
+
+#### 3.2.6 멀티 플랫폼 빌드 범위 축소 (`linux/amd64` 단일) — P1 (조건부)
+- **현황**: `.github/workflows/ci.yml:194` `platforms: linux/amd64,linux/arm64` 동시 빌드 (QEMU 에뮬레이션, `.github/workflows/ci.yml:150-151`).
+- **기대 효과**: 배포 대상이 단일 아키텍처(ECS Fargate/홈서버)면 `linux/amd64`만 빌드 → QEMU 에뮬레이션 비용 제거로 **빌드 시간 약 40~50% 단축**.
+- **적용 난이도**: Low
+- **리스크**: ARM 호스트(M 시리즈 맥 로컬 검증 등) 사용 시 별도 빌드 필요. **운영 인프라 아키텍처 확인 후 결정**.
+- **우선순위**: **P1** (조건부)
+
+#### 3.2.7 베이스 이미지 JDK → JRE 전환 — P1
+- **현황**: `docker/app/dockerfile:1` `amazoncorretto:21-alpine` (JDK 포함, ~330MB). 운영 시 javac/jlink는 불필요.
+- **기대 효과**: `amazoncorretto:21-alpine-jre` 또는 `eclipse-temurin:21-jre-alpine`(개발용 Dockerfile에 이미 사용, `docker/dev/dockerfile:4`) 전환 시 베이스 약 **150~180MB 절감(~50% 축소)**. ECR pull/deploy 시간도 비례 감소.
+- **적용 난이도**: Low (1줄 변경)
+- **리스크**: Heap dump 분석을 운영 컨테이너에서 직접 수행하는 경우 jcmd/jmap 부재. `HeapDumpOnOutOfMemoryError`(`docker/app/dockerfile:31`)는 JRE에서도 동작.
+- **우선순위**: **P1**
+
+#### 3.2.8 Jib Gradle 플러그인 도입 — P3 (대안)
+- **현황**: 미적용.
+- **기대 효과**: 데몬리스, 자동 layered, 변경 클래스만 push → CI 빌드 시간 **50~70% 단축** 가능.
+- **적용 난이도**: Med (베이스 이미지, non-root 유저, curl 설치, locale, JAVA_OPTS를 Jib 설정으로 이전 필요)
+- **리스크**: 현 Dockerfile의 커스텀 사항(non-root, curl, 한국어 locale, `JAVA_OPTS` 표현식)이 Jib 설정으로 모두 마이그레이션돼야 함. 멀티 플랫폼 push는 가능하나 별도 설정.
+- **우선순위**: **P3** (대안 경로)
+
+#### 3.2.9 `.dockerignore` 점검 — P3
+- **현황**: 이미 적용 (`.dockerignore:1-26`). `build`, `.gradle`, `.git`, `**/build`, `**/node_modules`, `application*.yml` 등 핵심 제외 포함. **`build/libs`는 의도적으로 허용**(`.dockerignore:25-26`).
+- **기대 효과**: 추가 개선 여지 적음. `docs/`, `*.md`, `out/` 추가 시 컨텍스트 전송 5~10% 절감.
+- **적용 난이도**: Low
+- **리스크**: 없음
+- **우선순위**: **P3** (미세 조정)
+
+#### 3.2.10 CI Job 병렬화 (test와 image-build 분리) — P3
+- **현황**: `.github/workflows/ci.yml:50-194` 단일 job 내 순차 실행.
+- **기대 효과**: `test`는 PR 게이트, `image-build`는 머지/배포 게이트로 분리 시 총 클럭타임 단축. 캐시 공유 설계 필수.
+- **적용 난이도**: Med
+- **리스크**: 캐시 미설계 시 중복 작업 증가. 3.2.1/3.2.4 적용 후 검토 권장.
+- **우선순위**: **P3**
+
+#### 3.2.11 `bootBuildImage` (Buildpacks) — P3 (비권장)
+- **현황**: 미적용. `build.gradle.kts:176-178`은 `springBoot { buildInfo() }`만 설정.
+- **기대 효과**: Paketo Buildpack 기반 자동 layered + Memory Calculator. 다만 첫 빌드 시간이 길고, layered jar + Dockerfile 조합이 더 가벼운 경우 많음.
+- **적용 난이도**: Low
+- **리스크**: 베이스 이미지 통제력 약화, 한국어 timezone 등 커스터마이징 까다로움. 현 Dockerfile 커스텀 사항(`docker/app/dockerfile:8-12, 28-35`) 이전 어려움.
+- **우선순위**: **P3** (비권장)
+
+### 3.3 Docker 빌드 최적화 요약표
+
+| 우선순위 | 기법 | 기대 효과 | 난이도 |
+|---|---|---|---|
+| P1 | Layered Jar + Dockerfile 분리 COPY (3.2.1) | 재빌드 시 layer 갱신 최소화, ECR push 1~3분 절감 | Low |
+| P1 | GHA Docker layer 캐시 활성화 (3.2.4) | 의존성 레이어 재사용, 멀티 플랫폼 5~10분 절감 | Low |
+| P1 | 멀티 플랫폼 범위 축소 (3.2.6, 조건부) | QEMU 제거로 빌드 시간 40~50% 감소 | Low |
+| P1 | 베이스 이미지 JRE 전환 (3.2.7) | 이미지 크기 150~180MB 감소, pull/deploy 단축 | Low |
+| P2 | Multi-stage + BuildKit cache mount (3.2.2, 3.2.3) | Gradle 의존성 캐싱 2~5분 절감 | Med |
+| P2 | ECR Registry 캐시 (3.2.5) | runner 간 캐시 공유, GHA 한도 회피 | Low |
+| P3 | Jib 도입 (3.2.8) | 50~70% 단축 가능, 대안 경로 | Med |
+| P3 | `.dockerignore` 미세 조정 (3.2.9) | 컨텍스트 전송 5~10% 절감 | Low |
+| P3 | CI Job 병렬화 (3.2.10) | 클럭타임 단축, 캐시 설계 의존 | Med |
+| P3 | `bootBuildImage` (3.2.11) | 자동 layered, 비권장 | Low |
+
+---
+
+## 4. 통합 우선순위 로드맵
+
+본 보고서의 권고는 다음 순서로 적용을 제안합니다.
+
+### Phase 0: Baseline 측정 (필수 선행)
+- 부팅 시간: `BufferingApplicationStartup` 활성화 + `/actuator/startup` 노출
+- Docker 빌드: 워크플로 step별 wall-clock 시간, 이미지 크기, layer 재사용률 기록
+- 본 보고서의 정량 수치는 **추정값**이므로 baseline 확보 후 회귀 측정 권장
+
+### Phase 1: 즉시 적용(P1, Low 난이도)
+1. **부팅**
+   - 2.2.1 Spring AI 멀티 starter 정리 (gradle profile 분기 또는 exclude)
+   - 2.2.2 Hikari `minimum-idle=2` + `initialization-fail-timeout=-1` (local/dev 우선)
+   - 2.2.3 Hibernate JDBC metadata 차단 + dialect 명시
+   - 2.2.4 `spring.main.lazy-initialization=true` (local 한정)
+2. **Docker**
+   - 3.2.1 Layered Jar 도입 → Dockerfile 분리 COPY
+   - 3.2.7 베이스 이미지 JRE 전환
+   - 3.2.4 GHA Docker layer 캐시 활성화 (3.2.1과 함께)
+   - 3.2.6 단일 플랫폼 빌드 검토 (인프라 확인 필요)
+
+### Phase 2: 운영 효과 최적화 (P2)
+- 부팅: AppCDS(2.2.8), p6spy prod 비활성화(2.2.7), Actuator/Tracing trim(2.2.6), Flyway 분리(2.2.5)
+- Docker: Multi-stage + BuildKit cache(3.2.2/3.2.3), ECR Registry 캐시(3.2.5)
+
+### Phase 3: 장기 검토 (P3)
+- CRaC(2.2.9), GraalVM Native(2.2.10), Jib(3.2.8), CI Job 병렬화(3.2.10), 가상 스레드(2.2.13)
+
+### 예상 누적 효과
+- **부팅**: P1+P2 적용 시 **-4~10초** (현재 미측정이라 비율로는 30~50% 단축 추정)
+- **Docker**: P1 적용 시 일반 PR 빌드 **5~15분 단축**, 이미지 크기 **150~180MB 감소**
+
+---
+
+## 5. 측정 및 검증 방법
+
+### 5.1 부팅 시간
+1. `spring.main.bufferedApplicationStartup.enabled=true` 활성화 후 `/actuator/startup` endpoint 노출 (`application.yml:237` exposure에 `startup` 추가). Spring Boot가 phase별 timing을 JSON으로 반환
+2. `-Dspring.context.exit=onRefresh`로 부팅 직후 종료 → `time ./gradlew bootRun`으로 본 부팅 비용만 측정 (요청 처리 시간 배제)
+3. **JFR (Java Flight Recorder)** 부팅 구간 캡처: `-XX:StartFlightRecording=duration=60s,filename=boot.jfr` 후 JDK Mission Control로 class loading / JIT / GC 비중 확인
+4. **CI 측정 hook 추가**: `.github/workflows/ci.yml`에 `bootRun &` + `until curl localhost:9090/actuator/health; do sleep 0.5; done` 패턴으로 매 PR 부팅 시간 시계열화 → 회귀 감지
+5. **AppCDS 비교**: `-Xlog:class+load=info,cds=info`로 클래스 로딩 시간 측정 후 jsa 적용 전/후 비교
+
+### 5.2 Docker 빌드
+1. **베이스라인**: `.github/workflows/ci.yml`의 `build-and-test` job 시작/종료 시각을 step별 기록(`time` 명령 또는 `gh run view --log` 분석). 최근 10건 평균 + 캐시 hit/miss 케이스 분리
+2. **이미지 크기**: `docker image inspect ... --format='{{.Size}}'` + `docker history`로 layer별 크기 베이스라인 확보. 옵션 적용 후 `dive` 또는 `docker image ls` 비교
+3. **레이어 캐시 효율**: `docker build --progress=plain` 출력에서 `CACHED` 비율, `docker/build-push-action`의 `actions/cache`/`gha` hit 로그 분석
+4. **A/B 실험 절차**
+   - PR 1: 3.2.1(Layered Jar) 단독 적용 → 같은 커밋을 두 번 빌드해 캐시 miss/hit 시간 모두 기록
+   - PR 2: 3.2.1 + 3.2.4(GHA 캐시) 추가
+   - PR 3: 3.2.7(JRE 베이스) 적용 및 이미지 크기 비교
+   - PR 4: 3.2.6(단일 플랫폼) 적용 후 ECS/홈서버 정상 기동 확인
+5. **회귀 방지**: 각 PR에 `Build Summary` 스텝(`.github/workflows/ci.yml:271-278`)을 확장하여 `IMAGE_SIZE_MB`, `BUILD_DURATION_SEC`를 `$GITHUB_STEP_SUMMARY`에 기록 → 추세 모니터링
+
+---
+
+## 6. 다음 단계 (Action Items)
+
+- [ ] **Phase 0 — Baseline**: 부팅 시간/Docker 빌드 시간 측정 hook 추가 PR
+- [ ] **Phase 1.1 — 부팅 P1**: Spring AI starter 정리, Hikari/Hibernate/Lazy init 설정 PR
+- [ ] **Phase 1.2 — Docker P1**: Layered Jar + Dockerfile 개편 + GHA 캐시 활성화 PR
+- [ ] **Phase 1.3 — Docker P1**: 베이스 이미지 JRE 전환 PR
+- [ ] **Phase 1.4 — Docker P1 (검토)**: 멀티 플랫폼 빌드 범위 결정 (인프라팀 확인 필요)
+- [ ] **Phase 2**: AppCDS, p6spy/Actuator/Flyway, Multi-stage+BuildKit, Registry 캐시
+- [ ] **Phase 3**: CRaC/Native/Jib/CI 병렬화 — Phase 1·2 측정 결과 기반 ROI 재평가

--- a/docs/analysis/boot-and-build-optimization-report.md
+++ b/docs/analysis/boot-and-build-optimization-report.md
@@ -63,7 +63,7 @@ UMC PRODUCT 백엔드의 **SpringBoot 부팅 시간**과 **Docker 빌드 시간*
 
 #### 2.2.3 Hibernate JDBC metadata 호출 차단 — P1
 - **현황**: `application.yml:83-94`에서 `hibernate.boot.allow_jdbc_metadata_access`, `hibernate.temp.use_jdbc_metadata_defaults` 모두 **미설정**. dialect 자동 판별을 위해 부팅 시 JDBC connection을 열고 metadata 1회 round-trip. PostgreSQL 18 + JTS extension lookup 포함 시 +0.3~0.6초.
-- **기대 효과**: `spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false` + `hibernate.temp.use_jdbc_metadata_defaults=false` 설정 시 **-0.3~0.6초**. dialect는 `org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect`로 명시.
+- **기대 효과**: `spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false` + `hibernate.temp.use_jdbc_metadata_defaults=false` 설정 시 **-0.3~0.6초**. dialect는 Hibernate 6의 공간 타입 지원이 통합된 `org.hibernate.dialect.PostgreSQLDialect`로 명시.
 - **적용 난이도**: Low (dialect 명시 한 줄 추가)
 - **리스크**: PostgreSQL 버전 업그레이드 시 dialect 갱신 누락 가능.
 - **우선순위**: **P1**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -299,7 +299,6 @@ management:
       enabled: false
 
 app:
-  base-url: ${APP_BASE_URL:http://localhost:${SERVER_PORT:8080}}
   # Figma_댓글_dev_prod_중복_방지_계획 §L4: Discord embed footer 의 환경 라벨 ([ENV: ...]) 으로 노출됨.
   # spring.profiles.active 가 콤마 구분 다중 profile 일 수 있으므로 운영자가 단일 라벨을 명시적으로 override 가능.
   environment: ${APP_ENVIRONMENT:${SPRING_PROFILES_ACTIVE:local}}
@@ -308,7 +307,6 @@ app:
     enabled: ${FCM_ENABLED:false}
     outbox-interval-ms: ${FCM_OUTBOX_INTERVAL_MS:60000}
     firebase-configuration: ${FIREBASE_CONFIGURATION}
-    topic-prefix: ${SPRING_PROFILES_ACTIVE:local}
 
   cors:
     allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,6 @@
 # 환경변수 변경 시에는 반드시 GitHub Actions에 업데이트 할 것
 # ==================================================================
 
-
 server:
   port: ${SERVER_PORT:8080}
   shutdown: graceful
@@ -53,7 +52,7 @@ spring:
     suffix: .html
     mode: HTML
     encoding: UTF-8
-    cache: false  # 개발 환경에서는 캐시 비활성화, 운영에서는 true로 변경 필요
+    cache: false # 개발 환경에서는 캐시 비활성화, 운영에서는 true로 변경 필요
 
   datasource:
     url: ${DATABASE_URL}
@@ -69,11 +68,11 @@ spring:
       initialization-fail-timeout: ${HIKARI_INITIALIZATION_FAIL_TIMEOUT:-1}
 
       # 3. 수명 및 타임아웃
-      max-lifetime: 1800000       # 30분
-      connection-timeout: 30000   # 30초
-      validation-timeout: 5000    # 5초
+      max-lifetime: 1800000 # 30분
+      connection-timeout: 30000 # 30초
+      validation-timeout: 5000 # 5초
 
-      keepalive-time: 60000       # DB에 1분마다 생존 신고 (유휴 커넥션 방지)
+      keepalive-time: 60000 # DB에 1분마다 생존 신고 (유휴 커넥션 방지)
 
   flyway:
     enabled: true
@@ -82,18 +81,13 @@ spring:
     out-of-order: ${FLYWAY_OUT_OF_ORDER:false}
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: validate
     open-in-view: false
     properties:
       hibernate:
         default_schema: public
-        format_sql: true
-        boot:
-          allow_jdbc_metadata_access: false
-        temp:
-          use_jdbc_metadata_defaults: false
+        format_sql: false
         show_sql: false # p6spy가 있어서 꺼둠
 
   # ====================================================================
@@ -178,23 +172,23 @@ springdoc:
     enabled: ${SWAGGER_ENABLE:false} # Swagger는 기본적으로 비활성화
 
     # 정렬 옵션
-    groups-order: DESC  # 그룹 정렬 (ASC/DESC)
-    tags-sorter: alpha  # 태그(컨트롤러) 정렬
-    operations-sorter: method  # API 메소드 정렬
+    groups-order: DESC # 그룹 정렬 (ASC/DESC)
+    tags-sorter: alpha # 태그(컨트롤러) 정렬
+    operations-sorter: method # API 메소드 정렬
 
     # UI 설정
-    doc-expansion: none  # API 펼침 상태 (none/list/full)
-    disable-swagger-default-url: true  # petstore 기본 URL 비활성화
-    display-request-duration: true  # 요청 소요 시간 표시
-    display-operation-id: false  # operation ID 표시 여부
+    doc-expansion: none # API 펼침 상태 (none/list/full)
+    disable-swagger-default-url: true # petstore 기본 URL 비활성화
+    display-request-duration: true # 요청 소요 시간 표시
+    display-operation-id: false # operation ID 표시 여부
 
     filter: true
     #    default-models-expand-depth: -1  # 스키마 모델도 접힌 상태로
 
     # 기타
-    deep-linking: true  # URL 딥링킹 지원
-    show-extensions: true  # 확장 속성 표시
-    show-common-extensions: true  # 공통 확장 속성 표시
+    deep-linking: true # URL 딥링킹 지원
+    show-extensions: true # 확장 속성 표시
+    show-common-extensions: true # 공통 확장 속성 표시
 
   api-docs:
     path: /docs-json # API 문서 경로
@@ -215,7 +209,7 @@ logging:
 
     # JPA/Hibernate
     org.hibernate.SQL: WARN
-    org.hibernate.orm.jdbc.bind: WARN  # 파라미터 숨김
+    org.hibernate.orm.jdbc.bind: WARN # 파라미터 숨김
 
     # 트랜잭션
     org.springframework.transaction: INFO
@@ -377,7 +371,7 @@ app:
       authorize-uri: https://www.figma.com/oauth
       token-uri: https://api.figma.com/v1/oauth/token
       refresh-uri: https://api.figma.com/v1/oauth/refresh
-      token-encryption-key: ${FIGMA_TOKEN_ENCRYPTION_KEY}  # 필수 — 기본값 없음. 미설정 시 애플리케이션 기동 실패.
+      token-encryption-key: ${FIGMA_TOKEN_ENCRYPTION_KEY} # 필수 — 기본값 없음. 미설정 시 애플리케이션 기동 실패.
     sync:
       enabled: ${FIGMA_SYNC_ENABLED:false}
       poll-interval: ${FIGMA_SYNC_POLL_INTERVAL:PT5M}
@@ -417,6 +411,7 @@ storage:
       key-name: ${CDN_KEY_NAME}
       private-key: ${CDN_PRIVATE_KEY}
 
+
 # ==================================================================
 # dev 환경에 대한 default override
 # ==================================================================
@@ -429,14 +424,3 @@ spring:
 app:
   seed:
     enabled: ${APP_SEED_ENABLED:true}
-
-# ==================================================================
-# local 환경에 대한 default override
-# ==================================================================
----
-spring:
-  config:
-    activate:
-      on-profile: local
-  main:
-    lazy-initialization: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,7 @@ spring:
     out-of-order: ${FLYWAY_OUT_OF_ORDER:false}
 
   jpa:
-    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: validate
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,7 +65,8 @@ spring:
       auto-commit: true
 
       maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:10}
-      minimum-idle: ${HIKARI_MIN_IDLE:10}
+      minimum-idle: ${HIKARI_MIN_IDLE:2}
+      initialization-fail-timeout: ${HIKARI_INITIALIZATION_FAIL_TIMEOUT:-1}
 
       # 3. 수명 및 타임아웃
       max-lifetime: 1800000       # 30분
@@ -81,8 +82,7 @@ spring:
     out-of-order: ${FLYWAY_OUT_OF_ORDER:false}
 
   jpa:
-    # database-platform은 SpringBoot가 hibernate-spatial 의존성을 기반으로 자동으로 선택함
-    # 따라서 포함하지 않도록 함.
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
     hibernate:
       ddl-auto: validate
     open-in-view: false
@@ -90,7 +90,10 @@ spring:
       hibernate:
         default_schema: public
         format_sql: true
-        # dialect는 명시가 불필요해서 생략
+        boot:
+          allow_jdbc_metadata_access: false
+        temp:
+          use_jdbc_metadata_defaults: false
         show_sql: false # p6spy가 있어서 꺼둠
 
   # ====================================================================
@@ -428,3 +431,14 @@ spring:
 app:
   seed:
     enabled: ${APP_SEED_ENABLED:true}
+
+# ==================================================================
+# local 환경에 대한 default override
+# ==================================================================
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  main:
+    lazy-initialization: true


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #889

## 🚀 작업 내용

### 변경 범위 요약

- Spring Boot 부팅 설정(`application.yml`)과 Docker 이미지 빌드 경로(`build.gradle.kts`, `docker/app/dockerfile`, `.github/workflows/ci.yml`)를 중심으로 Phase 1 성능 최적화를 적용했어요.
- 분석 보고서와 Phase 1 실행 계획을 `docs/analysis`에 추가하고, 불필요한 환경변수 설정을 정리했어요.

### 작업 단위별 상세

1. **무엇을**: Spring Boot 부팅 초기에 확보하는 DB connection 비용을 줄였어요.
   - **어떻게**: Hikari 기본 `minimum-idle`을 10에서 2로 낮추고, `initialization-fail-timeout=-1` 기본값을 추가했어요.
   - **왜**: 부팅 시점에 모든 connection을 즉시 확보하지 않고 필요한 시점에 점진적으로 확보하도록 해서 초기 기동 비용을 줄이기 위해서예요.

2. **무엇을**: Hibernate SQL formatting 기본값을 비활성화했어요.
   - **어떻게**: `spring.jpa.properties.hibernate.format_sql` 기본값을 `true`에서 `false`로 변경했어요.
   - **왜**: SQL 출력은 이미 p6spy와 logging level로 제어하고 있어, 기본 포맷팅 비용과 중복 설정을 줄이기 위해서예요.

3. **무엇을**: 사용하지 않는 application 설정과 예시 환경변수를 제거했어요.
   - **어떻게**: `app.base-url`, `app.fcm.topic-prefix`, `.env.example`의 `APP_BASE_URL`을 제거했어요.
   - **왜**: 코드에서 사용하지 않는 설정을 줄이고, IDE의 Spring configuration metadata 경고와 환경변수 관리 부담을 낮추기 위해서예요.

4. **무엇을**: Docker 이미지를 Spring Boot layered jar 구조로 재구성하고 runtime base를 JRE로 바꿨어요.
   - **어떻게**: `bootJar` layered archive 생성을 명시하고, Dockerfile builder stage에서 `java -Djarmode=tools -jar application.jar extract --layers`로 layer를 추출한 뒤 `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application` layer를 별도로 복사했어요. runtime 이미지는 `amazoncorretto:21-alpine`에서 `eclipse-temurin:21-jre-alpine`로 변경했어요.
   - **왜**: 애플리케이션 코드 변경 시 의존성 layer 재전송을 줄이고, runtime 이미지 크기와 pull/deploy 비용을 줄이기 위해서예요.

5. **무엇을**: Dockerfile의 중복 layer와 실행 방식 설명을 정리했어요.
   - **어떻게**: `/app/logs` 생성과 권한 설정을 한 번만 수행하도록 정리하고, Spring Boot 3.5 `jarmode=tools extract --layers` 결과에서 최종 이미지의 `application.jar`를 실행한다는 주석을 남겼어요.
   - **왜**: 불필요한 Docker layer를 줄이고, review comment에서 혼동됐던 `JarLauncher` 실행 방식과 현재 추출 layout의 차이를 명확히 하기 위해서예요.

6. **무엇을**: GitHub Actions Docker layer cache를 활성화했어요.
   - **어떻게**: `docker/build-push-action@v6`에 `cache-from: type=gha`, `cache-to: type=gha,mode=max`를 추가했어요.
   - **왜**: layered jar 적용 이후 Docker buildx가 의존성 layer를 재사용할 수 있게 해서 멀티 플랫폼 이미지 빌드 시간을 줄이기 위해서예요.

7. **무엇을**: SpringBoot 부팅 시간과 Docker 빌드 시간 최적화 분석 문서를 저장했어요.
   - **어떻게**: `docs/analysis/boot-and-build-optimization-report.md`에 현황 분석과 우선순위별 기대 효과를 정리하고, `docs/analysis/boot-and-build-optimization-phase1-plan.md`에 Phase 1 적용 범위와 보류 항목을 정리했어요.
   - **왜**: 이번 PR에 포함한 변경과 보류한 항목의 판단 근거를 리뷰어가 같은 맥락에서 확인할 수 있게 하기 위해서예요.

### 이번 PR에서 보류한 항목

- Spring AI starter 제거는 현재 provider별 adapter가 model class를 직접 import하고 있어 단순 의존성 제거 시 compile classpath가 깨질 수 있어요.
- `linux/amd64` 단일 플랫폼 전환은 운영과 개발 배포 아키텍처 확인 전에는 배포 가능성을 좁힐 수 있어 보류했어요.
- Hibernate JDBC metadata 접근 차단과 local lazy initialization은 문서상 후보로 검토했지만, 최신 코드 변경 범위에서는 제외했어요.

### 검증

- `./gradlew test bootJar` 성공했어요.
- `docker build -f docker/app/dockerfile -t umc-product-server:phase1-pr-check .` 성공했어요.
- Docker 이미지에서 `/app/application.jar`와 manifest `Class-Path: lib/` 구성을 확인했어요.
- 생성 이미지 크기는 `241,053,079` bytes로 확인했어요.
- 테스트 종료 훅에서 Telegram/Discord webhook 전송 실패 로그가 출력됐지만, 테스트 결과는 `BUILD SUCCESSFUL`이에요.

## 💬 리뷰 중점사항

- Hikari `minimum-idle=2` 기본값이 운영 시작 직후 burst 트래픽 관점에서 허용 가능한지 봐주세요. 필요하면 환경 변수 `HIKARI_MIN_IDLE`로 즉시 조정할 수 있어요.
- `hibernate.format_sql=false` 전환이 개발/운영 로그 확인 방식과 충돌하지 않는지 봐주세요.
- `app.base-url`, `app.fcm.topic-prefix`, `APP_BASE_URL` 제거가 실제 운영 환경변수나 외부 문서에 남은 참조와 충돌하지 않는지 봐주세요.
- Dockerfile의 Spring Boot `tools` layer 추출 구조와 `java -jar application.jar` 실행 방식이 배포 환경에서 문제없는지 봐주세요.
- GHA cache `mode=max`가 저장소의 Actions cache 사용량 정책과 맞는지 봐주세요.
