### PR TITLE
[Feat] 필수 약관 동의 상태 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/product/term/adapter/in/web/TermController.java
+++ b/src/main/java/com/umc/product/term/adapter/in/web/TermController.java
@@ -1,25 +1,31 @@
 package com.umc.product.term.adapter.in.web;
 
-import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
-import com.umc.product.authorization.domain.PermissionType;
-import com.umc.product.authorization.domain.ResourceType;
-import com.umc.product.global.security.annotation.Public;
-import com.umc.product.term.adapter.in.web.dto.request.CreateTermRequest;
-import com.umc.product.term.adapter.in.web.dto.response.TermResponse;
-import com.umc.product.term.application.port.in.command.ManageTermUseCase;
-import com.umc.product.term.application.port.in.command.dto.CreateTermCommand;
-import com.umc.product.term.application.port.in.query.GetTermUseCase;
-import com.umc.product.term.domain.enums.TermType;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.global.security.annotation.Public;
+import com.umc.product.term.adapter.in.web.dto.request.CreateTermRequest;
+import com.umc.product.term.adapter.in.web.dto.response.RequiredTermConsentStatusResponse;
+import com.umc.product.term.adapter.in.web.dto.response.TermResponse;
+import com.umc.product.term.application.port.in.command.ManageTermUseCase;
+import com.umc.product.term.application.port.in.command.dto.CreateTermCommand;
+import com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCase;
+import com.umc.product.term.application.port.in.query.GetTermUseCase;
+import com.umc.product.term.domain.enums.TermType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
@@ -28,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TermController {
 
     private final GetTermUseCase getTermUseCase;
+    private final GetRequiredTermConsentStatusUseCase getRequiredTermConsentStatusUseCase;
     private final ManageTermUseCase manageTermUseCase;
 
     @GetMapping("type/{termType}")
@@ -42,6 +49,14 @@ public class TermController {
     @Operation(summary = "[TERM-102] 약관 ID로 약관 조회")
     TermResponse getTermsById(@PathVariable Long termsId) {
         return TermResponse.from(getTermUseCase.getTermsById(termsId));
+    }
+
+    @GetMapping("consent-status/me")
+    @Operation(summary = "[TERM-103] 내 필수 약관 재동의 상태 조회")
+    RequiredTermConsentStatusResponse getMyRequiredTermConsentStatus(@CurrentMember MemberPrincipal memberPrincipal) {
+        return RequiredTermConsentStatusResponse.from(
+            getRequiredTermConsentStatusUseCase.getRequiredTermConsentStatus(memberPrincipal.getMemberId())
+        );
     }
 
     @PostMapping

--- a/src/main/java/com/umc/product/term/adapter/in/web/dto/response/RequiredTermConsentStatusResponse.java
+++ b/src/main/java/com/umc/product/term/adapter/in/web/dto/response/RequiredTermConsentStatusResponse.java
@@ -1,0 +1,20 @@
+package com.umc.product.term.adapter.in.web.dto.response;
+
+import java.util.List;
+
+import com.umc.product.term.application.port.in.query.dto.RequiredTermConsentStatusInfo;
+
+public record RequiredTermConsentStatusResponse(
+    boolean needsReconsent,
+    List<TermResponse> missingRequiredTerms
+) {
+
+    public static RequiredTermConsentStatusResponse from(RequiredTermConsentStatusInfo info) {
+        return new RequiredTermConsentStatusResponse(
+            info.needsReconsent(),
+            info.missingRequiredTerms().stream()
+                .map(TermResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentPersistenceAdapter.java
@@ -24,6 +24,11 @@ public class TermConsentPersistenceAdapter implements LoadTermConsentPort, SaveT
     }
 
     @Override
+    public List<TermConsent> listByMemberIdAndTermIds(Long memberId, List<Long> termIds) {
+        return repository.findByMemberIdAndTermIdIn(memberId, termIds);
+    }
+
+    @Override
     public Optional<TermConsent> findByMemberIdAndTermType(Long memberId, TermType termType) {
         return repository.findByMemberIdAndTermType(memberId, termType);
     }

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermConsentRepository.java
@@ -16,6 +16,11 @@ public interface TermConsentRepository extends JpaRepository<TermConsent, Long> 
     List<TermConsent> findByMemberId(Long memberId);
 
     /**
+     * 회원 ID와 약관 ID 목록으로 동의한 약관 목록을 조회합니다.
+     */
+    List<TermConsent> findByMemberIdAndTermIdIn(Long memberId, List<Long> termIds);
+
+    /**
      * 회원 ID와 약관 타입으로 동의 정보를 조회합니다.
      */
     Optional<TermConsent> findByMemberIdAndTermType(Long memberId, TermType termType);

--- a/src/main/java/com/umc/product/term/application/port/in/query/GetRequiredTermConsentStatusUseCase.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/GetRequiredTermConsentStatusUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.term.application.port.in.query;
+
+import com.umc.product.term.application.port.in.query.dto.RequiredTermConsentStatusInfo;
+
+public interface GetRequiredTermConsentStatusUseCase {
+
+    RequiredTermConsentStatusInfo getRequiredTermConsentStatus(Long memberId);
+}

--- a/src/main/java/com/umc/product/term/application/port/in/query/dto/RequiredTermConsentStatusInfo.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/dto/RequiredTermConsentStatusInfo.java
@@ -1,0 +1,26 @@
+package com.umc.product.term.application.port.in.query.dto;
+
+import java.util.List;
+
+import com.umc.product.term.domain.Term;
+
+public record RequiredTermConsentStatusInfo(
+    boolean needsReconsent,
+    List<TermInfo> missingRequiredTerms
+) {
+
+    public RequiredTermConsentStatusInfo {
+        missingRequiredTerms = List.copyOf(missingRequiredTerms);
+    }
+
+    public static RequiredTermConsentStatusInfo fromMissingTerms(List<Term> missingRequiredTerms) {
+        List<TermInfo> missingTermInfos = missingRequiredTerms.stream()
+            .map(TermInfo::from)
+            .toList();
+
+        return new RequiredTermConsentStatusInfo(
+            !missingTermInfos.isEmpty(),
+            missingTermInfos
+        );
+    }
+}

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermConsentPort.java
@@ -13,6 +13,11 @@ public interface LoadTermConsentPort {
     List<TermConsent> findByMemberId(Long memberId);
 
     /**
+     * 회원 ID와 약관 ID 목록으로 동의한 약관 목록을 조회합니다.
+     */
+    List<TermConsent> listByMemberIdAndTermIds(Long memberId, List<Long> termIds);
+
+    /**
      * 회원 ID와 약관 타입으로 동의 정보를 조회합니다.
      */
     Optional<TermConsent> findByMemberIdAndTermType(Long memberId, TermType termType);

--- a/src/main/java/com/umc/product/term/application/service/query/RequiredTermConsentStatusQueryService.java
+++ b/src/main/java/com/umc/product/term/application/service/query/RequiredTermConsentStatusQueryService.java
@@ -1,0 +1,54 @@
+package com.umc.product.term.application.service.query;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCase;
+import com.umc.product.term.application.port.in.query.dto.RequiredTermConsentStatusInfo;
+import com.umc.product.term.application.port.out.LoadTermConsentPort;
+import com.umc.product.term.application.port.out.LoadTermPort;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.exception.TermDomainException;
+import com.umc.product.term.domain.exception.TermErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RequiredTermConsentStatusQueryService implements GetRequiredTermConsentStatusUseCase {
+
+    private final LoadTermPort loadTermPort;
+    private final LoadTermConsentPort loadTermConsentPort;
+
+    @Override
+    public RequiredTermConsentStatusInfo getRequiredTermConsentStatus(Long memberId) {
+        if (memberId == null) {
+            throw new TermDomainException(TermErrorCode.MEMBER_ID_REQUIRED);
+        }
+
+        List<Term> requiredTerms = loadTermPort.findAllActiveRequired();
+        if (requiredTerms.isEmpty()) {
+            return RequiredTermConsentStatusInfo.fromMissingTerms(List.of());
+        }
+
+        List<Long> requiredTermIds = requiredTerms.stream()
+            .map(Term::getId)
+            .toList();
+        Set<Long> agreedTermIds = loadTermConsentPort.listByMemberIdAndTermIds(memberId, requiredTermIds)
+            .stream()
+            .map(TermConsent::getTermId)
+            .collect(Collectors.toSet());
+
+        List<Term> missingRequiredTerms = requiredTerms.stream()
+            .filter(term -> !agreedTermIds.contains(term.getId()))
+            .toList();
+
+        return RequiredTermConsentStatusInfo.fromMissingTerms(missingRequiredTerms);
+    }
+}

--- a/src/test/java/com/umc/product/term/application/port/in/query/GetRequiredTermConsentStatusUseCaseTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/query/GetRequiredTermConsentStatusUseCaseTest.java
@@ -1,0 +1,96 @@
+package com.umc.product.term.application.port.in.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.term.application.port.in.query.dto.RequiredTermConsentStatusInfo;
+import com.umc.product.term.application.port.out.LoadTermConsentPort;
+import com.umc.product.term.application.port.out.LoadTermPort;
+import com.umc.product.term.application.service.query.RequiredTermConsentStatusQueryService;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.TermConsent;
+import com.umc.product.term.domain.enums.TermType;
+
+@ExtendWith(MockitoExtension.class)
+class GetRequiredTermConsentStatusUseCaseTest {
+
+    @Mock
+    LoadTermPort loadTermPort;
+
+    @Mock
+    LoadTermConsentPort loadTermConsentPort;
+
+    @InjectMocks
+    RequiredTermConsentStatusQueryService sut;
+
+    @Test
+    @DisplayName("현재 활성 필수 약관 중 미동의 약관을 반환한다")
+    void 현재_활성_필수_약관_중_미동의_약관을_반환한다() {
+        // given
+        Term serviceTerm = createTerm(1L, TermType.SERVICE);
+        Term privacyTerm = createTerm(2L, TermType.PRIVACY);
+        given(loadTermPort.findAllActiveRequired()).willReturn(List.of(serviceTerm, privacyTerm));
+        given(loadTermConsentPort.listByMemberIdAndTermIds(100L, List.of(1L, 2L))).willReturn(List.of(
+            createConsent(100L, serviceTerm)
+        ));
+
+        // when
+        RequiredTermConsentStatusInfo result = sut.getRequiredTermConsentStatus(100L);
+
+        // then
+        assertThat(result.needsReconsent()).isTrue();
+        assertThat(result.missingRequiredTerms())
+            .extracting(term -> term.id())
+            .containsExactly(2L);
+    }
+
+    @Test
+    @DisplayName("현재 활성 필수 약관을 모두 동의한 경우 재동의가 필요하지 않다")
+    void 현재_활성_필수_약관을_모두_동의한_경우_재동의가_필요하지_않다() {
+        // given
+        Term serviceTerm = createTerm(1L, TermType.SERVICE);
+        Term privacyTerm = createTerm(2L, TermType.PRIVACY);
+        given(loadTermPort.findAllActiveRequired()).willReturn(List.of(serviceTerm, privacyTerm));
+        given(loadTermConsentPort.listByMemberIdAndTermIds(100L, List.of(1L, 2L))).willReturn(List.of(
+            createConsent(100L, serviceTerm),
+            createConsent(100L, privacyTerm)
+        ));
+
+        // when
+        RequiredTermConsentStatusInfo result = sut.getRequiredTermConsentStatus(100L);
+
+        // then
+        assertThat(result.needsReconsent()).isFalse();
+        assertThat(result.missingRequiredTerms()).isEmpty();
+    }
+
+    private TermConsent createConsent(Long memberId, Term term) {
+        return TermConsent.builder()
+            .memberId(memberId)
+            .termId(term.getId())
+            .termType(term.getType())
+            .agreedAt(Instant.parse("2026-05-26T00:00:00Z"))
+            .build();
+    }
+
+    private Term createTerm(Long id, TermType type) {
+        Term term = Term.builder()
+            .type(type)
+            .link("https://example.com/terms/" + type.name().toLowerCase())
+            .required(true)
+            .build();
+        ReflectionTestUtils.setField(term, "id", id);
+        return term;
+    }
+}


### PR DESCRIPTION
## 요약
- 현재 활성 필수 약관 중 회원이 아직 동의하지 않은 약관 목록을 계산하는 Query UseCase를 추가했습니다.
- `GET /api/v1/terms/consent-status/me` 엔드포인트를 추가했습니다.
- 후속 API 제한 필터에서 사용할 수 있도록 `LoadTermConsentPort#listByMemberIdAndTermIds`를 추가했습니다.

## 테스트
- `./gradlew compileJava compileTestJava test --tests "com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCaseTest"`

## 참고
- 이 PR은 #915 위에 쌓은 stacked PR입니다. #915 머지 후 base를 `develop`으로 변경하면 됩니다.