### PR TITLE
[Chore] Member 및 Challenger 도메인 테스트 보강

### DIFF
--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
@@ -14,6 +14,7 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -39,7 +40,7 @@ public class ChallengerCommandController {
     )
     @Operation(summary = "[CHALLENGER-001] 챌린저 생성")
     @PostMapping
-    ChallengerInfoResponse createChallenger(@RequestBody CreateChallengerInfoRequest request) {
+    ChallengerInfoResponse createChallenger(@Valid @RequestBody CreateChallengerInfoRequest request) {
         Long challengerId = manageChallengerUseCase.createChallenger(request.toCommand());
 
         return assembler.fromChallengerId(challengerId);
@@ -52,7 +53,7 @@ public class ChallengerCommandController {
     @Operation(summary = "[CHALLENGER-002] 챌린저 batch 생성", description = "한 번에 여러 건의 챌린저를 등록합니다. 기존에 `bulk`로 되어 있는 엔드포인트를 수정하였습니다.")
     @PostMapping("batch")
     List<ChallengerInfoResponse> bulkCreateChallenger(
-        @RequestBody List<CreateChallengerInfoRequest> requests
+        @Valid @RequestBody List<@Valid CreateChallengerInfoRequest> requests
     ) {
         return requests.stream()
             .map(request ->
@@ -71,7 +72,7 @@ public class ChallengerCommandController {
     @PostMapping("{challengerId}/deactivate")
     void deactivateChallenger(
         @PathVariable Long challengerId,
-        @RequestBody DeactivateChallengerRequest request
+        @Valid @RequestBody DeactivateChallengerRequest request
     ) {
         manageChallengerUseCase.deactivateChallenger(request.toCommand(challengerId));
     }
@@ -85,7 +86,7 @@ public class ChallengerCommandController {
     ChallengerInfoResponse editChallengerInfo(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long challengerId,
-        @RequestBody EditChallengerPartRequest request
+        @Valid @RequestBody EditChallengerPartRequest request
     ) {
         manageChallengerUseCase.updateChallenger(request.toCommand(challengerId, memberPrincipal.getMemberId()));
 

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
@@ -1,5 +1,16 @@
 package com.umc.product.challenger.adapter.in.web;
 
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -12,19 +23,11 @@ import com.umc.product.challenger.application.port.in.command.ManageChallengerUs
 import com.umc.product.challenger.application.port.in.command.dto.DeleteChallengerCommand;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/challenger")

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/challenger")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "Challenger | 챌린저 Command", description = "챌린저 정보를 조회하고, 기록 조회. 검색은 따로 구분되어 있습니다")
 public class ChallengerCommandController {
 

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java
@@ -11,6 +11,7 @@ import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResp
 import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,7 +40,7 @@ public class ChallengerPointCommandController {
     @PostMapping("{challengerId}/points")
     ChallengerInfoResponse grantChallengerPoints(
         @PathVariable Long challengerId,
-        @RequestBody GrantChallengerPointRequest request
+        @Valid @RequestBody GrantChallengerPointRequest request
     ) {
         manageChallengerUseCase.grantChallengerPoint(request.toCommand(challengerId));
 
@@ -56,7 +57,7 @@ public class ChallengerPointCommandController {
     @PatchMapping("points/{challengerPointId}")
     void editChallengerPoints(
         @PathVariable Long challengerPointId,
-        @RequestBody EditChallengerPointRequest request
+        @Valid @RequestBody EditChallengerPointRequest request
     ) {
         manageChallengerUseCase.updateChallengerPoint(request.toCommand(challengerPointId));
     }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java
@@ -1,5 +1,13 @@
 package com.umc.product.challenger.adapter.in.web;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -9,17 +17,11 @@ import com.umc.product.challenger.adapter.in.web.dto.request.EditChallengerPoint
 import com.umc.product.challenger.adapter.in.web.dto.request.GrantChallengerPointRequest;
 import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
 import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/challenger")

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
@@ -14,6 +14,7 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,7 +48,7 @@ public class ChallengerRecordController {
 //    )
     public void addChallengerRecordToMember(
         @CurrentMember MemberPrincipal memberPrincipal,
-        @RequestBody AddChallengerRecordToMemberRequest request) {
+        @Valid @RequestBody AddChallengerRecordToMemberRequest request) {
 
         manageChallengerRecordUseCase.consumeCode(
             ConsumeChallengerRecordCommand.builder()
@@ -94,7 +95,7 @@ public class ChallengerRecordController {
     @PostMapping
     public ChallengerRecordResponse createChallengerRecord(
         @CurrentMember MemberPrincipal memberPrincipal,
-        @RequestBody CreateChallengerRecordRequest request
+        @Valid @RequestBody CreateChallengerRecordRequest request
     ) {
         // TODO: SUPER_ADMIN 만 가능하도록 권한 설정
 
@@ -127,7 +128,7 @@ public class ChallengerRecordController {
     )
     public List<Long> createChallengerRecordBulk(
         @CurrentMember MemberPrincipal memberPrincipal,
-        @RequestBody List<CreateChallengerRecordRequest> request
+        @Valid @RequestBody List<@Valid CreateChallengerRecordRequest> request
     ) {
         List<Long> ids = manageChallengerRecordUseCase.createBulk(
             request.stream()

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
@@ -1,5 +1,15 @@
 package com.umc.product.challenger.adapter.in.web;
 
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -12,18 +22,11 @@ import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallen
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/challenger-record")

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/challenger-record")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "Challenger | 챌린저 기록", description = "챌린저 기록 관련")
 public class ChallengerRecordController {
 

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/AddChallengerRecordToMemberRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/AddChallengerRecordToMemberRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record AddChallengerRecordToMemberRequest(
-    @NotBlank(message = "챌린저 기록 코드는 필수입니다")
-    @Size(min = 6, max = 6, message = "챌린저 기록 코드는 6자리여야 합니다")
-    String code
+    @NotBlank(message = "챌린저 기록 코드는 필수입니다") @Size(min = 6, max = 6, message = "챌린저 기록 코드는 6자리여야 합니다") String code
 ) {
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/AddChallengerRecordToMemberRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/AddChallengerRecordToMemberRequest.java
@@ -1,6 +1,11 @@
 package com.umc.product.challenger.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record AddChallengerRecordToMemberRequest(
+    @NotBlank(message = "챌린저 기록 코드는 필수입니다")
+    @Size(min = 6, max = 6, message = "챌린저 기록 코드는 6자리여야 합니다")
     String code
 ) {
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerInfoRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerInfoRequest.java
@@ -2,10 +2,14 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import jakarta.validation.constraints.NotNull;
 
 public record CreateChallengerInfoRequest(
+        @NotNull(message = "회원 ID는 필수입니다")
         Long memberId,
+        @NotNull(message = "챌린저 파트는 필수입니다")
         ChallengerPart part,
+        @NotNull(message = "기수 ID는 필수입니다")
         Long gisuId
 ) {
     public CreateChallengerCommand toCommand() {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerInfoRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerInfoRequest.java
@@ -2,15 +2,13 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
+
 import jakarta.validation.constraints.NotNull;
 
 public record CreateChallengerInfoRequest(
-        @NotNull(message = "회원 ID는 필수입니다")
-        Long memberId,
-        @NotNull(message = "챌린저 파트는 필수입니다")
-        ChallengerPart part,
-        @NotNull(message = "기수 ID는 필수입니다")
-        Long gisuId
+        @NotNull(message = "회원 ID는 필수입니다") Long memberId,
+        @NotNull(message = "챌린저 파트는 필수입니다") ChallengerPart part,
+        @NotNull(message = "기수 ID는 필수입니다") Long gisuId
 ) {
     public CreateChallengerCommand toCommand() {
         return new CreateChallengerCommand(memberId, part, gisuId);

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
@@ -2,22 +2,17 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CreateChallengerRecordRequest(
-    @NotNull(message = "기수 ID는 필수입니다")
-    Long gisuId,
-    @NotNull(message = "지부 ID는 필수입니다")
-    Long chapterId,
-    @NotNull(message = "학교 ID는 필수입니다")
-    Long schoolId,
-    @NotNull(message = "챌린저 파트는 필수입니다")
-    ChallengerPart part,
-    @NotBlank(message = "회원 이름은 필수입니다")
-    @Size(max = 30, message = "회원 이름은 30자 이하여야 합니다")
-    String memberName,
+    @NotNull(message = "기수 ID는 필수입니다") Long gisuId,
+    @NotNull(message = "지부 ID는 필수입니다") Long chapterId,
+    @NotNull(message = "학교 ID는 필수입니다") Long schoolId,
+    @NotNull(message = "챌린저 파트는 필수입니다") ChallengerPart part,
+    @NotBlank(message = "회원 이름은 필수입니다") @Size(max = 30, message = "회원 이름은 30자 이하여야 합니다") String memberName,
     ChallengerRoleType challengerRoleType
 ) {
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
@@ -2,12 +2,21 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record CreateChallengerRecordRequest(
+    @NotNull(message = "기수 ID는 필수입니다")
     Long gisuId,
+    @NotNull(message = "지부 ID는 필수입니다")
     Long chapterId,
+    @NotNull(message = "학교 ID는 필수입니다")
     Long schoolId,
+    @NotNull(message = "챌린저 파트는 필수입니다")
     ChallengerPart part,
+    @NotBlank(message = "회원 이름은 필수입니다")
+    @Size(max = 30, message = "회원 이름은 30자 이하여야 합니다")
     String memberName,
     ChallengerRoleType challengerRoleType
 ) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
@@ -2,10 +2,17 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.ChallengerDeactivationType;
 import com.umc.product.challenger.application.port.in.command.dto.DeactivateChallengerCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record DeactivateChallengerRequest(
+        @NotNull(message = "비활성화 타입은 필수입니다")
         ChallengerDeactivationType deactivationType,
+        @NotNull(message = "수정자 ID는 필수입니다")
         Long modifiedBy,
+        @NotBlank(message = "사유는 필수입니다")
+        @Size(max = 200, message = "사유는 200자 이하여야 합니다")
         String reason
 ) {
     public DeactivateChallengerCommand toCommand(Long challengerId) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
@@ -2,18 +2,15 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.ChallengerDeactivationType;
 import com.umc.product.challenger.application.port.in.command.dto.DeactivateChallengerCommand;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record DeactivateChallengerRequest(
-        @NotNull(message = "비활성화 타입은 필수입니다")
-        ChallengerDeactivationType deactivationType,
-        @NotNull(message = "수정자 ID는 필수입니다")
-        Long modifiedBy,
-        @NotBlank(message = "사유는 필수입니다")
-        @Size(max = 200, message = "사유는 200자 이하여야 합니다")
-        String reason
+        @NotNull(message = "비활성화 타입은 필수입니다") ChallengerDeactivationType deactivationType,
+        @NotNull(message = "수정자 ID는 필수입니다") Long modifiedBy,
+        @NotBlank(message = "사유는 필수입니다") @Size(max = 200, message = "사유는 200자 이하여야 합니다") String reason
 ) {
     public DeactivateChallengerCommand toCommand(Long challengerId) {
         return DeactivateChallengerCommand.of(

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java
@@ -16,7 +16,7 @@ public record DeactivateChallengerRequest(
         String reason
 ) {
     public DeactivateChallengerCommand toCommand(Long challengerId) {
-        return new DeactivateChallengerCommand(
+        return DeactivateChallengerCommand.of(
             challengerId,
             deactivationType,
             modifiedBy,

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPartRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPartRequest.java
@@ -2,8 +2,10 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import jakarta.validation.constraints.NotNull;
 
 public record EditChallengerPartRequest(
+        @NotNull(message = "변경할 파트는 필수입니다")
         ChallengerPart newPart
 ) {
     public UpdateChallengerCommand toCommand(Long challengerId, Long modifiedBy) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPartRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPartRequest.java
@@ -2,11 +2,11 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
+
 import jakarta.validation.constraints.NotNull;
 
 public record EditChallengerPartRequest(
-        @NotNull(message = "변경할 파트는 필수입니다")
-        ChallengerPart newPart
+        @NotNull(message = "변경할 파트는 필수입니다") ChallengerPart newPart
 ) {
     public UpdateChallengerCommand toCommand(Long challengerId, Long modifiedBy) {
         return UpdateChallengerCommand.forPartChange(

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
@@ -1,13 +1,12 @@
 package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerPointCommand;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record EditChallengerPointRequest(
-        @NotBlank(message = "상벌점 설명은 필수입니다")
-        @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다")
-        String newDescription
+        @NotBlank(message = "상벌점 설명은 필수입니다") @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다") String newDescription
 ) {
     public UpdateChallengerPointCommand toCommand(Long challengerPointId) {
         return UpdateChallengerPointCommand.of(challengerPointId, newDescription);

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
@@ -1,8 +1,12 @@
 package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerPointCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record EditChallengerPointRequest(
+        @NotBlank(message = "상벌점 설명은 필수입니다")
+        @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다")
         String newDescription
 ) {
     public UpdateChallengerPointCommand toCommand(Long challengerPointId) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java
@@ -10,6 +10,6 @@ public record EditChallengerPointRequest(
         String newDescription
 ) {
     public UpdateChallengerPointCommand toCommand(Long challengerPointId) {
-        return new UpdateChallengerPointCommand(challengerPointId, newDescription);
+        return UpdateChallengerPointCommand.of(challengerPointId, newDescription);
     }
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/GrantChallengerPointRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/GrantChallengerPointRequest.java
@@ -2,10 +2,14 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
 import com.umc.product.challenger.domain.enums.PointType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record GrantChallengerPointRequest(
+    @NotNull(message = "상벌점 타입은 필수입니다")
     PointType pointType,
     Integer pointValue,
+    @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다")
     String description
 ) {
     public GrantChallengerPointCommand toCommand(Long challengerId) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/GrantChallengerPointRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/GrantChallengerPointRequest.java
@@ -2,15 +2,14 @@ package com.umc.product.challenger.adapter.in.web.dto.request;
 
 import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
 import com.umc.product.challenger.domain.enums.PointType;
+
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record GrantChallengerPointRequest(
-    @NotNull(message = "상벌점 타입은 필수입니다")
-    PointType pointType,
+    @NotNull(message = "상벌점 타입은 필수입니다") PointType pointType,
     Integer pointValue,
-    @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다")
-    String description
+    @Size(max = 200, message = "상벌점 설명은 200자 이하여야 합니다") String description
 ) {
     public GrantChallengerPointCommand toCommand(Long challengerId) {
         return new GrantChallengerPointCommand(challengerId, pointType, pointValue, description);

--- a/src/main/java/com/umc/product/challenger/application/port/in/command/dto/DeactivateChallengerCommand.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/command/dto/DeactivateChallengerCommand.java
@@ -6,4 +6,12 @@ public record DeactivateChallengerCommand(
         Long modifiedBy,
         String reason
 ) {
+    public static DeactivateChallengerCommand of(
+            Long challengerId,
+            ChallengerDeactivationType deactivationType,
+            Long modifiedBy,
+            String reason
+    ) {
+        return new DeactivateChallengerCommand(challengerId, deactivationType, modifiedBy, reason);
+    }
 }

--- a/src/main/java/com/umc/product/challenger/application/port/in/command/dto/UpdateChallengerPointCommand.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/command/dto/UpdateChallengerPointCommand.java
@@ -4,4 +4,7 @@ public record UpdateChallengerPointCommand(
         Long challengerPointId,
         String newDescription // 설명 수정
 ) {
+    public static UpdateChallengerPointCommand of(Long challengerPointId, String newDescription) {
+        return new UpdateChallengerPointCommand(challengerPointId, newDescription);
+    }
 }

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
@@ -92,6 +92,19 @@ class ChallengerCommandControllerTest {
     }
 
     @Test
+    @DisplayName("챌린저 batch 생성 요청 내부 항목의 part가 없으면 400")
+    void 챌린저_batch_생성_요청_내부_항목의_part가_없으면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger/batch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    [{"memberId":1,"gisuId":9}]
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerUseCase).should(never()).createChallenger(any());
+    }
+
+    @Test
     @DisplayName("파트 변경 요청의 newPart가 없으면 400")
     void 파트_변경_요청의_newPart가_없으면_400() throws Exception {
         mockMvc.perform(patch("/api/v1/challenger/{challengerId}/part", 100L)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
@@ -9,15 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
-import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
-import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
-import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
-import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +21,16 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
+import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
 
 @WebMvcTest(controllers = ChallengerCommandController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandControllerTest.java
@@ -1,0 +1,104 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
+import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerCommandController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerCommandController")
+class ChallengerCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ManageChallengerUseCase manageChallengerUseCase;
+
+    @MockitoBean
+    ChallengerResponseAssembler assembler;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(99L)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("챌린저 생성 성공 시 생성된 챌린저 정보를 반환한다")
+    void 챌린저_생성_성공시_생성된_챌린저_정보를_반환한다() throws Exception {
+        given(manageChallengerUseCase.createChallenger(any(CreateChallengerCommand.class))).willReturn(100L);
+        given(assembler.fromChallengerId(100L)).willReturn(ChallengerInfoResponse.builder()
+            .challengerId(100L)
+            .memberId(1L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .build());
+
+        mockMvc.perform(post("/api/v1/challenger")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"memberId":1,"part":"SPRINGBOOT","gisuId":9}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.challengerId").value(100L));
+    }
+
+    @Test
+    @DisplayName("챌린저 생성 요청의 part가 없으면 400")
+    void 챌린저_생성_요청의_part가_없으면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"memberId":1,"gisuId":9}
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerUseCase).should(never()).createChallenger(any());
+    }
+
+    @Test
+    @DisplayName("파트 변경 요청의 newPart가 없으면 400")
+    void 파트_변경_요청의_newPart가_없으면_400() throws Exception {
+        mockMvc.perform(patch("/api/v1/challenger/{challengerId}/part", 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerUseCase).should(never()).updateChallenger(any(UpdateChallengerCommand.class));
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandControllerTest.java
@@ -10,12 +10,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
-import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
-import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
-import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +19,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
 
 @WebMvcTest(controllers = ChallengerPointCommandController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandControllerTest.java
@@ -1,0 +1,94 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerPointCommandController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerPointCommandController")
+class ChallengerPointCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ManageChallengerUseCase manageChallengerUseCase;
+
+    @MockitoBean
+    ChallengerResponseAssembler assembler;
+
+    @Test
+    @DisplayName("상벌점 부여 성공 시 챌린저 정보를 반환한다")
+    void 상벌점_부여_성공시_챌린저_정보를_반환한다() throws Exception {
+        given(assembler.fromChallengerId(100L)).willReturn(ChallengerInfoResponse.builder()
+            .challengerId(100L)
+            .totalPoints(1.0)
+            .build());
+
+        mockMvc.perform(post("/api/v1/challenger/{challengerId}/points", 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"pointType":"CUSTOM","pointValue":1,"description":"조정"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.challengerId").value(100L));
+    }
+
+    @Test
+    @DisplayName("상벌점 부여 요청의 pointType이 없으면 400")
+    void 상벌점_부여_요청의_pointType이_없으면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger/{challengerId}/points", 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"pointValue":1,"description":"조정"}
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerUseCase).should(never()).grantChallengerPoint(any(GrantChallengerPointCommand.class));
+    }
+
+    @Test
+    @DisplayName("상벌점 설명을 수정한다")
+    void 상벌점_설명을_수정한다() throws Exception {
+        mockMvc.perform(patch("/api/v1/challenger/points/{challengerPointId}", 10L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"newDescription":"수정"}
+                    """))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("상벌점을 삭제한다")
+    void 상벌점을_삭제한다() throws Exception {
+        mockMvc.perform(delete("/api/v1/challenger/points/{challengerPointId}", 10L))
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryControllerTest.java
@@ -1,0 +1,48 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerQueryController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerQueryController")
+class ChallengerQueryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ChallengerResponseAssembler assembler;
+
+    @Test
+    @DisplayName("챌린저 단건 정보를 조회한다")
+    void 챌린저_단건_정보를_조회한다() throws Exception {
+        given(assembler.fromChallengerId(100L)).willReturn(ChallengerInfoResponse.builder()
+            .challengerId(100L)
+            .memberId(1L)
+            .build());
+
+        mockMvc.perform(get("/api/v1/challenger/{challengerId}", 100L))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.challengerId").value(100L));
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryControllerTest.java
@@ -5,10 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
-import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +13,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
 
 @WebMvcTest(controllers = ChallengerQueryController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.authorization.adapter.out.persistence.ChallengerRoleJpaRepository;
+import com.umc.product.challenger.adapter.out.persistence.ChallengerJpaRepository;
+import com.umc.product.challenger.adapter.out.persistence.ChallengerRecordJpaRepository;
+import com.umc.product.challenger.application.port.out.SaveChallengerPort;
+import com.umc.product.challenger.application.port.out.SaveChallengerRecordPort;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerRecord;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.application.port.out.SaveMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.application.port.out.query.LoadGisuPort;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.IntegrationTestSupport;
+import com.umc.product.support.fixture.ChapterFixture;
+import com.umc.product.support.fixture.GisuFixture;
+import com.umc.product.support.fixture.SchoolFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerRecordController 통합 테스트")
+class ChallengerRecordControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private GisuFixture gisuFixture;
+
+    @Autowired
+    private LoadGisuPort loadGisuPort;
+
+    @Autowired
+    private ChapterFixture chapterFixture;
+
+    @Autowired
+    private SchoolFixture schoolFixture;
+
+    @Autowired
+    private SaveMemberPort saveMemberPort;
+
+    @Autowired
+    private SaveChallengerPort saveChallengerPort;
+
+    @Autowired
+    private SaveChallengerRecordPort saveChallengerRecordPort;
+
+    @Autowired
+    private ChallengerJpaRepository challengerJpaRepository;
+
+    @Autowired
+    private ChallengerRecordJpaRepository challengerRecordJpaRepository;
+
+    @Autowired
+    private ChallengerRoleJpaRepository challengerRoleJpaRepository;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("일반 챌린저 기록 코드를 소비하면 챌린저가 생성되고 코드가 사용 처리된다")
+    void 일반_챌린저_기록_코드를_소비하면_챌린저가_생성되고_코드가_사용_처리된다() throws Exception {
+        // given
+        RecordContext context = recordContext(9201L, "일반코드");
+        Member member = member("홍길동", "길동", "regular-code@test.com", context.school().getId());
+        Member creator = member("관리자", "관리", "regular-code-admin@test.com", context.school().getId());
+        ChallengerRecord record = saveChallengerRecordPort.save(ChallengerRecord.create(
+            creator.getId(),
+            context.gisu().getId(),
+            context.chapter().getId(),
+            context.school().getId(),
+            ChallengerPart.SPRINGBOOT,
+            member.getName()
+        ));
+        authenticate(member.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenger-record/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(codeRequest(record.getCode())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        Challenger savedChallenger = challengerJpaRepository
+            .findByMemberIdAndGisuId(member.getId(), context.gisu().getId())
+            .orElseThrow();
+        assertThat(savedChallenger.getPart()).isEqualTo(ChallengerPart.SPRINGBOOT);
+
+        ChallengerRecord usedRecord = challengerRecordJpaRepository.findByCode(record.getCode()).orElseThrow();
+        assertThat(usedRecord.isUsed()).isTrue();
+        assertThat(usedRecord.getUsedMemberId()).isEqualTo(member.getId());
+        assertThat(usedRecord.getUsedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("운영진 기록 코드를 소비하면 기존 챌린저에 역할이 부여되고 새 챌린저는 만들지 않는다")
+    void 운영진_기록_코드를_소비하면_기존_챌린저에_역할이_부여되고_새_챌린저는_만들지_않는다() throws Exception {
+        // given
+        RecordContext context = recordContext(9202L, "운영진코드");
+        Member member = member("김운영", "운영", "admin-code@test.com", context.school().getId());
+        Member creator = member("관리자", "관리", "admin-code-admin@test.com", context.school().getId());
+        Challenger challenger = saveChallengerPort.save(Challenger.builder()
+            .memberId(member.getId())
+            .part(ChallengerPart.WEB)
+            .gisuId(context.gisu().getId())
+            .build());
+        ChallengerRecord record = saveChallengerRecordPort.save(ChallengerRecord.createAdmin(
+            creator.getId(),
+            context.gisu().getId(),
+            context.chapter().getId(),
+            context.school().getId(),
+            ChallengerPart.WEB,
+            member.getName(),
+            ChallengerRoleType.SCHOOL_PRESIDENT,
+            context.school().getId()
+        ));
+        authenticate(member.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenger-record/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(codeRequest(record.getCode())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        assertThat(challengerJpaRepository.findByMemberId(member.getId()))
+            .extracting(Challenger::getId)
+            .containsExactly(challenger.getId());
+
+        assertThat(challengerRoleJpaRepository.findByChallengerId(challenger.getId()))
+            .hasSize(1)
+            .first()
+            .satisfies(role -> {
+                assertThat(role.getChallengerRoleType()).isEqualTo(ChallengerRoleType.SCHOOL_PRESIDENT);
+                assertThat(role.getOrganizationId()).isEqualTo(context.school().getId());
+                assertThat(role.getGisuId()).isEqualTo(context.gisu().getId());
+            });
+
+        ChallengerRecord usedRecord = challengerRecordJpaRepository.findByCode(record.getCode()).orElseThrow();
+        assertThat(usedRecord.isUsed()).isTrue();
+        assertThat(usedRecord.getUsedMemberId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("이미 사용된 챌린저 기록 코드는 재사용할 수 없다")
+    void 이미_사용된_챌린저_기록_코드는_재사용할_수_없다() throws Exception {
+        // given
+        RecordContext context = recordContext(9203L, "재사용실패");
+        Member member = member("박실패", "실패", "reused-code@test.com", context.school().getId());
+        Member creator = member("관리자", "관리", "reused-code-admin@test.com", context.school().getId());
+        ChallengerRecord record = saveChallengerRecordPort.save(ChallengerRecord.create(
+            creator.getId(),
+            context.gisu().getId(),
+            context.chapter().getId(),
+            context.school().getId(),
+            ChallengerPart.ANDROID,
+            member.getName()
+        ));
+        authenticate(member.getId());
+
+        mockMvc.perform(post("/api/v1/challenger-record/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(codeRequest(record.getCode())))
+            .andExpect(status().isOk());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenger-record/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(codeRequest(record.getCode())))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("CHALLENGER-0012"));
+
+        assertThat(challengerJpaRepository.findByMemberId(member.getId()))
+            .hasSize(1)
+            .first()
+            .extracting(Challenger::getPart)
+            .isEqualTo(ChallengerPart.ANDROID);
+
+        ChallengerRecord usedRecord = challengerRecordJpaRepository.findByCode(record.getCode()).orElseThrow();
+        assertThat(usedRecord.isUsed()).isTrue();
+        assertThat(usedRecord.getUsedMemberId()).isEqualTo(member.getId());
+    }
+
+    private RecordContext recordContext(Long generation, String prefix) {
+        Gisu gisu = loadGisuPort.findActiveGisu()
+            .orElseGet(() -> gisuFixture.활성_기수(generation));
+        Chapter chapter = chapterFixture.지부(gisu, prefix + "지부");
+        School school = schoolFixture.지부에_소속된_학교(prefix + "학교", chapter);
+        return new RecordContext(gisu, chapter, school);
+    }
+
+    private Member member(String name, String nickname, String email, Long schoolId) {
+        return saveMemberPort.save(Member.create(name, nickname, email, schoolId, null));
+    }
+
+    private void authenticate(Long memberId) {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(memberId)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    private String codeRequest(String code) {
+        return """
+            {"code":"%s"}
+            """.formatted(code);
+    }
+
+    private record RecordContext(Gisu gisu, Chapter chapter, School school) {
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
@@ -5,6 +5,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 import com.umc.product.authorization.adapter.out.persistence.ChallengerRoleJpaRepository;
 import com.umc.product.challenger.adapter.out.persistence.ChallengerJpaRepository;
 import com.umc.product.challenger.adapter.out.persistence.ChallengerRecordJpaRepository;
@@ -25,14 +34,6 @@ import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.ChapterFixture;
 import com.umc.product.support.fixture.GisuFixture;
 import com.umc.product.support.fixture.SchoolFixture;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @AutoConfigureMockMvc(addFilters = false)
 @DisplayName("ChallengerRecordController 통합 테스트")

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
@@ -96,4 +96,17 @@ class ChallengerRecordControllerTest {
 
         then(manageChallengerRecordUseCase).should(never()).create(any());
     }
+
+    @Test
+    @DisplayName("기록 bulk 생성 요청 내부 항목의 gisuId가 없으면 400")
+    void 기록_bulk_생성_요청_내부_항목의_gisuId가_없으면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger-record/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    [{"chapterId":2,"schoolId":3,"part":"SPRINGBOOT","memberName":"홍길동"}]
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerRecordUseCase).should(never()).createBulk(any());
+    }
 }

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
@@ -1,0 +1,99 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerRecordResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerRecordResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerRecordController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerRecordController")
+class ChallengerRecordControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ChallengerRecordResponseAssembler assembler;
+
+    @MockitoBean
+    ManageChallengerRecordUseCase manageChallengerRecordUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(99L)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("코드로 챌린저 기록을 조회한다")
+    void 코드로_챌린저_기록을_조회한다() throws Exception {
+        given(assembler.from("ABC123")).willReturn(ChallengerRecordResponse.builder()
+            .code("ABC123")
+            .part(ChallengerPart.SPRINGBOOT)
+            .build());
+
+        mockMvc.perform(get("/api/v1/challenger-record/code/{code}", "ABC123"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.code").value("ABC123"));
+    }
+
+    @Test
+    @DisplayName("회원 기록 추가 요청의 code가 blank이면 400")
+    void 회원_기록_추가_요청의_code가_blank이면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger-record/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"code":" "}
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerRecordUseCase).should(never()).consumeCode(any(ConsumeChallengerRecordCommand.class));
+    }
+
+    @Test
+    @DisplayName("기록 생성 요청의 gisuId가 없으면 400")
+    void 기록_생성_요청의_gisuId가_없으면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/challenger-record")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"chapterId":2,"schoolId":3,"part":"SPRINGBOOT","memberName":"홍길동"}
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(manageChallengerRecordUseCase).should(never()).create(any());
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
@@ -9,14 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.challenger.adapter.in.web.assembler.ChallengerRecordResponseAssembler;
-import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerRecordResponse;
-import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
-import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +21,15 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.challenger.adapter.in.web.assembler.ChallengerRecordResponseAssembler;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerRecordResponse;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
 
 @WebMvcTest(controllers = ChallengerRecordController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchControllerTest.java
@@ -8,15 +8,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.challenger.application.port.in.query.SearchChallengerUseCase;
-import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerCursorResult;
-import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerItemInfo;
-import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerResult;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +21,14 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.challenger.application.port.in.query.SearchChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerCursorResult;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerItemInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerResult;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
 
 @WebMvcTest(controllers = ChallengerSearchController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchControllerTest.java
@@ -1,0 +1,81 @@
+package com.umc.product.challenger.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.challenger.application.port.in.query.SearchChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerCursorResult;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerItemInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerResult;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerSearchController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerSearchController")
+class ChallengerSearchControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    SearchChallengerUseCase searchChallengerUseCase;
+
+    @Test
+    @DisplayName("커서 검색 size는 최대 50으로 제한된다")
+    void 커서_검색_size는_최대_50으로_제한된다() throws Exception {
+        given(searchChallengerUseCase.cursorSearch(any(), eq(null), eq(50)))
+            .willReturn(new SearchChallengerCursorResult(List.of(), null, false, Map.of()));
+
+        mockMvc.perform(get("/api/v1/challenger/search/cursor")
+                .param("size", "100"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.cursor.hasNext").value(false));
+
+        then(searchChallengerUseCase).should().cursorSearch(any(), eq(null), eq(50));
+    }
+
+    @Test
+    @DisplayName("offset 검색 결과를 반환한다")
+    void offset_검색_결과를_반환한다() throws Exception {
+        given(searchChallengerUseCase.offsetSearch(any(), any())).willReturn(new SearchChallengerResult(
+            new PageImpl<>(
+                List.of(new SearchChallengerItemInfo(
+                    100L, 1L, 9L, 10L, ChallengerPart.SPRINGBOOT,
+                    "홍길동", "길동", "테스트대학교", 1.0, null, List.of()
+                )),
+                PageRequest.of(0, 10),
+                1
+            ),
+            Map.of(ChallengerPart.SPRINGBOOT, 1L)
+        ));
+
+        mockMvc.perform(get("/api/v1/challenger/search/offset")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.page.content[0].challengerId").value(100L));
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2ControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2ControllerTest.java
@@ -1,0 +1,64 @@
+package com.umc.product.challenger.adapter.in.web.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ChallengerSearchV2Controller.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChallengerSearchV2Controller")
+class ChallengerSearchV2ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    SearchMemberUseCase searchMemberUseCase;
+
+    @Test
+    @DisplayName("챌린저 검색 v2 응답은 이메일을 마스킹한다")
+    void 챌린저_검색_v2_응답은_이메일을_마스킹한다() throws Exception {
+        given(searchMemberUseCase.searchChallengersByV2(any(), any())).willReturn(new ChallengerSearchV2Result(
+            new PageImpl<>(
+                List.of(new ChallengerSearchItemV2Info(
+                    1L, "홍길동", "길동", "gildong@example.com",
+                    10L, "테스트대학교", null, 100L, 9L, 10L,
+                    ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE, List.of(), false
+                )),
+                PageRequest.of(0, 10),
+                1
+            )
+        ));
+
+        mockMvc.perform(get("/api/v2/challenger/search")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.page.content[0].email").value("gil****@example.com"));
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2ControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2ControllerTest.java
@@ -6,14 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerStatus;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
-import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
-import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +18,14 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.ChallengerSearchV2Result;
 
 @WebMvcTest(controllers = ChallengerSearchV2Controller.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
@@ -1,0 +1,200 @@
+package com.umc.product.challenger.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.challenger.application.port.in.command.dto.ChallengerDeactivationType;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
+import com.umc.product.challenger.application.port.in.command.dto.DeactivateChallengerCommand;
+import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
+import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
+import com.umc.product.challenger.application.port.out.LoadChallengerPointPort;
+import com.umc.product.challenger.application.port.out.LoadChallengerPort;
+import com.umc.product.challenger.application.port.out.SaveChallengerPointPort;
+import com.umc.product.challenger.application.port.out.SaveChallengerPort;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerPoint;
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChallengerCommandService")
+class ChallengerCommandServiceTest {
+
+    @Mock
+    Environment environment;
+
+    @Mock
+    LoadChallengerPort loadChallengerPort;
+
+    @Mock
+    SaveChallengerPort saveChallengerPort;
+
+    @Mock
+    LoadChallengerPointPort loadChallengerPointPort;
+
+    @Mock
+    SaveChallengerPointPort saveChallengerPointPort;
+
+    @InjectMocks
+    ChallengerCommandService sut;
+
+    @Nested
+    @DisplayName("createChallenger")
+    class CreateChallenger {
+
+        @Test
+        @DisplayName("동일 기수 챌린저가 없으면 생성한다")
+        void 동일_기수_챌린저가_없으면_생성한다() {
+            CreateChallengerCommand command = CreateChallengerCommand.builder()
+                .memberId(1L)
+                .part(ChallengerPart.SPRINGBOOT)
+                .gisuId(9L)
+                .build();
+            given(loadChallengerPort.findByMemberIdAndGisuId(1L, 9L)).willReturn(Optional.empty());
+            given(saveChallengerPort.save(any(Challenger.class))).willAnswer(invocation -> {
+                Challenger challenger = invocation.getArgument(0);
+                ReflectionTestUtils.setField(challenger, "id", 100L);
+                return challenger;
+            });
+
+            Long result = sut.createChallenger(command);
+
+            assertThat(result).isEqualTo(100L);
+            then(saveChallengerPort).should().save(any(Challenger.class));
+        }
+
+        @Test
+        @DisplayName("동일 기수 챌린저가 있으면 생성하지 않는다")
+        void 동일_기수_챌린저가_있으면_생성하지_않는다() {
+            CreateChallengerCommand command = CreateChallengerCommand.builder()
+                .memberId(1L)
+                .part(ChallengerPart.SPRINGBOOT)
+                .gisuId(9L)
+                .build();
+            given(loadChallengerPort.findByMemberIdAndGisuId(1L, 9L))
+                .willReturn(Optional.of(challenger(1L, ChallengerStatus.ACTIVE)));
+
+            assertThatThrownBy(() -> sut.createChallenger(command))
+                .isInstanceOf(ChallengerDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS);
+
+            then(saveChallengerPort).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateChallenger")
+    class UpdateChallenger {
+
+        @Test
+        @DisplayName("변경할 파트와 상태가 모두 없으면 실패한다")
+        void 변경할_파트와_상태가_모두_없으면_실패한다() {
+            given(loadChallengerPort.getById(1L)).willReturn(challenger(1L, ChallengerStatus.ACTIVE));
+
+            assertThatThrownBy(() -> sut.updateChallenger(
+                UpdateChallengerCommand.forPartChange(1L, null, 99L)
+            ))
+                .isInstanceOf(ChallengerDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ChallengerErrorCode.BAD_CHALLENGER_UPDATE_REQUEST);
+
+            then(saveChallengerPort).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("비활성 챌린저는 파트를 변경할 수 없다")
+        void 비활성_챌린저는_파트를_변경할_수_없다() {
+            given(loadChallengerPort.getById(1L)).willReturn(challenger(1L, ChallengerStatus.WITHDRAWN));
+
+            assertThatThrownBy(() -> sut.updateChallenger(
+                UpdateChallengerCommand.forPartChange(1L, ChallengerPart.WEB, 99L)
+            ))
+                .isInstanceOf(ChallengerDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ChallengerErrorCode.CHALLENGER_NOT_ACTIVE);
+
+            then(saveChallengerPort).should(never()).save(any());
+        }
+    }
+
+    @Test
+    @DisplayName("deactivateChallenger는 EXPEL 타입을 EXPELLED 상태로 매핑한다")
+    void deactivateChallenger는_EXPEL_타입을_EXPELLED_상태로_매핑한다() {
+        Challenger challenger = challenger(1L, ChallengerStatus.ACTIVE);
+        given(loadChallengerPort.getById(1L)).willReturn(challenger);
+
+        sut.deactivateChallenger(DeactivateChallengerCommand.of(
+            1L,
+            ChallengerDeactivationType.EXPEL,
+            99L,
+            "징계"
+        ));
+
+        assertThat(challenger.getStatus()).isEqualTo(ChallengerStatus.EXPELLED);
+        assertThat(challenger.getModifiedBy()).isEqualTo(99L);
+        assertThat(challenger.getModificationReason()).isEqualTo("징계");
+    }
+
+    @Test
+    @DisplayName("비활성 챌린저에게 상벌점을 부여할 수 없다")
+    void 비활성_챌린저에게_상벌점을_부여할_수_없다() {
+        given(loadChallengerPort.getById(1L)).willReturn(challenger(1L, ChallengerStatus.WITHDRAWN));
+
+        assertThatThrownBy(() -> sut.grantChallengerPoint(GrantChallengerPointCommand.builder()
+            .challengerId(1L)
+            .pointType(PointType.CUSTOM)
+            .pointValue(1)
+            .description("조정")
+            .build()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.CHALLENGER_NOT_ACTIVE);
+
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상벌점 설명을 수정한다")
+    void 상벌점_설명을_수정한다() {
+        Challenger challenger = challenger(1L, ChallengerStatus.ACTIVE);
+        ChallengerPoint point = ChallengerPoint.create(challenger, PointType.CUSTOM, 1, "기존");
+        given(loadChallengerPointPort.getById(10L)).willReturn(point);
+
+        sut.updateChallengerPoint(new com.umc.product.challenger.adapter.in.web.dto.request.EditChallengerPointRequest(
+            "수정"
+        ).toCommand(10L));
+
+        assertThat(point.getDescription()).isEqualTo("수정");
+        then(saveChallengerPointPort).should().save(point);
+    }
+
+    private Challenger challenger(Long id, ChallengerStatus status) {
+        Challenger challenger = Challenger.builder()
+            .memberId(1L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .gisuId(9L)
+            .build();
+        ReflectionTestUtils.setField(challenger, "id", id);
+        ReflectionTestUtils.setField(challenger, "status", status);
+        return challenger;
+    }
+}

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
@@ -12,6 +12,7 @@ import com.umc.product.challenger.application.port.in.command.dto.CreateChalleng
 import com.umc.product.challenger.application.port.in.command.dto.DeactivateChallengerCommand;
 import com.umc.product.challenger.application.port.in.command.dto.GrantChallengerPointCommand;
 import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerCommand;
+import com.umc.product.challenger.application.port.in.command.dto.UpdateChallengerPointCommand;
 import com.umc.product.challenger.application.port.out.LoadChallengerPointPort;
 import com.umc.product.challenger.application.port.out.LoadChallengerPort;
 import com.umc.product.challenger.application.port.out.SaveChallengerPointPort;
@@ -179,9 +180,7 @@ class ChallengerCommandServiceTest {
         ChallengerPoint point = ChallengerPoint.create(challenger, PointType.CUSTOM, 1, "기존");
         given(loadChallengerPointPort.getById(10L)).willReturn(point);
 
-        sut.updateChallengerPoint(new com.umc.product.challenger.adapter.in.web.dto.request.EditChallengerPointRequest(
-            "수정"
-        ).toCommand(10L));
+        sut.updateChallengerPoint(UpdateChallengerPointCommand.of(10L, "수정"));
 
         assertThat(point.getDescription()).isEqualTo("수정");
         then(saveChallengerPointPort).should().save(point);

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerCommandServiceTest.java
@@ -7,6 +7,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.challenger.application.port.in.command.dto.ChallengerDeactivationType;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
 import com.umc.product.challenger.application.port.in.command.dto.DeactivateChallengerCommand;
@@ -24,16 +36,6 @@ import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.Environment;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChallengerCommandService")

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
@@ -7,6 +7,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
 import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
@@ -26,14 +36,6 @@ import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChallengerRecordCommandService")

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
@@ -1,0 +1,259 @@
+package com.umc.product.challenger.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
+import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
+import com.umc.product.challenger.application.port.out.LoadChallengerPort;
+import com.umc.product.challenger.application.port.out.LoadChallengerRecordPort;
+import com.umc.product.challenger.application.port.out.SaveChallengerPort;
+import com.umc.product.challenger.application.port.out.SaveChallengerRecordPort;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerRecord;
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChallengerRecordCommandService")
+class ChallengerRecordCommandServiceTest {
+
+    @Mock
+    SaveChallengerRecordPort saveChallengerRecordPort;
+
+    @Mock
+    LoadChallengerRecordPort loadChallengerRecordPort;
+
+    @Mock
+    SaveChallengerPort saveChallengerPort;
+
+    @Mock
+    LoadChallengerPort loadChallengerPort;
+
+    @Mock
+    GetChapterUseCase getChapterUseCase;
+
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+
+    @Mock
+    ManageChallengerRoleUseCase manageChallengerRoleUseCase;
+
+    @Mock
+    SendWebhookAlarmUseCase sendWebhookAlarmUseCase;
+
+    @InjectMocks
+    ChallengerRecordCommandService sut;
+
+    @Test
+    @DisplayName("학교가 요청 지부에 속하면 기록 코드를 생성한다")
+    void 학교가_요청_지부에_속하면_기록_코드를_생성한다() {
+        CreateChallengerRecordCommand command = recordCommand();
+        given(getChapterUseCase.byGisuAndSchool(9L, 3L)).willReturn(new ChapterInfo(2L, "서울"));
+        given(saveChallengerRecordPort.save(any(ChallengerRecord.class))).willAnswer(invocation -> {
+            ChallengerRecord record = invocation.getArgument(0);
+            ReflectionTestUtils.setField(record, "id", 10L);
+            return record;
+        });
+
+        Long result = sut.create(command);
+
+        assertThat(result).isEqualTo(10L);
+        then(saveChallengerRecordPort).should().save(any(ChallengerRecord.class));
+    }
+
+    @Test
+    @DisplayName("학교가 요청 지부에 속하지 않으면 기록 코드를 생성하지 않는다")
+    void 학교가_요청_지부에_속하지_않으면_기록_코드를_생성하지_않는다() {
+        given(getChapterUseCase.byGisuAndSchool(9L, 3L)).willReturn(new ChapterInfo(99L, "다른 지부"));
+
+        assertThatThrownBy(() -> sut.create(recordCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST);
+
+        then(saveChallengerRecordPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("일반 기록 코드를 소비하면 챌린저를 생성하고 코드를 사용 처리한다")
+    void 일반_기록_코드를_소비하면_챌린저를_생성하고_코드를_사용_처리한다() {
+        ChallengerRecord record = normalRecord();
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(getMemberUseCase.getById(100L)).willReturn(member("홍길동", 3L));
+        given(loadChallengerPort.findByMemberIdAndGisuId(100L, 9L)).willReturn(Optional.empty());
+
+        sut.consumeCode(consumeCommand());
+
+        assertThat(record.isUsed()).isTrue();
+        assertThat(record.getUsedMemberId()).isEqualTo(100L);
+        then(saveChallengerPort).should().save(any(Challenger.class));
+    }
+
+    @Test
+    @DisplayName("이미 사용된 코드는 소비할 수 없다")
+    void 이미_사용된_코드는_소비할_수_없다() {
+        ChallengerRecord record = normalRecord();
+        record.markAsUsed(100L);
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+
+        assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.USED_CHALLENGER_RECORD_CODE);
+
+        then(getMemberUseCase).should(never()).getById(any());
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("일반 기록의 이름이 회원 정보와 다르면 챌린저를 생성하지 않는다")
+    void 일반_기록의_이름이_회원_정보와_다르면_챌린저를_생성하지_않는다() {
+        ChallengerRecord record = normalRecord();
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(getMemberUseCase.getById(100L)).willReturn(member("김철수", 3L));
+
+        assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.INVALID_MEMBER_NAME_FOR_RECORD);
+
+        assertThat(record.isUsed()).isFalse();
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("일반 기록의 학교가 회원 정보와 다르면 챌린저를 생성하지 않는다")
+    void 일반_기록의_학교가_회원_정보와_다르면_챌린저를_생성하지_않는다() {
+        ChallengerRecord record = normalRecord();
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(getMemberUseCase.getById(100L)).willReturn(member("홍길동", 4L));
+
+        assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.INVALID_SCHOOL_FOR_RECORD);
+
+        assertThat(record.isUsed()).isFalse();
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("같은 기수의 챌린저가 이미 있으면 일반 기록 코드를 소비하지 않는다")
+    void 같은_기수의_챌린저가_이미_있으면_일반_기록_코드를_소비하지_않는다() {
+        ChallengerRecord record = normalRecord();
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(getMemberUseCase.getById(100L)).willReturn(member("홍길동", 3L));
+        given(loadChallengerPort.findByMemberIdAndGisuId(100L, 9L))
+            .willReturn(Optional.of(challenger(1L)));
+
+        assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS);
+
+        assertThat(record.isUsed()).isFalse();
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("운영진 기록 코드는 기존 챌린저에 역할을 부여하고 코드를 사용 처리한다")
+    void 운영진_기록_코드는_기존_챌린저에_역할을_부여하고_코드를_사용_처리한다() {
+        ChallengerRecord record = ChallengerRecord.createAdmin(
+            1L, 9L, 2L, 3L, ChallengerPart.SPRINGBOOT, "홍길동",
+            ChallengerRoleType.SCHOOL_PRESIDENT, 3L
+        );
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(loadChallengerPort.findByMemberIdAndGisuId(100L, 9L))
+            .willReturn(Optional.of(challenger(50L)));
+        given(getMemberUseCase.getById(100L)).willReturn(member("홍길동", 3L));
+
+        sut.consumeCode(consumeCommand());
+
+        assertThat(record.isUsed()).isTrue();
+        then(manageChallengerRoleUseCase).should().createChallengerRole(any(CreateChallengerRoleCommand.class));
+        then(saveChallengerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("운영진 기록 코드 소비 시 해당 기수 챌린저가 없으면 실패한다")
+    void 운영진_기록_코드_소비_시_해당_기수_챌린저가_없으면_실패한다() {
+        ChallengerRecord record = ChallengerRecord.createAdmin(
+            1L, 9L, 2L, 3L, ChallengerPart.SPRINGBOOT, "홍길동",
+            ChallengerRoleType.SCHOOL_PRESIDENT, 3L
+        );
+        given(loadChallengerRecordPort.getByCode("ABC123")).willReturn(record);
+        given(loadChallengerPort.findByMemberIdAndGisuId(100L, 9L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.NO_CHALLENGER_IN_MEMBER_GISU);
+
+        assertThat(record.isUsed()).isFalse();
+        then(manageChallengerRoleUseCase).should(never()).createChallengerRole(any());
+    }
+
+    private CreateChallengerRecordCommand recordCommand() {
+        return CreateChallengerRecordCommand.builder()
+            .creatorMemberId(1L)
+            .gisuId(9L)
+            .chapterId(2L)
+            .schoolId(3L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .memberName("홍길동")
+            .build();
+    }
+
+    private ConsumeChallengerRecordCommand consumeCommand() {
+        return ConsumeChallengerRecordCommand.builder()
+            .targetMemberId(100L)
+            .code("ABC123")
+            .build();
+    }
+
+    private ChallengerRecord normalRecord() {
+        return ChallengerRecord.create(1L, 9L, 2L, 3L, ChallengerPart.SPRINGBOOT, "홍길동");
+    }
+
+    private MemberInfo member(String name, Long schoolId) {
+        return MemberInfo.builder()
+            .id(100L)
+            .name(name)
+            .nickname("길동")
+            .schoolId(schoolId)
+            .schoolName("테스트대학교")
+            .build();
+    }
+
+    private Challenger challenger(Long id) {
+        Challenger challenger = Challenger.builder()
+            .memberId(100L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .gisuId(9L)
+            .build();
+        ReflectionTestUtils.setField(challenger, "id", id);
+        return challenger;
+    }
+}

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerPointTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerPointTest.java
@@ -1,0 +1,55 @@
+package com.umc.product.challenger.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ChallengerPoint 도메인")
+class ChallengerPointTest {
+
+    @Test
+    @DisplayName("pointValue가 없으면 PointType의 기본 점수를 사용한다")
+    void pointValue가_없으면_PointType의_기본_점수를_사용한다() {
+        Challenger challenger = Challenger.builder()
+            .memberId(1L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .gisuId(9L)
+            .build();
+
+        ChallengerPoint point = ChallengerPoint.create(challenger, PointType.BEST_WORKBOOK, "베스트 워크북");
+
+        assertThat(point.getPointValue()).isEqualTo(PointType.BEST_WORKBOOK.getValue());
+    }
+
+    @Test
+    @DisplayName("pointValue가 있으면 PointType보다 custom 점수를 우선한다")
+    void pointValue가_있으면_PointType보다_custom_점수를_우선한다() {
+        Challenger challenger = Challenger.builder()
+            .memberId(1L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .gisuId(9L)
+            .build();
+
+        ChallengerPoint point = ChallengerPoint.create(challenger, PointType.CUSTOM, -7, "운영진 조정");
+
+        assertThat(point.getPointValue()).isEqualTo(-7.0);
+    }
+
+    @Test
+    @DisplayName("상벌점 설명을 수정한다")
+    void 상벌점_설명을_수정한다() {
+        Challenger challenger = Challenger.builder()
+            .memberId(1L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .gisuId(9L)
+            .build();
+        ChallengerPoint point = ChallengerPoint.create(challenger, PointType.CUSTOM, 1, "기존 설명");
+
+        point.updateDescription("새 설명");
+
+        assertThat(point.getDescription()).isEqualTo("새 설명");
+    }
+}

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerPointTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerPointTest.java
@@ -2,10 +2,11 @@ package com.umc.product.challenger.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.challenger.domain.enums.PointType;
-import com.umc.product.common.domain.enums.ChallengerPart;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import com.umc.product.challenger.domain.enums.PointType;
+import com.umc.product.common.domain.enums.ChallengerPart;
 
 @DisplayName("ChallengerPoint 도메인")
 class ChallengerPointTest {

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
@@ -1,0 +1,81 @@
+package com.umc.product.challenger.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ChallengerRecord 도메인")
+class ChallengerRecordTest {
+
+    @Test
+    @DisplayName("일반 챌린저 기록 코드를 생성한다")
+    void 일반_챌린저_기록_코드를_생성한다() {
+        ChallengerRecord record = ChallengerRecord.create(1L, 9L, 2L, 3L, ChallengerPart.WEB, "홍길동");
+
+        assertThat(record.getCode()).hasSize(6);
+        assertThat(record.isUsed()).isFalse();
+        assertThat(record.isAdminRecord()).isFalse();
+        assertThat(record.getMemberName()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("운영진 기록은 역할 타입과 조직 ID를 가진다")
+    void 운영진_기록은_역할_타입과_조직_ID를_가진다() {
+        ChallengerRecord record = ChallengerRecord.createAdmin(
+            1L, 9L, 2L, 3L, ChallengerPart.PLAN, "홍길동",
+            ChallengerRoleType.SCHOOL_PRESIDENT, 3L
+        );
+
+        assertThat(record.isAdminRecord()).isTrue();
+        assertThat(record.getChallengerRoleType()).isEqualTo(ChallengerRoleType.SCHOOL_PRESIDENT);
+        assertThat(record.getOrganizationId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("사용 처리 시 사용 회원과 시각을 기록한다")
+    void 사용_처리_시_사용_회원과_시각을_기록한다() {
+        ChallengerRecord record = ChallengerRecord.create(1L, 9L, 2L, 3L, ChallengerPart.WEB, "홍길동");
+
+        record.markAsUsed(100L);
+
+        assertThat(record.isUsed()).isTrue();
+        assertThat(record.getUsedMemberId()).isEqualTo(100L);
+        assertThat(record.getUsedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 사용된 코드는 다시 사용할 수 없다")
+    void 이미_사용된_코드는_다시_사용할_수_없다() {
+        ChallengerRecord record = ChallengerRecord.create(1L, 9L, 2L, 3L, ChallengerPart.WEB, "홍길동");
+        record.markAsUsed(100L);
+
+        assertThatThrownBy(() -> record.markAsUsed(101L))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.USED_CHALLENGER_RECORD_CODE);
+    }
+
+    @Test
+    @DisplayName("기록의 회원 이름과 학교가 요청자 정보와 일치해야 한다")
+    void 기록의_회원_이름과_학교가_요청자_정보와_일치해야_한다() {
+        ChallengerRecord record = ChallengerRecord.create(1L, 9L, 2L, 3L, ChallengerPart.WEB, "홍길동");
+
+        record.validateMember("홍길동", 3L);
+
+        assertThatThrownBy(() -> record.validateMember("김철수", 3L))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.INVALID_MEMBER_NAME_FOR_RECORD);
+
+        assertThatThrownBy(() -> record.validateMember("홍길동", 4L))
+            .isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(ChallengerErrorCode.INVALID_SCHOOL_FOR_RECORD);
+    }
+}

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
@@ -3,12 +3,13 @@ package com.umc.product.challenger.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 @DisplayName("ChallengerRecord 도메인")
 class ChallengerRecordTest {

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerTest.java
@@ -3,14 +3,15 @@ package com.umc.product.challenger.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.umc.product.challenger.domain.exception.ChallengerDomainException;
-import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 
 @DisplayName("Challenger 도메인")
 class ChallengerTest {

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerTest.java
@@ -1,13 +1,18 @@
 package com.umc.product.challenger.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("Challenger 도메인")
 class ChallengerTest {
     Challenger challenger;
 
@@ -25,24 +30,71 @@ class ChallengerTest {
         assertThat(challenger.getStatus()).isEqualTo(ChallengerStatus.ACTIVE);
     }
 
-    @Test
-    void 활성_상태가_아닌_챌린저는_상태를_변경할_수_없다() {
-        // given
+    @Nested
+    @DisplayName("changePart")
+    class ChangePart {
 
-        // when
+        @Test
+        @DisplayName("ACTIVE 챌린저는 파트를 변경할 수 있다")
+        void ACTIVE_챌린저는_파트를_변경할_수_있다() {
+            challenger.changePart(ChallengerPart.WEB);
 
-        // then
+            assertThat(challenger.getPart()).isEqualTo(ChallengerPart.WEB);
+        }
 
+        @Test
+        @DisplayName("ACTIVE 상태가 아니면 파트를 변경할 수 없다")
+        void ACTIVE_상태가_아니면_파트를_변경할_수_없다() {
+            challenger.changeStatus(ChallengerStatus.WITHDRAWN, 99L, "탈부");
+
+            assertThatThrownBy(() -> challenger.changePart(ChallengerPart.WEB))
+                .isInstanceOf(ChallengerDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ChallengerErrorCode.CHALLENGER_NOT_ACTIVE);
+        }
     }
 
-    @DisplayName("챌린저 상태를 변경할 때는 도메인 메서드를 이용해야 한다")
+    @Nested
+    @DisplayName("changeStatus")
+    class ChangeStatus {
+
+        @Test
+        @DisplayName("ACTIVE 챌린저는 상태 변경 사유와 수정자를 기록한다")
+        void ACTIVE_챌린저는_상태_변경_사유와_수정자를_기록한다() {
+            challenger.changeStatus(ChallengerStatus.EXPELLED, 99L, "징계");
+
+            assertThat(challenger.getStatus()).isEqualTo(ChallengerStatus.EXPELLED);
+            assertThat(challenger.getModifiedBy()).isEqualTo(99L);
+            assertThat(challenger.getModificationReason()).isEqualTo("징계");
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태가 아니면 다시 상태를 변경할 수 없다")
+        void ACTIVE_상태가_아니면_다시_상태를_변경할_수_없다() {
+            challenger.changeStatus(ChallengerStatus.WITHDRAWN, 99L, "탈부");
+
+            assertThatThrownBy(() -> challenger.changeStatus(ChallengerStatus.EXPELLED, 100L, "징계"))
+                .isInstanceOf(ChallengerDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ChallengerErrorCode.CHALLENGER_NOT_ACTIVE);
+        }
+    }
+
     @Test
-    void shouldUseDomainMethodWhenChangingStatus() {
-        // given
+    @DisplayName("상벌점 총합을 계산한다")
+    void 상벌점_총합을_계산한다() {
+        challenger.addPoint(ChallengerPoint.create(
+            challenger,
+            com.umc.product.challenger.domain.enums.PointType.BEST_WORKBOOK,
+            "베스트 워크북"
+        ));
+        challenger.addPoint(ChallengerPoint.create(
+            challenger,
+            com.umc.product.challenger.domain.enums.PointType.CUSTOM,
+            -3,
+            "운영진 조정"
+        ));
 
-        // when
-
-        // then
-
+        assertThat(challenger.getTotalPoints()).isEqualTo(-3.5);
     }
 }

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerIntegrationTest.java
@@ -6,13 +6,24 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.member.adapter.out.persistence.MemberJpaRepository;
 import com.umc.product.member.domain.Member;
+import com.umc.product.organization.application.port.out.query.LoadGisuPort;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.organization.domain.School;
-import com.umc.product.organization.application.port.out.query.LoadGisuPort;
 import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.ChapterFixture;
 import com.umc.product.support.fixture.GisuFixture;
@@ -21,15 +32,6 @@ import com.umc.product.support.fixture.TermFixture;
 import com.umc.product.term.adapter.out.persistence.TermConsentRepository;
 import com.umc.product.term.application.port.in.query.GetTermUseCase;
 import com.umc.product.term.domain.enums.TermType;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.http.MediaType;
 
 @AutoConfigureMockMvc(addFilters = false)
 @DisplayName("MemberCommandController 통합 테스트")

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerIntegrationTest.java
@@ -1,0 +1,133 @@
+package com.umc.product.member.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import com.umc.product.member.adapter.out.persistence.MemberJpaRepository;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.organization.application.port.out.query.LoadGisuPort;
+import com.umc.product.support.IntegrationTestSupport;
+import com.umc.product.support.fixture.ChapterFixture;
+import com.umc.product.support.fixture.GisuFixture;
+import com.umc.product.support.fixture.SchoolFixture;
+import com.umc.product.support.fixture.TermFixture;
+import com.umc.product.term.adapter.out.persistence.TermConsentRepository;
+import com.umc.product.term.application.port.in.query.GetTermUseCase;
+import com.umc.product.term.domain.enums.TermType;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemberCommandController 통합 테스트")
+class MemberCommandControllerIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private GisuFixture gisuFixture;
+
+    @Autowired
+    private LoadGisuPort loadGisuPort;
+
+    @Autowired
+    private ChapterFixture chapterFixture;
+
+    @Autowired
+    private SchoolFixture schoolFixture;
+
+    @Autowired
+    private TermFixture termFixture;
+
+    @Autowired
+    private GetTermUseCase getTermUseCase;
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @Autowired
+    private TermConsentRepository termConsentRepository;
+
+    @Test
+    @DisplayName("이메일 회원가입에 성공하면 회원, 자격증명, 필수 약관 동의가 저장된다")
+    void 이메일_회원가입에_성공하면_회원_자격증명_필수_약관_동의가_저장된다() throws Exception {
+        // given
+        School school = activeSchool("회원가입학교", 9101L);
+        List<Long> requiredTermIds = requiredTermIds();
+        String email = "email-register-e2e@test.com";
+
+        given(jwtTokenProvider.parseEmailVerificationToken("email-token", EmailVerificationPurpose.REGISTER))
+            .willReturn(email);
+        given(jwtTokenProvider.createAccessToken(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.isNull()))
+            .willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(org.mockito.ArgumentMatchers.anyLong()))
+            .willReturn("refresh-token");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/member/register/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(emailRegisterRequest(school.getId(), requiredTermIds)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.memberId").isString())
+            .andExpect(jsonPath("$.result.accessToken").value("access-token"))
+            .andExpect(jsonPath("$.result.refreshToken").value("refresh-token"));
+
+        Member savedMember = memberJpaRepository.findByEmail(email).orElseThrow();
+        assertThat(savedMember.getName()).isEqualTo("홍길동");
+        assertThat(savedMember.getNickname()).isEqualTo("길동");
+        assertThat(savedMember.getSchoolId()).isEqualTo(school.getId());
+        assertThat(savedMember.getPasswordHash())
+            .isNotBlank()
+            .isNotEqualTo("Password123!");
+        assertThat(termConsentRepository.findByMemberId(savedMember.getId()))
+            .extracting("termId")
+            .containsExactlyInAnyOrderElementsOf(requiredTermIds);
+    }
+
+    private School activeSchool(String schoolName, Long generation) {
+        Gisu gisu = loadGisuPort.findActiveGisu()
+            .orElseGet(() -> gisuFixture.활성_기수(generation));
+        Chapter chapter = chapterFixture.지부(gisu, schoolName + "지부");
+        return schoolFixture.지부에_소속된_학교(schoolName, chapter);
+    }
+
+    private List<Long> requiredTermIds() {
+        Set<Long> requiredTermIds = getTermUseCase.getRequiredTermIds();
+        if (requiredTermIds.isEmpty()) {
+            termFixture.필수_약관(TermType.SERVICE);
+            termFixture.필수_약관(TermType.PRIVACY);
+            requiredTermIds = getTermUseCase.getRequiredTermIds();
+        }
+        return requiredTermIds.stream().sorted().toList();
+    }
+
+    private String emailRegisterRequest(Long schoolId, List<Long> requiredTermIds) throws Exception {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("rawPassword", "Password123!");
+        request.put("name", "홍길동");
+        request.put("nickname", "길동");
+        request.put("emailVerificationToken", "email-token");
+        request.put("schoolId", schoolId);
+        request.put("termsAgreements", requiredTermIds.stream()
+            .map(termId -> {
+                Map<String, Object> termAgreement = new LinkedHashMap<>();
+                termAgreement.put("termsId", termId);
+                termAgreement.put("isAgreed", true);
+                return termAgreement;
+            })
+            .toList());
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
@@ -9,18 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
-import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
-import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
-import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
-import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
-import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
-import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
-import com.umc.product.member.application.port.in.command.dto.UpdateMemberCommand;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +21,19 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
+import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
+import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
+import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
+import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
+import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
+import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
+import com.umc.product.member.application.port.in.command.dto.UpdateMemberCommand;
 
 @WebMvcTest(controllers = MemberCommandController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
@@ -1,0 +1,145 @@
+package com.umc.product.member.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
+import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
+import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
+import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
+import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
+import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
+import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
+import com.umc.product.member.application.port.in.command.dto.UpdateMemberCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MemberCommandController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemberCommandController")
+class MemberCommandControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    MemberInfoResponseAssembler assembler;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ManageMemberUseCase manageMemberUseCase;
+
+    @MockitoBean
+    ManageMemberProfileUseCase manageMemberProfileUseCase;
+
+    @MockitoBean
+    RegisterOAuthMemberUseCase registerOAuthMemberUseCase;
+
+    @MockitoBean
+    RegisterEmailMemberUseCase registerEmailMemberUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("이메일 회원가입 성공 시 토큰과 memberId를 반환한다")
+    void 이메일_회원가입_성공시_토큰과_memberId를_반환한다() throws Exception {
+        given(jwtTokenProvider.parseEmailVerificationToken(any(), any())).willReturn("gildong@example.com");
+        given(registerEmailMemberUseCase.register(any(EmailRegisterMemberCommand.class))).willReturn(100L);
+        given(jwtTokenProvider.createAccessToken(100L, null)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(100L)).willReturn("refresh-token");
+
+        mockMvc.perform(post("/api/v1/member/register/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "rawPassword": "Password123!",
+                      "name": "홍길동",
+                      "nickname": "길동",
+                      "emailVerificationToken": "email-token",
+                      "schoolId": 1,
+                      "termsAgreements": [
+                        {"termsId": 10, "isAgreed": true}
+                      ]
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.memberId").value(100L))
+            .andExpect(jsonPath("$.result.accessToken").value("access-token"))
+            .andExpect(jsonPath("$.result.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    @DisplayName("이메일 회원가입 요청의 rawPassword가 blank이면 400")
+    void 이메일_회원가입_요청의_rawPassword가_blank이면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/member/register/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "rawPassword": " ",
+                      "name": "홍길동",
+                      "nickname": "길동",
+                      "emailVerificationToken": "email-token",
+                      "schoolId": 1,
+                      "termsAgreements": [
+                        {"termsId": 10, "isAgreed": true}
+                      ]
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+
+        then(registerEmailMemberUseCase).should(never()).register(any());
+    }
+
+    @Test
+    @DisplayName("내 회원 정보 수정은 로그인 회원 ID로 UseCase를 호출한다")
+    void 내_회원_정보_수정은_로그인_회원_ID로_UseCase를_호출한다() throws Exception {
+        given(assembler.fromMemberId(TEST_MEMBER_ID)).willReturn(MemberInfoResponse.builder()
+            .id(TEST_MEMBER_ID)
+            .name("홍길동")
+            .build());
+
+        mockMvc.perform(patch("/api/v1/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(java.util.Map.of("profileImageId", "file-id"))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.id").value(TEST_MEMBER_ID));
+
+        then(manageMemberUseCase).should().updateMember(any(UpdateMemberCommand.class));
+    }
+}

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberQueryControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberQueryControllerTest.java
@@ -6,6 +6,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.global.config.JacksonConfig;
@@ -16,20 +32,6 @@ import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
 import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @WebMvcTest(controllers = MemberQueryController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberQueryControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberQueryControllerTest.java
@@ -1,0 +1,98 @@
+package com.umc.product.member.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
+import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemInfo;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberResult;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebMvcTest(controllers = MemberQueryController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemberQueryController")
+class MemberQueryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    MemberInfoResponseAssembler assembler;
+
+    @MockitoBean
+    SearchMemberUseCase searchMemberUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(99L)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("내 프로필을 조회한다")
+    void 내_프로필을_조회한다() throws Exception {
+        given(assembler.fromMemberId(99L)).willReturn(MemberInfoResponse.builder()
+            .id(99L)
+            .name("홍길동")
+            .status(MemberStatus.ACTIVE)
+            .build());
+
+        mockMvc.perform(get("/api/v1/member/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.id").value(99L))
+            .andExpect(jsonPath("$.result.name").value("홍길동"));
+    }
+
+    @Test
+    @DisplayName("회원 검색 응답은 이메일을 마스킹한다")
+    void 회원_검색_응답은_이메일을_마스킹한다() throws Exception {
+        given(searchMemberUseCase.searchBy(any(), any())).willReturn(new SearchMemberResult(
+            new PageImpl<>(
+                List.of(new SearchMemberItemInfo(
+                    1L, "홍길동", "길동", "gildong@example.com",
+                    10L, "테스트대학교", null, 100L, 9L, 10L,
+                    ChallengerPart.SPRINGBOOT, List.of()
+                )),
+                PageRequest.of(0, 10),
+                1
+            )
+        ));
+
+        mockMvc.perform(get("/api/v1/member/search")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.page.content[0].email").value("gil****@example.com"));
+    }
+}

--- a/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
@@ -6,20 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.common.domain.enums.ChallengerStatus;
-import com.umc.product.common.domain.enums.MemberStatus;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
-import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
-import com.umc.product.member.application.port.in.query.dto.MemberInfo;
-import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
-import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
-import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
-import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +21,20 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
 
 @WebMvcTest(controllers = MemberQueryV2Controller.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
@@ -1,0 +1,115 @@
+package com.umc.product.member.adapter.in.web.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
+import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MemberQueryV2Controller.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemberQueryV2Controller")
+class MemberQueryV2ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetMemberSummaryV2UseCase getMemberSummaryV2UseCase;
+
+    @MockitoBean
+    SearchMemberUseCase searchMemberUseCase;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(99L)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("내 v2 종합 정보를 조회한다")
+    void 내_v2_종합_정보를_조회한다() throws Exception {
+        given(getMemberSummaryV2UseCase.getSummaryByMemberId(99L)).willReturn(new MemberSummaryV2Info(
+            MemberInfo.builder()
+                .id(99L)
+                .name("홍길동")
+                .nickname("길동")
+                .email("gildong@example.com")
+                .schoolId(1L)
+                .schoolName("테스트대학교")
+                .status(MemberStatus.ACTIVE)
+                .build(),
+            MemberProfileInfo.builder().github("https://github.com/umc").build(),
+            30L,
+            null,
+            List.of()
+        ));
+
+        mockMvc.perform(get("/api/v2/member/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.id").value(99L))
+            .andExpect(jsonPath("$.result.totalActivityDays").value(30L));
+    }
+
+    @Test
+    @DisplayName("회원 검색 v2 응답은 이메일을 마스킹한다")
+    void 회원_검색_v2_응답은_이메일을_마스킹한다() throws Exception {
+        given(searchMemberUseCase.searchByV2(any(), any())).willReturn(new SearchMemberV2Result(
+            new PageImpl<>(
+                List.of(new SearchMemberItemV2Info(
+                    1L, "홍길동", "길동", "gildong@example.com",
+                    10L, "테스트대학교", null,
+                    new SearchMemberItemV2Info.PrimaryChallenger(
+                        100L, 9L, 10L, ChallengerPart.SPRINGBOOT, ChallengerStatus.ACTIVE
+                    ),
+                    false,
+                    List.of()
+                )),
+                PageRequest.of(0, 10),
+                1
+            )
+        ));
+
+        mockMvc.perform(get("/api/v2/member/search")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.page.content[0].email").value("gil****@example.com"));
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/EmailMemberRegisterServiceTest.java
@@ -1,9 +1,12 @@
 package com.umc.product.member.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import java.util.List;
@@ -25,6 +28,8 @@ import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
+import com.umc.product.term.domain.exception.TermDomainException;
+import com.umc.product.term.domain.exception.TermErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class EmailMemberRegisterServiceTest {
@@ -90,5 +95,35 @@ class EmailMemberRegisterServiceTest {
         // then
         assertThat(memberId).isEqualTo(100L);
         then(manageTermAgreementUseCase).should(times(2)).createTermConsent(any());
+    }
+
+    @Test
+    @DisplayName("필수 약관 검증 실패 시 회원과 자격증명을 저장하지 않는다")
+    void 필수_약관_검증_실패시_회원과_자격증명을_저장하지_않는다() {
+        // given
+        EmailRegisterMemberCommand command = EmailRegisterMemberCommand.builder()
+            .rawPassword("Password123!")
+            .name("홍길동")
+            .nickname("길동")
+            .email("gildong@example.com")
+            .schoolId(1L)
+            .termConsents(List.of(
+                TermConsents.builder().termId(1L).isAgreed(false).build()
+            ))
+            .build();
+
+        willThrow(new TermDomainException(TermErrorCode.MANDATORY_TERMS_NOT_AGREED))
+            .given(registrationValidator).validateMandatoryTermsAgreed(command.termConsents());
+
+        // when & then
+        assertThatThrownBy(() -> sut.register(command))
+            .isInstanceOf(TermDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(TermErrorCode.MANDATORY_TERMS_NOT_AGREED);
+
+        then(saveMemberPort).should(never()).save(any());
+        then(credentialAuthenticationUseCase).should(never()).registerCredentialByEmail(any());
+        then(manageTermAgreementUseCase).should(never()).createTermConsent(any());
+        then(eventPublisher).should(never()).publish(any());
     }
 }

--- a/src/test/java/com/umc/product/member/application/service/MemberProfileCommandServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberProfileCommandServiceTest.java
@@ -1,0 +1,118 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.member.application.port.in.command.dto.UpsertMemberProfileCommand;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.application.port.out.SaveMemberPort;
+import com.umc.product.member.application.port.out.SaveMemberProfilePort;
+import com.umc.product.member.domain.LinkTypeAndLink;
+import com.umc.product.member.domain.Member;
+import com.umc.product.member.domain.MemberProfile;
+import com.umc.product.member.domain.MemberProfileLinkType;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberProfileCommandService")
+class MemberProfileCommandServiceTest {
+
+    @Mock
+    LoadMemberPort loadMemberPort;
+
+    @Mock
+    SaveMemberPort saveMemberPort;
+
+    @Mock
+    SaveMemberProfilePort saveMemberProfilePort;
+
+    @InjectMocks
+    MemberProfileCommandService sut;
+
+    @Test
+    @DisplayName("프로필이 없으면 새 프로필을 생성해 회원에 할당한다")
+    void 프로필이_없으면_새_프로필을_생성해_회원에_할당한다() {
+        Member member = member();
+        given(loadMemberPort.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        sut.upsert(UpsertMemberProfileCommand.builder()
+            .memberId(1L)
+            .links(List.of(new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/umc")))
+            .build());
+
+        assertThat(member.getProfile()).isNotNull();
+        assertThat(member.getProfile().getGithub()).isEqualTo("https://github.com/umc");
+        then(saveMemberProfilePort).should().save(any(MemberProfile.class));
+        then(saveMemberPort).should().save(member);
+    }
+
+    @Test
+    @DisplayName("프로필이 있으면 기존 링크를 갱신한다")
+    void 프로필이_있으면_기존_링크를_갱신한다() {
+        Member member = member();
+        MemberProfile profile = MemberProfile.fromLinks(List.of(
+            new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/old")
+        ));
+        member.assignProfile(profile);
+        given(loadMemberPort.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        sut.upsert(UpsertMemberProfileCommand.builder()
+            .memberId(1L)
+            .links(List.of(new LinkTypeAndLink(MemberProfileLinkType.BLOG, "https://blog.example.com")))
+            .build());
+
+        assertThat(profile.getGithub()).isNull();
+        assertThat(profile.getBlog()).isEqualTo("https://blog.example.com");
+        then(saveMemberProfilePort).should(never()).save(any());
+        then(saveMemberPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로필이 없으면 삭제할 수 없다")
+    void 프로필이_없으면_삭제할_수_없다() {
+        Member member = member();
+        given(loadMemberPort.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> sut.delete(1L))
+            .isInstanceOf(MemberDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(MemberErrorCode.MEMBER_PROFILE_NOT_FOUND);
+
+        then(saveMemberProfilePort).should(never()).delete(any());
+        then(saveMemberPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로필을 삭제하면 회원 연결을 제거하고 프로필을 삭제한다")
+    void 프로필을_삭제하면_회원_연결을_제거하고_프로필을_삭제한다() {
+        Member member = member();
+        MemberProfile profile = MemberProfile.fromLinks(List.of(
+            new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/umc")
+        ));
+        member.assignProfile(profile);
+        given(loadMemberPort.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        sut.delete(1L);
+
+        assertThat(member.getProfile()).isNull();
+        then(saveMemberPort).should().save(member);
+        then(saveMemberProfilePort).should().delete(profile);
+    }
+
+    private Member member() {
+        return Member.create("홍길동", "길동", "gildong@example.com", 1L, null);
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/MemberProfileCommandServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberProfileCommandServiceTest.java
@@ -7,6 +7,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.member.application.port.in.command.dto.UpsertMemberProfileCommand;
 import com.umc.product.member.application.port.out.LoadMemberPort;
 import com.umc.product.member.application.port.out.SaveMemberPort;
@@ -17,14 +27,6 @@ import com.umc.product.member.domain.MemberProfile;
 import com.umc.product.member.domain.MemberProfileLinkType;
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberProfileCommandService")

--- a/src/test/java/com/umc/product/member/application/service/MemberQueryServiceBatchTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberQueryServiceBatchTest.java
@@ -1,0 +1,121 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.storage.application.port.in.query.dto.FileInfo;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberQueryService batch 조회")
+class MemberQueryServiceBatchTest {
+
+    @Mock
+    LoadMemberPort loadMemberPort;
+
+    @Mock
+    GetSchoolUseCase getSchoolUseCase;
+
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @InjectMocks
+    MemberQueryService sut;
+
+    @Test
+    @DisplayName("findAllByIds는 빈 입력이면 외부 조회 없이 빈 Map을 반환한다")
+    void findAllByIds는_빈_입력이면_외부_조회_없이_빈_Map을_반환한다() {
+        assertThat(sut.findAllByIds(Set.of())).isEmpty();
+        assertThat(sut.findAllByIds(null)).isEmpty();
+
+        then(loadMemberPort).should(never()).findAllByIds(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("findAllByIds는 같은 schoolId와 profileImageId를 한 번만 조회한다")
+    void findAllByIds는_같은_schoolId와_profileImageId를_한_번만_조회한다() {
+        Member first = member(1L, "홍길동", 10L, "profile-file-id");
+        Member second = member(2L, "김철수", 10L, "profile-file-id");
+        given(loadMemberPort.findAllByIds(Set.of(1L, 2L))).willReturn(List.of(first, second));
+        given(getSchoolUseCase.getSchoolDetail(10L)).willReturn(school(10L, "테스트대학교"));
+        given(getFileUseCase.getById("profile-file-id")).willReturn(file("profile-file-id"));
+
+        Map<Long, MemberInfo> result = sut.findAllByIds(Set.of(1L, 2L));
+
+        assertThat(result).containsKeys(1L, 2L);
+        assertThat(result.get(1L).schoolName()).isEqualTo("테스트대학교");
+        assertThat(result.get(2L).profileImageLink()).isEqualTo("https://cdn.example.com/profile-file-id");
+        then(getSchoolUseCase).should(times(1)).getSchoolDetail(10L);
+        then(getFileUseCase).should(times(1)).getById("profile-file-id");
+    }
+
+    @Test
+    @DisplayName("listIdsBySchoolIds는 조회 결과가 없는 학교도 빈 Set으로 채운다")
+    void listIdsBySchoolIds는_조회_결과가_없는_학교도_빈_Set으로_채운다() {
+        given(loadMemberPort.listIdsBySchoolIds(Set.of(10L, 20L)))
+            .willReturn(Map.of(10L, Set.of(1L, 2L)));
+
+        Map<Long, Set<Long>> result = sut.listIdsBySchoolIds(Set.of(10L, 20L));
+
+        assertThat(result.get(10L)).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(result.get(20L)).isEmpty();
+    }
+
+    private Member member(Long id, String name, Long schoolId, String profileImageId) {
+        Member member = Member.create(name, name.substring(0, 2), name + "@example.com", schoolId, profileImageId);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private SchoolDetailInfo school(Long schoolId, String schoolName) {
+        return new SchoolDetailInfo(
+            1L,
+            "서울",
+            schoolName,
+            schoolId,
+            null,
+            null,
+            List.of(),
+            true,
+            Instant.parse("2024-01-01T00:00:00Z"),
+            Instant.parse("2024-01-01T00:00:00Z")
+        );
+    }
+
+    private FileInfo file(String fileId) {
+        return new FileInfo(
+            fileId,
+            "profile.png",
+            null,
+            "image/png",
+            100L,
+            "https://cdn.example.com/" + fileId,
+            true,
+            1L,
+            Instant.parse("2024-01-01T00:00:00Z")
+        );
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/MemberQueryServiceBatchTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberQueryServiceBatchTest.java
@@ -6,6 +6,19 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.out.LoadMemberPort;
@@ -14,17 +27,6 @@ import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.storage.application.port.in.query.dto.FileInfo;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberQueryService batch 조회")

--- a/src/test/java/com/umc/product/member/domain/MemberProfileTest.java
+++ b/src/test/java/com/umc/product/member/domain/MemberProfileTest.java
@@ -1,0 +1,46 @@
+package com.umc.product.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MemberProfile 도메인")
+class MemberProfileTest {
+
+    @Test
+    @DisplayName("fromLinks는 링크 타입별 컬럼에 값을 매핑한다")
+    void fromLinks는_링크_타입별_컬럼에_값을_매핑한다() {
+        MemberProfile profile = MemberProfile.fromLinks(List.of(
+            new LinkTypeAndLink(MemberProfileLinkType.LINKEDIN, "https://linkedin.com/in/umc"),
+            new LinkTypeAndLink(MemberProfileLinkType.INSTAGRAM, "https://instagram.com/umc"),
+            new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/umc"),
+            new LinkTypeAndLink(MemberProfileLinkType.BLOG, "https://blog.example.com"),
+            new LinkTypeAndLink(MemberProfileLinkType.PERSONAL, "https://umc.example.com")
+        ));
+
+        assertThat(profile.getLinkedIn()).isEqualTo("https://linkedin.com/in/umc");
+        assertThat(profile.getInstagram()).isEqualTo("https://instagram.com/umc");
+        assertThat(profile.getGithub()).isEqualTo("https://github.com/umc");
+        assertThat(profile.getBlog()).isEqualTo("https://blog.example.com");
+        assertThat(profile.getPersonal()).isEqualTo("https://umc.example.com");
+    }
+
+    @Test
+    @DisplayName("updateLinks는 기존 링크를 모두 초기화한 뒤 제공된 링크만 반영한다")
+    void updateLinks는_기존_링크를_모두_초기화한_뒤_제공된_링크만_반영한다() {
+        MemberProfile profile = MemberProfile.fromLinks(List.of(
+            new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/old"),
+            new LinkTypeAndLink(MemberProfileLinkType.BLOG, "https://old.example.com")
+        ));
+
+        profile.updateLinks(List.of(
+            new LinkTypeAndLink(MemberProfileLinkType.PERSONAL, "https://new.example.com")
+        ));
+
+        assertThat(profile.getGithub()).isNull();
+        assertThat(profile.getBlog()).isNull();
+        assertThat(profile.getPersonal()).isEqualTo("https://new.example.com");
+    }
+}

--- a/src/test/java/com/umc/product/member/domain/MemberProfileTest.java
+++ b/src/test/java/com/umc/product/member/domain/MemberProfileTest.java
@@ -3,6 +3,7 @@ package com.umc.product.member.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/umc/product/member/domain/MemberTest.java
+++ b/src/test/java/com/umc/product/member/domain/MemberTest.java
@@ -1,0 +1,91 @@
+package com.umc.product.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("Member 도메인")
+class MemberTest {
+
+    @Test
+    @DisplayName("create는 ACTIVE 상태 회원을 생성한다")
+    void create는_ACTIVE_상태_회원을_생성한다() {
+        Member member = Member.create("홍길동", "길동", "gildong@example.com", 1L, "profile-file-id");
+
+        assertThat(member.getName()).isEqualTo("홍길동");
+        assertThat(member.getNickname()).isEqualTo("길동");
+        assertThat(member.getEmail()).isEqualTo("gildong@example.com");
+        assertThat(member.getSchoolId()).isEqualTo(1L);
+        assertThat(member.getProfileImageId()).isEqualTo("profile-file-id");
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Nested
+    @DisplayName("updateProfile")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("nickname과 profileImageId를 부분 수정한다")
+        void nickname과_profileImageId를_부분_수정한다() {
+            Member member = Member.create("홍길동", "길동", "gildong@example.com", 1L, "old-file-id");
+
+            member.updateProfile("하늘", null);
+            member.updateProfile("new-file-id");
+
+            assertThat(member.getNickname()).isEqualTo("하늘");
+            assertThat(member.getProfileImageId()).isEqualTo("new-file-id");
+        }
+
+        @Test
+        @DisplayName("비활성 회원은 프로필을 수정할 수 없다")
+        void 비활성_회원은_프로필을_수정할_수_없다() {
+            Member member = Member.create("홍길동", "길동", "gildong@example.com", 1L, null);
+            ReflectionTestUtils.setField(member, "status", MemberStatus.INACTIVE);
+
+            assertThatThrownBy(() -> member.updateProfile("하늘", null))
+                .isInstanceOf(MemberDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(MemberErrorCode.MEMBER_NOT_ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("profile association")
+    class ProfileAssociation {
+
+        @Test
+        @DisplayName("프로필을 할당하고 제거할 수 있다")
+        void 프로필을_할당하고_제거할_수_있다() {
+            Member member = Member.create("홍길동", "길동", "gildong@example.com", 1L, null);
+            MemberProfile profile = MemberProfile.fromLinks(
+                java.util.List.of(new LinkTypeAndLink(MemberProfileLinkType.GITHUB, "https://github.com/umc"))
+            );
+
+            member.assignProfile(profile);
+            assertThat(member.getProfile()).isSameAs(profile);
+
+            member.removeProfile();
+            assertThat(member.getProfile()).isNull();
+        }
+
+        @Test
+        @DisplayName("비활성 회원은 프로필을 할당할 수 없다")
+        void 비활성_회원은_프로필을_할당할_수_없다() {
+            Member member = Member.create("홍길동", "길동", "gildong@example.com", 1L, null);
+            ReflectionTestUtils.setField(member, "status", MemberStatus.INACTIVE);
+            MemberProfile profile = MemberProfile.fromLinks(java.util.List.of());
+
+            assertThatThrownBy(() -> member.assignProfile(profile))
+                .isInstanceOf(MemberDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(MemberErrorCode.MEMBER_NOT_ACTIVE);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/member/domain/MemberTest.java
+++ b/src/test/java/com/umc/product/member/domain/MemberTest.java
@@ -3,13 +3,14 @@ package com.umc.product.member.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.umc.product.common.domain.enums.MemberStatus;
-import com.umc.product.member.domain.exception.MemberDomainException;
-import com.umc.product.member.domain.exception.MemberErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
 
 @DisplayName("Member 도메인")
 class MemberTest {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- member/challenger 도메인의 domain, application service, adapter/in web, E2E 테스트를 보강했어요.
- challenger API request validation과 controller `@Valid` 적용만 fast-fail 검증에 필요한 최소 production 변경으로 포함했어요.

### 작업 단위별 상세

1. **무엇을**: Member 도메인과 이메일 회원가입, 프로필 링크, 조회 batch 시나리오 테스트를 추가했어요.
   - **어떻게**: domain/service/WebMvcTest/IntegrationTestSupport 계층별로 성공 케이스와 fast-fail 케이스를 나눠 검증했어요.
   - **왜**: 회원가입, 프로필 링크, 조회 조립 로직의 회귀를 계층별로 빠르게 잡기 위해서예요.

2. **무엇을**: Challenger lifecycle, point, record code, query/search API 테스트를 추가했어요.
   - **어떻게**: 도메인 상태 변경, 서비스 fast-fail, WebMvc 컨트롤러 검증, 일반 코드/운영진 코드/코드 재사용 실패 E2E를 분리해 검증했어요.
   - **왜**: 챌린저 생성과 기록 코드 소비 흐름은 여러 도메인 상태가 함께 바뀌므로 실제 DB 상태까지 확인하는 안전망이 필요해서예요.

3. **무엇을**: Challenger request DTO의 fast-fail validation을 추가했어요.
   - **어떻게**: `@NotNull`, `@NotBlank`, `@Size`를 요청 DTO에 추가하고 controller `@RequestBody`에 `@Valid`를 적용했어요.
   - **왜**: 잘못된 요청 body가 UseCase까지 내려가기 전에 400으로 실패하도록 만들기 위해서예요.

4. **무엇을**: `DeactivateChallengerCommand.of(...)` factory를 추가했어요.
   - **어떻게**: record에 정적 팩토리 메서드를 추가해서 테스트와 호출부가 command 생성 규칙을 따르도록 했어요.
   - **왜**: command 객체를 직접 생성하지 않는 프로젝트 규칙과 테스트 구성의 일관성을 맞추기 위해서예요.

## 💬 리뷰 중점사항

- 새 API endpoint, DB migration, 환경 설정 변경은 없어요.
- challenger API에 추가한 필수 필드 validation 기준이 기존 클라이언트 요청 스키마와 맞는지 검토가 필요해요.
- E2E는 Testcontainers 기반으로 실제 DB 상태까지 검증하므로 CI 실행 시간이 일부 늘어날 수 있어요.
- 검증은 `./gradlew test`로 완료했어요.
