### PR TITLE
[Refactor] Filter Bypass URI를 한 파일에서 관리하도록 변경 및 OpenAPI 관련 설정 변경

### DIFF
--- a/src/main/java/com/umc/product/global/config/OpenApiConfig.java
+++ b/src/main/java/com/umc/product/global/config/OpenApiConfig.java
@@ -70,13 +70,13 @@ public class OpenApiConfig {
     private List<Server> servers() {
         return List.of(
             new Server()
+                .url("https://dev.api.university.neordinary.com")
+                .description("Development"),
+            new Server()
                 .url("http://localhost:" + serverPort)
                 .description("Local"),
             new Server()
-                .url("https://dev.api.umc.it.kr")
-                .description("Development"),
-            new Server()
-                .url("https://api.umc.it.kr")
+                .url("https://api.university.neordinary.com")
                 .description("Production")
         );
     }
@@ -94,7 +94,7 @@ public class OpenApiConfig {
                     .type(SecurityScheme.Type.HTTP)
                     .scheme("bearer")
                     .bearerFormat("JWT")
-                    .description("발급받은 Access Token을 입력해주세요.")
+                    .description("아래에 Access Token을 넣어주세요.")
             );
     }
 

--- a/src/main/java/com/umc/product/global/config/OpenApiConfig.java
+++ b/src/main/java/com/umc/product/global/config/OpenApiConfig.java
@@ -1,6 +1,14 @@
 package com.umc.product.global.config;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -8,12 +16,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.info.BuildProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @RequiredArgsConstructor
 @Configuration

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.umc.product.global.config;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -17,15 +15,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -52,16 +47,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SecurityConfig {
 
-    private static final String[] STATIC_FILE_PATHS = {
-        "/swagger-ui/**",
-        "/docs/**",
-        "/v3/api-docs/**",
-        "/docs-json/**",
-        "/swagger-resources/**",
-        "/webjars/**",
-        "/umc-logo.svg"
-    };
-
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final ApiAuthenticationEntryPoint authenticationEntryPoint;
     private final ApiAccessDeniedHandler accessDeniedHandler;
@@ -70,29 +55,6 @@ public class SecurityConfig {
     // application.yml에서 cors.allowed-origin-patterns 값을 List 형태로 주입받음
     @Value("${app.cors.allowed-origin-patterns}")
     private List<String> allowedOriginPatterns;
-
-    /**
-     * Swagger용 SecurityFilterChain (local을 제외한 환경에서 활성화)
-     * <p>
-     * HTTP Basic 인증 적용 - 순서가 먼저라서 Swagger 경로는 이 체인이 처리
-     */
-    @Bean
-    @Order(1)
-    @Profile("!local")
-    public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .securityMatcher(STATIC_FILE_PATHS)
-            .cors(Customizer.withDefaults())
-            .csrf(AbstractHttpConfigurer::disable)
-            .sessionManagement(session ->
-                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth
-                .anyRequest().authenticated()
-            )
-            .httpBasic(Customizer.withDefaults());  // HTTP Basic 인증
-
-        return http.build();
-    }
 
     /**
      * 점검 모드 필터. JWT 다음에 동작해서 점검 중 일반 사용자 요청을 503 으로 차단한다. {@code @Component} 가 아닌 명시 {@code @Bean} 으로 두는 이유: 슬라이스 테스트
@@ -112,7 +74,7 @@ public class SecurityConfig {
      * 메인 Security 체인. JWT → MaintenanceFilter → 인가 순서로 동작한다.
      */
     @Bean
-    @Order(2)
+    @Order(1)
     public SecurityFilterChain filterChain(HttpSecurity http, MaintenanceFilter maintenanceFilter) throws Exception {
         List<PublicEndpointCollector.EndpointMatcher> publicEndpoints = PublicEndpointCollector
             .collectPublicEndpoints(requestMappingHandlerMapping);
@@ -138,15 +100,8 @@ public class SecurityConfig {
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> {
-                // 공개 엔드포인트
-                auth.requestMatchers(
-                    // Health Check & Error
-                    "/actuator/**",
-                    "/error"
-                ).permitAll();
-
-                // Swagger
-                auth.requestMatchers(STATIC_FILE_PATHS).permitAll();
+                // 공통 공개 경로
+                auth.requestMatchers(SecurityPathConfig.securityPermitAllPaths()).permitAll();
 
                 // @Public 어노테이션이 달린 엔드포인트 (HTTP 메서드 포함)
                 for (PublicEndpointCollector.EndpointMatcher endpoint : publicEndpoints) {
@@ -171,24 +126,6 @@ public class SecurityConfig {
 
         return http.build();
     }
-
-    /**
-     * Swagger Basic Auth용 InMemoryUserDetailsManager (local 제외)
-     */
-    @Bean
-    @Profile("!local")
-    public UserDetailsService swaggerUserDetailsService(
-        @Value("${app.swagger-auth.username:username}") String username,
-        @Value("${app.swagger-auth.password:password}") String password,
-        PasswordEncoder passwordEncoder) {
-        UserDetails user = User.builder()
-            .username(username)
-            .password(passwordEncoder.encode(password))
-            .roles("SWAGGER")
-            .build();
-        return new InMemoryUserDetailsManager(user);
-    }
-
 
     /**
      * UserDetailsService Bean을 제공하여 Spring Security의 기본 사용자 자동 생성 방지

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -100,6 +100,9 @@ public class SecurityConfig {
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> {
+                // Swagger UI와 기존 Swagger 문서 경로는 인증 여부와 무관하게 차단
+                auth.requestMatchers(SecurityPathConfig.swaggerBlockedPaths()).denyAll();
+
                 // 공통 공개 경로
                 auth.requestMatchers(SecurityPathConfig.securityPermitAllPaths()).permitAll();
 

--- a/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
@@ -5,15 +5,31 @@ import java.util.stream.Stream;
 
 public final class SecurityPathConfig {
 
-    public static final List<String> DOCUMENTATION_PATHS = List.of(
+    public static final String SCALAR_ENTRY_PATH = "/docs";
+    public static final String SCALAR_ENTRY_SLASH_PATH = "/docs/";
+    public static final String SCALAR_DOCUMENTATION_PATTERN = "/docs/**";
+    public static final String OPENAPI_JSON_PATH = "/docs-json";
+    public static final String OPENAPI_JSON_PATTERN = "/docs-json/**";
+    public static final String MARKDOWN_IT_WEBJAR_PATTERN = "/webjars/markdown-it/**";
+    public static final String UMC_LOGO_PATH = "/umc-logo.svg";
+
+    public static final List<String> SWAGGER_BLOCKED_PATHS = List.of(
         "/swagger-ui/**",
         "/swagger-ui.html",
-        "/docs/**",
+        "/v3/api-docs",
         "/v3/api-docs/**",
-        "/docs-json/**",
         "/swagger-resources/**",
-        "/webjars/**",
-        "/umc-logo.svg"
+        "/webjars/swagger-ui/**"
+    );
+
+    public static final List<String> DOCUMENTATION_PATHS = List.of(
+        SCALAR_ENTRY_PATH,
+        SCALAR_ENTRY_SLASH_PATH,
+        SCALAR_DOCUMENTATION_PATTERN,
+        OPENAPI_JSON_PATH,
+        OPENAPI_JSON_PATTERN,
+        MARKDOWN_IT_WEBJAR_PATTERN,
+        UMC_LOGO_PATH
     );
 
     public static final List<String> SECURITY_PERMIT_ALL_PATHS = Stream.concat(
@@ -41,5 +57,16 @@ public final class SecurityPathConfig {
 
     public static String[] securityPermitAllPaths() {
         return SECURITY_PERMIT_ALL_PATHS.toArray(String[]::new);
+    }
+
+    public static String[] swaggerBlockedPaths() {
+        return SWAGGER_BLOCKED_PATHS.toArray(String[]::new);
+    }
+
+    public static String[] loggingExcludedPaths() {
+        return Stream.concat(
+            Stream.of("/actuator/**"),
+            DOCUMENTATION_PATHS.stream()
+        ).toArray(String[]::new);
     }
 }

--- a/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
@@ -47,7 +47,8 @@ public final class SecurityPathConfig {
             "/api/v1/auth/**",
             "/api/v1/terms",
             "/api/v1/terms/**",
-            "/actuator/**"
+            "/actuator/**",
+            "/error"
         ),
         DOCUMENTATION_PATHS.stream()
     ).toList();

--- a/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
@@ -1,0 +1,45 @@
+package com.umc.product.global.config;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class SecurityPathConfig {
+
+    public static final List<String> DOCUMENTATION_PATHS = List.of(
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/docs/**",
+        "/v3/api-docs/**",
+        "/docs-json/**",
+        "/swagger-resources/**",
+        "/webjars/**",
+        "/umc-logo.svg"
+    );
+
+    public static final List<String> SECURITY_PERMIT_ALL_PATHS = Stream.concat(
+        Stream.of(
+            "/actuator/**",
+            "/error"
+        ),
+        DOCUMENTATION_PATHS.stream()
+    ).toList();
+
+    public static final List<String> MAINTENANCE_ALWAYS_ALLOW_PATHS = Stream.concat(
+        Stream.of(
+            "/api/v1/system/status",
+            "/api/v1/admin/maintenance/**",
+            "/api/v1/auth/**",
+            "/api/v1/terms",
+            "/api/v1/terms/**",
+            "/actuator/**"
+        ),
+        DOCUMENTATION_PATHS.stream()
+    ).toList();
+
+    private SecurityPathConfig() {
+    }
+
+    public static String[] securityPermitAllPaths() {
+        return SECURITY_PERMIT_ALL_PATHS.toArray(String[]::new);
+    }
+}

--- a/src/main/java/com/umc/product/global/config/WebMvcConfig.java
+++ b/src/main/java/com/umc/product/global/config/WebMvcConfig.java
@@ -26,8 +26,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
-        registry.addRedirectViewController("/docs", "/docs/scalar.html");
-        registry.addRedirectViewController("/docs/", "/docs/scalar.html");
+        registry.addRedirectViewController(SecurityPathConfig.SCALAR_ENTRY_PATH, "/docs/scalar.html");
+        registry.addRedirectViewController(SecurityPathConfig.SCALAR_ENTRY_SLASH_PATH, "/docs/scalar.html");
         registry.addRedirectViewController("/docs/catalog/api", "/docs/catalog/api/index.html");
         registry.addRedirectViewController("/docs/catalog/api/", "/docs/catalog/api/index.html");
         registry.addRedirectViewController("/docs/catalog/error", "/docs/catalog/error/index.html");
@@ -38,12 +38,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns(
-                "/actuator/**",
-                "/swagger-ui/**",
-                "/docs/**",
-                "/docs-json/**",
-                "/v3/api-docs/**"
-            );
+            .excludePathPatterns(SecurityPathConfig.loggingExcludedPaths());
     }
 }

--- a/src/main/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilter.java
+++ b/src/main/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilter.java
@@ -1,6 +1,21 @@
 package com.umc.product.maintenance.adapter.in.web.filter;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.SecurityPathConfig;
 import com.umc.product.global.response.ApiResponse;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.maintenance.adapter.in.web.dto.response.MaintenanceWindowResponse;
@@ -11,30 +26,19 @@ import com.umc.product.maintenance.domain.MaintenanceDomain;
 import com.umc.product.maintenance.domain.MaintenanceScope;
 import com.umc.product.maintenance.domain.MaintenanceSnapshot;
 import com.umc.product.maintenance.exception.MaintenanceErrorCode;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.AntPathMatcher;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * 점검 활성 시 요청을 503 으로 차단하는 필터.
  * <p>
  * 통과 규칙:
  * <ol>
- *   <li>ALWAYS_ALLOW 경로 (시스템 상태/점검 관리/인증/헬스체크/스웨거)</li>
+ *   <li>ALWAYS_ALLOW 경로 (시스템 상태/점검 관리/인증/헬스체크/문서/약관)</li>
  *   <li>스냅샷이 비활성</li>
  *   <li>SUPER_ADMIN 등 bypass 정책 통과</li>
  *   <li>PER_DOMAIN 점검이고 요청 URI 가 대상 도메인이 아님</li>
@@ -43,20 +47,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class MaintenanceFilter extends OncePerRequestFilter {
 
-    private static final List<String> ALWAYS_ALLOW_PATTERNS = List.of(
-        "/api/v1/system/status",
-        "/api/v1/admin/maintenance/**",
-        "/api/v1/auth/**",
-        "/actuator/**",
-        // Swagger / OpenAPI 경로는 SecurityConfig.STATIC_FILE_PATHS 와 동일하게 맞춘다.
-        "/swagger-ui/**",
-        "/swagger-ui.html",
-        "/docs/**",
-        "/v3/api-docs/**",
-        "/docs-json/**",
-        "/swagger-resources/**",
-        "/webjars/**"
-    );
+    private static final List<String> ALWAYS_ALLOW_PATTERNS = SecurityPathConfig.MAINTENANCE_ALWAYS_ALLOW_PATHS;
 
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,36 +148,16 @@ jwt:
   refresh-token-validity-in-seconds: ${JWT_REFRESH_TOKEN_VALIDITY_IN_SECONDS:604800}
   verification-token-validity-in-seconds: ${JWT_VERIFICATION_TOKEN_VALIDITY_IN_SECONDS:600}
 
-# swagger 설정
+# OpenAPI / Scalar 문서 설정
 springdoc:
   swagger-ui:
-    path: /docs # Swagger 경로
-    enabled: ${SWAGGER_ENABLE:false} # Swagger는 기본적으로 비활성화
-
-    # 정렬 옵션
-    groups-order: DESC # 그룹 정렬 (ASC/DESC)
-    tags-sorter: alpha # 태그(컨트롤러) 정렬
-    operations-sorter: method # API 메소드 정렬
-
-    # UI 설정
-    doc-expansion: none # API 펼침 상태 (none/list/full)
-    disable-swagger-default-url: true # petstore 기본 URL 비활성화
-    display-request-duration: true # 요청 소요 시간 표시
-    display-operation-id: false # operation ID 표시 여부
-
-    filter: true
-    #    default-models-expand-depth: -1  # 스키마 모델도 접힌 상태로
-
-    # 기타
-    deep-linking: true # URL 딥링킹 지원
-    show-extensions: true # 확장 속성 표시
-    show-common-extensions: true # 공통 확장 속성 표시
+    enabled: false # Swagger UI는 노출하지 않고 /docs 는 Scalar로 고정한다.
 
   api-docs:
-    path: /docs-json # API 문서 경로
-    enabled: ${SWAGGER_ENABLE:false}
+    path: /docs-json # Scalar가 읽는 OpenAPI JSON 경로
+    enabled: ${OPENAPI_ENABLE:${SWAGGER_ENABLE:false}}
 
-  show-actuator: ${SWAGGER_ENABLE_ACTUATOR:false}
+  show-actuator: ${OPENAPI_ENABLE_ACTUATOR:${SWAGGER_ENABLE_ACTUATOR:false}}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -312,10 +312,6 @@ app:
     discord:
       url: ${DISCORD_WEBHOOK_URL:}
 
-  swagger-auth:
-    username: ${SWAGGER_AUTH_USERNAME:username}
-    password: ${SWAGGER_AUTH_PASSWORD:password}
-
   # test 도메인 시딩 API 설정. ADR-017 참조.
   # 기본값은 비활성. prod 가 아닌 환경에서 APP_SEED_ENABLED=true 로 켜야 시딩 API 가 노출된다.
   seed:

--- a/src/test/java/com/umc/product/global/config/SecurityConfigIntegrationTest.java
+++ b/src/test/java/com/umc/product/global/config/SecurityConfigIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.umc.product.global.config;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.umc.product.support.IntegrationTestSupport;
+
+@DisplayName("SecurityConfig 통합 테스트")
+class SecurityConfigIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("docs 진입 경로는 Scalar HTML로 리다이렉트한다")
+    void docsEntryRedirectsToScalar() throws Exception {
+        mockMvc.perform(get("/docs"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/docs/scalar.html"));
+    }
+
+    @Test
+    @DisplayName("인증된 요청이어도 Swagger UI 경로는 접근할 수 없다")
+    void authenticatedRequestCannotAccessSwaggerUi() throws Exception {
+        String token = "swagger-block-token";
+        given(jwtTokenProvider.validateAccessToken(token)).willReturn(true);
+        given(jwtTokenProvider.parseAccessToken(token)).willReturn(1L);
+        given(jwtTokenProvider.getRolesFromAccessToken(token)).willReturn(List.of("USER"));
+        given(jwtTokenProvider.getClientTypeFromAccessToken(token)).willReturn(null);
+
+        mockMvc.perform(get("/swagger-ui/index.html")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("인증된 요청이어도 기존 OpenAPI JSON 경로는 접근할 수 없다")
+    void authenticatedRequestCannotAccessDefaultOpenApiJson() throws Exception {
+        String token = "swagger-api-docs-block-token";
+        given(jwtTokenProvider.validateAccessToken(token)).willReturn(true);
+        given(jwtTokenProvider.parseAccessToken(token)).willReturn(1L);
+        given(jwtTokenProvider.getRolesFromAccessToken(token)).willReturn(List.of("USER"));
+        given(jwtTokenProvider.getClientTypeFromAccessToken(token)).willReturn(null);
+
+        mockMvc.perform(get("/v3/api-docs")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/umc/product/global/config/SecurityPathConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/SecurityPathConfigTest.java
@@ -1,0 +1,71 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+
+class SecurityPathConfigTest {
+
+    @Test
+    @DisplayName("문서 공개 경로는 Scalar와 문서 카탈로그에 필요한 경로만 포함한다")
+    void documentationPathsExposeScalarAndCatalogOnly() {
+        assertThat(SecurityPathConfig.DOCUMENTATION_PATHS)
+            .contains(
+                "/docs",
+                "/docs/",
+                "/docs/**",
+                "/docs-json",
+                "/docs-json/**",
+                "/webjars/markdown-it/**",
+                "/umc-logo.svg"
+            )
+            .doesNotContain(
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/v3/api-docs/**",
+                "/swagger-resources/**",
+                "/webjars/**",
+                "/webjars/swagger-ui/**"
+            );
+    }
+
+    @Test
+    @DisplayName("Swagger 경로는 인증 여부와 무관하게 차단 대상이다")
+    void swaggerPathsAreBlockedExplicitly() {
+        assertThat(SecurityPathConfig.SWAGGER_BLOCKED_PATHS)
+            .contains(
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/v3/api-docs",
+                "/v3/api-docs/**",
+                "/swagger-resources/**",
+                "/webjars/swagger-ui/**"
+            )
+            .doesNotContain(
+                "/docs",
+                "/docs/**",
+                "/docs-json",
+                "/docs-json/**",
+                "/webjars/markdown-it/**"
+            );
+    }
+
+    @Test
+    @DisplayName("Springdoc은 Swagger UI를 끄고 Scalar가 사용할 OpenAPI JSON만 제공한다")
+    void springdocDisablesSwaggerUiAndKeepsOpenApiJson() {
+        YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+        yamlPropertiesFactoryBean.setResources(new ClassPathResource("application.yml"));
+
+        Properties properties = yamlPropertiesFactoryBean.getObject();
+
+        assertThat(properties)
+            .containsEntry("springdoc.swagger-ui.enabled", Boolean.FALSE)
+            .containsEntry("springdoc.api-docs.path", "/docs-json")
+            .containsEntry("springdoc.api-docs.enabled", "${OPENAPI_ENABLE:${SWAGGER_ENABLE:false}}");
+    }
+}

--- a/src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java
+++ b/src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java
@@ -7,6 +7,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.umc.product.authorization.application.port.out.SaveChallengerRolePort;
 import com.umc.product.authorization.domain.ChallengerRole;
 import com.umc.product.challenger.domain.Challenger;
@@ -23,12 +31,6 @@ import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.ChallengerFixture;
 import com.umc.product.support.fixture.GisuFixture;
 import com.umc.product.support.fixture.MemberFixture;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.EnumSet;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("MaintenanceFilter 통합 테스트")
 class MaintenanceFilterIntegrationTest extends IntegrationTestSupport {
@@ -140,6 +142,16 @@ class MaintenanceFilterIntegrationTest extends IntegrationTestSupport {
             .andReturn().getResponse().getStatus();
 
         assertThat(actualStatus).isNotEqualTo(503);
+    }
+
+    @Test
+    @DisplayName("FULL 점검 중에도 약관 조회는 점검 필터를 통과한다")
+    void fullMaintenanceAllowsTermLookup() throws Exception {
+        saveActiveFullWindow();
+
+        mockMvc.perform(get("/api/v1/terms"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.terms").isArray());
     }
 
     private void saveActiveFullWindow() {


### PR DESCRIPTION
- Swagger를 비활성화 하고, Scalar로 통일해서 사용하도록 강제합니다.
- 변경된 Server URI를 적용했습니다.
  - 순서로 local-dev-prod 에서 자주 사용하는 순서에 따라 dev-local-prod로 변경하였습니다.
- Access Token 삽입 관련 문구를 Scalar에 맞추어서 "아래에" 입력하라고 변경했습니다.
- Basic Auth가 아니라 일반 SecurityFilter를 거치도록 변경했습니다. (추후 권한 검증 추가 예정)