### PR TITLE
[Fix] 테스트 컴파일 실패 수정

### DIFF
--- a/src/test/java/com/umc/product/organization/application/service/query/StudyGroupQueryServiceTest.java
+++ b/src/test/java/com/umc/product/organization/application/service/query/StudyGroupQueryServiceTest.java
@@ -8,29 +8,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerRoleType;
-import com.umc.product.common.domain.enums.MemberStatus;
-import com.umc.product.member.application.port.in.query.GetMemberUseCase;
-import com.umc.product.member.application.port.in.query.dto.MemberInfo;
-import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
-import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupInfo;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsPartLeader;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsSchoolCore;
-import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupMemberInfo;
-import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupWithMemberAndMentorInfo;
-import com.umc.product.organization.application.port.out.query.LoadStudyGroupPort;
-import com.umc.product.organization.application.port.service.query.StudyGroupQueryService;
-import com.umc.product.organization.domain.StudyGroup;
-import com.umc.product.organization.domain.StudyGroupMember;
-import com.umc.product.organization.domain.StudyGroupMentor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +21,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsPartLeader;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsSchoolCore;
+import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupInfo;
+import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupMemberInfo;
+import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupWithMemberAndMentorInfo;
+import com.umc.product.organization.application.port.out.query.LoadStudyGroupPort;
+import com.umc.product.organization.application.port.service.query.StudyGroupQueryService;
+import com.umc.product.organization.domain.StudyGroup;
+import com.umc.product.organization.domain.StudyGroupMember;
+import com.umc.product.organization.domain.StudyGroupMentor;
 
 @ExtendWith(MockitoExtension.class)
 class StudyGroupQueryServiceTest {

--- a/src/test/java/com/umc/product/organization/application/service/query/StudyGroupQueryServiceTest.java
+++ b/src/test/java/com/umc/product/organization/application/service/query/StudyGroupQueryServiceTest.java
@@ -65,7 +65,7 @@ class StudyGroupQueryServiceTest {
         given(getMemberUseCase.getById(memberId)).willReturn(memberInfo(memberId, schoolId));
         given(getGisuUseCase.getActiveGisuId()).willReturn(gisuId);
         given(getChallengerRoleUseCase.isSchoolCoreInGisu(memberId, gisuId, schoolId)).willReturn(true);
-        given(getMemberUseCase.findAllIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
+        given(getMemberUseCase.listIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
         given(getChallengerRoleUseCase.hasRoleTypeInGisu(memberId, gisuId, ChallengerRoleType.SCHOOL_PART_LEADER))
             .willReturn(false);
         given(loadStudyGroupPort.findStudyGroupHeaders(any(), eq(gisuId), eq(null), anyInt()))
@@ -118,7 +118,7 @@ class StudyGroupQueryServiceTest {
         given(getMemberUseCase.getById(memberId)).willReturn(memberInfo(memberId, schoolId));
         given(getGisuUseCase.getActiveGisuId()).willReturn(gisuId);
         given(getChallengerRoleUseCase.isSchoolCoreInGisu(memberId, gisuId, schoolId)).willReturn(true);
-        given(getMemberUseCase.findAllIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
+        given(getMemberUseCase.listIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
         given(getChallengerRoleUseCase.hasRoleTypeInGisu(memberId, gisuId, ChallengerRoleType.SCHOOL_PART_LEADER))
             .willReturn(true);
 
@@ -167,7 +167,7 @@ class StudyGroupQueryServiceTest {
         given(getMemberUseCase.getById(memberId)).willReturn(memberInfo(memberId, schoolId));
         given(getGisuUseCase.getActiveGisuId()).willReturn(gisuId);
         given(getChallengerRoleUseCase.isSchoolCoreInGisu(memberId, gisuId, schoolId)).willReturn(true);
-        given(getMemberUseCase.findAllIdsBySchoolId(schoolId)).willReturn(Set.of());
+        given(getMemberUseCase.listIdsBySchoolId(schoolId)).willReturn(Set.of());
         given(getChallengerRoleUseCase.hasRoleTypeInGisu(memberId, gisuId, ChallengerRoleType.SCHOOL_PART_LEADER))
             .willReturn(true);
         given(loadStudyGroupPort.findStudyGroupHeaders(any(), eq(gisuId), eq(null), anyInt()))
@@ -435,7 +435,7 @@ class StudyGroupQueryServiceTest {
         given(getMemberUseCase.getById(memberId)).willReturn(memberInfo(memberId, schoolId));
         given(getGisuUseCase.getActiveGisuId()).willReturn(gisuId);
         given(getChallengerRoleUseCase.isSchoolCoreInGisu(memberId, gisuId, schoolId)).willReturn(true);
-        given(getMemberUseCase.findAllIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
+        given(getMemberUseCase.listIdsBySchoolId(schoolId)).willReturn(schoolMemberIds);
         given(getChallengerRoleUseCase.hasRoleTypeInGisu(memberId, gisuId, ChallengerRoleType.SCHOOL_PART_LEADER))
             .willReturn(true);
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- `organization` 도메인의 `StudyGroupQueryServiceTest`만 수정했어요.

### 작업 단위별 상세

1. **무엇을**: `compileTestJava`를 깨뜨리던 테스트 모킹 메서드명을 현재 `GetMemberUseCase` 표면 API에 맞게 수정했어요.
   - **어떻게**: `findAllIdsBySchoolId` 모킹을 `listIdsBySchoolId`로 바꿨어요.
   - **왜**: 프로덕션 `StudyGroupQueryService`는 학교별 멤버 ID 조회에 `listIdsBySchoolId`를 호출하도록 정리되어 있는데, 테스트만 이전 메서드명을 참조해 테스트 컴파일이 실패하고 있었기 때문이에요.

## 💬 리뷰 중점사항

- 테스트 코드만 변경했어요. 애플리케이션 동작 변경은 없어요.
- `./gradlew test`가 통과했어요. 테스트 종료 시 로컬 웹훅 설정값 문제로 종료 훅 로그가 출력되지만 Gradle 결과는 `BUILD SUCCESSFUL`이에요.
