### PR TITLE
[Feat] Resource Permission Evaluating Batch API 제작

### DIFF
--- a/src/main/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionController.java
+++ b/src/main/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionController.java
@@ -1,16 +1,23 @@
 package com.umc.product.authorization.adapter.in.web;
 
+import com.umc.product.authorization.adapter.in.web.dto.request.BatchResourcePermissionRequest;
+import com.umc.product.authorization.adapter.in.web.dto.response.BatchResourcePermissionResponse;
 import com.umc.product.authorization.adapter.in.web.dto.response.ResourcePermissionResponse;
 import com.umc.product.authorization.application.port.in.query.ResourcePermissionUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
+import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,25 +26,47 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api/v1/authorization/resource-permission")
+@RequestMapping("/api/v1/authorization")
 public class ResourcePermissionController {
 
     private final ResourcePermissionUseCase resourcePermissionUseCase;
 
-    @GetMapping
-    @Operation(summary = "[PERMISSION-001] 리소스 권한 조회", description = "특정 리소스에 대해 현재 사용자가 가진 권한 목록을 조회합니다.")
+    @GetMapping("/resource-permission")
+    @Operation(
+        summary = "[PERMISSION-001] 리소스 권한 조회",
+        description = "특정 리소스에 대해 현재 사용자가 가진 권한을 조회합니다. permissionType을 지정하면 해당 권한만 평가합니다."
+    )
     ResourcePermissionResponse getResourcePermission(
         @RequestParam ResourceType resourceType,
         @RequestParam(required = false) Long resourceId,
+        @RequestParam(required = false) PermissionType permissionType,
         @CurrentMember MemberPrincipal principal
     ) {
 
         ResourcePermissionInfo permission = resourcePermissionUseCase.hasPermission(
             principal.getMemberId(),
             resourceType,
-            resourceId
+            resourceId,
+            permissionType
         );
 
         return ResourcePermissionResponse.from(permission);
+    }
+
+    @PostMapping("/resource-permissions/batch")
+    @Operation(
+        summary = "[PERMISSION-002] 리소스 권한 배치 조회",
+        description = "여러 리소스에 대해 현재 사용자의 권한을 한 번에 조회합니다. 유효하지 않은 query가 하나라도 있으면 요청 전체가 실패합니다."
+    )
+    BatchResourcePermissionResponse batchGetResourcePermission(
+        @RequestBody @Valid BatchResourcePermissionRequest request,
+        @CurrentMember MemberPrincipal principal
+    ) {
+        List<ResourcePermissionInfo> permissions = resourcePermissionUseCase.batchHasPermission(
+            principal.getMemberId(),
+            request.toQueries()
+        );
+
+        return BatchResourcePermissionResponse.from(permissions);
     }
 }

