### PR TITLE
[Fix] macOS CD에서 발생하는 Docker Keychain 인증 오류 수정

### DIFF
--- a/.github/workflows/cd-dev-home.yml
+++ b/.github/workflows/cd-dev-home.yml
@@ -213,9 +213,13 @@ jobs:
               exit 1
             fi
 
+            ORIGINAL_DOCKER_CONFIG="${DOCKER_CONFIG:-${HOME:-}/.docker}"
+            CURRENT_DOCKER_CONTEXT="$("${DOCKER_BIN}" context show 2>/dev/null || true)"
+            USING_DOCKER_HOST_FALLBACK=false
+
             echo "[1] Docker 환경 확인"
             echo "Docker Path=${DOCKER_BIN}"
-            echo "Docker Context=$("${DOCKER_BIN}" context show 2>/dev/null || echo "unknown")"
+            echo "Docker Context=${CURRENT_DOCKER_CONTEXT:-unknown}"
             echo "Docker Host=${DOCKER_HOST:-context-default}"
 
             if ! "${DOCKER_BIN}" info >/dev/null 2>&1; then
@@ -225,6 +229,7 @@ jobs:
               for docker_socket in "${HOME:-}/.docker/run/docker.sock" "${HOME:-}/.colima/default/docker.sock"; do
                 if [ -S "${docker_socket}" ]; then
                   export DOCKER_HOST="unix://${docker_socket}"
+                  USING_DOCKER_HOST_FALLBACK=true
                   echo "Docker socket fallback 적용: ${DOCKER_HOST}"
                   break
                 fi
@@ -236,6 +241,39 @@ jobs:
               fi
             fi
 
+            DOCKER_CONFIG="$(mktemp -d)"
+            export DOCKER_CONFIG
+
+            if [ -d "${ORIGINAL_DOCKER_CONFIG}/contexts" ]; then
+              cp -R "${ORIGINAL_DOCKER_CONFIG}/contexts" "${DOCKER_CONFIG}/contexts"
+            fi
+
+            if [ -d "${ORIGINAL_DOCKER_CONFIG}/cli-plugins" ]; then
+              mkdir -p "${DOCKER_CONFIG}/cli-plugins"
+              for plugin in "${ORIGINAL_DOCKER_CONFIG}"/cli-plugins/*; do
+                [ -e "${plugin}" ] || continue
+                ln -s "${plugin}" "${DOCKER_CONFIG}/cli-plugins/$(basename "${plugin}")"
+              done
+            fi
+
+            if [ "${USING_DOCKER_HOST_FALLBACK}" = "false" ] && [ -z "${DOCKER_HOST:-}" ] && [ -n "${CURRENT_DOCKER_CONTEXT}" ]; then
+              export DOCKER_CONTEXT="${CURRENT_DOCKER_CONTEXT}"
+            fi
+
+            cleanup() {
+              "${DOCKER_BIN}" logout "${ECR_REGISTRY}" >/dev/null 2>&1 || true
+              rm -rf "${DOCKER_CONFIG}"
+            }
+            trap cleanup EXIT
+
+            echo "Docker Isolated Config=${DOCKER_CONFIG}"
+
+            if ! "${DOCKER_BIN}" info >/dev/null 2>&1; then
+              echo "격리된 Docker config에서 Docker daemon에 연결할 수 없습니다."
+              "${DOCKER_BIN}" context ls || true
+              exit 1
+            fi
+
             if "${DOCKER_BIN}" compose version >/dev/null 2>&1; then
               COMPOSE_MODE="docker-plugin"
             elif command -v docker-compose >/dev/null 2>&1; then
@@ -243,7 +281,7 @@ jobs:
               DOCKER_COMPOSE_BIN="$(command -v docker-compose)"
             else
               echo "docker compose 플러그인을 찾을 수 없습니다."
-              find "${HOME:-}/.docker" -maxdepth 3 -type f -name 'docker-compose' 2>/dev/null || true
+              find "${ORIGINAL_DOCKER_CONFIG}" -maxdepth 3 -type f -name 'docker-compose' 2>/dev/null || true
               exit 1
             fi
 
@@ -258,12 +296,16 @@ jobs:
             echo "Docker Compose Mode=${COMPOSE_MODE}"
 
             echo "[2] ECR 인증 설정"
-            printf '%s' "${ECR_PASSWORD}" | "${DOCKER_BIN}" login --username AWS --password-stdin "${ECR_REGISTRY}" >/dev/null
-
-            cleanup() {
-              "${DOCKER_BIN}" logout "${ECR_REGISTRY}" >/dev/null 2>&1 || true
+            ECR_AUTH="$(printf 'AWS:%s' "${ECR_PASSWORD}" | base64 | tr -d '\n')"
+            cat > "${DOCKER_CONFIG}/config.json" << EOF
+            {
+              "auths": {
+                "${ECR_REGISTRY}": {
+                  "auth": "${ECR_AUTH}"
+                }
+              }
             }
-            trap cleanup EXIT
+            EOF
 
             echo "[3] 애플리케이션 디렉토리 확인"
             if [ ! -d "${SERVER_APP_DIRECTORY}" ]; then


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- related to #925

## 🚀 작업 내용

### 변경 범위 요약

- 홈서버 develop 배포 워크플로우(`.github/workflows/cd-dev-home.yml`)의 Docker ECR 인증 흐름만 수정했어요.

### 작업 단위별 상세

1. **무엇을**: macOS 홈서버 SSH 배포에서 `docker login`을 호출하지 않도록 바꿨어요.
   - **어떻게**: 임시 `DOCKER_CONFIG`를 만들고 ECR 인증 정보를 `config.json`의 `auths`에 직접 기록하도록 했어요.
   - **왜**: 비대화형 SSH 세션에서 Docker Desktop credential helper가 macOS Keychain 저장을 시도하면 `User interaction is not allowed. (-25308)` 오류로 배포가 중단되기 때문이에요.

2. **무엇을**: 임시 Docker config를 쓰면서도 기존 Docker Desktop context와 compose plugin 탐색이 깨지지 않게 했어요.
   - **어떻게**: 원본 Docker config의 `contexts`를 임시 config로 복사하고, `cli-plugins`는 symlink로 연결했어요. 기존 Docker context도 `DOCKER_CONTEXT`로 보존했어요.
   - **왜**: credential helper만 우회하고 Docker Desktop의 `desktop-linux` context 동작은 유지해야 하기 때문이에요.

## 💬 리뷰 중점사항

- macOS Docker Desktop 환경에서 credential helper를 호출하지 않고 ECR pull 권한만 제공하는 흐름이 의도대로 보이는지 확인 부탁드려요.
- 임시 `DOCKER_CONFIG`로 context와 compose plugin 탐색을 유지하는 방식이 홈서버 환경과 맞는지 확인 부탁드려요.
- 검증은 YAML 파싱, `git diff --check`, 추출한 SSH 스크립트의 `bash -n`과 `zsh -n`, `docker login` 제거 여부로 확인했어요.