### PR TITLE
[Fix] 프로젝트 현황 시딩 API Unpaged 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -23,6 +23,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
@@ -40,14 +41,22 @@ public class ProjectQueryRepository {
      */
     public Page<Project> search(SearchProjectQuery query) {
         BooleanBuilder condition = buildCondition(query);
+        Pageable pageable = query.pageable();
 
-        List<Project> content = queryFactory
+        JPQLQuery<Project> contentQuery = queryFactory
             .selectFrom(project)
             .where(condition)
-            .orderBy(toOrderSpecifiers(query.pageable().getSort()))
-            .offset(query.pageable().getOffset())
-            .limit(query.pageable().getPageSize())
-            .fetch();
+            .orderBy(toOrderSpecifiers(pageable.getSort()));
+
+        // Pageable.unpaged() 는 offset/pageSize 호출 시 UnsupportedOperationException 을 던지므로
+        // 페이징 요청일 때만 offset/limit 을 적용하고, unpaged 면 조건에 맞는 전건을 반환한다.
+        if (pageable.isPaged()) {
+            contentQuery
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+        }
+
+        List<Project> content = contentQuery.fetch();
 
         Long total = queryFactory
             .select(project.count())
@@ -55,7 +64,7 @@ public class ProjectQueryRepository {
             .where(condition)
             .fetchOne();
 
-        return new PageImpl<>(content, query.pageable(), total != null ? total : 0L);
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     private BooleanBuilder buildCondition(SearchProjectQuery query) {

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
@@ -124,6 +125,22 @@ class ProjectQueryRepositoryTest {
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
         assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    void unpaged_요청시_offset_limit_없이_전건_반환() {
+        // given — Pageable.unpaged() 로 호출 (시딩 등 전체 조회 시나리오)
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            gisuId, null, null, null, null, null, Pageable.unpaged());
+
+        // when — Unpaged 의 getOffset/getPageSize 호출로 인한 UnsupportedOperationException 이 없어야 한다
+        Page<Project> result = sut.search(query);
+
+        // then — 조건에 맞는 전건(기수 1 IN_PROGRESS 3건) 을 페이징 절단 없이 반환
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent())
+            .allMatch(p -> p.getStatus() == ProjectStatus.IN_PROGRESS);
     }
 
     @Test


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #942 

## 🚀 작업 내용
### 문제
POST /test/seed/project-applications (SEED-006) 호출 시 500 에러 발생.

매칭차수 검증 통과 후 지부 IN_PROGRESS 프로젝트 조회 단계에서
`java.lang.UnsupportedOperationException` 발생.

- 원인: 시딩 서비스가 전체 조회를 위해 `Pageable.unpaged()` 로 검색을 호출하는데,
  `ProjectQueryRepository.search` 가 Pageable 종류와 무관하게 항상
  `getOffset()` / `getPageSize()` 를 호출함.
  `Unpaged` 는 두 메서드 호출 시 설계상 `UnsupportedOperationException` 을 던짐.

### 해결
`ProjectQueryRepository.search` 에서 `pageable.isPaged()` 일 때만 offset/limit 을
적용하도록 수정. unpaged 면 조건에 맞는 전건을 반환.

- paged 경로(목록 조회 API 등)는 기존 동작과 완전히 동일.
- unpaged(시딩) 경로만 예외 없이 전건 반환하도록 정상화.

### 영향 범위
- `ProjectQueryRepository.search` 1개 메서드 (시그니처 변경 없음).
- 호출자(`ProjectPersistenceAdapter`) 및 목록 조회 API 동작 변화 없음.

### 테스트
- `ProjectQueryRepositoryTest` 에 unpaged 전건 반환 회귀 테스트 추가.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