--- a/src/main/java/com/umc/product/authorization/adapter/in/web/dto/request/BatchResourcePermissionRequest.java
+++ b/src/main/java/com/umc/product/authorization/adapter/in/web/dto/request/BatchResourcePermissionRequest.java
@@ -1,0 +1,33 @@
+package com.umc.product.authorization.adapter.in.web.dto.request;
+
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionQuery;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record BatchResourcePermissionRequest(
+    @NotEmpty(message = "queries는 최소 1개 이상이어야 합니다.")
+    List<@NotNull(message = "query는 null일 수 없습니다.") @Valid ResourcePermissionQueryRequest> queries
+) {
+
+    public List<ResourcePermissionQuery> toQueries() {
+        return queries.stream()
+            .map(ResourcePermissionQueryRequest::toQuery)
+            .toList();
+    }
+
+    public record ResourcePermissionQueryRequest(
+        @NotNull(message = "resourceType은 필수입니다.")
+        ResourceType resourceType,
+        List<@NotNull(message = "resourceIds는 null 값을 포함할 수 없습니다.") Long> resourceIds,
+        List<@NotNull(message = "permissionTypes는 null 값을 포함할 수 없습니다.") PermissionType> permissionTypes
+    ) {
+
+        public ResourcePermissionQuery toQuery() {
+            return ResourcePermissionQuery.of(resourceType, resourceIds, permissionTypes);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/authorization/adapter/in/web/dto/request/BatchResourcePermissionRequest.java
+++ b/src/main/java/com/umc/product/authorization/adapter/in/web/dto/request/BatchResourcePermissionRequest.java
@@ -6,6 +6,7 @@ import com.umc.product.authorization.domain.ResourceType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record BatchResourcePermissionRequest(
@@ -22,7 +23,9 @@ public record BatchResourcePermissionRequest(
     public record ResourcePermissionQueryRequest(
         @NotNull(message = "resourceType은 필수입니다.")
         ResourceType resourceType,
+        @Size(min = 1, message = "resourceIds는 비어 있을 수 없습니다.")
         List<@NotNull(message = "resourceIds는 null 값을 포함할 수 없습니다.") Long> resourceIds,
+        @Size(min = 1, message = "permissionTypes는 비어 있을 수 없습니다.")
         List<@NotNull(message = "permissionTypes는 null 값을 포함할 수 없습니다.") PermissionType> permissionTypes
     ) {
 

--- a/src/main/java/com/umc/product/authorization/adapter/in/web/dto/response/BatchResourcePermissionResponse.java
+++ b/src/main/java/com/umc/product/authorization/adapter/in/web/dto/response/BatchResourcePermissionResponse.java
@@ -1,0 +1,17 @@
+package com.umc.product.authorization.adapter.in.web.dto.response;
+
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
+import java.util.List;
+
+public record BatchResourcePermissionResponse(
+    List<ResourcePermissionResponse> results
+) {
+
+    public static BatchResourcePermissionResponse from(List<ResourcePermissionInfo> infos) {
+        return new BatchResourcePermissionResponse(
+            infos.stream()
+                .map(ResourcePermissionResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/authorization/application/port/in/CheckPermissionUseCase.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/CheckPermissionUseCase.java
@@ -1,6 +1,7 @@
 package com.umc.product.authorization.application.port.in;
 
 import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.SubjectAttributes;
 
 /**
  * 특정 주체가 권한이 있는지를 평가합니다.
@@ -12,6 +13,14 @@ import com.umc.product.authorization.domain.ResourcePermission;
 public interface CheckPermissionUseCase {
 
     /**
+     * 사용자 권한 평가에 필요한 주체 속성을 조회
+     *
+     * @param memberId 사용자 ID
+     * @return 권한 평가에 사용할 주체 속성
+     */
+    SubjectAttributes loadSubject(Long memberId);
+
+    /**
      * 사용자가 특정 리소스에 대한 권한이 있는지 확인
      *
      * @param memberId   사용자 ID
@@ -19,6 +28,15 @@ public interface CheckPermissionUseCase {
      * @return 권한 있으면 true, 없으면 false
      */
     boolean check(Long memberId, ResourcePermission permission);
+
+    /**
+     * 이미 조회된 주체 속성으로 특정 리소스에 대한 권한이 있는지 확인
+     *
+     * @param subjectAttributes 권한 평가에 사용할 주체 속성
+     * @param permission        확인할 권한
+     * @return 권한 있으면 true, 없으면 false
+     */
+    boolean check(SubjectAttributes subjectAttributes, ResourcePermission permission);
 
     /**
      * 권한이 없으면 예외를 발생시키는 메서드

--- a/src/main/java/com/umc/product/authorization/application/port/in/query/ResourcePermissionUseCase.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/query/ResourcePermissionUseCase.java
@@ -1,10 +1,22 @@
 package com.umc.product.authorization.application.port.in.query;
 
 import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionQuery;
+import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
+import java.util.List;
 
 public interface ResourcePermissionUseCase {
 
     ResourcePermissionInfo hasPermission(Long memberId, ResourceType resourceType, Long resourceId);
+
+    ResourcePermissionInfo hasPermission(
+        Long memberId,
+        ResourceType resourceType,
+        Long resourceId,
+        PermissionType permissionType
+    );
+
+    List<ResourcePermissionInfo> batchHasPermission(Long memberId, List<ResourcePermissionQuery> queries);
 
 }

--- a/src/main/java/com/umc/product/authorization/application/port/in/query/dto/ResourcePermissionQuery.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/query/dto/ResourcePermissionQuery.java
@@ -1,0 +1,20 @@
+package com.umc.product.authorization.application.port.in.query.dto;
+
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import java.util.List;
+
+public record ResourcePermissionQuery(
+    ResourceType resourceType,
+    List<Long> resourceIds,
+    List<PermissionType> permissionTypes
+) {
+
+    public static ResourcePermissionQuery of(
+        ResourceType resourceType,
+        List<Long> resourceIds,
+        List<PermissionType> permissionTypes
+    ) {
+        return new ResourcePermissionQuery(resourceType, resourceIds, permissionTypes);
+    }
+}

--- a/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
@@ -58,14 +58,13 @@ public class AuthorizationService implements CheckPermissionUseCase {
 
     @Override
     public boolean check(Long memberId, ResourcePermission permission) {
-        log.info("권한 평가 시작");
+        SubjectAttributes subjectAttributes = loadSubject(memberId);
+        return check(subjectAttributes, permission);
+    }
 
-        // 리소스 유형에 맞는 권한 평가기를 선택함. 없다면 에러 발생
-        ResourcePermissionEvaluator evaluator = evaluators.get(permission.resourceType());
-        if (evaluator == null) {
-            throw new AuthorizationDomainException(AuthorizationErrorCode.NO_EVALUATOR_MATCHING_RESOURCE_TYPE,
-                "Evaluator for Resource Type [" + permission.resourceType() + "] not found.");
-        }
+    @Override
+    public SubjectAttributes loadSubject(Long memberId) {
+        log.info("권한 평가 시작");
 
         // 사용자가 활동한 모든 기수를 확인
         // 해당 기수마다 chapterId, challengerRoleId를 가져옴
@@ -98,11 +97,24 @@ public class AuthorizationService implements CheckPermissionUseCase {
 
         log.info("Subject Attribute {}가 평가를 요청했습니다.", subjectAttributes.toString());
 
+        return subjectAttributes;
+    }
+
+    @Override
+    public boolean check(SubjectAttributes subjectAttributes, ResourcePermission permission) {
+        // 리소스 유형에 맞는 권한 평가기를 선택함. 없다면 에러 발생
+        ResourcePermissionEvaluator evaluator = evaluators.get(permission.resourceType());
+        if (evaluator == null) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.NO_EVALUATOR_MATCHING_RESOURCE_TYPE,
+                "Evaluator for Resource Type [" + permission.resourceType() + "] not found.");
+        }
+
         // 평가기로 평가
         boolean hasPermission = evaluator.evaluate(subjectAttributes, permission);
 
         log.debug("Permission check - memberId: {}, roles: {}, resource: {}:{}, permission: {}, result: {}",
-            memberId, roles, permission.resourceType(), permission.resourceId(),
+            subjectAttributes.memberId(), subjectAttributes.roleAttributes(), permission.resourceType(),
+            permission.resourceId(),
             permission.permission(), hasPermission);
 
         return hasPermission;

--- a/src/main/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionService.java
@@ -3,12 +3,15 @@ package com.umc.product.authorization.application.service.query;
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
 import com.umc.product.authorization.application.port.in.query.ResourcePermissionUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionQuery;
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,24 +40,168 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
 
     @Override
     public ResourcePermissionInfo hasPermission(Long memberId, ResourceType resourceType, Long resourceId) {
+        return hasPermission(memberId, resourceType, resourceId, (PermissionType) null);
+    }
+
+    @Override
+    public ResourcePermissionInfo hasPermission(
+        Long memberId,
+        ResourceType resourceType,
+        Long resourceId,
+        PermissionType permissionType
+    ) {
+        validateResourceTypeSupported(resourceType);
+
+        Map<PermissionType, Boolean> permissions = new LinkedHashMap<>();
+
+        if (permissionType != null) {
+            validatePermissionSupported(resourceType, permissionType);
+            putPermissionResult(memberId, resourceType, resourceId, permissionType, permissions);
+            return new ResourcePermissionInfo(resourceType, resourceId, permissions);
+        }
+
+        resourceType.getSupportedPermissions().stream()
+            .sorted(Comparator.comparingInt(Enum::ordinal))
+            .forEach(supportedPermission ->
+                putPermissionResult(memberId, resourceType, resourceId, supportedPermission, permissions)
+            );
+
+        return new ResourcePermissionInfo(resourceType, resourceId, permissions);
+    }
+
+    @Override
+    public List<ResourcePermissionInfo> batchHasPermission(Long memberId, List<ResourcePermissionQuery> queries) {
+        List<ResourcePermissionQuery> validQueries = validateBatchQueries(queries);
+
+        List<ResourcePermissionInfo> results = new ArrayList<>();
+        for (ResourcePermissionQuery query : validQueries) {
+            List<Long> resourceIds = query.resourceIds();
+            if (resourceIds == null) {
+                results.add(hasPermission(memberId, query.resourceType(), null, query.permissionTypes()));
+                continue;
+            }
+
+            for (Long resourceId : resourceIds) {
+                results.add(hasPermission(memberId, query.resourceType(), resourceId, query.permissionTypes()));
+            }
+        }
+
+        return results;
+    }
+
+    private ResourcePermissionInfo hasPermission(
+        Long memberId,
+        ResourceType resourceType,
+        Long resourceId,
+        List<PermissionType> permissionTypes
+    ) {
+        if (permissionTypes == null) {
+            return hasPermission(memberId, resourceType, resourceId);
+        }
+
+        Map<PermissionType, Boolean> permissions = new LinkedHashMap<>();
+        permissionTypes.stream()
+            .sorted(Comparator.comparingInt(Enum::ordinal))
+            .forEach(permissionType ->
+                putPermissionResult(memberId, resourceType, resourceId, permissionType, permissions)
+            );
+
+        return new ResourcePermissionInfo(resourceType, resourceId, permissions);
+    }
+
+    private List<ResourcePermissionQuery> validateBatchQueries(List<ResourcePermissionQuery> queries) {
+        if (queries == null || queries.isEmpty()) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "권한 배치 조회 요청은 최소 1개 이상의 query를 포함해야 합니다."
+            );
+        }
+
+        for (ResourcePermissionQuery query : queries) {
+            validateBatchQuery(query);
+        }
+
+        return queries;
+    }
+
+    private void validateBatchQuery(ResourcePermissionQuery query) {
+        if (query == null) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "권한 배치 조회 query는 null일 수 없습니다."
+            );
+        }
+
+        validateResourceTypeSupported(query.resourceType());
+        validateResourceIds(query.resourceIds());
+        validatePermissionTypes(query.resourceType(), query.permissionTypes());
+    }
+
+    private void validateResourceTypeSupported(ResourceType resourceType) {
+        if (resourceType == null) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "resourceType은 필수입니다."
+            );
+        }
+
         if (!supportedResourceTypes.contains(resourceType)) {
             throw new AuthorizationDomainException(
                 AuthorizationErrorCode.NO_EVALUATOR_MATCHING_RESOURCE_TYPE,
                 "리소스 타입 '" + resourceType + "'에 대한 권한 조회는 아직 지원되지 않습니다."
             );
         }
+    }
 
-        Map<PermissionType, Boolean> permissions = new LinkedHashMap<>();
-
-        for (PermissionType permissionType : resourceType.getSupportedPermissions()) {
-            ResourcePermission permission = resourceId != null
-                ? ResourcePermission.of(resourceType, resourceId, permissionType)
-                : ResourcePermission.ofType(resourceType, permissionType);
-
-            boolean hasAccess = checkPermissionUseCase.check(memberId, permission);
-            permissions.put(permissionType, hasAccess);
+    private void validateResourceIds(List<Long> resourceIds) {
+        if (resourceIds == null) {
+            return;
         }
 
-        return new ResourcePermissionInfo(resourceType, resourceId, permissions);
+        if (resourceIds.isEmpty() || resourceIds.stream().anyMatch(resourceId -> resourceId == null)) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "resourceIds는 비어 있거나 null 값을 포함할 수 없습니다."
+            );
+        }
+    }
+
+    private void validatePermissionTypes(ResourceType resourceType, List<PermissionType> permissionTypes) {
+        if (permissionTypes == null) {
+            return;
+        }
+
+        if (permissionTypes.isEmpty() || permissionTypes.stream().anyMatch(permissionType -> permissionType == null)) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                "permissionTypes는 비어 있거나 null 값을 포함할 수 없습니다."
+            );
+        }
+
+        permissionTypes.forEach(permissionType -> validatePermissionSupported(resourceType, permissionType));
+    }
+
+    private void validatePermissionSupported(ResourceType resourceType, PermissionType permissionType) {
+        if (!resourceType.supports(permissionType)) {
+            throw new AuthorizationDomainException(
+                AuthorizationErrorCode.INVALID_INPUT_VALUE,
+                String.format("리소스 타입 '%s'은(는) '%s' 권한을 지원하지 않습니다.", resourceType, permissionType)
+            );
+        }
+    }
+
+    private void putPermissionResult(
+        Long memberId,
+        ResourceType resourceType,
+        Long resourceId,
+        PermissionType permissionType,
+        Map<PermissionType, Boolean> permissions
+    ) {
+        ResourcePermission permission = resourceId != null
+            ? ResourcePermission.of(resourceType, resourceId, permissionType)
+            : ResourcePermission.ofType(resourceType, permissionType);
+
+        boolean hasAccess = checkPermissionUseCase.check(memberId, permission);
+        permissions.put(permissionType, hasAccess);
     }
 }

--- a/src/main/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionService.java
@@ -8,6 +8,7 @@ import com.umc.product.authorization.application.port.out.ResourcePermissionEval
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import java.util.ArrayList;
@@ -51,38 +52,42 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
         PermissionType permissionType
     ) {
         validateResourceTypeSupported(resourceType);
-
-        Map<PermissionType, Boolean> permissions = new LinkedHashMap<>();
-
         if (permissionType != null) {
             validatePermissionSupported(resourceType, permissionType);
-            putPermissionResult(memberId, resourceType, resourceId, permissionType, permissions);
-            return new ResourcePermissionInfo(resourceType, resourceId, permissions);
         }
 
-        resourceType.getSupportedPermissions().stream()
-            .sorted(Comparator.comparingInt(Enum::ordinal))
-            .forEach(supportedPermission ->
-                putPermissionResult(memberId, resourceType, resourceId, supportedPermission, permissions)
-            );
+        SubjectAttributes subjectAttributes = checkPermissionUseCase.loadSubject(memberId);
+        return hasPermission(subjectAttributes, resourceType, resourceId, permissionType);
+    }
 
-        return new ResourcePermissionInfo(resourceType, resourceId, permissions);
+    private ResourcePermissionInfo hasPermission(
+        SubjectAttributes subjectAttributes,
+        ResourceType resourceType,
+        Long resourceId,
+        PermissionType permissionType
+    ) {
+        if (permissionType != null) {
+            return hasPermission(subjectAttributes, resourceType, resourceId, List.of(permissionType));
+        }
+
+        return hasPermission(subjectAttributes, resourceType, resourceId, getSortedSupportedPermissions(resourceType));
     }
 
     @Override
     public List<ResourcePermissionInfo> batchHasPermission(Long memberId, List<ResourcePermissionQuery> queries) {
         List<ResourcePermissionQuery> validQueries = validateBatchQueries(queries);
+        SubjectAttributes subjectAttributes = checkPermissionUseCase.loadSubject(memberId);
 
         List<ResourcePermissionInfo> results = new ArrayList<>();
         for (ResourcePermissionQuery query : validQueries) {
             List<Long> resourceIds = query.resourceIds();
             if (resourceIds == null) {
-                results.add(hasPermission(memberId, query.resourceType(), null, query.permissionTypes()));
+                results.add(hasPermission(subjectAttributes, query.resourceType(), null, query.permissionTypes()));
                 continue;
             }
 
             for (Long resourceId : resourceIds) {
-                results.add(hasPermission(memberId, query.resourceType(), resourceId, query.permissionTypes()));
+                results.add(hasPermission(subjectAttributes, query.resourceType(), resourceId, query.permissionTypes()));
             }
         }
 
@@ -90,21 +95,17 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
     }
 
     private ResourcePermissionInfo hasPermission(
-        Long memberId,
+        SubjectAttributes subjectAttributes,
         ResourceType resourceType,
         Long resourceId,
         List<PermissionType> permissionTypes
     ) {
         if (permissionTypes == null) {
-            return hasPermission(memberId, resourceType, resourceId);
+            return hasPermission(subjectAttributes, resourceType, resourceId, getSortedSupportedPermissions(resourceType));
         }
 
         Map<PermissionType, Boolean> permissions = new LinkedHashMap<>();
-        permissionTypes.stream()
-            .sorted(Comparator.comparingInt(Enum::ordinal))
-            .forEach(permissionType ->
-                putPermissionResult(memberId, resourceType, resourceId, permissionType, permissions)
-            );
+        evaluateAndPutPermissions(subjectAttributes, resourceType, resourceId, permissionTypes, permissions);
 
         return new ResourcePermissionInfo(resourceType, resourceId, permissions);
     }
@@ -158,7 +159,7 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
             return;
         }
 
-        if (resourceIds.isEmpty() || resourceIds.stream().anyMatch(resourceId -> resourceId == null)) {
+        if (resourceIds.isEmpty() || new ArrayList<>(resourceIds).contains(null)) {
             throw new AuthorizationDomainException(
                 AuthorizationErrorCode.INVALID_INPUT_VALUE,
                 "resourceIds는 비어 있거나 null 값을 포함할 수 없습니다."
@@ -171,7 +172,7 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
             return;
         }
 
-        if (permissionTypes.isEmpty() || permissionTypes.stream().anyMatch(permissionType -> permissionType == null)) {
+        if (permissionTypes.isEmpty() || new ArrayList<>(permissionTypes).contains(null)) {
             throw new AuthorizationDomainException(
                 AuthorizationErrorCode.INVALID_INPUT_VALUE,
                 "permissionTypes는 비어 있거나 null 값을 포함할 수 없습니다."
@@ -190,8 +191,28 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
         }
     }
 
+    private List<PermissionType> getSortedSupportedPermissions(ResourceType resourceType) {
+        return resourceType.getSupportedPermissions().stream()
+            .sorted(Comparator.comparingInt(Enum::ordinal))
+            .toList();
+    }
+
+    private void evaluateAndPutPermissions(
+        SubjectAttributes subjectAttributes,
+        ResourceType resourceType,
+        Long resourceId,
+        List<PermissionType> permissionTypes,
+        Map<PermissionType, Boolean> permissions
+    ) {
+        permissionTypes.stream()
+            .sorted(Comparator.comparingInt(Enum::ordinal))
+            .forEach(permissionType ->
+                putPermissionResult(subjectAttributes, resourceType, resourceId, permissionType, permissions)
+            );
+    }
+
     private void putPermissionResult(
-        Long memberId,
+        SubjectAttributes subjectAttributes,
         ResourceType resourceType,
         Long resourceId,
         PermissionType permissionType,
@@ -201,7 +222,7 @@ public class CheckResourcePermissionService implements ResourcePermissionUseCase
             ? ResourcePermission.of(resourceType, resourceId, permissionType)
             : ResourcePermission.ofType(resourceType, permissionType);
 
-        boolean hasAccess = checkPermissionUseCase.check(memberId, permission);
+        boolean hasAccess = checkPermissionUseCase.check(subjectAttributes, permission);
         permissions.put(permissionType, hasAccess);
     }
 }

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -21,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -116,6 +118,37 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         String detail = simplifiedMessage + " - " + e.getMostSpecificCause().getMessage();
         return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, detail);
+    }
+
+    /**
+     * 필수 Request Parameter 누락 예외 처리
+     */
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+        MissingServletRequestParameterException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        String detail = String.format("필수 요청 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+        log.warn("[MISSING REQUEST PARAMETER] {}", detail);
+
+        return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, detail);
+    }
+
+    /**
+     * Request Parameter 타입 변환 실패 예외 처리
+     */
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+        TypeMismatchException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        log.warn("[REQUEST PARAMETER TYPE MISMATCH] {}", e.getMessage());
+
+        return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, "요청 파라미터 값이 올바르지 않습니다.");
     }
 
 

--- a/src/test/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionControllerTest.java
+++ b/src/test/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionControllerTest.java
@@ -221,4 +221,58 @@ class ResourcePermissionControllerTest {
 
         verifyNoInteractions(resourcePermissionUseCase);
     }
+
+    @Test
+    @DisplayName("배치 요청에 resourceIds가 빈 배열이면 실패한다")
+    void 배치_요청에_resourceIds가_빈_배열이면_실패한다() throws Exception {
+        // given
+        String requestBody = """
+            {
+              "queries": [
+                {
+                  "resourceType": "NOTICE",
+                  "resourceIds": [],
+                  "permissionTypes": ["READ"]
+                }
+              ]
+            }
+            """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/authorization/resource-permissions/batch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"));
+
+        verifyNoInteractions(resourcePermissionUseCase);
+    }
+
+    @Test
+    @DisplayName("배치 요청에 permissionTypes가 빈 배열이면 실패한다")
+    void 배치_요청에_permissionTypes가_빈_배열이면_실패한다() throws Exception {
+        // given
+        String requestBody = """
+            {
+              "queries": [
+                {
+                  "resourceType": "NOTICE",
+                  "resourceIds": [100],
+                  "permissionTypes": []
+                }
+              ]
+            }
+            """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/authorization/resource-permissions/batch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"));
+
+        verifyNoInteractions(resourcePermissionUseCase);
+    }
 }

--- a/src/test/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionControllerTest.java
+++ b/src/test/java/com/umc/product/authorization/adapter/in/web/ResourcePermissionControllerTest.java
@@ -1,0 +1,224 @@
+package com.umc.product.authorization.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.authorization.application.port.in.query.ResourcePermissionUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ResourcePermissionController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ResourcePermissionController")
+class ResourcePermissionControllerTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long RESOURCE_ID = 100L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ResourcePermissionUseCase resourcePermissionUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("특정 리소스와 특정 권한을 지정해 권한을 조회한다")
+    void 특정_리소스와_특정_권한을_지정해_권한을_조회한다() throws Exception {
+        // given
+        given(resourcePermissionUseCase.hasPermission(
+            MEMBER_ID,
+            ResourceType.NOTICE,
+            RESOURCE_ID,
+            PermissionType.READ
+        )).willReturn(new ResourcePermissionInfo(
+            ResourceType.NOTICE,
+            RESOURCE_ID,
+            Map.of(PermissionType.READ, true)
+        ));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/authorization/resource-permission")
+                .param("resourceType", "NOTICE")
+                .param("resourceId", String.valueOf(RESOURCE_ID))
+                .param("permissionType", "READ"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.resourceType").value("NOTICE"))
+            .andExpect(jsonPath("$.result.resourceId").value(RESOURCE_ID))
+            .andExpect(jsonPath("$.result.permissions[0].permissionType").value("READ"))
+            .andExpect(jsonPath("$.result.permissions[0].hasPermission").value(true));
+
+        verify(resourcePermissionUseCase).hasPermission(
+            eq(MEMBER_ID),
+            eq(ResourceType.NOTICE),
+            eq(RESOURCE_ID),
+            eq(PermissionType.READ)
+        );
+    }
+
+    @Test
+    @DisplayName("resourceId 없이 특정 권한을 지정해 타입 단위 권한을 조회한다")
+    void resourceId_없이_특정_권한을_지정해_타입_단위_권한을_조회한다() throws Exception {
+        // given
+        given(resourcePermissionUseCase.hasPermission(
+            MEMBER_ID,
+            ResourceType.NOTICE,
+            null,
+            PermissionType.READ
+        )).willReturn(new ResourcePermissionInfo(
+            ResourceType.NOTICE,
+            null,
+            Map.of(PermissionType.READ, true)
+        ));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/authorization/resource-permission")
+                .param("resourceType", "NOTICE")
+                .param("permissionType", "READ"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.resourceType").value("NOTICE"))
+            .andExpect(jsonPath("$.result.resourceId").doesNotExist())
+            .andExpect(jsonPath("$.result.permissions[0].permissionType").value("READ"))
+            .andExpect(jsonPath("$.result.permissions[0].hasPermission").value(true));
+
+        verify(resourcePermissionUseCase).hasPermission(
+            eq(MEMBER_ID),
+            eq(ResourceType.NOTICE),
+            eq(null),
+            eq(PermissionType.READ)
+        );
+    }
+
+    @Test
+    @DisplayName("GET 요청에 resourceType이 없으면 실패한다")
+    void GET_요청에_resourceType이_없으면_실패한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/authorization/resource-permission")
+                .param("resourceId", String.valueOf(RESOURCE_ID))
+                .param("permissionType", "READ"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"));
+
+        verifyNoInteractions(resourcePermissionUseCase);
+    }
+
+    @Test
+    @DisplayName("GET 요청에 유효하지 않은 enum 값이 있으면 실패한다")
+    void GET_요청에_유효하지_않은_enum_값이_있으면_실패한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/authorization/resource-permission")
+                .param("resourceType", "NOTICE")
+                .param("permissionType", "INVALID"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"));
+
+        verifyNoInteractions(resourcePermissionUseCase);
+    }
+
+    @Test
+    @DisplayName("여러 리소스에 대한 권한을 배치로 조회한다")
+    void 여러_리소스에_대한_권한을_배치로_조회한다() throws Exception {
+        // given
+        given(resourcePermissionUseCase.batchHasPermission(eq(MEMBER_ID), any()))
+            .willReturn(java.util.List.of(
+                new ResourcePermissionInfo(
+                    ResourceType.NOTICE,
+                    100L,
+                    Map.of(PermissionType.READ, true)
+                ),
+                new ResourcePermissionInfo(
+                    ResourceType.NOTICE,
+                    101L,
+                    Map.of(PermissionType.READ, false)
+                )
+            ));
+
+        String requestBody = """
+            {
+              "queries": [
+                {
+                  "resourceType": "NOTICE",
+                  "resourceIds": [100, 101],
+                  "permissionTypes": ["READ"]
+                }
+              ]
+            }
+            """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/authorization/resource-permissions/batch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.results[0].resourceType").value("NOTICE"))
+            .andExpect(jsonPath("$.result.results[0].resourceId").value(100L))
+            .andExpect(jsonPath("$.result.results[0].permissions[0].permissionType").value("READ"))
+            .andExpect(jsonPath("$.result.results[0].permissions[0].hasPermission").value(true))
+            .andExpect(jsonPath("$.result.results[1].resourceType").value("NOTICE"))
+            .andExpect(jsonPath("$.result.results[1].resourceId").value(101L))
+            .andExpect(jsonPath("$.result.results[1].permissions[0].hasPermission").value(false));
+    }
+
+    @Test
+    @DisplayName("배치 요청에 resourceType 없이 resourceIds만 있으면 실패한다")
+    void 배치_요청에_resourceType_없이_resourceIds만_있으면_실패한다() throws Exception {
+        // given
+        String requestBody = """
+            {
+              "queries": [
+                {
+                  "resourceIds": [100],
+                  "permissionTypes": ["READ"]
+                }
+              ]
+            }
+            """;
+
+        // when & then
+        mockMvc.perform(post("/api/v1/authorization/resource-permissions/batch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"));
+
+        verifyNoInteractions(resourcePermissionUseCase);
+    }
+}

--- a/src/test/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionServiceTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
@@ -15,6 +16,7 @@ import com.umc.product.authorization.application.port.out.ResourcePermissionEval
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import java.util.List;
@@ -53,6 +55,12 @@ class CheckResourcePermissionServiceTest {
 
     private static final Long MEMBER_ID = 1L;
     private static final Long RESOURCE_ID = 100L;
+    private static final SubjectAttributes SUBJECT_ATTRIBUTES = SubjectAttributes.builder()
+        .memberId(MEMBER_ID)
+        .schoolId(10L)
+        .gisuChallengerInfos(List.of())
+        .roleAttributes(List.of())
+        .build();
 
     @Nested
     @DisplayName("권한이 있나요?")
@@ -64,16 +72,17 @@ class CheckResourcePermissionServiceTest {
             ResourceType resourceType = ResourceType.NOTICE;
             // NOTICE supports: READ, EDIT, DELETE, CHECK
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.READ))))
                 .willReturn(true);
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.EDIT))))
                 .willReturn(false);
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.DELETE))))
                 .willReturn(false);
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.CHECK))))
                 .willReturn(false);
 
