### PR TITLE
[Feat] 프로젝트 삭제 및 중단 API 추가

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -5,20 +5,24 @@ import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.AddProjectMemberRequest;
 import com.umc.product.project.adapter.in.web.dto.request.CreateDraftProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.TransferProjectOwnershipRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdatePartQuotasRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdateProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectStatusResponse;
+import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
 import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
 import com.umc.product.project.application.port.in.command.RemoveProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.PublishProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.RemoveProjectMemberCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
@@ -51,6 +55,8 @@ public class ProjectCommandController {
     private final RemoveProjectMemberUseCase removeProjectMemberUseCase;
     private final UpdatePartQuotasUseCase updatePartQuotasUseCase;
     private final PublishProjectUseCase publishProjectUseCase;
+    private final DeleteProjectUseCase deleteProjectUseCase;
+    private final AbortProjectUseCase abortProjectUseCase;
 
     @PostMapping
     @Operation(
@@ -192,6 +198,46 @@ public class ProjectCommandController {
     ) {
         updatePartQuotasUseCase.update(
             request.toCommand(projectId, memberPrincipal.getMemberId()));
+    }
+
+    @DeleteMapping("/{projectId}")
+    @Operation(
+        summary = "[PROJECT-109] 프로젝트 삭제",
+        description = "DRAFT / PENDING_REVIEW 상태의 프로젝트를 hard delete 합니다. 연관 ProjectMember / PartQuota / ApplicationForm + survey Form 까지 cascade 삭제. PO 본인 또는 운영진(본인 지부장 / 해당 기수 총괄단)만 호출 가능. IN_PROGRESS 이상은 abort 엔드포인트 사용."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.DELETE,
+        message = "프로젝트 삭제 권한이 없습니다."
+    )
+    public void delete(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId
+    ) {
+        deleteProjectUseCase.delete(DeleteProjectCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(memberPrincipal.getMemberId())
+            .build());
+    }
+
+    @PostMapping("/{projectId}/abort")
+    @Operation(
+        summary = "[PROJECT-110] 프로젝트 중단",
+        description = "IN_PROGRESS 상태의 프로젝트를 ABORTED 로 전이합니다. ACTIVE ProjectMember 는 WITHDRAWN, 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 일괄 동기화. 운영진(본인 지부장 또는 Central Core) 만 호출 가능."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.MANAGE,
+        message = "프로젝트 중단 권한이 없습니다."
+    )
+    public void abort(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @Valid @RequestBody AbortProjectRequest request
+    ) {
+        abortProjectUseCase.abort(request.toCommand(projectId, memberPrincipal.getMemberId()));
     }
 
     @DeleteMapping("/{projectId}/members/{memberId}")

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/AbortProjectRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/AbortProjectRequest.java
@@ -1,0 +1,22 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.AbortProjectCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로젝트 중단(abort) 요청 DTO. 사유는 필수이며 운영진 감사 로그용으로 사용됩니다.
+ */
+public record AbortProjectRequest(
+    @NotBlank
+    @Size(max = 255)
+    String reason
+) {
+    public AbortProjectCommand toCommand(Long projectId, Long requesterMemberId) {
+        return AbortProjectCommand.builder()
+            .projectId(projectId)
+            .requesterMemberId(requesterMemberId)
+            .reason(reason)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormJpaRepository.java
@@ -3,10 +3,17 @@ package com.umc.product.project.adapter.out.persistence;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectApplicationFormJpaRepository extends JpaRepository<ProjectApplicationForm, Long> {
 
     boolean existsByProjectId(Long projectId);
 
     Optional<ProjectApplicationForm> findFirstByProjectIdOrderByIdAsc(Long projectId);
+
+    @Modifying
+    @Query("DELETE FROM ProjectApplicationForm f WHERE f.project.id = :projectId")
+    void deleteAllByProjectId(@Param("projectId") Long projectId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapter.java
@@ -39,4 +39,9 @@ public class ProjectApplicationFormPersistenceAdapter
     public void delete(ProjectApplicationForm form) {
         repository.delete(form);
     }
+
+    @Override
+    public void deleteAllByProjectId(Long projectId) {
+        repository.deleteAllByProjectId(projectId);
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyJpaRepository.java
@@ -3,6 +3,9 @@ package com.umc.product.project.adapter.out.persistence;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectApplicationFormPolicyJpaRepository
     extends JpaRepository<ProjectApplicationFormPolicy, Long> {
@@ -10,4 +13,8 @@ public interface ProjectApplicationFormPolicyJpaRepository
     List<ProjectApplicationFormPolicy> findAllByApplicationFormId(Long applicationFormId);
 
     void deleteByFormSectionId(Long formSectionId);
+
+    @Modifying
+    @Query("DELETE FROM ProjectApplicationFormPolicy p WHERE p.applicationForm.id = :applicationFormId")
+    void deleteAllByApplicationFormId(@Param("applicationFormId") Long applicationFormId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapter.java
@@ -40,4 +40,10 @@ public class ProjectApplicationFormPolicyPersistenceAdapter
     public void deleteByFormSectionId(Long formSectionId) {
         repository.deleteByFormSectionId(formSectionId);
     }
+
+    @Override
+    @Transactional
+    public void deleteAllByApplicationFormId(Long applicationFormId) {
+        repository.deleteAllByApplicationFormId(applicationFormId);
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationJpaRepository.java
@@ -1,12 +1,23 @@
 package com.umc.product.project.adapter.out.persistence;
 
 import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectApplicationJpaRepository extends JpaRepository<ProjectApplication, Long> {
 
     boolean existsByAppliedMatchingRound_Id(Long matchingRoundId);
 
     List<ProjectApplication> findAllByAppliedMatchingRound_Id(Long matchingRoundId);
+
+    @Query("SELECT a FROM ProjectApplication a "
+        + "WHERE a.applicationForm.project.id = :projectId "
+        + "AND a.status IN :statuses")
+    List<ProjectApplication> findAllByProjectIdAndStatusIn(
+        @Param("projectId") Long projectId,
+        @Param("statuses") List<ProjectApplicationStatus> statuses
+    );
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -119,4 +119,12 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     ) {
         return projectApplicationQueryRepository.searchProjectApplications(projectId, matchingRoundId, status);
     }
+
+    @Override
+    public List<ProjectApplication> listInProgressByProjectId(Long projectId) {
+        return projectApplicationJpaRepository.findAllByProjectIdAndStatusIn(
+            projectId,
+            List.of(ProjectApplicationStatus.DRAFT, ProjectApplicationStatus.SUBMITTED)
+        );
+    }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -31,4 +32,8 @@ public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember,
     boolean existsByProjectIdAndMemberIdAndPartAndStatus(
         Long projectId, Long memberId, ChallengerPart part, ProjectMemberStatus status
     );
+
+    @Modifying
+    @Query("DELETE FROM ProjectMember pm WHERE pm.project.id = :projectId")
+    void deleteAllByProjectId(@Param("projectId") Long projectId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -38,6 +38,11 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     }
 
     @Override
+    public void deleteAllByProjectId(Long projectId) {
+        repository.deleteAllByProjectId(projectId);
+    }
+
+    @Override
     public List<ProjectMember> listByProjectId(Long projectId) {
         return repository.findByProjectIdAndStatus(projectId, ProjectMemberStatus.ACTIVE);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaJpaRepository.java
@@ -20,4 +20,8 @@ public interface ProjectPartQuotaJpaRepository extends JpaRepository<ProjectPart
         + "WHERE q.project.id = :projectId AND q.part IN :parts")
     void deleteByProjectIdAndPartIn(@Param("projectId") Long projectId,
                                     @Param("parts") Collection<ChallengerPart> parts);
+
+    @Modifying
+    @Query("DELETE FROM ProjectPartQuota q WHERE q.project.id = :projectId")
+    void deleteAllByProjectId(@Param("projectId") Long projectId);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPartQuotaPersistenceAdapter.java
@@ -52,4 +52,9 @@ public class ProjectPartQuotaPersistenceAdapter
         }
         repository.deleteByProjectIdAndPartIn(projectId, parts);
     }
+
+    @Override
+    public void deleteAllByProjectId(Long projectId) {
+        repository.deleteAllByProjectId(projectId);
+    }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/AbortProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/AbortProjectUseCase.java
@@ -1,0 +1,18 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.AbortProjectCommand;
+
+/**
+ * 프로젝트 중단(abort) UseCase.
+ * <p>
+ * IN_PROGRESS 상태 프로젝트를 ABORTED 로 전이합니다. ACTIVE ProjectMember 는 WITHDRAWN,
+ * 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 일괄 동기화합니다.
+ * 권한 검증은 Controller 단의 {@code @CheckAccess(MANAGE)} 가 담당합니다.
+ */
+public interface AbortProjectUseCase {
+
+    /**
+     * 프로젝트를 중단 처리합니다.
+     */
+    void abort(AbortProjectCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/DeleteProjectUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/DeleteProjectUseCase.java
@@ -1,0 +1,20 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand;
+
+/**
+ * 프로젝트 hard delete UseCase.
+ * <p>
+ * DRAFT / PENDING_REVIEW 상태에서만 호출 가능. 자식 row(멤버/정원/지원 폼 매핑/Form/Policy)를
+ * 같은 트랜잭션 내에서 명시적으로 cascade 삭제합니다. IN_PROGRESS 이상은
+ * {@code AbortProjectUseCase} 로 상태 전이만 허용합니다.
+ */
+public interface DeleteProjectUseCase {
+
+    /**
+     * 프로젝트를 영구 삭제합니다.
+     *
+     * @param command 삭제 Command
+     */
+    void delete(DeleteProjectCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/AbortProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/AbortProjectCommand.java
@@ -1,0 +1,27 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 중단(abort) Command.
+ * <p>
+ * IN_PROGRESS 상태 프로젝트를 ABORTED 로 전이하고, ACTIVE 멤버는 WITHDRAWN, 진행 중 application 은 CANCELLED 로 동기화합니다.
+ * 종료 상태(COMPLETED/ABORTED)는 도메인 가드({@code Project#abort})가 거부합니다.
+ */
+@Builder
+public record AbortProjectCommand(
+    Long projectId,
+    Long requesterMemberId,
+    String reason
+) {
+    public AbortProjectCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+        if (reason == null || reason.isBlank()) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ABORT_REASON_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/DeleteProjectCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/DeleteProjectCommand.java
@@ -1,0 +1,22 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 프로젝트 hard delete Command.
+ * <p>
+ * DRAFT / PENDING_REVIEW 상태의 프로젝트와 연관 자식(ProjectMember, ProjectPartQuota,
+ * ProjectApplicationForm + Policy + 연결된 survey Form)을 cascade 삭제합니다.
+ * IN_PROGRESS 이상 상태는 {@code AbortProjectUseCase} 로 상태 전이만 가능합니다.
+ */
+@Builder
+public record DeleteProjectCommand(
+    Long projectId,
+    Long requesterMemberId
+) {
+    public DeleteProjectCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -103,4 +103,10 @@ public interface LoadProjectApplicationPort {
         Long matchingRoundId,
         ProjectApplicationStatus status
     );
+
+    /**
+     * 프로젝트 abort 시 일괄 취소 대상 application 조회용. DRAFT/SUBMITTED 상태 application 만 반환합니다.
+     * APPROVED/REJECTED/CANCELLED 는 이미 종결되어 추가 정리가 필요 없습니다.
+     */
+    List<ProjectApplication> listInProgressByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPolicyPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPolicyPort.java
@@ -23,4 +23,10 @@ public interface SaveProjectApplicationFormPolicyPort {
      * Survey 단의 {@code deleteSection} 호출 후 이 메서드로 매핑 row 를 정리합니다.
      */
     void deleteByFormSectionId(Long formSectionId);
+
+    /**
+     * 특정 지원 폼에 속한 모든 정책 row 를 일괄 삭제합니다. 프로젝트 hard delete 시
+     * ProjectApplicationForm 정리 전에 호출해야 합니다.
+     */
+    void deleteAllByApplicationFormId(Long applicationFormId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectApplicationFormPort.java
@@ -16,4 +16,10 @@ public interface SaveProjectApplicationFormPort {
     List<ProjectApplicationForm> saveAll(List<ProjectApplicationForm> forms);
 
     void delete(ProjectApplicationForm form);
+
+    /**
+     * 특정 프로젝트의 모든 지원 폼 매핑 row 를 일괄 삭제합니다. DRAFT/PENDING_REVIEW 단계 프로젝트 hard delete 시 자식 정리용.
+     * survey 도메인의 Form 자체는 호출 측에서 {@code ManageFormUseCase.deleteForm} 로 별도 정리해야 합니다.
+     */
+    void deleteAllByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectMemberPort.java
@@ -25,4 +25,9 @@ public interface SaveProjectMemberPort {
      * IN_PROGRESS 이후 단계에서는 사용 금지 — 매칭/출석 등 외부 도메인 데이터에 영향. soft delete(상태 변경) 사용.
      */
     void hardDelete(Long projectMemberId);
+
+    /**
+     * 특정 프로젝트의 모든 멤버 row 를 일괄 삭제합니다. DRAFT/PENDING_REVIEW 단계 프로젝트 hard delete 시 자식 정리용.
+     */
+    void deleteAllByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/application/port/out/SaveProjectPartQuotaPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/SaveProjectPartQuotaPort.java
@@ -18,4 +18,9 @@ public interface SaveProjectPartQuotaPort {
      * 프로젝트의 특정 파트 quota row 들을 일괄 삭제한다 (PROJECT-105 diff 적용 시).
      */
     void deleteByProjectIdAndPartIn(Long projectId, Collection<ChallengerPart> parts);
+
+    /**
+     * 프로젝트의 모든 part quota row 를 일괄 삭제합니다. DRAFT/PENDING_REVIEW 단계 프로젝트 hard delete 시 자식 정리용.
+     */
+    void deleteAllByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -11,12 +11,14 @@ import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.dto.AbortProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.PublishProjectCommand;
@@ -24,6 +26,8 @@ import com.umc.product.project.application.port.in.command.dto.SubmitProjectComm
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
@@ -32,7 +36,9 @@ import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.port.out.SaveProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
@@ -55,12 +61,15 @@ public class ProjectCommandService implements
     SubmitProjectUseCase,
     TransferProjectOwnershipUseCase,
     PublishProjectUseCase,
-    DeleteProjectUseCase {
+    DeleteProjectUseCase,
+    AbortProjectUseCase {
 
     private final LoadProjectPort loadProjectPort;
     private final SaveProjectPort saveProjectPort;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectMemberPort saveProjectMemberPort;
     private final SaveProjectPartQuotaPort saveProjectPartQuotaPort;
     private final SaveProjectApplicationFormPort saveProjectApplicationFormPort;
@@ -254,5 +263,31 @@ public class ProjectCommandService implements
         saveProjectPartQuotaPort.deleteAllByProjectId(project.getId());
         saveProjectMemberPort.deleteAllByProjectId(project.getId());
         saveProjectPort.delete(project);
+    }
+
+    /**
+     * 프로젝트 중단(abort). IN_PROGRESS → ABORTED 상태 전이 + 자식 도메인 일괄 동기화.
+     * <ul>
+     *   <li>{@link Project#abort} 로 상태 전이 (COMPLETED/ABORTED 는 도메인 가드가 거부)</li>
+     *   <li>ACTIVE 인 ProjectMember 는 모두 WITHDRAWN, statusChangeReason 에 중단 사유 기록</li>
+     *   <li>진행 중(DRAFT/SUBMITTED) ProjectApplication 은 모두 CANCELLED</li>
+     * </ul>
+     * 권한 검증은 Controller 단의 {@code @CheckAccess(MANAGE)} 가 담당.
+     */
+    @Override
+    public void abort(AbortProjectCommand command) {
+        Project project = loadProjectPort.getById(command.projectId());
+        project.abort(command.reason(), command.requesterMemberId());
+
+        List<ProjectMember> activeMembers = loadProjectMemberPort.listByProjectId(project.getId());
+        for (ProjectMember member : activeMembers) {
+            member.withdraw(command.reason(), command.requesterMemberId());
+        }
+
+        List<ProjectApplication> inProgressApplications =
+            loadProjectApplicationPort.listInProgressByProjectId(project.getId());
+        for (ProjectApplication application : inProgressApplications) {
+            application.cancel(command.requesterMemberId(), command.reason());
+        }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -12,11 +12,13 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.PublishProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
@@ -24,6 +26,10 @@ import com.umc.product.project.application.port.in.command.dto.UpdateProjectComm
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort;
+import com.umc.product.project.application.port.out.SaveProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.application.port.out.SaveProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
@@ -32,6 +38,7 @@ import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.PublishFormCommand;
 import java.util.List;
 import java.util.Objects;
@@ -47,12 +54,17 @@ public class ProjectCommandService implements
     UpdateProjectUseCase,
     SubmitProjectUseCase,
     TransferProjectOwnershipUseCase,
-    PublishProjectUseCase {
+    PublishProjectUseCase,
+    DeleteProjectUseCase {
 
     private final LoadProjectPort loadProjectPort;
     private final SaveProjectPort saveProjectPort;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final SaveProjectMemberPort saveProjectMemberPort;
+    private final SaveProjectPartQuotaPort saveProjectPartQuotaPort;
+    private final SaveProjectApplicationFormPort saveProjectApplicationFormPort;
+    private final SaveProjectApplicationFormPolicyPort saveProjectApplicationFormPolicyPort;
 
     // Cross-domain UseCases
     private final GetMemberUseCase getMemberUseCase;
@@ -210,5 +222,37 @@ public class ProjectCommandService implements
             .build());
 
         return project.getStatus();
+    }
+
+    /**
+     * 프로젝트 hard delete. DRAFT/PENDING_REVIEW 상태에서만 호출 가능하며 자식 row 들을 순서대로 정리한다.
+     * <ol>
+     *   <li>ProjectApplicationForm 이 등록되어 있으면 Policy → ApplicationForm row → survey Form 순으로 정리.
+     *       (Form 삭제는 survey 도메인의 cascade 가 보장)</li>
+     *   <li>ProjectPartQuota 일괄 삭제</li>
+     *   <li>ProjectMember 일괄 삭제</li>
+     *   <li>Project 삭제</li>
+     * </ol>
+     * 권한 검증은 Controller 단의 {@code @CheckAccess(DELETE)} + {@link com.umc.product.project.application.service.evaluator.ProjectPermissionEvaluator}
+     * 가 담당. 본 Service 는 도메인 상태 invariant 만 책임진다.
+     */
+    @Override
+    public void delete(DeleteProjectCommand command) {
+        Project project = loadProjectPort.getById(command.projectId());
+        project.validateDeletable();
+
+        loadProjectApplicationFormPort.findByProjectId(project.getId())
+            .ifPresent(form -> {
+                saveProjectApplicationFormPolicyPort.deleteAllByApplicationFormId(form.getId());
+                saveProjectApplicationFormPort.deleteAllByProjectId(project.getId());
+                manageFormUseCase.deleteForm(DeleteFormCommand.builder()
+                    .formId(form.getFormId())
+                    .requesterMemberId(command.requesterMemberId())
+                    .build());
+            });
+
+        saveProjectPartQuotaPort.deleteAllByProjectId(project.getId());
+        saveProjectMemberPort.deleteAllByProjectId(project.getId());
+        saveProjectPort.delete(project);
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -38,7 +38,7 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
             case WRITE -> canWrite(subject);
             case EDIT -> canEdit(subject, permission);
             case MANAGE -> canManage(subject, permission);
-            case DELETE -> isCentralCore(subject);
+            case DELETE -> canDelete(subject, permission);
             default -> false;
         };
     }
@@ -106,6 +106,21 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
     }
 
     /**
+     * 단건 DELETE 분기. 프로젝트 hard delete 액션의 권한 판정.
+     * <ul>
+     *   <li>DRAFT / PENDING_REVIEW: PO 본인 또는 운영진(해당 기수 총괄단 / 본인 지부장)만 통과.</li>
+     *   <li>IN_PROGRESS / COMPLETED / ABORTED: 절대 차단 — abort() 로 상태 전이만 허용.</li>
+     * </ul>
+     */
+    private boolean canDelete(SubjectAttributes subject, ResourcePermission permission) {
+        Project project = loadProject(permission);
+        return switch (project.getStatus()) {
+            case DRAFT, PENDING_REVIEW -> isOwner(subject, project) || isProjectAdmin(subject, project);
+            case IN_PROGRESS, COMPLETED, ABORTED -> false;
+        };
+    }
+
+    /**
      * 운영진 전용 액션 (publish / abort / complete / 정원 설정 등). PM 은 차단 — Admin 검토 우회 방지.
      * <p>
      * 해당 기수의 총괄단(SUPER_ADMIN 은 글로벌) 또는 본인 지부장(해당 기수)만 통과.
@@ -141,6 +156,7 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
                 && Objects.equals(role.gisuId(), gisuId));
     }
 
+    @SuppressWarnings("unused")
     private boolean isCentralCore(SubjectAttributes subject) {
         return subject.roleAttributes().stream()
             .anyMatch(role -> role.roleType().isAtLeastCentralCore());

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -257,6 +257,16 @@ public class Project extends BaseEntity {
     }
 
     /**
+     * 프로젝트 hard delete 가능 상태인지 검증한다. DRAFT/PENDING_REVIEW 단계에서만 허용.
+     * IN_PROGRESS 이상은 모집/매칭 데이터가 누적되므로 {@link #abort} 로 상태 전이해야 한다.
+     */
+    public void validateDeletable() {
+        if (this.status != ProjectStatus.DRAFT && this.status != ProjectStatus.PENDING_REVIEW) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DELETE_NOT_ALLOWED_IN_STATUS);
+        }
+    }
+
+    /**
      * 프로젝트가 중간에 와해되었을 때 사용합니다. 사유를 반드시 제공하여야 합니다.
      *
      * @param reason            와해 사유

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -112,4 +112,17 @@ public class ProjectMember extends BaseEntity {
         this.statusChangeReason = reason;
         this.statusChangedMemberId = removedByMemberId;
     }
+
+    /**
+     * 멤버 활동을 자진 종료 처리합니다 (soft delete).
+     * status 를 {@link ProjectMemberStatus#WITHDRAWN} 으로 바꾸고 변경 메타데이터를 기록합니다.
+     * <p>
+     * 프로젝트 중단(abort) 시 일괄 처리에도 동일 메서드를 사용하며, 사유에 명시합니다.
+     */
+    public void withdraw(String reason, Long decidedByMemberId) {
+        this.status = ProjectMemberStatus.WITHDRAWN;
+        this.statusUpdatedAt = Instant.now();
+        this.statusChangeReason = reason;
+        this.statusChangedMemberId = decidedByMemberId;
+    }
 }

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -39,6 +39,9 @@ public enum ProjectErrorCode implements BaseCode {
     PROJECT_OWNER_NOT_PLAN_CHALLENGER(HttpStatus.BAD_REQUEST, "PROJECT-0010", "프로젝트 PO는 PLAN 파트 챌린저여야 합니다."),
     PROJECT_SUBMIT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "PROJECT-0011", "제출에 필요한 필수 정보가 누락되었습니다."),
     PROJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PROJECT-0012", "해당 프로젝트에 대한 접근 권한이 없습니다."),
+    PROJECT_DELETE_NOT_ALLOWED_IN_STATUS(HttpStatus.CONFLICT, "PROJECT-0022",
+        "현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능)"),
+    PROJECT_ABORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "PROJECT-0023", "프로젝트 중단 사유는 필수입니다."),
 
     // ProjectMember (PROJECT-003/004/005)
     PROJECT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-0100", "프로젝트 멤버를 찾을 수 없습니다."),

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
@@ -1,0 +1,125 @@
+package com.umc.product.project.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
+import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
+import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
+import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
+import com.umc.product.project.application.port.in.command.RemoveProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
+import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ProjectCommandController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProjectCommandControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+    private static final Long PROJECT_ID = 42L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    CreateDraftProjectUseCase createDraftProjectUseCase;
+    @MockitoBean
+    UpdateProjectUseCase updateProjectUseCase;
+    @MockitoBean
+    SubmitProjectUseCase submitProjectUseCase;
+    @MockitoBean
+    TransferProjectOwnershipUseCase transferProjectOwnershipUseCase;
+    @MockitoBean
+    AddProjectMemberUseCase addProjectMemberUseCase;
+    @MockitoBean
+    RemoveProjectMemberUseCase removeProjectMemberUseCase;
+    @MockitoBean
+    UpdatePartQuotasUseCase updatePartQuotasUseCase;
+    @MockitoBean
+    PublishProjectUseCase publishProjectUseCase;
+    @MockitoBean
+    DeleteProjectUseCase deleteProjectUseCase;
+    @MockitoBean
+    AbortProjectUseCase abortProjectUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    void DELETE_프로젝트_삭제_204() throws Exception {
+        mockMvc.perform(delete("/api/v1/projects/" + PROJECT_ID))
+            .andExpect(status().isOk());
+
+        then(deleteProjectUseCase).should().delete(any());
+    }
+
+    @Test
+    void POST_프로젝트_중단_204() throws Exception {
+        AbortProjectRequest request = new AbortProjectRequest("팀이 데모데이 불참으로 와해됨");
+
+        mockMvc.perform(post("/api/v1/projects/" + PROJECT_ID + "/abort")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        then(abortProjectUseCase).should().abort(any());
+    }
+
+    @Test
+    void POST_프로젝트_중단_reason_누락이면_400() throws Exception {
+        AbortProjectRequest request = new AbortProjectRequest("  ");
+
+        mockMvc.perform(post("/api/v1/projects/" + PROJECT_ID + "/abort")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(abortProjectUseCase).should(never()).abort(any());
+    }
+
+    @Test
+    void POST_프로젝트_중단_body_누락이면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/projects/" + PROJECT_ID + "/abort")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(abortProjectUseCase).should(never()).abort(any());
+    }
+}

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -51,6 +51,18 @@ class ProjectCommandServiceTest {
     @Mock
     com.umc.product.project.application.port.out.LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     @Mock
+    com.umc.product.project.application.port.out.LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
+    com.umc.product.project.application.port.out.LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
+    com.umc.product.project.application.port.out.SaveProjectMemberPort saveProjectMemberPort;
+    @Mock
+    com.umc.product.project.application.port.out.SaveProjectPartQuotaPort saveProjectPartQuotaPort;
+    @Mock
+    com.umc.product.project.application.port.out.SaveProjectApplicationFormPort saveProjectApplicationFormPort;
+    @Mock
+    com.umc.product.project.application.port.out.SaveProjectApplicationFormPolicyPort saveProjectApplicationFormPolicyPort;
+    @Mock
     GetMemberUseCase getMemberUseCase;
     @Mock
     GetChallengerUseCase getChallengerUseCase;
@@ -620,6 +632,113 @@ class ProjectCommandServiceTest {
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.APPLICATION_FORM_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    class delete {
+
+        @Test
+        void DRAFT_상태에서_form이_없으면_자식만_정리하고_삭제() {
+            Project project = createProject(ProjectStatus.DRAFT);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectApplicationFormPort.findByProjectId(1L))
+                .willReturn(java.util.Optional.empty());
+
+            sut.delete(com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand.builder()
+                .projectId(1L).requesterMemberId(99L).build());
+
+            then(saveProjectApplicationFormPolicyPort).should(never()).deleteAllByApplicationFormId(any());
+            then(saveProjectApplicationFormPort).should(never()).deleteAllByProjectId(any());
+            then(manageFormUseCase).should(never()).deleteForm(any());
+            then(saveProjectPartQuotaPort).should().deleteAllByProjectId(1L);
+            then(saveProjectMemberPort).should().deleteAllByProjectId(1L);
+            then(saveProjectPort).should().delete(project);
+        }
+
+        @Test
+        void PENDING_REVIEW_상태에서_form이_있으면_Form까지_cascade_삭제() {
+            Project project = createProject(ProjectStatus.PENDING_REVIEW);
+            com.umc.product.project.domain.ProjectApplicationForm form =
+                com.umc.product.project.domain.ProjectApplicationForm.create(project, 777L);
+            ReflectionTestUtils.setField(form, "id", 55L);
+
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectApplicationFormPort.findByProjectId(1L))
+                .willReturn(java.util.Optional.of(form));
+
+            sut.delete(com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand.builder()
+                .projectId(1L).requesterMemberId(99L).build());
+
+            then(saveProjectApplicationFormPolicyPort).should().deleteAllByApplicationFormId(55L);
+            then(saveProjectApplicationFormPort).should().deleteAllByProjectId(1L);
+            then(manageFormUseCase).should().deleteForm(any());
+            then(saveProjectPartQuotaPort).should().deleteAllByProjectId(1L);
+            then(saveProjectMemberPort).should().deleteAllByProjectId(1L);
+            then(saveProjectPort).should().delete(project);
+        }
+
+        @Test
+        void IN_PROGRESS_상태이면_PROJECT_DELETE_NOT_ALLOWED_IN_STATUS() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.delete(
+                com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand.builder()
+                    .projectId(1L).requesterMemberId(99L).build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DELETE_NOT_ALLOWED_IN_STATUS);
+
+            then(saveProjectPort).should(never()).delete(any());
+        }
+    }
+
+    @Nested
+    class abort {
+
+        @Test
+        void IN_PROGRESS_상태에서_멤버_WITHDRAWN_application_CANCELLED() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            com.umc.product.project.domain.ProjectMember activeMember =
+                com.umc.product.project.domain.ProjectMember.create(project, 500L, ChallengerPart.WEB, 100L);
+
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectMemberPort.listByProjectId(1L)).willReturn(java.util.List.of(activeMember));
+            given(loadProjectApplicationPort.listInProgressByProjectId(1L))
+                .willReturn(java.util.List.of());
+
+            sut.abort(com.umc.product.project.application.port.in.command.dto.AbortProjectCommand.builder()
+                .projectId(1L).requesterMemberId(99L).reason("팀 와해").build());
+
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.ABORTED);
+            assertThat(project.getStatusChangedReason()).isEqualTo("팀 와해");
+            assertThat(activeMember.getStatus())
+                .isEqualTo(com.umc.product.project.domain.enums.ProjectMemberStatus.WITHDRAWN);
+            assertThat(activeMember.getStatusChangeReason()).isEqualTo("팀 와해");
+        }
+
+        @Test
+        void COMPLETED_상태이면_PROJECT_ABORT_UNAVAILABLE() {
+            Project project = createProject(ProjectStatus.COMPLETED);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.abort(
+                com.umc.product.project.application.port.in.command.dto.AbortProjectCommand.builder()
+                    .projectId(1L).requesterMemberId(99L).reason("사유").build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_ABORT_UNAVAILABLE);
+        }
+
+        @Test
+        void 사유가_blank이면_Command_생성_단계에서_PROJECT_ABORT_REASON_REQUIRED() {
+            assertThatThrownBy(() ->
+                com.umc.product.project.application.port.in.command.dto.AbortProjectCommand.builder()
+                    .projectId(1L).requesterMemberId(99L).reason("  ").build())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_ABORT_REASON_REQUIRED);
         }
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -690,17 +690,99 @@ class ProjectPermissionEvaluatorTest {
     // --- DELETE ---
 
     @Test
-    void DELETE는_중앙총괄만_허용() {
-        SubjectAttributes subject = subjectWith(1L, List.of(), List.of(centralCoreRole()));
-        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.DELETE);
+    void DELETE는_DRAFT_프로젝트를_PO_본인이면_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(10L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
 
         assertThat(sut.evaluate(subject, permission)).isTrue();
     }
 
     @Test
-    void DELETE는_일반_사용자_거부() {
-        SubjectAttributes subject = subjectWith(1L, List.of(), List.of());
-        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.DELETE);
+    void DELETE는_PENDING_REVIEW_프로젝트를_PO_본인이면_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.PENDING_REVIEW)));
+
+        SubjectAttributes subject = subjectWith(10L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void DELETE는_DRAFT_프로젝트를_본인_지부장이면_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(),
+            List.of(chapterPresidentRole(1L, 1L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void DELETE는_DRAFT_프로젝트를_해당_기수_중앙총괄단이면_허용() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void DELETE는_DRAFT_프로젝트를_다른_지부장이면_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(),
+            List.of(chapterPresidentRole(999L, 1L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void DELETE는_DRAFT_프로젝트를_일반_사용자면_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void DELETE는_IN_PROGRESS_프로젝트에는_누구도_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.IN_PROGRESS)));
+
+        SubjectAttributes subject = subjectWith(10L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void DELETE는_COMPLETED_프로젝트에는_누구도_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.COMPLETED)));
+
+        SubjectAttributes subject = subjectWith(10L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.DELETE);
 
         assertThat(sut.evaluate(subject, permission)).isFalse();
     }

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -337,6 +337,52 @@ class ProjectTest {
         }
     }
 
+    @Nested
+    class validateDeletable {
+
+        @Test
+        void DRAFT_상태에서는_통과() {
+            project.validateDeletable();
+        }
+
+        @Test
+        void PENDING_REVIEW_상태에서는_통과() {
+            setStatus(project, ProjectStatus.PENDING_REVIEW);
+
+            project.validateDeletable();
+        }
+
+        @Test
+        void IN_PROGRESS_상태에서는_DELETE_NOT_ALLOWED() {
+            setStatus(project, ProjectStatus.IN_PROGRESS);
+
+            assertThatThrownBy(() -> project.validateDeletable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DELETE_NOT_ALLOWED_IN_STATUS);
+        }
+
+        @Test
+        void COMPLETED_상태에서는_DELETE_NOT_ALLOWED() {
+            setStatus(project, ProjectStatus.COMPLETED);
+
+            assertThatThrownBy(() -> project.validateDeletable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DELETE_NOT_ALLOWED_IN_STATUS);
+        }
+
+        @Test
+        void ABORTED_상태에서는_DELETE_NOT_ALLOWED() {
+            setStatus(project, ProjectStatus.ABORTED);
+
+            assertThatThrownBy(() -> project.validateDeletable())
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DELETE_NOT_ALLOWED_IN_STATUS);
+        }
+    }
+
     private void setStatus(Project project, ProjectStatus status) {
         try {
             var field = Project.class.getDeclaredField("status");


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #900

## 🚀 작업 내용

프로젝트 hard delete API 와 abort API 를 추가했습니다.

### 1. API
- `DELETE /api/v1/projects/{projectId}` — DRAFT / PENDING_REVIEW 상태 프로젝트 hard delete
- `POST /api/v1/projects/{projectId}/abort` — IN_PROGRESS 상태 프로젝트를 ABORTED 로 전이 (body: `reason` 필수)

### 2. 권한 정책
- **Delete**: PO 본인 + 본인 지부장 / 해당 기수 총괄단
- **Abort**: 본인 지부장 / 해당 기수 총괄단만 (PO 단독 결정 불가, 운영 사무국 검토 필요)
- 종료 상태(COMPLETED / ABORTED)는 양쪽 모두 거부

### 3. 자식 데이터 처리
- **Delete**: ProjectMember / ProjectPartQuota / ProjectApplicationForm + Policy + Survey Form 까지 명시적 cascade 정리
- **Abort**: ACTIVE 멤버 → WITHDRAWN, DRAFT/SUBMITTED 지원서 → CANCELLED 일괄 동기화

### 4. ProjectPermissionEvaluator 수정
- `ProjectPermissionEvaluator` 의 DELETE 분기를 새 정책(상태 + PO/Admin)에 맞게 재작성

## 💬 리뷰 중점사항
