### PR TITLE
[Refactor] 운영진용 대시보드 API를 역할에 따라 분리

### DIFF
--- a/.run/Local.run.xml
+++ b/.run/Local.run.xml
@@ -1,34 +1,29 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="local" />
-    <option name="envFilePaths">
-      <option value="$PROJECT_DIR$/src/main/resources/.env.local" />
-    </option>
-    <module name="umc-product.main" />
-    <selectedOptions>
-      <option name="environmentVariables" />
-    </selectedOptions>
-    <option name="SHORTEN_COMMAND_LINE" value="ARGS_FILE" />
-    <option name="SPRING_BOOT_MAIN_CLASS" value="com.umc.product.UmcProductApplication" />
-    <extension name="net.ashald.envfile">
-      <option name="IS_ENABLED" value="true" />
-      <option name="IS_SUBST" value="false" />
-      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
-      <option name="IS_IGNORE_MISSING_FILES" value="true" />
-      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
-      <ENTRIES>
-        <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="src/main/resources/.env.local" />
-        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
-      </ENTRIES>
-    </extension>
-    <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
-      <option name="credential" />
-      <option name="region" />
-      <option name="useCurrentConnection" value="false" />
-    </extension>
-    <method v="2">
-      <option name="RunConfigurationTask" enabled="false" run_configuration_name="Test" run_configuration_type="GradleRunConfiguration" />
-      <option name="Make" enabled="true" />
-    </method>
-  </configuration>
+    <configuration default="false" name="Local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+        <option name="ACTIVE_PROFILES" value="local"/>
+        <module name="umc-product.main"/>
+        <option name="SHORTEN_COMMAND_LINE" value="ARGS_FILE"/>
+        <option name="SPRING_BOOT_MAIN_CLASS" value="com.umc.product.UmcProductApplication"/>
+        <extension name="net.ashald.envfile">
+            <option name="IS_ENABLED" value="true"/>
+            <option name="IS_SUBST" value="false"/>
+            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+            <option name="IS_IGNORE_MISSING_FILES" value="true"/>
+            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+            <ENTRIES>
+                <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="src/main/resources/.env.local"/>
+                <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+            </ENTRIES>
+        </extension>
+        <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
+            <option name="credential"/>
+            <option name="region"/>
+            <option name="useCurrentConnection" value="false"/>
+        </extension>
+        <method v="2">
+            <option name="RunConfigurationTask" enabled="false" run_configuration_name="Test"
+                    run_configuration_type="GradleRunConfiguration"/>
+            <option name="Make" enabled="true"/>
+        </method>
+    </configuration>
 </component>