@@ -87,6 +96,7 @@ class CheckResourcePermissionServiceTest {
             assertThat(result.permissions()).containsEntry(PermissionType.EDIT, false);
             assertThat(result.permissions()).containsEntry(PermissionType.DELETE, false);
             assertThat(result.permissions()).containsEntry(PermissionType.CHECK, false);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -94,7 +104,8 @@ class CheckResourcePermissionServiceTest {
             // given
             ResourceType resourceType = ResourceType.NOTICE;
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID), any(ResourcePermission.class)))
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES), any(ResourcePermission.class)))
                 .willReturn(true);
 
             // when
@@ -102,6 +113,7 @@ class CheckResourcePermissionServiceTest {
 
             // then
             assertThat(result.permissions().values()).allMatch(hasPermission -> hasPermission);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -110,7 +122,8 @@ class CheckResourcePermissionServiceTest {
             ResourceType resourceType = ResourceType.WORKBOOK_SUBMISSION;
             // WORKBOOK_SUBMISSION supports: READ
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.ofType(resourceType, PermissionType.READ))))
                 .willReturn(true);
 
@@ -120,6 +133,7 @@ class CheckResourcePermissionServiceTest {
             // then
             assertThat(result.resourceId()).isNull();
             assertThat(result.permissions()).containsEntry(PermissionType.READ, true);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -128,7 +142,8 @@ class CheckResourcePermissionServiceTest {
             ResourceType resourceType = ResourceType.NOTICE;
             // NOTICE supports: READ, EDIT, DELETE, CHECK (4개)
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID), any(ResourcePermission.class)))
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES), any(ResourcePermission.class)))
                 .willReturn(false);
 
             // when
