### PR TITLE
[Feat] 지원서 시나리오 시딩 API 구현

### DIFF
--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -37,8 +37,8 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * test 도메인 시딩 API. ADR-017 참조.
  * <p>
- * @Profile("!prod") + app.seed.enabled=true 두 조건을 모두 만족할 때만 빈으로 등록된다.
- * prod 환경에서는 빈 등록 자체가 차단되어 외부 노출 가능성이 없다.
+ *
+ * @Profile("!prod") + app.seed.enabled=true 두 조건을 모두 만족할 때만 빈으로 등록된다. prod 환경에서는 빈 등록 자체가 차단되어 외부 노출 가능성이 없다.
  */
 @RestController
 @RequestMapping("/test/seed")
@@ -122,28 +122,6 @@ public class SeedController {
         return SeedProjectScenariosResponse.from(seedProjectScenariosUseCase.seed(request.toCommand()));
     }
 
-    @Operation(
-        summary = "[SEED-006] 지원서 시나리오 시딩",
-        description = """
-            지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
-            랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행합니다.
-
-            전제 조건:
-            - 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 합니다.
-            - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
-            - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
-
-            APPROVED 처리된 챌린저는 ProjectMember로도 등록되어 매칭현황 통계에 반영됩니다.
-            """
-    )
-    @PostMapping("/project-applications")
-    public SeedProjectApplicationsResponse seedProjectApplications(
-        @RequestBody @Valid SeedProjectApplicationsRequest request
-    ) {
-        return SeedProjectApplicationsResponse.from(
-            seedProjectApplicationsUseCase.seed(request.toCommand())
-        );
-    }
 
     @Operation(
         summary = "[SEED-004] Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission)",
@@ -175,5 +153,28 @@ public class SeedController {
     @PostMapping("/notice")
     public SeedNoticeResponse seedNotice(@RequestBody @Valid SeedNoticeRequest request) {
         return SeedNoticeResponse.from(seedNoticeUseCase.seed(request.toCommand()));
+    }
+
+    @Operation(
+        summary = "[SEED-006] 지원서 시나리오 시딩",
+        description = """
+            지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
+            랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행합니다.
+
+            전제 조건:
+            - 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 합니다.
+            - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
+            - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
+
+            APPROVED 처리된 챌린저는 ProjectMember로도 등록되어 매칭현황 통계에 반영됩니다.
+            """
+    )
+    @PostMapping("/project-applications")
+    public SeedProjectApplicationsResponse seedProjectApplications(
+        @RequestBody @Valid SeedProjectApplicationsRequest request
+    ) {
+        return SeedProjectApplicationsResponse.from(
+            seedProjectApplicationsUseCase.seed(request.toCommand())
+        );
     }
 }

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -9,6 +9,8 @@ import com.umc.product.test.adapter.in.web.dto.SeedMembersRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedMembersResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedNoticeRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedNoticeResponse;
+import com.umc.product.test.adapter.in.web.dto.SeedProjectApplicationsRequest;
+import com.umc.product.test.adapter.in.web.dto.SeedProjectApplicationsResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsRequest;
@@ -17,6 +19,7 @@ import com.umc.product.test.application.port.in.command.SeedChallengersUseCase;
 import com.umc.product.test.application.port.in.command.SeedCurriculumUseCase;
 import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
 import com.umc.product.test.application.port.in.command.SeedNoticeUseCase;
+import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectScenariosUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectsUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,6 +54,7 @@ public class SeedController {
     private final SeedChallengersUseCase seedChallengersUseCase;
     private final SeedProjectsUseCase seedProjectsUseCase;
     private final SeedProjectScenariosUseCase seedProjectScenariosUseCase;
+    private final SeedProjectApplicationsUseCase seedProjectApplicationsUseCase;
     private final SeedCurriculumUseCase seedCurriculumUseCase;
     private final SeedNoticeUseCase seedNoticeUseCase;
 
@@ -116,6 +120,29 @@ public class SeedController {
         @RequestBody @Valid SeedProjectScenariosRequest request
     ) {
         return SeedProjectScenariosResponse.from(seedProjectScenariosUseCase.seed(request.toCommand()));
+    }
+
+    @Operation(
+        summary = "[SEED-006] 지원서 시나리오 시딩",
+        description = """
+            지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
+            랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행합니다.
+
+            전제 조건:
+            - 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 합니다.
+            - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
+            - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
+
+            APPROVED 처리된 챌린저는 ProjectMember로도 등록되어 매칭현황 통계에 반영됩니다.
+            """
+    )
+    @PostMapping("/project-applications")
+    public SeedProjectApplicationsResponse seedProjectApplications(
+        @RequestBody @Valid SeedProjectApplicationsRequest request
+    ) {
+        return SeedProjectApplicationsResponse.from(
+            seedProjectApplicationsUseCase.seed(request.toCommand())
+        );
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -166,6 +166,10 @@ public class SeedController {
             - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
             - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
 
+            파라미터:
+            - approveRatio: 제출된 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0, 생략 시 기본값 0.5).
+              예) 0.7 이면 지원자의 약 70%가 APPROVED, 나머지 30%는 REJECTED 처리됩니다.
+
             APPROVED 처리된 챌린저는 ProjectMember로도 등록되어 매칭현황 통계에 반영됩니다.
             """
     )

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -161,18 +161,20 @@ public class SeedController {
         summary = "[SEED-006] 지원서 시나리오 시딩",
         description = """
             지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
-            랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행합니다.
+            지부의 IN_PROGRESS 프로젝트에 지원서를 제출하는 시나리오를 실행합니다.
 
             전제 조건:
             - 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 합니다.
             - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
             - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
 
-            파라미터:
-            - approveRatio: 제출된 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0, 생략 시 기본값 0.5).
-              예) 0.7 이면 지원자의 약 70%가 APPROVED, 나머지 30%는 REJECTED 처리됩니다.
+            동작:
+            각 챌린저는 createDraft → fill → submit 까지 진행한 뒤, 최종 상태가
+            SUBMITTED / APPROVED / REJECTED 중 하나로 무작위 결정됩니다 (약 1/3 분포).
+            그 결과로 운영 화면의 "검토 대기 + 합격자 + 불합격자" 분포가 자연스럽게 채워집니다.
 
