### PR TITLE
[Feat] 현행 약관 전체 조회 API 추가

### DIFF
--- a/src/main/java/com/umc/product/term/adapter/in/web/TermController.java
+++ b/src/main/java/com/umc/product/term/adapter/in/web/TermController.java
@@ -14,6 +14,7 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.global.security.annotation.Public;
 import com.umc.product.term.adapter.in.web.dto.request.CreateTermRequest;
+import com.umc.product.term.adapter.in.web.dto.response.ActiveTermsResponse;
 import com.umc.product.term.adapter.in.web.dto.response.RequiredTermConsentStatusResponse;
 import com.umc.product.term.adapter.in.web.dto.response.TermResponse;
 import com.umc.product.term.application.port.in.command.ManageTermUseCase;
@@ -36,6 +37,13 @@ public class TermController {
     private final GetTermUseCase getTermUseCase;
     private final GetRequiredTermConsentStatusUseCase getRequiredTermConsentStatusUseCase;
     private final ManageTermUseCase manageTermUseCase;
+
+    @GetMapping
+    @Public
+    @Operation(summary = "[TERM-104] 활성 약관 전체 조회")
+    ActiveTermsResponse getActiveTerms() {
+        return ActiveTermsResponse.from(getTermUseCase.listActiveTerms());
+    }
 
     @GetMapping("type/{termType}")
     @Public

--- a/src/main/java/com/umc/product/term/adapter/in/web/dto/response/ActiveTermsResponse.java
+++ b/src/main/java/com/umc/product/term/adapter/in/web/dto/response/ActiveTermsResponse.java
@@ -1,0 +1,48 @@
+package com.umc.product.term.adapter.in.web.dto.response;
+
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
+import com.umc.product.term.domain.enums.TermType;
+import java.time.Instant;
+import java.util.List;
+
+public record ActiveTermsResponse(
+    List<ActiveTermResponse> terms
+) {
+
+    public ActiveTermsResponse {
+        terms = List.copyOf(terms);
+    }
+
+    public static ActiveTermsResponse from(List<ActiveTermInfo> activeTerms) {
+        return new ActiveTermsResponse(
+            activeTerms.stream()
+                .map(ActiveTermResponse::from)
+                .toList()
+        );
+    }
+
+    public record ActiveTermResponse(
+        Long id,
+        TermType type,
+        String typeDescription,
+        String link,
+        boolean isMandatory,
+        Long version,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+
+        public static ActiveTermResponse from(ActiveTermInfo activeTermInfo) {
+            return new ActiveTermResponse(
+                activeTermInfo.id(),
+                activeTermInfo.type(),
+                activeTermInfo.typeDescription(),
+                activeTermInfo.link(),
+                activeTermInfo.isMandatory(),
+                activeTermInfo.version(),
+                activeTermInfo.createdAt(),
+                activeTermInfo.updatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/term/adapter/in/web/dto/response/ActiveTermsResponse.java
+++ b/src/main/java/com/umc/product/term/adapter/in/web/dto/response/ActiveTermsResponse.java
@@ -1,9 +1,10 @@
 package com.umc.product.term.adapter.in.web.dto.response;
 
-import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
-import com.umc.product.term.domain.enums.TermType;
 import java.time.Instant;
 import java.util.List;
+
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
+import com.umc.product.term.domain.enums.TermType;
 
 public record ActiveTermsResponse(
     List<ActiveTermResponse> terms

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapter.java
@@ -30,6 +30,11 @@ public class TermPersistenceAdapter implements LoadTermPort, SaveTermPort {
     }
 
     @Override
+    public List<Term> listActive() {
+        return repository.findAllByActiveIsTrueOrderByIdAsc();
+    }
+
+    @Override
     public boolean existsById(Long id) {
         return repository.existsById(id);
     }

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermRepository.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermRepository.java
@@ -11,4 +11,9 @@ public interface TermRepository extends JpaRepository<Term, Long> {
      * IN 절을 사용하여 전달받은 타입들에 해당하는 활성 약관을 한 번에 조회합니다.
      */
     List<Term> findAllByTypeInAndActiveIsTrue(List<TermType> types);
+
+    /**
+     * 현재 활성화된 모든 약관을 ID 오름차순으로 조회합니다.
+     */
+    List<Term> findAllByActiveIsTrueOrderByIdAsc();
 }

--- a/src/main/java/com/umc/product/term/adapter/out/persistence/TermRepository.java
+++ b/src/main/java/com/umc/product/term/adapter/out/persistence/TermRepository.java
@@ -1,9 +1,11 @@
 package com.umc.product.term.adapter.out.persistence;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
-import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
 

--- a/src/main/java/com/umc/product/term/application/port/in/query/GetTermUseCase.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/GetTermUseCase.java
@@ -1,7 +1,9 @@
 package com.umc.product.term.application.port.in.query;
 
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.domain.enums.TermType;
+import java.util.List;
 import java.util.Set;
 
 public interface GetTermUseCase {
@@ -16,6 +18,11 @@ public interface GetTermUseCase {
      * ID로 약관 정보를 가져옵니다.
      */
     TermInfo getTermsById(Long termsId);
+
+    /**
+     * 현재 활성화된 모든 약관을 조회합니다.
+     */
+    List<ActiveTermInfo> listActiveTerms();
 
     /**
      * 현재 활성화된 필수 약관 ID 목록을 조회합니다.

--- a/src/main/java/com/umc/product/term/application/port/in/query/GetTermUseCase.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/GetTermUseCase.java
@@ -1,10 +1,11 @@
 package com.umc.product.term.application.port.in.query;
 
+import java.util.List;
+import java.util.Set;
+
 import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.domain.enums.TermType;
-import java.util.List;
-import java.util.Set;
 
 public interface GetTermUseCase {
     /**

--- a/src/main/java/com/umc/product/term/application/port/in/query/dto/ActiveTermInfo.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/dto/ActiveTermInfo.java
@@ -1,0 +1,30 @@
+package com.umc.product.term.application.port.in.query.dto;
+
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.enums.TermType;
+import java.time.Instant;
+
+public record ActiveTermInfo(
+    Long id,
+    TermType type,
+    String typeDescription,
+    String link,
+    boolean isMandatory,
+    Long version,
+    Instant createdAt,
+    Instant updatedAt
+) {
+
+    public static ActiveTermInfo from(Term term) {
+        return new ActiveTermInfo(
+            term.getId(),
+            term.getType(),
+            term.getType().getDescription(),
+            term.getLink(),
+            term.isRequired(),
+            term.getId(),
+            term.getCreatedAt(),
+            term.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/term/application/port/in/query/dto/ActiveTermInfo.java
+++ b/src/main/java/com/umc/product/term/application/port/in/query/dto/ActiveTermInfo.java
@@ -1,8 +1,9 @@
 package com.umc.product.term.application.port.in.query.dto;
 
+import java.time.Instant;
+
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
-import java.time.Instant;
 
 public record ActiveTermInfo(
     Long id,

--- a/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
+++ b/src/main/java/com/umc/product/term/application/port/out/LoadTermPort.java
@@ -18,6 +18,11 @@ public interface LoadTermPort {
     Optional<Term> findActiveByType(TermType type);
 
     /**
+     * 현재 활성화된 모든 약관을 조회합니다.
+     */
+    List<Term> listActive();
+
+    /**
      * ID로 약관이 존재하는지 확인합니다.
      */
     boolean existsById(Long id);

--- a/src/main/java/com/umc/product/term/application/service/query/TermQueryService.java
+++ b/src/main/java/com/umc/product/term/application/service/query/TermQueryService.java
@@ -1,5 +1,12 @@
 package com.umc.product.term.application.service.query;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.term.application.port.in.query.GetTermUseCase;
 import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
@@ -8,12 +15,8 @@ import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/term/application/service/query/TermQueryService.java
+++ b/src/main/java/com/umc/product/term/application/service/query/TermQueryService.java
@@ -1,12 +1,14 @@
 package com.umc.product.term.application.service.query;
 
 import com.umc.product.term.application.port.in.query.GetTermUseCase;
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.application.port.out.LoadTermPort;
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,13 @@ public class TermQueryService implements GetTermUseCase {
             .orElseThrow(() -> new TermDomainException(TermErrorCode.TERMS_NOT_FOUND));
 
         return TermInfo.from(term);
+    }
+
+    @Override
+    public List<ActiveTermInfo> listActiveTerms() {
+        return loadTermPort.listActive().stream()
+            .map(ActiveTermInfo::from)
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/umc/product/term/domain/enums/TermType.java
+++ b/src/main/java/com/umc/product/term/domain/enums/TermType.java
@@ -10,4 +10,8 @@ public enum TermType {
     TermType(String description) {
         this.description = description;
     }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/test/java/com/umc/product/term/adapter/in/web/TermControllerTest.java
+++ b/src/test/java/com/umc/product/term/adapter/in/web/TermControllerTest.java
@@ -5,15 +5,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.term.application.port.in.command.ManageTermUseCase;
-import com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCase;
-import com.umc.product.term.application.port.in.query.GetTermUseCase;
-import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
-import com.umc.product.term.domain.enums.TermType;
 import java.time.Instant;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +16,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.term.application.port.in.command.ManageTermUseCase;
+import com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCase;
+import com.umc.product.term.application.port.in.query.GetTermUseCase;
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
+import com.umc.product.term.domain.enums.TermType;
 
 @WebMvcTest(controllers = TermController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/term/adapter/in/web/TermControllerTest.java
+++ b/src/test/java/com/umc/product/term/adapter/in/web/TermControllerTest.java
@@ -1,0 +1,89 @@
+package com.umc.product.term.adapter.in.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.term.application.port.in.command.ManageTermUseCase;
+import com.umc.product.term.application.port.in.query.GetRequiredTermConsentStatusUseCase;
+import com.umc.product.term.application.port.in.query.GetTermUseCase;
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
+import com.umc.product.term.domain.enums.TermType;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = TermController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("TermController")
+class TermControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetTermUseCase getTermUseCase;
+
+    @MockitoBean
+    GetRequiredTermConsentStatusUseCase getRequiredTermConsentStatusUseCase;
+
+    @MockitoBean
+    ManageTermUseCase manageTermUseCase;
+
+    @Test
+    @DisplayName("GET /api/v1/terms 활성 약관 전체 목록을 반환한다")
+    void 활성_약관_전체_목록을_반환한다() throws Exception {
+        // given
+        given(getTermUseCase.listActiveTerms()).willReturn(List.of(
+            new ActiveTermInfo(
+                1L,
+                TermType.SERVICE,
+                "서비스 이용약관",
+                "https://example.com/terms/service",
+                true,
+                1L,
+                Instant.parse("2026-05-26T00:00:00Z"),
+                Instant.parse("2026-05-27T00:00:00Z")
+            ),
+            new ActiveTermInfo(
+                2L,
+                TermType.PRIVACY,
+                "개인정보 처리방침",
+                "https://example.com/terms/privacy",
+                true,
+                2L,
+                Instant.parse("2026-05-28T00:00:00Z"),
+                Instant.parse("2026-05-29T00:00:00Z")
+            )
+        ));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/terms"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.terms").isArray())
+            .andExpect(jsonPath("$.result.terms[0].id").value("1"))
+            .andExpect(jsonPath("$.result.terms[0].type").value("SERVICE"))
+            .andExpect(jsonPath("$.result.terms[0].typeDescription").value("서비스 이용약관"))
+            .andExpect(jsonPath("$.result.terms[0].link").value("https://example.com/terms/service"))
+            .andExpect(jsonPath("$.result.terms[0].isMandatory").value(true))
+            .andExpect(jsonPath("$.result.terms[0].version").value("1"))
+            .andExpect(jsonPath("$.result.terms[0].createdAt").value("2026-05-26T00:00:00Z"))
+            .andExpect(jsonPath("$.result.terms[0].updatedAt").value("2026-05-27T00:00:00Z"))
+            .andExpect(jsonPath("$.result.terms[1].type").value("PRIVACY"));
+    }
+}

--- a/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
@@ -1,0 +1,71 @@
+package com.umc.product.term.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.support.TestContainersConfig;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.enums.TermType;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+    TermPersistenceAdapter.class, TermQueryRepository.class})
+@DisplayName("TermPersistenceAdapter")
+class TermPersistenceAdapterTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    TermPersistenceAdapter sut;
+
+    @Test
+    @DisplayName("listActive는 활성 약관만 ID 오름차순으로 반환한다")
+    void listActive는_활성_약관만_ID_오름차순으로_반환한다() {
+        // given
+        Term serviceTerm = persistTerm(TermType.SERVICE, true, true);
+        Term privacyTerm = persistTerm(TermType.PRIVACY, true, true);
+        Term inactiveTerm = persistTerm(TermType.MARKETING, false, false);
+        em.flush();
+        em.clear();
+
+        // when
+        List<Term> result = sut.listActive();
+
+        // then
+        List<Long> resultIds = result.stream()
+            .map(Term::getId)
+            .toList();
+
+        assertThat(resultIds)
+            .contains(serviceTerm.getId(), privacyTerm.getId())
+            .doesNotContain(inactiveTerm.getId())
+            .isSortedAccordingTo(Comparator.naturalOrder());
+        assertThat(result)
+            .extracting(Term::isActive)
+            .containsOnly(true);
+    }
+
+    private Term persistTerm(TermType type, boolean required, boolean active) {
+        Term term = Term.builder()
+            .type(type)
+            .link("https://example.com/terms/" + type.name().toLowerCase())
+            .required(required)
+            .build();
+        if (!active) {
+            term.deactivate();
+        }
+        return em.persist(term);
+    }
+}

--- a/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
@@ -2,13 +2,9 @@ package com.umc.product.term.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.support.TestContainersConfig;
-import com.umc.product.term.domain.Term;
-import com.umc.product.term.domain.enums.TermType;
 import java.util.Comparator;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +12,12 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.support.TestContainersConfig;
+import com.umc.product.term.domain.Term;
+import com.umc.product.term.domain.enums.TermType;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/umc/product/term/application/port/in/query/GetTermUseCaseTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/query/GetTermUseCaseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.application.port.out.LoadTermPort;
 import com.umc.product.term.application.service.query.TermQueryService;
@@ -11,12 +12,16 @@ import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class GetTermUseCaseTest {
@@ -98,11 +103,62 @@ class GetTermUseCaseTest {
             .isEqualTo(TermErrorCode.TERMS_NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("활성 약관 전체 목록을 조회한다")
+    void 활성_약관_전체_목록을_조회한다() {
+        // given
+        Term serviceTerm = createTerms(1L, TermType.SERVICE, true);
+        Term marketingTerm = createTerms(3L, TermType.MARKETING, false);
+        given(loadTermPort.listActive()).willReturn(List.of(serviceTerm, marketingTerm));
+
+        // when
+        List<ActiveTermInfo> result = sut.listActiveTerms();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result)
+            .extracting(ActiveTermInfo::type)
+            .containsExactly(TermType.SERVICE, TermType.MARKETING);
+        assertThat(result)
+            .extracting(ActiveTermInfo::version)
+            .containsExactly(1L, 3L);
+        assertThat(result.get(0).typeDescription()).isEqualTo("서비스 이용약관");
+        assertThat(result.get(0).link()).isEqualTo("http://example.com/terms/service");
+        assertThat(result.get(0).isMandatory()).isTrue();
+        assertThat(result.get(0).createdAt()).isEqualTo(Instant.parse("2026-05-26T00:00:00Z"));
+        assertThat(result.get(0).updatedAt()).isEqualTo(Instant.parse("2026-05-27T00:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("활성 약관이 없으면 빈 목록을 반환한다")
+    void 활성_약관이_없으면_빈_목록을_반환한다() {
+        // given
+        given(loadTermPort.listActive()).willReturn(List.of());
+
+        // when
+        List<ActiveTermInfo> result = sut.listActiveTerms();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
     private Term createTerms(TermType type, String title, boolean required) {
         return Term.builder()
             .type(type)
             .link("http://example.com/terms/" + type.name().toLowerCase())
             .required(required)
             .build();
+    }
+
+    private Term createTerms(Long id, TermType type, boolean required) {
+        Term term = Term.builder()
+            .type(type)
+            .link("http://example.com/terms/" + type.name().toLowerCase())
+            .required(required)
+            .build();
+        ReflectionTestUtils.setField(term, "id", id);
+        ReflectionTestUtils.setField(term, "createdAt", Instant.parse("2026-05-26T00:00:00Z"));
+        ReflectionTestUtils.setField(term, "updatedAt", Instant.parse("2026-05-27T00:00:00Z"));
+        return term;
     }
 }

--- a/src/test/java/com/umc/product/term/application/port/in/query/GetTermUseCaseTest.java
+++ b/src/test/java/com/umc/product/term/application/port/in/query/GetTermUseCaseTest.java
@@ -4,6 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.term.application.port.in.query.dto.ActiveTermInfo;
 import com.umc.product.term.application.port.in.query.dto.TermInfo;
 import com.umc.product.term.application.port.out.LoadTermPort;
@@ -12,16 +24,6 @@ import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 import com.umc.product.term.domain.exception.TermDomainException;
 import com.umc.product.term.domain.exception.TermErrorCode;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class GetTermUseCaseTest {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- term 도메인의 adapter/in, application, adapter/out 계층과 관련 테스트를 변경했어요.
- DB 마이그레이션이나 환경 설정 변경은 없어요.

### 작업 단위별 상세

1. **무엇을**: [TERM-104] GET /api/v1/terms 활성 약관 전체 조회 API를 추가했어요.
   - **어떻게**: TermController에 공개 GET endpoint를 추가하고, GlobalResponseWrapper가 감쌀 수 있도록 ActiveTermsResponse를 그대로 반환하게 했어요.
   - **왜**: 클라이언트가 약관 종류별 조회 API를 모두 호출하지 않아도 현재 활성 상태인 약관 종류와 링크, 버전성 메타데이터를 한 번에 알 수 있게 하기 위해서예요.

2. **무엇을**: 활성 약관 목록 조회용 UseCase/Port/DTO 흐름을 추가했어요.
   - **어떻게**: GetTermUseCase에 listActiveTerms를 추가하고, LoadTermPort.listActive와 TermRepository.findAllByActiveIsTrueOrderByIdAsc를 통해 active=true 약관만 ID 오름차순으로 조회하게 했어요.
   - **왜**: enum 타입 전체를 외부에서 순회하는 방식이 아니라 서버가 실제 존재하는 활성 약관 목록을 단일 조회 경로로 제공해야 하기 때문이에요.

3. **무엇을**: 응답 메타데이터에 typeDescription, version, createdAt, updatedAt을 포함했어요.
   - **어떻게**: ActiveTermInfo와 ActiveTermsResponse를 새로 추가하고, version은 기존 ADR의 방향과 맞춰 term.id를 사용하게 했어요.
   - **왜**: 별도 version 컬럼이나 DB 마이그레이션 없이도 약관 row 단위의 버전 식별자를 클라이언트에 제공하기 위해서예요.

4. **무엇을**: 활성 약관 전체 조회 동작을 검증하는 테스트를 추가했어요.
   - **어떻게**: TermQueryService 단위 테스트, TermController WebMvc 테스트, TermPersistenceAdapter DataJpa 테스트를 추가했어요.
   - **왜**: 서비스 매핑, API 응답 계약, active=false 약관 제외 및 정렬 조건을 각각의 계층에서 검증하기 위해서예요.

## 💬 리뷰 중점사항

- version을 명시적 컬럼이 아니라 term.id로 내려주는 계약이 의도와 맞는지 확인 부탁드려요.
- 기존 단건 약관 조회 응답은 유지하고, 새 전체 조회 응답에만 type, typeDescription, createdAt, updatedAt을 포함하도록 분리한 점을 확인 부탁드려요.
- DB 마이그레이션 없이 Repository 파생 쿼리만 추가한 변경이에요.
- 검증은 ./gradlew test로 완료했어요.
