### PR TITLE
[Refactor] PO 기수 중복 제약을 DRAFT 한정 partial index로 조정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -14,4 +14,7 @@ public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 
     boolean existsByCreatorMemberIdAndGisuIdAndStatus(
         Long creatorMemberId, Long gisuId, ProjectStatus status);
+
+    boolean existsByProductOwnerMemberIdAndGisuIdAndStatus(
+        Long productOwnerMemberId, Long gisuId, ProjectStatus status);
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -1,9 +1,11 @@
 package com.umc.product.project.adapter.out.persistence;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -49,6 +49,12 @@ public class ProjectPersistenceAdapter implements LoadProjectPort, SaveProjectPo
     }
 
     @Override
+    public boolean existsDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
+        return jpaRepository.existsByProductOwnerMemberIdAndGisuIdAndStatus(
+            productOwnerMemberId, gisuId, ProjectStatus.DRAFT);
+    }
+
+    @Override
     public Page<Project> search(SearchProjectQuery query) {
         return queryRepository.search(query);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -1,5 +1,11 @@
 package com.umc.product.project.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
@@ -7,11 +13,8 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
@@ -1,9 +1,11 @@
 package com.umc.product.project.application.port.out;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.Project;
-import java.util.Optional;
-import org.springframework.data.domain.Page;
 
 /**
  * Project 조회 Port (Driven / Port Out).

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
@@ -44,6 +44,13 @@ public interface LoadProjectPort {
     boolean existsDraftByCreatorAndGisu(Long creatorMemberId, Long gisuId);
 
     /**
+     * 특정 PO 가 특정 기수에 활성 DRAFT 프로젝트를 보유하고 있는지 확인합니다.
+     * 운영진이 다른 챌린저를 PO 로 임명하는 경로에서 PO 의 DRAFT 중복을 차단하기 위한 체크.
+     * (owner, gisu) DRAFT 1 개 partial unique index 와 짝.
+     */
+    boolean existsDraftByOwnerAndGisu(Long productOwnerMemberId, Long gisuId);
+
+    /**
      * 동적 조건으로 프로젝트 목록을 페이지 조회합니다.
      */
     Page<Project> search(SearchProjectQuery query);

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -1,5 +1,11 @@
 package com.umc.product.project.application.service.command;
 
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -46,11 +52,8 @@ import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.PublishFormCommand;
-import java.util.List;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -98,6 +98,10 @@ public class ProjectCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
         }
 
