### PR TITLE
[Feat] 프로젝트 시나리오 시딩 API 추가

### DIFF
--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -9,12 +9,15 @@ import com.umc.product.test.adapter.in.web.dto.SeedMembersRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedMembersResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedNoticeRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedNoticeResponse;
+import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosRequest;
+import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsResponse;
 import com.umc.product.test.application.port.in.command.SeedChallengersUseCase;
 import com.umc.product.test.application.port.in.command.SeedCurriculumUseCase;
 import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
 import com.umc.product.test.application.port.in.command.SeedNoticeUseCase;
+import com.umc.product.test.application.port.in.command.SeedProjectScenariosUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectsUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,6 +50,7 @@ public class SeedController {
     private final SeedMembersUseCase seedMembersUseCase;
     private final SeedChallengersUseCase seedChallengersUseCase;
     private final SeedProjectsUseCase seedProjectsUseCase;
+    private final SeedProjectScenariosUseCase seedProjectScenariosUseCase;
     private final SeedCurriculumUseCase seedCurriculumUseCase;
     private final SeedNoticeUseCase seedNoticeUseCase;
 
@@ -92,6 +96,26 @@ public class SeedController {
     @PostMapping("/projects")
     public SeedProjectsResponse seedProjects(@RequestBody @Valid SeedProjectsRequest request) {
         return SeedProjectsResponse.from(seedProjectsUseCase.seed(request.toCommand()));
+    }
+
+    @Operation(
+        summary = "[SEED-003-S] 프로젝트 시나리오 시딩",
+        description = """
+            활성 기수에 대해 DRAFT / PENDING_REVIEW / IN_PROGRESS 중 하나의 상태까지 도달한
+            프로젝트를 N 개 생성합니다. SQL 직접 주입이 아니라 도메인 UseCase 시퀀스 호출로 만들기 때문에
+            도메인 가드를 모두 통과한 데이터가 됩니다.
+            productOwnerMemberIds 를 명시하면 그 리스트로만 PO 를 사용하고(size 가 projectCount 와
+            같아야 하며 각각 활성 기수 PLAN 챌린저여야 함), null 이면 활성 기수 PLAN 챌린저 풀에서
+            랜덤 픽 합니다. 시딩 측에서 챌린저를 강제로 만들지는 않습니다.
+            IN_PROGRESS 단계에서는 DESIGN×1~2 + FE 1 개×3~4 + BE 1 개×3~4 의 partQuota 가 자동 분배되고,
+            각 파트마다 PO 학교의 해당 파트 챌린저 풀에서 random(0, quota) 만큼 멤버가 충원됩니다.
+            """
+    )
+    @PostMapping("/projects/scenarios")
+    public SeedProjectScenariosResponse seedProjectScenarios(
+        @RequestBody @Valid SeedProjectScenariosRequest request
+    ) {
+        return SeedProjectScenariosResponse.from(seedProjectScenariosUseCase.seed(request.toCommand()));
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectScenariosRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectScenariosRequest.java
@@ -1,0 +1,26 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosCommand;
+import com.umc.product.test.application.port.in.command.dto.TargetProjectStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+/**
+ * 시나리오 시딩 Request.
+ *
+ * @param targetStatus           도달할 프로젝트 상태
+ * @param projectCount           생성할 프로젝트 수
+ * @param productOwnerMemberIds  PO 로 사용할 멤버 ID 목록. null 이면 활성 기수 PLAN 챌린저 풀에서 랜덤 픽.
+ *                               명시 시 size 가 정확히 {@code projectCount} 와 같아야 한다.
+ */
+public record SeedProjectScenariosRequest(
+    @NotNull TargetProjectStatus targetStatus,
+    @Positive int projectCount,
+    List<Long> productOwnerMemberIds
+) {
+
+    public SeedProjectScenariosCommand toCommand() {
+        return new SeedProjectScenariosCommand(targetStatus, projectCount, productOwnerMemberIds);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectScenariosResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectScenariosResponse.java
@@ -1,0 +1,69 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult;
+import com.umc.product.test.application.port.in.command.dto.TargetProjectStatus;
+import java.util.List;
+
+public record SeedProjectScenariosResponse(
+    List<CreatedProject> createdProjects,
+    List<FailedProject> failedProjects
+) {
+
+    public record CreatedProject(
+        Long projectId,
+        TargetProjectStatus finalStatus,
+        Long productOwnerMemberId,
+        Long chapterId,
+        Long schoolId,
+        Long applicationFormId,
+        List<PartFill> partFills
+    ) {
+
+        public static CreatedProject from(SeedProjectScenariosResult.CreatedProject src) {
+            return new CreatedProject(
+                src.projectId(),
+                src.finalStatus(),
+                src.productOwnerMemberId(),
+                src.chapterId(),
+                src.schoolId(),
+                src.applicationFormId(),
+                src.partFills() == null ? null
+                    : src.partFills().stream().map(PartFill::from).toList()
+            );
+        }
+    }
+
+    public record PartFill(ChallengerPart part, long quota, long filled) {
+
+        public static PartFill from(SeedProjectScenariosResult.PartFill src) {
+            return new PartFill(src.part(), src.quota(), src.filled());
+        }
+    }
+
+    public record FailedProject(
+        Long projectId,
+        TargetProjectStatus reachedStatus,
+        TargetProjectStatus intendedStatus,
+        String failedStep,
+        String reason
+    ) {
+
+        public static FailedProject from(SeedProjectScenariosResult.FailedProject src) {
+            return new FailedProject(
+                src.projectId(),
+                src.reachedStatus(),
+                src.intendedStatus(),
+                src.failedStep(),
+                src.reason()
+            );
+        }
+    }
+
+    public static SeedProjectScenariosResponse from(SeedProjectScenariosResult result) {
+        return new SeedProjectScenariosResponse(
+            result.createdProjects().stream().map(CreatedProject::from).toList(),
+            result.failedProjects().stream().map(FailedProject::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/SeedProjectScenariosUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/SeedProjectScenariosUseCase.java
@@ -1,0 +1,15 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult;
+
+/**
+ * 프로젝트 시나리오 시딩 UseCase.
+ * <p>
+ * 활성 기수에 대해 DRAFT / PENDING_REVIEW / IN_PROGRESS 중 하나의 상태까지 도달한 프로젝트를
+ * 생성한다. SQL 직접 주입이 아닌 도메인 UseCase 시퀀스 호출로 만들어진다.
+ */
+public interface SeedProjectScenariosUseCase {
+
+    SeedProjectScenariosResult seed(SeedProjectScenariosCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectScenariosCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectScenariosCommand.java
@@ -1,0 +1,23 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import java.util.List;
+
+/**
+ * 시나리오 시딩 Command.
+ * <p>
+ * 활성 기수에 대해 {@link TargetProjectStatus} 까지 도달한 프로젝트를 {@code projectCount} 개 생성한다.
+ * <p>
+ * {@code productOwnerMemberIds} 가 null 이면 활성 기수의 PLAN 챌린저 풀에서 무작위로 N 명을 PO 로
+ * 선정한다. 명시되면 그 리스트의 size 가 정확히 {@code projectCount} 와 같아야 하고, 각 멤버는
+ * 활성 기수의 PLAN 챌린저여야 한다(시딩 측에서 챌린저를 강제로 만들지 않는다).
+ *
+ * @param targetStatus           시딩 시 도달할 프로젝트 상태
+ * @param projectCount           생성할 프로젝트 수
+ * @param productOwnerMemberIds  PO 로 사용할 멤버 ID 목록. null 이면 랜덤 픽
+ */
+public record SeedProjectScenariosCommand(
+    TargetProjectStatus targetStatus,
+    int projectCount,
+    List<Long> productOwnerMemberIds
+) {
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectScenariosResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectScenariosResult.java
@@ -1,0 +1,60 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.util.List;
+
+/**
+ * 시나리오 시딩 결과.
+ *
+ * @param createdProjects {@code targetStatus} 까지 도달한 프로젝트 목록
+ * @param failedProjects  단계 중간에 실패해 {@code targetStatus} 에 도달하지 못한 프로젝트 목록.
+ *                        중간까지 진행된 데이터(예: DRAFT) 는 DB 에 남아있을 수 있으므로 호출자가
+ *                        orphan 정리 여부를 판단해야 한다.
+ */
+public record SeedProjectScenariosResult(
+    List<CreatedProject> createdProjects,
+    List<FailedProject> failedProjects
+) {
+
+    /**
+     * 시나리오의 모든 단계가 성공한 프로젝트.
+     *
+     * @param applicationFormId {@link TargetProjectStatus#PENDING_REVIEW} 이상에서만 not null
+     * @param partFills         {@link TargetProjectStatus#IN_PROGRESS} 에서만 not null.
+     *                          {@code filled == 0} 인 entry 도 포함된다(의도된 0 / 풀 부족 0 구분 정보).
+     */
+    public record CreatedProject(
+        Long projectId,
+        TargetProjectStatus finalStatus,
+        Long productOwnerMemberId,
+        Long chapterId,
+        Long schoolId,
+        Long applicationFormId,
+        List<PartFill> partFills
+    ) {
+    }
+
+    /**
+     * 한 파트의 quota 와 실제 추가된 멤버 수.
+     */
+    public record PartFill(ChallengerPart part, long quota, long filled) {
+    }
+
+    /**
+     * 중간 단계에서 실패한 프로젝트.
+     *
+     * @param projectId       create 까지는 성공해 ID 가 발급된 경우 not null
+     * @param reachedStatus   현재 DB 에 남아있는 상태. create 자체가 실패했으면 null
+     * @param intendedStatus  의도했던 최종 상태
+     * @param failedStep      실패한 단계 식별자 (CREATE_DRAFT, UPDATE, FORM, SUBMIT, QUOTA, PUBLISH, FILL_MEMBERS)
+     * @param reason          실패 원인 메시지
+     */
+    public record FailedProject(
+        Long projectId,
+        TargetProjectStatus reachedStatus,
+        TargetProjectStatus intendedStatus,
+        String failedStep,
+        String reason
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/TargetProjectStatus.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/TargetProjectStatus.java
@@ -1,0 +1,13 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+/**
+ * 시나리오 시딩이 도달 가능한 프로젝트 상태 집합.
+ * <p>
+ * {@code COMPLETED} / {@code ABORTED} 는 기수 종료 / 운영진 abort 등 별도 도메인 액션이 필요해
+ * 시나리오 시딩 범위 밖이다.
+ */
+public enum TargetProjectStatus {
+    DRAFT,
+    PENDING_REVIEW,
+    IN_PROGRESS
+}

--- a/src/main/java/com/umc/product/test/application/service/DummyApplicationFormFactory.java
+++ b/src/main/java/com/umc/product/test/application/service/DummyApplicationFormFactory.java
@@ -1,0 +1,46 @@
+package com.umc.product.test.application.service;
+
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationFormSectionEntry;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationQuestionEntry;
+import com.umc.product.project.domain.enums.FormSectionType;
+import com.umc.product.survey.domain.enums.QuestionType;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * 시나리오 시딩용 최소 ApplicationForm 스펙 생성기.
+ * <p>
+ * COMMON 섹션 1 개 + LONG_TEXT 질문 1 개의 가장 단순한 구조를 만든다. 옵션이 필요한 질문 타입
+ * (RADIO/CHECKBOX/DROPDOWN) 은 시딩 본문에서 제외해 도메인 검증 ({@code APPLICATION_FORM_OPTIONS_REQUIRED}) 통과를 보장한다.
+ */
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+public class DummyApplicationFormFactory {
+
+    public List<ApplicationFormSectionEntry> defaultSections() {
+        return List.of(
+            ApplicationFormSectionEntry.builder()
+                .sectionId(null)
+                .type(FormSectionType.COMMON)
+                .allowedParts(null)
+                .title("공통 질문")
+                .description("시딩 더미 공통 섹션")
+                .orderNo(0L)
+                .questions(List.of(
+                    ApplicationQuestionEntry.builder()
+                        .questionId(null)
+                        .type(QuestionType.LONG_TEXT)
+                        .title("지원 동기를 알려주세요")
+                        .description(null)
+                        .isRequired(true)
+                        .orderNo(0L)
+                        .options(List.of())
+                        .build()
+                ))
+                .build()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/DummyProjectFactory.java
+++ b/src/main/java/com/umc/product/test/application/service/DummyProjectFactory.java
@@ -1,0 +1,42 @@
+package com.umc.product.test.application.service;
+
+import java.util.Locale;
+import net.datafaker.Faker;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * datafaker 를 사용해 시나리오 시딩용 프로젝트 name / description 을 생성한다.
+ * <p>
+ * Project.name 컬럼은 length 100, description 은 length 200 이라 생성 시 컷오프한다.
+ * 모든 더미 값에는 {@code [SEED]} 접두사가 붙어 운영 화면에서 시딩 데이터를 식별할 수 있다.
+ */
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+public class DummyProjectFactory {
+
+    private static final int MAX_NAME_LENGTH = 100;
+    private static final int MAX_DESCRIPTION_LENGTH = 200;
+    private static final String NAME_PREFIX = "[SEED] ";
+
+    private final Faker faker = new Faker(Locale.KOREAN);
+
+    public String nextName(int sequence) {
+        String raw = "%sUMC 프로젝트 #%04d %s".formatted(NAME_PREFIX, sequence, faker.book().title());
+        return clip(raw, MAX_NAME_LENGTH);
+    }
+
+    public String nextDescription(int sequence) {
+        String raw = "시딩 더미 프로젝트 #%04d — %s".formatted(sequence, faker.lorem().paragraph());
+        return clip(raw, MAX_DESCRIPTION_LENGTH);
+    }
+
+    private String clip(String value, int max) {
+        if (value.length() <= max) {
+            return value;
+        }
+        return value.substring(0, max);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/ProjectScenarioSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectScenarioSeedService.java
@@ -1,0 +1,359 @@
+package com.umc.product.test.application.service;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.command.dto.AddProjectMemberCommand;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.PublishProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand.Entry;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.test.application.port.in.command.SeedProjectScenariosUseCase;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult.CreatedProject;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult.FailedProject;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult.PartFill;
+import com.umc.product.test.application.port.in.command.dto.TargetProjectStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 시나리오 기반 프로젝트 시딩 서비스.
+ * <p>
+ * 활성 기수에 대해 {@link TargetProjectStatus} 까지 도달한 프로젝트를 N 개 생성한다. SQL 직접 주입이
+ * 아니라 도메인 UseCase 시퀀스를 호출해 만들기 때문에 도메인 가드를 모두 통과한 데이터가 된다.
+ * <ul>
+ *   <li>{@code DRAFT}        — createDraft + updateProject(name/desc)</li>
+ *   <li>{@code PENDING_REVIEW} — 위 + upsertForm + submit</li>
+ *   <li>{@code IN_PROGRESS}    — 위 + updatePartQuotas + publish + addProjectMember 충원</li>
+ * </ul>
+ * <p>
+ * PO 선정 정책: {@code productOwnerMemberIds} 가 명시되면 그 리스트로만 사용한다(size 검증,
+ * 활성 기수 PLAN 챌린저 검증). null 이면 활성 기수의 ACTIVE PLAN 챌린저 풀에서 무작위로 N 명을
+ * 뽑는다. 풀에 없는 멤버를 PLAN 으로 강제 등록하지는 않는다.
+ * <p>
+ * IN_PROGRESS 멤버 충원: PartQuota 의 각 entry 에 대해 {@code target = random(0, quota)} 만큼
+ * PO 학교의 해당 파트 ACTIVE 챌린저 풀에서 무작위 추출. 풀이 부족하면 부족한 만큼만 추가하고
+ * {@link PartFill#filled()} 에 실제 수치를 노출한다.
+ * <p>
+ * <b>트랜잭션 정책</b>: 외부 트랜잭션 차단({@link Propagation#NOT_SUPPORTED}). 각 단계 UseCase 가
+ * 자체 트랜잭션을 가지므로 중간 단계가 실패해도 그 앞까지의 변경은 commit 된다. 호출자는
+ * {@link FailedProject} 의 {@code reachedStatus} 로 orphan 정리 여부를 판단해야 한다.
+ */
+@Slf4j
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class ProjectScenarioSeedService implements SeedProjectScenariosUseCase {
+
+    private final GetGisuUseCase getGisuUseCase;
+    private final GetMemberUseCase getMemberUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetChapterUseCase getChapterUseCase;
+    private final CreateDraftProjectUseCase createDraftProjectUseCase;
+    private final UpdateProjectUseCase updateProjectUseCase;
+    private final UpsertProjectApplicationFormUseCase upsertProjectApplicationFormUseCase;
+    private final SubmitProjectUseCase submitProjectUseCase;
+    private final UpdatePartQuotasUseCase updatePartQuotasUseCase;
+    private final PublishProjectUseCase publishProjectUseCase;
+    private final AddProjectMemberUseCase addProjectMemberUseCase;
+    private final DummyProjectFactory dummyProjectFactory;
+    private final DummyApplicationFormFactory dummyApplicationFormFactory;
+    private final ScenarioPartQuotaPolicy scenarioPartQuotaPolicy;
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public SeedProjectScenariosResult seed(SeedProjectScenariosCommand command) {
+        Long gisuId = getGisuUseCase.getActiveGisuId();
+        long startedAt = System.currentTimeMillis();
+        log.info(
+            "project scenario seed start: targetStatus={}, projectCount={}, gisuId={}",
+            command.targetStatus(), command.projectCount(), gisuId
+        );
+
+        List<Long> poIds = resolvePOs(command, gisuId);
+
+        List<CreatedProject> created = new ArrayList<>();
+        List<FailedProject> failed = new ArrayList<>();
+
+        int seq = 1;
+        for (Long poMemberId : poIds) {
+            ScenarioOutcome outcome = runScenario(poMemberId, command.targetStatus(), gisuId, seq);
+            if (outcome.failure != null) {
+                failed.add(outcome.failure);
+            } else {
+                created.add(outcome.success);
+            }
+            seq++;
+        }
+
+        long elapsedMs = System.currentTimeMillis() - startedAt;
+        log.info(
+            "project scenario seed completed in {}ms: created={}, failed={}",
+            elapsedMs, created.size(), failed.size()
+        );
+
+        return new SeedProjectScenariosResult(created, failed);
+    }
+
+    private List<Long> resolvePOs(SeedProjectScenariosCommand command, Long gisuId) {
+        List<Long> input = command.productOwnerMemberIds();
+        int count = command.projectCount();
+
+        if (input != null) {
+            if (input.size() != count) {
+                throw new IllegalArgumentException(
+                    "productOwnerMemberIds size (%d) must equal projectCount (%d)"
+                        .formatted(input.size(), count)
+                );
+            }
+            validateAllArePlanChallengers(input, gisuId);
+            return List.copyOf(input);
+        }
+
+        List<Long> pool = getChallengerUseCase.getAllByGisuId(gisuId).stream()
+            .filter(c -> c.part() == ChallengerPart.PLAN)
+            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
+            .map(ChallengerInfo::memberId)
+            .toList();
+        if (pool.size() < count) {
+            throw new IllegalArgumentException(
+                "active PLAN challenger pool size (%d) is less than projectCount (%d)"
+                    .formatted(pool.size(), count)
+            );
+        }
+        List<Long> shuffled = new ArrayList<>(pool);
+        Collections.shuffle(shuffled);
+        return List.copyOf(shuffled.subList(0, count));
+    }
+
+    private void validateAllArePlanChallengers(List<Long> memberIds, Long gisuId) {
+        Map<Long, ChallengerInfo> map = getChallengerUseCase.listByMemberIdsAndGisuId(
+            new HashSet<>(memberIds), gisuId
+        );
+        for (Long memberId : memberIds) {
+            ChallengerInfo c = map.get(memberId);
+            if (c == null) {
+                throw new IllegalArgumentException(
+                    "memberId=%d is not a challenger of gisuId=%d".formatted(memberId, gisuId)
+                );
+            }
+            if (c.part() != ChallengerPart.PLAN) {
+                throw new IllegalArgumentException(
+                    "memberId=%d is not a PLAN challenger (actual=%s)".formatted(memberId, c.part())
+                );
+            }
+        }
+    }
+
+    private ScenarioOutcome runScenario(Long poMemberId, TargetProjectStatus target, Long gisuId, int seq) {
+        Long projectId;
+        try {
+            projectId = createDraftProjectUseCase.create(CreateDraftProjectCommand.builder()
+                .gisuId(gisuId)
+                .productOwnerMemberId(poMemberId)
+                .requesterMemberId(poMemberId)
+                .build());
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(null, null, target, "CREATE_DRAFT", e));
+        }
+        TargetProjectStatus reached = TargetProjectStatus.DRAFT;
+
+        try {
+            updateProjectUseCase.update(UpdateProjectCommand.builder()
+                .projectId(projectId)
+                .requesterMemberId(poMemberId)
+                .name(dummyProjectFactory.nextName(seq))
+                .description(dummyProjectFactory.nextDescription(seq))
+                .build());
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(projectId, reached, target, "UPDATE", e));
+        }
+
+        MemberInfo poMember = getMemberUseCase.getById(poMemberId);
+        Long schoolId = poMember.schoolId();
+        ChapterInfo chapter = getChapterUseCase.byGisuAndSchool(gisuId, schoolId);
+        Long chapterId = chapter.id();
+
+        if (target == TargetProjectStatus.DRAFT) {
+            return ScenarioOutcome.success(new CreatedProject(
+                projectId, TargetProjectStatus.DRAFT, poMemberId, chapterId, schoolId, null, null
+            ));
+        }
+
+        Long applicationFormId;
+        try {
+            ApplicationFormInfo formInfo = upsertProjectApplicationFormUseCase.upsert(
+                UpsertApplicationFormCommand.builder()
+                    .projectId(projectId)
+                    .requesterMemberId(poMemberId)
+                    .title(null)
+                    .description("시딩 더미 지원서")
+                    .sections(dummyApplicationFormFactory.defaultSections())
+                    .build()
+            );
+            applicationFormId = formInfo.applicationFormId();
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(projectId, reached, target, "FORM", e));
+        }
+
+        try {
+            submitProjectUseCase.submit(SubmitProjectCommand.builder()
+                .projectId(projectId)
+                .build());
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(projectId, reached, target, "SUBMIT", e));
+        }
+        reached = TargetProjectStatus.PENDING_REVIEW;
+
+        if (target == TargetProjectStatus.PENDING_REVIEW) {
+            return ScenarioOutcome.success(new CreatedProject(
+                projectId, TargetProjectStatus.PENDING_REVIEW, poMemberId, chapterId, schoolId,
+                applicationFormId, null
+            ));
+        }
+
+        List<Entry> quotas = scenarioPartQuotaPolicy.pickQuotas();
+        try {
+            updatePartQuotasUseCase.update(UpdatePartQuotasCommand.builder()
+                .projectId(projectId)
+                .entries(quotas)
+                .requesterMemberId(poMemberId)
+                .build());
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(projectId, reached, target, "QUOTA", e));
+        }
+
+        try {
+            publishProjectUseCase.publish(PublishProjectCommand.builder()
+                .projectId(projectId)
+                .requesterMemberId(poMemberId)
+                .build());
+        } catch (Exception e) {
+            return ScenarioOutcome.failure(failureOf(projectId, reached, target, "PUBLISH", e));
+        }
+        reached = TargetProjectStatus.IN_PROGRESS;
+
+        List<PartFill> partFills = fillMembers(projectId, schoolId, gisuId, poMemberId, quotas);
+        return ScenarioOutcome.success(new CreatedProject(
+            projectId, TargetProjectStatus.IN_PROGRESS, poMemberId, chapterId, schoolId,
+            applicationFormId, partFills
+        ));
+    }
+
+    /**
+     * 각 quota entry 마다 {@code target = random(0, quota)} 만큼 PO 학교의 해당 파트 ACTIVE 챌린저
+     * 풀에서 무작위 추출해 add 한다. 풀이 부족하거나 개별 add 가 실패해도 best-effort 로 진행하고
+     * 실제 추가된 수만 {@code filled} 에 반영한다.
+     */
+    private List<PartFill> fillMembers(Long projectId, Long schoolId, Long gisuId,
+                                       Long poMemberId, List<Entry> quotas) {
+        List<ChallengerInfo> allChallengers = getChallengerUseCase.getAllByGisuId(gisuId).stream()
+            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
+            .filter(c -> !Objects.equals(c.memberId(), poMemberId))
+            .toList();
+
+        Set<Long> memberIds = allChallengers.stream()
+            .map(ChallengerInfo::memberId)
+            .collect(Collectors.toSet());
+        Map<Long, Long> memberSchoolMap = memberIds.isEmpty()
+            ? Map.of()
+            : getMemberUseCase.findAllSchoolIdsByIds(memberIds);
+
+        Map<ChallengerPart, List<Long>> poolByPart = allChallengers.stream()
+            .filter(c -> Objects.equals(memberSchoolMap.get(c.memberId()), schoolId))
+            .collect(Collectors.groupingBy(
+                ChallengerInfo::part,
+                Collectors.mapping(ChallengerInfo::memberId, Collectors.toList())
+            ));
+
+        Set<Long> used = new HashSet<>();
+        List<PartFill> fills = new ArrayList<>();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        for (Entry quota : quotas) {
+            long target = random.nextLong(0, quota.quota() + 1);
+            List<Long> available = new ArrayList<>(
+                poolByPart.getOrDefault(quota.part(), List.of()).stream()
+                    .filter(id -> !used.contains(id))
+                    .toList()
+            );
+            Collections.shuffle(available);
+            long actualTarget = Math.min(target, available.size());
+            List<Long> picked = available.subList(0, (int) actualTarget);
+
+            long added = 0;
+            for (Long memberId : picked) {
+                try {
+                    addProjectMemberUseCase.add(AddProjectMemberCommand.builder()
+                        .projectId(projectId)
+                        .memberId(memberId)
+                        .part(quota.part())
+                        .requesterMemberId(poMemberId)
+                        .build());
+                    used.add(memberId);
+                    added++;
+                } catch (Exception e) {
+                    log.error(
+                        "project scenario seed addMember failed (projectId={}, memberId={}, part={}): {}",
+                        projectId, memberId, quota.part(), e.toString()
+                    );
+                }
+            }
+            fills.add(new PartFill(quota.part(), quota.quota(), added));
+        }
+        return fills;
+    }
+
+    private FailedProject failureOf(Long projectId, TargetProjectStatus reached,
+                                    TargetProjectStatus intended, String step, Exception cause) {
+        log.error(
+            "project scenario seed step failed (step={}, projectId={}, reached={}, intended={}): {}",
+            step, projectId, reached, intended, cause.toString()
+        );
+        return new FailedProject(projectId, reached, intended, step, cause.toString());
+    }
+
+    private record ScenarioOutcome(CreatedProject success, FailedProject failure) {
+        static ScenarioOutcome success(CreatedProject p) {
+            return new ScenarioOutcome(p, null);
+        }
+
+        static ScenarioOutcome failure(FailedProject f) {
+            return new ScenarioOutcome(null, f);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/ScenarioPartQuotaPolicy.java
+++ b/src/main/java/com/umc/product/test/application/service/ScenarioPartQuotaPolicy.java
@@ -1,0 +1,65 @@
+package com.umc.product.test.application.service;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand.Entry;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * IN_PROGRESS 시나리오의 PartQuota 분배 정책.
+ * <p>
+ * 한 프로젝트당 {@code DESIGN} × 1~2 + 프론트엔드 파트 1 개 × 3~4 + 백엔드 파트 1 개 × 3~4 를
+ * 만든다. 프론트엔드는 {@code WEB, ANDROID, IOS}, 백엔드는 {@code NODEJS, SPRINGBOOT} 중
+ * 균등 무작위로 선정한다. quota 는 모두 1 이상이라 {@code PROJECT_PART_QUOTA_INVALID} 가드를
+ * 항상 통과한다.
+ */
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+public class ScenarioPartQuotaPolicy {
+
+    static final long DESIGN_MIN = 1L;
+    static final long DESIGN_MAX = 2L;
+    static final long FE_MIN = 3L;
+    static final long FE_MAX = 4L;
+    static final long BE_MIN = 3L;
+    static final long BE_MAX = 4L;
+
+    private static final List<ChallengerPart> FRONTEND_PARTS = List.of(
+        ChallengerPart.WEB,
+        ChallengerPart.ANDROID,
+        ChallengerPart.IOS
+    );
+
+    private static final List<ChallengerPart> BACKEND_PARTS = List.of(
+        ChallengerPart.NODEJS,
+        ChallengerPart.SPRINGBOOT
+    );
+
+    /**
+     * 한 프로젝트의 partQuota 3 entry 를 만든다. 순서는 항상 {@code [DESIGN, FE, BE]}.
+     */
+    public List<Entry> pickQuotas() {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        long designQuota = randomInclusive(random, DESIGN_MIN, DESIGN_MAX);
+        long feQuota = randomInclusive(random, FE_MIN, FE_MAX);
+        long beQuota = randomInclusive(random, BE_MIN, BE_MAX);
+        ChallengerPart fePart = FRONTEND_PARTS.get(random.nextInt(FRONTEND_PARTS.size()));
+        ChallengerPart bePart = BACKEND_PARTS.get(random.nextInt(BACKEND_PARTS.size()));
+        return List.of(
+            Entry.builder().part(ChallengerPart.DESIGN).quota(designQuota).build(),
+            Entry.builder().part(fePart).quota(feQuota).build(),
+            Entry.builder().part(bePart).quota(beQuota).build()
+        );
+    }
+
+    private long randomInclusive(ThreadLocalRandom random, long min, long max) {
+        if (max <= min) {
+            return min;
+        }
+        return random.nextLong(min, max + 1);
+    }
+}

--- a/src/test/java/com/umc/product/test/application/service/ProjectScenarioSeedServiceTest.java
+++ b/src/test/java/com/umc/product/test/application/service/ProjectScenarioSeedServiceTest.java
@@ -1,0 +1,526 @@
+package com.umc.product.test.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand.Entry;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult.CreatedProject;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectScenariosResult.FailedProject;
+import com.umc.product.test.application.port.in.command.dto.TargetProjectStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectScenarioSeedServiceTest {
+
+    private static final Long GISU_ID = 9L;
+    private static final Long CHAPTER_ID = 1L;
+    private static final Long SCHOOL_ID = 11L;
+    private static final Long PO_MEMBER_ID = 100L;
+
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    GetChapterUseCase getChapterUseCase;
+    @Mock
+    CreateDraftProjectUseCase createDraftProjectUseCase;
+    @Mock
+    UpdateProjectUseCase updateProjectUseCase;
+    @Mock
+    UpsertProjectApplicationFormUseCase upsertProjectApplicationFormUseCase;
+    @Mock
+    SubmitProjectUseCase submitProjectUseCase;
+    @Mock
+    UpdatePartQuotasUseCase updatePartQuotasUseCase;
+    @Mock
+    PublishProjectUseCase publishProjectUseCase;
+    @Mock
+    AddProjectMemberUseCase addProjectMemberUseCase;
+    @Mock
+    ScenarioPartQuotaPolicy scenarioPartQuotaPolicy;
+
+    DummyProjectFactory dummyProjectFactory = new DummyProjectFactory();
+    DummyApplicationFormFactory dummyApplicationFormFactory = new DummyApplicationFormFactory();
+    ProjectScenarioSeedService sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new ProjectScenarioSeedService(
+            getGisuUseCase,
+            getMemberUseCase,
+            getChallengerUseCase,
+            getChapterUseCase,
+            createDraftProjectUseCase,
+            updateProjectUseCase,
+            upsertProjectApplicationFormUseCase,
+            submitProjectUseCase,
+            updatePartQuotasUseCase,
+            publishProjectUseCase,
+            addProjectMemberUseCase,
+            dummyProjectFactory,
+            dummyApplicationFormFactory,
+            scenarioPartQuotaPolicy
+        );
+    }
+
+    // ===== Helpers =====
+
+    private ChallengerInfo challengerInfo(Long memberId, ChallengerPart part) {
+        return challengerInfo(memberId, part, ChallengerStatus.ACTIVE);
+    }
+
+    private ChallengerInfo challengerInfo(Long memberId, ChallengerPart part, ChallengerStatus status) {
+        return ChallengerInfo.builder()
+            .challengerId(memberId * 10)
+            .memberId(memberId)
+            .gisuId(GISU_ID)
+            .part(part)
+            .challengerStatus(status)
+            .build();
+    }
+
+    private MemberInfo memberInfo(Long memberId, Long schoolId) {
+        return MemberInfo.builder()
+            .id(memberId)
+            .schoolId(schoolId)
+            .build();
+    }
+
+    private ApplicationFormInfo applicationFormInfo(Long projectId, Long formId) {
+        return ApplicationFormInfo.builder()
+            .projectId(projectId)
+            .applicationFormId(formId)
+            .build();
+    }
+
+    private void givenActiveGisu() {
+        given(getGisuUseCase.getActiveGisuId()).willReturn(GISU_ID);
+    }
+
+    private void givenPoIsPlanChallenger(Long poMemberId) {
+        Map<Long, ChallengerInfo> map = new HashMap<>();
+        map.put(poMemberId, challengerInfo(poMemberId, ChallengerPart.PLAN));
+        given(getChallengerUseCase.listByMemberIdsAndGisuId(Set.of(poMemberId), GISU_ID))
+            .willReturn(map);
+    }
+
+    private void givenPoMemberSchool(Long poMemberId, Long schoolId) {
+        given(getMemberUseCase.getById(poMemberId)).willReturn(memberInfo(poMemberId, schoolId));
+        given(getChapterUseCase.byGisuAndSchool(GISU_ID, schoolId))
+            .willReturn(new ChapterInfo(CHAPTER_ID, "지부"));
+    }
+
+    private void givenCreateDraftReturns(Long projectId) {
+        AtomicLong counter = new AtomicLong(projectId);
+        given(createDraftProjectUseCase.create(any(CreateDraftProjectCommand.class)))
+            .willAnswer(inv -> counter.getAndIncrement());
+    }
+
+    // ===== Test Cases =====
+
+    @Nested
+    @DisplayName("DRAFT 시나리오")
+    class DraftScenario {
+
+        @Test
+        @DisplayName("createDraft와 updateProject만 호출되고 form/submit/publish는 호출되지 않는다")
+        void calls_only_create_and_update() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(500L);
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            assertThat(result.createdProjects()).hasSize(1);
+            CreatedProject created = result.createdProjects().get(0);
+            assertThat(created.projectId()).isEqualTo(500L);
+            assertThat(created.finalStatus()).isEqualTo(TargetProjectStatus.DRAFT);
+            assertThat(created.productOwnerMemberId()).isEqualTo(PO_MEMBER_ID);
+            assertThat(created.chapterId()).isEqualTo(CHAPTER_ID);
+            assertThat(created.schoolId()).isEqualTo(SCHOOL_ID);
+            assertThat(created.applicationFormId()).isNull();
+            assertThat(created.partFills()).isNull();
+
+            then(createDraftProjectUseCase).should().create(any());
+            then(updateProjectUseCase).should().update(any());
+            then(upsertProjectApplicationFormUseCase).should(never()).upsert(any());
+            then(submitProjectUseCase).should(never()).submit(any());
+            then(updatePartQuotasUseCase).should(never()).update(any());
+            then(publishProjectUseCase).should(never()).publish(any());
+            then(addProjectMemberUseCase).should(never()).add(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("PENDING_REVIEW 시나리오")
+    class PendingReviewScenario {
+
+        @Test
+        @DisplayName("DRAFT 단계 호출에 더해 upsertForm + submit이 호출되고 publish는 호출되지 않는다")
+        void runs_through_submit_but_not_publish() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(501L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(501L, 9001L));
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.PENDING_REVIEW, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            assertThat(result.createdProjects()).hasSize(1);
+            CreatedProject created = result.createdProjects().get(0);
+            assertThat(created.finalStatus()).isEqualTo(TargetProjectStatus.PENDING_REVIEW);
+            assertThat(created.applicationFormId()).isEqualTo(9001L);
+            assertThat(created.partFills()).isNull();
+
+            then(upsertProjectApplicationFormUseCase).should().upsert(any());
+            then(submitProjectUseCase).should().submit(any());
+            then(updatePartQuotasUseCase).should(never()).update(any());
+            then(publishProjectUseCase).should(never()).publish(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("IN_PROGRESS 시나리오")
+    class InProgressScenario {
+
+        @Test
+        @DisplayName("전체 단계가 호출되고 PartFill이 quota 범위 내에서 채워진다")
+        void runs_all_steps_and_fills_members_within_quota() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(502L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(502L, 9002L));
+
+            List<Entry> quotas = List.of(
+                Entry.builder().part(ChallengerPart.DESIGN).quota(2L).build(),
+                Entry.builder().part(ChallengerPart.WEB).quota(4L).build(),
+                Entry.builder().part(ChallengerPart.NODEJS).quota(3L).build()
+            );
+            given(scenarioPartQuotaPolicy.pickQuotas()).willReturn(quotas);
+
+            List<ChallengerInfo> sameSchoolChallengers = List.of(
+                challengerInfo(201L, ChallengerPart.DESIGN),
+                challengerInfo(202L, ChallengerPart.DESIGN),
+                challengerInfo(203L, ChallengerPart.WEB),
+                challengerInfo(204L, ChallengerPart.WEB),
+                challengerInfo(205L, ChallengerPart.WEB),
+                challengerInfo(206L, ChallengerPart.WEB),
+                challengerInfo(207L, ChallengerPart.NODEJS),
+                challengerInfo(208L, ChallengerPart.NODEJS),
+                challengerInfo(209L, ChallengerPart.NODEJS),
+                challengerInfo(PO_MEMBER_ID, ChallengerPart.PLAN)
+            );
+            given(getChallengerUseCase.getAllByGisuId(GISU_ID)).willReturn(sameSchoolChallengers);
+
+            Map<Long, Long> memberSchoolMap = new HashMap<>();
+            for (long id = 201L; id <= 209L; id++) {
+                memberSchoolMap.put(id, SCHOOL_ID);
+            }
+            given(getMemberUseCase.findAllSchoolIdsByIds(any())).willReturn(memberSchoolMap);
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.IN_PROGRESS, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            assertThat(result.createdProjects()).hasSize(1);
+            CreatedProject created = result.createdProjects().get(0);
+            assertThat(created.finalStatus()).isEqualTo(TargetProjectStatus.IN_PROGRESS);
+            assertThat(created.partFills()).hasSize(3);
+            assertThat(created.partFills().get(0).part()).isEqualTo(ChallengerPart.DESIGN);
+            assertThat(created.partFills().get(0).quota()).isEqualTo(2L);
+            assertThat(created.partFills().get(0).filled()).isBetween(0L, 2L);
+            assertThat(created.partFills().get(1).part()).isEqualTo(ChallengerPart.WEB);
+            assertThat(created.partFills().get(1).filled()).isBetween(0L, 4L);
+            assertThat(created.partFills().get(2).part()).isEqualTo(ChallengerPart.NODEJS);
+            assertThat(created.partFills().get(2).filled()).isBetween(0L, 3L);
+
+            then(updatePartQuotasUseCase).should().update(any());
+            then(publishProjectUseCase).should().publish(any());
+        }
+
+        @Test
+        @DisplayName("PO 본인은 멤버 충원에서 제외된다")
+        void po_is_excluded_from_member_pool() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(503L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(503L, 9003L));
+            given(scenarioPartQuotaPolicy.pickQuotas()).willReturn(List.of(
+                Entry.builder().part(ChallengerPart.DESIGN).quota(2L).build(),
+                Entry.builder().part(ChallengerPart.WEB).quota(4L).build(),
+                Entry.builder().part(ChallengerPart.NODEJS).quota(3L).build()
+            ));
+            given(getChallengerUseCase.getAllByGisuId(GISU_ID))
+                .willReturn(List.of(challengerInfo(PO_MEMBER_ID, ChallengerPart.PLAN)));
+
+            sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.IN_PROGRESS, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            // PO 만 챌린저로 등록된 상태 → fillMembers 의 pre-filter 단계에서 모든 풀이 비어 addMember 미호출
+            then(addProjectMemberUseCase).should(never()).add(any());
+        }
+
+        @Test
+        @DisplayName("멤버 풀이 비어있어도 partFills는 quota entry 수만큼 0으로 채워서 반환한다")
+        void empty_pool_returns_zero_filled_entries() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(504L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(504L, 9004L));
+            given(scenarioPartQuotaPolicy.pickQuotas()).willReturn(List.of(
+                Entry.builder().part(ChallengerPart.DESIGN).quota(2L).build(),
+                Entry.builder().part(ChallengerPart.WEB).quota(4L).build(),
+                Entry.builder().part(ChallengerPart.NODEJS).quota(3L).build()
+            ));
+            given(getChallengerUseCase.getAllByGisuId(GISU_ID)).willReturn(List.of());
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.IN_PROGRESS, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            CreatedProject created = result.createdProjects().get(0);
+            assertThat(created.partFills()).hasSize(3);
+            assertThat(created.partFills()).allMatch(f -> f.filled() == 0L);
+            assertThat(created.partFills().get(0).quota()).isEqualTo(2L);
+            assertThat(created.partFills().get(1).quota()).isEqualTo(4L);
+            assertThat(created.partFills().get(2).quota()).isEqualTo(3L);
+        }
+    }
+
+    @Nested
+    @DisplayName("PO 입력 검증")
+    class PoValidation {
+
+        @Test
+        @DisplayName("productOwnerMemberIds size가 projectCount와 다르면 IllegalArgumentException")
+        void size_mismatch_throws() {
+            givenActiveGisu();
+
+            assertThatThrownBy(() -> sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 3, List.of(100L, 101L)
+            ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size");
+        }
+
+        @Test
+        @DisplayName("입력된 PO가 PLAN 챌린저가 아니면 IllegalArgumentException")
+        void non_plan_po_throws() {
+            givenActiveGisu();
+            Map<Long, ChallengerInfo> map = new HashMap<>();
+            map.put(100L, challengerInfo(100L, ChallengerPart.WEB));
+            given(getChallengerUseCase.listByMemberIdsAndGisuId(Set.of(100L), GISU_ID))
+                .willReturn(map);
+
+            assertThatThrownBy(() -> sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 1, List.of(100L)
+            ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("PLAN");
+        }
+
+        @Test
+        @DisplayName("입력된 PO가 챌린저가 아니면 IllegalArgumentException")
+        void missing_challenger_throws() {
+            givenActiveGisu();
+            given(getChallengerUseCase.listByMemberIdsAndGisuId(Set.of(100L), GISU_ID))
+                .willReturn(Map.of());
+
+            assertThatThrownBy(() -> sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 1, List.of(100L)
+            ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a challenger");
+        }
+    }
+
+    @Nested
+    @DisplayName("랜덤 PO 픽")
+    class RandomPoPick {
+
+        @Test
+        @DisplayName("PO 입력이 null이고 PLAN 풀이 부족하면 IllegalArgumentException")
+        void insufficient_pool_throws() {
+            givenActiveGisu();
+            given(getChallengerUseCase.getAllByGisuId(GISU_ID))
+                .willReturn(List.of(challengerInfo(100L, ChallengerPart.PLAN)));
+
+            assertThatThrownBy(() -> sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 3, null
+            ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("pool size");
+        }
+
+        @Test
+        @DisplayName("PO 입력이 null이면 PLAN ACTIVE 챌린저 풀에서 N명 픽한다")
+        void picks_random_pos_from_active_plan_pool() {
+            givenActiveGisu();
+            given(getChallengerUseCase.getAllByGisuId(GISU_ID)).willReturn(List.of(
+                challengerInfo(100L, ChallengerPart.PLAN),
+                challengerInfo(101L, ChallengerPart.PLAN),
+                challengerInfo(102L, ChallengerPart.PLAN),
+                challengerInfo(103L, ChallengerPart.WEB),
+                challengerInfo(104L, ChallengerPart.PLAN, ChallengerStatus.GRADUATED)
+            ));
+            given(getMemberUseCase.getById(anyLong())).willAnswer(inv ->
+                memberInfo(inv.getArgument(0), SCHOOL_ID));
+            given(getChapterUseCase.byGisuAndSchool(GISU_ID, SCHOOL_ID))
+                .willReturn(new ChapterInfo(CHAPTER_ID, "지부"));
+            givenCreateDraftReturns(600L);
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 2, null
+            ));
+
+            assertThat(result.createdProjects()).hasSize(2);
+            assertThat(result.createdProjects())
+                .allMatch(p -> List.of(100L, 101L, 102L).contains(p.productOwnerMemberId()));
+        }
+    }
+
+    @Nested
+    @DisplayName("단계별 실패 격리")
+    class FailureIsolation {
+
+        @Test
+        @DisplayName("submit 실패 시 reachedStatus=DRAFT, failedStep=SUBMIT으로 failedProjects에 기록된다")
+        void submit_failure_recorded_with_draft_reached() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(700L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(700L, 9700L));
+            willThrow(new RuntimeException("submit boom"))
+                .given(submitProjectUseCase).submit(any());
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.PENDING_REVIEW, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            assertThat(result.createdProjects()).isEmpty();
+            assertThat(result.failedProjects()).hasSize(1);
+            FailedProject failed = result.failedProjects().get(0);
+            assertThat(failed.projectId()).isEqualTo(700L);
+            assertThat(failed.reachedStatus()).isEqualTo(TargetProjectStatus.DRAFT);
+            assertThat(failed.intendedStatus()).isEqualTo(TargetProjectStatus.PENDING_REVIEW);
+            assertThat(failed.failedStep()).isEqualTo("SUBMIT");
+            assertThat(failed.reason()).contains("submit boom");
+        }
+
+        @Test
+        @DisplayName("publish 실패 시 reachedStatus=PENDING_REVIEW, failedStep=PUBLISH로 기록된다")
+        void publish_failure_recorded_with_pending_review_reached() {
+            givenActiveGisu();
+            givenPoIsPlanChallenger(PO_MEMBER_ID);
+            givenPoMemberSchool(PO_MEMBER_ID, SCHOOL_ID);
+            givenCreateDraftReturns(701L);
+            given(upsertProjectApplicationFormUseCase.upsert(any()))
+                .willReturn(applicationFormInfo(701L, 9701L));
+            given(scenarioPartQuotaPolicy.pickQuotas()).willReturn(List.of(
+                Entry.builder().part(ChallengerPart.DESIGN).quota(1L).build()
+            ));
+            willThrow(new RuntimeException("publish boom"))
+                .given(publishProjectUseCase).publish(any());
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.IN_PROGRESS, 1, List.of(PO_MEMBER_ID)
+            ));
+
+            assertThat(result.createdProjects()).isEmpty();
+            assertThat(result.failedProjects()).hasSize(1);
+            FailedProject failed = result.failedProjects().get(0);
+            assertThat(failed.projectId()).isEqualTo(701L);
+            assertThat(failed.reachedStatus()).isEqualTo(TargetProjectStatus.PENDING_REVIEW);
+            assertThat(failed.intendedStatus()).isEqualTo(TargetProjectStatus.IN_PROGRESS);
+            assertThat(failed.failedStep()).isEqualTo("PUBLISH");
+            assertThat(failed.reason()).contains("publish boom");
+        }
+
+        @Test
+        @DisplayName("한 프로젝트가 실패해도 다른 프로젝트의 시딩은 계속 진행된다")
+        void one_failure_does_not_block_others() {
+            Long poA = 100L;
+            Long poB = 101L;
+            givenActiveGisu();
+            Map<Long, ChallengerInfo> map = new HashMap<>();
+            map.put(poA, challengerInfo(poA, ChallengerPart.PLAN));
+            map.put(poB, challengerInfo(poB, ChallengerPart.PLAN));
+            given(getChallengerUseCase.listByMemberIdsAndGisuId(Set.of(poA, poB), GISU_ID))
+                .willReturn(map);
+            given(getMemberUseCase.getById(poB)).willReturn(memberInfo(poB, SCHOOL_ID));
+            given(getChapterUseCase.byGisuAndSchool(GISU_ID, SCHOOL_ID))
+                .willReturn(new ChapterInfo(CHAPTER_ID, "지부"));
+
+            AtomicLong idSeq = new AtomicLong(800L);
+            given(createDraftProjectUseCase.create(any())).willAnswer(inv -> {
+                CreateDraftProjectCommand cmd = inv.getArgument(0);
+                if (cmd.productOwnerMemberId().equals(poA)) {
+                    throw new RuntimeException("draft boom A");
+                }
+                return idSeq.getAndIncrement();
+            });
+
+            SeedProjectScenariosResult result = sut.seed(new SeedProjectScenariosCommand(
+                TargetProjectStatus.DRAFT, 2, List.of(poA, poB)
+            ));
+
+            assertThat(result.createdProjects()).hasSize(1);
+            assertThat(result.createdProjects().get(0).productOwnerMemberId()).isEqualTo(poB);
+            assertThat(result.failedProjects()).hasSize(1);
+            assertThat(result.failedProjects().get(0).failedStep()).isEqualTo("CREATE_DRAFT");
+            assertThat(result.failedProjects().get(0).projectId()).isNull();
+            assertThat(result.failedProjects().get(0).reachedStatus()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/umc/product/test/application/service/ScenarioPartQuotaPolicyTest.java
+++ b/src/test/java/com/umc/product/test/application/service/ScenarioPartQuotaPolicyTest.java
@@ -1,0 +1,54 @@
+package com.umc.product.test.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand.Entry;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScenarioPartQuotaPolicyTest {
+
+    private static final Set<ChallengerPart> FRONTEND_PARTS = Set.of(
+        ChallengerPart.WEB, ChallengerPart.ANDROID, ChallengerPart.IOS
+    );
+    private static final Set<ChallengerPart> BACKEND_PARTS = Set.of(
+        ChallengerPart.NODEJS, ChallengerPart.SPRINGBOOT
+    );
+
+    private final ScenarioPartQuotaPolicy sut = new ScenarioPartQuotaPolicy();
+
+    @Test
+    @DisplayName("pickQuotas는 DESIGN 1, FE 1, BE 1로 항상 3개 entry를 반환한다")
+    void pickQuotas_returns_three_entries_with_design_fe_be() {
+        for (int i = 0; i < 200; i++) {
+            List<Entry> quotas = sut.pickQuotas();
+
+            assertThat(quotas).hasSize(3);
+            assertThat(quotas.get(0).part()).isEqualTo(ChallengerPart.DESIGN);
+            assertThat(FRONTEND_PARTS).contains(quotas.get(1).part());
+            assertThat(BACKEND_PARTS).contains(quotas.get(2).part());
+        }
+    }
+
+    @Test
+    @DisplayName("DESIGN quota는 항상 1~2 사이")
+    void design_quota_is_within_one_to_two() {
+        for (int i = 0; i < 200; i++) {
+            List<Entry> quotas = sut.pickQuotas();
+            assertThat(quotas.get(0).quota()).isBetween(1L, 2L);
+        }
+    }
+
+    @Test
+    @DisplayName("FE quota와 BE quota는 항상 3~4 사이")
+    void fe_and_be_quota_are_within_three_to_four() {
+        for (int i = 0; i < 200; i++) {
+            List<Entry> quotas = sut.pickQuotas();
+            assertThat(quotas.get(1).quota()).isBetween(3L, 4L);
+            assertThat(quotas.get(2).quota()).isBetween(3L, 4L);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #902

## 🚀 작업 내용

활성 기수에 대해 `DRAFT` / `PENDING_REVIEW` / `IN_PROGRESS` 중 하나의 상태까지 도달한 프로젝트를 N개 만들어주는 시딩 API를 추가합니다.

- 엔드포인트: `POST /test/seed/projects/scenarios`
- SQL 직접 주입이 아니라 도메인 UseCase 시퀀스를 호출해서 만들기 때문에 도메인 가드를 모두 통과한 데이터가 됩니다.
- 기존 `POST /test/seed/projects` (DRAFT 골격 대량 시딩)는 그대로 두고 책임을 분리했습니다.

### 주요 정책

**PO 선정**
- `productOwnerMemberIds` 명시: size가 `projectCount`와 정확히 같아야 하고, 각각 활성 기수의 PLAN 챌린저여야 함 (강제로 만들지 않음)
- `productOwnerMemberIds: null`: 활성 기수 ACTIVE PLAN 챌린저 풀에서 랜덤 N명 픽. 풀 부족이면 에러

**PartQuota 분배 (IN_PROGRESS만)**
- `DESIGN` × random(1~2)
- 프론트엔드 1개 파트 (`WEB`/`ANDROID`/`IOS` 중 무작위) × random(3~4)
- 백엔드 1개 파트 (`NODEJS`/`SPRINGBOOT` 중 무작위) × random(3~4)

**멤버 충원 (IN_PROGRESS만)**
- 각 partQuota entry마다 `target = random(0, quota)`만큼 PO 학교의 해당 파트 ACTIVE 챌린저 풀에서 무작위 추출
- 풀이 부족하면 부족한 만큼만 추가 (best-effort)
- `partFills.filled == 0`도 응답에 포함 (의도된 0 / 풀 부족 0 구분 정보)

### 사용 예시

**Request**
```json
POST /test/seed/projects/scenarios
{
  "targetStatus": "IN_PROGRESS",
  "projectCount": 3,
  "productOwnerMemberIds": [42, 87, 91]
}