-            APPROVED 처리된 챌린저는 ProjectMember로도 등록되어 매칭현황 통계에 반영됩니다.
+            ProjectMember 등록은 시딩 책임 밖입니다. 매칭 완료(APPROVED → ProjectMember 일괄 등록)는
+            차수 종료 시점의 autoDecide 가 처리합니다.
             """
     )
     @PostMapping("/project-applications")

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -1,5 +1,12 @@
 package com.umc.product.test.adapter.in.web;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.global.security.annotation.Public;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersResponse;
@@ -22,17 +29,12 @@ import com.umc.product.test.application.port.in.command.SeedNoticeUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectScenariosUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectsUseCase;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * test 도메인 시딩 API. ADR-017 참조.

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
@@ -1,0 +1,30 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 지원서 시나리오 시딩 Request.
+ *
+ * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
+ * @param chapterId       대상 지부 ID.
+ * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0). 기본값 0.5.
+ */
+public record SeedProjectApplicationsRequest(
+    @NotNull Long matchingRoundId,
+    @NotNull Long chapterId,
+    @DecimalMin("0.0") @DecimalMax("1.0") double approveRatio
+) {
+
+    public SeedProjectApplicationsRequest {
+        if (approveRatio < 0.0 || approveRatio > 1.0) {
+            approveRatio = 0.5;
+        }
+    }
+
+    public SeedProjectApplicationsCommand toCommand() {
+        return new SeedProjectApplicationsCommand(matchingRoundId, chapterId, approveRatio);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
@@ -10,16 +10,16 @@ import jakarta.validation.constraints.NotNull;
  *
  * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
  * @param chapterId       대상 지부 ID.
- * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0). 기본값 0.5.
+ * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0). 생략 시 기본값 0.5.
  */
 public record SeedProjectApplicationsRequest(
     @NotNull Long matchingRoundId,
     @NotNull Long chapterId,
-    @DecimalMin("0.0") @DecimalMax("1.0") double approveRatio
+    @DecimalMin("0.0") @DecimalMax("1.0") Double approveRatio
 ) {
 
     public SeedProjectApplicationsRequest {
-        if (approveRatio < 0.0 || approveRatio > 1.0) {
+        if (approveRatio == null) {
             approveRatio = 0.5;
         }
     }

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
@@ -1,6 +1,7 @@
 package com.umc.product.test.adapter.in.web.dto;
 
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
+
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsRequest.java
@@ -2,30 +2,20 @@ package com.umc.product.test.adapter.in.web.dto;
 
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
 
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * 지원서 시나리오 시딩 Request.
  *
- * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
+ * @param matchingRoundId 지원할 매칭 차수 ID. 현재 OPEN 상태여야 한다.
  * @param chapterId       대상 지부 ID.
- * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0). 생략 시 기본값 0.5.
  */
 public record SeedProjectApplicationsRequest(
     @NotNull Long matchingRoundId,
-    @NotNull Long chapterId,
-    @DecimalMin("0.0") @DecimalMax("1.0") Double approveRatio
+    @NotNull Long chapterId
 ) {
 
-    public SeedProjectApplicationsRequest {
-        if (approveRatio == null) {
-            approveRatio = 0.5;
-        }
-    }
-
     public SeedProjectApplicationsCommand toCommand() {
-        return new SeedProjectApplicationsCommand(matchingRoundId, chapterId, approveRatio);
+        return new SeedProjectApplicationsCommand(matchingRoundId, chapterId);
     }
 }

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
@@ -1,0 +1,40 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
+import java.util.List;
+
+public record SeedProjectApplicationsResponse(
+    int submittedCount,
+    int approvedCount,
+    int rejectedCount,
+    int failedCount,
+    List<FailedApplication> failures
+) {
+
+    public record FailedApplication(
+        Long applicantMemberId,
+        Long projectId,
+        String failedStep,
+        String reason
+    ) {
+
+        public static FailedApplication from(SeedProjectApplicationsResult.FailedApplication src) {
+            return new FailedApplication(
+                src.applicantMemberId(),
+                src.projectId(),
+                src.failedStep(),
+                src.reason()
+            );
+        }
+    }
+
+    public static SeedProjectApplicationsResponse from(SeedProjectApplicationsResult result) {
+        return new SeedProjectApplicationsResponse(
+            result.submittedCount(),
+            result.approvedCount(),
+            result.rejectedCount(),
+            result.failures().size(),
+            result.failures().stream().map(FailedApplication::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
@@ -1,7 +1,8 @@
 package com.umc.product.test.adapter.in.web.dto;
 
-import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
 import java.util.List;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
 
 public record SeedProjectApplicationsResponse(
     int submittedCount,

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/SeedProjectApplicationsResponse.java
@@ -2,19 +2,68 @@ package com.umc.product.test.adapter.in.web.dto;
 
 import java.util.List;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
 
 public record SeedProjectApplicationsResponse(
-    int submittedCount,
-    int approvedCount,
-    int rejectedCount,
-    int failedCount,
-    List<FailedApplication> failures
+    Long matchingRoundId,
+    List<ProjectApplications> createdApplications,
+    List<FailedApplication> failedApplications,
+    Counts counts
 ) {
+
+    public record ProjectApplications(
+        Long projectId,
+        List<ApplicationEntry> applications
+    ) {
+
+        public static ProjectApplications from(SeedProjectApplicationsResult.ProjectApplications src) {
+            return new ProjectApplications(
+                src.projectId(),
+                src.applications().stream().map(ApplicationEntry::from).toList()
+            );
+        }
+    }
+
+    public record ApplicationEntry(
+        Long applicationId,
+        Long applicantMemberId,
+        ChallengerPart part,
+        ProjectApplicationStatus finalStatus
+    ) {
+
+        public static ApplicationEntry from(SeedProjectApplicationsResult.ApplicationEntry src) {
+            return new ApplicationEntry(
+                src.applicationId(),
+                src.applicantMemberId(),
+                src.part(),
+                src.finalStatus()
+            );
+        }
+    }
+
+    public record Counts(
+        int submittedTotal,
+        int approvedTotal,
+        int rejectedTotal,
+        int failedTotal
+    ) {
+
+        public static Counts from(SeedProjectApplicationsResult.Counts src) {
+            return new Counts(
+                src.submittedTotal(),
+                src.approvedTotal(),
+                src.rejectedTotal(),
+                src.failedTotal()
+            );
+        }
+    }
 
     public record FailedApplication(
         Long applicantMemberId,
         Long projectId,
+        Long applicationId,
         String failedStep,
         String reason
     ) {
@@ -23,6 +72,7 @@ public record SeedProjectApplicationsResponse(
             return new FailedApplication(
                 src.applicantMemberId(),
                 src.projectId(),
+                src.applicationId(),
                 src.failedStep(),
                 src.reason()
             );
@@ -31,11 +81,10 @@ public record SeedProjectApplicationsResponse(
 
     public static SeedProjectApplicationsResponse from(SeedProjectApplicationsResult result) {
         return new SeedProjectApplicationsResponse(
-            result.submittedCount(),
-            result.approvedCount(),
-            result.rejectedCount(),
-            result.failures().size(),
-            result.failures().stream().map(FailedApplication::from).toList()
+            result.matchingRoundId(),
+            result.createdApplications().stream().map(ProjectApplications::from).toList(),
+            result.failedApplications().stream().map(FailedApplication::from).toList(),
+            Counts.from(result.counts())
         );
     }
 }

--- a/src/main/java/com/umc/product/test/application/port/in/command/SeedProjectApplicationsUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/SeedProjectApplicationsUseCase.java
@@ -1,0 +1,16 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
+
+/**
+ * 지원서 시나리오 시딩 UseCase.
+ * <p>
+ * 지정 매칭 차수 + 지부 기준으로 아직 팀에 합류하지 않은 챌린저들이 랜덤 프로젝트에
+ * 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행한다.
+ * SQL 직접 주입이 아닌 도메인 UseCase 시퀀스 호출로 만들어진다.
+ */
+public interface SeedProjectApplicationsUseCase {
+
+    SeedProjectApplicationsResult seed(SeedProjectApplicationsCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
@@ -3,18 +3,18 @@ package com.umc.product.test.application.port.in.command.dto;
 /**
  * 지원서 시나리오 시딩 Command.
  * <p>
- * 지정 매칭 차수와 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
- * 랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행한다.
+ * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 IN_PROGRESS 프로젝트에
+ * 지원서를 제출한다. 각 챌린저는 도메인 시퀀스 (createDraft → fill → submit) 를 거친 뒤 최종 상태가
+ * {@code SUBMITTED} / {@code APPROVED} / {@code REJECTED} 중 하나로 무작위 결정된다 (≈ 1/3 분포).
+ * <p>
+ * ProjectMember 등록은 시딩이 손대지 않는다 — 정상 플로우인 차수 종료 시점의 {@code autoDecide} 에서 일괄 처리된다.
  *
- * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
+ * @param matchingRoundId 지원할 매칭 차수 ID. 현재 OPEN 상태여야 한다.
  * @param chapterId       대상 지부 ID. 해당 지부의 IN_PROGRESS 프로젝트가 지원 대상이 된다.
- * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0, 기본값 0.5).
- *                        나머지는 REJECTED 처리된다.
  */
 public record SeedProjectApplicationsCommand(
     Long matchingRoundId,
-    Long chapterId,
-    Double approveRatio
+    Long chapterId
 ) {
 
 }

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
@@ -1,0 +1,20 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+/**
+ * 지원서 시나리오 시딩 Command.
+ * <p>
+ * 지정 매칭 차수와 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
+ * 랜덤 프로젝트에 지원서를 제출하고 합불 결정까지 완료하는 시나리오를 실행한다.
+ *
+ * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
+ * @param chapterId       대상 지부 ID. 해당 지부의 IN_PROGRESS 프로젝트가 지원 대상이 된다.
+ * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0).
+ *                        나머지는 REJECTED 처리된다.
+ */
+public record SeedProjectApplicationsCommand(
+    Long matchingRoundId,
+    Long chapterId,
+    double approveRatio
+) {
+
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsCommand.java
@@ -8,13 +8,13 @@ package com.umc.product.test.application.port.in.command.dto;
  *
  * @param matchingRoundId 지원할 매칭 차수 ID. 반드시 현재 OPEN 상태여야 한다.
  * @param chapterId       대상 지부 ID. 해당 지부의 IN_PROGRESS 프로젝트가 지원 대상이 된다.
- * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0).
+ * @param approveRatio    SUBMITTED 지원서 중 APPROVED 처리할 비율 (0.0 ~ 1.0, 기본값 0.5).
  *                        나머지는 REJECTED 처리된다.
  */
 public record SeedProjectApplicationsCommand(
     Long matchingRoundId,
     Long chapterId,
-    double approveRatio
+    Double approveRatio
 ) {
 
 }

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsResult.java
@@ -1,0 +1,36 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import java.util.List;
+
+/**
+ * 지원서 시나리오 시딩 결과.
+ *
+ * @param submittedCount SUBMITTED 까지 완료된 지원서 수
+ * @param approvedCount  APPROVED 처리된 지원서 수 (ProjectMember 생성 포함)
+ * @param rejectedCount  REJECTED 처리된 지원서 수
+ * @param failures       단계 중간에 실패한 건 목록
+ */
+public record SeedProjectApplicationsResult(
+    int submittedCount,
+    int approvedCount,
+    int rejectedCount,
+    List<FailedApplication> failures
+) {
+
+    /**
+     * 중간 단계에서 실패한 지원서 건.
+     *
+     * @param applicantMemberId 지원자 Member ID
+     * @param projectId         지원 시도한 프로젝트 ID. Draft 생성 전 실패한 경우 null.
+     * @param failedStep        실패 단계 (DRAFT / FILL / SUBMIT / DECIDE / ADD_MEMBER)
+     * @param reason            실패 원인 메시지
+     */
+    public record FailedApplication(
+        Long applicantMemberId,
+        Long projectId,
+        String failedStep,
+        String reason
+    ) {
+
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/SeedProjectApplicationsResult.java
@@ -2,32 +2,81 @@ package com.umc.product.test.application.port.in.command.dto;
 
 import java.util.List;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+
 /**
  * 지원서 시나리오 시딩 결과.
  *
- * @param submittedCount SUBMITTED 까지 완료된 지원서 수
- * @param approvedCount  APPROVED 처리된 지원서 수 (ProjectMember 생성 포함)
- * @param rejectedCount  REJECTED 처리된 지원서 수
- * @param failures       단계 중간에 실패한 건 목록
+ * @param matchingRoundId      사용된 매칭 차수 ID
+ * @param createdApplications  성공한 지원서 — 프로젝트별로 그룹핑된 목록
+ * @param failedApplications   단계 중간에 실패한 건 목록
+ * @param counts               전체 통계 요약
  */
 public record SeedProjectApplicationsResult(
-    int submittedCount,
-    int approvedCount,
-    int rejectedCount,
-    List<FailedApplication> failures
+    Long matchingRoundId,
+    List<ProjectApplications> createdApplications,
+    List<FailedApplication> failedApplications,
+    Counts counts
 ) {
+
+    /**
+     * 한 프로젝트에 들어간 지원서 묶음.
+     */
+    public record ProjectApplications(
+        Long projectId,
+        List<ApplicationEntry> applications
+    ) {
+
+    }
+
+    /**
+     * 성공한 지원서 1건의 최종 정보.
+     *
+     * @param applicationId     ProjectApplication ID
+     * @param applicantMemberId 지원자 Member ID
+     * @param part              지원 파트 (= 챌린저 본인의 part)
+     * @param finalStatus       최종 status (SUBMITTED / APPROVED / REJECTED)
+     */
+    public record ApplicationEntry(
+        Long applicationId,
+        Long applicantMemberId,
+        ChallengerPart part,
+        ProjectApplicationStatus finalStatus
+    ) {
+
+    }
+
+    /**
+     * 시딩 호출 전체에 대한 카운트.
+     *
+     * @param submittedTotal 최종 SUBMITTED 상태로 남은 건 수
+     * @param approvedTotal  최종 APPROVED 처리된 건 수
+     * @param rejectedTotal  최종 REJECTED 처리된 건 수
+     * @param failedTotal    단계 중간에 실패한 건 수
+     */
+    public record Counts(
+        int submittedTotal,
+        int approvedTotal,
+        int rejectedTotal,
+        int failedTotal
+    ) {
+
+    }
 
     /**
      * 중간 단계에서 실패한 지원서 건.
      *
      * @param applicantMemberId 지원자 Member ID
-     * @param projectId         지원 시도한 프로젝트 ID. Draft 생성 전 실패한 경우 null.
-     * @param failedStep        실패 단계 (DRAFT / FILL / SUBMIT / DECIDE / ADD_MEMBER)
+     * @param projectId         지원 시도한 프로젝트 ID. NO_PROJECT 의 경우 null.
+     * @param applicationId     ProjectApplication ID. DRAFT 단계 실패 시 null.
+     * @param failedStep        실패 단계 (NO_PROJECT / DRAFT / FILL / SUBMIT / DECIDE)
      * @param reason            실패 원인 메시지
      */
     public record FailedApplication(
         Long applicantMemberId,
         Long projectId,
+        Long applicationId,
         String failedStep,
         String reason
     ) {

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -2,17 +2,15 @@ package com.umc.product.test.application.service;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,17 +30,11 @@ import com.umc.product.project.application.port.in.command.dto.SubmitProjectAppl
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
 import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectMatchingRoundUseCase;
-import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
-import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
-import com.umc.product.project.application.port.out.LoadProjectMemberPort;
-import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
-import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
-import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
-import com.umc.product.project.domain.ProjectApplication;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
@@ -55,13 +47,21 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * 지원서 시나리오 시딩 서비스.
  * <p>
- * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 랜덤 프로젝트에 Draft 생성 → 더미 답변 → Submit → 합불 결정 → APPROVED 시 ProjectMember
- * 등록까지 실행한다.
+ * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 IN_PROGRESS 프로젝트에
+ * Draft → 더미 답변 → Submit 까지 진행한다. 그 뒤 각 챌린저의 최종 상태는
+ * {@code SUBMITTED} / {@code APPROVED} / {@code REJECTED} 중 하나로 무작위 결정된다 (≈ 1/3 분포).
+ * 그 결과로 운영 화면의 "검토 대기 + 합격자 + 불합격자" 분포가 자연스럽게 채워진다.
  * <p>
- * <b>전제 조건</b>: 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 한다.
+ * <b>전제 조건</b>: 매칭 차수가 현재 OPEN 상태(startsAt &lt;= now &lt;= endsAt)여야 한다.
  * <p>
- * <b>트랜잭션 정책</b>: {@link Propagation#NOT_SUPPORTED}. 각 UseCase 가 자체 트랜잭션을 가지므로
- * 한 챌린저 시나리오가 실패해도 이전 성공 건은 commit 된다.
+ * <b>도메인 가드에 위임</b>: 자기지원 / 이미 팀원 / 같은 차수 중복 지원 / 파트 불일치 등은 시딩이 사전
+ * 필터링하지 않고 도메인 UseCase 가 던지는 가드 예외를 그대로 받아 {@code failedApplications} 에 누적한다.
+ * <p>
+ * <b>ProjectMember 등록은 시딩 책임 밖</b>: APPROVED status 만 변경하고 ProjectMember 는 생성하지 않는다.
+ * 매칭 완료 (APPROVED → ProjectMember 일괄 등록) 는 차수 종료 시점의 {@code autoDecide} 가 처리한다.
+ * <p>
+ * <b>트랜잭션 정책</b>: {@link Propagation#NOT_SUPPORTED}. 각 UseCase 가 자체 트랜잭션을 가지므로 한
+ * 챌린저 시나리오가 실패해도 이전 성공 건은 commit 된다.
  */
 @Slf4j
 @Service
@@ -71,28 +71,22 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class ProjectApplicationSeedService implements SeedProjectApplicationsUseCase {
 
+    private final GetGisuUseCase getGisuUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetProjectMatchingRoundUseCase getProjectMatchingRoundUseCase;
     private final GetProjectApplicationFormUseCase getProjectApplicationFormUseCase;
-    private final GetProjectUseCase getProjectUseCase;
-    private final GetGisuUseCase getGisuUseCase;
+    private final SearchProjectUseCase searchProjectUseCase;
 
     private final CreateDraftProjectApplicationUseCase createDraftProjectApplicationUseCase;
     private final UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
     private final SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
     private final DecideApplicationUseCase decideApplicationUseCase;
 
-    // 시딩 서비스 특성상 통계/조회용 Port 직접 주입 (UseCase 미존재 or 과도한 데이터 로딩 방지)
-    private final LoadProjectStatisticsPort loadProjectStatisticsPort;
-    private final LoadProjectApplicationPort loadProjectApplicationPort;
-    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
-    private final LoadProjectMemberPort loadProjectMemberPort;
-
     @Override
     public SeedProjectApplicationsResult seed(SeedProjectApplicationsCommand command) {
         long startedAt = System.currentTimeMillis();
 
-        // 1. 매칭차수 조회 - chapterId 소속 여부 검증 및 type 파악
+        // 1. 매칭차수 조회 — chapterId 소속 + OPEN 검증
         ProjectMatchingRoundInfo round = getProjectMatchingRoundUseCase
             .list(command.chapterId(), null).stream()
             .filter(r -> r.id().equals(command.matchingRoundId()))
@@ -102,7 +96,6 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                     .formatted(command.matchingRoundId(), command.chapterId())
             ));
 
-        // 1-a. 차수 OPEN 검증 — 닫힌 차수면 모든 챌린저가 도메인 가드에 막혀 의미 없는 N번 실패가 됨
         Instant now = Instant.now();
         if (now.isBefore(round.startsAt()) || now.isAfter(round.endsAt())) {
             throw new IllegalArgumentException(
@@ -111,66 +104,35 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             );
         }
 
-        // 2. 지부 내 IN_PROGRESS 프로젝트 목록
-        List<ProjectStatisticsProjectRow> projects =
-            loadProjectStatisticsPort.listProjectsByChapterId(command.chapterId());
+        // 2. 차수 type 에 맞는 ACTIVE 챌린저 풀 — 사전 필터링은 part 와 status 만, 나머지는 도메인 가드 위임
+        Long gisuId = getGisuUseCase.getActiveGisuId();
+        Set<ChallengerPart> eligibleParts = eligibleParts(round.type());
+        List<ChallengerInfo> challengers = getChallengerUseCase.getAllByGisuId(gisuId).stream()
+            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
+            .filter(c -> eligibleParts.contains(c.part()))
+            .toList();
+
+        if (challengers.isEmpty()) {
+            log.warn("project application seed skipped: gisuId={} 에 type={} 챌린저가 없습니다.",
+                gisuId, round.type());
+            return new SeedProjectApplicationsResult(0, 0, 0, List.of());
+        }
+
+        // 3. 지부의 IN_PROGRESS 프로젝트 목록 — 챌린저 시점 검색 호출자로 풀의 첫 ID 사용
+        Long searcherMemberId = challengers.get(0).memberId();
+        Page<ProjectInfo> projectPage = searchProjectUseCase.search(
+            SearchProjectQuery.forChallenger(
+                gisuId, null, command.chapterId(), null, null, null, Pageable.unpaged()
+            ),
+            searcherMemberId
+        );
+        List<ProjectInfo> projects = projectPage.getContent();
+
         if (projects.isEmpty()) {
             log.warn("project application seed skipped: chapterId={} 에 IN_PROGRESS 프로젝트가 없습니다.",
                 command.chapterId());
             return new SeedProjectApplicationsResult(0, 0, 0, List.of());
         }
-
-        Set<Long> projectIds = projects.stream()
-            .map(ProjectStatisticsProjectRow::projectId)
-            .collect(Collectors.toSet());
-        Long gisuId = getGisuUseCase.getActiveGisuId();
-
-        // 3. 프로젝트별 PO memberId 사전 캐시 (AddProjectMemberUseCase requesterMemberId 용)
-        Map<Long, Long> ownerByProjectId = projectIds.stream()
-            .collect(Collectors.toMap(
-                id -> id,
-                id -> getProjectUseCase.getById(id).productOwnerMemberId()
-            ));
-
-        // 4. 프로젝트별 파트 TO 사전 캐시
-        Map<Long, Map<ChallengerPart, Long>> quotaByProject =
-            loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(projectIds).entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> e.getValue().stream().collect(
-                        Collectors.toMap(ProjectPartQuota::getPart, ProjectPartQuota::getQuota))
-                ));
-
-        // 4-1. 프로젝트별·파트별 현재 ACTIVE 멤버 수 캐시 (쿼터 초과 방지용, 시딩 중 인메모리 갱신)
-        Map<Long, Map<ChallengerPart, Long>> currentMemberCounts =
-            loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(projectIds).entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> new HashMap<>(e.getValue()),
-                    (a, b) -> a,
-                    HashMap::new
-                ));
-
-        // 4-2. 이미 팀원인 memberId Set 배치 조회 (N+1 방지 — 챌린저 풀 필터링에 사용)
-        Set<Long> alreadyMemberIds = loadProjectMemberPort.listByProjectIds(projectIds).values().stream()
-            .flatMap(List::stream)
-            .map(ProjectMember::getMemberId)
-            .collect(Collectors.toSet());
-
-        // 5. 이미 해당 차수에 지원한 memberId Set (중복 지원 방지)
-        Set<Long> alreadyApplied = loadProjectApplicationPort
-            .listByMatchingRoundId(command.matchingRoundId()).stream()
-            .map(ProjectApplication::getApplicantMemberId)
-            .collect(Collectors.toSet());
-
-        // 6. 매칭차수 type에 맞는 ACTIVE 챌린저 풀 구성 (이미 팀원이거나 이미 지원한 챌린저 제외)
-        Set<ChallengerPart> eligibleParts = eligibleParts(round.type());
-        List<ChallengerInfo> challengers = getChallengerUseCase.getAllByGisuId(gisuId).stream()
-            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
-            .filter(c -> eligibleParts.contains(c.part()))
-            .filter(c -> !alreadyApplied.contains(c.memberId()))
-            .filter(c -> !alreadyMemberIds.contains(c.memberId()))
-            .toList();
 
         log.info(
             "project application seed start: chapterId={}, matchingRoundId={}, roundType={}, "
@@ -179,58 +141,39 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             projects.size(), challengers.size()
         );
 
-        // 7. 챌린저마다 시나리오 실행
+        // 4. 각 챌린저마다 시나리오 실행
         List<FailedApplication> failures = new ArrayList<>();
         int submittedCount = 0;
         int approvedCount = 0;
         int rejectedCount = 0;
 
         for (ChallengerInfo challenger : challengers) {
-            // 쿼터 여유분이 있는 프로젝트만 후보로 포함 (현재 ACTIVE 수 < 쿼터)
-            List<Long> candidates = projectIds.stream()
-                .filter(pid -> {
-                    Long quota = quotaByProject.getOrDefault(pid, Map.of()).get(challenger.part());
-                    if (quota == null) {
-                        return false;
-                    }
-                    long current = currentMemberCounts
-                        .getOrDefault(pid, Map.of())
-                        .getOrDefault(challenger.part(), 0L);
-                    return current < quota;
-                })
-                .filter(pid -> !ownerByProjectId.get(pid).equals(challenger.memberId()))
-                .collect(Collectors.toList());
+            // 본인 part 모집 중이고 본인이 PO 가 아닌 프로젝트 후보 — 나머지 (이미 팀원/지원 등) 는 도메인 가드 위임
+            List<ProjectInfo> candidates = projects.stream()
+                .filter(p -> p.partQuotas().stream().anyMatch(q -> q.part() == challenger.part()))
+                .filter(p -> !p.productOwnerMemberId().equals(challenger.memberId()))
+                .toList();
 
             if (candidates.isEmpty()) {
                 failures.add(new FailedApplication(
                     challenger.memberId(), null, "NO_PROJECT",
-                    "파트=%s 를 모집하는 프로젝트가 없거나 모든 프로젝트의 쿼터가 소진되었습니다.".formatted(challenger.part())
+                    "파트=%s 를 모집하는 프로젝트가 없습니다.".formatted(challenger.part())
                 ));
                 continue;
             }
 
-            Collections.shuffle(candidates);
-            Long projectId = candidates.get(0);
-            Long poMemberId = ownerByProjectId.get(projectId);
+            ProjectInfo picked = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+            Long projectId = picked.id();
+            Long poMemberId = picked.productOwnerMemberId();
 
             ApplicationOutcome outcome = runApplicationScenario(
-                challenger, projectId, poMemberId, command.matchingRoundId(), command.approveRatio()
+                challenger, projectId, poMemberId, command.matchingRoundId()
             );
 
             switch (outcome.step()) {
-                case "APPROVED" -> {
-                    submittedCount++;
-                    approvedCount++;
-                    // 이번 호출 안에서 같은 프로젝트·파트 쿼터 여유분이 다음 챌린저 후보 필터에 반영되도록 갱신.
-                    // ProjectMember 직접 추가는 도메인 정상 플로우(autoDecide)가 처리해야 하므로 시딩이 손대지 않는다.
-                    currentMemberCounts
-                        .computeIfAbsent(projectId, k -> new HashMap<>())
-                        .merge(challenger.part(), 1L, Long::sum);
-                }
-                case "REJECTED" -> {
-                    submittedCount++;
-                    rejectedCount++;
-                }
+                case "SUBMITTED" -> submittedCount++;
+                case "APPROVED" -> approvedCount++;
+                case "REJECTED" -> rejectedCount++;
                 default -> failures.add(new FailedApplication(
                     challenger.memberId(), projectId, outcome.step(), outcome.reason()
                 ));
@@ -247,8 +190,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
     }
 
     private ApplicationOutcome runApplicationScenario(
-        ChallengerInfo challenger, Long projectId, Long poMemberId,
-        Long matchingRoundId, Double approveRatio
+        ChallengerInfo challenger, Long projectId, Long poMemberId, Long matchingRoundId
     ) {
         // DRAFT 생성
         Long applicationId;
@@ -299,10 +241,16 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             return ApplicationOutcome.fail("SUBMIT", e.toString());
         }
 
-        // 합불 결정
-        boolean approve = ThreadLocalRandom.current().nextDouble() < approveRatio;
-        ApplicationDecisionStatus decision =
-            approve ? ApplicationDecisionStatus.APPROVED : ApplicationDecisionStatus.REJECTED;
+        // 최종 상태 무작위 결정: SUBMITTED / APPROVED / REJECTED ≈ 1/3 분포
+        // 도메인이 상태 토글을 자유롭게 허용하므로 어떤 분포든 운영자가 화면에서 보정 가능 (revertToPending 등).
+        int rand = ThreadLocalRandom.current().nextInt(3);
+        if (rand == 0) {
+            return ApplicationOutcome.success("SUBMITTED");
+        }
+
+        ApplicationDecisionStatus decision = (rand == 1)
+            ? ApplicationDecisionStatus.APPROVED
+            : ApplicationDecisionStatus.REJECTED;
         try {
             decideApplicationUseCase.decide(applicationId, decision, null, poMemberId);
         } catch (Exception e) {
@@ -310,12 +258,12 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                 challenger.memberId(), projectId, decision, e.toString());
             return ApplicationOutcome.fail("DECIDE", e.toString());
         }
-
-        return ApplicationOutcome.success(approve ? "APPROVED" : "REJECTED");
+        return ApplicationOutcome.success(decision.name());
     }
 
     /**
-     * isRequired=true 인 질문만 추려 더미 텍스트 답변을 구성한다. 챌린저 시점으로 form 조회 — COMMON 섹션 + 본인 파트 PART 섹션만 노출되어 마스킹된 섹션은 자동 제외된다.
+     * isRequired=true 인 질문만 추려 더미 텍스트 답변을 구성한다. 챌린저 시점으로 form 조회 — COMMON 섹션 +
+     * 본인 파트 PART 섹션만 노출되어 마스킹된 섹션은 자동 제외된다.
      */
     private List<UpdateProjectApplicationDraftCommand.AnswerEntry> buildDummyAnswers(
         Long projectId, Long challengerMemberId

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -21,6 +21,7 @@ import com.umc.product.project.application.port.in.query.GetProjectUseCase;
 import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
@@ -34,6 +35,7 @@ import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicati
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,8 +52,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 지원서 시나리오 시딩 서비스.
  * <p>
- * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 랜덤 프로젝트에
- * Draft 생성 → 더미 답변 → Submit → 합불 결정 → APPROVED 시 ProjectMember 등록까지 실행한다.
+ * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 랜덤 프로젝트에 Draft 생성 → 더미 답변 → Submit → 합불 결정 → APPROVED 시 ProjectMember
+ * 등록까지 실행한다.
  * <p>
  * <b>전제 조건</b>: 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 한다.
  * <p>
@@ -82,6 +84,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
     private final LoadProjectStatisticsPort loadProjectStatisticsPort;
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
 
     @Override
     public SeedProjectApplicationsResult seed(SeedProjectApplicationsCommand command) {
@@ -127,6 +130,16 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                         Collectors.toMap(ProjectPartQuota::getPart, ProjectPartQuota::getQuota))
                 ));
 
+        // 4-1. 프로젝트별·파트별 현재 ACTIVE 멤버 수 캐시 (쿼터 초과 방지용, 시딩 중 인메모리 갱신)
+        Map<Long, Map<ChallengerPart, Long>> currentMemberCounts =
+            loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(projectIds).entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> new HashMap<>(e.getValue()),
+                    (a, b) -> a,
+                    HashMap::new
+                ));
+
         // 5. 이미 해당 차수에 지원한 memberId Set (중복 지원 방지)
         Set<Long> alreadyApplied = loadProjectApplicationPort
             .listByMatchingRoundId(command.matchingRoundId()).stream()
@@ -155,15 +168,25 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         int rejectedCount = 0;
 
         for (ChallengerInfo challenger : challengers) {
+            // 쿼터 여유분이 있는 프로젝트만 후보로 포함 (현재 ACTIVE 수 < 쿼터)
             List<Long> candidates = projectIds.stream()
-                .filter(pid -> quotaByProject.getOrDefault(pid, Map.of()).containsKey(challenger.part()))
+                .filter(pid -> {
+                    Long quota = quotaByProject.getOrDefault(pid, Map.of()).get(challenger.part());
+                    if (quota == null) {
+                        return false;
+                    }
+                    long current = currentMemberCounts
+                        .getOrDefault(pid, Map.of())
+                        .getOrDefault(challenger.part(), 0L);
+                    return current < quota;
+                })
                 .filter(pid -> !ownerByProjectId.get(pid).equals(challenger.memberId()))
                 .collect(Collectors.toList());
 
             if (candidates.isEmpty()) {
                 failures.add(new FailedApplication(
                     challenger.memberId(), null, "NO_PROJECT",
-                    "파트=%s 를 모집하는 프로젝트가 없습니다.".formatted(challenger.part())
+                    "파트=%s 를 모집하는 프로젝트가 없거나 모든 프로젝트의 쿼터가 소진되었습니다.".formatted(challenger.part())
                 ));
                 continue;
             }
@@ -181,6 +204,10 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                 case "APPROVED" -> {
                     submittedCount++;
                     approvedCount++;
+                    // ADD_MEMBER 성공 → 인메모리 카운트 갱신 (다음 챌린저의 쿼터 여유분 계산에 반영)
+                    currentMemberCounts
+                        .computeIfAbsent(projectId, k -> new HashMap<>())
+                        .merge(challenger.part(), 1L, Long::sum);
                 }
                 case "REJECTED" -> {
                     submittedCount++;
@@ -203,7 +230,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
 
     private ApplicationOutcome runApplicationScenario(
         ChallengerInfo challenger, Long projectId, Long poMemberId,
-        Long matchingRoundId, double approveRatio
+        Long matchingRoundId, Double approveRatio
     ) {
         // DRAFT 생성
         Long applicationId;
@@ -290,8 +317,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
     }
 
     /**
-     * isRequired=true 인 질문만 추려 더미 텍스트 답변을 구성한다.
-     * 챌린저 시점으로 form 조회 — COMMON 섹션 + 본인 파트 PART 섹션만 노출되어 마스킹된 섹션은 자동 제외된다.
+     * isRequired=true 인 질문만 추려 더미 텍스트 답변을 구성한다. 챌린저 시점으로 form 조회 — COMMON 섹션 + 본인 파트 PART 섹션만 노출되어 마스킹된 섹션은 자동 제외된다.
      */
     private List<UpdateProjectApplicationDraftCommand.AnswerEntry> buildDummyAnswers(
         Long projectId, Long challengerMemberId

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -146,12 +146,13 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             .map(ProjectApplication::getApplicantMemberId)
             .collect(Collectors.toSet());
 
-        // 6. 매칭차수 type에 맞는 ACTIVE 챌린저 풀 구성
+        // 6. 매칭차수 type에 맞는 ACTIVE 챌린저 풀 구성 (이미 팀원이거나 이미 지원한 챌린저 제외)
         Set<ChallengerPart> eligibleParts = eligibleParts(round.type());
         List<ChallengerInfo> challengers = getChallengerUseCase.getAllByGisuId(gisuId).stream()
             .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
             .filter(c -> eligibleParts.contains(c.part()))
             .filter(c -> !alreadyApplied.contains(c.memberId()))
+            .filter(c -> !loadProjectMemberPort.existsByGisuAndMember(gisuId, c.memberId()))
             .toList();
 
         log.info(

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -3,7 +3,9 @@ package com.umc.product.test.application.service;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -36,10 +38,14 @@ import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.ApplicationEntry;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.Counts;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.FailedApplication;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.ProjectApplications;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -115,7 +121,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         if (challengers.isEmpty()) {
             log.warn("project application seed skipped: gisuId={} 에 type={} 챌린저가 없습니다.",
                 gisuId, round.type());
-            return new SeedProjectApplicationsResult(0, 0, 0, List.of());
+            return emptyResult(command.matchingRoundId());
         }
 
         // 3. 지부의 IN_PROGRESS 프로젝트 목록 — 챌린저 시점 검색 호출자로 풀의 첫 ID 사용
@@ -131,7 +137,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         if (projects.isEmpty()) {
             log.warn("project application seed skipped: chapterId={} 에 IN_PROGRESS 프로젝트가 없습니다.",
                 command.chapterId());
-            return new SeedProjectApplicationsResult(0, 0, 0, List.of());
+            return emptyResult(command.matchingRoundId());
         }
 
         log.info(
@@ -142,6 +148,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         );
 
         // 4. 각 챌린저마다 시나리오 실행
+        Map<Long, List<ApplicationEntry>> applicationsByProject = new LinkedHashMap<>();
         List<FailedApplication> failures = new ArrayList<>();
         int submittedCount = 0;
         int approvedCount = 0;
@@ -156,7 +163,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
 
             if (candidates.isEmpty()) {
                 failures.add(new FailedApplication(
-                    challenger.memberId(), null, "NO_PROJECT",
+                    challenger.memberId(), null, null, "NO_PROJECT",
                     "파트=%s 를 모집하는 프로젝트가 없습니다.".formatted(challenger.part())
                 ));
                 continue;
@@ -171,11 +178,24 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             );
 
             switch (outcome.step()) {
-                case "SUBMITTED" -> submittedCount++;
-                case "APPROVED" -> approvedCount++;
-                case "REJECTED" -> rejectedCount++;
+                case "SUBMITTED" -> {
+                    submittedCount++;
+                    recordApplication(applicationsByProject, projectId, outcome.applicationId(),
+                        challenger, ProjectApplicationStatus.SUBMITTED);
+                }
+                case "APPROVED" -> {
+                    approvedCount++;
+                    recordApplication(applicationsByProject, projectId, outcome.applicationId(),
+                        challenger, ProjectApplicationStatus.APPROVED);
+                }
+                case "REJECTED" -> {
+                    rejectedCount++;
+                    recordApplication(applicationsByProject, projectId, outcome.applicationId(),
+                        challenger, ProjectApplicationStatus.REJECTED);
+                }
                 default -> failures.add(new FailedApplication(
-                    challenger.memberId(), projectId, outcome.step(), outcome.reason()
+                    challenger.memberId(), projectId, outcome.applicationId(),
+                    outcome.step(), outcome.reason()
                 ));
             }
         }
@@ -186,7 +206,28 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             elapsed, submittedCount, approvedCount, rejectedCount, failures.size()
         );
 
-        return new SeedProjectApplicationsResult(submittedCount, approvedCount, rejectedCount, failures);
+        List<ProjectApplications> createdApplications = applicationsByProject.entrySet().stream()
+            .map(e -> new ProjectApplications(e.getKey(), e.getValue()))
+            .toList();
+        Counts counts = new Counts(submittedCount, approvedCount, rejectedCount, failures.size());
+        return new SeedProjectApplicationsResult(
+            command.matchingRoundId(), createdApplications, failures, counts
+        );
+    }
+
+    private SeedProjectApplicationsResult emptyResult(Long matchingRoundId) {
+        return new SeedProjectApplicationsResult(
+            matchingRoundId, List.of(), List.of(), new Counts(0, 0, 0, 0)
+        );
+    }
+
+    private void recordApplication(
+        Map<Long, List<ApplicationEntry>> byProject,
+        Long projectId, Long applicationId,
+        ChallengerInfo challenger, ProjectApplicationStatus status
+    ) {
+        byProject.computeIfAbsent(projectId, k -> new ArrayList<>())
+            .add(new ApplicationEntry(applicationId, challenger.memberId(), challenger.part(), status));
     }
 
     private ApplicationOutcome runApplicationScenario(
@@ -205,7 +246,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         } catch (Exception e) {
             log.error("seed DRAFT 실패 (memberId={}, projectId={}): {}",
                 challenger.memberId(), projectId, e.toString());
-            return ApplicationOutcome.fail("DRAFT", e.toString());
+            return ApplicationOutcome.fail("DRAFT", e.toString(), null);
         }
 
         // 더미 답변 채우기 (isRequired=true 질문 대응)
@@ -224,7 +265,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         } catch (Exception e) {
             log.error("seed FILL 실패 (memberId={}, projectId={}): {}",
                 challenger.memberId(), projectId, e.toString());
-            return ApplicationOutcome.fail("FILL", e.toString());
+            return ApplicationOutcome.fail("FILL", e.toString(), applicationId);
         }
 
         // 제출
@@ -238,14 +279,14 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         } catch (Exception e) {
             log.error("seed SUBMIT 실패 (memberId={}, projectId={}): {}",
                 challenger.memberId(), projectId, e.toString());
-            return ApplicationOutcome.fail("SUBMIT", e.toString());
+            return ApplicationOutcome.fail("SUBMIT", e.toString(), applicationId);
         }
 
         // 최종 상태 무작위 결정: SUBMITTED / APPROVED / REJECTED ≈ 1/3 분포
         // 도메인이 상태 토글을 자유롭게 허용하므로 어떤 분포든 운영자가 화면에서 보정 가능 (revertToPending 등).
         int rand = ThreadLocalRandom.current().nextInt(3);
         if (rand == 0) {
-            return ApplicationOutcome.success("SUBMITTED");
+            return ApplicationOutcome.success("SUBMITTED", applicationId);
         }
 
         ApplicationDecisionStatus decision = (rand == 1)
@@ -256,9 +297,9 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         } catch (Exception e) {
             log.error("seed DECIDE 실패 (memberId={}, projectId={}, decision={}): {}",
                 challenger.memberId(), projectId, decision, e.toString());
-            return ApplicationOutcome.fail("DECIDE", e.toString());
+            return ApplicationOutcome.fail("DECIDE", e.toString(), applicationId);
         }
-        return ApplicationOutcome.success(decision.name());
+        return ApplicationOutcome.success(decision.name(), applicationId);
     }
 
     /**
@@ -296,14 +337,14 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
         );
     }
 
-    private record ApplicationOutcome(String step, String reason) {
+    private record ApplicationOutcome(String step, String reason, Long applicationId) {
 
-        static ApplicationOutcome success(String step) {
-            return new ApplicationOutcome(step, null);
+        static ApplicationOutcome success(String step, Long applicationId) {
+            return new ApplicationOutcome(step, null, applicationId);
         }
 
-        static ApplicationOutcome fail(String step, String reason) {
-            return new ApplicationOutcome(step, reason);
+        static ApplicationOutcome fail(String step, String reason, Long applicationId) {
+            return new ApplicationOutcome(step, reason, applicationId);
         }
     }
 }

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -1,0 +1,337 @@
+package com.umc.product.test.application.service;
+
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
+import com.umc.product.project.application.port.in.command.dto.AddProjectMemberCommand;
+import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
+import com.umc.product.project.application.port.in.query.GetProjectApplicationFormUseCase;
+import com.umc.product.project.application.port.in.query.GetProjectMatchingRoundUseCase;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ApplicationFormInfo;
+import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
+import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
+import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
+import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.FailedApplication;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 지원서 시나리오 시딩 서비스.
+ * <p>
+ * 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이 랜덤 프로젝트에
+ * Draft 생성 → 더미 답변 → Submit → 합불 결정 → APPROVED 시 ProjectMember 등록까지 실행한다.
+ * <p>
+ * <b>전제 조건</b>: 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 한다.
+ * <p>
+ * <b>트랜잭션 정책</b>: {@link Propagation#NOT_SUPPORTED}. 각 UseCase 가 자체 트랜잭션을 가지므로
+ * 한 챌린저 시나리오가 실패해도 이전 성공 건은 commit 된다.
+ */
+@Slf4j
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class ProjectApplicationSeedService implements SeedProjectApplicationsUseCase {
+
+    private final GetChallengerUseCase getChallengerUseCase;
+    private final GetProjectMatchingRoundUseCase getProjectMatchingRoundUseCase;
+    private final GetProjectApplicationFormUseCase getProjectApplicationFormUseCase;
+    private final GetProjectUseCase getProjectUseCase;
+    private final GetGisuUseCase getGisuUseCase;
+
+    private final CreateDraftProjectApplicationUseCase createDraftProjectApplicationUseCase;
+    private final UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
+    private final SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
+    private final DecideApplicationUseCase decideApplicationUseCase;
+    private final AddProjectMemberUseCase addProjectMemberUseCase;
+
+    // 시딩 서비스 특성상 통계/조회용 Port 직접 주입 (UseCase 미존재 or 과도한 데이터 로딩 방지)
+    private final LoadProjectStatisticsPort loadProjectStatisticsPort;
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
+    private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
+
+    @Override
+    public SeedProjectApplicationsResult seed(SeedProjectApplicationsCommand command) {
+        long startedAt = System.currentTimeMillis();
+
+        // 1. 매칭차수 조회 - chapterId 소속 여부 검증 및 type 파악
+        ProjectMatchingRoundInfo round = getProjectMatchingRoundUseCase
+            .list(command.chapterId(), null).stream()
+            .filter(r -> r.id().equals(command.matchingRoundId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                "matchingRoundId=%d 가 chapterId=%d 에 속하지 않습니다."
+                    .formatted(command.matchingRoundId(), command.chapterId())
+            ));
+
+        // 2. 지부 내 IN_PROGRESS 프로젝트 목록
+        List<ProjectStatisticsProjectRow> projects =
+            loadProjectStatisticsPort.listProjectsByChapterId(command.chapterId());
+        if (projects.isEmpty()) {
+            log.warn("project application seed skipped: chapterId={} 에 IN_PROGRESS 프로젝트가 없습니다.",
+                command.chapterId());
+            return new SeedProjectApplicationsResult(0, 0, 0, List.of());
+        }
+
+        Set<Long> projectIds = projects.stream()
+            .map(ProjectStatisticsProjectRow::projectId)
+            .collect(Collectors.toSet());
+        Long gisuId = getGisuUseCase.getActiveGisuId();
+
+        // 3. 프로젝트별 PO memberId 사전 캐시 (AddProjectMemberUseCase requesterMemberId 용)
+        Map<Long, Long> ownerByProjectId = projectIds.stream()
+            .collect(Collectors.toMap(
+                id -> id,
+                id -> getProjectUseCase.getById(id).productOwnerMemberId()
+            ));
+
+        // 4. 프로젝트별 파트 TO 사전 캐시
+        Map<Long, Map<ChallengerPart, Long>> quotaByProject =
+            loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(projectIds).entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().stream().collect(
+                        Collectors.toMap(ProjectPartQuota::getPart, ProjectPartQuota::getQuota))
+                ));
+
+        // 5. 이미 해당 차수에 지원한 memberId Set (중복 지원 방지)
+        Set<Long> alreadyApplied = loadProjectApplicationPort
+            .listByMatchingRoundId(command.matchingRoundId()).stream()
+            .map(ProjectApplication::getApplicantMemberId)
+            .collect(Collectors.toSet());
+
+        // 6. 매칭차수 type에 맞는 ACTIVE 챌린저 풀 구성
+        Set<ChallengerPart> eligibleParts = eligibleParts(round.type());
+        List<ChallengerInfo> challengers = getChallengerUseCase.getAllByGisuId(gisuId).stream()
+            .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
+            .filter(c -> eligibleParts.contains(c.part()))
+            .filter(c -> !alreadyApplied.contains(c.memberId()))
+            .toList();
+
+        log.info(
+            "project application seed start: chapterId={}, matchingRoundId={}, roundType={}, "
+                + "projectCount={}, challengerPoolSize={}",
+            command.chapterId(), command.matchingRoundId(), round.type(),
+            projects.size(), challengers.size()
+        );
+
+        // 7. 챌린저마다 시나리오 실행
+        List<FailedApplication> failures = new ArrayList<>();
+        int submittedCount = 0;
+        int approvedCount = 0;
+        int rejectedCount = 0;
+
+        for (ChallengerInfo challenger : challengers) {
+            List<Long> candidates = projectIds.stream()
+                .filter(pid -> quotaByProject.getOrDefault(pid, Map.of()).containsKey(challenger.part()))
+                .filter(pid -> !ownerByProjectId.get(pid).equals(challenger.memberId()))
+                .collect(Collectors.toList());
+
+            if (candidates.isEmpty()) {
+                failures.add(new FailedApplication(
+                    challenger.memberId(), null, "NO_PROJECT",
+                    "파트=%s 를 모집하는 프로젝트가 없습니다.".formatted(challenger.part())
+                ));
+                continue;
+            }
+
+            Collections.shuffle(candidates);
+            Long projectId = candidates.get(0);
+            Long poMemberId = ownerByProjectId.get(projectId);
+
+            ApplicationOutcome outcome = runApplicationScenario(
+                challenger, projectId, poMemberId, command.matchingRoundId(), command.approveRatio()
+            );
+
+            switch (outcome.step()) {
+                case "SUBMITTED" -> submittedCount++;
+                case "APPROVED" -> {
+                    submittedCount++;
+                    approvedCount++;
+                }
+                case "REJECTED" -> {
+                    submittedCount++;
+                    rejectedCount++;
+                }
+                default -> failures.add(new FailedApplication(
+                    challenger.memberId(), projectId, outcome.step(), outcome.reason()
+                ));
+            }
+        }
+
+        long elapsed = System.currentTimeMillis() - startedAt;
+        log.info(
+            "project application seed completed in {}ms: submitted={}, approved={}, rejected={}, failed={}",
+            elapsed, submittedCount, approvedCount, rejectedCount, failures.size()
+        );
+
+        return new SeedProjectApplicationsResult(submittedCount, approvedCount, rejectedCount, failures);
+    }
+
+    private ApplicationOutcome runApplicationScenario(
+        ChallengerInfo challenger, Long projectId, Long poMemberId,
+        Long matchingRoundId, double approveRatio
+    ) {
+        // DRAFT 생성
+        Long applicationId;
+        try {
+            applicationId = createDraftProjectApplicationUseCase.create(
+                CreateDraftProjectApplicationCommand.builder()
+                    .projectId(projectId)
+                    .applicantMemberId(challenger.memberId())
+                    .matchingRoundId(matchingRoundId)
+                    .build()
+            ).applicationId();
+        } catch (Exception e) {
+            log.error("seed DRAFT 실패 (memberId={}, projectId={}): {}",
+                challenger.memberId(), projectId, e.toString());
+            return ApplicationOutcome.fail("DRAFT", e.toString());
+        }
+
+        // 더미 답변 채우기 (isRequired=true 질문 대응)
+        try {
+            List<UpdateProjectApplicationDraftCommand.AnswerEntry> answers =
+                buildDummyAnswers(projectId, challenger.memberId());
+            if (!answers.isEmpty()) {
+                updateProjectApplicationDraftUseCase.update(
+                    UpdateProjectApplicationDraftCommand.builder()
+                        .projectId(projectId)
+                        .requesterMemberId(challenger.memberId())
+                        .answers(answers)
+                        .build()
+                );
+            }
+        } catch (Exception e) {
+            log.error("seed FILL 실패 (memberId={}, projectId={}): {}",
+                challenger.memberId(), projectId, e.toString());
+            return ApplicationOutcome.fail("FILL", e.toString());
+        }
+
+        // 제출
+        try {
+            submitProjectApplicationUseCase.submit(
+                SubmitProjectApplicationCommand.builder()
+                    .projectId(projectId)
+                    .requesterMemberId(challenger.memberId())
+                    .build()
+            );
+        } catch (Exception e) {
+            log.error("seed SUBMIT 실패 (memberId={}, projectId={}): {}",
+                challenger.memberId(), projectId, e.toString());
+            return ApplicationOutcome.fail("SUBMIT", e.toString());
+        }
+
+        // 합불 결정
+        boolean approve = ThreadLocalRandom.current().nextDouble() < approveRatio;
+        ApplicationDecisionStatus decision =
+            approve ? ApplicationDecisionStatus.APPROVED : ApplicationDecisionStatus.REJECTED;
+        try {
+            decideApplicationUseCase.decide(applicationId, decision, null, poMemberId);
+        } catch (Exception e) {
+            log.error("seed DECIDE 실패 (memberId={}, projectId={}, decision={}): {}",
+                challenger.memberId(), projectId, decision, e.toString());
+            return ApplicationOutcome.fail("DECIDE", e.toString());
+        }
+
+        if (!approve) {
+            return ApplicationOutcome.success("REJECTED");
+        }
+
+        // APPROVED → ProjectMember 추가 (통계의 APPROVED + ACTIVE 교집합 조건 충족용)
+        try {
+            addProjectMemberUseCase.add(
+                AddProjectMemberCommand.builder()
+                    .projectId(projectId)
+                    .memberId(challenger.memberId())
+                    .part(challenger.part())
+                    .requesterMemberId(poMemberId)
+                    .build()
+            );
+        } catch (Exception e) {
+            log.error("seed ADD_MEMBER 실패 (memberId={}, projectId={}): {}",
+                challenger.memberId(), projectId, e.toString());
+            return ApplicationOutcome.fail("ADD_MEMBER", e.toString());
+        }
+
+        return ApplicationOutcome.success("APPROVED");
+    }
+
+    /**
+     * isRequired=true 인 질문만 추려 더미 텍스트 답변을 구성한다.
+     * 챌린저 시점으로 form 조회 — COMMON 섹션 + 본인 파트 PART 섹션만 노출되어 마스킹된 섹션은 자동 제외된다.
+     */
+    private List<UpdateProjectApplicationDraftCommand.AnswerEntry> buildDummyAnswers(
+        Long projectId, Long challengerMemberId
+    ) {
+        return getProjectApplicationFormUseCase
+            .findByProjectId(projectId, challengerMemberId)
+            .map(form -> form.sections().stream()
+                .flatMap(s -> s.questions().stream())
+                .filter(ApplicationFormInfo.QuestionInfo::isRequired)
+                .map(q -> UpdateProjectApplicationDraftCommand.AnswerEntry.builder()
+                    .questionId(q.questionId())
+                    .textValue("[시딩 더미 답변]")
+                    .selectedOptionIds(List.of())
+                    .fileIds(List.of())
+                    .build())
+                .toList())
+            .orElse(List.of());
+    }
+
+    private Set<ChallengerPart> eligibleParts(MatchingType type) {
+        if (type == MatchingType.PLAN_DESIGN) {
+            return EnumSet.of(ChallengerPart.DESIGN);
+        }
+        return EnumSet.of(
+            ChallengerPart.WEB,
+            ChallengerPart.ANDROID,
+            ChallengerPart.IOS,
+            ChallengerPart.NODEJS,
+            ChallengerPart.SPRINGBOOT
+        );
+    }
+
+    private record ApplicationOutcome(String step, String reason) {
+
+        static ApplicationOutcome success(String step) {
+            return new ApplicationOutcome(step, null);
+        }
+
+        static ApplicationOutcome fail(String step, String reason) {
+            return new ApplicationOutcome(step, reason);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -1,5 +1,6 @@
 package com.umc.product.test.application.service;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -21,12 +22,10 @@ import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
-import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
-import com.umc.product.project.application.port.in.command.dto.AddProjectMemberCommand;
 import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
@@ -82,7 +81,6 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
     private final UpdateProjectApplicationDraftUseCase updateProjectApplicationDraftUseCase;
     private final SubmitProjectApplicationUseCase submitProjectApplicationUseCase;
     private final DecideApplicationUseCase decideApplicationUseCase;
-    private final AddProjectMemberUseCase addProjectMemberUseCase;
 
     // 시딩 서비스 특성상 통계/조회용 Port 직접 주입 (UseCase 미존재 or 과도한 데이터 로딩 방지)
     private final LoadProjectStatisticsPort loadProjectStatisticsPort;
@@ -103,6 +101,15 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                 "matchingRoundId=%d 가 chapterId=%d 에 속하지 않습니다."
                     .formatted(command.matchingRoundId(), command.chapterId())
             ));
+
+        // 1-a. 차수 OPEN 검증 — 닫힌 차수면 모든 챌린저가 도메인 가드에 막혀 의미 없는 N번 실패가 됨
+        Instant now = Instant.now();
+        if (now.isBefore(round.startsAt()) || now.isAfter(round.endsAt())) {
+            throw new IllegalArgumentException(
+                "matchingRoundId=%d 는 현재 OPEN 상태가 아닙니다 (now=%s, startsAt=%s, endsAt=%s)."
+                    .formatted(command.matchingRoundId(), now, round.startsAt(), round.endsAt())
+            );
+        }
 
         // 2. 지부 내 IN_PROGRESS 프로젝트 목록
         List<ProjectStatisticsProjectRow> projects =
@@ -211,11 +218,11 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             );
 
             switch (outcome.step()) {
-                case "SUBMITTED" -> submittedCount++;
                 case "APPROVED" -> {
                     submittedCount++;
                     approvedCount++;
-                    // ADD_MEMBER 성공 → 인메모리 카운트 갱신 (다음 챌린저의 쿼터 여유분 계산에 반영)
+                    // 이번 호출 안에서 같은 프로젝트·파트 쿼터 여유분이 다음 챌린저 후보 필터에 반영되도록 갱신.
+                    // ProjectMember 직접 추가는 도메인 정상 플로우(autoDecide)가 처리해야 하므로 시딩이 손대지 않는다.
                     currentMemberCounts
                         .computeIfAbsent(projectId, k -> new HashMap<>())
                         .merge(challenger.part(), 1L, Long::sum);
@@ -304,27 +311,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             return ApplicationOutcome.fail("DECIDE", e.toString());
         }
 
-        if (!approve) {
-            return ApplicationOutcome.success("REJECTED");
-        }
-
-        // APPROVED → ProjectMember 추가 (통계의 APPROVED + ACTIVE 교집합 조건 충족용)
-        try {
-            addProjectMemberUseCase.add(
-                AddProjectMemberCommand.builder()
-                    .projectId(projectId)
-                    .memberId(challenger.memberId())
-                    .part(challenger.part())
-                    .requesterMemberId(poMemberId)
-                    .build()
-            );
-        } catch (Exception e) {
-            log.error("seed ADD_MEMBER 실패 (memberId={}, projectId={}): {}",
-                challenger.memberId(), projectId, e.toString());
-            return ApplicationOutcome.fail("ADD_MEMBER", e.toString());
-        }
-
-        return ApplicationOutcome.success("APPROVED");
+        return ApplicationOutcome.success(approve ? "APPROVED" : "REJECTED");
     }
 
     /**

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -1,5 +1,21 @@
 package com.umc.product.test.application.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -26,28 +42,16 @@ import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
 import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsCommand;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult;
 import com.umc.product.test.application.port.in.command.dto.SeedProjectApplicationsResult.FailedApplication;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 지원서 시나리오 시딩 서비스.
@@ -140,6 +144,12 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                     HashMap::new
                 ));
 
+        // 4-2. 이미 팀원인 memberId Set 배치 조회 (N+1 방지 — 챌린저 풀 필터링에 사용)
+        Set<Long> alreadyMemberIds = loadProjectMemberPort.listByProjectIds(projectIds).values().stream()
+            .flatMap(List::stream)
+            .map(ProjectMember::getMemberId)
+            .collect(Collectors.toSet());
+
         // 5. 이미 해당 차수에 지원한 memberId Set (중복 지원 방지)
         Set<Long> alreadyApplied = loadProjectApplicationPort
             .listByMatchingRoundId(command.matchingRoundId()).stream()
@@ -152,7 +162,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             .filter(c -> c.challengerStatus() == ChallengerStatus.ACTIVE)
             .filter(c -> eligibleParts.contains(c.part()))
             .filter(c -> !alreadyApplied.contains(c.memberId()))
-            .filter(c -> !loadProjectMemberPort.existsByGisuAndMember(gisuId, c.memberId()))
+            .filter(c -> !alreadyMemberIds.contains(c.memberId()))
             .toList();
 
         log.info(

--- a/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
+++ b/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
@@ -2,6 +2,12 @@ package com.umc.product.test.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+
 import com.umc.product.test.application.service.ChallengerSeedService;
 import com.umc.product.test.application.service.CurriculumSeedService;
 import com.umc.product.test.application.service.DummyCurriculumFactory;
@@ -10,13 +16,9 @@ import com.umc.product.test.application.service.DummyNoticeFactory;
 import com.umc.product.test.application.service.MemberSeedService;
 import com.umc.product.test.application.service.NoticeSeedService;
 import com.umc.product.test.application.service.PartAssignmentPolicy;
+import com.umc.product.test.application.service.ProjectApplicationSeedService;
 import com.umc.product.test.application.service.ProjectSeedService;
 import com.umc.product.test.application.service.SeedProperties;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
 
 /**
  * 시딩 관련 빈들의 가드 어노테이션이 회귀 없이 유지되는지 검증한다.
@@ -33,6 +35,7 @@ class SeedControllerBeanRegistrationTest {
         MemberSeedService.class,
         ChallengerSeedService.class,
         ProjectSeedService.class,
+        ProjectApplicationSeedService.class,
         CurriculumSeedService.class,
         NoticeSeedService.class,
         DummyMemberFactory.class,


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 **최대한 자세히** 설명해주세요.
>
> **작업 내용에 대한 근거**가 되는 문서(Team Notion, 회의록 등)나 Slack/Discord 메세지 링크 등을 반드시 **하이퍼링크 형식**으로 첨부해주세요.
>
> 작업 사항과 관련된 따라서 생성된 문서가 있는 경우, 해당 문서에 대한 링크 또한 첨부해주세요. 내부용 문서의 경우 반드시 접근 권한을 확인하고 첨부해주세요.
>
> _e.g._ [프로덕트팀 N차 회의](#)의 결정사항에 따라서 회원가입 시 추가 정보를 받도록 수정하였습니다.

지원현황/매칭현황을 위한 시딩 API를 구현합니다. 지정한 매칭 차수와 지부를 기준으로 프로젝트 팀이 확정되지 않은 챌린저가 프로젝트에 지원하는 시나리오를 실행합니다.

요청에서 approved 비율을 받고 해당 비율에 맞게 합격률을 정할 수 있도록 했습니다.

실행 전제조건
- 매칭차수가 open 상태여야합니다.
- 지부 내 IN_PROGRESS 프로젝트가 존재해야합니다. 
- 챌린저 시딩이 선행되어야 합니다.

지원 가능한 챌린저 풀 필터 조건은 다음과 같습니다. 
  1. ChallengerStatus.ACTIVE                                                         
  2. 해당 매칭 차수에 이미 지원하지 않은 챌린저                                      
  3. 해당 기수에 이미 ProjectMember로 소속되지 않은 챌린저


### 시나리오 흐름
 DRAFT 생성
    -> isRequired 질문 더미 답변 자동 주입
    -> SUBMIT
    -> DECIDE (approveRatio 기반 확률적 APPROVED / REJECTED)
    -> [APPROVED인 경우] ProjectMember 등록                                           
  챌린저 선정 기준
  - 해당 기수 ACTIVE 챌린저 중 매칭 타입에 맞는 파트만 포함
    - PLAN_DESIGN -> DESIGN
    - PLAN_DEVELOPER -> WEB / ANDROID / IOS / NODEJS / SPRINGBOOT
  - 해당 차수에 이미 지원한 챌린저 제외
  - 이미 해당 기수 프로젝트 팀원인 챌린저 제외

  프로젝트 선정 기준                                                                 
  - 챌린저 파트를 모집 중이며 쿼터 여유가 있는 프로젝트 중 랜덤 선택
  - PO 본인 프로젝트 제외
  
  결과
  - APPROVED 챌린저는 ProjectMember로 등록되어 매칭현황 통계(matchedMemberCount)에 반영됨 
  -  챌린저 단위 실패 격리 -> 한 챌린저 시나리오 실패 시 이전 성공 건은 롤백되지 않음



## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

## +수정 사항 (커너)

### 1. ProjectMember 직접 등록 제거 (도메인 워크플로우 우회 차단)
시딩이 APPROVED 처리 직후 `addProjectMemberUseCase.add()` 를 직접 호출해 ProjectMember 를
생성하던 부분을 제거. ProjectMember 등록은 정상 플로우상 차수 종료 시점의 `autoDecide` 가
일괄 처리하는 책임이므로 시딩이 손대지 않음. (프로젝트 시딩 시에 IN_PROGRESS로 넣으면 멤버도 추가하므로 매칭현황 확인 가능)

### 2. 사전 OPEN 검증 추가
차수가 닫혀 있을 때 실패가 누적되던 문제. seed() 진입 직후 `now ∈ [startsAt, endsAt]` 검증으로
사전 차단.

### 3. Port 직접 의존 5건 제거 + 도메인 가드에 위임
시딩 서비스는 다른 도메인의 UseCase 만 호출함으로 시나리오 API와 최대한 유사한 동작을 하도록 함.

### 4. approveRatio 제거 + 최종 status 3-way 랜덤화
기존 `approveRatio` 는 "APPROVED → ProjectMember 등록" 시뮬레이션 목적이었는데 ProjectMember
등록을 시딩이 안 하기로 결정한 이상 의미가 없어짐. 또한 도메인이 상태 토글 (approve /
reject / revertToPending) 을 자유롭게 허용하므로 결과 분포가 정확할 필요도 없으므로 랜덤 배정.
→ 입력에서 `approveRatio` 제거. 각 챌린저의 최종 상태를 `SUBMITTED / APPROVED / REJECTED`
≈ 1/3 분포로 무작위 결정.

### 5. 응답 구조 보강
기존 응답에 추가하여 디테일 정보 추가. (시딩 특성 상 만들어진 데이터를 확인하고 이후 동작을 해야하므로 응답을 뚱뚱하게 가져감)

```json
{
  "matchingRoundId": 5001,
  "createdApplications": [
    {
      "projectId": 101,
      "applications": [
        { "applicationId": 7001, "applicantMemberId": 50, "part": "WEB", "finalStatus": "APPROVED" },
        ...
      ]
    }
  ],
  "failedApplications": [
    { "applicantMemberId": 88, "projectId": 101, "applicationId": null, "failedStep": "DRAFT", "reason": "..." }
  ],
  "counts": { "submittedTotal": 10, "approvedTotal": 9, "rejectedTotal": 11, "failedTotal": 0 }
}