@@ -136,6 +151,7 @@ class CheckResourcePermissionServiceTest {
 
             // then
             assertThat(result.permissions()).hasSize(resourceType.getSupportedPermissions().size());
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -144,7 +160,8 @@ class CheckResourcePermissionServiceTest {
             // given
             ResourceType resourceType = ResourceType.NOTICE;
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.READ))))
                 .willReturn(true);
 
@@ -161,8 +178,9 @@ class CheckResourcePermissionServiceTest {
             assertThat(result.resourceId()).isEqualTo(RESOURCE_ID);
             assertThat(result.permissions()).containsOnlyKeys(PermissionType.READ);
             assertThat(result.permissions()).containsEntry(PermissionType.READ, true);
-            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID),
+            verify(checkPermissionUseCase, never()).check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.EDIT)));
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -171,7 +189,8 @@ class CheckResourcePermissionServiceTest {
             // given
             ResourceType resourceType = ResourceType.NOTICE;
 
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.ofType(resourceType, PermissionType.CHECK))))
                 .willReturn(false);
 
@@ -187,6 +206,7 @@ class CheckResourcePermissionServiceTest {
             assertThat(result.resourceId()).isNull();
             assertThat(result.permissions()).containsOnlyKeys(PermissionType.CHECK);
             assertThat(result.permissions()).containsEntry(PermissionType.CHECK, false);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -202,7 +222,8 @@ class CheckResourcePermissionServiceTest {
                 .isInstanceOf(AuthorizationDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(AuthorizationErrorCode.INVALID_INPUT_VALUE);
-            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID), any(ResourcePermission.class));
+            verify(checkPermissionUseCase, never()).loadSubject(MEMBER_ID);
+            verify(checkPermissionUseCase, never()).check(eq(SUBJECT_ATTRIBUTES), any(ResourcePermission.class));
         }
 
         @Test