+        if (loadProjectPort.existsDraftByOwnerAndGisu(command.productOwnerMemberId(), command.gisuId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
+        }
+
         MemberInfo member = getMemberUseCase.getById(command.productOwnerMemberId());
         ChapterInfo chapter = getChapterUseCase.byGisuAndSchool(command.gisuId(), member.schoolId());
 

--- a/src/main/resources/db/migration/V2026.05.25.10.00__change_project_owner_gisu_unique_to_partial_index.sql
+++ b/src/main/resources/db/migration/V2026.05.25.10.00__change_project_owner_gisu_unique_to_partial_index.sql
@@ -1,0 +1,11 @@
+-- "한 PO당 한 기수 1 DRAFT" 정책으로 좁힌다.
+-- V2026.04.25.11.00 에서 status 무관 unique 제약을 걸었으나, IN_PROGRESS/COMPLETED/ABORTED 같은
+-- 종료/진행 상태에서도 같은 PO 의 새 DRAFT 생성을 차단해버려 의도와 다르게 동작했다.
+-- creator 쪽 V2026.05.10.14.00 의 partial index 와 같은 패턴 (status='DRAFT' 한정) 으로 맞춘다.
+-- DRAFT → PENDING_REVIEW 로 전이되는 즉시 슬롯이 풀려 같은 PO 의 새 DRAFT 시작이 가능해진다.
+
+ALTER TABLE project DROP CONSTRAINT uk_project_owner_gisu;
+
+CREATE UNIQUE INDEX uk_project_owner_gisu_draft
+    ON project (product_owner_member_id, gisu_id)
+    WHERE status = 'DRAFT';

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -7,6 +7,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -31,13 +39,6 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectCommandServiceTest {

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -207,10 +207,10 @@ class ProjectCommandServiceTest {
         }
 
         @Test
-        void creator_DRAFT_미보유면_PO_기수_중복은_검증하지_않고_생성_성공() {
-            // PO 룰 제거 검증: 기존엔 existsByOwnerAndGisu 로 PO 중복을 검사했지만
-            // 이제는 호출 자체가 사라졌다. PM 이 같은 기수에 PENDING_REVIEW 등 다른 프로젝트를
-            // 보유한 채 새 DRAFT 를 시작해도 차단되지 않는다.
+        void status_무관_PO_중복은_검사하지_않고_DRAFT_한정으로만_검사한다() {
+            // PM 이 같은 기수에 PENDING_REVIEW / IN_PROGRESS / COMPLETED 등 DRAFT 가 아닌 상태의
+            // 다른 프로젝트를 보유한 채 새 DRAFT 를 시작해도 차단되지 않는다.
+            // status 무관 existsByOwnerAndGisu 는 호출되지 않고, DRAFT 한정 existsDraftByOwnerAndGisu 만 호출된다.
             var command = CreateDraftProjectCommand.builder()
                 .gisuId(1L)
                 .productOwnerMemberId(100L)
@@ -221,6 +221,7 @@ class ProjectCommandServiceTest {
             given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
                 .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
             given(loadProjectPort.existsDraftByCreatorAndGisu(any(), any())).willReturn(false);
+            given(loadProjectPort.existsDraftByOwnerAndGisu(100L, 1L)).willReturn(false);
             given(getMemberUseCase.getById(100L)).willReturn(memberInfo(10L));
             given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(5L, "서울"));
             given(saveProjectPort.save(any())).willAnswer(inv -> {
@@ -232,6 +233,29 @@ class ProjectCommandServiceTest {
             sut.create(command);
 
             then(loadProjectPort).should(never()).existsByOwnerAndGisu(any(), any());
+            then(loadProjectPort).should().existsDraftByOwnerAndGisu(100L, 1L);
+        }
+
+        @Test
+        void PO가_같은_기수에_DRAFT_보유시_예외() {
+            // 운영진(requester=200)이 PM(productOwner=100)을 임명할 때, PM 이 이미 같은 기수에
+            // DRAFT 프로젝트를 보유하고 있으면 creator 검증을 통과해도 owner 검증에서 막힌다.
+            var command = CreateDraftProjectCommand.builder()
+                .gisuId(1L)
+                .productOwnerMemberId(100L)
+                .requesterMemberId(200L)
+                .build();
+
+            given(getGisuUseCase.getById(1L)).willReturn(gisuInfo());
+            given(getChallengerUseCase.getByMemberIdAndGisuId(100L, 1L))
+                .willReturn(challengerInfo(100L, ChallengerPart.PLAN));
+            given(loadProjectPort.existsDraftByCreatorAndGisu(200L, 1L)).willReturn(false);
+            given(loadProjectPort.existsDraftByOwnerAndGisu(100L, 1L)).willReturn(true);
+
+            assertThatThrownBy(() -> sut.create(command))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DRAFT_ALREADY_IN_PROGRESS);
         }
 
         @Test


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #913

## 🚀 작업 내용

`uk_project_owner_gisu` UNIQUE 제약(status 무관)을 DROP 하고, **DRAFT 한정 partial unique index** `uk_project_owner_gisu_draft` 로 교체합니다. 같이 ProjectCommandService.create 에 owner DRAFT 중복 체크를 추가해 DB partial index 위반 전에 도메인 예외로 떨어지도록 정렬합니다.

### 결과 동작 변화

| 시나리오 | 이전 | 이후 |
|---|---|---|
| PM 이 IN_PROGRESS 진행 중 새 DRAFT 시작 | ✗ `DataIntegrityViolationException` | ✓ 정상 |
| PM 이 같은 기수에 DRAFT 2 개 시도 | ✗ DB 위반 | ✗ `PROJECT_DRAFT_ALREADY_IN_PROGRESS` (도메인 예외) |
| 운영진이 이미 DRAFT 보유 PM 을 PO 로 임명 시도 | ✗ DB 위반 | ✗ `PROJECT_DRAFT_ALREADY_IN_PROGRESS` (도메인 예외) |
| 운영진 두 명이 동시에 같은 PM 임명 (TOCTOU race) | ✗ 한쪽 DB 위반 | ✗ 한쪽 DB partial index 위반 (방어 유지) |
| COMPLETED / ABORTED 된 PM 의 새 프로젝트 시작 | ✗ DB 위반 | ✓ 정상 |
| DRAFT → PENDING_REVIEW 로 전이 후 같은 PM 새 DRAFT | ✗ DB 위반 | ✓ 정상 |

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

