### PR TITLE
[Feat] 약관 동의 기록 저장 로직 개선

### DIFF
--- a/docs/adr/022-versioned-term-consent-proof.md
+++ b/docs/adr/022-versioned-term-consent-proof.md
@@ -1,0 +1,143 @@
+# ADR-022: 약관 동의 버전 증빙 모델
+
+## Status
+
+Accepted
+
+## Context
+
+2026년 5월 기준 `term` 도메인은 약관을 `TermType` 단위로 활성/비활성 처리하고, 회원 동의는 `term_consent.member_id + term_type`으로 저장한다.
+
+- 약관 생성: `TermCommandService#createTerms`는 같은 `TermType`의 기존 활성 약관을 비활성화하고 새 `Term`을 저장한다.
+- OAuth 회원가입: `MemberService#register`는 회원 생성 후 `ManageTermAgreementUseCase#createTermConsent`를 호출한다.
+- 이메일 회원가입: `EmailMemberRegisterService#registerInternal`은 필수 약관 동의 여부를 검증하지만 동의 저장을 호출하지 않는다.
+- 동의 모델: `TermConsent`와 `TermConsentLog`는 `termType`만 저장하므로 “어떤 약관 row에 동의했는지”를 증빙할 수 없다.
+- 조회 모델: `TermAgreementQueryService#getAgreedTermsByMemberId`는 저장된 `termType`으로 현재 활성 약관을 다시 조회한다. 과거 동의가 최신 활성 약관 동의처럼 보일 수 있다.
+
+이 프로젝트는 Hexagonal Architecture를 따른다. `member` 도메인은 `term` 도메인의 내부 repository에 접근하지 않고, 공개 UseCase인 `ManageTermAgreementUseCase`만 호출해야 한다. 도메인 간 참조는 Aggregate 객체가 아니라 ID 참조로 유지한다.
+
+### 문제점
+
+1. 이메일 회원가입은 약관 동의가 저장되지 않는다. 가입 직후 JWT가 발급되지만 `term_consent`와 `term_consent_log`에는 증빙이 남지 않는다.
+2. 현재 동의 데이터는 `termType` 기준이라 약관 변경 후 재동의 여부를 정확히 판단할 수 없다. 동일 타입의 새 약관이 만들어져도 기존 사용자의 동의가 어느 약관 버전에 대한 것인지 알 수 없다.
+3. 약관 동의 조회가 현재 활성 약관을 기준으로 재해석된다. 운영/감사 화면에서 과거 동의를 최신 약관 동의로 오인할 가능성이 있다.
+4. 재동의 미완료 사용자의 API 차단을 구현하려면 “현재 필수 활성 약관 ID”와 “회원이 동의한 약관 ID”를 비교할 수 있어야 한다.
+
+### 결정이 필요한 이유
+
+약관 변경 시 미동의 사용자의 API 호출 제한, 선택 동의 철회, 마케팅 수신 동의 관리, 감사 로그 확장을 안전하게 구현하려면 동의 증빙의 기준을 `TermType`에서 `Term` row ID로 올려야 한다. 이 작업을 뒤로 미루면 API 차단 로직을 추가하더라도 과거/현재 약관을 구분할 수 없어 잘못된 차단 또는 미차단이 발생한다.
+
+## Decision
+
+우리는 약관 동의를 `termId` 기준으로 증빙하도록 변경하기로 결정한다.
+
+1. `term_consent`와 `term_consent_log`에 `term_id`를 추가한다.
+2. 신규 동의 저장 시 `TermAgreementCommandService`는 조회한 `Term`의 `id`와 `type`을 함께 저장한다.
+3. 중복 동의 검사는 `memberId + termType`이 아니라 `memberId + termId` 기준으로 수행한다. 이렇게 해야 같은 `TermType`의 새 약관 재동의를 저장할 수 있다.
+4. 동의 약관 조회는 저장된 `termId`로 원본 약관을 조회한다. 현재 활성 약관으로 재해석하지 않는다.
+5. 이메일 회원가입도 OAuth 회원가입과 동일하게 `ManageTermAgreementUseCase`를 통해 동의 정보를 저장한다.
+
+### 단계적 진행 / PR 분할
+
+- **Phase 1 (이 PR / 본 ADR)**: 이메일 회원가입 동의 저장 누락 수정, `term_consent`/`term_consent_log.term_id` 추가, 신규 동의 저장과 조회를 `termId` 기준으로 전환한다.
+- **Phase 2 (별도 PR)**: 현재 활성 필수 약관 대비 회원의 미동의 상태를 계산하는 Query UseCase를 추가한다.
+- **Phase 3 (별도 PR)**: JWT 인증 이후 Controller 진입 전 재동의 미완료 사용자를 제한하는 필터 또는 인터셉터를 추가하고, 재동의/약관 조회/로그아웃/탈퇴 등 예외 API allowlist를 구성한다.
+- **Phase 4 (별도 PR)**: 선택 약관 철회, 마케팅 수신 동의 처리 결과 통지, 관리자용 약관 변경 메타데이터를 확장한다.
+
+## Alternatives Considered
+
+### 대안 A: 현행 `termType` 기준 유지
+
+현재 구조를 유지하고 재동의 여부도 `termType`만으로 판단한다.
+
+장점:
+
+- DB 마이그레이션이 없다.
+- 기존 코드 변경량이 가장 작다.
+
+단점:
+
+- 약관 변경 전/후 동의를 구분할 수 없다.
+- 재동의 차단 로직이 정확하지 않다.
+- 감사 증빙으로 사용할 데이터가 부족하다.
+
+선택하지 않은 이유:
+
+- 사용자가 명시적으로 약관 변경 후 미동의자 제한을 요구했고, 이 요구는 `termType`만으로 구현할 수 없다.
+
+### 대안 B: `term_consent`는 유지하고 로그에만 `termId` 추가
+
+최신 상태 테이블은 `termType` 기준으로 유지하고, 감사 로그에만 `termId`를 남긴다.
+
+장점:
+
+- 상태 테이블 변경이 작다.
+- 과거 로그를 기준으로 일부 증빙은 가능하다.
+
+단점:
+
+- 매 요청에서 재동의 여부를 판단할 때 로그를 집계해야 한다.
+- 상태 테이블과 로그의 의미가 달라져 조회/운영 로직이 복잡해진다.
+
+선택하지 않은 이유:
+
+- 재동의 차단은 고빈도 요청 경로에 붙을 가능성이 높으므로 최신 상태 테이블만으로 빠르게 판단할 수 있어야 한다.
+
+### 대안 C: `termId` 기준 상태 테이블과 불변 로그 병행
+
+`term_consent`와 `term_consent_log` 모두 `termId`를 저장한다.
+
+장점:
+
+- 현재 동의 상태 조회와 감사 증빙을 모두 안정적으로 지원한다.
+- 같은 타입의 새 약관 재동의를 자연스럽게 저장할 수 있다.
+- Phase 2/3의 재동의 판정과 API 차단 구현이 단순해진다.
+
+단점:
+
+- DB 마이그레이션과 기존 테스트/Fixture 수정이 필요하다.
+- 기존 row의 정확한 역사적 `termId`는 복구할 수 없으므로 backfill은 현재 활성 약관 또는 같은 타입의 최신 약관 기준으로만 가능하다.
+
+선택한 이유:
+
+- 요구사항의 핵심인 “약관 변경 후 재동의 대상자 판정”을 가장 단순하고 검증 가능하게 만든다.
+
+## Consequences
+
+### Positive
+
+- 이메일 회원가입도 약관 동의 증빙이 남는다.
+- 약관 변경 후 같은 `TermType`의 새 `termId`에 대한 재동의를 저장할 수 있다.
+- 동의 조회가 과거 동의를 최신 약관으로 오인하지 않는다.
+- Phase 2/3에서 미동의 사용자 API 제한을 정확하게 구현할 수 있다.
+
+### Negative
+
+- 기존 데이터는 과거 실제 동의 약관 ID를 완벽히 복구할 수 없다. 마이그레이션은 같은 타입의 활성 약관을 우선 매핑하고, 없으면 최신 약관을 사용한다.
+- `term_consent` row 수가 약관 버전이 늘어날수록 증가한다.
+- 재동의 차단 필터를 도입하기 전까지는 저장 모델만 보강되고 실제 API 제한은 발생하지 않는다.
+
+### Neutral / Trade-offs
+
+- `Term`에 명시적 `version` 컬럼을 바로 추가하지 않고 `termId`를 버전 식별자로 사용한다. 운영자에게 사람이 읽는 버전명을 제공하는 기능은 Phase 4에서 별도 확장한다.
+
+## Implementation Notes
+
+### 변경 영역 요약
+
+1. **도메인** (`com.umc.product.term.domain.*`): `TermConsent`, `TermConsentLog`에 `termId` 필드를 추가한다.
+2. **응용 / Port** (`...application.service.*`, `...application.port.*`): `TermAgreementCommandService`는 `termId` 기준 중복 검사/저장을 수행한다. `LoadTermPort`는 `termId` 목록 조회를 제공한다.
+3. **어댑터 (out)** (`...adapter.out.persistence.*`): `TermRepository`, `TermConsentRepository`, `TermPersistenceAdapter`, `TermConsentPersistenceAdapter`에 `termId` 기반 조회를 추가한다.
+4. **DB / 마이그레이션** (`src/main/resources/db/migration/V*__*.sql`): `term_consent.term_id`, `term_consent_log.term_id`를 추가하고 기존 row를 backfill한다.
+5. **테스트** (`src/test/...`): 이메일 회원가입 동의 저장 테스트, `termId` 기반 중복/조회 테스트를 추가 또는 갱신한다.
+
+### 롤백 시 주의할 점
+
+- Phase 1 롤백 시 신규 코드가 저장한 `term_id` 컬럼은 제거하지 말고 무시하는 방향이 안전하다. 이미 저장된 감사 증빙을 삭제하면 운영상 추적성이 손상된다.
+- `member_id + term_id` unique index를 제거하면 동일 약관 중복 동의가 다시 허용될 수 있다.
+
+## References
+
+- [개인정보 보호법 시행령 제17조](https://www.law.go.kr/LSW/lsLawLinkInfo.do?chrClsCd=010202&lsJoLnkSeq=1000572094)
+- [약관의 규제에 관한 법률 제3조](https://www.law.go.kr/LSW/lsLawLinkInfo.do?chrClsCd=010202&lsJoLnkSeq=1000526624)
+- [정보통신망법 제50조](https://www.law.go.kr/lsLinkProc.do?chrClsCd=010202&joLnkStr=%EC%A0%9C50%EC%A1%B0+%EB%98%90%EB%8A%94+%EC%A0%9C50%EC%A1%B0%EC%9D%988&joNo=005000000%5E005000000%5E005002000%5E005003000%5E005004000%5E005005000%5E005006000%5E005007000%5E005008000&lsId=000030&lsNm=%EC%A0%95%EB%B3%B4%ED%86%B5%EC%8B%A0%EB%A7%9D+%EC%9D%B4%EC%9A%A9%EC%B4%89%EC%A7%84+%EB%B0%8F+%EC%A0%95%EB%B3%B4%EB%B3%B4%ED%98%B8+%EB%93%B1%EC%97%90+%EA%B4%80%ED%95%9C+%EB%B2%95%EB%A5%A0&mode=2)

--- a/docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md
+++ b/docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md
@@ -43,7 +43,7 @@
 
 `docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md`에 PR 분할과 커밋 단위 계획을 저장한다.
 
-- [ ] **Step 3: 문서 커밋**
+- [x] **Step 3: 문서 커밋**
 
 Run:
 
@@ -61,11 +61,11 @@ Expected: commit succeeds.
 - Modify: `src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java`
 - Modify: `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java`
 
-- [ ] **Step 1: 실패 테스트 작성**
+- [x] **Step 1: 실패 테스트 작성**
 
 `EmailMemberRegisterServiceTest`에 이메일 회원가입 성공 시 전달된 약관 동의마다 `ManageTermAgreementUseCase#createTermConsent`가 호출되는 테스트를 추가한다.
 
-- [ ] **Step 2: 실패 확인**
+- [x] **Step 2: 실패 확인**
 
 Run:
 
@@ -75,11 +75,11 @@ Run:
 
 Expected: compile 또는 test failure. 원인은 `EmailMemberRegisterService`가 `ManageTermAgreementUseCase`를 주입받지 않거나 호출하지 않기 때문이다.
 
-- [ ] **Step 3: 구현**
+- [x] **Step 3: 구현**
 
 `EmailMemberRegisterService`에 `ManageTermAgreementUseCase`를 주입하고 `created.getId()` 기준으로 `command.termConsents()`를 저장한다. OAuth 회원가입 요청에도 `@Valid`를 추가한다.
 
-- [ ] **Step 4: 통과 확인**
+- [x] **Step 4: 통과 확인**
 
 Run:
 
@@ -104,14 +104,15 @@ Expected: PASS.
 - Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java`
 - Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java`
 - Modify: `src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java`
+- Create: `src/test/java/com/umc/product/term/application/port/in/query/TermAgreementQueryServiceTest.java`
 - Modify: `src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java`
 - Modify: `src/test/java/com/umc/product/support/fixture/TermFixture.java`
 
-- [ ] **Step 1: 실패 테스트 작성**
+- [x] **Step 1: 실패 테스트 작성**
 
 `ManageTermAgreementUseCaseTest`에서 저장되는 `TermConsent`와 `TermConsentLog`가 `termId`를 포함하는지 검증한다. 통합 테스트에서는 같은 `TermType`의 새 약관에 재동의할 수 있는지 검증한다.
 
-- [ ] **Step 2: 실패 확인**
+- [x] **Step 2: 실패 확인**
 
 Run:
 
@@ -121,7 +122,7 @@ Run:
 
 Expected: compile 또는 test failure. 원인은 `TermConsent`/`TermConsentLog`에 `termId`가 없고 중복 검사가 `termType` 기준이기 때문이다.
 
-- [ ] **Step 3: 구현**
+- [x] **Step 3: 구현**
 
 `termId` 필드, repository 조회 메서드, service 저장/조회 로직, Flyway migration을 추가한다.
 
@@ -134,6 +135,12 @@ Run:
 ```
 
 Expected: PASS.
+
+현 작업 환경에서는 `TermAgreementIntegrationTest`가 Testcontainers Docker 클라이언트 초기화 실패로 실행되지 않았다. Docker가 준비된 CI 또는 로컬 환경에서 재실행해야 한다. 대신 아래 Docker 비의존 단위 테스트는 통과했다.
+
+```bash
+./gradlew test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest" --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.term.application.port.in.query.TermAgreementQueryServiceTest"
+```
 
 - [ ] **Step 5: PR 1 범위 전체 검증**
 

--- a/docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md
+++ b/docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md
@@ -1,0 +1,200 @@
+# Terms Consent Reconsent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 약관 동의를 `termId` 기준으로 증빙하고, 이메일 회원가입의 동의 저장 누락을 수정한 뒤 재동의 차단 기능을 단계적으로 도입한다.
+
+**Architecture:** `member` 도메인은 `term` 도메인의 공개 UseCase만 호출한다. 약관 동의 저장과 조회는 `term` 도메인 내부에서 `termId` 기준으로 처리하며, API 차단은 이후 PR에서 JWT 인증 이후의 중앙 필터/인터셉터로 분리한다.
+
+**Tech Stack:** Java 21, Spring Boot 3.5, JPA/Hibernate, Flyway, JUnit 5, Mockito, PostgreSQL.
+
+---
+
+## PR 분할 요약
+
+1. **PR 1: 약관 동의 증빙 기반 보강**
+   - 이메일 회원가입 동의 저장 누락 수정
+   - `term_consent.term_id`, `term_consent_log.term_id` 추가
+   - `TermConsent`/`TermConsentLog`/조회 로직을 `termId` 기준으로 전환
+2. **PR 2: 재동의 상태 Query API**
+   - `GetRequiredTermConsentStatusUseCase` 추가
+   - 현재 활성 필수 약관 대비 미동의 목록 반환
+3. **PR 3: 재동의 미완료 사용자 API 제한**
+   - JWT 인증 이후 `TermConsentEnforcementFilter` 또는 `HandlerInterceptor` 추가
+   - 약관 조회, 재동의 제출, 토큰 갱신, 로그아웃, 탈퇴 등 allowlist 적용
+4. **PR 4: 선택 동의/마케팅/운영 메타데이터**
+   - 선택 동의 철회 API
+   - 마케팅 수신 동의 처리 결과 저장/통지
+   - 약관 변경 사유, 시행일, 요약 문구 관리
+
+## 커밋 단위 계획
+
+### Commit 1: `docs: record term consent reconsent plan`
+
+**Files:**
+- Create: `docs/adr/022-versioned-term-consent-proof.md`
+- Create: `docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md`
+
+- [x] **Step 1: ADR 작성**
+
+`docs/adr/022-versioned-term-consent-proof.md`에 현재 문제, 결정, 대안, PR 분할, 구현 메모를 기록한다.
+
+- [x] **Step 2: 실행 계획 보고서 작성**
+
+`docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md`에 PR 분할과 커밋 단위 계획을 저장한다.
+
+- [ ] **Step 3: 문서 커밋**
+
+Run:
+
+```bash
+git add docs/adr/022-versioned-term-consent-proof.md docs/superpowers/plans/2026-05-26-terms-consent-reconsent.md
+git commit -m "docs: record term consent reconsent plan"
+```
+
+Expected: commit succeeds.
+
+### Commit 2: `fix: persist email signup term consent`
+
+**Files:**
+- Create: `src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java`
+- Modify: `src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java`
+- Modify: `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`EmailMemberRegisterServiceTest`에 이메일 회원가입 성공 시 전달된 약관 동의마다 `ManageTermAgreementUseCase#createTermConsent`가 호출되는 테스트를 추가한다.
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest"
+```
+
+Expected: compile 또는 test failure. 원인은 `EmailMemberRegisterService`가 `ManageTermAgreementUseCase`를 주입받지 않거나 호출하지 않기 때문이다.
+
+- [ ] **Step 3: 구현**
+
+`EmailMemberRegisterService`에 `ManageTermAgreementUseCase`를 주입하고 `created.getId()` 기준으로 `command.termConsents()`를 저장한다. OAuth 회원가입 요청에도 `@Valid`를 추가한다.
+
+- [ ] **Step 4: 통과 확인**
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest"
+```
+
+Expected: PASS.
+
+### Commit 3: `feat: store term id in consent records`
+
+**Files:**
+- Create: `src/main/resources/db/migration/V2026.05.26.10.00__add_term_id_to_term_consent.sql`
+- Modify: `src/main/java/com/umc/product/term/domain/TermConsent.java`
+- Modify: `src/main/java/com/umc/product/term/domain/TermConsentLog.java`
+- Modify: `src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java`
+- Modify: `src/main/java/com/umc/product/term/application/service/query/TermAgreementQueryService.java`
+- Modify: `src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java`
+- Modify: `src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java`
+- Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermRepository.java`
+- Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java`
+- Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java`
+- Modify: `src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java`
+- Modify: `src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java`
+- Modify: `src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java`
+- Modify: `src/test/java/com/umc/product/support/fixture/TermFixture.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`ManageTermAgreementUseCaseTest`에서 저장되는 `TermConsent`와 `TermConsentLog`가 `termId`를 포함하는지 검증한다. 통합 테스트에서는 같은 `TermType`의 새 약관에 재동의할 수 있는지 검증한다.
+
+- [ ] **Step 2: 실패 확인**
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.integration.term.TermAgreementIntegrationTest"
+```
+
+Expected: compile 또는 test failure. 원인은 `TermConsent`/`TermConsentLog`에 `termId`가 없고 중복 검사가 `termType` 기준이기 때문이다.
+
+- [ ] **Step 3: 구현**
+
+`termId` 필드, repository 조회 메서드, service 저장/조회 로직, Flyway migration을 추가한다.
+
+- [ ] **Step 4: 통과 확인**
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.integration.term.TermAgreementIntegrationTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: PR 1 범위 전체 검증**
+
+Run:
+
+```bash
+./gradlew test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest" --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.integration.term.TermAgreementIntegrationTest"
+```
+
+Expected: PASS.
+
+## 후속 PR 상세 계획
+
+### PR 2: 재동의 상태 Query API
+
+**Commit:** `feat: add required term consent status query`
+
+- `term.application.port.in.query.GetRequiredTermConsentStatusUseCase` 생성
+- `RequiredTermConsentStatusInfo` 생성
+- `LoadTermConsentPort#listByMemberIdAndTermIds` 추가
+- `TermAgreementQueryService` 또는 별도 `TermConsentStatusQueryService`에서 현재 활성 필수 약관과 회원 동의 약관을 비교
+- Controller는 별도 `GET /api/v1/terms/consent-status/me`로 추가
+
+### PR 3: 재동의 미완료 사용자 API 제한
+
+**Commit 1:** `feat: add term consent enforcement filter`
+
+- JWT 인증 이후 실행되는 `TermConsentEnforcementFilter` 추가
+- `CurrentMember` 기반 memberId 추출 대신 `SecurityContextHolder`의 `MemberPrincipal` 사용
+- allowlist는 설정 프로퍼티로 시작하되 기본값을 코드에 둔다
+
+**Commit 2:** `test: cover term consent enforcement filter`
+
+- 미인증 요청은 필터가 우회
+- 인증 요청 중 약관 조회/재동의 제출은 우회
+- 인증 요청 중 일반 API는 `RECONSENT_REQUIRED`로 차단
+
+### PR 4: 선택 동의와 운영 메타데이터 확장
+
+**Commit 1:** `feat: add optional term withdrawal`
+
+- 선택 약관 철회 UseCase 추가
+- `TermConsentLog`에 `WITHDRAWN` 저장
+
+**Commit 2:** `feat: add term publication metadata`
+
+- `term.effective_at`, `term.summary`, `term.change_reason`, `term.reconsent_required` 추가
+- 관리자 약관 생성 요청 DTO 확장
+
+## 검증 기준
+
+- PR 1은 최소 아래 테스트가 통과해야 한다.
+
+```bash
+./gradlew test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest" --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.integration.term.TermAgreementIntegrationTest"
+```
+
+- 전체 PR 제출 전 가능한 경우 `./gradlew test`를 실행한다.
+
+## Self-Review
+
+- Spec coverage: 이메일 회원가입 저장 누락, `termId` 기반 증빙, PR 분할 계획을 포함했다.
+- Placeholder scan: 후속 PR은 실행 전 재검토가 필요하지만, PR 1 작업은 파일과 검증 명령을 명시했다.
+- Type consistency: `termId`, `TermConsent`, `TermConsentLog`, `ManageTermAgreementUseCase`, `LoadTermPort`, `LoadTermConsentPort` 명칭을 현재 코드 기준으로 맞췄다.

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -1,5 +1,13 @@
 package com.umc.product.member.adapter.in.web;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
@@ -26,17 +34,11 @@ import com.umc.product.member.application.port.in.command.dto.OAuthRegisterMembe
 import com.umc.product.member.application.port.in.command.dto.TermConsents;
 import com.umc.product.member.application.port.in.command.dto.UpdateMemberCommand;
 import com.umc.product.notification.application.port.in.annotation.WebhookAlarm;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/member")

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -69,7 +69,7 @@ public class MemberCommandController {
         title = "'새로운 회원이 가입했어요!'",
         content = "'회원 ID: ' + #result.memberId + '\n닉네임/이름: ' + #request.nickname + '/' + #request.name + '\n학교: ' + #request.schoolId"
     )
-    RegisterResponse registerMemberByOAuth(@RequestBody OAuthRegisterMemberRequest request) {
+    RegisterResponse registerMemberByOAuth(@Valid @RequestBody OAuthRegisterMemberRequest request) {
         OAuthVerificationClaims claims = jwtTokenProvider.parseOAuthVerificationToken(request.oAuthVerificationToken());
         String email = jwtTokenProvider.parseEmailVerificationToken(
             request.emailVerificationToken(),

--- a/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
+++ b/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
@@ -1,5 +1,10 @@
 package com.umc.product.member.application.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.audit.domain.AuditLogEvent;
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
@@ -12,11 +17,9 @@ import com.umc.product.member.application.port.out.SaveMemberPort;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
+
 import jakarta.transaction.Transactional;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 /**
  * 이메일 기반 회원가입 서비스. ADR-017 흐름.

--- a/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
+++ b/src/main/java/com/umc/product/member/application/service/EmailMemberRegisterService.java
@@ -11,6 +11,7 @@ import com.umc.product.member.application.port.in.command.dto.EmailRegisterMembe
 import com.umc.product.member.application.port.out.SaveMemberPort;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public class EmailMemberRegisterService implements RegisterEmailMemberUseCase {
     private final MemberRegistrationValidator registrationValidator;
 
     private final CredentialAuthenticationUseCase credentialAuthenticationUseCase;
+    private final ManageTermAgreementUseCase manageTermAgreementUseCase;
     private final GetSchoolUseCase getSchoolUseCase;
 
     private final DomainEventPublisher eventPublisher;
@@ -67,6 +69,10 @@ public class EmailMemberRegisterService implements RegisterEmailMemberUseCase {
 
         credentialAuthenticationUseCase.registerCredentialByEmail(
             RegisterCredentialByEmailCommand.of(created.getId(), command.rawPassword())
+        );
+
+        command.termConsents().forEach(termConsent ->
+            manageTermAgreementUseCase.createTermConsent(termConsent.toCommand(created.getId()))
         );
 
         String logDescription = getSchoolUseCase.getSchoolDetail(command.schoolId()).schoolName()

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
@@ -26,8 +26,18 @@ public class TermConsentPersistenceAdapter implements LoadTermConsentPort, SaveT
     }
 
     @Override
+    public Optional<TermConsent> findByMemberIdAndTermId(Long memberId, Long termId) {
+        return repository.findByMemberIdAndTermId(memberId, termId);
+    }
+
+    @Override
     public boolean existsByMemberIdAndTermType(Long memberId, TermType termType) {
         return repository.existsByMemberIdAndTermType(memberId, termType);
+    }
+
+    @Override
+    public boolean existsByMemberIdAndTermId(Long memberId, Long termId) {
+        return repository.existsByMemberIdAndTermId(memberId, termId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
@@ -1,13 +1,16 @@
 package com.umc.product.term.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.term.application.port.out.LoadTermConsentPort;
 import com.umc.product.term.application.port.out.SaveTermConsentPort;
 import com.umc.product.term.domain.TermConsent;
 import com.umc.product.term.domain.enums.TermType;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
@@ -19,7 +19,17 @@ public interface TermConsentRepository extends JpaRepository<TermConsent, Long> 
     Optional<TermConsent> findByMemberIdAndTermType(Long memberId, TermType termType);
 
     /**
+     * 회원 ID와 약관 ID로 동의 정보를 조회합니다.
+     */
+    Optional<TermConsent> findByMemberIdAndTermId(Long memberId, Long termId);
+
+    /**
      * 회원이 특정 타입의 약관에 동의했는지 확인합니다.
      */
     boolean existsByMemberIdAndTermType(Long memberId, TermType termType);
+
+    /**
+     * 회원이 특정 약관 row 에 동의했는지 확인합니다.
+     */
+    boolean existsByMemberIdAndTermId(Long memberId, Long termId);
 }

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
@@ -1,10 +1,12 @@
 package com.umc.product.term.adapter.out.persistence;
 
-import com.umc.product.term.domain.TermConsent;
-import com.umc.product.term.domain.enums.TermType;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.enums.TermType;
 
 public interface TermConsentRepository extends JpaRepository<TermConsent, Long> {
 

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
@@ -1,13 +1,16 @@
 package com.umc.product.term.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.term.application.port.out.LoadTermPort;
 import com.umc.product.term.application.port.out.SaveTermPort;
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
@@ -36,6 +36,11 @@ public class TermPersistenceAdapter implements LoadTermPort, SaveTermPort {
         return repository.findAllByTypeInAndActiveIsTrue(types);
     }
 
+    @Override
+    public List<Term> listByIds(List<Long> ids) {
+        return repository.findAllById(ids);
+    }
+
     public List<Term> findAllActiveRequired() {
         return queryRepository.findAllActiveRequired();
     }

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
@@ -1,9 +1,10 @@
 package com.umc.product.term.application.port.out;
 
-import com.umc.product.term.domain.TermConsent;
-import com.umc.product.term.domain.enums.TermType;
 import java.util.List;
 import java.util.Optional;
+
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.enums.TermType;
 
 public interface LoadTermConsentPort {
     /**

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
@@ -17,7 +17,17 @@ public interface LoadTermConsentPort {
     Optional<TermConsent> findByMemberIdAndTermType(Long memberId, TermType termType);
 
     /**
+     * 회원 ID와 약관 ID로 동의 정보를 조회합니다.
+     */
+    Optional<TermConsent> findByMemberIdAndTermId(Long memberId, Long termId);
+
+    /**
      * 회원이 특정 타입의 약관에 동의했는지 확인합니다.
      */
     boolean existsByMemberIdAndTermType(Long memberId, TermType termType);
+
+    /**
+     * 회원이 특정 약관 row 에 동의했는지 확인합니다.
+     */
+    boolean existsByMemberIdAndTermId(Long memberId, Long termId);
 }

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
@@ -1,9 +1,10 @@
 package com.umc.product.term.application.port.out;
 
-import com.umc.product.term.domain.Term;
-import com.umc.product.term.domain.enums.TermType;
 import java.util.List;
 import java.util.Optional;
+
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.enums.TermType;
 
 public interface LoadTermPort {
     /**

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
@@ -27,6 +27,11 @@ public interface LoadTermPort {
     List<Term> findAllActiveByTypes(List<TermType> types);
 
     /**
+     * 전달받은 ID에 해당하는 약관을 한 번에 조회합니다.
+     */
+    List<Term> listByIds(List<Long> ids);
+
+    /**
      * 현재 활성화된 필수 약관 목록을 조회합니다.
      */
     List<Term> findAllActiveRequired();

--- a/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
@@ -1,5 +1,10 @@
 package com.umc.product.term.application.service.command;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
 import com.umc.product.term.application.port.in.command.dto.CreateTermConsentCommand;
 import com.umc.product.term.application.port.out.LoadTermConsentPort;
@@ -13,10 +18,8 @@ import com.umc.product.term.domain.enums.TermConsentStatus;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.time.Instant;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
@@ -37,12 +37,13 @@ public class TermAgreementCommandService implements ManageTermAgreementUseCase {
         if (command.isAgreed()) {
             // 동의 처리
             // 이미 동의했는지 확인
-            if (loadTermConsentPort.existsByMemberIdAndTermType(command.memberId(), term.getType())) {
+            if (loadTermConsentPort.existsByMemberIdAndTermId(command.memberId(), term.getId())) {
                 throw new TermDomainException(TermErrorCode.TERMS_CONSENT_ALREADY_EXISTS);
             }
 
             TermConsent termConsent = TermConsent.builder()
                 .memberId(command.memberId())
+                .termId(term.getId())
                 .termType(term.getType())
                 .agreedAt(Instant.now())
                 .build();
@@ -50,16 +51,17 @@ public class TermAgreementCommandService implements ManageTermAgreementUseCase {
             saveTermConsentPort.save(termConsent);
 
             // 동의 로그 기록
-            saveConsentLog(command.memberId(), term.getType(), TermConsentStatus.AGREED);
+            saveConsentLog(command.memberId(), term.getId(), term.getType(), TermConsentStatus.AGREED);
         }
         // 미동의 시 아무것도 하지 않음 (회원가입 시나리오에서 기존 동의 기록이 없음)
         // TODO: 동의 철회의 경우에 대한 처리 로직을 추가할 것
     }
 
-    private void saveConsentLog(Long memberId, TermType termType, TermConsentStatus status) {
+    private void saveConsentLog(Long memberId, Long termId, TermType termType, TermConsentStatus status) {
         saveTermConsentLogPort.save(
             TermConsentLog.builder()
                 .memberId(memberId)
+                .termId(termId)
                 .termType(termType)
                 .status(status)
                 .build()

--- a/src/main/java/com/umc/product/term/application/service/query/TermAgreementQueryService.java
+++ b/src/main/java/com/umc/product/term/application/service/query/TermAgreementQueryService.java
@@ -6,7 +6,6 @@ import com.umc.product.term.application.port.out.LoadTermConsentPort;
 import com.umc.product.term.application.port.out.LoadTermPort;
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.TermConsent;
-import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
 import java.util.List;
@@ -33,20 +32,22 @@ public class TermAgreementQueryService implements GetTermAgreementUseCase {
         // 사용자의 동의 내역 가져오기
         List<TermConsent> consents = loadTermConsentPort.findByMemberId(memberId);
 
-        // 동의한 항목들의 타입(SERVICE, PRIVACY 등)만 리스트로 뽑기
-        List<TermType> types = consents.stream().map(TermConsent::getTermType).toList();
+        // 동의한 약관 row ID만 리스트로 뽑기
+        List<Long> termIds = consents.stream().map(TermConsent::getTermId).toList();
 
-        // 해당 타입들의 활성 약관 상세 정보 가져오기
-        List<Term> activeTermList = loadTermPort.findAllActiveByTypes(types);
+        if (termIds.isEmpty()) {
+            return List.of();
+        }
 
-        // Map<타입, 약관객체> 형태로 변환 (중복 발생 시 최근 거 선택)
-        Map<TermType, Term> termsMap = activeTermList.stream()
-            .collect(Collectors.toMap(Term::getType, terms -> terms, (oldValue, newValue) -> newValue));
+        // 동의 당시의 약관 row 를 그대로 조회한다. 현재 활성 약관으로 재해석하지 않는다.
+        List<Term> terms = loadTermPort.listByIds(termIds);
+        Map<Long, Term> termsMap = terms.stream()
+            .collect(Collectors.toMap(Term::getId, term -> term));
 
         // 동의 내역을 순회하며 Map에서 데이터를 꺼내 TermsInfo 만들기
         return consents.stream()
             .map(consent -> {
-                Term term = termsMap.get(consent.getTermType());
+                Term term = termsMap.get(consent.getTermId());
                 if (term == null) {
                     throw new TermDomainException(TermErrorCode.TERMS_NOT_FOUND);
                 }

--- a/src/main/java/com/umc/product/term/application/service/query/TermAgreementQueryService.java
+++ b/src/main/java/com/umc/product/term/application/service/query/TermAgreementQueryService.java
@@ -1,5 +1,12 @@
 package com.umc.product.term.application.service.query;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.term.application.port.in.query.GetTermAgreementUseCase;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.application.port.out.LoadTermConsentPort;
@@ -8,12 +15,8 @@ import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.TermConsent;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/term/domain/TermConsent.java
+++ b/src/main/java/com/umc/product/term/domain/TermConsent.java
@@ -29,6 +29,9 @@ public class TermConsent extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;  // ID 참조만
 
+    @Column(name = "term_id", nullable = false)
+    private Long termId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "term_type", nullable = false, length = 20)
     private TermType termType;
@@ -37,8 +40,9 @@ public class TermConsent extends BaseEntity {
     private Instant agreedAt;
 
     @Builder
-    private TermConsent(Long memberId, TermType termType, Instant agreedAt) {
+    private TermConsent(Long memberId, Long termId, TermType termType, Instant agreedAt) {
         this.memberId = memberId;
+        this.termId = termId;
         this.termType = termType;
         this.agreedAt = agreedAt != null ? agreedAt : Instant.now();
     }

--- a/src/main/java/com/umc/product/term/domain/TermConsent.java
+++ b/src/main/java/com/umc/product/term/domain/TermConsent.java
@@ -1,7 +1,10 @@
 package com.umc.product.term.domain;
 
+import java.time.Instant;
+
 import com.umc.product.common.BaseEntity;
 import com.umc.product.term.domain.enums.TermType;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/umc/product/term/domain/TermConsentLog.java
+++ b/src/main/java/com/umc/product/term/domain/TermConsentLog.java
@@ -30,6 +30,9 @@ public class TermConsentLog extends BaseEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Column(name = "term_id", nullable = false)
+    private Long termId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "term_type", nullable = false, length = 20)
     private TermType termType;
@@ -42,8 +45,9 @@ public class TermConsentLog extends BaseEntity {
     private Instant occurredAt;
 
     @Builder
-    private TermConsentLog(Long memberId, TermType termType, TermConsentStatus status) {
+    private TermConsentLog(Long memberId, Long termId, TermType termType, TermConsentStatus status) {
         this.memberId = memberId;
+        this.termId = termId;
         this.termType = termType;
         this.status = status;
         this.occurredAt = Instant.now();

--- a/src/main/java/com/umc/product/term/domain/TermConsentLog.java
+++ b/src/main/java/com/umc/product/term/domain/TermConsentLog.java
@@ -1,8 +1,11 @@
 package com.umc.product.term.domain;
 
+import java.time.Instant;
+
 import com.umc.product.common.BaseEntity;
 import com.umc.product.term.domain.enums.TermConsentStatus;
 import com.umc.product.term.domain.enums.TermType;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,7 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/resources/db/migration/V2026.05.26.10.00__add_term_id_to_term_consent.sql
+++ b/src/main/resources/db/migration/V2026.05.26.10.00__add_term_id_to_term_consent.sql
@@ -4,6 +4,10 @@ ALTER TABLE public.term_consent
 ALTER TABLE public.term_consent_log
     ADD COLUMN term_id bigint;
 
+-- 기존 동의 데이터는 term_type만 보유하고 있어 실제 동의 당시의 term row를 역추적할 수 없다.
+-- 현재 배포 시점에는 약관 변경 이력이 없다는 전제하에, 같은 type의 최신/활성 약관 row로 term_id를 백필한다.
+-- 이후 약관 변경 이력이 존재하는 환경에서 이 마이그레이션을 재사용하는 경우,
+-- NOT NULL 및 unique index 적용 전에 미매핑/중복 데이터 검증이 선행되어야 한다.
 WITH latest_term_by_type AS (
     SELECT DISTINCT ON (type)
         id,

--- a/src/main/resources/db/migration/V2026.05.26.10.00__add_term_id_to_term_consent.sql
+++ b/src/main/resources/db/migration/V2026.05.26.10.00__add_term_id_to_term_consent.sql
@@ -1,0 +1,51 @@
+ALTER TABLE public.term_consent
+    ADD COLUMN term_id bigint;
+
+ALTER TABLE public.term_consent_log
+    ADD COLUMN term_id bigint;
+
+WITH latest_term_by_type AS (
+    SELECT DISTINCT ON (type)
+        id,
+        type
+    FROM public.term
+    ORDER BY type, active DESC, created_at DESC, id DESC
+)
+UPDATE public.term_consent consent
+SET term_id = term.id
+FROM latest_term_by_type term
+WHERE consent.term_type = term.type
+  AND consent.term_id IS NULL;
+
+WITH latest_term_by_type AS (
+    SELECT DISTINCT ON (type)
+        id,
+        type
+    FROM public.term
+    ORDER BY type, active DESC, created_at DESC, id DESC
+)
+UPDATE public.term_consent_log consent_log
+SET term_id = term.id
+FROM latest_term_by_type term
+WHERE consent_log.term_type = term.type
+  AND consent_log.term_id IS NULL;
+
+ALTER TABLE public.term_consent
+    ALTER COLUMN term_id SET NOT NULL;
+
+ALTER TABLE public.term_consent_log
+    ALTER COLUMN term_id SET NOT NULL;
+
+ALTER TABLE public.term_consent
+    ADD CONSTRAINT fk_term_consent_term
+        FOREIGN KEY (term_id) REFERENCES public.term (id);
+
+ALTER TABLE public.term_consent_log
+    ADD CONSTRAINT fk_term_consent_log_term
+        FOREIGN KEY (term_id) REFERENCES public.term (id);
+
+CREATE UNIQUE INDEX ux_term_consent_member_term
+    ON public.term_consent (member_id, term_id);
+
+CREATE INDEX ix_term_consent_log_member_term_occurred
+    ON public.term_consent_log (member_id, term_id, occurred_at DESC);

--- a/src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java
@@ -3,6 +3,11 @@ package com.umc.product.integration.term;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.umc.product.member.domain.Member;
 import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.MemberFixture;
@@ -16,9 +21,6 @@ import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * {@link IntegrationTestSupport} + Fixture 결합 사용 예시.

--- a/src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/term/TermAgreementIntegrationTest.java
@@ -62,7 +62,7 @@ class TermAgreementIntegrationTest extends IntegrationTestSupport {
         manageTermAgreementUseCase.createTermConsent(command);
 
         // then: Port 로 직접 조회해 영속 상태 검증
-        assertThat(loadTermConsentPort.existsByMemberIdAndTermType(member.getId(), TermType.SERVICE))
+        assertThat(loadTermConsentPort.existsByMemberIdAndTermId(member.getId(), term.getId()))
             .isTrue();
 
         // and: Query UseCase 도 동일하게 동의 약관을 반환
@@ -77,7 +77,7 @@ class TermAgreementIntegrationTest extends IntegrationTestSupport {
         // given
         Member member = memberFixture.일반("이몽룡");
         Term term = termFixture.필수_약관(TermType.PRIVACY);
-        termFixture.약관_동의(member.getId(), TermType.PRIVACY);
+        termFixture.약관_동의(member.getId(), term);
 
         CreateTermConsentCommand command = CreateTermConsentCommand.builder()
             .memberId(member.getId())
@@ -90,6 +90,30 @@ class TermAgreementIntegrationTest extends IntegrationTestSupport {
             .isInstanceOf(TermDomainException.class)
             .extracting("baseCode")
             .isEqualTo(TermErrorCode.TERMS_CONSENT_ALREADY_EXISTS);
+    }
+
+    @Test
+    void 같은_타입의_새_약관에는_재동의할_수_있다() {
+        // given
+        Member member = memberFixture.일반("변사또");
+        Term oldTerm = termFixture.필수_약관(TermType.SERVICE);
+        termFixture.약관_동의(member.getId(), oldTerm);
+
+        Term newTerm = termFixture.필수_약관(TermType.SERVICE);
+        CreateTermConsentCommand command = CreateTermConsentCommand.builder()
+            .memberId(member.getId())
+            .termId(newTerm.getId())
+            .isAgreed(true)
+            .build();
+
+        // when
+        manageTermAgreementUseCase.createTermConsent(command);
+
+        // then
+        List<TermInfo> agreed = getTermAgreementUseCase.getAgreedTermsByMemberId(member.getId());
+        assertThat(agreed)
+            .extracting(TermInfo::id)
+            .containsExactlyInAnyOrder(oldTerm.getId(), newTerm.getId());
     }
 
     @Test

--- a/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
@@ -6,6 +6,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
 import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
@@ -15,14 +25,6 @@ import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class EmailMemberRegisterServiceTest {

--- a/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
@@ -1,0 +1,92 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
+import com.umc.product.global.event.application.port.out.DomainEventPublisher;
+import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
+import com.umc.product.member.application.port.in.command.dto.TermConsents;
+import com.umc.product.member.application.port.out.SaveMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
+import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EmailMemberRegisterServiceTest {
+
+    @Mock
+    SaveMemberPort saveMemberPort;
+
+    @Mock
+    MemberRegistrationValidator registrationValidator;
+
+    @Mock
+    CredentialAuthenticationUseCase credentialAuthenticationUseCase;
+
+    @Mock
+    GetSchoolUseCase getSchoolUseCase;
+
+    @Mock
+    DomainEventPublisher eventPublisher;
+
+    @Mock
+    ManageTermAgreementUseCase manageTermAgreementUseCase;
+
+    @InjectMocks
+    EmailMemberRegisterService sut;
+
+    @Test
+    @DisplayName("이메일 회원가입 성공 시 약관 동의 정보를 저장한다")
+    void 이메일_회원가입_성공시_약관_동의_정보를_저장한다() {
+        // given
+        EmailRegisterMemberCommand command = EmailRegisterMemberCommand.builder()
+            .rawPassword("Password123!")
+            .name("홍길동")
+            .nickname("길동")
+            .email("gildong@example.com")
+            .schoolId(1L)
+            .termConsents(List.of(
+                TermConsents.builder().termId(1L).isAgreed(true).build(),
+                TermConsents.builder().termId(2L).isAgreed(true).build()
+            ))
+            .build();
+
+        given(saveMemberPort.save(any(Member.class))).willAnswer(invocation -> {
+            Member member = invocation.getArgument(0);
+            ReflectionTestUtils.setField(member, "id", 100L);
+            return member;
+        });
+        given(getSchoolUseCase.getSchoolDetail(1L)).willReturn(new SchoolDetailInfo(
+            10L,
+            "중앙",
+            "테스트대학교",
+            1L,
+            null,
+            null,
+            List.of(),
+            true,
+            null,
+            null
+        ));
+
+        // when
+        Long memberId = sut.register(command);
+
+        // then
+        assertThat(memberId).isEqualTo(100L);
+        then(manageTermAgreementUseCase).should(times(2)).createTermConsent(any());
+    }
+}

--- a/src/test/java/com/umc/product/support/fixture/TermFixture.java
+++ b/src/test/java/com/umc/product/support/fixture/TermFixture.java
@@ -1,12 +1,14 @@
 package com.umc.product.support.fixture;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.term.application.port.out.SaveTermConsentPort;
 import com.umc.product.term.application.port.out.SaveTermPort;
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.TermConsent;
 import com.umc.product.term.domain.enums.TermType;
-import java.time.Instant;
-import org.springframework.stereotype.Component;
 
 /**
  * 약관(Term) / 약관 동의(TermConsent) 테스트용 Fixture.

--- a/src/test/java/com/umc/product/support/fixture/TermFixture.java
+++ b/src/test/java/com/umc/product/support/fixture/TermFixture.java
@@ -49,12 +49,13 @@ public class TermFixture extends FixtureSupport {
     }
 
     /**
-     * 회원이 특정 타입의 약관에 동의한 상태(고정 시각).
+     * 회원이 특정 약관 row 에 동의한 상태(고정 시각).
      */
-    public TermConsent 약관_동의(Long memberId, TermType type) {
+    public TermConsent 약관_동의(Long memberId, Term term) {
         return saveTermConsentPort.save(TermConsent.builder()
             .memberId(memberId)
-            .termType(type)
+            .termId(term.getId())
+            .termType(term.getType())
             .agreedAt(DEFAULT_AGREED_AT)
             .build());
     }

--- a/src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java
@@ -1,11 +1,21 @@
 package com.umc.product.term.application.port.in.command;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.term.application.port.in.command.dto.CreateTermConsentCommand;
 import com.umc.product.term.application.port.out.LoadTermConsentPort;
@@ -20,14 +30,6 @@ import com.umc.product.term.domain.enums.TermConsentStatus;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ManageTermAgreementUseCaseTest {

--- a/src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/command/ManageTermAgreementUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.umc.product.term.application.port.in.command;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -26,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ManageTermAgreementUseCaseTest {
@@ -52,7 +54,7 @@ class ManageTermAgreementUseCaseTest {
         // given
         Term term = createTerms(TermType.SERVICE);
         given(loadTermPort.findById(1L)).willReturn(Optional.of(term));
-        given(loadTermConsentPort.existsByMemberIdAndTermType(100L, TermType.SERVICE)).willReturn(false);
+        given(loadTermConsentPort.existsByMemberIdAndTermId(100L, 1L)).willReturn(false);
 
         CreateTermConsentCommand command = CreateTermConsentCommand.builder()
             .memberId(100L)
@@ -64,16 +66,23 @@ class ManageTermAgreementUseCaseTest {
         sut.createTermConsent(command);
 
         // then
-        then(saveTermConsentPort).should().save(any(TermConsent.class));
+        ArgumentCaptor<TermConsent> consentCaptor = ArgumentCaptor.forClass(TermConsent.class);
+        then(saveTermConsentPort).should().save(consentCaptor.capture());
         then(saveTermConsentPort).should(never()).delete(any());
 
         ArgumentCaptor<TermConsentLog> logCaptor = ArgumentCaptor.forClass(TermConsentLog.class);
         then(saveTermConsentLogPort).should().save(logCaptor.capture());
 
+        TermConsent savedConsent = consentCaptor.getValue();
+        assertThat(savedConsent.getMemberId()).isEqualTo(100L);
+        assertThat(savedConsent.getTermId()).isEqualTo(1L);
+        assertThat(savedConsent.getTermType()).isEqualTo(TermType.SERVICE);
+
         TermConsentLog savedLog = logCaptor.getValue();
-        assert savedLog.getMemberId().equals(100L);
-        assert savedLog.getTermType() == TermType.SERVICE;
-        assert savedLog.getStatus() == TermConsentStatus.AGREED;
+        assertThat(savedLog.getMemberId()).isEqualTo(100L);
+        assertThat(savedLog.getTermId()).isEqualTo(1L);
+        assertThat(savedLog.getTermType()).isEqualTo(TermType.SERVICE);
+        assertThat(savedLog.getStatus()).isEqualTo(TermConsentStatus.AGREED);
     }
 
     @Test
@@ -81,7 +90,7 @@ class ManageTermAgreementUseCaseTest {
         // given
         Term term = createTerms(TermType.SERVICE);
         given(loadTermPort.findById(1L)).willReturn(Optional.of(term));
-        given(loadTermConsentPort.existsByMemberIdAndTermType(100L, TermType.SERVICE)).willReturn(true);
+        given(loadTermConsentPort.existsByMemberIdAndTermId(100L, 1L)).willReturn(true);
 
         CreateTermConsentCommand command = CreateTermConsentCommand.builder()
             .memberId(100L)
@@ -145,10 +154,18 @@ class ManageTermAgreementUseCaseTest {
     }
 
     private Term createTerms(TermType type) {
-        return Term.builder()
+        Term term = Term.builder()
             .type(type)
             .link("http://example.com/terms")
             .required(type == TermType.SERVICE || type == TermType.PRIVACY)
             .build();
+        Long id = switch (type) {
+            case SERVICE -> 1L;
+            case MARKETING -> 2L;
+            case PRIVACY -> 3L;
+            case LOCATION -> 4L;
+        };
+        ReflectionTestUtils.setField(term, "id", id);
+        return term;
     }
 }

--- a/src/test/java/com/umc/product/term/application/port/in/query/TermAgreementQueryServiceTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/query/TermAgreementQueryServiceTest.java
@@ -3,15 +3,9 @@ package com.umc.product.term.application.port.in.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-import com.umc.product.term.application.port.in.query.dto.TermInfo;
-import com.umc.product.term.application.port.out.LoadTermConsentPort;
-import com.umc.product.term.application.port.out.LoadTermPort;
-import com.umc.product.term.application.service.query.TermAgreementQueryService;
-import com.umc.product.term.domain.Term;
-import com.umc.product.term.domain.TermConsent;
-import com.umc.product.term.domain.enums.TermType;
 import java.time.Instant;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +13,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.term.application.port.in.query.dto.TermInfo;
+import com.umc.product.term.application.port.out.LoadTermConsentPort;
+import com.umc.product.term.application.port.out.LoadTermPort;
+import com.umc.product.term.application.service.query.TermAgreementQueryService;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.enums.TermType;
 
 @ExtendWith(MockitoExtension.class)
 class TermAgreementQueryServiceTest {

--- a/src/test/java/com/umc/product/term/application/port/in/query/TermAgreementQueryServiceTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/query/TermAgreementQueryServiceTest.java
@@ -1,0 +1,75 @@
+package com.umc.product.term.application.port.in.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.umc.product.term.application.port.in.query.dto.TermInfo;
+import com.umc.product.term.application.port.out.LoadTermConsentPort;
+import com.umc.product.term.application.port.out.LoadTermPort;
+import com.umc.product.term.application.service.query.TermAgreementQueryService;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.enums.TermType;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TermAgreementQueryServiceTest {
+
+    @Mock
+    LoadTermConsentPort loadTermConsentPort;
+
+    @Mock
+    LoadTermPort loadTermPort;
+
+    @InjectMocks
+    TermAgreementQueryService sut;
+
+    @Test
+    @DisplayName("동의한 약관은 현재 활성 약관이 아니라 저장된 약관 ID 기준으로 조회한다")
+    void 동의한_약관은_저장된_약관_ID_기준으로_조회한다() {
+        // given
+        Term oldServiceTerm = createTerm(10L, TermType.SERVICE, "https://example.com/terms/service-v1");
+        Term privacyTerm = createTerm(20L, TermType.PRIVACY, "https://example.com/terms/privacy-v1");
+
+        given(loadTermConsentPort.findByMemberId(100L)).willReturn(List.of(
+            createConsent(100L, oldServiceTerm),
+            createConsent(100L, privacyTerm)
+        ));
+        given(loadTermPort.listByIds(List.of(10L, 20L))).willReturn(List.of(oldServiceTerm, privacyTerm));
+
+        // when
+        List<TermInfo> result = sut.getAgreedTermsByMemberId(100L);
+
+        // then
+        assertThat(result)
+            .extracting(TermInfo::id)
+            .containsExactly(10L, 20L);
+    }
+
+    private TermConsent createConsent(Long memberId, Term term) {
+        return TermConsent.builder()
+            .memberId(memberId)
+            .termId(term.getId())
+            .termType(term.getType())
+            .agreedAt(Instant.parse("2026-05-26T00:00:00Z"))
+            .build();
+    }
+
+    private Term createTerm(Long id, TermType type, String link) {
+        Term term = Term.builder()
+            .type(type)
+            .link(link)
+            .required(true)
+            .build();
+        ReflectionTestUtils.setField(term, "id", id);
+        return term;
+    }
+}


### PR DESCRIPTION
## 요약
- 이메일 회원가입 시 누락되던 약관 동의 저장을 OAuth 회원가입과 동일하게 보강했습니다.
- `term_consent`, `term_consent_log`에 `term_id`를 추가해 약관 row 기준으로 동의 증빙을 남기도록 변경했습니다.
- 같은 `TermType`의 새 약관에 재동의할 수 있도록 중복 검사를 `memberId + termId` 기준으로 전환했습니다.
- ADR과 실행 계획 보고서를 추가했습니다.

## 테스트
- `./gradlew compileJava compileTestJava test --tests "com.umc.product.member.application.service.EmailMemberRegisterServiceTest" --tests "com.umc.product.term.application.port.in.command.ManageTermAgreementUseCaseTest" --tests "com.umc.product.term.application.port.in.query.TermAgreementQueryServiceTest"`

## 참고
- 로컬 환경에서는 Docker/Testcontainers 초기화 실패로 `TermAgreementIntegrationTest`는 실행하지 못했습니다. CI 또는 Docker 사용 가능한 환경에서 확인이 필요합니다.