@@ -224,13 +245,14 @@ class CheckResourcePermissionServiceTest {
         @DisplayName("여러 리소스에 대한 특정 권한을 요청 순서대로 조회한다")
         void 여러_리소스에_대한_특정_권한을_요청_순서대로_조회한다() {
             // given
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(ResourceType.NOTICE, 100L, PermissionType.READ))))
                 .willReturn(true);
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(ResourceType.NOTICE, 101L, PermissionType.READ))))
                 .willReturn(false);
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.of(ResourceType.WORKBOOK_SUBMISSION, 200L, PermissionType.READ))))
                 .willReturn(true);
 
@@ -253,6 +275,7 @@ class CheckResourcePermissionServiceTest {
             assertThat(result.get(2).resourceType()).isEqualTo(ResourceType.WORKBOOK_SUBMISSION);
             assertThat(result.get(2).resourceId()).isEqualTo(200L);
             assertThat(result.get(2).permissions()).containsEntry(PermissionType.READ, true);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
 
         @Test
@@ -269,14 +292,16 @@ class CheckResourcePermissionServiceTest {
                 .isInstanceOf(AuthorizationDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(AuthorizationErrorCode.INVALID_INPUT_VALUE);
-            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID), any(ResourcePermission.class));
+            verify(checkPermissionUseCase, never()).loadSubject(MEMBER_ID);
+            verify(checkPermissionUseCase, never()).check(eq(SUBJECT_ATTRIBUTES), any(ResourcePermission.class));
         }
 
         @Test
         @DisplayName("resourceIds가 null이면 타입 단위 권한을 배치로 조회한다")
         void resourceIds가_null이면_타입_단위_권한을_배치로_조회한다() {
             // given
-            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+            given(checkPermissionUseCase.loadSubject(MEMBER_ID)).willReturn(SUBJECT_ATTRIBUTES);
+            given(checkPermissionUseCase.check(eq(SUBJECT_ATTRIBUTES),
                 eq(ResourcePermission.ofType(ResourceType.NOTICE, PermissionType.CHECK))))
                 .willReturn(true);
 
@@ -292,6 +317,7 @@ class CheckResourcePermissionServiceTest {
             assertThat(result.getFirst().resourceType()).isEqualTo(ResourceType.NOTICE);
             assertThat(result.getFirst().resourceId()).isNull();
             assertThat(result.getFirst().permissions()).containsEntry(PermissionType.CHECK, true);
+            verify(checkPermissionUseCase, times(1)).loadSubject(MEMBER_ID);
         }
     }
 }