--- a/.run/Local.run.xml
+++ b/.run/Local.run.xml
@@ -1,29 +1,34 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="Local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-        <option name="ACTIVE_PROFILES" value="local"/>
-        <module name="umc-product.main"/>
-        <option name="SHORTEN_COMMAND_LINE" value="ARGS_FILE"/>
-        <option name="SPRING_BOOT_MAIN_CLASS" value="com.umc.product.UmcProductApplication"/>
-        <extension name="net.ashald.envfile">
-            <option name="IS_ENABLED" value="true"/>
-            <option name="IS_SUBST" value="false"/>
-            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
-            <option name="IS_IGNORE_MISSING_FILES" value="true"/>
-            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
-            <ENTRIES>
-                <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="src/main/resources/.env.local"/>
-                <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
-            </ENTRIES>
-        </extension>
-        <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
-            <option name="credential"/>
-            <option name="region"/>
-            <option name="useCurrentConnection" value="false"/>
-        </extension>
-        <method v="2">
-            <option name="RunConfigurationTask" enabled="false" run_configuration_name="Test"
-                    run_configuration_type="GradleRunConfiguration"/>
-            <option name="Make" enabled="true"/>
-        </method>
-    </configuration>
+  <configuration default="false" name="Local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="local" />
+    <option name="envFilePaths">
+      <option value="$PROJECT_DIR$/src/main/resources/.env.local" />
+    </option>
+    <module name="umc-product.main" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
+    <option name="SHORTEN_COMMAND_LINE" value="ARGS_FILE" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.umc.product.UmcProductApplication" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="true" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="true" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="src/main/resources/.env.local" />
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+      </ENTRIES>
+    </extension>
+    <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
+      <option name="credential" />
+      <option name="region" />
+      <option name="useCurrentConnection" value="false" />
+    </extension>
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="false" run_configuration_name="Test" run_configuration_type="GradleRunConfiguration" />
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
 </component>

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -3,18 +3,21 @@ package com.umc.product.analytics.adapter.in.web;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardActionQueueRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsPointsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSchoolsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerRequest;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActionQueueResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardSummaryResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsPointsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSchoolsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallengerResponse;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
@@ -44,6 +47,7 @@ public class AdminDashboardController {
     private final GetAdminRiskChallengerUseCase getAdminRiskChallengerUseCase;
     private final GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
     private final GetAdminOperationsSchoolsUseCase getAdminOperationsSchoolsUseCase;
+    private final GetAdminOperationsPointsUseCase getAdminOperationsPointsUseCase;
 
     @Operation(summary = "[DASHBOARD-001] 운영진 대시보드 요약 조회")
     @GetMapping("summary")
@@ -101,6 +105,18 @@ public class AdminDashboardController {
     ) {
         return AdminOperationsSchoolsResponse.from(
             getAdminOperationsSchoolsUseCase.getOperationsSchools(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[DASHBOARD-007] 운영 현황 - 지부 내 파트별 상벌점 부여 현황 조회")
+    @GetMapping("operations/points")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsPointsResponse getOperationsPoints(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsPointsRequest request
+    ) {
+        return AdminOperationsPointsResponse.from(
+            getAdminOperationsPointsUseCase.getOperationsPoints(request.toQuery(memberPrincipal.getMemberId()))
         );
     }
 

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -96,7 +96,8 @@ public class AdminDashboardController {
         );
     }
 
-    @Operation(summary = "[DASHBOARD-005] 운영 현황 집계 조회")
+    @Operation(summary = "[DASHBOARD-005] 운영 현황 집계 조회", deprecated = true)
+    @Deprecated
     @GetMapping("operations")
     @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
     public AdminOperationsOverviewResponse getOperationsOverview(

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -3,16 +3,19 @@ package com.umc.product.analytics.adapter.in.web;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardActionQueueRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSchoolsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerRequest;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActionQueueResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardSummaryResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSchoolsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallengerResponse;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
@@ -40,6 +43,7 @@ public class AdminDashboardController {
     private final GetAdminDashboardContextUseCase getAdminDashboardContextUseCase;
     private final GetAdminRiskChallengerUseCase getAdminRiskChallengerUseCase;
     private final GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
+    private final GetAdminOperationsSchoolsUseCase getAdminOperationsSchoolsUseCase;
 
     @Operation(summary = "[DASHBOARD-001] 운영진 대시보드 요약 조회")
     @GetMapping("summary")
@@ -85,6 +89,18 @@ public class AdminDashboardController {
     ) {
         return AdminOperationsOverviewResponse.from(
             getAdminOperationsOverviewUseCase.getOperationsOverview(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[DASHBOARD-006] 운영 현황 - 지부별 학교/챌린저 현황 조회")
+    @GetMapping("operations/schools")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsSchoolsResponse getOperationsSchools(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsSchoolsRequest request
+    ) {
+        return AdminOperationsSchoolsResponse.from(
+            getAdminOperationsSchoolsUseCase.getOperationsSchools(request.toQuery(memberPrincipal.getMemberId()))
         );
     }
 

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -1,9 +1,15 @@
 package com.umc.product.analytics.adapter.in.web;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardActionQueueRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardRequest;
-import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsAttendanceRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsPointsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSchoolsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSignupsRequest;
@@ -12,8 +18,8 @@ import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerR
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActionQueueResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardSummaryResponse;
-import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsAttendanceResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsPointsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSchoolsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSignupsResponse;
@@ -22,8 +28,8 @@ import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallenger
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
-import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSignupsUseCase;
@@ -35,14 +41,10 @@ import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/admin/dashboard")

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -6,6 +6,8 @@ import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverv
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsAttendanceRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsPointsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSchoolsRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSignupsRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsStudyGroupsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerRequest;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActionQueueResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
@@ -14,6 +16,8 @@ import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOver
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsAttendanceResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsPointsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSchoolsResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSignupsResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsStudyGroupsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallengerResponse;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
@@ -22,6 +26,8 @@ import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOve
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSignupsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsStudyGroupsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
@@ -52,6 +58,8 @@ public class AdminDashboardController {
     private final GetAdminOperationsSchoolsUseCase getAdminOperationsSchoolsUseCase;
     private final GetAdminOperationsPointsUseCase getAdminOperationsPointsUseCase;
     private final GetAdminOperationsAttendanceUseCase getAdminOperationsAttendanceUseCase;
+    private final GetAdminOperationsStudyGroupsUseCase getAdminOperationsStudyGroupsUseCase;
+    private final GetAdminOperationsSignupsUseCase getAdminOperationsSignupsUseCase;
 
     @Operation(summary = "[DASHBOARD-001] 운영진 대시보드 요약 조회")
     @GetMapping("summary")
@@ -133,6 +141,30 @@ public class AdminDashboardController {
     ) {
         return AdminOperationsAttendanceResponse.from(
             getAdminOperationsAttendanceUseCase.getOperationsAttendance(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[DASHBOARD-009] 운영 현황 - 스터디 그룹 및 일정 생성 현황 조회")
+    @GetMapping("operations/study-groups")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsStudyGroupsResponse getOperationsStudyGroups(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsStudyGroupsRequest request
+    ) {
+        return AdminOperationsStudyGroupsResponse.from(
+            getAdminOperationsStudyGroupsUseCase.getOperationsStudyGroups(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[DASHBOARD-010] 운영 현황 - 기간별 신규 가입자 현황 조회")
+    @GetMapping("operations/signups")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsSignupsResponse getOperationsSignups(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsSignupsRequest request
+    ) {
+        return AdminOperationsSignupsResponse.from(
+            getAdminOperationsSignupsUseCase.getOperationsSignups(request.toQuery(memberPrincipal.getMemberId()))
         );
     }
 

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -3,6 +3,7 @@ package com.umc.product.analytics.adapter.in.web;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardActionQueueRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminDashboardRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsOverviewRequest;
+import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsAttendanceRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsPointsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminOperationsSchoolsRequest;
 import com.umc.product.analytics.adapter.in.web.dto.request.AdminRiskChallengerRequest;
@@ -10,6 +11,7 @@ import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardActio
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardContextResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminDashboardSummaryResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsOverviewResponse;
+import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsAttendanceResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsPointsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminOperationsSchoolsResponse;
 import com.umc.product.analytics.adapter.in.web.dto.response.AdminRiskChallengerResponse;
@@ -17,6 +19,7 @@ import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActi
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
@@ -48,6 +51,7 @@ public class AdminDashboardController {
     private final GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
     private final GetAdminOperationsSchoolsUseCase getAdminOperationsSchoolsUseCase;
     private final GetAdminOperationsPointsUseCase getAdminOperationsPointsUseCase;
+    private final GetAdminOperationsAttendanceUseCase getAdminOperationsAttendanceUseCase;
 
     @Operation(summary = "[DASHBOARD-001] 운영진 대시보드 요약 조회")
     @GetMapping("summary")
@@ -117,6 +121,18 @@ public class AdminDashboardController {
     ) {
         return AdminOperationsPointsResponse.from(
             getAdminOperationsPointsUseCase.getOperationsPoints(request.toQuery(memberPrincipal.getMemberId()))
+        );
+    }
+
+    @Operation(summary = "[DASHBOARD-008] 운영 현황 - 일정 및 출석 생성 현황 조회")
+    @GetMapping("operations/attendance")
+    @CheckAccess(resourceType = ResourceType.ANALYTICS, permission = PermissionType.READ)
+    public AdminOperationsAttendanceResponse getOperationsAttendance(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @ParameterObject AdminOperationsAttendanceRequest request
+    ) {
+        return AdminOperationsAttendanceResponse.from(
+            getAdminOperationsAttendanceUseCase.getOperationsAttendance(request.toQuery(memberPrincipal.getMemberId()))
         );
     }
 

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsAttendanceRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsAttendanceRequest.java
@@ -1,7 +1,8 @@
 package com.umc.product.analytics.adapter.in.web.dto.request;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
 import java.time.Instant;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
 
 public record AdminOperationsAttendanceRequest(
     Long gisuId,

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsAttendanceRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsAttendanceRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
+import java.time.Instant;
+
+public record AdminOperationsAttendanceRequest(
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public AdminOperationsAttendanceQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsAttendanceQuery.of(requesterMemberId, gisuId, from, to);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsPointsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsPointsRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
+import java.time.Instant;
+
+public record AdminOperationsPointsRequest(
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public AdminOperationsPointsQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsPointsQuery.of(requesterMemberId, gisuId, from, to);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsPointsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsPointsRequest.java
@@ -1,7 +1,8 @@
 package com.umc.product.analytics.adapter.in.web.dto.request;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 import java.time.Instant;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 
 public record AdminOperationsPointsRequest(
     Long gisuId,

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSchoolsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSchoolsRequest.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsQuery;
+
+public record AdminOperationsSchoolsRequest(Long gisuId) {
+
+    public AdminOperationsSchoolsQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsSchoolsQuery.of(requesterMemberId, gisuId);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSignupsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSignupsRequest.java
@@ -1,7 +1,8 @@
 package com.umc.product.analytics.adapter.in.web.dto.request;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsQuery;
 import java.time.Instant;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsQuery;
 
 public record AdminOperationsSignupsRequest(
     Long gisuId,

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSignupsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsSignupsRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsQuery;
+import java.time.Instant;
+
+public record AdminOperationsSignupsRequest(
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public AdminOperationsSignupsQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsSignupsQuery.of(requesterMemberId, gisuId, from, to);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsStudyGroupsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsStudyGroupsRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.analytics.adapter.in.web.dto.request;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsQuery;
+import java.time.Instant;
+
+public record AdminOperationsStudyGroupsRequest(
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public AdminOperationsStudyGroupsQuery toQuery(Long requesterMemberId) {
+        return AdminOperationsStudyGroupsQuery.of(requesterMemberId, gisuId, from, to);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsStudyGroupsRequest.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/request/AdminOperationsStudyGroupsRequest.java
@@ -1,7 +1,8 @@
 package com.umc.product.analytics.adapter.in.web.dto.request;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsQuery;
 import java.time.Instant;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsQuery;
 
 public record AdminOperationsStudyGroupsRequest(
     Long gisuId,

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsAttendanceResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsAttendanceResponse.java
@@ -1,8 +1,10 @@
 package com.umc.product.analytics.adapter.in.web.dto.response;
 
+import java.util.Map;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
-import java.util.Map;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsAttendanceResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsAttendanceResponse.java
@@ -1,0 +1,24 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsAttendanceResponse(
+    long scheduleCount,
+    long attendanceRequiredScheduleCount,
+    long attendanceRecordCount,
+    Map<AttendanceStatus, Long> attendanceStatusCounts
+) {
+
+    public static AdminOperationsAttendanceResponse from(AdminOperationsAttendanceInfo info) {
+        return AdminOperationsAttendanceResponse.builder()
+            .scheduleCount(info.scheduleCount())
+            .attendanceRequiredScheduleCount(info.attendanceRequiredScheduleCount())
+            .attendanceRecordCount(info.attendanceRecordCount())
+            .attendanceStatusCounts(info.attendanceStatusCounts())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsPointsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsPointsResponse.java
@@ -1,8 +1,10 @@
 package com.umc.product.analytics.adapter.in.web.dto.response;
 
+import java.util.List;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
-import java.util.List;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsPointsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsPointsResponse.java
@@ -1,0 +1,40 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsPointsResponse(List<ChapterPartPointGrantStatusResponse> pointGrantStatuses) {
+
+    public static AdminOperationsPointsResponse from(AdminOperationsPointsInfo info) {
+        return AdminOperationsPointsResponse.builder()
+            .pointGrantStatuses(info.pointGrantStatuses().stream()
+                .map(ChapterPartPointGrantStatusResponse::from)
+                .toList())
+            .build();
+    }
+
+    @Builder
+    public record ChapterPartPointGrantStatusResponse(
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        long grantCount,
+        double pointSum
+    ) {
+
+        public static ChapterPartPointGrantStatusResponse from(
+            AdminOperationsPointsInfo.ChapterPartPointGrantStatusInfo info
+        ) {
+            return ChapterPartPointGrantStatusResponse.builder()
+                .chapterId(info.chapterId())
+                .chapterName(info.chapterName())
+                .part(info.part())
+                .grantCount(info.grantCount())
+                .pointSum(info.pointSum())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSchoolsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSchoolsResponse.java
@@ -1,0 +1,55 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsSchoolsResponse(List<ChapterStatusResponse> chapters) {
+
+    public static AdminOperationsSchoolsResponse from(AdminOperationsSchoolsInfo info) {
+        return AdminOperationsSchoolsResponse.builder()
+            .chapters(info.chapters().stream()
+                .map(ChapterStatusResponse::from)
+                .toList())
+            .build();
+    }
+
+    @Builder
+    public record ChapterStatusResponse(
+        Long chapterId,
+        String chapterName,
+        List<SchoolChallengerStatusResponse> schools
+    ) {
+
+        public static ChapterStatusResponse from(AdminOperationsSchoolsInfo.ChapterStatusInfo info) {
+            return ChapterStatusResponse.builder()
+                .chapterId(info.chapterId())
+                .chapterName(info.chapterName())
+                .schools(info.schools().stream()
+                    .map(SchoolChallengerStatusResponse::from)
+                    .toList())
+                .build();
+        }
+    }
+
+    @Builder
+    public record SchoolChallengerStatusResponse(
+        Long schoolId,
+        String schoolName,
+        long totalChallengerCount,
+        Map<ChallengerPart, Long> challengerPartCounts
+    ) {
+
+        public static SchoolChallengerStatusResponse from(AdminOperationsSchoolsInfo.SchoolChallengerStatusInfo info) {
+            return SchoolChallengerStatusResponse.builder()
+                .schoolId(info.schoolId())
+                .schoolName(info.schoolName())
+                .totalChallengerCount(info.totalChallengerCount())
+                .challengerPartCounts(info.challengerPartCounts())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSchoolsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSchoolsResponse.java
@@ -1,9 +1,11 @@
 package com.umc.product.analytics.adapter.in.web.dto.response;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
-import com.umc.product.common.domain.enums.ChallengerPart;
 import java.util.List;
 import java.util.Map;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.common.domain.enums.ChallengerPart;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSignupsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSignupsResponse.java
@@ -1,0 +1,27 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsSignupsResponse(List<SignupBucketResponse> signupBuckets) {
+
+    public static AdminOperationsSignupsResponse from(AdminOperationsSignupsInfo info) {
+        return AdminOperationsSignupsResponse.builder()
+            .signupBuckets(info.signupBuckets().stream().map(SignupBucketResponse::from).toList())
+            .build();
+    }
+
+    @Builder
+    public record SignupBucketResponse(LocalDate date, long count) {
+
+        public static SignupBucketResponse from(AdminOperationsSignupsInfo.SignupBucketInfo info) {
+            return SignupBucketResponse.builder()
+                .date(info.date())
+                .count(info.count())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSignupsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsSignupsResponse.java
@@ -1,8 +1,10 @@
 package com.umc.product.analytics.adapter.in.web.dto.response;
 
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
 import java.time.LocalDate;
 import java.util.List;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsStudyGroupsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsStudyGroupsResponse.java
@@ -1,6 +1,7 @@
 package com.umc.product.analytics.adapter.in.web.dto.response;
 
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsStudyGroupsResponse.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/dto/response/AdminOperationsStudyGroupsResponse.java
@@ -1,0 +1,18 @@
+package com.umc.product.analytics.adapter.in.web.dto.response;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsStudyGroupsResponse(
+    long studyGroupCount,
+    long studyGroupScheduleCount
+) {
+
+    public static AdminOperationsStudyGroupsResponse from(AdminOperationsStudyGroupsInfo info) {
+        return AdminOperationsStudyGroupsResponse.builder()
+            .studyGroupCount(info.studyGroupCount())
+            .studyGroupScheduleCount(info.studyGroupScheduleCount())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -1,5 +1,9 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
@@ -14,9 +18,8 @@ import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchools
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSignupsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsStudyGroupsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
-import java.time.Instant;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -1,10 +1,12 @@
 package com.umc.product.analytics.adapter.out.persistence;
 
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsAttendancePort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -17,7 +19,8 @@ import org.springframework.stereotype.Component;
 public class AdminOperationsAnalyticsPersistenceAdapter implements
     LoadAdminOperationsAnalyticsPort,
     LoadAdminOperationsSchoolsPort,
-    LoadAdminOperationsPointsPort {
+    LoadAdminOperationsPointsPort,
+    LoadAdminOperationsAttendancePort {
 
     private final AdminOperationsAnalyticsQueryRepository queryRepository;
 
@@ -37,5 +40,10 @@ public class AdminOperationsAnalyticsPersistenceAdapter implements
     @Override
     public AdminOperationsPointsInfo getOperationsPoints(AdminAnalyticsScope scope, Instant from, Instant to) {
         return queryRepository.getOperationsPoints(scope, from, to);
+    }
+
+    @Override
+    public AdminOperationsAttendanceInfo getOperationsAttendance(AdminAnalyticsScope scope, Instant from, Instant to) {
+        return queryRepository.getOperationsAttendance(scope, from, to);
     }
 }

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -5,10 +5,14 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOv
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAttendancePort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsSignupsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsStudyGroupsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +24,9 @@ public class AdminOperationsAnalyticsPersistenceAdapter implements
     LoadAdminOperationsAnalyticsPort,
     LoadAdminOperationsSchoolsPort,
     LoadAdminOperationsPointsPort,
-    LoadAdminOperationsAttendancePort {
+    LoadAdminOperationsAttendancePort,
+    LoadAdminOperationsStudyGroupsPort,
+    LoadAdminOperationsSignupsPort {
 
     private final AdminOperationsAnalyticsQueryRepository queryRepository;
 
@@ -45,5 +51,15 @@ public class AdminOperationsAnalyticsPersistenceAdapter implements
     @Override
     public AdminOperationsAttendanceInfo getOperationsAttendance(AdminAnalyticsScope scope, Instant from, Instant to) {
         return queryRepository.getOperationsAttendance(scope, from, to);
+    }
+
+    @Override
+    public AdminOperationsStudyGroupsInfo getOperationsStudyGroups(AdminAnalyticsScope scope, Instant from, Instant to) {
+        return queryRepository.getOperationsStudyGroups(scope, from, to);
+    }
+
+    @Override
+    public AdminOperationsSignupsInfo getOperationsSignups(AdminAnalyticsScope scope, Instant from, Instant to) {
+        return queryRepository.getOperationsSignups(scope, from, to);
     }
 }

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -2,14 +2,18 @@ package com.umc.product.analytics.adapter.out.persistence;
 
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class AdminOperationsAnalyticsPersistenceAdapter implements LoadAdminOperationsAnalyticsPort {
+public class AdminOperationsAnalyticsPersistenceAdapter implements
+    LoadAdminOperationsAnalyticsPort,
+    LoadAdminOperationsSchoolsPort {
 
     private final AdminOperationsAnalyticsQueryRepository queryRepository;
 
@@ -19,5 +23,10 @@ public class AdminOperationsAnalyticsPersistenceAdapter implements LoadAdminOper
         AdminOperationsOverviewQuery query
     ) {
         return queryRepository.getOperationsOverview(scope, query);
+    }
+
+    @Override
+    public AdminOperationsSchoolsInfo getOperationsSchools(AdminAnalyticsScope scope) {
+        return queryRepository.getOperationsSchools(scope);
     }
 }

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsPersistenceAdapter.java
@@ -2,10 +2,13 @@ package com.umc.product.analytics.adapter.out.persistence;
 
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +16,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AdminOperationsAnalyticsPersistenceAdapter implements
     LoadAdminOperationsAnalyticsPort,
-    LoadAdminOperationsSchoolsPort {
+    LoadAdminOperationsSchoolsPort,
+    LoadAdminOperationsPointsPort {
 
     private final AdminOperationsAnalyticsQueryRepository queryRepository;
 
@@ -28,5 +32,10 @@ public class AdminOperationsAnalyticsPersistenceAdapter implements
     @Override
     public AdminOperationsSchoolsInfo getOperationsSchools(AdminAnalyticsScope scope) {
         return queryRepository.getOperationsSchools(scope);
+    }
+
+    @Override
+    public AdminOperationsPointsInfo getOperationsPoints(AdminAnalyticsScope scope, Instant from, Instant to) {
+        return queryRepository.getOperationsPoints(scope, from, to);
     }
 }

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallenger;
@@ -45,6 +46,43 @@ public class AdminOperationsAnalyticsQueryRepository {
     private static final ZoneId DASHBOARD_ZONE = ZoneId.of("Asia/Seoul");
 
     private final JPAQueryFactory queryFactory;
+
+    public AdminOperationsPointsInfo getOperationsPoints(AdminAnalyticsScope scope, Instant from, Instant to) {
+        QChallengerPoint point = new QChallengerPoint("operationsPoint");
+        QChallenger challenger = new QChallenger("operationsPointChallenger");
+        QMember member = new QMember("operationsPointMember");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsPointChapterSchool");
+        QChapter chapter = new QChapter("operationsPointChapter");
+        NumberExpression<Long> grantCount = point.id.count();
+        NumberExpression<Double> pointSum = pointScore(point).sum().coalesce(0.0);
+
+        List<com.querydsl.core.Tuple> rows = queryFactory
+            .select(chapter.id, chapter.name, challenger.part, grantCount, pointSum)
+            .from(point)
+            .join(point.challenger, challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope, challenger, member, chapterSchool, chapter)
+                .and(periodCondition(point.createdAt, from, to))
+                .and(chapter.id.isNotNull()))
+            .groupBy(chapter.id, chapter.name, challenger.part)
+            .orderBy(chapter.name.asc(), challenger.part.asc())
+            .fetch();
+
+        return AdminOperationsPointsInfo.from(
+            rows.stream()
+                .map(row -> AdminOperationsPointsInfo.ChapterPartPointGrantStatusInfo.of(
+                    row.get(chapter.id),
+                    row.get(chapter.name),
+                    row.get(challenger.part),
+                    defaultLong(row.get(grantCount)),
+                    defaultDouble(row.get(pointSum))
+                ))
+                .toList()
+        );
+    }
 
     public AdminOperationsSchoolsInfo getOperationsSchools(AdminAnalyticsScope scope) {
         return AdminOperationsSchoolsInfo.from(
@@ -444,9 +482,13 @@ public class AdminOperationsAnalyticsQueryRepository {
     }
 
     private BooleanBuilder periodCondition(DateTimePath<Instant> path, AdminOperationsOverviewQuery query) {
+        return periodCondition(path, query.from(), query.to());
+    }
+
+    private BooleanBuilder periodCondition(DateTimePath<Instant> path, Instant from, Instant to) {
         return new BooleanBuilder()
-            .and(path.goe(query.from()))
-            .and(path.lt(query.to()));
+            .and(path.goe(from))
+            .and(path.lt(to));
     }
 
     private Map<ChallengerPart, Long> emptyPartCounts() {

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallenger;
 import com.umc.product.challenger.domain.QChallengerPoint;
@@ -44,6 +45,25 @@ public class AdminOperationsAnalyticsQueryRepository {
     private static final ZoneId DASHBOARD_ZONE = ZoneId.of("Asia/Seoul");
 
     private final JPAQueryFactory queryFactory;
+
+    public AdminOperationsSchoolsInfo getOperationsSchools(AdminAnalyticsScope scope) {
+        return AdminOperationsSchoolsInfo.from(
+            listChapterSchoolStatuses(scope).stream()
+                .map(s -> AdminOperationsSchoolsInfo.ChapterStatusInfo.of(
+                    s.chapterId(),
+                    s.chapterName(),
+                    s.schools().stream()
+                        .map(school -> AdminOperationsSchoolsInfo.SchoolChallengerStatusInfo.of(
+                            school.schoolId(),
+                            school.schoolName(),
+                            school.totalChallengerCount(),
+                            school.challengerPartCounts()
+                        ))
+                        .toList()
+                ))
+                .toList()
+        );
+    }
 
     public AdminOperationsOverviewInfo getOperationsOverview(
         AdminAnalyticsScope scope,

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -14,6 +14,8 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOv
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
 import com.umc.product.challenger.domain.QChallenger;
 import com.umc.product.challenger.domain.QChallengerPoint;
@@ -47,6 +49,63 @@ public class AdminOperationsAnalyticsQueryRepository {
     private static final ZoneId DASHBOARD_ZONE = ZoneId.of("Asia/Seoul");
 
     private final JPAQueryFactory queryFactory;
+
+    public AdminOperationsStudyGroupsInfo getOperationsStudyGroups(AdminAnalyticsScope scope, Instant from, Instant to) {
+        QStudyGroup studyGroup = new QStudyGroup("operationsStudyGroup");
+        JPAQuery<Long> studyGroupCountQuery = queryFactory
+            .select(studyGroup.id.countDistinct())
+            .from(studyGroup);
+        long studyGroupCount = defaultLong(studyGroupCountQuery
+            .where(studyGroupCondition(scope, studyGroup, studyGroupCountQuery))
+            .fetchOne());
+
+        QStudyGroupSchedule studyGroupSchedule = new QStudyGroupSchedule("operationsStudyGroupSchedule");
+        QStudyGroup scheduledStudyGroup = new QStudyGroup("operationsScheduledStudyGroup");
+        JPAQuery<Long> scheduleCountQuery = queryFactory
+            .select(studyGroupSchedule.id.countDistinct())
+            .from(studyGroupSchedule)
+            .join(scheduledStudyGroup).on(scheduledStudyGroup.id.eq(studyGroupSchedule.studyGroupId));
+        long studyGroupScheduleCount = defaultLong(scheduleCountQuery
+            .where(studyGroupCondition(scope, scheduledStudyGroup, scheduleCountQuery)
+                .and(periodCondition(studyGroupSchedule.createdAt, from, to)))
+            .fetchOne());
+
+        return AdminOperationsStudyGroupsInfo.of(studyGroupCount, studyGroupScheduleCount);
+    }
+
+    public AdminOperationsSignupsInfo getOperationsSignups(AdminAnalyticsScope scope, Instant from, Instant to) {
+        QChallenger challenger = new QChallenger("operationsSignupChallenger");
+        QMember member = new QMember("operationsSignupMember");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsSignupChapterSchool");
+        QChapter chapter = new QChapter("operationsSignupChapter");
+
+        List<Tuple> rows = queryFactory
+            .select(member.id, member.createdAt)
+            .from(challenger)
+            .join(member).on(member.id.eq(challenger.memberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(member.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id)
+                .and(chapter.gisu.id.eq(challenger.gisuId)))
+            .where(challengerScopeCondition(scope, challenger, member, chapterSchool, chapter)
+                .and(periodCondition(member.createdAt, from, to)))
+            .groupBy(member.id, member.createdAt)
+            .fetch();
+
+        Map<LocalDate, Long> countsByDate = rows.stream()
+            .map(row -> row.get(member.createdAt))
+            .filter(createdAt -> createdAt != null)
+            .collect(Collectors.groupingBy(
+                createdAt -> createdAt.atZone(DASHBOARD_ZONE).toLocalDate(),
+                TreeMap::new,
+                Collectors.counting()
+            ));
+
+        return AdminOperationsSignupsInfo.from(
+            countsByDate.entrySet().stream()
+                .map(entry -> AdminOperationsSignupsInfo.SignupBucketInfo.of(entry.getKey(), entry.getValue()))
+                .toList()
+        );
+    }
 
     public AdminOperationsAttendanceInfo getOperationsAttendance(AdminAnalyticsScope scope, Instant from, Instant to) {
         QSchedule schedule = new QSchedule("operationsAttSchedule");

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -46,6 +47,66 @@ public class AdminOperationsAnalyticsQueryRepository {
     private static final ZoneId DASHBOARD_ZONE = ZoneId.of("Asia/Seoul");
 
     private final JPAQueryFactory queryFactory;
+
+    public AdminOperationsAttendanceInfo getOperationsAttendance(AdminAnalyticsScope scope, Instant from, Instant to) {
+        QSchedule schedule = new QSchedule("operationsAttSchedule");
+        QMember author = new QMember("operationsAttAuthor");
+        QChapterSchool chapterSchool = new QChapterSchool("operationsAttChapterSchool");
+        QChapter chapter = new QChapter("operationsAttChapter");
+
+        BooleanBuilder scheduleCondition = scheduleScopeCondition(scope, from, to, schedule, author, chapter);
+        Long scheduleCount = queryFactory
+            .select(schedule.id.countDistinct())
+            .from(schedule)
+            .join(author).on(author.id.eq(schedule.authorMemberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(author.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id))
+            .where(scheduleCondition)
+            .fetchOne();
+
+        Long attendanceRequiredScheduleCount = queryFactory
+            .select(schedule.id.countDistinct())
+            .from(schedule)
+            .join(author).on(author.id.eq(schedule.authorMemberId))
+            .leftJoin(chapterSchool).on(chapterSchool.school.id.eq(author.schoolId))
+            .leftJoin(chapter).on(chapter.id.eq(chapterSchool.chapter.id))
+            .where(scheduleScopeCondition(scope, from, to, schedule, author, chapter)
+                .and(schedule.policy.attendanceGraceMinutes.isNotNull()))
+            .fetchOne();
+
+        QScheduleParticipant participant = new QScheduleParticipant("operationsAttParticipant");
+        QSchedule attSchedule = new QSchedule("operationsAttAttendanceSchedule");
+        QMember attAuthor = new QMember("operationsAttAttendanceAuthor");
+        QChapterSchool attChapterSchool = new QChapterSchool("operationsAttAttChapterSchool");
+        QChapter attChapter = new QChapter("operationsAttAttChapter");
+        NumberExpression<Long> statusCount = participant.id.count();
+
+        List<Tuple> rows = queryFactory
+            .select(participant.attendance.status, statusCount)
+            .from(participant)
+            .join(participant.schedule, attSchedule)
+            .join(attAuthor).on(attAuthor.id.eq(attSchedule.authorMemberId))
+            .leftJoin(attChapterSchool).on(attChapterSchool.school.id.eq(attAuthor.schoolId))
+            .leftJoin(attChapter).on(attChapter.id.eq(attChapterSchool.chapter.id))
+            .where(scheduleAuthorScopeCondition(scope, attAuthor, attChapter)
+                .and(periodCondition(participant.updatedAt, from, to))
+                .and(participant.attendance.status.isNotNull()))
+            .groupBy(participant.attendance.status)
+            .fetch();
+
+        Map<AttendanceStatus, Long> attendanceStatusCounts = new EnumMap<>(AttendanceStatus.class);
+        for (Tuple row : rows) {
+            attendanceStatusCounts.put(row.get(participant.attendance.status), defaultLong(row.get(statusCount)));
+        }
+        long attendanceRecordCount = attendanceStatusCounts.values().stream().mapToLong(Long::longValue).sum();
+
+        return AdminOperationsAttendanceInfo.of(
+            defaultLong(scheduleCount),
+            defaultLong(attendanceRequiredScheduleCount),
+            attendanceRecordCount,
+            attendanceStatusCounts
+        );
+    }
 
     public AdminOperationsPointsInfo getOperationsPoints(AdminAnalyticsScope scope, Instant from, Instant to) {
         QChallengerPoint point = new QChallengerPoint("operationsPoint");
@@ -427,8 +488,19 @@ public class AdminOperationsAnalyticsQueryRepository {
         QMember author,
         QChapter chapter
     ) {
+        return scheduleScopeCondition(scope, query.from(), query.to(), schedule, author, chapter);
+    }
+
+    private BooleanBuilder scheduleScopeCondition(
+        AdminAnalyticsScope scope,
+        Instant from,
+        Instant to,
+        QSchedule schedule,
+        QMember author,
+        QChapter chapter
+    ) {
         return scheduleAuthorScopeCondition(scope, author, chapter)
-            .and(periodCondition(schedule.createdAt, query));
+            .and(periodCondition(schedule.createdAt, from, to));
     }
 
     private BooleanBuilder scheduleAuthorScopeCondition(

--- a/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
+++ b/src/main/java/com/umc/product/analytics/adapter/out/persistence/AdminOperationsAnalyticsQueryRepository.java
@@ -3,15 +3,27 @@ package com.umc.product.analytics.adapter.out.persistence;
 import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.chapterMatchedOrNoMapping;
 import static com.umc.product.analytics.adapter.out.persistence.AdminAnalyticsQueryExpressions.pointScore;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
@@ -30,17 +42,8 @@ import com.umc.product.organization.domain.QStudyGroupSchedule;
 import com.umc.product.schedule.domain.QSchedule;
 import com.umc.product.schedule.domain.QScheduleParticipant;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.EnumMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsAttendanceUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsAttendanceUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
+
+public interface GetAdminOperationsAttendanceUseCase {
+
+    AdminOperationsAttendanceInfo getOperationsAttendance(AdminOperationsAttendanceQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsPointsUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsPointsUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
+
+public interface GetAdminOperationsPointsUseCase {
+
+    AdminOperationsPointsInfo getOperationsPoints(AdminOperationsPointsQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsSchoolsUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsSchoolsUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsQuery;
+
+public interface GetAdminOperationsSchoolsUseCase {
+
+    AdminOperationsSchoolsInfo getOperationsSchools(AdminOperationsSchoolsQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsSignupsUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsSignupsUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsQuery;
+
+public interface GetAdminOperationsSignupsUseCase {
+
+    AdminOperationsSignupsInfo getOperationsSignups(AdminOperationsSignupsQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsStudyGroupsUseCase.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/GetAdminOperationsStudyGroupsUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.in.query;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsQuery;
+
+public interface GetAdminOperationsStudyGroupsUseCase {
+
+    AdminOperationsStudyGroupsInfo getOperationsStudyGroups(AdminOperationsStudyGroupsQuery query);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceInfo.java
@@ -1,7 +1,9 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import java.util.Map;
+
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceInfo.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsAttendanceInfo(
+    long scheduleCount,
+    long attendanceRequiredScheduleCount,
+    long attendanceRecordCount,
+    Map<AttendanceStatus, Long> attendanceStatusCounts
+) {
+
+    public static AdminOperationsAttendanceInfo of(
+        long scheduleCount,
+        long attendanceRequiredScheduleCount,
+        long attendanceRecordCount,
+        Map<AttendanceStatus, Long> attendanceStatusCounts
+    ) {
+        return AdminOperationsAttendanceInfo.builder()
+            .scheduleCount(scheduleCount)
+            .attendanceRequiredScheduleCount(attendanceRequiredScheduleCount)
+            .attendanceRecordCount(attendanceRecordCount)
+            .attendanceStatusCounts(Map.copyOf(attendanceStatusCounts))
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceQuery.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public record AdminOperationsAttendanceQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public static AdminOperationsAttendanceQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Instant from,
+        Instant to
+    ) {
+        Instant normalizedTo = to != null ? to : Instant.now();
+        Instant normalizedFrom = from != null ? from : normalizedTo.minus(30, ChronoUnit.DAYS);
+        if (!normalizedFrom.isBefore(normalizedTo)) {
+            throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_PERIOD);
+        }
+        return new AdminOperationsAttendanceQuery(requesterMemberId, gisuId, normalizedFrom, normalizedTo);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsAttendanceQuery.java
@@ -1,9 +1,10 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.analytics.domain.AnalyticsDomainException;
-import com.umc.product.analytics.domain.AnalyticsErrorCode;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
 
 public record AdminOperationsAttendanceQuery(
     Long requesterMemberId,

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsInfo.java
@@ -1,0 +1,41 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsPointsInfo(List<ChapterPartPointGrantStatusInfo> pointGrantStatuses) {
+
+    public static AdminOperationsPointsInfo from(List<ChapterPartPointGrantStatusInfo> pointGrantStatuses) {
+        return AdminOperationsPointsInfo.builder()
+            .pointGrantStatuses(List.copyOf(pointGrantStatuses))
+            .build();
+    }
+
+    @Builder
+    public record ChapterPartPointGrantStatusInfo(
+        Long chapterId,
+        String chapterName,
+        ChallengerPart part,
+        long grantCount,
+        double pointSum
+    ) {
+
+        public static ChapterPartPointGrantStatusInfo of(
+            Long chapterId,
+            String chapterName,
+            ChallengerPart part,
+            long grantCount,
+            double pointSum
+        ) {
+            return ChapterPartPointGrantStatusInfo.builder()
+                .chapterId(chapterId)
+                .chapterName(chapterName)
+                .part(part)
+                .grantCount(grantCount)
+                .pointSum(pointSum)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsInfo.java
@@ -1,7 +1,9 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
 import java.util.List;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsQuery.java
@@ -1,9 +1,10 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.analytics.domain.AnalyticsDomainException;
-import com.umc.product.analytics.domain.AnalyticsErrorCode;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
 
 public record AdminOperationsPointsQuery(
     Long requesterMemberId,

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsPointsQuery.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public record AdminOperationsPointsQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public static AdminOperationsPointsQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Instant from,
+        Instant to
+    ) {
+        Instant normalizedTo = to != null ? to : Instant.now();
+        Instant normalizedFrom = from != null ? from : normalizedTo.minus(30, ChronoUnit.DAYS);
+        if (!normalizedFrom.isBefore(normalizedTo)) {
+            throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_PERIOD);
+        }
+        return new AdminOperationsPointsQuery(requesterMemberId, gisuId, normalizedFrom, normalizedTo);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsInfo.java
@@ -1,8 +1,10 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
 import java.util.List;
 import java.util.Map;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsInfo.java
@@ -1,0 +1,61 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsSchoolsInfo(
+    List<ChapterStatusInfo> chapters
+) {
+
+    public static AdminOperationsSchoolsInfo from(List<ChapterStatusInfo> chapters) {
+        return AdminOperationsSchoolsInfo.builder()
+            .chapters(List.copyOf(chapters))
+            .build();
+    }
+
+    @Builder
+    public record ChapterStatusInfo(
+        Long chapterId,
+        String chapterName,
+        List<SchoolChallengerStatusInfo> schools
+    ) {
+
+        public static ChapterStatusInfo of(
+            Long chapterId,
+            String chapterName,
+            List<SchoolChallengerStatusInfo> schools
+        ) {
+            return ChapterStatusInfo.builder()
+                .chapterId(chapterId)
+                .chapterName(chapterName)
+                .schools(List.copyOf(schools))
+                .build();
+        }
+    }
+
+    @Builder
+    public record SchoolChallengerStatusInfo(
+        Long schoolId,
+        String schoolName,
+        long totalChallengerCount,
+        Map<ChallengerPart, Long> challengerPartCounts
+    ) {
+
+        public static SchoolChallengerStatusInfo of(
+            Long schoolId,
+            String schoolName,
+            long totalChallengerCount,
+            Map<ChallengerPart, Long> challengerPartCounts
+        ) {
+            return SchoolChallengerStatusInfo.builder()
+                .schoolId(schoolId)
+                .schoolName(schoolName)
+                .totalChallengerCount(totalChallengerCount)
+                .challengerPartCounts(Map.copyOf(challengerPartCounts))
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSchoolsQuery.java
@@ -1,0 +1,11 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+public record AdminOperationsSchoolsQuery(
+    Long requesterMemberId,
+    Long gisuId
+) {
+
+    public static AdminOperationsSchoolsQuery of(Long requesterMemberId, Long gisuId) {
+        return new AdminOperationsSchoolsQuery(requesterMemberId, gisuId);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsInfo.java
@@ -2,6 +2,7 @@ package com.umc.product.analytics.application.port.in.query.dto;
 
 import java.time.LocalDate;
 import java.util.List;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsInfo.java
@@ -1,0 +1,26 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsSignupsInfo(List<SignupBucketInfo> signupBuckets) {
+
+    public static AdminOperationsSignupsInfo from(List<SignupBucketInfo> signupBuckets) {
+        return AdminOperationsSignupsInfo.builder()
+            .signupBuckets(List.copyOf(signupBuckets))
+            .build();
+    }
+
+    @Builder
+    public record SignupBucketInfo(LocalDate date, long count) {
+
+        public static SignupBucketInfo of(LocalDate date, long count) {
+            return SignupBucketInfo.builder()
+                .date(date)
+                .count(count)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsQuery.java
@@ -1,9 +1,10 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.analytics.domain.AnalyticsDomainException;
-import com.umc.product.analytics.domain.AnalyticsErrorCode;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
 
 public record AdminOperationsSignupsQuery(
     Long requesterMemberId,

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsSignupsQuery.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public record AdminOperationsSignupsQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public static AdminOperationsSignupsQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Instant from,
+        Instant to
+    ) {
+        Instant normalizedTo = to != null ? to : Instant.now();
+        Instant normalizedFrom = from != null ? from : normalizedTo.minus(30, ChronoUnit.DAYS);
+        if (!normalizedFrom.isBefore(normalizedTo)) {
+            throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_PERIOD);
+        }
+        return new AdminOperationsSignupsQuery(requesterMemberId, gisuId, normalizedFrom, normalizedTo);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsInfo.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsInfo.java
@@ -1,0 +1,17 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AdminOperationsStudyGroupsInfo(
+    long studyGroupCount,
+    long studyGroupScheduleCount
+) {
+
+    public static AdminOperationsStudyGroupsInfo of(long studyGroupCount, long studyGroupScheduleCount) {
+        return AdminOperationsStudyGroupsInfo.builder()
+            .studyGroupCount(studyGroupCount)
+            .studyGroupScheduleCount(studyGroupScheduleCount)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsQuery.java
@@ -1,0 +1,28 @@
+package com.umc.product.analytics.application.port.in.query.dto;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public record AdminOperationsStudyGroupsQuery(
+    Long requesterMemberId,
+    Long gisuId,
+    Instant from,
+    Instant to
+) {
+
+    public static AdminOperationsStudyGroupsQuery of(
+        Long requesterMemberId,
+        Long gisuId,
+        Instant from,
+        Instant to
+    ) {
+        Instant normalizedTo = to != null ? to : Instant.now();
+        Instant normalizedFrom = from != null ? from : normalizedTo.minus(30, ChronoUnit.DAYS);
+        if (!normalizedFrom.isBefore(normalizedTo)) {
+            throw new AnalyticsDomainException(AnalyticsErrorCode.INVALID_PERIOD);
+        }
+        return new AdminOperationsStudyGroupsQuery(requesterMemberId, gisuId, normalizedFrom, normalizedTo);
+    }
+}

--- a/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsQuery.java
+++ b/src/main/java/com/umc/product/analytics/application/port/in/query/dto/AdminOperationsStudyGroupsQuery.java
@@ -1,9 +1,10 @@
 package com.umc.product.analytics.application.port.in.query.dto;
 
-import com.umc.product.analytics.domain.AnalyticsDomainException;
-import com.umc.product.analytics.domain.AnalyticsErrorCode;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+
+import com.umc.product.analytics.domain.AnalyticsDomainException;
+import com.umc.product.analytics.domain.AnalyticsErrorCode;
 
 public record AdminOperationsStudyGroupsQuery(
     Long requesterMemberId,

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAttendancePort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAttendancePort.java
@@ -1,8 +1,9 @@
 package com.umc.product.analytics.application.port.out;
 
+import java.time.Instant;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
-import java.time.Instant;
 
 public interface LoadAdminOperationsAttendancePort {
 

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAttendancePort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsAttendancePort.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import java.time.Instant;
+
+public interface LoadAdminOperationsAttendancePort {
+
+    AdminOperationsAttendanceInfo getOperationsAttendance(AdminAnalyticsScope scope, Instant from, Instant to);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsPointsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsPointsPort.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import java.time.Instant;
+
+public interface LoadAdminOperationsPointsPort {
+
+    AdminOperationsPointsInfo getOperationsPoints(AdminAnalyticsScope scope, Instant from, Instant to);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsPointsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsPointsPort.java
@@ -1,8 +1,9 @@
 package com.umc.product.analytics.application.port.out;
 
+import java.time.Instant;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
-import java.time.Instant;
 
 public interface LoadAdminOperationsPointsPort {
 

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSchoolsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSchoolsPort.java
@@ -1,0 +1,9 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+
+public interface LoadAdminOperationsSchoolsPort {
+
+    AdminOperationsSchoolsInfo getOperationsSchools(AdminAnalyticsScope scope);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSignupsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSignupsPort.java
@@ -1,8 +1,9 @@
 package com.umc.product.analytics.application.port.out;
 
+import java.time.Instant;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
-import java.time.Instant;
 
 public interface LoadAdminOperationsSignupsPort {
 

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSignupsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsSignupsPort.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import java.time.Instant;
+
+public interface LoadAdminOperationsSignupsPort {
+
+    AdminOperationsSignupsInfo getOperationsSignups(AdminAnalyticsScope scope, Instant from, Instant to);
+}

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsStudyGroupsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsStudyGroupsPort.java
@@ -1,8 +1,9 @@
 package com.umc.product.analytics.application.port.out;
 
+import java.time.Instant;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
-import java.time.Instant;
 
 public interface LoadAdminOperationsStudyGroupsPort {
 

--- a/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsStudyGroupsPort.java
+++ b/src/main/java/com/umc/product/analytics/application/port/out/LoadAdminOperationsStudyGroupsPort.java
@@ -1,0 +1,10 @@
+package com.umc.product.analytics.application.port.out;
+
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
+import com.umc.product.analytics.domain.AdminAnalyticsScope;
+import java.time.Instant;
+
+public interface LoadAdminOperationsStudyGroupsPort {
+
+    AdminOperationsStudyGroupsInfo getOperationsStudyGroups(AdminAnalyticsScope scope, Instant from, Instant to);
+}

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -4,6 +4,7 @@ import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActi
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
@@ -14,6 +15,8 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQue
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
@@ -22,6 +25,7 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummar
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
 import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
@@ -41,7 +45,8 @@ public class AdminAnalyticsQueryService implements
     GetAdminSchoolSummaryUseCase,
     GetAdminRiskChallengerUseCase,
     GetAdminOperationsOverviewUseCase,
-    GetAdminOperationsSchoolsUseCase {
+    GetAdminOperationsSchoolsUseCase,
+    GetAdminOperationsPointsUseCase {
 
     private final AdminAnalyticsScopeResolver scopeResolver;
     private final LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
@@ -49,6 +54,7 @@ public class AdminAnalyticsQueryService implements
     private final LoadAdminRiskChallengerAnalyticsPort loadAdminRiskChallengerAnalyticsPort;
     private final LoadAdminOperationsAnalyticsPort loadAdminOperationsAnalyticsPort;
     private final LoadAdminOperationsSchoolsPort loadAdminOperationsSchoolsPort;
+    private final LoadAdminOperationsPointsPort loadAdminOperationsPointsPort;
 
     @Override
     public AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query) {
@@ -107,5 +113,11 @@ public class AdminAnalyticsQueryService implements
     public AdminOperationsSchoolsInfo getOperationsSchools(AdminOperationsSchoolsQuery query) {
         AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
         return loadAdminOperationsSchoolsPort.getOperationsSchools(scope);
+    }
+
+    @Override
+    public AdminOperationsPointsInfo getOperationsPoints(AdminOperationsPointsQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsPointsPort.getOperationsPoints(scope, query.from(), query.to());
     }
 }

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -1,10 +1,14 @@
 package com.umc.product.analytics.application.service.query;
 
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
-import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSignupsUseCase;
@@ -16,10 +20,10 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardAct
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
-import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
@@ -42,10 +46,8 @@ import com.umc.product.analytics.application.port.out.LoadAdminOperationsStudyGr
 import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -4,6 +4,7 @@ import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActi
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
@@ -15,6 +16,8 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQue
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsAttendanceQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
@@ -25,6 +28,7 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummar
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
 import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsAttendancePort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
@@ -46,7 +50,8 @@ public class AdminAnalyticsQueryService implements
     GetAdminRiskChallengerUseCase,
     GetAdminOperationsOverviewUseCase,
     GetAdminOperationsSchoolsUseCase,
-    GetAdminOperationsPointsUseCase {
+    GetAdminOperationsPointsUseCase,
+    GetAdminOperationsAttendanceUseCase {
 
     private final AdminAnalyticsScopeResolver scopeResolver;
     private final LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
@@ -55,6 +60,7 @@ public class AdminAnalyticsQueryService implements
     private final LoadAdminOperationsAnalyticsPort loadAdminOperationsAnalyticsPort;
     private final LoadAdminOperationsSchoolsPort loadAdminOperationsSchoolsPort;
     private final LoadAdminOperationsPointsPort loadAdminOperationsPointsPort;
+    private final LoadAdminOperationsAttendancePort loadAdminOperationsAttendancePort;
 
     @Override
     public AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query) {
@@ -119,5 +125,11 @@ public class AdminAnalyticsQueryService implements
     public AdminOperationsPointsInfo getOperationsPoints(AdminOperationsPointsQuery query) {
         AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
         return loadAdminOperationsPointsPort.getOperationsPoints(scope, query.from(), query.to());
+    }
+
+    @Override
+    public AdminOperationsAttendanceInfo getOperationsAttendance(AdminOperationsAttendanceQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsAttendancePort.getOperationsAttendance(scope, query.from(), query.to());
     }
 }

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -4,6 +4,7 @@ import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActi
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
@@ -13,12 +14,15 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardQue
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsOverviewQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
 import com.umc.product.analytics.application.port.out.LoadAdminDashboardAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyticsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -36,13 +40,15 @@ public class AdminAnalyticsQueryService implements
     GetAdminDashboardContextUseCase,
     GetAdminSchoolSummaryUseCase,
     GetAdminRiskChallengerUseCase,
-    GetAdminOperationsOverviewUseCase {
+    GetAdminOperationsOverviewUseCase,
+    GetAdminOperationsSchoolsUseCase {
 
     private final AdminAnalyticsScopeResolver scopeResolver;
     private final LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
     private final LoadAdminSchoolAnalyticsPort loadAdminSchoolAnalyticsPort;
     private final LoadAdminRiskChallengerAnalyticsPort loadAdminRiskChallengerAnalyticsPort;
     private final LoadAdminOperationsAnalyticsPort loadAdminOperationsAnalyticsPort;
+    private final LoadAdminOperationsSchoolsPort loadAdminOperationsSchoolsPort;
 
     @Override
     public AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query) {
@@ -95,5 +101,11 @@ public class AdminAnalyticsQueryService implements
     public AdminOperationsOverviewInfo getOperationsOverview(AdminOperationsOverviewQuery query) {
         AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
         return loadAdminOperationsAnalyticsPort.getOperationsOverview(scope, query);
+    }
+
+    @Override
+    public AdminOperationsSchoolsInfo getOperationsSchools(AdminOperationsSchoolsQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsSchoolsPort.getOperationsSchools(scope);
     }
 }

--- a/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
+++ b/src/main/java/com/umc/product/analytics/application/service/query/AdminAnalyticsQueryService.java
@@ -7,6 +7,8 @@ import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOve
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSignupsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsStudyGroupsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
@@ -22,6 +24,10 @@ import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPo
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsPointsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSchoolsQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsSignupsQuery;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsInfo;
+import com.umc.product.analytics.application.port.in.query.dto.AdminOperationsStudyGroupsQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
@@ -31,6 +37,8 @@ import com.umc.product.analytics.application.port.out.LoadAdminOperationsAnalyti
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsAttendancePort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsPointsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminOperationsSchoolsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsSignupsPort;
+import com.umc.product.analytics.application.port.out.LoadAdminOperationsStudyGroupsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminRiskChallengerAnalyticsPort;
 import com.umc.product.analytics.application.port.out.LoadAdminSchoolAnalyticsPort;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -51,7 +59,9 @@ public class AdminAnalyticsQueryService implements
     GetAdminOperationsOverviewUseCase,
     GetAdminOperationsSchoolsUseCase,
     GetAdminOperationsPointsUseCase,
-    GetAdminOperationsAttendanceUseCase {
+    GetAdminOperationsAttendanceUseCase,
+    GetAdminOperationsStudyGroupsUseCase,
+    GetAdminOperationsSignupsUseCase {
 
     private final AdminAnalyticsScopeResolver scopeResolver;
     private final LoadAdminDashboardAnalyticsPort loadAdminDashboardAnalyticsPort;
@@ -61,6 +71,8 @@ public class AdminAnalyticsQueryService implements
     private final LoadAdminOperationsSchoolsPort loadAdminOperationsSchoolsPort;
     private final LoadAdminOperationsPointsPort loadAdminOperationsPointsPort;
     private final LoadAdminOperationsAttendancePort loadAdminOperationsAttendancePort;
+    private final LoadAdminOperationsStudyGroupsPort loadAdminOperationsStudyGroupsPort;
+    private final LoadAdminOperationsSignupsPort loadAdminOperationsSignupsPort;
 
     @Override
     public AdminDashboardSummaryInfo getSummary(AdminDashboardQuery query) {
@@ -131,5 +143,17 @@ public class AdminAnalyticsQueryService implements
     public AdminOperationsAttendanceInfo getOperationsAttendance(AdminOperationsAttendanceQuery query) {
         AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
         return loadAdminOperationsAttendancePort.getOperationsAttendance(scope, query.from(), query.to());
+    }
+
+    @Override
+    public AdminOperationsStudyGroupsInfo getOperationsStudyGroups(AdminOperationsStudyGroupsQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsStudyGroupsPort.getOperationsStudyGroups(scope, query.from(), query.to());
+    }
+
+    @Override
+    public AdminOperationsSignupsInfo getOperationsSignups(AdminOperationsSignupsQuery query) {
+        AdminAnalyticsScope scope = scopeResolver.resolve(query.requesterMemberId(), query.gisuId(), null, null, null);
+        return loadAdminOperationsSignupsPort.getOperationsSignups(scope, query.from(), query.to());
     }
 }

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
@@ -9,7 +9,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsAttendanceUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminOperationsOverviewUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsPointsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSchoolsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsSignupsUseCase;
+import com.umc.product.analytics.application.port.in.query.GetAdminOperationsStudyGroupsUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminRiskChallengerUseCase;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardContextInfo;
@@ -72,6 +77,21 @@ class AdminDashboardControllerTest {
 
     @MockitoBean
     GetAdminOperationsOverviewUseCase getAdminOperationsOverviewUseCase;
+
+    @MockitoBean
+    GetAdminOperationsSchoolsUseCase getAdminOperationsSchoolsUseCase;
+
+    @MockitoBean
+    GetAdminOperationsPointsUseCase getAdminOperationsPointsUseCase;
+
+    @MockitoBean
+    GetAdminOperationsAttendanceUseCase getAdminOperationsAttendanceUseCase;
+
+    @MockitoBean
+    GetAdminOperationsStudyGroupsUseCase getAdminOperationsStudyGroupsUseCase;
+
+    @MockitoBean
+    GetAdminOperationsSignupsUseCase getAdminOperationsSignupsUseCase;
 
     @BeforeEach
     void setUpSecurityContext() {

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
@@ -6,6 +6,24 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardActionQueueUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardContextUseCase;
 import com.umc.product.analytics.application.port.in.query.GetAdminDashboardSummaryUseCase;
@@ -28,22 +46,6 @@ import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import com.umc.product.support.RestDocsConfig;
-import java.time.LocalDate;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AdminDashboardController.class)
 @Import({JacksonConfig.class, RestDocsConfig.class})


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #905 

## 🚀 작업 내용
기존 `GET /api/v1/admin/dashboard/operations` 엔드포인트는 학교 현황, 상벌점, 출석, 스터디 그룹, 신규 가입자 등 5가지 성격이 다른 데이터를 하나의 응답으로 묶어 반환하고 있었습니다. 이로 인해 프론트엔드가 데이터를 독립적으로 로딩할 수 없었고, 하나의 집계가 느려지면 전체 카드가 블로킹되는 구조였습니다.
이에 해당 엔드포인트를 성격에 따라 5개로 분리합니다. 프론트 백오피스 코드를 해당 엔드포인트를 사용하는 구조로 변경이 필요하며, 기존 구조를 해치지 않기 위해 기존 엔드포인트(`GET operations` (DASHBOARD-005))를 삭제하는 대신 deprecated 처리 하였습니다.

| # | 엔드포인트 | 설명 | 기간 파라미터 |
|---|---|---|---|
| DASHBOARD-006 | `GET operations/schools` | 지부별 학교/챌린저 현황 | ❌ |
| DASHBOARD-007 | `GET operations/points` | 지부 내 파트별 상벌점 현황 | ✅ |
| DASHBOARD-008 | `GET operations/attendance` | 일정 및 출석 생성 현황 | ✅ |
| DASHBOARD-009 | `GET operations/study-groups` | 스터디 그룹 및 일정 생성 현황 | ✅ |
| DASHBOARD-010 | `GET operations/signups` | 기간별 신규 가입자 현황 (일별 버킷) | ✅ |

## 💬 리뷰 중점사항
- periodCondition / scheduleScopeCondition 오버로드 
  - 기존 메서드는 `AdminOperationsOverviewQuery`를 통째로 받고 있었는데, 신규 엔드포인트들은 각자의 Query 타입을 쓰기 때문에 재사용이 불가능했습니다. 
  - Query 타입마다 오버로드를 추가하는 대신, Instant from, to를 직접 받는 오버로드를 추가하고 기존 메서드가 이를 위임하도록 변경했습니다. 기존 /operations 엔드포인트 삭제 시 위임 메서드도 함께 제거 예정입니다.