### PR TITLE
[Feat] WebSocket SUBSCRIBE/SEND 권한 체크 및 에러 응답 처리 구현

### DIFF
--- a/src/main/java/com/umc/product/chat/application/port/in/query/CheckChatRoomAccessUseCase.java
+++ b/src/main/java/com/umc/product/chat/application/port/in/query/CheckChatRoomAccessUseCase.java
@@ -1,0 +1,6 @@
+package com.umc.product.chat.application.port.in.query;
+
+public interface CheckChatRoomAccessUseCase {
+
+    boolean hasChatRoomAccess(Long memberId, Long chatRoomId);
+}

--- a/src/main/java/com/umc/product/chat/application/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/umc/product/chat/application/service/query/ChatRoomQueryService.java
@@ -1,5 +1,6 @@
 package com.umc.product.chat.application.service.query;
 
+import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
 import com.umc.product.chat.application.port.in.query.GetChatRoomUseCase;
 import com.umc.product.chat.application.port.in.query.dto.ChatRoomInfo;
 import com.umc.product.chat.application.port.out.LoadChatMemberPort;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ChatRoomQueryService implements GetChatRoomUseCase {
+public class ChatRoomQueryService implements GetChatRoomUseCase, CheckChatRoomAccessUseCase {
 
     private final LoadChatRoomPort loadChatRoomPort;
     private final LoadChatMemberPort loadChatMemberPort;
@@ -26,5 +27,10 @@ public class ChatRoomQueryService implements GetChatRoomUseCase {
             .map(ChatMember::getMemberId)
             .toList();
         return new ChatRoomInfo(chatRoom.getId(), chatRoom.getCreatedAt(), memberIds);
+    }
+
+    @Override
+    public boolean hasChatRoomAccess(Long memberId, Long chatRoomId) {
+        return loadChatMemberPort.existsByRoomIdAndMemberId(chatRoomId, memberId);
     }
 }

--- a/src/main/java/com/umc/product/global/config/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/umc/product/global/config/WebSocketMessageBrokerConfig.java
@@ -1,6 +1,7 @@
 package com.umc.product.global.config;
 
 import com.umc.product.global.websocket.interceptor.ShutdownAwareHandshakeInterceptor;
+import com.umc.product.global.websocket.interceptor.StompAuthChannelInterceptor;
 import com.umc.product.global.websocket.interceptor.StompPrincipalInterceptor;
 import com.umc.product.global.websocket.interceptor.WebSocketInboundMetricInterceptor;
 import com.umc.product.global.websocket.interceptor.WebSocketOutboundMetricInterceptor;
@@ -26,6 +27,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompPrincipalInterceptor stompPrincipalInterceptor;
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
     private final WebSocketRateLimitInterceptor webSocketRateLimitInterceptor;
     private final WebSocketInboundMetricInterceptor webSocketInboundMetricInterceptor;
     private final WebSocketOutboundMetricInterceptor webSocketOutboundMetricInterceptor;
@@ -60,6 +62,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(
             stompPrincipalInterceptor,
+            stompAuthChannelInterceptor,
             webSocketInboundMetricInterceptor,
             webSocketRateLimitInterceptor
         );

--- a/src/main/java/com/umc/product/global/config/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/umc/product/global/config/WebSocketMessageBrokerConfig.java
@@ -1,5 +1,6 @@
 package com.umc.product.global.config;
 
+import com.umc.product.global.websocket.handler.ApiResponseStompErrorHandler;
 import com.umc.product.global.websocket.interceptor.ShutdownAwareHandshakeInterceptor;
 import com.umc.product.global.websocket.interceptor.StompAuthChannelInterceptor;
 import com.umc.product.global.websocket.interceptor.StompPrincipalInterceptor;
@@ -32,6 +33,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     private final WebSocketInboundMetricInterceptor webSocketInboundMetricInterceptor;
     private final WebSocketOutboundMetricInterceptor webSocketOutboundMetricInterceptor;
     private final ShutdownAwareHandshakeInterceptor shutdownAwareHandshakeInterceptor;
+    private final ApiResponseStompErrorHandler apiResponseStompErrorHandler;
     private final ObservationRegistry observationRegistry;
     private final ContextSnapshotFactory snapshotFactory;
 
@@ -45,6 +47,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.setErrorHandler(apiResponseStompErrorHandler);
         registry.addEndpoint("/ws")
             .addInterceptors(shutdownAwareHandshakeInterceptor)
             .withSockJS();

--- a/src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java
+++ b/src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java
@@ -32,6 +32,8 @@ public enum CommonErrorCode implements BaseCode {
     // SECURITY: Spring Security에서 발생하는 에러
     SECURITY_NOT_GIVEN(HttpStatus.UNAUTHORIZED, "SECURITY-0001", "인증 정보가 전달되지 않았습니다."),
     SECURITY_FORBIDDEN(HttpStatus.FORBIDDEN, "SECURITY-0002", "권한이 부족합니다."),
+    SECURITY_WEBSOCKET_BROKER_ACCESS(HttpStatus.FORBIDDEN, "SECURITY-0003", "브로커 경로로 직접 메시지를 전송할 수 없습니다."),
+    SECURITY_WEBSOCKET_INVALID_DESTINATION(HttpStatus.FORBIDDEN, "SECURITY-0004", "허용되지 않은 웹소켓 경로입니다."),
 
     // ENVIRONMENT: SpringBoot 실행환경 관련 에러
     INVALID_ENV(HttpStatus.BAD_REQUEST, "ENV-0001", "현재 실행 환경에서는 사용할 수 없는 기능입니다."),

--- a/src/main/java/com/umc/product/global/security/MemberPrincipal.java
+++ b/src/main/java/com/umc/product/global/security/MemberPrincipal.java
@@ -5,10 +5,11 @@ import java.util.Collection;
 import java.util.Collections;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 
 @Getter
-public class MemberPrincipal {
+public class MemberPrincipal implements AuthenticatedPrincipal {
 
     private final Long memberId;
 
@@ -28,6 +29,11 @@ public class MemberPrincipal {
 
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(memberId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandler.java
+++ b/src/main/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandler.java
@@ -55,7 +55,7 @@ public class ApiResponseStompErrorHandler extends StompSubProtocolErrorHandler {
         if (businessException.isPresent()) {
             BusinessException exception = businessException.get();
             log.warn("[WEBSOCKET BUSINESS EXCEPTION] domain={}, code={}, message={}",
-                exception.getDomain(), exception.getBaseCode().getCode(), exception.getBaseCode().getMessage(), ex);
+                exception.getDomain(), exception.getBaseCode().getCode(), exception.getBaseCode().getMessage());
             return;
         }
 

--- a/src/main/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandler.java
+++ b/src/main/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandler.java
@@ -1,0 +1,121 @@
+package com.umc.product.global.websocket.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.exception.BusinessException;
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.code.BaseCode;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+/**
+ * STOMP 예외를 HTTP API와 동일한 ApiResponse 형식의 ERROR 프레임으로 변환한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiResponseStompErrorHandler extends StompSubProtocolErrorHandler {
+
+    private static final byte[] INTERNAL_SERVER_ERROR_PAYLOAD = (
+        "{\"success\":false,\"code\":\"COMMON-0001\","
+            + "\"message\":\"알 수 없는 오류입니다. 관리자에게 문의해주세요.\"}"
+    ).getBytes(StandardCharsets.UTF_8);
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(
+        @Nullable Message<byte[]> clientMessage,
+        Throwable ex
+    ) {
+        Optional<BusinessException> businessException = findBusinessException(ex);
+        BaseCode errorCode = businessException
+            .map(BusinessException::getBaseCode)
+            .orElse(CommonErrorCode.INTERNAL_SERVER_ERROR);
+
+        logException(ex, businessException);
+
+        byte[] payload = createErrorPayload(errorCode);
+        return createErrorMessage(clientMessage, errorCode, payload);
+    }
+
+    private void logException(Throwable ex, Optional<BusinessException> businessException) {
+        if (businessException.isPresent()) {
+            BusinessException exception = businessException.get();
+            log.warn("[WEBSOCKET BUSINESS EXCEPTION] domain={}, code={}, message={}",
+                exception.getDomain(), exception.getBaseCode().getCode(), exception.getBaseCode().getMessage(), ex);
+            return;
+        }
+
+        log.error("[WEBSOCKET UNHANDLED EXCEPTION] {}", ex.getMessage(), ex);
+    }
+
+    private byte[] createErrorPayload(BaseCode errorCode) {
+        ApiResponse<Object> response = ApiResponse.onFailure(
+            errorCode.getCode(),
+            errorCode.getMessage(),
+            null
+        );
+
+        try {
+            return objectMapper.writeValueAsBytes(response);
+        } catch (JsonProcessingException e) {
+            log.error("[WEBSOCKET ERROR SERIALIZATION FAILED] {}", e.getMessage(), e);
+            return INTERNAL_SERVER_ERROR_PAYLOAD;
+        }
+    }
+
+    private Message<byte[]> createErrorMessage(
+        @Nullable Message<byte[]> clientMessage,
+        BaseCode errorCode,
+        byte[] payload
+    ) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setMessage(errorCode.getMessage());
+        accessor.setContentType(MimeTypeUtils.APPLICATION_JSON);
+        accessor.setLeaveMutable(true);
+        copyReceiptId(clientMessage, accessor);
+
+        return MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+    }
+
+    private void copyReceiptId(@Nullable Message<byte[]> clientMessage, StompHeaderAccessor errorAccessor) {
+        if (clientMessage == null) {
+            return;
+        }
+
+        StompHeaderAccessor clientAccessor =
+            MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
+        if (clientAccessor != null && clientAccessor.getReceipt() != null) {
+            errorAccessor.setReceiptId(clientAccessor.getReceipt());
+        }
+    }
+
+    private Optional<BusinessException> findBusinessException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof BusinessException businessException) {
+                return Optional.of(businessException);
+            }
+
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                break;
+            }
+            current = cause;
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorEvent.java
+++ b/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorEvent.java
@@ -1,0 +1,9 @@
+package com.umc.product.global.websocket.handler;
+
+import com.umc.product.global.response.code.BaseCode;
+
+/**
+ * WebSocket 에러 응답 전송이 필요할 때 발행하는 이벤트다.
+ */
+public record WebSocketErrorEvent(String userName, BaseCode errorCode) {
+}

--- a/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisher.java
+++ b/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisher.java
@@ -1,0 +1,36 @@
+package com.umc.product.global.websocket.handler;
+
+import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.code.BaseCode;
+import java.security.Principal;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebSocket 세션 사용자에게 ApiResponse 형식의 에러 메시지를 전송한다.
+ */
+@Component
+public class WebSocketErrorPublisher {
+
+    private static final String USER_ERROR_DESTINATION = "/queue/errors";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public WebSocketErrorPublisher(@Lazy SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    /**
+     * 사용자가 구독 중인 /user/queue/errors destination으로 에러 응답을 보낸다.
+     */
+    public void sendErrorToUser(Principal user, BaseCode errorCode) {
+        ApiResponse<Object> response = ApiResponse.onFailure(
+            errorCode.getCode(),
+            errorCode.getMessage(),
+            null
+        );
+
+        messagingTemplate.convertAndSendToUser(user.getName(), USER_ERROR_DESTINATION, response);
+    }
+}

--- a/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisher.java
+++ b/src/main/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisher.java
@@ -2,8 +2,7 @@ package com.umc.product.global.websocket.handler;
 
 import com.umc.product.global.response.ApiResponse;
 import com.umc.product.global.response.code.BaseCode;
-import java.security.Principal;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -17,20 +16,25 @@ public class WebSocketErrorPublisher {
 
     private final SimpMessagingTemplate messagingTemplate;
 
-    public WebSocketErrorPublisher(@Lazy SimpMessagingTemplate messagingTemplate) {
+    public WebSocketErrorPublisher(SimpMessagingTemplate messagingTemplate) {
         this.messagingTemplate = messagingTemplate;
     }
 
     /**
-     * 사용자가 구독 중인 /user/queue/errors destination으로 에러 응답을 보낸다.
+     * WebSocket 에러 이벤트를 받아 사용자의 에러 큐로 응답을 보낸다.
      */
-    public void sendErrorToUser(Principal user, BaseCode errorCode) {
+    @EventListener
+    public void sendErrorToUser(WebSocketErrorEvent event) {
+        sendErrorToUser(event.userName(), event.errorCode());
+    }
+
+    private void sendErrorToUser(String userName, BaseCode errorCode) {
         ApiResponse<Object> response = ApiResponse.onFailure(
             errorCode.getCode(),
             errorCode.getMessage(),
             null
         );
 
-        messagingTemplate.convertAndSendToUser(user.getName(), USER_ERROR_DESTINATION, response);
+        messagingTemplate.convertAndSendToUser(userName, USER_ERROR_DESTINATION, response);
     }
 }

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -1,11 +1,11 @@
 package com.umc.product.global.websocket.interceptor;
 
-import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
 import com.umc.product.common.domain.exception.CommonException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.websocket.handler.WebSocketErrorPublisher;
 import java.security.Principal;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +28,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
 
     private final CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
+    private final WebSocketErrorPublisher webSocketErrorPublisher;
 
     /**
      * 클라이언트에서 들어오는 STOMP 프레임 중 채팅방 접근 권한이 필요한 프레임을 검사한다.
@@ -45,12 +46,14 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
-        Long memberId = extractMemberId(accessor);
+        Principal user = accessor.getUser();
+        Long memberId = extractMemberId(user);
         if (memberId == null) {
             throw new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN);
         }
         if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
-            throw new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+            webSocketErrorPublisher.sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+            return null;
         }
 
         return message;
@@ -99,8 +102,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     /**
      * STOMP 사용자 정보에서 인증된 회원 ID를 꺼낸다.
      */
-    private Long extractMemberId(StompHeaderAccessor accessor) {
-        Principal user = accessor.getUser();
+    private Long extractMemberId(Principal user) {
         if (user instanceof UsernamePasswordAuthenticationToken auth
             && auth.getPrincipal() instanceof MemberPrincipal principal) {
             return principal.getMemberId();

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -26,10 +26,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     // 클라이언트가 채팅 메시지를 서버로 보낼 때 사용하는 주소
     private static final String CHAT_APP_DESTINATION = "/app/chat";
-    private static final String CHAT_APP_PREFIX = CHAT_APP_DESTINATION + "/";
+    private static final String CHAT_APP_MESSAGE_PREFIX = CHAT_APP_DESTINATION + "/rooms/";
     // 클라이언트가 채팅방 메시지를 받기 위해 구독하는 주소
     private static final String CHAT_TOPIC_DESTINATION = "/topic/chat";
-    private static final String CHAT_TOPIC_PREFIX = CHAT_TOPIC_DESTINATION + "/";
+    private static final String CHAT_TOPIC_MESSAGE_PREFIX = CHAT_TOPIC_DESTINATION + "/rooms/";
+    private static final String CHAT_MESSAGE_SUFFIX = "/messages";
     // 클라이언트가 직접 SEND할 수 없는 브로커 경로
     private static final String BROKER_TOPIC_PREFIX = "/topic";
     private static final String BROKER_QUEUE_PREFIX = "/queue";
@@ -102,16 +103,16 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
      */
     private ChatDestination parseChatDestination(StompCommand command, String destination) {
         if (StompCommand.SUBSCRIBE.equals(command)) {
-            return parseChatDestination(destination, CHAT_TOPIC_DESTINATION, CHAT_TOPIC_PREFIX);
+            return parseChatDestination(destination, CHAT_TOPIC_DESTINATION, CHAT_TOPIC_MESSAGE_PREFIX);
         }
         if (StompCommand.SEND.equals(command)) {
-            return parseChatDestination(destination, CHAT_APP_DESTINATION, CHAT_APP_PREFIX);
+            return parseChatDestination(destination, CHAT_APP_DESTINATION, CHAT_APP_MESSAGE_PREFIX);
         }
         return ChatDestination.notTarget();
     }
 
     /**
-     * /app/chat/{id}, /topic/chat/{id} 형식이면 id를 파싱하고,
+     * /app/chat/rooms/{id}/messages, /topic/chat/rooms/{id}/messages 형식이면 id를 파싱하고,
      * chat 경로가 아니면 검사 대상에서 제외한다.
      */
     private ChatDestination parseChatDestination(String destination, String namespace, String prefix) {
@@ -122,7 +123,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return ChatDestination.invalid();
         }
 
-        String rawChatRoomId = destination.substring(prefix.length());
+        if (!destination.startsWith(prefix) || !destination.endsWith(CHAT_MESSAGE_SUFFIX)) {
+            return ChatDestination.invalid();
+        }
+
+        String rawChatRoomId = destination.substring(prefix.length(), destination.length() - CHAT_MESSAGE_SUFFIX.length());
         if (rawChatRoomId.isBlank() || rawChatRoomId.contains("/")) {
             return ChatDestination.invalid();
         }

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -19,10 +19,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
+    // 클라이언트가 채팅 메시지를 서버로 보낼 때 사용하는 주소
+    private static final String CHAT_APP_PREFIX = "/app/chat/";
+    // 클라이언트가 채팅방 메시지를 받기 위해 구독하는 주소
     private static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
 
     private final CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
 
+    /**
+     * 클라이언트에서 들어오는 STOMP 프레임 중 채팅방 접근 권한이 필요한 프레임을 검사한다.
+     */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
@@ -31,7 +37,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
-        Optional<Long> chatRoomId = extractChatRoomId(accessor.getDestination());
+        Optional<Long> chatRoomId = extractChatRoomId(accessor.getCommand(), accessor.getDestination());
         if (chatRoomId.isEmpty()) {
             return message;
         }
@@ -44,16 +50,35 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         return message;
     }
 
+    /**
+     * 채팅방 접근 권한 검사가 필요한 STOMP 명령인지 확인한다.
+     */
     private boolean isAuthorizationTarget(StompCommand command) {
         return StompCommand.SUBSCRIBE.equals(command) || StompCommand.SEND.equals(command);
     }
 
-    private Optional<Long> extractChatRoomId(String destination) {
-        if (destination == null || !destination.startsWith(CHAT_TOPIC_PREFIX)) {
+    /**
+     * STOMP 명령과 destination에 맞는 채팅방 ID를 추출한다.
+     */
+    private Optional<Long> extractChatRoomId(StompCommand command, String destination) {
+        if (StompCommand.SUBSCRIBE.equals(command)) {
+            return extractChatRoomId(destination, CHAT_TOPIC_PREFIX);
+        }
+        if (StompCommand.SEND.equals(command)) {
+            return extractChatRoomId(destination, CHAT_APP_PREFIX);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 지정된 prefix 뒤에 있는 채팅방 ID를 Long 타입으로 파싱한다.
+     */
+    private Optional<Long> extractChatRoomId(String destination, String prefix) {
+        if (destination == null || !destination.startsWith(prefix)) {
             return Optional.empty();
         }
 
-        String rawChatRoomId = destination.substring(CHAT_TOPIC_PREFIX.length());
+        String rawChatRoomId = destination.substring(prefix.length());
         if (rawChatRoomId.isBlank() || rawChatRoomId.contains("/")) {
             return Optional.empty();
         }
@@ -65,6 +90,9 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
     }
 
+    /**
+     * STOMP 사용자 정보에서 인증된 회원 ID를 꺼낸다.
+     */
     private Long extractMemberId(StompHeaderAccessor accessor) {
         Principal user = accessor.getUser();
         if (user instanceof UsernamePasswordAuthenticationToken auth

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -7,7 +7,6 @@ import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.websocket.handler.WebSocketErrorEvent;
 import java.security.Principal;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
@@ -24,9 +23,14 @@ import org.springframework.stereotype.Component;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     // 클라이언트가 채팅 메시지를 서버로 보낼 때 사용하는 주소
-    private static final String CHAT_APP_PREFIX = "/app/chat/";
+    private static final String CHAT_APP_DESTINATION = "/app/chat";
+    private static final String CHAT_APP_PREFIX = CHAT_APP_DESTINATION + "/";
     // 클라이언트가 채팅방 메시지를 받기 위해 구독하는 주소
-    private static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
+    private static final String CHAT_TOPIC_DESTINATION = "/topic/chat";
+    private static final String CHAT_TOPIC_PREFIX = CHAT_TOPIC_DESTINATION + "/";
+    // 클라이언트가 직접 SEND할 수 없는 브로커 경로
+    private static final String BROKER_TOPIC_PREFIX = "/topic";
+    private static final String BROKER_QUEUE_PREFIX = "/queue";
 
     private final CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -42,9 +46,16 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
-        Optional<Long> chatRoomId = extractChatRoomId(accessor.getCommand(), accessor.getDestination());
-        if (chatRoomId.isEmpty()) {
+        if (StompCommand.SEND.equals(accessor.getCommand()) && isBrokerDestination(accessor.getDestination())) {
+            throw new CommonException(CommonErrorCode.SECURITY_WEBSOCKET_BROKER_ACCESS);
+        }
+
+        ChatDestination chatDestination = parseChatDestination(accessor.getCommand(), accessor.getDestination());
+        if (!chatDestination.target()) {
             return message;
+        }
+        if (!chatDestination.valid()) {
+            throw new CommonException(CommonErrorCode.SECURITY_WEBSOCKET_INVALID_DESTINATION);
         }
 
         Principal user = accessor.getUser();
@@ -52,7 +63,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         if (memberId == null) {
             throw new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN);
         }
-        if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
+        if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatDestination.chatRoomId())) {
             applicationEventPublisher.publishEvent(
                 new WebSocketErrorEvent(user.getName(), AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
             );
@@ -63,6 +74,19 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
+     * 클라이언트가 직접 SEND할 수 없는 브로커 경로인지 확인한다.
+     */
+    private boolean isBrokerDestination(String destination) {
+        return destination != null
+            && (hasDestinationPrefix(destination, BROKER_TOPIC_PREFIX)
+            || hasDestinationPrefix(destination, BROKER_QUEUE_PREFIX));
+    }
+
+    private boolean hasDestinationPrefix(String destination, String prefix) {
+        return destination.equals(prefix) || destination.startsWith(prefix + "/");
+    }
+
+    /**
      * 채팅방 접근 권한 검사가 필요한 STOMP 명령인지 확인한다.
      */
     private boolean isAuthorizationTarget(StompCommand command) {
@@ -70,35 +94,39 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
-     * STOMP 명령과 destination에 맞는 채팅방 ID를 추출한다.
+     * STOMP 명령에 맞는 채팅 destination을 판별하고 채팅방 ID를 파싱한다.
      */
-    private Optional<Long> extractChatRoomId(StompCommand command, String destination) {
+    private ChatDestination parseChatDestination(StompCommand command, String destination) {
         if (StompCommand.SUBSCRIBE.equals(command)) {
-            return extractChatRoomId(destination, CHAT_TOPIC_PREFIX);
+            return parseChatDestination(destination, CHAT_TOPIC_DESTINATION, CHAT_TOPIC_PREFIX);
         }
         if (StompCommand.SEND.equals(command)) {
-            return extractChatRoomId(destination, CHAT_APP_PREFIX);
+            return parseChatDestination(destination, CHAT_APP_DESTINATION, CHAT_APP_PREFIX);
         }
-        return Optional.empty();
+        return ChatDestination.notTarget();
     }
 
     /**
-     * 지정된 prefix 뒤에 있는 채팅방 ID를 Long 타입으로 파싱한다.
+     * /app/chat/{id}, /topic/chat/{id} 형식이면 id를 파싱하고,
+     * chat 경로가 아니면 검사 대상에서 제외한다.
      */
-    private Optional<Long> extractChatRoomId(String destination, String prefix) {
-        if (destination == null || !destination.startsWith(prefix)) {
-            return Optional.empty();
+    private ChatDestination parseChatDestination(String destination, String namespace, String prefix) {
+        if (destination == null || !hasDestinationPrefix(destination, namespace)) {
+            return ChatDestination.notTarget();
+        }
+        if (destination.equals(namespace)) {
+            return ChatDestination.invalid();
         }
 
         String rawChatRoomId = destination.substring(prefix.length());
         if (rawChatRoomId.isBlank() || rawChatRoomId.contains("/")) {
-            return Optional.empty();
+            return ChatDestination.invalid();
         }
 
         try {
-            return Optional.of(Long.parseLong(rawChatRoomId));
+            return ChatDestination.valid(Long.parseLong(rawChatRoomId));
         } catch (NumberFormatException ignored) {
-            return Optional.empty();
+            return ChatDestination.invalid();
         }
     }
 
@@ -111,5 +139,36 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             return principal.getMemberId();
         }
         return null;
+    }
+
+    /**
+     * 채팅 destination 파싱 결과.
+     *
+     * @param target     chat namespace 여부
+     * @param valid      채팅방 ID 형식 유효성
+     * @param chatRoomId 추출된 채팅방 ID
+     */
+    private record ChatDestination(boolean target, boolean valid, Long chatRoomId) {
+
+        /**
+         * chat namespace가 아닌 destination.
+         */
+        private static ChatDestination notTarget() {
+            return new ChatDestination(false, false, null);
+        }
+
+        /**
+         * chat namespace 내부지만 형식이 잘못된 destination.
+         */
+        private static ChatDestination invalid() {
+            return new ChatDestination(true, false, null);
+        }
+
+        /**
+         * chat namespace 내부이며 채팅방 ID가 유효한 destination.
+         */
+        private static ChatDestination valid(Long chatRoomId) {
+            return new ChatDestination(true, true, chatRoomId);
+        }
     }
 }

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -8,6 +8,7 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.websocket.handler.WebSocketErrorEvent;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -19,6 +20,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
@@ -64,6 +66,8 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             throw new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN);
         }
         if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatDestination.chatRoomId())) {
+            log.warn("WebSocket 채팅방 접근 거부: memberId={}, chatRoomId={}, command={}, destination={}",
+                memberId, chatDestination.chatRoomId(), accessor.getCommand(), accessor.getDestination());
             applicationEventPublisher.publishEvent(
                 new WebSocketErrorEvent(user.getName(), AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
             );

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -1,13 +1,16 @@
 package com.umc.product.global.websocket.interceptor;
 
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
+import com.umc.product.common.domain.exception.CommonException;
+import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
 import java.security.Principal;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -43,8 +46,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
 
         Long memberId = extractMemberId(accessor);
-        if (memberId == null || !checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
-            throw new MessageDeliveryException("채팅방 접근 권한이 없습니다.");
+        if (memberId == null) {
+            throw new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN);
+        }
+        if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
+            throw new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
         }
 
         return message;

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -5,10 +5,11 @@ import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase
 import com.umc.product.common.domain.exception.CommonException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.global.websocket.handler.WebSocketErrorPublisher;
+import com.umc.product.global.websocket.handler.WebSocketErrorEvent;
 import java.security.Principal;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -28,7 +29,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
 
     private final CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
-    private final WebSocketErrorPublisher webSocketErrorPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 클라이언트에서 들어오는 STOMP 프레임 중 채팅방 접근 권한이 필요한 프레임을 검사한다.
@@ -52,7 +53,9 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             throw new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN);
         }
         if (!checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
-            webSocketErrorPublisher.sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+            applicationEventPublisher.publishEvent(
+                new WebSocketErrorEvent(user.getName(), AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
+            );
             return null;
         }
 

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptor.java
@@ -1,0 +1,76 @@
+package com.umc.product.global.websocket.interceptor;
+
+import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
+import com.umc.product.global.security.MemberPrincipal;
+import java.security.Principal;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
+
+    private final CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !isAuthorizationTarget(accessor.getCommand())) {
+            return message;
+        }
+
+        Optional<Long> chatRoomId = extractChatRoomId(accessor.getDestination());
+        if (chatRoomId.isEmpty()) {
+            return message;
+        }
+
+        Long memberId = extractMemberId(accessor);
+        if (memberId == null || !checkChatRoomAccessUseCase.hasChatRoomAccess(memberId, chatRoomId.get())) {
+            throw new MessageDeliveryException("채팅방 접근 권한이 없습니다.");
+        }
+
+        return message;
+    }
+
+    private boolean isAuthorizationTarget(StompCommand command) {
+        return StompCommand.SUBSCRIBE.equals(command) || StompCommand.SEND.equals(command);
+    }
+
+    private Optional<Long> extractChatRoomId(String destination) {
+        if (destination == null || !destination.startsWith(CHAT_TOPIC_PREFIX)) {
+            return Optional.empty();
+        }
+
+        String rawChatRoomId = destination.substring(CHAT_TOPIC_PREFIX.length());
+        if (rawChatRoomId.isBlank() || rawChatRoomId.contains("/")) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Long.parseLong(rawChatRoomId));
+        } catch (NumberFormatException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private Long extractMemberId(StompHeaderAccessor accessor) {
+        Principal user = accessor.getUser();
+        if (user instanceof UsernamePasswordAuthenticationToken auth
+            && auth.getPrincipal() instanceof MemberPrincipal principal) {
+            return principal.getMemberId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/umc/product/global/websocket/interceptor/StompPrincipalInterceptor.java
+++ b/src/main/java/com/umc/product/global/websocket/interceptor/StompPrincipalInterceptor.java
@@ -42,7 +42,6 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
 
         String token = authHeader.substring(7);
 
-        // TODO: 인증 실패 시 STOMP ERROR 프레임을 ApiResponse 형식으로 포맷팅하는 StompSubProtocolErrorHandler 구현 필요
         ParsedAccessToken parsed = jwtTokenProvider.parseAndValidateAccessToken(token);
 
         MemberPrincipal principal = MemberPrincipal.builder()

--- a/src/test/java/com/umc/product/global/security/MemberPrincipalTest.java
+++ b/src/test/java/com/umc/product/global/security/MemberPrincipalTest.java
@@ -1,0 +1,26 @@
+package com.umc.product.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.common.domain.enums.ClientType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@DisplayName("MemberPrincipal")
+class MemberPrincipalTest {
+
+    @Test
+    @DisplayName("인증 토큰의 name은 MemberPrincipal의 회원 ID 문자열이다")
+    void authentication_name_is_member_id() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(1L)
+            .clientType(ClientType.WEB)
+            .build();
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        assertThat(principal.getName()).isEqualTo("1");
+        assertThat(authentication.getName()).isEqualTo("1");
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerIntegrationTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.umc.product.global.websocket.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
+import com.umc.product.common.domain.enums.ClientType;
+import com.umc.product.global.config.WebSocketMessageBrokerConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.ParsedAccessToken;
+import com.umc.product.global.websocket.interceptor.ShutdownAwareHandshakeInterceptor;
+import com.umc.product.global.websocket.interceptor.StompAuthChannelInterceptor;
+import com.umc.product.global.websocket.interceptor.StompPrincipalInterceptor;
+import com.umc.product.global.websocket.interceptor.WebSocketInboundMetricInterceptor;
+import com.umc.product.global.websocket.interceptor.WebSocketOutboundMetricInterceptor;
+import com.umc.product.global.websocket.interceptor.WebSocketRateLimitInterceptor;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+@DisplayName("ApiResponseStompErrorHandler 통합 테스트")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = ApiResponseStompErrorHandlerIntegrationTest.TestApplication.class
+)
+@ActiveProfiles("test")
+class ApiResponseStompErrorHandlerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 CONNECT하면 ApiResponse 형식의 ERROR 프레임을 받는다")
+    void connect_without_authorization_header_receives_api_response_error_frame() throws Exception {
+        BlockingQueue<StompErrorFrame> errors = new LinkedBlockingQueue<>();
+        WebSocketStompClient stompClient = connect(new StompHeaders(), errors);
+
+        try {
+            StompErrorFrame errorFrame = errors.poll(5, TimeUnit.SECONDS);
+            assertThat(errorFrame).isNotNull();
+            assertErrorFrame(errorFrame, "JWT-0004", "잘못된 JWT 토큰입니다.");
+        } finally {
+            stompClient.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("잘못된 JWT로 CONNECT하면 ApiResponse 형식의 ERROR 프레임을 받는다")
+    void connect_with_invalid_jwt_receives_api_response_error_frame() throws Exception {
+        when(jwtTokenProvider.parseAndValidateAccessToken(eq("invalid-token")))
+            .thenThrow(new AuthenticationDomainException(AuthenticationErrorCode.INVALID_JWT));
+
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer invalid-token");
+        BlockingQueue<StompErrorFrame> errors = new LinkedBlockingQueue<>();
+        WebSocketStompClient stompClient = connect(connectHeaders, errors);
+
+        try {
+            StompErrorFrame errorFrame = errors.poll(5, TimeUnit.SECONDS);
+            assertThat(errorFrame).isNotNull();
+            assertErrorFrame(errorFrame, "JWT-0004", "잘못된 JWT 토큰입니다.");
+        } finally {
+            stompClient.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("권한 없는 채팅방 구독은 사용자 에러 큐로 ApiResponse 메시지를 받는다")
+    void subscribe_without_chat_room_access_receives_user_error_message() throws Exception {
+        when(jwtTokenProvider.parseAndValidateAccessToken(eq("valid-token")))
+            .thenReturn(new ParsedAccessToken(1L, List.of("USER"), ClientType.WEB));
+        when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
+
+        BlockingQueue<String> userErrors = new LinkedBlockingQueue<>();
+        WebSocketStompClient stompClient = stompClient();
+        StompSession session = connectSession(stompClient, "Bearer valid-token");
+
+        try {
+            session.subscribe("/user/queue/errors", new PayloadCollectingFrameHandler(userErrors));
+            TimeUnit.MILLISECONDS.sleep(300);
+
+            session.subscribe("/topic/chat/10", new PayloadCollectingFrameHandler(new LinkedBlockingQueue<>()));
+
+            String payload = userErrors.poll(5, TimeUnit.SECONDS);
+            assertThat(payload).isNotNull();
+            assertApiResponsePayload(payload, "AUTHORIZATION-0002", "해당 리소스에 접근할 권한이 없습니다.");
+        } finally {
+            if (session.isConnected()) {
+                session.disconnect();
+            }
+            stompClient.stop();
+        }
+    }
+
+    private WebSocketStompClient connect(StompHeaders connectHeaders, BlockingQueue<StompErrorFrame> errors) {
+        WebSocketStompClient stompClient = stompClient();
+        stompClient.connectAsync(
+            "http://localhost:%d/ws".formatted(port),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new ErrorCollectingSessionHandler(errors)
+        );
+        return stompClient;
+    }
+
+    private WebSocketStompClient stompClient() {
+        SockJsClient sockJsClient = new SockJsClient(
+            List.of(new WebSocketTransport(new StandardWebSocketClient()))
+        );
+        WebSocketStompClient stompClient = new WebSocketStompClient(sockJsClient);
+        return stompClient;
+    }
+
+    private StompSession connectSession(WebSocketStompClient stompClient, String authorizationHeader) throws Exception {
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", authorizationHeader);
+        return stompClient.connectAsync(
+            "http://localhost:%d/ws".formatted(port),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+            }
+        ).get(5, TimeUnit.SECONDS);
+    }
+
+    private void assertErrorFrame(StompErrorFrame errorFrame, String code, String message) throws Exception {
+        assertThat(errorFrame.headers().getContentType()).isEqualTo(MimeTypeUtils.APPLICATION_JSON);
+
+        assertApiResponsePayload(errorFrame.payload(), code, message);
+    }
+
+    private void assertApiResponsePayload(String payload, String code, String message) throws Exception {
+        JsonNode body = objectMapper.readTree(payload);
+        assertThat(body.path("success").asBoolean()).isFalse();
+        assertThat(body.path("code").asText()).isEqualTo(code);
+        assertThat(body.path("message").asText()).isEqualTo(message);
+        assertThat(body.has("result")).isFalse();
+    }
+
+    private record StompErrorFrame(StompHeaders headers, String payload) {
+    }
+
+    private static class PayloadCollectingFrameHandler implements StompFrameHandler {
+
+        private final BlockingQueue<String> payloads;
+
+        private PayloadCollectingFrameHandler(BlockingQueue<String> payloads) {
+            this.payloads = payloads;
+        }
+
+        @Override
+        public Type getPayloadType(StompHeaders headers) {
+            return byte[].class;
+        }
+
+        @Override
+        public void handleFrame(StompHeaders headers, Object payload) {
+            byte[] bytes = (byte[]) payload;
+            payloads.offer(new String(bytes, StandardCharsets.UTF_8));
+        }
+    }
+
+    private static class ErrorCollectingSessionHandler extends StompSessionHandlerAdapter {
+
+        private final BlockingQueue<StompErrorFrame> errors;
+
+        private ErrorCollectingSessionHandler(BlockingQueue<StompErrorFrame> errors) {
+            this.errors = errors;
+        }
+
+        @Override
+        public Type getPayloadType(StompHeaders headers) {
+            return byte[].class;
+        }
+
+        @Override
+        public void handleFrame(StompHeaders headers, Object payload) {
+            byte[] bytes = (byte[]) payload;
+            errors.offer(new StompErrorFrame(headers, new String(bytes, StandardCharsets.UTF_8)));
+        }
+
+        @Override
+        public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+            session.disconnect();
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        FlywayAutoConfiguration.class,
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        ManagementWebSecurityAutoConfiguration.class
+    })
+    @Import({
+        WebSocketMessageBrokerConfig.class,
+        ApiResponseStompErrorHandler.class,
+        WebSocketErrorPublisher.class,
+        StompPrincipalInterceptor.class,
+        StompAuthChannelInterceptor.class,
+        WebSocketRateLimitInterceptor.class,
+        WebSocketInboundMetricInterceptor.class,
+        WebSocketOutboundMetricInterceptor.class,
+        ShutdownAwareHandshakeInterceptor.class
+    })
+    static class TestApplication {
+
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        ObservationRegistry observationRegistry() {
+            return ObservationRegistry.create();
+        }
+
+        @Bean
+        ContextSnapshotFactory contextSnapshotFactory() {
+            return ContextSnapshotFactory.builder().build();
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerIntegrationTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerIntegrationTest.java
@@ -127,7 +127,7 @@ class ApiResponseStompErrorHandlerIntegrationTest {
             session.subscribe("/user/queue/errors", new PayloadCollectingFrameHandler(userErrors));
             TimeUnit.MILLISECONDS.sleep(300);
 
-            session.subscribe("/topic/chat/10", new PayloadCollectingFrameHandler(new LinkedBlockingQueue<>()));
+            session.subscribe("/topic/chat/rooms/10/messages", new PayloadCollectingFrameHandler(new LinkedBlockingQueue<>()));
 
             String payload = userErrors.poll(5, TimeUnit.SECONDS);
             assertThat(payload).isNotNull();

--- a/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerTest.java
@@ -74,7 +74,7 @@ class ApiResponseStompErrorHandlerTest {
 
     private Message<byte[]> stompMessageWithReceipt(String receipt) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
-        accessor.setDestination("/topic/chat/10");
+        accessor.setDestination("/topic/chat/rooms/10/messages");
         accessor.setReceipt(receipt);
         return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
     }

--- a/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/ApiResponseStompErrorHandlerTest.java
@@ -1,0 +1,81 @@
+package com.umc.product.global.websocket.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.common.domain.exception.CommonException;
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.util.MimeTypeUtils;
+
+@DisplayName("ApiResponseStompErrorHandler")
+class ApiResponseStompErrorHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ApiResponseStompErrorHandler sut = new ApiResponseStompErrorHandler(objectMapper);
+
+    @Test
+    @DisplayName("BusinessException은 해당 에러 코드의 ApiResponse ERROR 프레임으로 변환된다")
+    void business_exception_is_converted_to_api_response_error_frame() throws Exception {
+        Message<byte[]> clientMessage = stompMessageWithReceipt("receipt-1");
+
+        Message<byte[]> result = sut.handleClientMessageProcessingError(
+            clientMessage,
+            new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
+        );
+
+        JsonNode body = objectMapper.readTree(result.getPayload());
+        assertThat(body.path("success").asBoolean()).isFalse();
+        assertThat(body.path("code").asText()).isEqualTo("AUTHORIZATION-0002");
+        assertThat(body.path("message").asText()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+        assertThat(body.has("result")).isFalse();
+
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(result, StompHeaderAccessor.class);
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getContentType()).isEqualTo(MimeTypeUtils.APPLICATION_JSON);
+        assertThat(accessor.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+        assertThat(accessor.getReceiptId()).isEqualTo("receipt-1");
+    }
+
+    @Test
+    @DisplayName("감싸진 BusinessException도 원래 에러 코드로 변환된다")
+    void wrapped_business_exception_is_converted_to_original_error_code() throws Exception {
+        RuntimeException exception = new RuntimeException(new CommonException(CommonErrorCode.SECURITY_NOT_GIVEN));
+
+        Message<byte[]> result = sut.handleClientMessageProcessingError(null, exception);
+
+        JsonNode body = objectMapper.readTree(result.getPayload());
+        assertThat(body.path("success").asBoolean()).isFalse();
+        assertThat(body.path("code").asText()).isEqualTo("SECURITY-0001");
+        assertThat(body.path("message").asText()).isEqualTo("인증 정보가 전달되지 않았습니다.");
+        assertThat(body.has("result")).isFalse();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 예외는 공통 서버 에러 코드로 변환된다")
+    void unknown_exception_is_converted_to_internal_server_error() throws Exception {
+        Message<byte[]> result = sut.handleClientMessageProcessingError(null, new IllegalStateException("boom"));
+
+        JsonNode body = objectMapper.readTree(result.getPayload());
+        assertThat(body.path("success").asBoolean()).isFalse();
+        assertThat(body.path("code").asText()).isEqualTo("COMMON-0001");
+        assertThat(body.path("message").asText()).isEqualTo("알 수 없는 오류입니다. 관리자에게 문의해주세요.");
+        assertThat(body.has("result")).isFalse();
+    }
+
+    private Message<byte[]> stompMessageWithReceipt(String receipt) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination("/topic/chat/10");
+        accessor.setReceipt(receipt);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisherTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisherTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.verify;
 
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.global.response.ApiResponse;
-import java.security.Principal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,9 +21,12 @@ class WebSocketErrorPublisherTest {
     @DisplayName("사용자의 에러 큐로 ApiResponse 형식의 실패 응답을 전송한다")
     @SuppressWarnings({"unchecked", "rawtypes"})
     void send_error_to_user() {
-        Principal user = () -> "member-1";
+        WebSocketErrorEvent event = new WebSocketErrorEvent(
+            "member-1",
+            AuthorizationErrorCode.RESOURCE_ACCESS_DENIED
+        );
 
-        sut.sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+        sut.sendErrorToUser(event);
 
         ArgumentCaptor<ApiResponse<Object>> responseCaptor = ArgumentCaptor.forClass(ApiResponse.class);
         verify(messagingTemplate).convertAndSendToUser(

--- a/src/test/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisherTest.java
+++ b/src/test/java/com/umc/product/global/websocket/handler/WebSocketErrorPublisherTest.java
@@ -1,0 +1,42 @@
+package com.umc.product.global.websocket.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.response.ApiResponse;
+import java.security.Principal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@DisplayName("WebSocketErrorPublisher")
+class WebSocketErrorPublisherTest {
+
+    private final SimpMessagingTemplate messagingTemplate =
+        org.mockito.Mockito.mock(SimpMessagingTemplate.class);
+    private final WebSocketErrorPublisher sut = new WebSocketErrorPublisher(messagingTemplate);
+
+    @Test
+    @DisplayName("사용자의 에러 큐로 ApiResponse 형식의 실패 응답을 전송한다")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void send_error_to_user() {
+        Principal user = () -> "member-1";
+
+        sut.sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+
+        ArgumentCaptor<ApiResponse<Object>> responseCaptor = ArgumentCaptor.forClass(ApiResponse.class);
+        verify(messagingTemplate).convertAndSendToUser(
+            org.mockito.ArgumentMatchers.eq("member-1"),
+            org.mockito.ArgumentMatchers.eq("/queue/errors"),
+            responseCaptor.capture()
+        );
+
+        ApiResponse<Object> response = responseCaptor.getValue();
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getCode()).isEqualTo("AUTHORIZATION-0002");
+        assertThat(response.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+        assertThat(response.getResult()).isNull();
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -48,7 +48,7 @@ class StompAuthChannelInterceptorTest {
     @DisplayName("채팅방 접근 권한이 있는 멤버의 SUBSCRIBE 프레임은 통과된다")
     void subscribe_with_access_passes() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(true);
-        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/rooms/10/messages", 1L);
 
         Message<?> result = sut.preSend(message, channel);
 
@@ -60,7 +60,7 @@ class StompAuthChannelInterceptorTest {
     @DisplayName("채팅방 접근 권한이 있는 멤버의 SEND 프레임은 통과된다")
     void send_with_access_passes() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(true);
-        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/rooms/10/messages", 1L);
 
         Message<?> result = sut.preSend(message, channel);
 
@@ -72,7 +72,7 @@ class StompAuthChannelInterceptorTest {
     @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 에러 메시지를 전송하고 차단된다")
     void send_to_app_without_access_publishes_error_and_blocks() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
-        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/rooms/10/messages", 1L);
 
         Message<?> result = sut.preSend(message, channel);
 
@@ -87,7 +87,7 @@ class StompAuthChannelInterceptorTest {
     @DisplayName("채팅방 접근 권한이 없는 멤버의 SUBSCRIBE 프레임은 에러 메시지를 전송하고 차단된다")
     void subscribe_without_access_publishes_error_and_blocks() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
-        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/rooms/10/messages", 1L);
 
         Message<?> result = sut.preSend(message, channel);
 
@@ -101,7 +101,7 @@ class StompAuthChannelInterceptorTest {
     @Test
     @DisplayName("/topic 하위 경로로 직접 SEND하는 프레임은 CommonException이 발생한다")
     void send_directly_to_broker_topic_throws() {
-        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/rooms/10/messages", 1L);
 
         assertThatThrownBy(() -> sut.preSend(message, channel))
             .isInstanceOf(CommonException.class)
@@ -153,7 +153,7 @@ class StompAuthChannelInterceptorTest {
     @Test
     @DisplayName("Principal이 없는 채팅방 프레임은 CommonException이 발생한다")
     void chat_frame_without_principal_throws() {
-        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", null);
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/rooms/10/messages", null);
 
         assertThatThrownBy(() -> sut.preSend(message, channel))
             .isInstanceOf(CommonException.class)
@@ -164,7 +164,7 @@ class StompAuthChannelInterceptorTest {
     @Test
     @DisplayName("SEND와 SUBSCRIBE가 아닌 프레임은 인가 처리 없이 통과된다")
     void non_target_command_passes() {
-        Message<byte[]> message = stompMessage(StompCommand.CONNECT, "/topic/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.CONNECT, "/topic/chat/rooms/10/messages", 1L);
 
         assertThat(sut.preSend(message, channel)).isSameAs(message);
         verifyNoInteractions(checkChatRoomAccessUseCase);
@@ -173,7 +173,20 @@ class StompAuthChannelInterceptorTest {
     @Test
     @DisplayName("SUBSCRIBE의 chat namespace 안에서 잘못된 destination은 CommonException이 발생한다")
     void subscribe_invalid_chat_destination_throws() {
-        List.of("/topic/chat", "/topic/chat/", "/topic/chat/not-number", "/topic/chat/*", "/topic/chat/10/extra")
+        List.of(
+                "/topic/chat",
+                "/topic/chat/",
+                "/topic/chat/not-number",
+                "/topic/chat/*",
+                "/topic/chat/10/extra",
+                "/topic/chat/10",
+                "/topic/chat/rooms",
+                "/topic/chat/rooms/",
+                "/topic/chat/rooms/not-number/messages",
+                "/topic/chat/rooms/*/messages",
+                "/topic/chat/rooms/10",
+                "/topic/chat/rooms/10/messages/extra"
+            )
             .forEach(destination -> assertInvalidDestination(StompCommand.SUBSCRIBE, destination));
 
         verifyNoInteractions(checkChatRoomAccessUseCase);
@@ -183,7 +196,20 @@ class StompAuthChannelInterceptorTest {
     @Test
     @DisplayName("SEND의 chat namespace 안에서 잘못된 destination은 CommonException이 발생한다")
     void send_invalid_chat_destination_throws() {
-        List.of("/app/chat", "/app/chat/", "/app/chat/not-number", "/app/chat/*", "/app/chat/10/extra")
+        List.of(
+                "/app/chat",
+                "/app/chat/",
+                "/app/chat/not-number",
+                "/app/chat/*",
+                "/app/chat/10/extra",
+                "/app/chat/10",
+                "/app/chat/rooms",
+                "/app/chat/rooms/",
+                "/app/chat/rooms/not-number/messages",
+                "/app/chat/rooms/*/messages",
+                "/app/chat/rooms/10",
+                "/app/chat/rooms/10/messages/extra"
+            )
             .forEach(destination -> assertInvalidDestination(StompCommand.SEND, destination));
 
         verifyNoInteractions(checkChatRoomAccessUseCase);

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -99,11 +99,53 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
-    @DisplayName("topic으로 직접 SEND하는 프레임은 채팅 전송 경로가 아니므로 인가 처리 없이 통과된다")
-    void send_to_topic_passes_without_authorization() {
+    @DisplayName("/topic 하위 경로로 직접 SEND하는 프레임은 CommonException이 발생한다")
+    void send_directly_to_broker_topic_throws() {
         Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/10", 1L);
 
-        assertThat(sut.preSend(message, channel)).isSameAs(message);
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_WEBSOCKET_BROKER_ACCESS);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+        verifyNoInteractions(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("/topic 경로로 직접 SEND하는 프레임은 CommonException이 발생한다")
+    void send_directly_to_exact_broker_topic_throws() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic", 1L);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_WEBSOCKET_BROKER_ACCESS);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+        verifyNoInteractions(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("/queue 하위 경로로 직접 SEND하는 프레임은 CommonException이 발생한다")
+    void send_directly_to_broker_queue_throws() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/queue/errors", 1L);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_WEBSOCKET_BROKER_ACCESS);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+        verifyNoInteractions(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("/queue 경로로 직접 SEND하는 프레임은 CommonException이 발생한다")
+    void send_directly_to_exact_broker_queue_throws() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/queue", 1L);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_WEBSOCKET_BROKER_ACCESS);
         verifyNoInteractions(checkChatRoomAccessUseCase);
         verifyNoInteractions(applicationEventPublisher);
     }
@@ -129,12 +171,41 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
-    @DisplayName("채팅방 destination으로 파싱할 수 없는 프레임은 인가 처리 없이 통과된다")
-    void invalid_chat_destination_passes() {
-        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/not-number", 1L);
+    @DisplayName("SUBSCRIBE의 chat namespace 안에서 잘못된 destination은 CommonException이 발생한다")
+    void subscribe_invalid_chat_destination_throws() {
+        List.of("/topic/chat", "/topic/chat/", "/topic/chat/not-number", "/topic/chat/*", "/topic/chat/10/extra")
+            .forEach(destination -> assertInvalidDestination(StompCommand.SUBSCRIBE, destination));
+
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+        verifyNoInteractions(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("SEND의 chat namespace 안에서 잘못된 destination은 CommonException이 발생한다")
+    void send_invalid_chat_destination_throws() {
+        List.of("/app/chat", "/app/chat/", "/app/chat/not-number", "/app/chat/*", "/app/chat/10/extra")
+            .forEach(destination -> assertInvalidDestination(StompCommand.SEND, destination));
+
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+        verifyNoInteractions(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("chat namespace가 아닌 application destination은 인가 처리 없이 통과된다")
+    void non_chat_application_destination_passes() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/inquiry/10", 1L);
 
         assertThat(sut.preSend(message, channel)).isSameAs(message);
         verifyNoInteractions(checkChatRoomAccessUseCase);
+    }
+
+    private void assertInvalidDestination(StompCommand command, String destination) {
+        Message<byte[]> message = stompMessage(command, destination, 1L);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_WEBSOCKET_INVALID_DESTINATION);
     }
 
     private Message<byte[]> stompMessage(StompCommand command, String destination, Long memberId) {

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -1,0 +1,99 @@
+package com.umc.product.global.websocket.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
+import com.umc.product.global.security.MemberPrincipal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@DisplayName("StompAuthChannelInterceptor")
+@ExtendWith(MockitoExtension.class)
+class StompAuthChannelInterceptorTest {
+
+    @Mock
+    private CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
+
+    @Mock
+    private MessageChannel channel;
+
+    @InjectMocks
+    private StompAuthChannelInterceptor sut;
+
+    @Test
+    @DisplayName("채팅방 접근 권한이 있는 멤버의 SUBSCRIBE 프레임은 통과된다")
+    void subscribe_with_access_passes() {
+        when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(true);
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", 1L);
+
+        Message<?> result = sut.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(checkChatRoomAccessUseCase).hasChatRoomAccess(1L, 10L);
+    }
+
+    @Test
+    @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 MessageDeliveryException이 발생한다")
+    void send_without_access_throws() {
+        when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/10", 1L);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(MessageDeliveryException.class)
+            .hasMessageContaining("채팅방 접근 권한");
+    }
+
+    @Test
+    @DisplayName("Principal이 없는 채팅방 프레임은 MessageDeliveryException이 발생한다")
+    void chat_frame_without_principal_throws() {
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", null);
+
+        assertThatThrownBy(() -> sut.preSend(message, channel))
+            .isInstanceOf(MessageDeliveryException.class)
+            .hasMessageContaining("채팅방 접근 권한");
+    }
+
+    @Test
+    @DisplayName("SEND와 SUBSCRIBE가 아닌 프레임은 인가 처리 없이 통과된다")
+    void non_target_command_passes() {
+        Message<byte[]> message = stompMessage(StompCommand.CONNECT, "/topic/chat/10", 1L);
+
+        assertThat(sut.preSend(message, channel)).isSameAs(message);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+    }
+
+    @Test
+    @DisplayName("채팅방 destination으로 파싱할 수 없는 프레임은 인가 처리 없이 통과된다")
+    void invalid_chat_destination_passes() {
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/not-number", 1L);
+
+        assertThat(sut.preSend(message, channel)).isSameAs(message);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
+    }
+
+    private Message<byte[]> stompMessage(StompCommand command, String destination, Long memberId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        accessor.setDestination(destination);
+        if (memberId != null) {
+            MemberPrincipal principal = MemberPrincipal.builder().memberId(memberId).build();
+            accessor.setUser(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+        }
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -2,16 +2,18 @@ package com.umc.product.global.websocket.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
 import com.umc.product.common.domain.exception.CommonException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.websocket.handler.WebSocketErrorPublisher;
+import java.security.Principal;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,9 @@ class StompAuthChannelInterceptorTest {
 
     @Mock
     private CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
+
+    @Mock
+    private WebSocketErrorPublisher webSocketErrorPublisher;
 
     @Mock
     private MessageChannel channel;
@@ -64,15 +69,29 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
-    @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 AuthorizationDomainException이 발생한다")
-    void send_to_app_without_access_throws() {
+    @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 에러 메시지를 전송하고 차단된다")
+    void send_to_app_without_access_publishes_error_and_blocks() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
         Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
 
-        assertThatThrownBy(() -> sut.preSend(message, channel))
-            .isInstanceOf(AuthorizationDomainException.class)
-            .extracting("baseCode")
-            .isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+        Message<?> result = sut.preSend(message, channel);
+
+        Principal user = StompHeaderAccessor.wrap(message).getUser();
+        assertThat(result).isNull();
+        verify(webSocketErrorPublisher).sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("채팅방 접근 권한이 없는 멤버의 SUBSCRIBE 프레임은 에러 메시지를 전송하고 차단된다")
+    void subscribe_without_access_publishes_error_and_blocks() {
+        when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", 1L);
+
+        Message<?> result = sut.preSend(message, channel);
+
+        Principal user = StompHeaderAccessor.wrap(message).getUser();
+        assertThat(result).isNull();
+        verify(webSocketErrorPublisher).sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
     }
 
     @Test
@@ -82,6 +101,8 @@ class StompAuthChannelInterceptorTest {
 
         assertThat(sut.preSend(message, channel)).isSameAs(message);
         verifyNoInteractions(checkChatRoomAccessUseCase);
+        verify(webSocketErrorPublisher, never())
+            .sendErrorToUser(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -6,7 +6,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase;
+import com.umc.product.common.domain.exception.CommonException;
+import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +21,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
@@ -61,14 +64,15 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
-    @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 MessageDeliveryException이 발생한다")
+    @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 AuthorizationDomainException이 발생한다")
     void send_to_app_without_access_throws() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
         Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
 
         assertThatThrownBy(() -> sut.preSend(message, channel))
-            .isInstanceOf(MessageDeliveryException.class)
-            .hasMessageContaining("채팅방 접근 권한");
+            .isInstanceOf(AuthorizationDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
     }
 
     @Test
@@ -81,13 +85,14 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
-    @DisplayName("Principal이 없는 채팅방 프레임은 MessageDeliveryException이 발생한다")
+    @DisplayName("Principal이 없는 채팅방 프레임은 CommonException이 발생한다")
     void chat_frame_without_principal_throws() {
         Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat/10", null);
 
         assertThatThrownBy(() -> sut.preSend(message, channel))
-            .isInstanceOf(MessageDeliveryException.class)
-            .hasMessageContaining("채팅방 접근 권한");
+            .isInstanceOf(CommonException.class)
+            .extracting("baseCode")
+            .isEqualTo(CommonErrorCode.SECURITY_NOT_GIVEN);
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -49,14 +49,35 @@ class StompAuthChannelInterceptorTest {
     }
 
     @Test
+    @DisplayName("채팅방 접근 권한이 있는 멤버의 SEND 프레임은 통과된다")
+    void send_with_access_passes() {
+        when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(true);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
+
+        Message<?> result = sut.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(checkChatRoomAccessUseCase).hasChatRoomAccess(1L, 10L);
+    }
+
+    @Test
     @DisplayName("채팅방 접근 권한이 없는 멤버의 SEND 프레임은 MessageDeliveryException이 발생한다")
-    void send_without_access_throws() {
+    void send_to_app_without_access_throws() {
         when(checkChatRoomAccessUseCase.hasChatRoomAccess(1L, 10L)).thenReturn(false);
-        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/10", 1L);
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/app/chat/10", 1L);
 
         assertThatThrownBy(() -> sut.preSend(message, channel))
             .isInstanceOf(MessageDeliveryException.class)
             .hasMessageContaining("채팅방 접근 권한");
+    }
+
+    @Test
+    @DisplayName("topic으로 직접 SEND하는 프레임은 채팅 전송 경로가 아니므로 인가 처리 없이 통과된다")
+    void send_to_topic_passes_without_authorization() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, "/topic/chat/10", 1L);
+
+        assertThat(sut.preSend(message, channel)).isSameAs(message);
+        verifyNoInteractions(checkChatRoomAccessUseCase);
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/interceptor/StompAuthChannelInterceptorTest.java
@@ -2,7 +2,6 @@ package com.umc.product.global.websocket.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -12,7 +11,7 @@ import com.umc.product.chat.application.port.in.query.CheckChatRoomAccessUseCase
 import com.umc.product.common.domain.exception.CommonException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.global.websocket.handler.WebSocketErrorPublisher;
+import com.umc.product.global.websocket.handler.WebSocketErrorEvent;
 import java.security.Principal;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -36,7 +36,7 @@ class StompAuthChannelInterceptorTest {
     private CheckChatRoomAccessUseCase checkChatRoomAccessUseCase;
 
     @Mock
-    private WebSocketErrorPublisher webSocketErrorPublisher;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Mock
     private MessageChannel channel;
@@ -78,7 +78,9 @@ class StompAuthChannelInterceptorTest {
 
         Principal user = StompHeaderAccessor.wrap(message).getUser();
         assertThat(result).isNull();
-        verify(webSocketErrorPublisher).sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+        verify(applicationEventPublisher).publishEvent(
+            new WebSocketErrorEvent(user.getName(), AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
+        );
     }
 
     @Test
@@ -91,7 +93,9 @@ class StompAuthChannelInterceptorTest {
 
         Principal user = StompHeaderAccessor.wrap(message).getUser();
         assertThat(result).isNull();
-        verify(webSocketErrorPublisher).sendErrorToUser(user, AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+        verify(applicationEventPublisher).publishEvent(
+            new WebSocketErrorEvent(user.getName(), AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)
+        );
     }
 
     @Test
@@ -101,8 +105,7 @@ class StompAuthChannelInterceptorTest {
 
         assertThat(sut.preSend(message, channel)).isSameAs(message);
         verifyNoInteractions(checkChatRoomAccessUseCase);
-        verify(webSocketErrorPublisher, never())
-            .sendErrorToUser(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        verifyNoInteractions(applicationEventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #929 

## 🚀 작업 내용

### 변경 범위 요약
STOMP 채팅방 접근 권한 검사, WebSocket 에러 응답 포맷, 사용자 전용 에러 큐 기반의 인가 실패 응답 방식을 정리했습니다.

### 작업 단위별 상세
1. 무엇을: STOMP 채팅방 접근 권한 검사를 추가했습니다.
    - 어떻게: CheckChatRoomAccessUseCase를 추가하고, ChatRoomQueryService가 이를 구현하도록 했습니다. StompAuthChannelInterceptor에서는 SUBSCRIBE /topic/chat/{id}, SEND /app/chat/{id} 요청의 채팅방 접근 권한을 검사하도록 했습니다.
    - 왜: WebSocket 채팅에서도 HTTP API처럼 사용자가 접근 가능한 채팅방에 대해서만 구독하거나 메시지를 보낼 수 있게 하기 위해서입니다.

2. 무엇을: STOMP 채팅 destination 처리 기준을 정리했습니다.
    - 어떻게: 구독은 /topic/chat/{id}, 전송은 /app/chat/{id}만 채팅방 인가 검사 대상으로 분리했습니다. /topic/chat/{id}로 직접 SEND하는 케이스는 STOMP 채팅 구조가 아니라고 보고 검사 대상에서 제외했습니다.
    - 왜: 현재 서버 설정상 /app은 서버가 클라이언트 메시지를 처리하는 애플리케이션 경로이고, /topic은 브로커가 메시지를 배포하는 구독 경로입니다. 그래서 채팅 전송과 구독 destination을 분리해, 서버 설정의 책임과 맞는 경로만 인가 검사 대상으로 삼았습니다.

| STOMP Command | Destination | 의미 | 처리 방식 |
| :--- | :--- | :--- | :--- |
| **SUBSCRIBE** | `/topic/chat/{chatRoomId}` | 클라이언트가 채팅방 메시지를 받기 위해 구독하는 경로 | 채팅방 접근 권한 검사 |
| **SEND** | `/app/chat/{chatRoomId}` | 클라이언트가 채팅 메시지를 서버로 전송하는 경로 | 채팅방 접근 권한 검사 |
| **SEND** | `/topic/chat/{chatRoomId}` | 브로커 구독 경로로 직접 메시지를 보내는 비일반적인 경로 | 채팅 전송 경로로 보지 않아 권한 검사 대상에서 제외 |
| **SUBSCRIBE / SEND** | 그 외 destination | 채팅방 접근과 무관한 STOMP 요청 | 인가 처리 없이 통과 |

3. 무엇을: STOMP 예외 응답을 HTTP와 같은 ApiResponse 형식으로 변환했습니다.
    - 어떻게: ApiResponseStompErrorHandler를 추가하고, BusinessException 계열 예외를 STOMP ERROR 프레임의 JSON body로 변환하도록 했습니다.
    - 왜: WebSocket에서도 클라이언트가 HTTP와 동일한 success, code, message 형식으로 에러를 해석할 수 있게 하기 위해서입니다.

4. 무엇을: 채팅방 인가 실패 응답 방식을 사용자 에러 큐 기반으로 개선했습니다.
    - 어떻게: WebSocketErrorPublisher를 추가하고, 권한 없는 SUBSCRIBE/SEND가 들어오면 /user/queue/errors로 ApiResponse 형식의 에러를 보낸 뒤 원래 프레임은 차단하도록 바꿨습니다.
    - 왜: 브라우저/SockJS 환경에서는 CONNECT 실패 직후 STOMP ERROR body가 유실될 수 있어서, 연결 이후의 인가 실패는 사용자 전용 큐로 안정적으로 전달하기 위해서입니다.

5. 무엇을: 관련 단위 테스트와 통합 테스트를 추가했습니다.
    - 어떻게: 인터셉터 권한 검사, 사용자 에러 큐 발행, STOMP ERROR 프레임 변환, /user/queue/errors 수신 흐름을 테스트했습니다.
    - 왜: 서버 내부 처리뿐 아니라 실제 STOMP 연결 흐름에서도 에러 응답이 의도한 JSON 형식으로 전달되는지 검증하기 위해서입니다.

## 💬 리뷰 중점사항
  - WebSocket 채팅방 인가 실패는 STOMP ERROR가 아니라 /user/queue/errors로 내려가도록 정리했습니다. 프론트는 CONNECT 이후 이 개인 에러 큐를 구독해야 합니다.
  - 채팅방 접근 권한은 ChatMember 존재 여부로 판단합니다. 이 방식상 채팅방이 존재하지 않는 경우와 실제 참여자가 아닌 경우가 같은 인가 실패 흐름으로 처리될 수 있어, 채팅 도메인 정책과 맞는지 확인이 필요합니다. @kanghana1 
  - WebSocket 에러 응답은 HTTP와 동일한 ApiResponse 형식으로 맞췄습니다. 프론트는 WebSocket 에러도 success, code, message 기준으로 처리할 수 있습니다.
  - StompAuthChannelInterceptor는 직접 메시지를 보내지 않고 이벤트만 발행하도록 정리했습니다. 실제 전송은 WebSocketErrorPublisher가 담당합니다.