--- a/src/test/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionServiceTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/query/CheckResourcePermissionServiceTest.java
@@ -5,14 +5,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionQuery;
 import com.umc.product.authorization.application.port.in.query.dto.ResourcePermissionInfo;
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -135,6 +139,73 @@ class CheckResourcePermissionServiceTest {
         }
 
         @Test
+        @DisplayName("특정 권한을 지정하면 해당 권한만 평가한다")
+        void 특정_권한을_지정하면_해당_권한만_평가한다() {
+            // given
+            ResourceType resourceType = ResourceType.NOTICE;
+
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.READ))))
+                .willReturn(true);
+
+            // when
+            ResourcePermissionInfo result = sut.hasPermission(
+                MEMBER_ID,
+                resourceType,
+                RESOURCE_ID,
+                PermissionType.READ
+            );
+
+            // then
+            assertThat(result.resourceType()).isEqualTo(ResourceType.NOTICE);
+            assertThat(result.resourceId()).isEqualTo(RESOURCE_ID);
+            assertThat(result.permissions()).containsOnlyKeys(PermissionType.READ);
+            assertThat(result.permissions()).containsEntry(PermissionType.READ, true);
+            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID),
+                eq(ResourcePermission.of(resourceType, String.valueOf(RESOURCE_ID), PermissionType.EDIT)));
+        }
+
+        @Test
+        @DisplayName("resourceId 없이 특정 권한을 지정하면 타입 단위 권한을 평가한다")
+        void resourceId_없이_특정_권한을_지정하면_타입_단위_권한을_평가한다() {
+            // given
+            ResourceType resourceType = ResourceType.NOTICE;
+
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.ofType(resourceType, PermissionType.CHECK))))
+                .willReturn(false);
+
+            // when
+            ResourcePermissionInfo result = sut.hasPermission(
+                MEMBER_ID,
+                resourceType,
+                null,
+                PermissionType.CHECK
+            );
+
+            // then
+            assertThat(result.resourceId()).isNull();
+            assertThat(result.permissions()).containsOnlyKeys(PermissionType.CHECK);
+            assertThat(result.permissions()).containsEntry(PermissionType.CHECK, false);
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 특정 권한을 지정하면 아무 권한도 평가하지 않고 예외가 발생한다")
+        void 지원하지_않는_특정_권한을_지정하면_아무_권한도_평가하지_않고_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> sut.hasPermission(
+                MEMBER_ID,
+                ResourceType.WORKBOOK_SUBMISSION,
+                RESOURCE_ID,
+                PermissionType.DELETE
+            ))
+                .isInstanceOf(AuthorizationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthorizationErrorCode.INVALID_INPUT_VALUE);
+            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID), any(ResourcePermission.class));
+        }
+
+        @Test
         void Evaluator가_구현되지_않은_리소스_타입이면_예외가_발생한다() {
             // given
             ResourceType resourceType = ResourceType.CURRICULUM;
@@ -142,6 +213,85 @@ class CheckResourcePermissionServiceTest {
             // when & then
             assertThatThrownBy(() -> sut.hasPermission(MEMBER_ID, resourceType, RESOURCE_ID))
                 .isInstanceOf(AuthorizationDomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("권한을 배치로 조회한다")
+    class BatchHasPermissionTest {
+
+        @Test
+        @DisplayName("여러 리소스에 대한 특정 권한을 요청 순서대로 조회한다")
+        void 여러_리소스에_대한_특정_권한을_요청_순서대로_조회한다() {
+            // given
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.of(ResourceType.NOTICE, 100L, PermissionType.READ))))
+                .willReturn(true);
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.of(ResourceType.NOTICE, 101L, PermissionType.READ))))
+                .willReturn(false);
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.of(ResourceType.WORKBOOK_SUBMISSION, 200L, PermissionType.READ))))
+                .willReturn(true);
+
+            List<ResourcePermissionQuery> queries = List.of(
+                ResourcePermissionQuery.of(ResourceType.NOTICE, List.of(100L, 101L), List.of(PermissionType.READ)),
+                ResourcePermissionQuery.of(ResourceType.WORKBOOK_SUBMISSION, List.of(200L), List.of(PermissionType.READ))
+            );
+
+            // when
+            List<ResourcePermissionInfo> result = sut.batchHasPermission(MEMBER_ID, queries);
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).resourceType()).isEqualTo(ResourceType.NOTICE);
+            assertThat(result.get(0).resourceId()).isEqualTo(100L);
+            assertThat(result.get(0).permissions()).containsEntry(PermissionType.READ, true);
+            assertThat(result.get(1).resourceType()).isEqualTo(ResourceType.NOTICE);
+            assertThat(result.get(1).resourceId()).isEqualTo(101L);
+            assertThat(result.get(1).permissions()).containsEntry(PermissionType.READ, false);
+            assertThat(result.get(2).resourceType()).isEqualTo(ResourceType.WORKBOOK_SUBMISSION);
+            assertThat(result.get(2).resourceId()).isEqualTo(200L);
+            assertThat(result.get(2).permissions()).containsEntry(PermissionType.READ, true);
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 권한이 하나라도 있으면 아무 권한도 평가하지 않고 예외가 발생한다")
+        void 지원하지_않는_권한이_하나라도_있으면_아무_권한도_평가하지_않고_예외가_발생한다() {
+            // given
+            List<ResourcePermissionQuery> queries = List.of(
+                ResourcePermissionQuery.of(ResourceType.NOTICE, List.of(100L), List.of(PermissionType.READ)),
+                ResourcePermissionQuery.of(ResourceType.WORKBOOK_SUBMISSION, List.of(200L), List.of(PermissionType.DELETE))
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.batchHasPermission(MEMBER_ID, queries))
+                .isInstanceOf(AuthorizationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthorizationErrorCode.INVALID_INPUT_VALUE);
+            verify(checkPermissionUseCase, never()).check(eq(MEMBER_ID), any(ResourcePermission.class));
+        }
+
+        @Test
+        @DisplayName("resourceIds가 null이면 타입 단위 권한을 배치로 조회한다")
+        void resourceIds가_null이면_타입_단위_권한을_배치로_조회한다() {
+            // given
+            given(checkPermissionUseCase.check(eq(MEMBER_ID),
+                eq(ResourcePermission.ofType(ResourceType.NOTICE, PermissionType.CHECK))))
+                .willReturn(true);
+
+            List<ResourcePermissionQuery> queries = List.of(
+                ResourcePermissionQuery.of(ResourceType.NOTICE, null, List.of(PermissionType.CHECK))
+            );
+
+            // when
+            List<ResourcePermissionInfo> result = sut.batchHasPermission(MEMBER_ID, queries);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().resourceType()).isEqualTo(ResourceType.NOTICE);
+            assertThat(result.getFirst().resourceId()).isNull();
+            assertThat(result.getFirst().permissions()).containsEntry(PermissionType.CHECK, true);
         }
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- authorization 도메인의 리소스 권한 조회 API와 application query service를 확장했어요.
- 공통 예외 처리에서 request parameter 누락과 타입 변환 실패를 실패 응답으로 내려주도록 보강했어요.

