### PR TITLE
[Feat] 내 정보 조회 v2 API에 local credential 보유 여부 추가

### DIFF
--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
@@ -24,6 +24,8 @@ public record MemberSummaryV2Response(
     String nickname,
 
     String email,
+    @Schema(description = "로컬 계정 비밀번호 자격증명 보유 여부")
+    boolean hasLocalCredential,
 
     Long schoolId,
     String schoolName,
@@ -48,6 +50,7 @@ public record MemberSummaryV2Response(
             m.name(),
             m.nickname(),
             m.email(),
+            info.hasLocalCredential(),
             m.schoolId(),
             m.schoolName(),
             m.profileImageLink(),

--- a/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/v2/dto/response/MemberSummaryV2Response.java
@@ -1,5 +1,7 @@
 package com.umc.product.member.adapter.in.web.v2.dto.response;
 
+import java.util.List;
+
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerPointInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -8,8 +10,8 @@ import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 
 /**
  * GET /api/v2/member/me 응답 DTO.

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
@@ -1,5 +1,8 @@
 package com.umc.product.member.application.port.in.query.dto;
 
+import java.util.List;
+import java.util.Map;
+
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerPointInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -7,8 +10,6 @@ import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
-import java.util.List;
-import java.util.Map;
 
 /**
  * /api/v2/member/me 응답에 사용되는 BFF Info DTO 입니다. 어댑터의 Response 매핑은 단순 위임만 합니다.

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberSummaryV2Info.java
@@ -16,6 +16,7 @@ import java.util.Map;
 public record MemberSummaryV2Info(
     MemberInfo member,
     MemberProfileInfo profile,
+    boolean hasLocalCredential,
     long totalActivityDays,
     CurrentGisuMembership currentGisuMembership,
     List<ChallengerHistoryItem> challengerHistory

--- a/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
@@ -1,5 +1,16 @@
 package com.umc.product.member.application.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerActivityPeriodUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -21,16 +32,8 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * /api/v2/member/me BFF UseCase 구현체.

--- a/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSummaryV2QueryService.java
@@ -7,6 +7,7 @@ import com.umc.product.challenger.application.port.in.query.dto.ActivityPeriodSu
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberProfileUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberSummaryV2UseCase;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -43,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
 
     private final GetMemberUseCase getMemberUseCase;
+    private final GetMemberCredentialUseCase getMemberCredentialUseCase;
     private final GetMemberProfileUseCase getMemberProfileUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetGisuUseCase getGisuUseCase;
@@ -53,6 +55,7 @@ public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
     @Override
     public MemberSummaryV2Info getSummaryByMemberId(Long memberId) {
         MemberInfo memberInfo = getMemberUseCase.getById(memberId);
+        boolean hasLocalCredential = getMemberCredentialUseCase.findCredentialByMemberId(memberId).isPresent();
         MemberProfileInfo profileInfo = getMemberProfileUseCase.getMemberProfileById(memberId);
 
         // 챌린저 + 점수 일괄 로딩 (D13에서 batch로 교체됨)
@@ -110,6 +113,7 @@ public class MemberSummaryV2QueryService implements GetMemberSummaryV2UseCase {
         return new MemberSummaryV2Info(
             memberInfo,
             profileInfo,
+            hasLocalCredential,
             activitySummary.totalActivityDays(),
             currentMembership,
             history

--- a/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2ControllerTest.java
@@ -78,6 +78,7 @@ class MemberQueryV2ControllerTest {
                 .status(MemberStatus.ACTIVE)
                 .build(),
             MemberProfileInfo.builder().github("https://github.com/umc").build(),
+            true,
             30L,
             null,
             List.of()
@@ -86,6 +87,7 @@ class MemberQueryV2ControllerTest {
         mockMvc.perform(get("/api/v2/member/me"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.id").value(99L))
+            .andExpect(jsonPath("$.result.hasLocalCredential").value(true))
             .andExpect(jsonPath("$.result.totalActivityDays").value(30L));
     }
 

--- a/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
@@ -5,6 +5,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerActivityPeriodUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -25,17 +38,6 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberSummaryV2QueryService — BFF 조립")

--- a/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSummaryV2QueryServiceTest.java
@@ -14,8 +14,10 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.common.domain.enums.MemberStatus;
+import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberProfileUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberSummaryV2Info;
@@ -40,6 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MemberSummaryV2QueryServiceTest {
 
     @Mock GetMemberUseCase getMemberUseCase;
+    @Mock GetMemberCredentialUseCase getMemberCredentialUseCase;
     @Mock GetMemberProfileUseCase getMemberProfileUseCase;
     @Mock GetChallengerUseCase getChallengerUseCase;
     @Mock GetGisuUseCase getGisuUseCase;
@@ -201,5 +204,40 @@ class MemberSummaryV2QueryServiceTest {
         assertThat(info.currentGisuMembership().challenger()).isNull();
         assertThat(info.currentGisuMembership().isAdmin()).isFalse();
         assertThat(info.currentGisuMembership().roleTypes()).isEmpty();
+    }
+
+    @Test
+    void 로컬_자격증명이_있는_회원은_hasLocalCredential이_true이다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberCredentialUseCase.findCredentialByMemberId(100L))
+            .willReturn(Optional.of(new MemberCredentialInfo(100L, "{bcrypt}encoded")));
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of());
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(0L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.hasLocalCredential()).isTrue();
+    }
+
+    @Test
+    void 로컬_자격증명이_없는_회원은_hasLocalCredential이_false이다() {
+        MemberInfo m = member();
+        given(getMemberUseCase.getById(100L)).willReturn(m);
+        given(getMemberCredentialUseCase.findCredentialByMemberId(100L)).willReturn(Optional.empty());
+        given(getMemberProfileUseCase.getMemberProfileById(100L)).willReturn(profile());
+
+        given(getChallengerUseCase.getAllByMemberId(100L)).willReturn(List.of());
+        given(getGisuUseCase.findActiveGisu()).willReturn(Optional.empty());
+        given(getChallengerActivityPeriodUseCase.calculateActivityPeriod(any(), any()))
+            .willReturn(new ActivityPeriodSummary(0L, List.of()));
+
+        MemberSummaryV2Info info = service.getSummaryByMemberId(100L);
+
+        assertThat(info.hasLocalCredential()).isFalse();
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- member v2 내 정보 조회 API인 [MEMBER-201] GET /api/v2/member/me 응답과 BFF 조립 서비스, 관련 테스트를 수정했어요.

### 작업 단위별 상세

1. **무엇을**: /api/v2/member/me 응답에 `hasLocalCredential` 필드를 추가했어요.
   - **어떻게**: `MemberSummaryV2Info`와 `MemberSummaryV2Response`에 boolean 필드를 추가하고, 응답 매핑 시 그대로 내려주도록 연결했어요.
   - **왜**: FE 계정 설정 화면에서 로컬 비밀번호를 보유한 회원에게만 비밀번호 변경 버튼을 노출해야 해서예요.

2. **무엇을**: 회원이 로컬 자격증명을 보유했는지 조회하는 로직을 추가했어요.
   - **어떻게**: `MemberSummaryV2QueryService`에서 `GetMemberCredentialUseCase.findCredentialByMemberId(memberId).isPresent()`로 계산했어요.
   - **왜**: 가입 방식이 아니라 현재 비밀번호 기반 credential 보유 여부만 판단해야, 로컬 로그인 후 소셜 계정을 연동한 회원도 올바르게 `true`로 응답할 수 있어서예요.

3. **무엇을**: 서비스와 컨트롤러 테스트를 보강했어요.
   - **어떻게**: 로컬 자격증명 보유 여부가 true/false로 조립되는 케이스와 JSON 응답에 `hasLocalCredential`이 포함되는 케이스를 검증했어요.
   - **왜**: 계정 설정 화면의 버튼 노출 분기가 API 응답 계약에 의존하므로 회귀를 막기 위해서예요.

## 💬 리뷰 중점사항

- `hasLocalCredential`이 로그인 방식이 아니라 비밀번호 credential 보유 여부를 의미하도록 계산되는지 확인 부탁드려요.
- 새 API 추가가 아니라 기존 member v2 응답 계약 확장이므로, FE 적용 전 응답 필드명이 의도와 맞는지 확인 부탁드려요.
- DB 마이그레이션, 환경 설정, 인프라 설정 변경은 없어요.