### 작업 단위별 상세

1. **무엇을**: `[PERMISSION-001] GET /api/v1/authorization/resource-permission`에서 `permissionType`을 선택적으로 받을 수 있게 했어요.
   - **어떻게**: 기존 전체 권한 조회 흐름은 유지하고, `permissionType`이 있으면 해당 권한만 평가하도록 `ResourcePermissionUseCase`와 `CheckResourcePermissionService`를 확장했어요.
   - **왜**: 화면에서 특정 리소스에 대한 특정 권한만 필요할 때 불필요하게 모든 권한을 평가하지 않도록 하기 위해서예요.

2. **무엇을**: `[PERMISSION-002] POST /api/v1/authorization/resource-permissions/batch` API를 추가했어요.
   - **어떻게**: adapter 요청 DTO에서 batch query를 application DTO로 변환하고, service에서 요청 순서를 보존해 리소스별 권한 결과를 펼쳐 반환하도록 구성했어요.
   - **왜**: 목록 화면처럼 여러 리소스의 권한을 한 번에 확인해야 하는 경우 API 호출 수를 줄이기 위해서예요.

3. **무엇을**: 유효하지 않은 권한 조회 입력은 fail-fast로 실패하도록 검증을 추가했어요.
   - **어떻게**: batch 요청 전체를 먼저 검증하고, `resourceType` 누락, 빈 `resourceIds`, 빈 `permissionTypes`, 지원하지 않는 권한 조합이 있으면 권한 평가를 수행하지 않고 `AUTHORIZATION-0007` 또는 `COMMON-400` 응답을 반환하도록 했어요.
   - **왜**: 일부 결과만 내려주는 부분 성공 응답이 프론트엔드 상태를 애매하게 만들 수 있어서, 잘못된 요청은 명확하게 실패시키기 위해서예요.

4. **무엇을**: GET query parameter 바인딩 오류가 공통 실패 응답으로 내려가도록 예외 처리를 보강했어요.
   - **어떻게**: `MissingServletRequestParameterException`과 `TypeMismatchException`을 `GlobalExceptionHandler`에서 `COMMON-400`으로 처리하도록 추가했어요.
   - **왜**: `resourceType` 누락이나 enum 값 오류도 성공 응답 래퍼로 감싸지지 않고 오류 코드로 내려가야 하기 때문이에요.

5. **무엇을**: 단건/배치 권한 조회와 실패 케이스 테스트를 추가했어요.
   - **어떻게**: `CheckResourcePermissionServiceTest`에서 fail-fast와 요청 순서 보존을 검증하고, `ResourcePermissionControllerTest`에서 GET/POST 바인딩과 오류 응답을 검증했어요.
   - **왜**: 권한 API는 프론트엔드 분기와 보안 정책에 직접 영향을 주므로 입력 검증과 응답 계약을 회귀 테스트로 고정하기 위해서예요.

## 💬 리뷰 중점사항

- authorization 도메인의 API 계약 변경이라 `permissionType` 선택 파라미터와 batch request/response 형태가 프론트엔드 사용 시나리오에 맞는지 확인해주세요.
- batch API는 현재 기존 단건 evaluator를 반복 호출하는 fallback 방식이에요. 성능 최적화가 더 필요하면 후속으로 `SubjectAttributes` 요청 단위 캐싱이나 evaluator batch 평가를 추가할 수 있어요.
- `GlobalExceptionHandler`의 request parameter 오류 처리 추가가 다른 컨트롤러의 400 응답 기대값과 충돌하지 않는지 확인해주세요.
- 검증은 `./gradlew test`로 완료했어요.
