### PR TITLE
[Feat] 프로젝트 멤버 조회 시 매칭된 차수를 함께 응답하도록 추가

### DIFF
--- a/docs/guides/API_목록.json
+++ b/docs/guides/API_목록.json
@@ -92,7 +92,7 @@
     "role": "비밀번호 자격증명 최초 등록",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 45,
+    "line": 47,
     "operationId": null
   },
   {
@@ -104,7 +104,7 @@
     "role": "비밀번호 변경",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 58,
+    "line": 60,
     "operationId": null
   },
   {
@@ -116,7 +116,7 @@
     "role": "이메일 사용 가능 여부 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 87,
+    "line": 89,
     "operationId": null
   },
   {
@@ -128,7 +128,7 @@
     "role": "비밀번호 초기화",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 71,
+    "line": 73,
     "operationId": null
   },
   {
@@ -224,7 +224,7 @@
     "role": "이메일/PW 로그인",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 98,
+    "line": 100,
     "operationId": null
   },
   {
@@ -344,7 +344,7 @@
     "role": "챌린저 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 40,
+    "line": 46,
     "operationId": null
   },
   {
@@ -356,7 +356,7 @@
     "role": "챌린저 batch 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 52,
+    "line": 58,
     "operationId": null
   },
   {
@@ -368,7 +368,7 @@
     "role": "챌린저 비활성화 (제명/탈부 처리)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 70,
+    "line": 76,
     "operationId": null
   },
   {
@@ -380,7 +380,7 @@
     "role": "챌린저 파트 변경",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 83,
+    "line": 89,
     "operationId": null
   },
   {
@@ -392,7 +392,7 @@
     "role": "[주의] 챌린저 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 99,
+    "line": 105,
     "operationId": null
   },
   {
@@ -464,7 +464,7 @@
     "role": "6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 36,
+    "line": 42,
     "operationId": null
   },
   {
@@ -476,7 +476,7 @@
     "role": "[ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 89,
+    "line": 95,
     "operationId": null
   },
   {
@@ -488,7 +488,7 @@
     "role": "[ADMIN] 챌린저 기록용 코드 벌크 추가",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 116,
+    "line": 122,
     "operationId": null
   },
   {
@@ -500,7 +500,7 @@
     "role": "코드로 ChallengerRecord 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 65,
+    "line": 71,
     "operationId": null
   },
   {
@@ -512,7 +512,7 @@
     "role": "ID로 ChallengerRecord 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 77,
+    "line": 83,
     "operationId": null
   },
   {
@@ -524,7 +524,7 @@
     "role": "챌린저 상벌점 부여",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 38,
+    "line": 41,
     "operationId": null
   },
   {
@@ -536,7 +536,7 @@
     "role": "챌린저 상벌점 사유 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 55,
+    "line": 58,
     "operationId": null
   },
   {
@@ -548,7 +548,7 @@
     "role": "챌린저 상벌점 삭제",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 70,
+    "line": 73,
     "operationId": null
   },
   {
@@ -1189,6 +1189,30 @@
   },
   {
     "sequence": 100,
+    "domain": "feedback",
+    "apiId": "<미지정>",
+    "endpoint": "/api/v1/user-feedbacks/responses",
+    "httpMethod": "POST",
+    "role": "사용자 피드백 응답 제출",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java",
+    "line": 58,
+    "operationId": null
+  },
+  {
+    "sequence": 101,
+    "domain": "feedback",
+    "apiId": "<미지정>",
+    "endpoint": "/api/v1/user-feedbacks/templates",
+    "httpMethod": "GET",
+    "role": "사용자 피드백 템플릿 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java",
+    "line": 34,
+    "operationId": null
+  },
+  {
+    "sequence": 102,
     "domain": "figma",
     "apiId": "FIGMA-001",
     "endpoint": "/api/v1/admin/figma/oauth",
@@ -1200,7 +1224,7 @@
     "operationId": null
   },
   {
-    "sequence": 101,
+    "sequence": 103,
     "domain": "figma",
     "apiId": "FIGMA-002",
     "endpoint": "/api/v1/admin/figma/oauth/callback",
@@ -1212,7 +1236,7 @@
     "operationId": null
   },
   {
-    "sequence": 102,
+    "sequence": 104,
     "domain": "figma",
     "apiId": "FIGMA-003",
     "endpoint": "/api/v1/admin/figma/watched-files",
@@ -1224,7 +1248,7 @@
     "operationId": null
   },
   {
-    "sequence": 103,
+    "sequence": 105,
     "domain": "figma",
     "apiId": "FIGMA-004",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}",
@@ -1236,7 +1260,7 @@
     "operationId": null
   },
   {
-    "sequence": 104,
+    "sequence": 106,
     "domain": "figma",
     "apiId": "FIGMA-005",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}/enable",
@@ -1248,7 +1272,7 @@
     "operationId": null
   },
   {
-    "sequence": 105,
+    "sequence": 107,
     "domain": "figma",
     "apiId": "FIGMA-006",
     "endpoint": "/api/v1/admin/figma/sync",
@@ -1260,7 +1284,7 @@
     "operationId": null
   },
   {
-    "sequence": 106,
+    "sequence": 108,
     "domain": "figma",
     "apiId": "FIGMA-007",
     "endpoint": "/api/v1/admin/figma/sync/watched-files/{watchedFileId}",
@@ -1272,7 +1296,7 @@
     "operationId": null
   },
   {
-    "sequence": 107,
+    "sequence": 109,
     "domain": "figma",
     "apiId": "FIGMA-008",
     "endpoint": "/api/v1/admin/figma/watched-files",
@@ -1284,7 +1308,7 @@
     "operationId": null
   },
   {
-    "sequence": 108,
+    "sequence": 110,
     "domain": "figma",
     "apiId": "FIGMA-009",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}",
@@ -1296,7 +1320,7 @@
     "operationId": null
   },
   {
-    "sequence": 109,
+    "sequence": 111,
     "domain": "figma",
     "apiId": "FIGMA-010",
     "endpoint": "/api/v1/admin/figma/preview",
@@ -1308,7 +1332,7 @@
     "operationId": null
   },
   {
-    "sequence": 110,
+    "sequence": 112,
     "domain": "figma",
     "apiId": "FIGMA-011",
     "endpoint": "/api/v1/admin/figma/routing-domains",
@@ -1320,7 +1344,7 @@
     "operationId": null
   },
   {
-    "sequence": 111,
+    "sequence": 113,
     "domain": "figma",
     "apiId": "FIGMA-012",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1332,7 +1356,7 @@
     "operationId": null
   },
   {
-    "sequence": 112,
+    "sequence": 114,
     "domain": "figma",
     "apiId": "FIGMA-013",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}/mentions",
@@ -1344,7 +1368,7 @@
     "operationId": null
   },
   {
-    "sequence": 113,
+    "sequence": 115,
     "domain": "figma",
     "apiId": "FIGMA-014",
     "endpoint": "/api/v1/admin/figma/routing-domains/mentions/{mentionId}",
@@ -1356,7 +1380,7 @@
     "operationId": null
   },
   {
-    "sequence": 114,
+    "sequence": 116,
     "domain": "figma",
     "apiId": "FIGMA-015",
     "endpoint": "/api/v1/admin/figma/digest",
@@ -1368,7 +1392,7 @@
     "operationId": null
   },
   {
-    "sequence": 115,
+    "sequence": 117,
     "domain": "figma",
     "apiId": "FIGMA-016",
     "endpoint": "/api/v1/admin/figma/routing-domains",
@@ -1380,7 +1404,7 @@
     "operationId": null
   },
   {
-    "sequence": 116,
+    "sequence": 118,
     "domain": "figma",
     "apiId": "FIGMA-017",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1392,7 +1416,7 @@
     "operationId": null
   },
   {
-    "sequence": 117,
+    "sequence": 119,
     "domain": "figma",
     "apiId": "FIGMA-018",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}/mentions",
@@ -1404,7 +1428,7 @@
     "operationId": null
   },
   {
-    "sequence": 118,
+    "sequence": 120,
     "domain": "figma",
     "apiId": "FIGMA-019",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1416,7 +1440,7 @@
     "operationId": null
   },
   {
-    "sequence": 119,
+    "sequence": 121,
     "domain": "figma",
     "apiId": "FIGMA-020",
     "endpoint": "/api/v1/admin/figma/routing-domains/mentions/{mentionId}",
@@ -1428,7 +1452,7 @@
     "operationId": null
   },
   {
-    "sequence": 120,
+    "sequence": 122,
     "domain": "global",
     "apiId": "<미지정>",
     "endpoint": "/error",
@@ -1440,7 +1464,7 @@
     "operationId": null
   },
   {
-    "sequence": 121,
+    "sequence": 123,
     "domain": "maintenance",
     "apiId": "MAINT-001",
     "endpoint": "/api/v1/admin/maintenance",
@@ -1452,7 +1476,7 @@
     "operationId": null
   },
   {
-    "sequence": 122,
+    "sequence": 124,
     "domain": "maintenance",
     "apiId": "MAINT-002",
     "endpoint": "/api/v1/admin/maintenance/{windowId}/end",
@@ -1464,7 +1488,7 @@
     "operationId": null
   },
   {
-    "sequence": 123,
+    "sequence": 125,
     "domain": "maintenance",
     "apiId": "MAINT-003",
     "endpoint": "/api/v1/admin/maintenance",
@@ -1476,7 +1500,7 @@
     "operationId": null
   },
   {
-    "sequence": 124,
+    "sequence": 126,
     "domain": "maintenance",
     "apiId": "MAINT-004",
     "endpoint": "/api/v1/admin/maintenance/{windowId}",
@@ -1488,7 +1512,7 @@
     "operationId": null
   },
   {
-    "sequence": 125,
+    "sequence": 127,
     "domain": "maintenance",
     "apiId": "SYSTEM-001",
     "endpoint": "/api/v1/system/status",
@@ -1500,7 +1524,7 @@
     "operationId": null
   },
   {
-    "sequence": 126,
+    "sequence": 128,
     "domain": "member",
     "apiId": "MEMBER-001",
     "endpoint": "/api/v1/member",
@@ -1508,11 +1532,11 @@
     "role": "내 회원 정보 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 128,
+    "line": 130,
     "operationId": null
   },
   {
-    "sequence": 127,
+    "sequence": 129,
     "domain": "member",
     "apiId": "MEMBER-002",
     "endpoint": "/api/v1/member/profile/links",
@@ -1520,11 +1544,11 @@
     "role": "내 회원 프로필 링크 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 142,
+    "line": 144,
     "operationId": null
   },
   {
-    "sequence": 128,
+    "sequence": 130,
     "domain": "member",
     "apiId": "MEMBER-003",
     "endpoint": "/api/v1/member",
@@ -1532,11 +1556,11 @@
     "role": "회원 탈퇴",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 156,
+    "line": 158,
     "operationId": null
   },
   {
-    "sequence": 129,
+    "sequence": 131,
     "domain": "member",
     "apiId": "MEMBER-004",
     "endpoint": "/api/v1/member/{memberId}",
@@ -1544,11 +1568,11 @@
     "role": "관리자 권한으로 회원 게정 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 169,
+    "line": 171,
     "operationId": null
   },
   {
-    "sequence": 130,
+    "sequence": 132,
     "domain": "member",
     "apiId": "MEMBER-101",
     "endpoint": "/api/v1/member/profile/{memberId}",
@@ -1560,7 +1584,7 @@
     "operationId": null
   },
   {
-    "sequence": 131,
+    "sequence": 133,
     "domain": "member",
     "apiId": "MEMBER-102",
     "endpoint": "/api/v1/member/me",
@@ -1572,7 +1596,7 @@
     "operationId": null
   },
   {
-    "sequence": 132,
+    "sequence": 134,
     "domain": "member",
     "apiId": "MEMBER-103",
     "endpoint": "/api/v1/member/search",
@@ -1584,7 +1608,7 @@
     "operationId": null
   },
   {
-    "sequence": 133,
+    "sequence": 135,
     "domain": "member",
     "apiId": "MEMBER-201",
     "endpoint": "/api/v2/member/me",
@@ -1596,7 +1620,7 @@
     "operationId": null
   },
   {
-    "sequence": 134,
+    "sequence": 136,
     "domain": "member",
     "apiId": "MEMBER-202",
     "endpoint": "/api/v2/member/search",
@@ -1608,7 +1632,7 @@
     "operationId": null
   },
   {
-    "sequence": 135,
+    "sequence": 137,
     "domain": "member",
     "apiId": "REGISTER-001",
     "endpoint": "/api/v1/member/register",
@@ -1616,11 +1640,11 @@
     "role": "OAuth 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 59,
+    "line": 61,
     "operationId": null
   },
   {
-    "sequence": 136,
+    "sequence": 138,
     "domain": "member",
     "apiId": "REGISTER-003",
     "endpoint": "/api/v1/member/register/email",
@@ -1628,11 +1652,11 @@
     "role": "이메일/PW 이용 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 101,
+    "line": 103,
     "operationId": null
   },
   {
-    "sequence": 137,
+    "sequence": 139,
     "domain": "notice",
     "apiId": "NOTICE-001",
     "endpoint": "/api/v1/notices",
@@ -1644,7 +1668,7 @@
     "operationId": null
   },
   {
-    "sequence": 138,
+    "sequence": 140,
     "domain": "notice",
     "apiId": "NOTICE-002",
     "endpoint": "/api/v1/notices/search",
@@ -1656,7 +1680,7 @@
     "operationId": null
   },
   {
-    "sequence": 139,
+    "sequence": 141,
     "domain": "notice",
     "apiId": "NOTICE-003",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1668,7 +1692,7 @@
     "operationId": null
   },
   {
-    "sequence": 140,
+    "sequence": 142,
     "domain": "notice",
     "apiId": "NOTICE-004",
     "endpoint": "/api/v1/notices/{noticeId}/read-statics",
@@ -1680,7 +1704,7 @@
     "operationId": null
   },
   {
-    "sequence": 141,
+    "sequence": 143,
     "domain": "notice",
     "apiId": "NOTICE-005",
     "endpoint": "/api/v1/notices/{noticeId}/read-status",
@@ -1692,7 +1716,7 @@
     "operationId": null
   },
   {
-    "sequence": 142,
+    "sequence": 144,
     "domain": "notice",
     "apiId": "NOTICE-101",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -1704,7 +1728,7 @@
     "operationId": null
   },
   {
-    "sequence": 143,
+    "sequence": 145,
     "domain": "notice",
     "apiId": "NOTICE-102",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -1716,7 +1740,7 @@
     "operationId": null
   },
   {
-    "sequence": 144,
+    "sequence": 146,
     "domain": "notice",
     "apiId": "NOTICE-103",
     "endpoint": "/api/v1/notices/{noticeId}/votes",
@@ -1728,7 +1752,7 @@
     "operationId": null
   },
   {
-    "sequence": 145,
+    "sequence": 147,
     "domain": "notice",
     "apiId": "NOTICE-104",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -1740,7 +1764,7 @@
     "operationId": null
   },
   {
-    "sequence": 146,
+    "sequence": 148,
     "domain": "notice",
     "apiId": "NOTICE-105",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -1752,7 +1776,7 @@
     "operationId": null
   },
   {
-    "sequence": 147,
+    "sequence": 149,
     "domain": "notice",
     "apiId": "NOTICE-106",
     "endpoint": "/api/v1/notices/{noticeId}/vote",
@@ -1764,7 +1788,7 @@
     "operationId": null
   },
   {
-    "sequence": 148,
+    "sequence": 150,
     "domain": "notice",
     "apiId": "NOTICE-201",
     "endpoint": "/api/v1/notices",
@@ -1776,7 +1800,7 @@
     "operationId": null
   },
   {
-    "sequence": 149,
+    "sequence": 151,
     "domain": "notice",
     "apiId": "NOTICE-202",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1788,7 +1812,7 @@
     "operationId": null
   },
   {
-    "sequence": 150,
+    "sequence": 152,
     "domain": "notice",
     "apiId": "NOTICE-203",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1800,7 +1824,7 @@
     "operationId": null
   },
   {
-    "sequence": 151,
+    "sequence": 153,
     "domain": "notice",
     "apiId": "NOTICE-204",
     "endpoint": "/api/v1/notices/{noticeId}/reminders",
@@ -1812,7 +1836,7 @@
     "operationId": null
   },
   {
-    "sequence": 152,
+    "sequence": 154,
     "domain": "notice",
     "apiId": "NOTICE-205",
     "endpoint": "/api/v1/notices/{noticeId}/read",
@@ -1824,7 +1848,7 @@
     "operationId": null
   },
   {
-    "sequence": 153,
+    "sequence": 155,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-001",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -1836,7 +1860,7 @@
     "operationId": null
   },
   {
-    "sequence": 154,
+    "sequence": 156,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-002",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -1848,7 +1872,7 @@
     "operationId": null
   },
   {
-    "sequence": 155,
+    "sequence": 157,
     "domain": "notification",
     "apiId": "FCM-001",
     "endpoint": "/api/v1/notification/fcm/token",
@@ -1860,7 +1884,7 @@
     "operationId": null
   },
   {
-    "sequence": 156,
+    "sequence": 158,
     "domain": "notification",
     "apiId": "FCM-002",
     "endpoint": "/api/v1/notification/fcm/topics/legacy",
@@ -1872,7 +1896,7 @@
     "operationId": null
   },
   {
-    "sequence": 157,
+    "sequence": 159,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -1884,7 +1908,7 @@
     "operationId": null
   },
   {
-    "sequence": 158,
+    "sequence": 160,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/schools/gisu/{gisuId}",
@@ -1896,7 +1920,7 @@
     "operationId": null
   },
   {
-    "sequence": 159,
+    "sequence": 161,
     "domain": "organization",
     "apiId": "CHAPTER-001",
     "endpoint": "/api/v1/chapters",
@@ -1908,7 +1932,7 @@
     "operationId": null
   },
   {
-    "sequence": 160,
+    "sequence": 162,
     "domain": "organization",
     "apiId": "CHAPTER-002",
     "endpoint": "/api/v1/chapters/bulk",
@@ -1920,7 +1944,7 @@
     "operationId": null
   },
   {
-    "sequence": 161,
+    "sequence": 163,
     "domain": "organization",
     "apiId": "CHAPTER-003",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -1932,7 +1956,7 @@
     "operationId": null
   },
   {
-    "sequence": 162,
+    "sequence": 164,
     "domain": "organization",
     "apiId": "CHAPTER-101",
     "endpoint": "/api/v1/chapters",
@@ -1944,7 +1968,7 @@
     "operationId": null
   },
   {
-    "sequence": 163,
+    "sequence": 165,
     "domain": "organization",
     "apiId": "CHAPTER-102",
     "endpoint": "/api/v1/chapters/with-schools",
@@ -1956,7 +1980,7 @@
     "operationId": null
   },
   {
-    "sequence": 164,
+    "sequence": 166,
     "domain": "organization",
     "apiId": "CHAPTER-103",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -1968,7 +1992,7 @@
     "operationId": null
   },
   {
-    "sequence": 165,
+    "sequence": 167,
     "domain": "organization",
     "apiId": "GISU-001",
     "endpoint": "/api/v1/gisu",
@@ -1980,7 +2004,7 @@
     "operationId": null
   },
   {
-    "sequence": 166,
+    "sequence": 168,
     "domain": "organization",
     "apiId": "GISU-002",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -1992,7 +2016,7 @@
     "operationId": null
   },
   {
-    "sequence": 167,
+    "sequence": 169,
     "domain": "organization",
     "apiId": "GISU-003",
     "endpoint": "/api/v1/gisu/{gisuId}/active",
@@ -2004,7 +2028,7 @@
     "operationId": null
   },
   {
-    "sequence": 168,
+    "sequence": 170,
     "domain": "organization",
     "apiId": "GISU-101",
     "endpoint": "/api/v1/gisu",
@@ -2016,7 +2040,7 @@
     "operationId": null
   },
   {
-    "sequence": 169,
+    "sequence": 171,
     "domain": "organization",
     "apiId": "GISU-102",
     "endpoint": "/api/v1/gisu/all",
@@ -2028,7 +2052,7 @@
     "operationId": null
   },
   {
-    "sequence": 170,
+    "sequence": 172,
     "domain": "organization",
     "apiId": "GISU-103",
     "endpoint": "/api/v1/gisu/active",
@@ -2040,7 +2064,7 @@
     "operationId": null
   },
   {
-    "sequence": 171,
+    "sequence": 173,
     "domain": "organization",
     "apiId": "SCHOOL-001",
     "endpoint": "/api/v1/schools",
@@ -2052,7 +2076,7 @@
     "operationId": null
   },
   {
-    "sequence": 172,
+    "sequence": 174,
     "domain": "organization",
     "apiId": "SCHOOL-002",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2064,7 +2088,7 @@
     "operationId": null
   },
   {
-    "sequence": 173,
+    "sequence": 175,
     "domain": "organization",
     "apiId": "SCHOOL-003",
     "endpoint": "/api/v1/schools",
@@ -2076,7 +2100,7 @@
     "operationId": null
   },
   {
-    "sequence": 174,
+    "sequence": 176,
     "domain": "organization",
     "apiId": "SCHOOL-004",
     "endpoint": "/api/v1/schools/{schoolId}/assign",
@@ -2088,7 +2112,7 @@
     "operationId": null
   },
   {
-    "sequence": 175,
+    "sequence": 177,
     "domain": "organization",
     "apiId": "SCHOOL-005",
     "endpoint": "/api/v1/schools/{schoolId}/unassign",
@@ -2100,7 +2124,7 @@
     "operationId": null
   },
   {
-    "sequence": 176,
+    "sequence": 178,
     "domain": "organization",
     "apiId": "SCHOOL-101",
     "endpoint": "/api/v1/schools/all",
@@ -2112,7 +2136,7 @@
     "operationId": null
   },
   {
-    "sequence": 177,
+    "sequence": 179,
     "domain": "organization",
     "apiId": "SCHOOL-102",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2124,7 +2148,7 @@
     "operationId": null
   },
   {
-    "sequence": 178,
+    "sequence": 180,
     "domain": "organization",
     "apiId": "SCHOOL-103",
     "endpoint": "/api/v1/schools/unassigned",
@@ -2136,7 +2160,7 @@
     "operationId": null
   },
   {
-    "sequence": 179,
+    "sequence": 181,
     "domain": "organization",
     "apiId": "SCHOOL-104",
     "endpoint": "/api/v1/schools/link/{schoolId}",
@@ -2148,7 +2172,7 @@
     "operationId": null
   },
   {
-    "sequence": 180,
+    "sequence": 182,
     "domain": "organization",
     "apiId": "STUDY-GROUP-001",
     "endpoint": "/api/v1/study-groups",
@@ -2160,7 +2184,7 @@
     "operationId": null
   },
   {
-    "sequence": 181,
+    "sequence": 183,
     "domain": "organization",
     "apiId": "STUDY-GROUP-002",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2172,7 +2196,7 @@
     "operationId": null
   },
   {
-    "sequence": 182,
+    "sequence": 184,
     "domain": "organization",
     "apiId": "STUDY-GROUP-003",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2184,7 +2208,7 @@
     "operationId": null
   },
   {
-    "sequence": 183,
+    "sequence": 185,
     "domain": "organization",
     "apiId": "STUDY-GROUP-004",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2196,7 +2220,7 @@
     "operationId": null
   },
   {
-    "sequence": 184,
+    "sequence": 186,
     "domain": "organization",
     "apiId": "STUDY-GROUP-005",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2208,7 +2232,7 @@
     "operationId": null
   },
   {
-    "sequence": 185,
+    "sequence": 187,
     "domain": "organization",
     "apiId": "STUDY-GROUP-006",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2220,7 +2244,7 @@
     "operationId": null
   },
   {
-    "sequence": 186,
+    "sequence": 188,
     "domain": "organization",
     "apiId": "STUDY-GROUP-007",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2232,7 +2256,7 @@
     "operationId": null
   },
   {
-    "sequence": 187,
+    "sequence": 189,
     "domain": "organization",
     "apiId": "STUDY-GROUP-101",
     "endpoint": "/api/v1/study-groups/managed",
@@ -2244,7 +2268,7 @@
     "operationId": null
   },
   {
-    "sequence": 188,
+    "sequence": 190,
     "domain": "organization",
     "apiId": "STUDY-GROUP-102",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2256,7 +2280,7 @@
     "operationId": null
   },
   {
-    "sequence": 189,
+    "sequence": 191,
     "domain": "organization",
     "apiId": "STUDY-GROUP-SCHEDULE-001",
     "endpoint": "/api/v1/study-groups/schedules",
@@ -2268,7 +2292,7 @@
     "operationId": null
   },
   {
-    "sequence": 190,
+    "sequence": 192,
     "domain": "project",
     "apiId": "APPLY-001",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2280,7 +2304,7 @@
     "operationId": null
   },
   {
-    "sequence": 191,
+    "sequence": 193,
     "domain": "project",
     "apiId": "APPLY-002",
     "endpoint": "/api/v1/projects/{projectId}/applications/me",
@@ -2292,7 +2316,7 @@
     "operationId": null
   },
   {
-    "sequence": 192,
+    "sequence": 194,
     "domain": "project",
     "apiId": "APPLY-003",
     "endpoint": "/api/v1/projects/{projectId}/applications/me/submit",
@@ -2304,7 +2328,7 @@
     "operationId": null
   },
   {
-    "sequence": 193,
+    "sequence": 195,
     "domain": "project",
     "apiId": "APPLY-004",
     "endpoint": "/api/v1/projects/me/applications",
@@ -2316,7 +2340,7 @@
     "operationId": null
   },
   {
-    "sequence": 194,
+    "sequence": 196,
     "domain": "project",
     "apiId": "APPLY-005",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2328,7 +2352,7 @@
     "operationId": null
   },
   {
-    "sequence": 195,
+    "sequence": 197,
     "domain": "project",
     "apiId": "APPLY-101",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2340,7 +2364,7 @@
     "operationId": null
   },
   {
-    "sequence": 196,
+    "sequence": 198,
     "domain": "project",
     "apiId": "APPLY-102",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2352,7 +2376,7 @@
     "operationId": null
   },
   {
-    "sequence": 197,
+    "sequence": 199,
     "domain": "project",
     "apiId": "APPLY-103",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}/decision",
@@ -2364,7 +2388,7 @@
     "operationId": null
   },
   {
-    "sequence": 198,
+    "sequence": 200,
     "domain": "project",
     "apiId": "PROJECT-001",
     "endpoint": "/api/v1/projects",
@@ -2372,11 +2396,11 @@
     "role": "프로젝트 목록 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 43,
+    "line": 46,
     "operationId": null
   },
   {
-    "sequence": 199,
+    "sequence": 201,
     "domain": "project",
     "apiId": "PROJECT-002",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2384,11 +2408,11 @@
     "role": "프로젝트 상세 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 62,
+    "line": 65,
     "operationId": null
   },
   {
-    "sequence": 200,
+    "sequence": 202,
     "domain": "project",
     "apiId": "PROJECT-003",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -2396,23 +2420,11 @@
     "role": "프로젝트 팀원 구성 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 80,
+    "line": 83,
     "operationId": null
   },
   {
-    "sequence": 201,
-    "domain": "project",
-    "apiId": "PROJECT-004",
-    "endpoint": "/api/v1/projects/members",
-    "httpMethod": "GET",
-    "role": "프로젝트 팀원 구성 일괄 조회",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 98,
-    "operationId": null
-  },
-  {
-    "sequence": 202,
+    "sequence": 203,
     "domain": "project",
     "apiId": "PROJECT-004",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -2424,7 +2436,7 @@
     "operationId": null
   },
   {
-    "sequence": 203,
+    "sequence": 204,
     "domain": "project",
     "apiId": "PROJECT-005",
     "endpoint": "/api/v1/projects/{projectId}/members/{memberId}",
@@ -2436,7 +2448,7 @@
     "operationId": null
   },
   {
-    "sequence": 204,
+    "sequence": 205,
     "domain": "project",
     "apiId": "PROJECT-006",
     "endpoint": "/api/v1/projects/me/managed",
@@ -2444,11 +2456,23 @@
     "role": "내가 관리하는 프로젝트 목록",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 115,
+    "line": 118,
     "operationId": null
   },
   {
-    "sequence": 205,
+    "sequence": 206,
+    "domain": "project",
+    "apiId": "PROJECT-007",
+    "endpoint": "/api/v1/projects/members",
+    "httpMethod": "GET",
+    "role": "프로젝트 팀원 구성 일괄 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
+    "line": 101,
+    "operationId": null
+  },
+  {
+    "sequence": 207,
     "domain": "project",
     "apiId": "PROJECT-101",
     "endpoint": "/api/v1/projects",
@@ -2460,7 +2484,7 @@
     "operationId": null
   },
   {
-    "sequence": 206,
+    "sequence": 208,
     "domain": "project",
     "apiId": "PROJECT-102",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2472,7 +2496,7 @@
     "operationId": null
   },
   {
-    "sequence": 207,
+    "sequence": 209,
     "domain": "project",
     "apiId": "PROJECT-103",
     "endpoint": "/api/v1/projects/me/draft",
@@ -2480,11 +2504,11 @@
     "role": "내 Draft 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 134,
+    "line": 137,
     "operationId": null
   },
   {
-    "sequence": 208,
+    "sequence": 210,
     "domain": "project",
     "apiId": "PROJECT-104",
     "endpoint": "/api/v1/projects/{projectId}/transfer-ownership",
@@ -2496,7 +2520,7 @@
     "operationId": null
   },
   {
-    "sequence": 209,
+    "sequence": 211,
     "domain": "project",
     "apiId": "PROJECT-105",
     "endpoint": "/api/v1/projects/{projectId}/part-quotas",
@@ -2508,7 +2532,7 @@
     "operationId": null
   },
   {
-    "sequence": 210,
+    "sequence": 212,
     "domain": "project",
     "apiId": "PROJECT-106",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -2520,7 +2544,7 @@
     "operationId": null
   },
   {
-    "sequence": 211,
+    "sequence": 213,
     "domain": "project",
     "apiId": "PROJECT-106-GET",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -2532,7 +2556,7 @@
     "operationId": null
   },
   {
-    "sequence": 212,
+    "sequence": 214,
     "domain": "project",
     "apiId": "PROJECT-107",
     "endpoint": "/api/v1/projects/{projectId}/submit",
@@ -2544,7 +2568,7 @@
     "operationId": null
   },
   {
-    "sequence": 213,
+    "sequence": 215,
     "domain": "project",
     "apiId": "PROJECT-108",
     "endpoint": "/api/v1/projects/{projectId}/publish",
@@ -2556,7 +2580,7 @@
     "operationId": null
   },
   {
-    "sequence": 214,
+    "sequence": 216,
     "domain": "project",
     "apiId": "PROJECT-109",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2568,7 +2592,7 @@
     "operationId": null
   },
   {
-    "sequence": 215,
+    "sequence": 217,
     "domain": "project",
     "apiId": "PROJECT-110",
     "endpoint": "/api/v1/projects/{projectId}/abort",
@@ -2580,7 +2604,7 @@
     "operationId": null
   },
   {
-    "sequence": 216,
+    "sequence": 218,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-001",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -2592,7 +2616,7 @@
     "operationId": null
   },
   {
-    "sequence": 217,
+    "sequence": 219,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-101",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -2604,7 +2628,7 @@
     "operationId": null
   },
   {
-    "sequence": 218,
+    "sequence": 220,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-102",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -2616,7 +2640,7 @@
     "operationId": null
   },
   {
-    "sequence": 219,
+    "sequence": 221,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-103",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -2628,7 +2652,7 @@
     "operationId": null
   },
   {
-    "sequence": 220,
+    "sequence": 222,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-201",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide",
@@ -2640,7 +2664,7 @@
     "operationId": null
   },
   {
-    "sequence": 221,
+    "sequence": 223,
     "domain": "project",
     "apiId": "PROJECT-STAT-001",
     "endpoint": "/api/v1/projects/{projectId}/statistics",
@@ -2652,7 +2676,7 @@
     "operationId": null
   },
   {
-    "sequence": 222,
+    "sequence": 224,
     "domain": "project",
     "apiId": "PROJECT-STAT-002",
     "endpoint": "/api/v1/projects/statistics",
@@ -2664,7 +2688,7 @@
     "operationId": null
   },
   {
-    "sequence": 223,
+    "sequence": 225,
     "domain": "schedule",
     "apiId": "SCHEDULE-C001",
     "endpoint": "/api/v2/schedules",
@@ -2676,7 +2700,7 @@
     "operationId": null
   },
   {
-    "sequence": 224,
+    "sequence": 226,
     "domain": "schedule",
     "apiId": "SCHEDULE-C002",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2688,7 +2712,7 @@
     "operationId": null
   },
   {
-    "sequence": 225,
+    "sequence": 227,
     "domain": "schedule",
     "apiId": "SCHEDULE-C003",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/request",
@@ -2700,7 +2724,7 @@
     "operationId": null
   },
   {
-    "sequence": 226,
+    "sequence": 228,
     "domain": "schedule",
     "apiId": "SCHEDULE-C004",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/excuse",
@@ -2712,7 +2736,7 @@
     "operationId": null
   },
   {
-    "sequence": 227,
+    "sequence": 229,
     "domain": "schedule",
     "apiId": "SCHEDULE-C005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/decide",
@@ -2724,7 +2748,7 @@
     "operationId": null
   },
   {
-    "sequence": 228,
+    "sequence": 230,
     "domain": "schedule",
     "apiId": "SCHEDULE-C006",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2736,7 +2760,7 @@
     "operationId": null
   },
   {
-    "sequence": 229,
+    "sequence": 231,
     "domain": "schedule",
     "apiId": "SCHEDULE-C007",
     "endpoint": "/api/v2/schedules/{scheduleId}/force",
@@ -2748,7 +2772,7 @@
     "operationId": null
   },
   {
-    "sequence": 230,
+    "sequence": 232,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q001",
     "endpoint": "/api/v2/schedules/capabilities",
@@ -2760,7 +2784,7 @@
     "operationId": null
   },
   {
-    "sequence": 231,
+    "sequence": 233,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q002",
     "endpoint": "/api/v2/schedules/me",
@@ -2772,7 +2796,7 @@
     "operationId": null
   },
   {
-    "sequence": 232,
+    "sequence": 234,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q003",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2784,7 +2808,7 @@
     "operationId": null
   },
   {
-    "sequence": 233,
+    "sequence": 235,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q004",
     "endpoint": "/api/v2/schedules/attendance",
@@ -2796,7 +2820,7 @@
     "operationId": null
   },
   {
-    "sequence": 234,
+    "sequence": 236,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendance",
@@ -2808,7 +2832,7 @@
     "operationId": null
   },
   {
-    "sequence": 235,
+    "sequence": 237,
     "domain": "storage",
     "apiId": "STORAGE-001",
     "endpoint": "/api/v1/storage/prepare-upload",
@@ -2820,7 +2844,7 @@
     "operationId": null
   },
   {
-    "sequence": 236,
+    "sequence": 238,
     "domain": "storage",
     "apiId": "STORAGE-002",
     "endpoint": "/api/v1/storage/{fileId}/confirm",
@@ -2832,7 +2856,7 @@
     "operationId": null
   },
   {
-    "sequence": 237,
+    "sequence": 239,
     "domain": "storage",
     "apiId": "STORAGE-003",
     "endpoint": "/api/v1/storage/{fileId}",
@@ -2844,7 +2868,7 @@
     "operationId": null
   },
   {
-    "sequence": 238,
+    "sequence": 240,
     "domain": "term",
     "apiId": "TERM-001",
     "endpoint": "/api/v1/terms",
@@ -2852,11 +2876,11 @@
     "role": "약관 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 48,
+    "line": 71,
     "operationId": null
   },
   {
-    "sequence": 239,
+    "sequence": 241,
     "domain": "term",
     "apiId": "TERM-101",
     "endpoint": "/api/v1/terms/type/{termType}",
@@ -2864,11 +2888,11 @@
     "role": "약관 유형으로 약관 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 35,
+    "line": 50,
     "operationId": null
   },
   {
-    "sequence": 240,
+    "sequence": 242,
     "domain": "term",
     "apiId": "TERM-102",
     "endpoint": "/api/v1/terms/{termsId}",
@@ -2876,11 +2900,35 @@
     "role": "약관 ID로 약관 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 42,
+    "line": 57,
     "operationId": null
   },
   {
-    "sequence": 241,
+    "sequence": 243,
+    "domain": "term",
+    "apiId": "TERM-103",
+    "endpoint": "/api/v1/terms/consent-status/me",
+    "httpMethod": "GET",
+    "role": "내 필수 약관 재동의 상태 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
+    "line": 63,
+    "operationId": null
+  },
+  {
+    "sequence": 244,
+    "domain": "term",
+    "apiId": "TERM-104",
+    "endpoint": "/api/v1/terms",
+    "httpMethod": "GET",
+    "role": "활성 약관 전체 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
+    "line": 43,
+    "operationId": null
+  },
+  {
+    "sequence": 245,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/email/send-test",
@@ -2888,11 +2936,11 @@
     "role": "<요약 없음>",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 82,
+    "line": 85,
     "operationId": null
   },
   {
-    "sequence": 242,
+    "sequence": 246,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/log-test",
@@ -2900,11 +2948,11 @@
     "role": "<요약 없음>",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 209,
+    "line": 212,
     "operationId": null
   },
   {
-    "sequence": 243,
+    "sequence": 247,
     "domain": "test",
     "apiId": "SEED-001",
     "endpoint": "/test/seed/members",
@@ -2912,11 +2960,11 @@
     "role": "더미 멤버 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 57,
+    "line": 63,
     "operationId": "SEED-001"
   },
   {
-    "sequence": 244,
+    "sequence": 248,
     "domain": "test",
     "apiId": "SEED-002",
     "endpoint": "/test/seed/challengers",
@@ -2924,11 +2972,11 @@
     "role": "챌린저 분포 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 73,
+    "line": 79,
     "operationId": "SEED-002"
   },
   {
-    "sequence": 245,
+    "sequence": 249,
     "domain": "test",
     "apiId": "SEED-003",
     "endpoint": "/test/seed/projects",
@@ -2936,11 +2984,11 @@
     "role": "프로젝트 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 88,
+    "line": 94,
     "operationId": "SEED-003"
   },
   {
-    "sequence": 246,
+    "sequence": 250,
     "domain": "test",
     "apiId": "SEED-003-S",
     "endpoint": "/test/seed/projects/scenarios",
@@ -2948,11 +2996,11 @@
     "role": "프로젝트 시나리오 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 104,
+    "line": 110,
     "operationId": "SEED-003-S"
   },
   {
-    "sequence": 247,
+    "sequence": 251,
     "domain": "test",
     "apiId": "SEED-004",
     "endpoint": "/test/seed/curriculum",
@@ -2960,11 +3008,11 @@
     "role": "Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 125,
+    "line": 132,
     "operationId": "SEED-004"
   },
   {
-    "sequence": 248,
+    "sequence": 252,
     "domain": "test",
     "apiId": "SEED-005",
     "endpoint": "/test/seed/notice",
@@ -2972,11 +3020,23 @@
     "role": "Notice 시딩 (지부 · 학교 · 파트 분포)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 140,
+    "line": 147,
     "operationId": "SEED-005"
   },
   {
-    "sequence": 249,
+    "sequence": 253,
+    "domain": "test",
+    "apiId": "SEED-006",
+    "endpoint": "/test/seed/project-applications",
+    "httpMethod": "POST",
+    "role": "지원서 시나리오 시딩",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
+    "line": 166,
+    "operationId": null
+  },
+  {
+    "sequence": 254,
     "domain": "test",
     "apiId": "TEST-001",
     "endpoint": "/test/file/{fileId}",
@@ -2984,11 +3044,11 @@
     "role": "[개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 62,
+    "line": 65,
     "operationId": "TEST-001"
   },
   {
-    "sequence": 250,
+    "sequence": 255,
     "domain": "test",
     "apiId": "TEST-002",
     "endpoint": "/test/fcm/test-send",
@@ -2996,11 +3056,11 @@
     "role": "FCM 푸시 알림 테스트 전송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 74,
+    "line": 77,
     "operationId": "TEST-002"
   },
   {
-    "sequence": 251,
+    "sequence": 256,
     "domain": "test",
     "apiId": "TEST-003",
     "endpoint": "/test/webhook/aop-test",
@@ -3008,11 +3068,11 @@
     "role": "AOP로 전송하는 알람 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 101,
+    "line": 104,
     "operationId": "TEST-003"
   },
   {
-    "sequence": 252,
+    "sequence": 257,
     "domain": "test",
     "apiId": "TEST-004",
     "endpoint": "/test/webhook/alarm",
@@ -3020,11 +3080,11 @@
     "role": "웹훅 알람 전송 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 114,
+    "line": 117,
     "operationId": "TEST-004"
   },
   {
-    "sequence": 253,
+    "sequence": 258,
     "domain": "test",
     "apiId": "TEST-005",
     "endpoint": "/test/webhook/alarm/buffer",
@@ -3032,11 +3092,11 @@
     "role": "웹훅 알람 버퍼 전송 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 130,
+    "line": 133,
     "operationId": "TEST-005"
   },
   {
-    "sequence": 254,
+    "sequence": 259,
     "domain": "test",
     "apiId": "TEST-006",
     "endpoint": "/test/apple-client-secret",
@@ -3044,11 +3104,11 @@
     "role": "Apple Client Secret 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 151,
+    "line": 154,
     "operationId": "TEST-006"
   },
   {
-    "sequence": 255,
+    "sequence": 260,
     "domain": "test",
     "apiId": "TEST-007",
     "endpoint": "/test/token/access",
@@ -3056,11 +3116,11 @@
     "role": "AccessToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 157,
+    "line": 160,
     "operationId": "TEST-007"
   },
   {
-    "sequence": 256,
+    "sequence": 261,
     "domain": "test",
     "apiId": "TEST-008",
     "endpoint": "/test/token/refresh",
@@ -3068,11 +3128,11 @@
     "role": "RefreshToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 170,
+    "line": 173,
     "operationId": "TEST-008"
   },
   {
-    "sequence": 257,
+    "sequence": 262,
     "domain": "test",
     "apiId": "TEST-009",
     "endpoint": "/test/token/email",
@@ -3080,11 +3140,11 @@
     "role": "EmailVerificationToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 177,
+    "line": 180,
     "operationId": "TEST-009"
   },
   {
-    "sequence": 258,
+    "sequence": 263,
     "domain": "test",
     "apiId": "TEST-010",
     "endpoint": "/test/token/oauth",
@@ -3092,11 +3152,11 @@
     "role": "oAuthVerificationToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 187,
+    "line": 190,
     "operationId": "TEST-010"
   },
   {
-    "sequence": 259,
+    "sequence": 264,
     "domain": "test",
     "apiId": "TEST-011",
     "endpoint": "/test/health-check",
@@ -3104,11 +3164,11 @@
     "role": "헬스 체크 API",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 195,
+    "line": 198,
     "operationId": "TEST-011"
   },
   {
-    "sequence": 260,
+    "sequence": 265,
     "domain": "test",
     "apiId": "TEST-012",
     "endpoint": "/test/check-authenticated",
@@ -3116,7 +3176,7 @@
     "role": "인증된 사용자인지 여부를 확인합니다.",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 202,
+    "line": 205,
     "operationId": "TEST-012"
   }
 ]

--- a/docs/guides/API_목록.md
+++ b/docs/guides/API_목록.md
@@ -25,10 +25,10 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 8 | authentication | CREDENTIAL-002 | POST | `/api/v1/auth/credentials` | 비밀번호 자격증명 최초 등록 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:45` |
-| 9 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:58` |
-| 10 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:87` |
-| 11 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:71` |
+| 8 | authentication | CREDENTIAL-002 | POST | `/api/v1/auth/credentials` | 비밀번호 자격증명 최초 등록 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:47` |
+| 9 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:60` |
+| 10 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:89` |
+| 11 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:73` |
 | 12 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:34` |
 | 13 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:60` |
 | 14 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:85` |
@@ -36,7 +36,7 @@
 | 16 | authentication | LOGIN-005 | POST | `/api/v1/auth/login/kakao` | Kakao 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:32` |
 | 17 | authentication | LOGIN-006 | POST | `/api/v1/auth/login/kakao/code` | Kakao 로그인 (Authorization Code 흐름) | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:50` |
 | 18 | authentication | LOGIN-010 | POST | `/api/v1/auth/login/apple` | Apple 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:68` |
-| 19 | authentication | LOGIN-011 | POST | `/api/v1/auth/login/email` | 이메일/PW 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:98` |
+| 19 | authentication | LOGIN-011 | POST | `/api/v1/auth/login/email` | 이메일/PW 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:100` |
 | 20 | authentication | OAUTH-001 | POST | `/api/v1/member-oauth` | 로그인용 OAuth 수단 추가 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:37` |
 | 21 | authentication | OAUTH-002 | DELETE | `/api/v1/member-oauth/{memberOAuthId}` | 로그인용 OAuth 수단 제거 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:58` |
 | 22 | authentication | OAUTH-101 | GET | `/api/v1/member-oauth/me` | 현재 회원 계정과 연동된 OAuth 정보 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:81` |
@@ -56,24 +56,24 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 29 | challenger | CHALLENGER-001 | POST | `/api/v1/challenger` | 챌린저 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:40` |
-| 30 | challenger | CHALLENGER-002 | POST | `/api/v1/challenger/batch` | 챌린저 batch 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:52` |
-| 31 | challenger | CHALLENGER-003 | POST | `/api/v1/challenger/{challengerId}/deactivate` | 챌린저 비활성화 (제명/탈부 처리) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:70` |
-| 32 | challenger | CHALLENGER-004 | PATCH | `/api/v1/challenger/{challengerId}/part` | 챌린저 파트 변경 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:83` |
-| 33 | challenger | CHALLENGER-005 | DELETE | `/api/v1/challenger/{challengerId}` | [주의] 챌린저 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:99` |
+| 29 | challenger | CHALLENGER-001 | POST | `/api/v1/challenger` | 챌린저 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:46` |
+| 30 | challenger | CHALLENGER-002 | POST | `/api/v1/challenger/batch` | 챌린저 batch 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:58` |
+| 31 | challenger | CHALLENGER-003 | POST | `/api/v1/challenger/{challengerId}/deactivate` | 챌린저 비활성화 (제명/탈부 처리) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:76` |
+| 32 | challenger | CHALLENGER-004 | PATCH | `/api/v1/challenger/{challengerId}/part` | 챌린저 파트 변경 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:89` |
+| 33 | challenger | CHALLENGER-005 | DELETE | `/api/v1/challenger/{challengerId}` | [주의] 챌린저 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:105` |
 | 34 | challenger | CHALLENGER-101 | GET | `/api/v1/challenger/{challengerId}` | 챌린저 정보 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryController.java:44` |
 | 35 | challenger | CHALLENGER-102 | GET | `/api/v1/challenger/search/cursor` | 챌린저 검색 (Cursor 기반) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:29` |
 | 36 | challenger | CHALLENGER-103 | GET | `/api/v1/challenger/search/offset` | 챌린저 검색 (Offset 기반) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:52` |
 | 37 | challenger | CHALLENGER-104 | GET | `/api/v1/challenger/search/global` | deprecated: 챌린저 전체 검색 (Cursor 기반, 일정 생성용) | O | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:66` |
 | 38 | challenger | CHALLENGER-201 | GET | `/api/v2/challenger/search` | 챌린저 검색 v2 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java:31` |
-| 39 | challenger | CHALLENGER-RECORD-001 | POST | `/api/v1/challenger-record/member` | 6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:36` |
-| 40 | challenger | CHALLENGER-RECORD-002 | POST | `/api/v1/challenger-record` | [ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:89` |
-| 41 | challenger | CHALLENGER-RECORD-003 | POST | `/api/v1/challenger-record/bulk` | [ADMIN] 챌린저 기록용 코드 벌크 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:116` |
-| 42 | challenger | CHALLENGER-RECORD-101 | GET | `/api/v1/challenger-record/code/{code}` | 코드로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:65` |
-| 43 | challenger | CHALLENGER-RECORD-102 | GET | `/api/v1/challenger-record/id/{id}` | ID로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:77` |
-| 44 | challenger | POINT-001 | POST | `/api/v1/challenger/{challengerId}/points` | 챌린저 상벌점 부여 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:38` |
-| 45 | challenger | POINT-002 | PATCH | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 사유 수정 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:55` |
-| 46 | challenger | POINT-003 | DELETE | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 삭제 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:70` |
+| 39 | challenger | CHALLENGER-RECORD-001 | POST | `/api/v1/challenger-record/member` | 6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:42` |
+| 40 | challenger | CHALLENGER-RECORD-002 | POST | `/api/v1/challenger-record` | [ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:95` |
+| 41 | challenger | CHALLENGER-RECORD-003 | POST | `/api/v1/challenger-record/bulk` | [ADMIN] 챌린저 기록용 코드 벌크 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:122` |
+| 42 | challenger | CHALLENGER-RECORD-101 | GET | `/api/v1/challenger-record/code/{code}` | 코드로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:71` |
+| 43 | challenger | CHALLENGER-RECORD-102 | GET | `/api/v1/challenger-record/id/{id}` | ID로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:83` |
+| 44 | challenger | POINT-001 | POST | `/api/v1/challenger/{challengerId}/points` | 챌린저 상벌점 부여 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:41` |
+| 45 | challenger | POINT-002 | PATCH | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 사유 수정 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:58` |
+| 46 | challenger | POINT-003 | DELETE | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 삭제 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:73` |
 
 ## community
 
@@ -138,224 +138,234 @@
 | 98 | curriculum | WORKBOOK-102 | GET | `/api/v2/curriculums/challenger-workbooks/{challengerWorkbookId}` | ChallengerWorkbook 상세 조회 | X | `src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java:38` |
 | 99 | curriculum | WORKBOOK-103 | GET | `/api/v2/curriculums/weekly-best-workbooks` | 베스트 워크북 조회 | X | `src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java:54` |
 
+## feedback
+
+| 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
+|---:|---|---|---|---|---|:---:|---|
+| 100 | feedback | <미지정> | POST | `/api/v1/user-feedbacks/responses` | 사용자 피드백 응답 제출 | X | `src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java:58` |
+| 101 | feedback | <미지정> | GET | `/api/v1/user-feedbacks/templates` | 사용자 피드백 템플릿 조회 | X | `src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java:34` |
+
 ## figma
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 100 | figma | FIGMA-001 | GET | `/api/v1/admin/figma/oauth` | Figma OAuth authorize URL 발급 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:32` |
-| 101 | figma | FIGMA-002 | GET | `/api/v1/admin/figma/oauth/callback` | Figma OAuth 콜백 처리 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:47` |
-| 102 | figma | FIGMA-003 | POST | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:37` |
-| 103 | figma | FIGMA-004 | DELETE | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 비활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:47` |
-| 104 | figma | FIGMA-005 | POST | `/api/v1/admin/figma/watched-files/{watchedFileId}/enable` | 폴링 대상 파일 활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:54` |
-| 105 | figma | FIGMA-006 | POST | `/api/v1/admin/figma/sync` | 활성 파일 전체 즉시 동기화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:52` |
-| 106 | figma | FIGMA-007 | POST | `/api/v1/admin/figma/sync/watched-files/{watchedFileId}` | 특정 파일 즉시 동기화 (enabled 무관) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:68` |
-| 107 | figma | FIGMA-008 | GET | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 목록 조회 (enabled 필터) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:61` |
-| 108 | figma | FIGMA-009 | GET | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 단건 조회 (sync 상태 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:72` |
-| 109 | figma | FIGMA-010 | GET | `/api/v1/admin/figma/preview` | 특정 시간대 미리보기 (Discord 발송 X, dispatch / cursor 비변경) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:100` |
-| 110 | figma | FIGMA-011 | POST | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:46` |
-| 111 | figma | FIGMA-012 | DELETE | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 삭제 (mention 도 cascade) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:67` |
-| 112 | figma | FIGMA-013 | POST | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인에 담당자 mention 추가 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:75` |
-| 113 | figma | FIGMA-014 | DELETE | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 삭제 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:97` |
-| 114 | figma | FIGMA-015 | POST | `/api/v1/admin/figma/digest` | 특정 시간대 catch-up | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:82` |
-| 115 | figma | FIGMA-016 | GET | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 목록 조회 (mention 본문 미포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:105` |
-| 116 | figma | FIGMA-017 | GET | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 단건 조회 (mention 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:114` |
-| 117 | figma | FIGMA-018 | GET | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인의 담당자 mention 목록 조회 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:121` |
-| 118 | figma | FIGMA-019 | PATCH | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 수정 (설명 · webhook URL · fallback) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:56` |
-| 119 | figma | FIGMA-020 | PATCH | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 수정 (Discord ID · 라벨) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:86` |
+| 102 | figma | FIGMA-001 | GET | `/api/v1/admin/figma/oauth` | Figma OAuth authorize URL 발급 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:32` |
+| 103 | figma | FIGMA-002 | GET | `/api/v1/admin/figma/oauth/callback` | Figma OAuth 콜백 처리 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:47` |
+| 104 | figma | FIGMA-003 | POST | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:37` |
+| 105 | figma | FIGMA-004 | DELETE | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 비활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:47` |
+| 106 | figma | FIGMA-005 | POST | `/api/v1/admin/figma/watched-files/{watchedFileId}/enable` | 폴링 대상 파일 활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:54` |
+| 107 | figma | FIGMA-006 | POST | `/api/v1/admin/figma/sync` | 활성 파일 전체 즉시 동기화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:52` |
+| 108 | figma | FIGMA-007 | POST | `/api/v1/admin/figma/sync/watched-files/{watchedFileId}` | 특정 파일 즉시 동기화 (enabled 무관) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:68` |
+| 109 | figma | FIGMA-008 | GET | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 목록 조회 (enabled 필터) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:61` |
+| 110 | figma | FIGMA-009 | GET | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 단건 조회 (sync 상태 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:72` |
+| 111 | figma | FIGMA-010 | GET | `/api/v1/admin/figma/preview` | 특정 시간대 미리보기 (Discord 발송 X, dispatch / cursor 비변경) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:100` |
+| 112 | figma | FIGMA-011 | POST | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:46` |
+| 113 | figma | FIGMA-012 | DELETE | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 삭제 (mention 도 cascade) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:67` |
+| 114 | figma | FIGMA-013 | POST | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인에 담당자 mention 추가 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:75` |
+| 115 | figma | FIGMA-014 | DELETE | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 삭제 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:97` |
+| 116 | figma | FIGMA-015 | POST | `/api/v1/admin/figma/digest` | 특정 시간대 catch-up | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:82` |
+| 117 | figma | FIGMA-016 | GET | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 목록 조회 (mention 본문 미포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:105` |
+| 118 | figma | FIGMA-017 | GET | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 단건 조회 (mention 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:114` |
+| 119 | figma | FIGMA-018 | GET | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인의 담당자 mention 목록 조회 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:121` |
+| 120 | figma | FIGMA-019 | PATCH | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 수정 (설명 · webhook URL · fallback) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:56` |
+| 121 | figma | FIGMA-020 | PATCH | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 수정 (Discord ID · 라벨) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:86` |
 
 ## global
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 120 | global | <미지정> | REQUEST | `/error` | <요약 없음> | X | `src/main/java/com/umc/product/global/exception/CustomErrorController.java:27` |
+| 122 | global | <미지정> | REQUEST | `/error` | <요약 없음> | X | `src/main/java/com/umc/product/global/exception/CustomErrorController.java:27` |
 
 ## maintenance
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 121 | maintenance | MAINT-001 | POST | `/api/v1/admin/maintenance` | 점검 윈도우 생성 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:36` |
-| 122 | maintenance | MAINT-002 | PATCH | `/api/v1/admin/maintenance/{windowId}/end` | 점검 윈도우 강제 종료 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:50` |
-| 123 | maintenance | MAINT-003 | GET | `/api/v1/admin/maintenance` | 점검 윈도우 전체 목록 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:64` |
-| 124 | maintenance | MAINT-004 | GET | `/api/v1/admin/maintenance/{windowId}` | 점검 윈도우 단건 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:76` |
-| 125 | maintenance | SYSTEM-001 | GET | `/api/v1/system/status` | 시스템 점검 상태 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/SystemStatusController.java:23` |
+| 123 | maintenance | MAINT-001 | POST | `/api/v1/admin/maintenance` | 점검 윈도우 생성 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:36` |
+| 124 | maintenance | MAINT-002 | PATCH | `/api/v1/admin/maintenance/{windowId}/end` | 점검 윈도우 강제 종료 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:50` |
+| 125 | maintenance | MAINT-003 | GET | `/api/v1/admin/maintenance` | 점검 윈도우 전체 목록 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:64` |
+| 126 | maintenance | MAINT-004 | GET | `/api/v1/admin/maintenance/{windowId}` | 점검 윈도우 단건 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:76` |
+| 127 | maintenance | SYSTEM-001 | GET | `/api/v1/system/status` | 시스템 점검 상태 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/SystemStatusController.java:23` |
 
 ## member
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 126 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:128` |
-| 127 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:142` |
-| 128 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:156` |
-| 129 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:169` |
-| 130 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
-| 131 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
-| 132 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
-| 133 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
-| 134 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
-| 135 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:59` |
-| 136 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:101` |
+| 128 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:130` |
+| 129 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:144` |
+| 130 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:158` |
+| 131 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:171` |
+| 132 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
+| 133 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
+| 134 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
+| 135 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
+| 136 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
+| 137 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:61` |
+| 138 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:103` |
 
 ## notice
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 137 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
-| 138 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
-| 139 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
-| 140 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
-| 141 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
-| 142 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
-| 143 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
-| 144 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
-| 145 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
-| 146 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
-| 147 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
-| 148 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
-| 149 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
-| 150 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
-| 151 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
-| 152 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
-| 153 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
-| 154 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
+| 139 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
+| 140 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
+| 141 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
+| 142 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
+| 143 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
+| 144 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
+| 145 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
+| 146 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
+| 147 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
+| 148 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
+| 149 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
+| 150 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
+| 151 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
+| 152 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
+| 153 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
+| 154 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
+| 155 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
+| 156 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
 
 ## notification
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 155 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
-| 156 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
+| 157 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
+| 158 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
 
 ## organization
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 157 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
-| 158 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
-| 159 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
-| 160 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
-| 161 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
-| 162 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
-| 163 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
-| 164 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
-| 165 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
-| 166 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
-| 167 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
-| 168 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
-| 169 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
-| 170 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
-| 171 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
-| 172 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
-| 173 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
-| 174 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
-| 175 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
-| 176 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
-| 177 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
-| 178 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
-| 179 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
-| 180 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
-| 181 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
-| 182 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
-| 183 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
-| 184 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
-| 185 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
-| 186 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
-| 187 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
-| 188 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
-| 189 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 159 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
+| 160 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
+| 161 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
+| 162 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
+| 163 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
+| 164 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
+| 165 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
+| 166 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
+| 167 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
+| 168 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
+| 169 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
+| 170 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
+| 171 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
+| 172 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
+| 173 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
+| 174 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
+| 175 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
+| 176 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
+| 177 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
+| 178 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
+| 179 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
+| 180 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
+| 181 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
+| 182 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
+| 183 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
+| 184 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
+| 185 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
+| 186 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
+| 187 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
+| 188 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
+| 189 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
+| 190 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
+| 191 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
 
 ## project
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 190 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:47` |
-| 191 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:70` |
-| 192 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:93` |
-| 193 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:37` |
-| 194 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:147` |
-| 195 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:76` |
-| 196 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:127` |
-| 197 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:118` |
-| 198 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:43` |
-| 199 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:62` |
-| 200 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:80` |
-| 201 | project | PROJECT-004 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:98` |
-| 202 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:142` |
-| 203 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:244` |
-| 204 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:115` |
-| 205 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:62` |
-| 206 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:81` |
-| 207 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:134` |
-| 208 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:122` |
-| 209 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:184` |
-| 210 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:35` |
-| 211 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:56` |
-| 212 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:102` |
-| 213 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:162` |
-| 214 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:204` |
-| 215 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:225` |
-| 216 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
-| 217 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
-| 218 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
-| 219 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
-| 220 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
-| 221 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:30` |
-| 222 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:56` |
+| 192 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:47` |
+| 193 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:70` |
+| 194 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:93` |
+| 195 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:37` |
+| 196 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:147` |
+| 197 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:76` |
+| 198 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:127` |
+| 199 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:118` |
+| 200 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
+| 201 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
+| 202 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
+| 203 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:142` |
+| 204 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:244` |
+| 205 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
+| 206 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
+| 207 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:62` |
+| 208 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:81` |
+| 209 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
+| 210 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:122` |
+| 211 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:184` |
+| 212 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:35` |
+| 213 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:56` |
+| 214 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:102` |
+| 215 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:162` |
+| 216 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:204` |
+| 217 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:225` |
+| 218 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
+| 219 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
+| 220 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
+| 221 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
+| 222 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
+| 223 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:30` |
+| 224 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:56` |
 
 ## schedule
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 223 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:59` |
-| 224 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:125` |
-| 225 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:263` |
-| 226 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:312` |
-| 227 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:359` |
-| 228 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:186` |
-| 229 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:227` |
-| 230 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:42` |
-| 231 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:66` |
-| 232 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:103` |
-| 233 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:143` |
-| 234 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:206` |
+| 225 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:59` |
+| 226 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:125` |
+| 227 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:263` |
+| 228 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:312` |
+| 229 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:359` |
+| 230 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:186` |
+| 231 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:227` |
+| 232 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:42` |
+| 233 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:66` |
+| 234 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:103` |
+| 235 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:143` |
+| 236 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:206` |
 
 ## storage
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 235 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:35` |
-| 236 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:57` |
-| 237 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:67` |
+| 237 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:35` |
+| 238 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:57` |
+| 239 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:67` |
 
 ## term
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 238 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:48` |
-| 239 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:35` |
-| 240 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:42` |
+| 240 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
+| 241 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
+| 242 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
+| 243 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
+| 244 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
 
 ## test
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 241 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:82` |
-| 242 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:209` |
-| 243 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:57` |
-| 244 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:73` |
-| 245 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:88` |
-| 246 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:104` |
-| 247 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:125` |
-| 248 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:140` |
-| 249 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:62` |
-| 250 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:74` |
-| 251 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:101` |
-| 252 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:114` |
-| 253 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:130` |
-| 254 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:151` |
-| 255 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:157` |
-| 256 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:170` |
-| 257 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:177` |
-| 258 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:187` |
-| 259 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:195` |
-| 260 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:202` |
+| 245 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
+| 246 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
+| 247 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:63` |
+| 248 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:79` |
+| 249 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:94` |
+| 250 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:110` |
+| 251 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:132` |
+| 252 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:147` |
+| 253 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:166` |
+| 254 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
+| 255 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
+| 256 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
+| 257 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
+| 258 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
+| 259 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
+| 260 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
+| 261 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
+| 262 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
+| 263 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
+| 264 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
+| 265 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
 

--- a/docs/guides/ErrorCode_목록.json
+++ b/docs/guides/ErrorCode_목록.json
@@ -1222,6 +1222,17 @@
   },
   {
     "sequence": 112,
+    "domain": "feedback",
+    "enumName": "FeedbackErrorCode",
+    "constantName": "USER_FEEDBACK_TEMPLATE_NOT_FOUND",
+    "httpStatus": "NOT_FOUND",
+    "code": "FEEDBACK-0001",
+    "message": "사용자 피드백 템플릿을 찾을 수 없습니다.",
+    "source": "src/main/java/com/umc/product/feedback/domain/exception/FeedbackErrorCode.java",
+    "line": 15
+  },
+  {
+    "sequence": 113,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "INTEGRATION_NOT_FOUND",
@@ -1232,7 +1243,7 @@
     "line": 12
   },
   {
-    "sequence": 113,
+    "sequence": 114,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_TOKEN_EXCHANGE_FAILED",
@@ -1243,7 +1254,7 @@
     "line": 13
   },
   {
-    "sequence": 114,
+    "sequence": 115,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_TOKEN_REFRESH_FAILED",
@@ -1254,7 +1265,7 @@
     "line": 14
   },
   {
-    "sequence": 115,
+    "sequence": 116,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "COMMENT_FETCH_FAILED",
@@ -1265,7 +1276,7 @@
     "line": 15
   },
   {
-    "sequence": 116,
+    "sequence": 117,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "FILE_METADATA_FETCH_FAILED",
@@ -1276,7 +1287,7 @@
     "line": 16
   },
   {
-    "sequence": 117,
+    "sequence": 118,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "WATCHED_FILE_NOT_FOUND",
@@ -1287,7 +1298,7 @@
     "line": 17
   },
   {
-    "sequence": 118,
+    "sequence": 119,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "WATCHED_FILE_ALREADY_EXISTS",
@@ -1298,7 +1309,7 @@
     "line": 18
   },
   {
-    "sequence": 119,
+    "sequence": 120,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_STATE_MISMATCH",
@@ -1309,7 +1320,7 @@
     "line": 19
   },
   {
-    "sequence": 120,
+    "sequence": 121,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "TOKEN_ENCRYPTION_FAILED",
@@ -1320,7 +1331,7 @@
     "line": 20
   },
   {
-    "sequence": 121,
+    "sequence": 122,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "DISCORD_MENTION_SEND_FAILED",
@@ -1331,7 +1342,7 @@
     "line": 21
   },
   {
-    "sequence": 122,
+    "sequence": 123,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_NOT_FOUND",
@@ -1342,7 +1353,7 @@
     "line": 22
   },
   {
-    "sequence": 123,
+    "sequence": 124,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_ALREADY_EXISTS",
@@ -1353,7 +1364,7 @@
     "line": 23
   },
   {
-    "sequence": 124,
+    "sequence": 125,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_MENTION_NOT_FOUND",
@@ -1364,7 +1375,7 @@
     "line": 24
   },
   {
-    "sequence": 125,
+    "sequence": 126,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_NOT_REGISTERED",
@@ -1375,7 +1386,7 @@
     "line": 25
   },
   {
-    "sequence": 126,
+    "sequence": 127,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "DIGEST_RANGE_INVALID",
@@ -1386,7 +1397,7 @@
     "line": 26
   },
   {
-    "sequence": 127,
+    "sequence": 128,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "INTERNAL_SERVER_ERROR",
@@ -1397,7 +1408,7 @@
     "line": 24
   },
   {
-    "sequence": 128,
+    "sequence": 129,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "BAD_REQUEST",
@@ -1408,7 +1419,7 @@
     "line": 26
   },
   {
-    "sequence": 129,
+    "sequence": 130,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "UNAUTHORIZED",
@@ -1419,7 +1430,7 @@
     "line": 27
   },
   {
-    "sequence": 130,
+    "sequence": 131,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "FORBIDDEN",
@@ -1430,7 +1441,7 @@
     "line": 28
   },
   {
-    "sequence": 131,
+    "sequence": 132,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "NOT_FOUND",
@@ -1441,7 +1452,7 @@
     "line": 29
   },
   {
-    "sequence": 132,
+    "sequence": 133,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "NOT_IMPLEMENTED",
@@ -1452,7 +1463,7 @@
     "line": 30
   },
   {
-    "sequence": 133,
+    "sequence": 134,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "INVALID_ENV",
@@ -1463,7 +1474,7 @@
     "line": 37
   },
   {
-    "sequence": 134,
+    "sequence": 135,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "PERMISSION_TYPE_NOT_IMPLEMENTED",
@@ -1474,7 +1485,7 @@
     "line": 40
   },
   {
-    "sequence": 135,
+    "sequence": 136,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "SECURITY_NOT_GIVEN",
@@ -1485,7 +1496,7 @@
     "line": 33
   },
   {
-    "sequence": 136,
+    "sequence": 137,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "SECURITY_FORBIDDEN",
@@ -1496,7 +1507,7 @@
     "line": 34
   },
   {
-    "sequence": 137,
+    "sequence": 138,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "CHAT_COMPLETION_FAILED",
@@ -1507,7 +1518,7 @@
     "line": 12
   },
   {
-    "sequence": 138,
+    "sequence": 139,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "CHAT_COMPLETION_INVALID_RESPONSE",
@@ -1518,7 +1529,7 @@
     "line": 13
   },
   {
-    "sequence": 139,
+    "sequence": 140,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "PROVIDER_NOT_CONFIGURED",
@@ -1529,7 +1540,7 @@
     "line": 14
   },
   {
-    "sequence": 140,
+    "sequence": 141,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "SERVICE_UNDER_MAINTENANCE",
@@ -1540,7 +1551,7 @@
     "line": 12
   },
   {
-    "sequence": 141,
+    "sequence": 142,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "MAINTENANCE_WINDOW_NOT_FOUND",
@@ -1551,7 +1562,7 @@
     "line": 13
   },
   {
-    "sequence": 142,
+    "sequence": 143,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "INVALID_TIME_RANGE",
@@ -1562,7 +1573,7 @@
     "line": 14
   },
   {
-    "sequence": 143,
+    "sequence": 144,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "START_AT_IN_PAST",
@@ -1573,7 +1584,7 @@
     "line": 15
   },
   {
-    "sequence": 144,
+    "sequence": 145,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "TARGET_DOMAINS_REQUIRED",
@@ -1584,7 +1595,7 @@
     "line": 16
   },
   {
-    "sequence": 145,
+    "sequence": 146,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "OVERLAPPING_WINDOW",
@@ -1595,7 +1606,7 @@
     "line": 17
   },
   {
-    "sequence": 146,
+    "sequence": 147,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "ALREADY_ENDED",
@@ -1606,7 +1617,7 @@
     "line": 18
   },
   {
-    "sequence": 147,
+    "sequence": 148,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "NOT_SUPER_ADMIN",
@@ -1617,7 +1628,7 @@
     "line": 19
   },
   {
-    "sequence": 148,
+    "sequence": 149,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_NOT_FOUND",
@@ -1628,7 +1639,7 @@
     "line": 12
   },
   {
-    "sequence": 149,
+    "sequence": 150,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_EXISTS",
@@ -1639,7 +1650,7 @@
     "line": 13
   },
   {
-    "sequence": 150,
+    "sequence": 151,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "EMAIL_ALREADY_EXISTS",
@@ -1650,7 +1661,7 @@
     "line": 14
   },
   {
-    "sequence": 151,
+    "sequence": 152,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_WITHDRAWN",
@@ -1661,7 +1672,7 @@
     "line": 15
   },
   {
-    "sequence": 152,
+    "sequence": 153,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_MEMBER_STATUS",
@@ -1672,7 +1683,7 @@
     "line": 16
   },
   {
-    "sequence": 153,
+    "sequence": 154,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_NOT_ACTIVE",
@@ -1683,7 +1694,7 @@
     "line": 17
   },
   {
-    "sequence": 154,
+    "sequence": 155,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_REGISTERED",
@@ -1694,7 +1705,7 @@
     "line": 18
   },
   {
-    "sequence": 155,
+    "sequence": 156,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_PROFILE_NOT_FOUND",
@@ -1705,7 +1716,7 @@
     "line": 19
   },
   {
-    "sequence": 156,
+    "sequence": 157,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_SCHOOL_NOT_ASSIGNED",
@@ -1716,7 +1727,7 @@
     "line": 20
   },
   {
-    "sequence": 157,
+    "sequence": 158,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "CREDENTIAL_ALREADY_REGISTERED",
@@ -1727,7 +1738,7 @@
     "line": 21
   },
   {
-    "sequence": 158,
+    "sequence": 159,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "CREDENTIAL_NOT_REGISTERED",
@@ -1738,7 +1749,7 @@
     "line": 22
   },
   {
-    "sequence": 159,
+    "sequence": 160,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_LOGIN_ID",
@@ -1749,7 +1760,7 @@
     "line": 23
   },
   {
-    "sequence": 160,
+    "sequence": 161,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_PASSWORD",
@@ -1760,7 +1771,7 @@
     "line": 24
   },
   {
-    "sequence": 161,
+    "sequence": 162,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_NOT_FOUND",
@@ -1771,7 +1782,7 @@
     "line": 12
   },
   {
-    "sequence": 162,
+    "sequence": 163,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "ALREADY_PUBLISHED_NOTICE",
@@ -1782,7 +1793,7 @@
     "line": 13
   },
   {
-    "sequence": 163,
+    "sequence": 164,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_TITLE",
@@ -1793,7 +1804,7 @@
     "line": 14
   },
   {
-    "sequence": 164,
+    "sequence": 165,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_CONTENT",
@@ -1804,7 +1815,7 @@
     "line": 15
   },
   {
-    "sequence": 165,
+    "sequence": 166,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_STATUS_FOR_REMINDER",
@@ -1815,7 +1826,7 @@
     "line": 16
   },
   {
-    "sequence": 166,
+    "sequence": 167,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "AUTHOR_REQUIRED",
@@ -1826,7 +1837,7 @@
     "line": 17
   },
   {
-    "sequence": 167,
+    "sequence": 168,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_SCOPE_REQUIRED",
@@ -1837,7 +1848,7 @@
     "line": 18
   },
   {
-    "sequence": 168,
+    "sequence": 169,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_AUTHOR_MISMATCH",
@@ -1848,7 +1859,7 @@
     "line": 19
   },
   {
-    "sequence": 169,
+    "sequence": 170,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_WRITE_PERMISSION",
@@ -1859,7 +1870,7 @@
     "line": 20
   },
   {
-    "sequence": 170,
+    "sequence": 171,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_TARGET_SETTING",
@@ -1870,7 +1881,7 @@
     "line": 22
   },
   {
-    "sequence": 171,
+    "sequence": 172,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_TARGET_FOUND",
@@ -1881,7 +1892,7 @@
     "line": 23
   },
   {
-    "sequence": 172,
+    "sequence": 173,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_READ_PERMISSION",
@@ -1892,7 +1903,7 @@
     "line": 21
   },
   {
-    "sequence": 173,
+    "sequence": 174,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOT_IMPLEMENTED_YET",
@@ -1903,7 +1914,7 @@
     "line": 41
   },
   {
-    "sequence": 174,
+    "sequence": 175,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_IDS_REQUIRED",
@@ -1914,7 +1925,7 @@
     "line": 26
   },
   {
-    "sequence": 175,
+    "sequence": 176,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "IMAGE_URLS_REQUIRED",
@@ -1925,7 +1936,7 @@
     "line": 27
   },
   {
-    "sequence": 176,
+    "sequence": 177,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "LINK_URLS_REQUIRED",
@@ -1936,7 +1947,7 @@
     "line": 28
   },
   {
-    "sequence": 177,
+    "sequence": 178,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_VOTE_NOT_FOUND",
@@ -1947,7 +1958,7 @@
     "line": 29
   },
   {
-    "sequence": 178,
+    "sequence": 179,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_IMAGE_NOT_FOUND",
@@ -1958,7 +1969,7 @@
     "line": 30
   },
   {
-    "sequence": 179,
+    "sequence": 180,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_LINK_NOT_FOUND",
@@ -1969,7 +1980,7 @@
     "line": 31
   },
   {
-    "sequence": 180,
+    "sequence": 181,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "IMAGE_LIMIT_EXCEEDED",
@@ -1980,7 +1991,7 @@
     "line": 32
   },
   {
-    "sequence": 181,
+    "sequence": 182,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_ALREADY_EXISTS",
@@ -1991,7 +2002,7 @@
     "line": 33
   },
   {
-    "sequence": 182,
+    "sequence": 183,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_VOTE_OPTION_COUNT",
@@ -2002,7 +2013,7 @@
     "line": 34
   },
   {
-    "sequence": 183,
+    "sequence": 184,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_VOTE_OPTION_CONTENT",
@@ -2013,7 +2024,7 @@
     "line": 35
   },
   {
-    "sequence": 184,
+    "sequence": 185,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_NOT_STARTED",
@@ -2024,7 +2035,7 @@
     "line": 36
   },
   {
-    "sequence": 185,
+    "sequence": 186,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_CLOSED",
@@ -2035,7 +2046,7 @@
     "line": 37
   },
   {
-    "sequence": 186,
+    "sequence": 187,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "SELECTED_OPTION_IDS_REQUIRED",
@@ -2046,37 +2057,26 @@
     "line": 38
   },
   {
-    "sequence": 187,
-    "domain": "notification",
-    "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_GENERAL_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0001",
-    "message": "알 수 없는 사유로 이메일 전송에 실패했습니다.",
-    "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 11
-  },
-  {
     "sequence": 188,
     "domain": "notification",
     "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_ENCODING_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0002",
-    "message": "인코딩 과정에서 오류가 발생했습니다.",
+    "constantName": "EMAIL_TEMPLATE_RENDER_FAILED",
+    "httpStatus": "INTERNAL_SERVER_ERROR",
+    "code": "EMAIL-0004",
+    "message": "이메일 본문 템플릿 렌더링에 실패했습니다.",
     "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 12
+    "line": 11
   },
   {
     "sequence": 189,
     "domain": "notification",
     "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_MESSAGING_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0003",
-    "message": "메일 전송 과정에서 오류가 발생했습니다.",
+    "constantName": "EMAIL_SEND_FAILED",
+    "httpStatus": "INTERNAL_SERVER_ERROR",
+    "code": "EMAIL-0005",
+    "message": "이메일 발송에 실패했습니다.",
     "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 13
+    "line": 12
   },
   {
     "sequence": 190,
@@ -2604,7 +2604,7 @@
     "code": "PROJECT-0001",
     "message": "프로젝트를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 13
+    "line": 15
   },
   {
     "sequence": 238,
@@ -2615,7 +2615,7 @@
     "code": "PROJECT-0002",
     "message": "이미 완료된 프로젝트입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 14
+    "line": 16
   },
   {
     "sequence": 239,
@@ -2626,7 +2626,7 @@
     "code": "PROJECT-0003",
     "message": "해당 프로젝트를 해산시킬 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 15
+    "line": 17
   },
   {
     "sequence": 240,
@@ -2637,7 +2637,7 @@
     "code": "PROJECT-0004",
     "message": "요청하신 조작은 지원서가 제출된 상태에서만 가능합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 18
+    "line": 20
   },
   {
     "sequence": 241,
@@ -2648,7 +2648,7 @@
     "code": "PROJECT-0005",
     "message": "이미 지원서가 제출되었거나 평가가 완료된 상태입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 19
+    "line": 21
   },
   {
     "sequence": 242,
@@ -2659,7 +2659,7 @@
     "code": "PROJECT-0006",
     "message": "프로젝트에서 해당 지원용 폼을 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 27
+    "line": 29
   },
   {
     "sequence": 243,
@@ -2670,7 +2670,7 @@
     "code": "PROJECT-0007",
     "message": "요청하신 지원용 폼 섹션에 접근 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 28
+    "line": 30
   },
   {
     "sequence": 244,
@@ -2681,7 +2681,7 @@
     "code": "PROJECT-0008",
     "message": "작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 37
+    "line": 39
   },
   {
     "sequence": 245,
@@ -2692,7 +2692,7 @@
     "code": "PROJECT-0009",
     "message": "현재 상태에서 수행할 수 없는 작업입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 38
+    "line": 40
   },
   {
     "sequence": 246,
@@ -2703,7 +2703,7 @@
     "code": "PROJECT-0010",
     "message": "프로젝트 PO는 PLAN 파트 챌린저여야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 39
+    "line": 41
   },
   {
     "sequence": 247,
@@ -2714,7 +2714,7 @@
     "code": "PROJECT-0011",
     "message": "제출에 필요한 필수 정보가 누락되었습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 40
+    "line": 42
   },
   {
     "sequence": 248,
@@ -2725,7 +2725,7 @@
     "code": "PROJECT-0012",
     "message": "해당 프로젝트에 대한 접근 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 41
+    "line": 43
   },
   {
     "sequence": 249,
@@ -2736,7 +2736,7 @@
     "code": "PROJECT-0013",
     "message": "PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 29
+    "line": 31
   },
   {
     "sequence": 250,
@@ -2747,7 +2747,7 @@
     "code": "PROJECT-0014",
     "message": "현재 폼에 존재하지 않는 sectionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 30
+    "line": 32
   },
   {
     "sequence": 251,
@@ -2758,7 +2758,7 @@
     "code": "PROJECT-0015",
     "message": "해당 섹션에 속하지 않는 questionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 31
+    "line": 33
   },
   {
     "sequence": 252,
@@ -2769,7 +2769,7 @@
     "code": "PROJECT-0016",
     "message": "해당 질문에 속하지 않는 optionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 32
+    "line": 34
   },
   {
     "sequence": 253,
@@ -2780,7 +2780,7 @@
     "code": "PROJECT-0017",
     "message": "선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 33
+    "line": 35
   },
   {
     "sequence": 254,
@@ -2791,7 +2791,7 @@
     "code": "PROJECT-0018",
     "message": "선택지 타입 질문에는 1개 이상의 옵션이 필요합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 34
+    "line": 36
   },
   {
     "sequence": 255,
@@ -2802,7 +2802,7 @@
     "code": "PROJECT-0019",
     "message": "임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 20
+    "line": 22
   },
   {
     "sequence": 256,
@@ -2813,7 +2813,7 @@
     "code": "PROJECT-0020",
     "message": "임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 22
+    "line": 24
   },
   {
     "sequence": 257,
@@ -2824,7 +2824,7 @@
     "code": "PROJECT-0021",
     "message": "지원서를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 24
+    "line": 26
   },
   {
     "sequence": 258,
@@ -2835,7 +2835,7 @@
     "code": "PROJECT-0022",
     "message": "현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능)",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 42
+    "line": 44
   },
   {
     "sequence": 259,
@@ -2846,7 +2846,7 @@
     "code": "PROJECT-0023",
     "message": "프로젝트 중단 사유는 필수입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 44
+    "line": 46
   },
   {
     "sequence": 260,
@@ -2857,7 +2857,7 @@
     "code": "PROJECT-0100",
     "message": "프로젝트 멤버를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 47
+    "line": 49
   },
   {
     "sequence": 261,
@@ -2868,7 +2868,7 @@
     "code": "PROJECT-0101",
     "message": "이미 해당 프로젝트의 멤버입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 48
+    "line": 50
   },
   {
     "sequence": 262,
@@ -2879,7 +2879,7 @@
     "code": "PROJECT-0102",
     "message": "메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 49
+    "line": 51
   },
   {
     "sequence": 263,
@@ -2890,7 +2890,7 @@
     "code": "PROJECT-0200",
     "message": "파트 정원은 1 이상이어야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 52
+    "line": 54
   },
   {
     "sequence": 264,
@@ -2901,7 +2901,7 @@
     "code": "PROJECT-0202",
     "message": "공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 53
+    "line": 55
   },
   {
     "sequence": 265,
@@ -2912,7 +2912,7 @@
     "code": "PROJECT-0203",
     "message": "동일 파트가 중복으로 입력되었습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 54
+    "line": 56
   },
   {
     "sequence": 266,
@@ -2923,7 +2923,7 @@
     "code": "PROJECT-0204",
     "message": "작성 중인 지원서를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 76
+    "line": 78
   },
   {
     "sequence": 267,
@@ -2934,7 +2934,7 @@
     "code": "PROJECT-0205",
     "message": "해당 프로젝트에 지원 가능한 파트가 아닙니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 77
+    "line": 79
   },
   {
     "sequence": 268,
@@ -2945,7 +2945,7 @@
     "code": "PROJECT-0206",
     "message": "이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 78
+    "line": 80
   },
   {
     "sequence": 269,
@@ -2956,7 +2956,7 @@
     "code": "PROJECT-0207",
     "message": "동일한 매칭 차수에 이미 제출된 지원서가 있습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 79
+    "line": 81
   },
   {
     "sequence": 270,
@@ -2967,7 +2967,7 @@
     "code": "PROJECT-0208",
     "message": "해당 매칭 차수의 지원 기간이 아닙니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 80
+    "line": 82
   },
   {
     "sequence": 271,
@@ -2978,7 +2978,7 @@
     "code": "PROJECT-0209",
     "message": "선택한 매칭 차수가 본인 파트에 해당하지 않습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 81
+    "line": 83
   },
   {
     "sequence": 272,
@@ -2989,7 +2989,7 @@
     "code": "PROJECT-0210",
     "message": "이미 작성 중인 지원서가 있습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 82
+    "line": 84
   },
   {
     "sequence": 273,
@@ -3000,7 +3000,7 @@
     "code": "PROJECT-0211",
     "message": "본인이 운영하는 프로젝트에는 지원할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 83
+    "line": 85
   },
   {
     "sequence": 274,
@@ -3011,7 +3011,7 @@
     "code": "PROJECT-0212",
     "message": "현재 상태에서는 합/불 결정을 변경할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 84
+    "line": 86
   },
   {
     "sequence": 275,
@@ -3022,7 +3022,7 @@
     "code": "PROJECT-0213",
     "message": "해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 86
+    "line": 88
   },
   {
     "sequence": 276,
@@ -3033,7 +3033,7 @@
     "code": "PROJECT-0214",
     "message": "이미 종결된 지원서는 철회할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 88
+    "line": 90
   },
   {
     "sequence": 277,
@@ -3044,7 +3044,7 @@
     "code": "PROJECT-0215",
     "message": "매칭 차수가 종료되어 지원서를 철회할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 89
+    "line": 91
   },
   {
     "sequence": 278,
@@ -3055,7 +3055,7 @@
     "code": "PROJECT-0300",
     "message": "매칭 차수를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 57
+    "line": 59
   },
   {
     "sequence": 279,
@@ -3066,7 +3066,7 @@
     "code": "PROJECT-0301",
     "message": "매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 58
+    "line": 60
   },
   {
     "sequence": 280,
@@ -3077,7 +3077,7 @@
     "code": "PROJECT-0302",
     "message": "같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 60
+    "line": 62
   },
   {
     "sequence": 281,
@@ -3088,7 +3088,7 @@
     "code": "PROJECT-0303",
     "message": "해당 매칭 차수에 대한 관리 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 62
+    "line": 64
   },
   {
     "sequence": 282,
@@ -3099,7 +3099,7 @@
     "code": "PROJECT-0304",
     "message": "연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 64
+    "line": 66
   },
   {
     "sequence": 283,
@@ -3110,7 +3110,7 @@
     "code": "PROJECT-0305",
     "message": "time 기준 조회는 chapterId와 함께 요청해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 66
+    "line": 68
   },
   {
     "sequence": 284,
@@ -3121,7 +3121,7 @@
     "code": "PROJECT-0306",
     "message": "매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 68
+    "line": 70
   },
   {
     "sequence": 285,
@@ -3132,7 +3132,7 @@
     "code": "PROJECT-0307",
     "message": "결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 70
+    "line": 72
   },
   {
     "sequence": 286,
@@ -3143,7 +3143,7 @@
     "code": "PROJECT-0308",
     "message": "해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 72
+    "line": 74
   },
   {
     "sequence": 287,

--- a/docs/guides/ErrorCode_목록.md
+++ b/docs/guides/ErrorCode_목록.md
@@ -145,118 +145,123 @@
 | 110 | curriculum | `CURRICULUM-0018` | 409 CONFLICT | 이미 동일한 주차와 부록 여부를 가진 주차별 커리큘럼이 존재합니다. | CurriculumErrorCode | `WEEKLY_CURRICULUM_ALREADY_EXISTS` | `src/main/java/com/umc/product/curriculum/domain/exception/CurriculumErrorCode.java:29` |
 | 111 | curriculum | `CURRICULUM-0019` | 400 BAD_REQUEST | 이미 종료된 기간으로 주차별 커리큘럼을 생성하거나 수정할 수 없습니다. | CurriculumErrorCode | `WEEKLY_CURRICULUM_PERIOD_ALREADY_ENDED` | `src/main/java/com/umc/product/curriculum/domain/exception/CurriculumErrorCode.java:30` |
 
+## feedback
+
+| 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
+|---:|---|---|---|---|---|---|---|
+| 112 | feedback | `FEEDBACK-0001` | 404 NOT_FOUND | 사용자 피드백 템플릿을 찾을 수 없습니다. | FeedbackErrorCode | `USER_FEEDBACK_TEMPLATE_NOT_FOUND` | `src/main/java/com/umc/product/feedback/domain/exception/FeedbackErrorCode.java:15` |
+
 ## figma
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 112 | figma | `FIGMA-0001` | 404 NOT_FOUND | Figma OAuth 통합 정보가 등록되어 있지 않습니다. | FigmaErrorCode | `INTEGRATION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:12` |
-| 113 | figma | `FIGMA-0002` | 502 BAD_GATEWAY | Figma OAuth 토큰 교환에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_EXCHANGE_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:13` |
-| 114 | figma | `FIGMA-0003` | 502 BAD_GATEWAY | Figma access token 갱신에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_REFRESH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:14` |
-| 115 | figma | `FIGMA-0004` | 502 BAD_GATEWAY | Figma 댓글 조회에 실패했습니다. | FigmaErrorCode | `COMMENT_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:15` |
-| 116 | figma | `FIGMA-0005` | 502 BAD_GATEWAY | Figma 파일 메타데이터 조회에 실패했습니다. | FigmaErrorCode | `FILE_METADATA_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:16` |
-| 117 | figma | `FIGMA-0006` | 404 NOT_FOUND | 등록된 Figma 폴링 대상 파일이 아닙니다. | FigmaErrorCode | `WATCHED_FILE_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:17` |
-| 118 | figma | `FIGMA-0007` | 409 CONFLICT | 이미 등록된 Figma 파일 키 입니다. | FigmaErrorCode | `WATCHED_FILE_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:18` |
-| 119 | figma | `FIGMA-0008` | 400 BAD_REQUEST | Figma OAuth state 값이 일치하지 않습니다. | FigmaErrorCode | `OAUTH_STATE_MISMATCH` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:19` |
-| 120 | figma | `FIGMA-0009` | 500 INTERNAL_SERVER_ERROR | Figma 토큰 암복호화에 실패했습니다. | FigmaErrorCode | `TOKEN_ENCRYPTION_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:20` |
-| 121 | figma | `FIGMA-0010` | 502 BAD_GATEWAY | Discord 멘션 전송에 실패했습니다. | FigmaErrorCode | `DISCORD_MENTION_SEND_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:21` |
-| 122 | figma | `FIGMA-0013` | 404 NOT_FOUND | 등록된 Figma 라우팅 도메인이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:22` |
-| 123 | figma | `FIGMA-0014` | 409 CONFLICT | 동일한 domain_key 의 라우팅 도메인이 이미 등록되어 있습니다. | FigmaErrorCode | `ROUTING_DOMAIN_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:23` |
-| 124 | figma | `FIGMA-0015` | 404 NOT_FOUND | 해당 라우팅 도메인의 mention 이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_MENTION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:24` |
-| 125 | figma | `FIGMA-0016` | 412 PRECONDITION_FAILED | 라우팅 도메인이 한 건도 등록되어 있지 않습니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_REGISTERED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:25` |
-| 126 | figma | `FIGMA-0017` | 400 BAD_REQUEST | digest 의 from/to 시간창이 유효하지 않습니다. | FigmaErrorCode | `DIGEST_RANGE_INVALID` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:26` |
+| 113 | figma | `FIGMA-0001` | 404 NOT_FOUND | Figma OAuth 통합 정보가 등록되어 있지 않습니다. | FigmaErrorCode | `INTEGRATION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:12` |
+| 114 | figma | `FIGMA-0002` | 502 BAD_GATEWAY | Figma OAuth 토큰 교환에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_EXCHANGE_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:13` |
+| 115 | figma | `FIGMA-0003` | 502 BAD_GATEWAY | Figma access token 갱신에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_REFRESH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:14` |
+| 116 | figma | `FIGMA-0004` | 502 BAD_GATEWAY | Figma 댓글 조회에 실패했습니다. | FigmaErrorCode | `COMMENT_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:15` |
+| 117 | figma | `FIGMA-0005` | 502 BAD_GATEWAY | Figma 파일 메타데이터 조회에 실패했습니다. | FigmaErrorCode | `FILE_METADATA_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:16` |
+| 118 | figma | `FIGMA-0006` | 404 NOT_FOUND | 등록된 Figma 폴링 대상 파일이 아닙니다. | FigmaErrorCode | `WATCHED_FILE_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:17` |
+| 119 | figma | `FIGMA-0007` | 409 CONFLICT | 이미 등록된 Figma 파일 키 입니다. | FigmaErrorCode | `WATCHED_FILE_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:18` |
+| 120 | figma | `FIGMA-0008` | 400 BAD_REQUEST | Figma OAuth state 값이 일치하지 않습니다. | FigmaErrorCode | `OAUTH_STATE_MISMATCH` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:19` |
+| 121 | figma | `FIGMA-0009` | 500 INTERNAL_SERVER_ERROR | Figma 토큰 암복호화에 실패했습니다. | FigmaErrorCode | `TOKEN_ENCRYPTION_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:20` |
+| 122 | figma | `FIGMA-0010` | 502 BAD_GATEWAY | Discord 멘션 전송에 실패했습니다. | FigmaErrorCode | `DISCORD_MENTION_SEND_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:21` |
+| 123 | figma | `FIGMA-0013` | 404 NOT_FOUND | 등록된 Figma 라우팅 도메인이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:22` |
+| 124 | figma | `FIGMA-0014` | 409 CONFLICT | 동일한 domain_key 의 라우팅 도메인이 이미 등록되어 있습니다. | FigmaErrorCode | `ROUTING_DOMAIN_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:23` |
+| 125 | figma | `FIGMA-0015` | 404 NOT_FOUND | 해당 라우팅 도메인의 mention 이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_MENTION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:24` |
+| 126 | figma | `FIGMA-0016` | 412 PRECONDITION_FAILED | 라우팅 도메인이 한 건도 등록되어 있지 않습니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_REGISTERED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:25` |
+| 127 | figma | `FIGMA-0017` | 400 BAD_REQUEST | digest 의 from/to 시간창이 유효하지 않습니다. | FigmaErrorCode | `DIGEST_RANGE_INVALID` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:26` |
 
 ## global
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 127 | global | `COMMON-0001` | 500 INTERNAL_SERVER_ERROR | 알 수 없는 오류입니다. 관리자에게 문의해주세요. | CommonErrorCode | `INTERNAL_SERVER_ERROR` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:24` |
-| 128 | global | `COMMON-400` | 400 BAD_REQUEST | 잘못된 요청입니다. | CommonErrorCode | `BAD_REQUEST` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:26` |
-| 129 | global | `COMMON-401` | 401 UNAUTHORIZED | 인증이 필요합니다. | CommonErrorCode | `UNAUTHORIZED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:27` |
-| 130 | global | `COMMON-403` | 403 FORBIDDEN | 허용되지 않는 요청입니다. | CommonErrorCode | `FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:28` |
-| 131 | global | `COMMON-404` | 404 NOT_FOUND | 요청한 리소스를 찾을 수 없습니다. | CommonErrorCode | `NOT_FOUND` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:29` |
-| 132 | global | `COMMON-501` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. 서버팀에게 문의해주세요. | CommonErrorCode | `NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:30` |
-| 133 | global | `ENV-0001` | 400 BAD_REQUEST | 현재 실행 환경에서는 사용할 수 없는 기능입니다. | CommonErrorCode | `INVALID_ENV` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:37` |
-| 134 | global | `PE-0001` | 501 NOT_IMPLEMENTED | 요청하신 PE가 존재하지 않습니다. 관리자에게 문의해주세요. | CommonErrorCode | `PERMISSION_TYPE_NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:40` |
-| 135 | global | `SECURITY-0001` | 401 UNAUTHORIZED | 인증 정보가 전달되지 않았습니다. | CommonErrorCode | `SECURITY_NOT_GIVEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:33` |
-| 136 | global | `SECURITY-0002` | 403 FORBIDDEN | 권한이 부족합니다. | CommonErrorCode | `SECURITY_FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:34` |
+| 128 | global | `COMMON-0001` | 500 INTERNAL_SERVER_ERROR | 알 수 없는 오류입니다. 관리자에게 문의해주세요. | CommonErrorCode | `INTERNAL_SERVER_ERROR` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:24` |
+| 129 | global | `COMMON-400` | 400 BAD_REQUEST | 잘못된 요청입니다. | CommonErrorCode | `BAD_REQUEST` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:26` |
+| 130 | global | `COMMON-401` | 401 UNAUTHORIZED | 인증이 필요합니다. | CommonErrorCode | `UNAUTHORIZED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:27` |
+| 131 | global | `COMMON-403` | 403 FORBIDDEN | 허용되지 않는 요청입니다. | CommonErrorCode | `FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:28` |
+| 132 | global | `COMMON-404` | 404 NOT_FOUND | 요청한 리소스를 찾을 수 없습니다. | CommonErrorCode | `NOT_FOUND` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:29` |
+| 133 | global | `COMMON-501` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. 서버팀에게 문의해주세요. | CommonErrorCode | `NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:30` |
+| 134 | global | `ENV-0001` | 400 BAD_REQUEST | 현재 실행 환경에서는 사용할 수 없는 기능입니다. | CommonErrorCode | `INVALID_ENV` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:37` |
+| 135 | global | `PE-0001` | 501 NOT_IMPLEMENTED | 요청하신 PE가 존재하지 않습니다. 관리자에게 문의해주세요. | CommonErrorCode | `PERMISSION_TYPE_NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:40` |
+| 136 | global | `SECURITY-0001` | 401 UNAUTHORIZED | 인증 정보가 전달되지 않았습니다. | CommonErrorCode | `SECURITY_NOT_GIVEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:33` |
+| 137 | global | `SECURITY-0002` | 403 FORBIDDEN | 권한이 부족합니다. | CommonErrorCode | `SECURITY_FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:34` |
 
 ## llm
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 137 | llm | `LLM-0001` | 502 BAD_GATEWAY | LLM 호출에 실패했습니다. | LlmErrorCode | `CHAT_COMPLETION_FAILED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:12` |
-| 138 | llm | `LLM-0002` | 502 BAD_GATEWAY | LLM 응답을 해석할 수 없습니다. | LlmErrorCode | `CHAT_COMPLETION_INVALID_RESPONSE` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:13` |
-| 139 | llm | `LLM-0003` | 500 INTERNAL_SERVER_ERROR | LLM provider 설정이 누락되었습니다. | LlmErrorCode | `PROVIDER_NOT_CONFIGURED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:14` |
+| 138 | llm | `LLM-0001` | 502 BAD_GATEWAY | LLM 호출에 실패했습니다. | LlmErrorCode | `CHAT_COMPLETION_FAILED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:12` |
+| 139 | llm | `LLM-0002` | 502 BAD_GATEWAY | LLM 응답을 해석할 수 없습니다. | LlmErrorCode | `CHAT_COMPLETION_INVALID_RESPONSE` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:13` |
+| 140 | llm | `LLM-0003` | 500 INTERNAL_SERVER_ERROR | LLM provider 설정이 누락되었습니다. | LlmErrorCode | `PROVIDER_NOT_CONFIGURED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:14` |
 
 ## maintenance
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 140 | maintenance | `MAINTENANCE-0001` | 503 SERVICE_UNAVAILABLE | 서비스 점검 중입니다. | MaintenanceErrorCode | `SERVICE_UNDER_MAINTENANCE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:12` |
-| 141 | maintenance | `MAINTENANCE-0002` | 404 NOT_FOUND | 점검 윈도우를 찾을 수 없습니다. | MaintenanceErrorCode | `MAINTENANCE_WINDOW_NOT_FOUND` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:13` |
-| 142 | maintenance | `MAINTENANCE-0003` | 400 BAD_REQUEST | 종료 시각은 시작 시각 이후여야 합니다. | MaintenanceErrorCode | `INVALID_TIME_RANGE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:14` |
-| 143 | maintenance | `MAINTENANCE-0004` | 400 BAD_REQUEST | 시작 시각은 현재 시각 이후여야 합니다. | MaintenanceErrorCode | `START_AT_IN_PAST` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:15` |
-| 144 | maintenance | `MAINTENANCE-0005` | 400 BAD_REQUEST | PER_DOMAIN 점검은 대상 도메인을 1개 이상 지정해야 합니다. | MaintenanceErrorCode | `TARGET_DOMAINS_REQUIRED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:16` |
-| 145 | maintenance | `MAINTENANCE-0006` | 409 CONFLICT | 다른 점검 윈도우와 시간이 겹칩니다. | MaintenanceErrorCode | `OVERLAPPING_WINDOW` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:17` |
-| 146 | maintenance | `MAINTENANCE-0007` | 400 BAD_REQUEST | 이미 종료된 점검 윈도우입니다. | MaintenanceErrorCode | `ALREADY_ENDED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:18` |
-| 147 | maintenance | `MAINTENANCE-0008` | 403 FORBIDDEN | 점검 관리 권한이 없습니다. | MaintenanceErrorCode | `NOT_SUPER_ADMIN` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:19` |
+| 141 | maintenance | `MAINTENANCE-0001` | 503 SERVICE_UNAVAILABLE | 서비스 점검 중입니다. | MaintenanceErrorCode | `SERVICE_UNDER_MAINTENANCE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:12` |
+| 142 | maintenance | `MAINTENANCE-0002` | 404 NOT_FOUND | 점검 윈도우를 찾을 수 없습니다. | MaintenanceErrorCode | `MAINTENANCE_WINDOW_NOT_FOUND` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:13` |
+| 143 | maintenance | `MAINTENANCE-0003` | 400 BAD_REQUEST | 종료 시각은 시작 시각 이후여야 합니다. | MaintenanceErrorCode | `INVALID_TIME_RANGE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:14` |
+| 144 | maintenance | `MAINTENANCE-0004` | 400 BAD_REQUEST | 시작 시각은 현재 시각 이후여야 합니다. | MaintenanceErrorCode | `START_AT_IN_PAST` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:15` |
+| 145 | maintenance | `MAINTENANCE-0005` | 400 BAD_REQUEST | PER_DOMAIN 점검은 대상 도메인을 1개 이상 지정해야 합니다. | MaintenanceErrorCode | `TARGET_DOMAINS_REQUIRED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:16` |
+| 146 | maintenance | `MAINTENANCE-0006` | 409 CONFLICT | 다른 점검 윈도우와 시간이 겹칩니다. | MaintenanceErrorCode | `OVERLAPPING_WINDOW` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:17` |
+| 147 | maintenance | `MAINTENANCE-0007` | 400 BAD_REQUEST | 이미 종료된 점검 윈도우입니다. | MaintenanceErrorCode | `ALREADY_ENDED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:18` |
+| 148 | maintenance | `MAINTENANCE-0008` | 403 FORBIDDEN | 점검 관리 권한이 없습니다. | MaintenanceErrorCode | `NOT_SUPER_ADMIN` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:19` |
 
 ## member
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 148 | member | `MEMBER-0001` | 404 NOT_FOUND | 사용자를 찾을 수 없습니다. | MemberErrorCode | `MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:12` |
-| 149 | member | `MEMBER-0002` | 409 CONFLICT | 이미 등록된 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:13` |
-| 150 | member | `MEMBER-0003` | 409 CONFLICT | 이미 사용 중인 이메일입니다. | MemberErrorCode | `EMAIL_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:14` |
-| 151 | member | `MEMBER-0004` | 400 BAD_REQUEST | 이미 탈퇴한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_WITHDRAWN` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:15` |
-| 152 | member | `MEMBER-0005` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `INVALID_MEMBER_STATUS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:16` |
-| 153 | member | `MEMBER-0006` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `MEMBER_NOT_ACTIVE` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:17` |
-| 154 | member | `MEMBER-0007` | 400 BAD_REQUEST | 이미 회원가입을 완료한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:18` |
-| 155 | member | `MEMBER-0008` | 404 NOT_FOUND | 프로필을 찾을 수 없습니다. | MemberErrorCode | `MEMBER_PROFILE_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:19` |
-| 156 | member | `MEMBER-0009` | 400 BAD_REQUEST | 학교가 등록되지 않은 사용자입니다. | MemberErrorCode | `MEMBER_SCHOOL_NOT_ASSIGNED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:20` |
-| 157 | member | `MEMBER-0010` | 409 CONFLICT | 이미 ID/PW 자격증명이 등록된 사용자입니다. | MemberErrorCode | `CREDENTIAL_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:21` |
-| 158 | member | `MEMBER-0011` | 400 BAD_REQUEST | ID/PW 자격증명이 등록되지 않은 사용자입니다. | MemberErrorCode | `CREDENTIAL_NOT_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:22` |
-| 159 | member | `MEMBER-0012` | 400 BAD_REQUEST | 올바르지 않은 로그인 아이디입니다. | MemberErrorCode | `INVALID_LOGIN_ID` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:23` |
-| 160 | member | `MEMBER-0013` | 400 BAD_REQUEST | 올바르지 않은 비밀번호입니다. | MemberErrorCode | `INVALID_PASSWORD` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:24` |
+| 149 | member | `MEMBER-0001` | 404 NOT_FOUND | 사용자를 찾을 수 없습니다. | MemberErrorCode | `MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:12` |
+| 150 | member | `MEMBER-0002` | 409 CONFLICT | 이미 등록된 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:13` |
+| 151 | member | `MEMBER-0003` | 409 CONFLICT | 이미 사용 중인 이메일입니다. | MemberErrorCode | `EMAIL_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:14` |
+| 152 | member | `MEMBER-0004` | 400 BAD_REQUEST | 이미 탈퇴한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_WITHDRAWN` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:15` |
+| 153 | member | `MEMBER-0005` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `INVALID_MEMBER_STATUS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:16` |
+| 154 | member | `MEMBER-0006` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `MEMBER_NOT_ACTIVE` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:17` |
+| 155 | member | `MEMBER-0007` | 400 BAD_REQUEST | 이미 회원가입을 완료한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:18` |
+| 156 | member | `MEMBER-0008` | 404 NOT_FOUND | 프로필을 찾을 수 없습니다. | MemberErrorCode | `MEMBER_PROFILE_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:19` |
+| 157 | member | `MEMBER-0009` | 400 BAD_REQUEST | 학교가 등록되지 않은 사용자입니다. | MemberErrorCode | `MEMBER_SCHOOL_NOT_ASSIGNED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:20` |
+| 158 | member | `MEMBER-0010` | 409 CONFLICT | 이미 ID/PW 자격증명이 등록된 사용자입니다. | MemberErrorCode | `CREDENTIAL_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:21` |
+| 159 | member | `MEMBER-0011` | 400 BAD_REQUEST | ID/PW 자격증명이 등록되지 않은 사용자입니다. | MemberErrorCode | `CREDENTIAL_NOT_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:22` |
+| 160 | member | `MEMBER-0012` | 400 BAD_REQUEST | 올바르지 않은 로그인 아이디입니다. | MemberErrorCode | `INVALID_LOGIN_ID` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:23` |
+| 161 | member | `MEMBER-0013` | 400 BAD_REQUEST | 올바르지 않은 비밀번호입니다. | MemberErrorCode | `INVALID_PASSWORD` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:24` |
 
 ## notice
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 161 | notice | `NOTICE-0001` | 404 NOT_FOUND | 공지사항을 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:12` |
-| 162 | notice | `NOTICE-0002` | 400 BAD_REQUEST | 이미 게시된 공지사항입니다. | NoticeErrorCode | `ALREADY_PUBLISHED_NOTICE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:13` |
-| 163 | notice | `NOTICE-0003` | 400 BAD_REQUEST | 공지사항 제목이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_TITLE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:14` |
-| 164 | notice | `NOTICE-0004` | 400 BAD_REQUEST | 공지사항 내용이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:15` |
-| 165 | notice | `NOTICE-0005` | 400 BAD_REQUEST | 공지사항 알림을 보낼 수 없는 상태입니다. | NoticeErrorCode | `INVALID_NOTICE_STATUS_FOR_REMINDER` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:16` |
-| 166 | notice | `NOTICE-0006` | 400 BAD_REQUEST | 공지사항 작성자는 필수입니다. | NoticeErrorCode | `AUTHOR_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:17` |
-| 167 | notice | `NOTICE-0007` | 400 BAD_REQUEST | 공지사항 대상 범위는 필수입니다. | NoticeErrorCode | `NOTICE_SCOPE_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:18` |
-| 168 | notice | `NOTICE-0008` | 403 FORBIDDEN | 공지사항 작성자가 아닙니다. | NoticeErrorCode | `NOTICE_AUTHOR_MISMATCH` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:19` |
-| 169 | notice | `NOTICE-0009` | 403 FORBIDDEN | 해당 공지사항을 작성할 권한이 없습니다. | NoticeErrorCode | `NO_WRITE_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:20` |
-| 170 | notice | `NOTICE-0010` | 400 BAD_REQUEST | 공지사항 수신자 설정이 잘못되었습니다. | NoticeErrorCode | `INVALID_TARGET_SETTING` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:22` |
-| 171 | notice | `NOTICE-0011` | 404 NOT_FOUND | 해당 공지사항에 설정된 수신 대상이 존재하지 않습니다. | NoticeErrorCode | `NO_TARGET_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:23` |
-| 172 | notice | `NOTICE-0012` | 403 FORBIDDEN | 해당 공지사항을 조회할 권한이 없습니다. | NoticeErrorCode | `NO_READ_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:21` |
-| 173 | notice | `NOTICE-9999` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. | NoticeErrorCode | `NOT_IMPLEMENTED_YET` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:41` |
-| 174 | notice | `NOTICE-CONTENTS-0001` | 400 BAD_REQUEST | 투표 ID 목록은 필수입니다. | NoticeErrorCode | `VOTE_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:26` |
-| 175 | notice | `NOTICE-CONTENTS-0002` | 400 BAD_REQUEST | 이미지 URL 목록은 필수입니다. | NoticeErrorCode | `IMAGE_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:27` |
-| 176 | notice | `NOTICE-CONTENTS-0003` | 400 BAD_REQUEST | 링크 URL 목록은 필수입니다. | NoticeErrorCode | `LINK_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:28` |
-| 177 | notice | `NOTICE-CONTENTS-0004` | 404 NOT_FOUND | 공지사항 투표를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_VOTE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:29` |
-| 178 | notice | `NOTICE-CONTENTS-0005` | 404 NOT_FOUND | 공지사항 이미지를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_IMAGE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:30` |
-| 179 | notice | `NOTICE-CONTENTS-0006` | 404 NOT_FOUND | 공지사항 링크를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_LINK_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:31` |
-| 180 | notice | `NOTICE-CONTENTS-0007` | 400 BAD_REQUEST | 공지사항 이미지는 최대 10장까지 등록할 수 있습니다. | NoticeErrorCode | `IMAGE_LIMIT_EXCEEDED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:32` |
-| 181 | notice | `NOTICE-CONTENTS-0008` | 409 CONFLICT | 해당 공지사항에 이미 투표가 존재합니다. | NoticeErrorCode | `VOTE_ALREADY_EXISTS` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:33` |
-| 182 | notice | `NOTICE-CONTENTS-0009` | 400 BAD_REQUEST | 투표 항목은 2개 이상 5개 이하여야 합니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_COUNT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:34` |
-| 183 | notice | `NOTICE-CONTENTS-0010` | 400 BAD_REQUEST | 투표 항목에 빈 값이 포함될 수 없습니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:35` |
-| 184 | notice | `NOTICE-CONTENTS-0011` | 400 BAD_REQUEST | 아직 투표 기간이 시작되지 않았습니다. | NoticeErrorCode | `VOTE_NOT_STARTED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:36` |
-| 185 | notice | `NOTICE-CONTENTS-0012` | 400 BAD_REQUEST | 이미 종료된 투표입니다. | NoticeErrorCode | `VOTE_CLOSED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:37` |
-| 186 | notice | `NOTICE-CONTENTS-0013` | 400 BAD_REQUEST | 선택한 투표 항목 ID 목록은 필수입니다. | NoticeErrorCode | `SELECTED_OPTION_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:38` |
+| 162 | notice | `NOTICE-0001` | 404 NOT_FOUND | 공지사항을 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:12` |
+| 163 | notice | `NOTICE-0002` | 400 BAD_REQUEST | 이미 게시된 공지사항입니다. | NoticeErrorCode | `ALREADY_PUBLISHED_NOTICE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:13` |
+| 164 | notice | `NOTICE-0003` | 400 BAD_REQUEST | 공지사항 제목이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_TITLE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:14` |
+| 165 | notice | `NOTICE-0004` | 400 BAD_REQUEST | 공지사항 내용이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:15` |
+| 166 | notice | `NOTICE-0005` | 400 BAD_REQUEST | 공지사항 알림을 보낼 수 없는 상태입니다. | NoticeErrorCode | `INVALID_NOTICE_STATUS_FOR_REMINDER` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:16` |
+| 167 | notice | `NOTICE-0006` | 400 BAD_REQUEST | 공지사항 작성자는 필수입니다. | NoticeErrorCode | `AUTHOR_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:17` |
+| 168 | notice | `NOTICE-0007` | 400 BAD_REQUEST | 공지사항 대상 범위는 필수입니다. | NoticeErrorCode | `NOTICE_SCOPE_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:18` |
+| 169 | notice | `NOTICE-0008` | 403 FORBIDDEN | 공지사항 작성자가 아닙니다. | NoticeErrorCode | `NOTICE_AUTHOR_MISMATCH` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:19` |
+| 170 | notice | `NOTICE-0009` | 403 FORBIDDEN | 해당 공지사항을 작성할 권한이 없습니다. | NoticeErrorCode | `NO_WRITE_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:20` |
+| 171 | notice | `NOTICE-0010` | 400 BAD_REQUEST | 공지사항 수신자 설정이 잘못되었습니다. | NoticeErrorCode | `INVALID_TARGET_SETTING` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:22` |
+| 172 | notice | `NOTICE-0011` | 404 NOT_FOUND | 해당 공지사항에 설정된 수신 대상이 존재하지 않습니다. | NoticeErrorCode | `NO_TARGET_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:23` |
+| 173 | notice | `NOTICE-0012` | 403 FORBIDDEN | 해당 공지사항을 조회할 권한이 없습니다. | NoticeErrorCode | `NO_READ_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:21` |
+| 174 | notice | `NOTICE-9999` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. | NoticeErrorCode | `NOT_IMPLEMENTED_YET` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:41` |
+| 175 | notice | `NOTICE-CONTENTS-0001` | 400 BAD_REQUEST | 투표 ID 목록은 필수입니다. | NoticeErrorCode | `VOTE_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:26` |
+| 176 | notice | `NOTICE-CONTENTS-0002` | 400 BAD_REQUEST | 이미지 URL 목록은 필수입니다. | NoticeErrorCode | `IMAGE_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:27` |
+| 177 | notice | `NOTICE-CONTENTS-0003` | 400 BAD_REQUEST | 링크 URL 목록은 필수입니다. | NoticeErrorCode | `LINK_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:28` |
+| 178 | notice | `NOTICE-CONTENTS-0004` | 404 NOT_FOUND | 공지사항 투표를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_VOTE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:29` |
+| 179 | notice | `NOTICE-CONTENTS-0005` | 404 NOT_FOUND | 공지사항 이미지를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_IMAGE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:30` |
+| 180 | notice | `NOTICE-CONTENTS-0006` | 404 NOT_FOUND | 공지사항 링크를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_LINK_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:31` |
+| 181 | notice | `NOTICE-CONTENTS-0007` | 400 BAD_REQUEST | 공지사항 이미지는 최대 10장까지 등록할 수 있습니다. | NoticeErrorCode | `IMAGE_LIMIT_EXCEEDED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:32` |
+| 182 | notice | `NOTICE-CONTENTS-0008` | 409 CONFLICT | 해당 공지사항에 이미 투표가 존재합니다. | NoticeErrorCode | `VOTE_ALREADY_EXISTS` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:33` |
+| 183 | notice | `NOTICE-CONTENTS-0009` | 400 BAD_REQUEST | 투표 항목은 2개 이상 5개 이하여야 합니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_COUNT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:34` |
+| 184 | notice | `NOTICE-CONTENTS-0010` | 400 BAD_REQUEST | 투표 항목에 빈 값이 포함될 수 없습니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:35` |
+| 185 | notice | `NOTICE-CONTENTS-0011` | 400 BAD_REQUEST | 아직 투표 기간이 시작되지 않았습니다. | NoticeErrorCode | `VOTE_NOT_STARTED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:36` |
+| 186 | notice | `NOTICE-CONTENTS-0012` | 400 BAD_REQUEST | 이미 종료된 투표입니다. | NoticeErrorCode | `VOTE_CLOSED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:37` |
+| 187 | notice | `NOTICE-CONTENTS-0013` | 400 BAD_REQUEST | 선택한 투표 항목 ID 목록은 필수입니다. | NoticeErrorCode | `SELECTED_OPTION_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:38` |
 
 ## notification
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 187 | notification | `EMAIL-0001` | 400 BAD_REQUEST | 알 수 없는 사유로 이메일 전송에 실패했습니다. | EmailErrorCode | `EMAIL_GENERAL_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:11` |
-| 188 | notification | `EMAIL-0002` | 400 BAD_REQUEST | 인코딩 과정에서 오류가 발생했습니다. | EmailErrorCode | `EMAIL_ENCODING_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:12` |
-| 189 | notification | `EMAIL-0003` | 400 BAD_REQUEST | 메일 전송 과정에서 오류가 발생했습니다. | EmailErrorCode | `EMAIL_MESSAGING_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:13` |
+| 188 | notification | `EMAIL-0004` | 500 INTERNAL_SERVER_ERROR | 이메일 본문 템플릿 렌더링에 실패했습니다. | EmailErrorCode | `EMAIL_TEMPLATE_RENDER_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:11` |
+| 189 | notification | `EMAIL-0005` | 500 INTERNAL_SERVER_ERROR | 이메일 발송에 실패했습니다. | EmailErrorCode | `EMAIL_SEND_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:12` |
 | 190 | notification | `FCM-0001` | 404 NOT_FOUND | FCM 토큰을 찾을 수 없습니다. | FcmErrorCode | `FCM_NOT_FOUND` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:12` |
 | 191 | notification | `FCM-0002` | 404 NOT_FOUND | 해당 유저의 FCM 토큰을 찾을 수 없습니다. | FcmErrorCode | `USER_FCM_NOT_FOUND` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:13` |
 | 192 | notification | `FCM-0003` | 500 INTERNAL_SERVER_ERROR | FCM 메시지 전송에 실패했습니다. | FcmErrorCode | `FCM_SEND_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:14` |
@@ -314,56 +319,56 @@
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 237 | project | `PROJECT-0001` | 404 NOT_FOUND | 프로젝트를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:13` |
-| 238 | project | `PROJECT-0002` | 400 BAD_REQUEST | 이미 완료된 프로젝트입니다. | ProjectErrorCode | `ALREADY_COMPLETED_PROJECT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:14` |
-| 239 | project | `PROJECT-0003` | 400 BAD_REQUEST | 해당 프로젝트를 해산시킬 수 없습니다. | ProjectErrorCode | `PROJECT_ABORT_UNAVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:15` |
-| 240 | project | `PROJECT-0004` | 400 BAD_REQUEST | 요청하신 조작은 지원서가 제출된 상태에서만 가능합니다. | ProjectErrorCode | `APPLICATION_NOT_SUBMITTED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:18` |
-| 241 | project | `PROJECT-0005` | 400 BAD_REQUEST | 이미 지원서가 제출되었거나 평가가 완료된 상태입니다. | ProjectErrorCode | `APPLICATION_SUBMIT_NOT_AVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:19` |
-| 242 | project | `PROJECT-0006` | 404 NOT_FOUND | 프로젝트에서 해당 지원용 폼을 찾을 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:27` |
-| 243 | project | `PROJECT-0007` | 403 FORBIDDEN | 요청하신 지원용 폼 섹션에 접근 권한이 없습니다. | ProjectErrorCode | `APPLICATION_FORM_ACCESS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:28` |
-| 244 | project | `PROJECT-0008` | 409 CONFLICT | 작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:37` |
-| 245 | project | `PROJECT-0009` | 400 BAD_REQUEST | 현재 상태에서 수행할 수 없는 작업입니다. | ProjectErrorCode | `PROJECT_INVALID_STATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:38` |
-| 246 | project | `PROJECT-0010` | 400 BAD_REQUEST | 프로젝트 PO는 PLAN 파트 챌린저여야 합니다. | ProjectErrorCode | `PROJECT_OWNER_NOT_PLAN_CHALLENGER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:39` |
-| 247 | project | `PROJECT-0011` | 400 BAD_REQUEST | 제출에 필요한 필수 정보가 누락되었습니다. | ProjectErrorCode | `PROJECT_SUBMIT_VALIDATION_FAILED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:40` |
-| 248 | project | `PROJECT-0012` | 403 FORBIDDEN | 해당 프로젝트에 대한 접근 권한이 없습니다. | ProjectErrorCode | `PROJECT_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:41` |
-| 249 | project | `PROJECT-0013` | 400 BAD_REQUEST | PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다. | ProjectErrorCode | `APPLICATION_FORM_POLICY_PARTS_EMPTY` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:29` |
-| 250 | project | `PROJECT-0014` | 400 BAD_REQUEST | 현재 폼에 존재하지 않는 sectionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_SECTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:30` |
-| 251 | project | `PROJECT-0015` | 400 BAD_REQUEST | 해당 섹션에 속하지 않는 questionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_QUESTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:31` |
-| 252 | project | `PROJECT-0016` | 400 BAD_REQUEST | 해당 질문에 속하지 않는 optionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_OPTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:32` |
-| 253 | project | `PROJECT-0017` | 400 BAD_REQUEST | 선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:33` |
-| 254 | project | `PROJECT-0018` | 400 BAD_REQUEST | 선택지 타입 질문에는 1개 이상의 옵션이 필요합니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:34` |
-| 255 | project | `PROJECT-0019` | 500 INTERNAL_SERVER_ERROR | 임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_NOT_EXPOSABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:20` |
-| 256 | project | `PROJECT-0020` | 400 BAD_REQUEST | 임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_FILTER_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:22` |
-| 257 | project | `PROJECT-0021` | 404 NOT_FOUND | 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:24` |
-| 258 | project | `PROJECT-0022` | 409 CONFLICT | 현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능) | ProjectErrorCode | `PROJECT_DELETE_NOT_ALLOWED_IN_STATUS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:42` |
-| 259 | project | `PROJECT-0023` | 400 BAD_REQUEST | 프로젝트 중단 사유는 필수입니다. | ProjectErrorCode | `PROJECT_ABORT_REASON_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:44` |
-| 260 | project | `PROJECT-0100` | 404 NOT_FOUND | 프로젝트 멤버를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:47` |
-| 261 | project | `PROJECT-0101` | 409 CONFLICT | 이미 해당 프로젝트의 멤버입니다. | ProjectErrorCode | `PROJECT_MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:48` |
-| 262 | project | `PROJECT-0102` | 400 BAD_REQUEST | 메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다. | ProjectErrorCode | `PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:49` |
-| 263 | project | `PROJECT-0200` | 400 BAD_REQUEST | 파트 정원은 1 이상이어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_INVALID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:52` |
-| 264 | project | `PROJECT-0202` | 400 BAD_REQUEST | 공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:53` |
-| 265 | project | `PROJECT-0203` | 400 BAD_REQUEST | 동일 파트가 중복으로 입력되었습니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_DUPLICATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:54` |
-| 266 | project | `PROJECT-0204` | 404 NOT_FOUND | 작성 중인 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:76` |
-| 267 | project | `PROJECT-0205` | 403 FORBIDDEN | 해당 프로젝트에 지원 가능한 파트가 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_PART_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:77` |
-| 268 | project | `PROJECT-0206` | 409 CONFLICT | 이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:78` |
-| 269 | project | `PROJECT-0207` | 409 CONFLICT | 동일한 매칭 차수에 이미 제출된 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DUPLICATE_SUBMISSION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:79` |
-| 270 | project | `PROJECT-0208` | 400 BAD_REQUEST | 해당 매칭 차수의 지원 기간이 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_NOT_OPEN` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:80` |
-| 271 | project | `PROJECT-0209` | 400 BAD_REQUEST | 선택한 매칭 차수가 본인 파트에 해당하지 않습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_TYPE_MISMATCH` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:81` |
-| 272 | project | `PROJECT-0210` | 409 CONFLICT | 이미 작성 중인 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:82` |
-| 273 | project | `PROJECT-0211` | 403 FORBIDDEN | 본인이 운영하는 프로젝트에는 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:83` |
-| 274 | project | `PROJECT-0212` | 400 BAD_REQUEST | 현재 상태에서는 합/불 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DECISION_INVALID_TRANSITION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:84` |
-| 275 | project | `PROJECT-0213` | 409 CONFLICT | 해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_QUOTA_EXCEEDED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:86` |
-| 276 | project | `PROJECT-0214` | 400 BAD_REQUEST | 이미 종결된 지원서는 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:88` |
-| 277 | project | `PROJECT-0215` | 400 BAD_REQUEST | 매칭 차수가 종료되어 지원서를 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_ROUND_CLOSED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:89` |
-| 278 | project | `PROJECT-0300` | 404 NOT_FOUND | 매칭 차수를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:57` |
-| 279 | project | `PROJECT-0301` | 400 BAD_REQUEST | 매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_INVALID_PERIOD` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:58` |
-| 280 | project | `PROJECT-0302` | 409 CONFLICT | 같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_PERIOD_OVERLAPPED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:60` |
-| 281 | project | `PROJECT-0303` | 403 FORBIDDEN | 해당 매칭 차수에 대한 관리 권한이 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:62` |
-| 282 | project | `PROJECT-0304` | 409 CONFLICT | 연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_DELETE_CONFLICT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:64` |
-| 283 | project | `PROJECT-0305` | 400 BAD_REQUEST | time 기준 조회는 chapterId와 함께 요청해야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:66` |
-| 284 | project | `PROJECT-0306` | 400 BAD_REQUEST | 매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_LOCKED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:68` |
-| 285 | project | `PROJECT-0307` | 400 BAD_REQUEST | 결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FINALIZABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:70` |
-| 286 | project | `PROJECT-0308` | 500 INTERNAL_SERVER_ERROR | 해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:72` |
+| 237 | project | `PROJECT-0001` | 404 NOT_FOUND | 프로젝트를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:15` |
+| 238 | project | `PROJECT-0002` | 400 BAD_REQUEST | 이미 완료된 프로젝트입니다. | ProjectErrorCode | `ALREADY_COMPLETED_PROJECT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:16` |
+| 239 | project | `PROJECT-0003` | 400 BAD_REQUEST | 해당 프로젝트를 해산시킬 수 없습니다. | ProjectErrorCode | `PROJECT_ABORT_UNAVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:17` |
+| 240 | project | `PROJECT-0004` | 400 BAD_REQUEST | 요청하신 조작은 지원서가 제출된 상태에서만 가능합니다. | ProjectErrorCode | `APPLICATION_NOT_SUBMITTED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:20` |
+| 241 | project | `PROJECT-0005` | 400 BAD_REQUEST | 이미 지원서가 제출되었거나 평가가 완료된 상태입니다. | ProjectErrorCode | `APPLICATION_SUBMIT_NOT_AVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:21` |
+| 242 | project | `PROJECT-0006` | 404 NOT_FOUND | 프로젝트에서 해당 지원용 폼을 찾을 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:29` |
+| 243 | project | `PROJECT-0007` | 403 FORBIDDEN | 요청하신 지원용 폼 섹션에 접근 권한이 없습니다. | ProjectErrorCode | `APPLICATION_FORM_ACCESS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:30` |
+| 244 | project | `PROJECT-0008` | 409 CONFLICT | 작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:39` |
+| 245 | project | `PROJECT-0009` | 400 BAD_REQUEST | 현재 상태에서 수행할 수 없는 작업입니다. | ProjectErrorCode | `PROJECT_INVALID_STATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:40` |
+| 246 | project | `PROJECT-0010` | 400 BAD_REQUEST | 프로젝트 PO는 PLAN 파트 챌린저여야 합니다. | ProjectErrorCode | `PROJECT_OWNER_NOT_PLAN_CHALLENGER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:41` |
+| 247 | project | `PROJECT-0011` | 400 BAD_REQUEST | 제출에 필요한 필수 정보가 누락되었습니다. | ProjectErrorCode | `PROJECT_SUBMIT_VALIDATION_FAILED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:42` |
+| 248 | project | `PROJECT-0012` | 403 FORBIDDEN | 해당 프로젝트에 대한 접근 권한이 없습니다. | ProjectErrorCode | `PROJECT_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:43` |
+| 249 | project | `PROJECT-0013` | 400 BAD_REQUEST | PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다. | ProjectErrorCode | `APPLICATION_FORM_POLICY_PARTS_EMPTY` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:31` |
+| 250 | project | `PROJECT-0014` | 400 BAD_REQUEST | 현재 폼에 존재하지 않는 sectionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_SECTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:32` |
+| 251 | project | `PROJECT-0015` | 400 BAD_REQUEST | 해당 섹션에 속하지 않는 questionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_QUESTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:33` |
+| 252 | project | `PROJECT-0016` | 400 BAD_REQUEST | 해당 질문에 속하지 않는 optionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_OPTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:34` |
+| 253 | project | `PROJECT-0017` | 400 BAD_REQUEST | 선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:35` |
+| 254 | project | `PROJECT-0018` | 400 BAD_REQUEST | 선택지 타입 질문에는 1개 이상의 옵션이 필요합니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:36` |
+| 255 | project | `PROJECT-0019` | 500 INTERNAL_SERVER_ERROR | 임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_NOT_EXPOSABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:22` |
+| 256 | project | `PROJECT-0020` | 400 BAD_REQUEST | 임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_FILTER_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:24` |
+| 257 | project | `PROJECT-0021` | 404 NOT_FOUND | 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:26` |
+| 258 | project | `PROJECT-0022` | 409 CONFLICT | 현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능) | ProjectErrorCode | `PROJECT_DELETE_NOT_ALLOWED_IN_STATUS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:44` |
+| 259 | project | `PROJECT-0023` | 400 BAD_REQUEST | 프로젝트 중단 사유는 필수입니다. | ProjectErrorCode | `PROJECT_ABORT_REASON_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:46` |
+| 260 | project | `PROJECT-0100` | 404 NOT_FOUND | 프로젝트 멤버를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:49` |
+| 261 | project | `PROJECT-0101` | 409 CONFLICT | 이미 해당 프로젝트의 멤버입니다. | ProjectErrorCode | `PROJECT_MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:50` |
+| 262 | project | `PROJECT-0102` | 400 BAD_REQUEST | 메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다. | ProjectErrorCode | `PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:51` |
+| 263 | project | `PROJECT-0200` | 400 BAD_REQUEST | 파트 정원은 1 이상이어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_INVALID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:54` |
+| 264 | project | `PROJECT-0202` | 400 BAD_REQUEST | 공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:55` |
+| 265 | project | `PROJECT-0203` | 400 BAD_REQUEST | 동일 파트가 중복으로 입력되었습니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_DUPLICATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:56` |
+| 266 | project | `PROJECT-0204` | 404 NOT_FOUND | 작성 중인 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:78` |
+| 267 | project | `PROJECT-0205` | 403 FORBIDDEN | 해당 프로젝트에 지원 가능한 파트가 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_PART_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:79` |
+| 268 | project | `PROJECT-0206` | 409 CONFLICT | 이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:80` |
+| 269 | project | `PROJECT-0207` | 409 CONFLICT | 동일한 매칭 차수에 이미 제출된 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DUPLICATE_SUBMISSION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:81` |
+| 270 | project | `PROJECT-0208` | 400 BAD_REQUEST | 해당 매칭 차수의 지원 기간이 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_NOT_OPEN` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:82` |
+| 271 | project | `PROJECT-0209` | 400 BAD_REQUEST | 선택한 매칭 차수가 본인 파트에 해당하지 않습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_TYPE_MISMATCH` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:83` |
+| 272 | project | `PROJECT-0210` | 409 CONFLICT | 이미 작성 중인 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:84` |
+| 273 | project | `PROJECT-0211` | 403 FORBIDDEN | 본인이 운영하는 프로젝트에는 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:85` |
+| 274 | project | `PROJECT-0212` | 400 BAD_REQUEST | 현재 상태에서는 합/불 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DECISION_INVALID_TRANSITION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:86` |
+| 275 | project | `PROJECT-0213` | 409 CONFLICT | 해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_QUOTA_EXCEEDED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:88` |
+| 276 | project | `PROJECT-0214` | 400 BAD_REQUEST | 이미 종결된 지원서는 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:90` |
+| 277 | project | `PROJECT-0215` | 400 BAD_REQUEST | 매칭 차수가 종료되어 지원서를 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_ROUND_CLOSED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:91` |
+| 278 | project | `PROJECT-0300` | 404 NOT_FOUND | 매칭 차수를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:59` |
+| 279 | project | `PROJECT-0301` | 400 BAD_REQUEST | 매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_INVALID_PERIOD` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:60` |
+| 280 | project | `PROJECT-0302` | 409 CONFLICT | 같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_PERIOD_OVERLAPPED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:62` |
+| 281 | project | `PROJECT-0303` | 403 FORBIDDEN | 해당 매칭 차수에 대한 관리 권한이 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:64` |
+| 282 | project | `PROJECT-0304` | 409 CONFLICT | 연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_DELETE_CONFLICT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:66` |
+| 283 | project | `PROJECT-0305` | 400 BAD_REQUEST | time 기준 조회는 chapterId와 함께 요청해야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:68` |
+| 284 | project | `PROJECT-0306` | 400 BAD_REQUEST | 매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_LOCKED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:70` |
+| 285 | project | `PROJECT-0307` | 400 BAD_REQUEST | 결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FINALIZABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:72` |
+| 286 | project | `PROJECT-0308` | 500 INTERNAL_SERVER_ERROR | 해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:74` |
 
 ## schedule
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -1,5 +1,22 @@
 package com.umc.product.project.adapter.in.web.assembler;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
@@ -13,7 +30,9 @@ import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ManagedProjectSummaryResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectMembersResponse;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectMembersResponse.MatchedRoundInfo;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectMembersResponse.PartGroup;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectMembersResponse.ProjectMemberBrief;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
 import com.umc.product.project.adapter.in.web.dto.response.statistics.ChapterProjectStatisticsResponse;
 import com.umc.product.project.adapter.in.web.dto.response.statistics.ProjectStatisticsResponse;
@@ -25,25 +44,14 @@ import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchManagedProjectQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectMember;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Component;
 
 /**
  * Project Response 조립기. Controller에서 여러 UseCase를 조합하는 로직을 캡슐화합니다.
@@ -58,6 +66,7 @@ public class ProjectResponseAssembler {
     private final SearchManagedProjectUseCase searchManagedProjectUseCase;
     private final GetMemberUseCase getMemberUseCase;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+    private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
     private final GetProjectStatisticsUseCase getProjectStatisticsUseCase;
     private final CheckPermissionUseCase checkPermissionUseCase;
@@ -138,8 +147,10 @@ public class ProjectResponseAssembler {
         Map<Long, MemberInfo> memberMap = memberIds.isEmpty()
             ? Map.of()
             : getMemberUseCase.findAllByIds(memberIds);
+        Map<ProjectMemberKey, MatchedRoundInfo> matchedRoundMap =
+            loadMatchedRoundMap(Set.of(projectId), memberIds);
 
-        return buildMembersResponse(projectId, info, members, memberMap);
+        return buildMembersResponse(projectId, info, members, memberMap, matchedRoundMap);
     }
 
     /**
@@ -184,12 +195,18 @@ public class ProjectResponseAssembler {
         Map<Long, MemberInfo> memberMap = allMemberIds.isEmpty()
             ? Map.of()
             : getMemberUseCase.findAllByIds(allMemberIds);
+        Map<ProjectMemberKey, MatchedRoundInfo> matchedRoundMap =
+            loadMatchedRoundMap(validProjects.keySet(), allMemberIds);
 
         // Step 4: 응답 조립
         Map<Long, ProjectMembersResponse> result = new LinkedHashMap<>();
         validProjects.forEach((projectId, info) ->
             result.put(projectId, buildMembersResponse(
-                projectId, info, projectMembersMap.getOrDefault(projectId, List.of()), memberMap)));
+                projectId,
+                info,
+                projectMembersMap.getOrDefault(projectId, List.of()),
+                memberMap,
+                matchedRoundMap)));
 
         return result;
     }
@@ -229,23 +246,33 @@ public class ProjectResponseAssembler {
     }
 
     private ProjectMembersResponse buildMembersResponse(
-        Long projectId, ProjectInfo info, List<ProjectMember> members, Map<Long, MemberInfo> memberMap
+        Long projectId,
+        ProjectInfo info,
+        List<ProjectMember> members,
+        Map<Long, MemberInfo> memberMap,
+        Map<ProjectMemberKey, MatchedRoundInfo> matchedRoundMap
     ) {
-        MemberBrief productOwner = toBrief(memberMap.get(info.productOwnerMemberId()));
+        ProjectMemberBrief productOwner = toProjectMemberBrief(
+            memberMap.get(info.productOwnerMemberId()),
+            matchedRoundMap.get(ProjectMemberKey.of(projectId, info.productOwnerMemberId()))
+        );
 
-        Map<ChallengerPart, List<MemberBrief>> partToMembers = new EnumMap<>(ChallengerPart.class);
+        Map<ChallengerPart, List<ProjectMemberBrief>> partToMembers = new EnumMap<>(ChallengerPart.class);
         for (ProjectMember m : members) {
-            MemberBrief brief = toBrief(memberMap.get(m.getMemberId()));
+            ProjectMemberBrief brief = toProjectMemberBrief(
+                memberMap.get(m.getMemberId()),
+                matchedRoundMap.get(ProjectMemberKey.of(projectId, m.getMemberId()))
+            );
             if (brief == null) {
                 continue;
             }
             partToMembers.computeIfAbsent(m.getPart(), p -> new ArrayList<>()).add(brief);
         }
 
-        Comparator<MemberBrief> byNickname = Comparator.comparing(
-            MemberBrief::nickname, Comparator.nullsLast(Comparator.naturalOrder()));
+        Comparator<ProjectMemberBrief> byNickname = Comparator.comparing(
+            ProjectMemberBrief::nickname, Comparator.nullsLast(Comparator.naturalOrder()));
 
-        List<MemberBrief> coProductOwners = partToMembers.getOrDefault(ChallengerPart.PLAN, List.of()).stream()
+        List<ProjectMemberBrief> coProductOwners = partToMembers.getOrDefault(ChallengerPart.PLAN, List.of()).stream()
             .filter(b -> !Objects.equals(b.memberId(), info.productOwnerMemberId()))
             .sorted(byNickname)
             .toList();
@@ -265,6 +292,33 @@ public class ProjectResponseAssembler {
             .build();
     }
 
+    private Map<ProjectMemberKey, MatchedRoundInfo> loadMatchedRoundMap(
+        Collection<Long> projectIds,
+        Collection<Long> memberIds
+    ) {
+        if (projectIds == null || projectIds.isEmpty() || memberIds == null || memberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<ProjectMemberMatchedRoundInfo> rows = loadProjectApplicationPort
+            .listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(projectIds, memberIds);
+        if (rows == null || rows.isEmpty()) {
+            return Map.of();
+        }
+
+        return rows.stream()
+            .collect(Collectors.toMap(
+                ProjectMemberKey::from,
+                row -> new MatchedRoundInfo(
+                    row.matchingRoundId(),
+                    row.matchingRoundType(),
+                    row.matchingRoundPhase()
+                ),
+                (left, right) -> left,
+                LinkedHashMap::new
+            ));
+    }
+
     private Long resolveApplicationFormId(Long projectId) {
         return loadProjectApplicationFormPort.findByProjectId(projectId)
             .map(ProjectApplicationForm::getId)
@@ -280,5 +334,20 @@ public class ProjectResponseAssembler {
 
     private MemberBrief toBrief(MemberInfo info) {
         return info == null ? null : MemberBrief.from(info);
+    }
+
+    private ProjectMemberBrief toProjectMemberBrief(MemberInfo info, MatchedRoundInfo matchedRoundInfo) {
+        return info == null ? null : ProjectMemberBrief.from(info, matchedRoundInfo);
+    }
+
+    private record ProjectMemberKey(Long projectId, Long memberId) {
+
+        private static ProjectMemberKey of(Long projectId, Long memberId) {
+            return new ProjectMemberKey(projectId, memberId);
+        }
+
+        private static ProjectMemberKey from(ProjectMemberMatchedRoundInfo info) {
+            return new ProjectMemberKey(info.projectId(), info.memberId());
+        }
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -154,7 +154,7 @@ public class ProjectResponseAssembler {
     }
 
     /**
-     * PROJECT-004 프로젝트 팀원 구성 일괄 조회.
+     * PROJECT-007 프로젝트 팀원 구성 일괄 조회.
      * <p>
      * 각 projectId에 대해 per-project 권한 체크 및 데이터 조회를 수행하며, 실패한 프로젝트는 결과에서 제외 멤버 정보는 유효한 프로젝트 전체를 모아 한 번에 조회한다.
      */

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectMembersResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/ProjectMembersResponse.java
@@ -1,8 +1,12 @@
 package com.umc.product.project.adapter.in.web.dto.response;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.project.adapter.in.web.dto.common.MemberBrief;
 import java.util.List;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+
 import lombok.Builder;
 
 /**
@@ -13,12 +17,43 @@ import lombok.Builder;
 @Builder
 public record ProjectMembersResponse(
     Long projectId,
-    MemberBrief productOwner,
-    List<MemberBrief> coProductOwners,
+    ProjectMemberBrief productOwner,
+    List<ProjectMemberBrief> coProductOwners,
     List<PartGroup> partGroups
 ) {
 
     /** 파트별 멤버 묶음. {@code part} 는 PLAN 외 파트만 등장한다. */
-    public record PartGroup(ChallengerPart part, List<MemberBrief> members) {
+    public record PartGroup(ChallengerPart part, List<ProjectMemberBrief> members) {
+    }
+
+    /**
+     * 프로젝트 팀원 조회 전용 멤버 간략 정보.
+     * <p>
+     * 공용 {@code MemberBrief} 에 매칭 차수 필드를 섞지 않기 위해 PROJECT-003 응답 안에서만 사용한다.
+     */
+    @Builder
+    public record ProjectMemberBrief(
+        Long memberId,
+        String nickname,
+        String name,
+        String schoolName,
+        MatchedRoundInfo matchedRoundInfo
+    ) {
+        public static ProjectMemberBrief from(MemberInfo info, MatchedRoundInfo matchedRoundInfo) {
+            return ProjectMemberBrief.builder()
+                .memberId(info.id())
+                .nickname(info.nickname())
+                .name(info.name())
+                .schoolName(info.schoolName())
+                .matchedRoundInfo(matchedRoundInfo)
+                .build();
+        }
+    }
+
+    public record MatchedRoundInfo(
+        Long id,
+        MatchingType type,
+        MatchingPhase phase
+    ) {
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -1,17 +1,21 @@
 package com.umc.product.project.adapter.out.persistence;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -118,6 +122,15 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
         ProjectApplicationStatus status
     ) {
         return projectApplicationQueryRepository.searchProjectApplications(projectId, matchingRoundId, status);
+    }
+
+    @Override
+    public List<ProjectMemberMatchedRoundInfo> listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
+        Collection<Long> projectIds,
+        Collection<Long> memberIds
+    ) {
+        return projectApplicationQueryRepository.listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
+            projectIds, memberIds);
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -5,15 +5,24 @@ import static com.umc.product.project.domain.QProjectApplication.projectApplicat
 import static com.umc.product.project.domain.QProjectApplicationForm.projectApplicationForm;
 import static com.umc.product.project.domain.QProjectMatchingRound.projectMatchingRound;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 /**
  * ProjectApplication QueryDSL 동적 검색 구현.
@@ -132,6 +141,52 @@ public class ProjectApplicationQueryRepository {
     }
 
     /**
+     * 프로젝트/멤버 쌍별 APPROVED 지원서 중 가장 최신 매칭 차수를 반환한다.
+     * <p>
+     * DB 에서 최신 우선 정렬로 가져온 뒤, Java 에서 각 (projectId, memberId) 의 첫 row 만 남겨 DB 벤더별 window function 차이를 피한다.
+     */
+    public List<ProjectMemberMatchedRoundInfo> listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
+        Collection<Long> projectIds,
+        Collection<Long> memberIds
+    ) {
+        if (projectIds == null || projectIds.isEmpty() || memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProjectMemberMatchedRoundInfo> rows = queryFactory
+            .select(Projections.constructor(
+                ProjectMemberMatchedRoundInfo.class,
+                project.id,
+                projectApplication.applicantMemberId,
+                projectMatchingRound.id,
+                projectMatchingRound.type,
+                projectMatchingRound.phase
+            ))
+            .from(projectApplication)
+            .innerJoin(projectApplication.applicationForm, projectApplicationForm)
+            .innerJoin(projectApplicationForm.project, project)
+            .innerJoin(projectApplication.appliedMatchingRound, projectMatchingRound)
+            .where(
+                project.id.in(projectIds),
+                projectApplication.applicantMemberId.in(memberIds),
+                projectApplication.status.eq(ProjectApplicationStatus.APPROVED)
+            )
+            .orderBy(
+                project.id.asc(),
+                projectApplication.applicantMemberId.asc(),
+                projectMatchingRound.startsAt.desc(),
+                projectApplication.id.desc()
+            )
+            .fetch();
+
+        Map<ProjectMemberKey, ProjectMemberMatchedRoundInfo> latestByMember = new LinkedHashMap<>();
+        for (ProjectMemberMatchedRoundInfo row : rows) {
+            latestByMember.putIfAbsent(new ProjectMemberKey(row.projectId(), row.memberId()), row);
+        }
+        return new ArrayList<>(latestByMember.values());
+    }
+
+    /**
      * 단건 상세 조회 — applicationForm/project, appliedMatchingRound 를 fetch join 한다.
      * <p>
      * formResponse 는 별도 도메인이라 본 쿼리에서 fetch 하지 않는다 — 호출자가 cross-domain UseCase 로 로드한다.
@@ -175,5 +230,8 @@ public class ProjectApplicationQueryRepository {
         return status == null
             ? projectApplication.status.ne(ProjectApplicationStatus.DRAFT)
             : projectApplication.status.eq(status);
+    }
+
+    private record ProjectMemberKey(Long projectId, Long memberId) {
     }
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -1,10 +1,13 @@
 package com.umc.product.project.application.port.out;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * {@code findBy*} — 없어도 정상 ({@link Optional})
@@ -102,6 +105,17 @@ public interface LoadProjectApplicationPort {
         Long projectId,
         Long matchingRoundId,
         ProjectApplicationStatus status
+    );
+
+    /**
+     * 프로젝트/멤버 쌍별 APPROVED 지원서 중 가장 최신 매칭 차수를 조회합니다.
+     * <p>
+     * 최신 기준: matchingRound.startsAt DESC, 동률이면 application.id DESC.
+     * 지원서가 없는 쌍은 결과에 포함하지 않습니다.
+     */
+    List<ProjectMemberMatchedRoundInfo> listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
+        Collection<Long> projectIds,
+        Collection<Long> memberIds
     );
 
     /**

--- a/src/main/java/com/umc/product/project/application/port/out/dto/ProjectMemberMatchedRoundInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/out/dto/ProjectMemberMatchedRoundInfo.java
@@ -1,0 +1,13 @@
+package com.umc.product.project.application.port.out.dto;
+
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+
+public record ProjectMemberMatchedRoundInfo(
+    Long projectId,
+    Long memberId,
+    Long matchingRoundId,
+    MatchingType matchingRoundType,
+    MatchingPhase matchingRoundPhase
+) {
+}

--- a/src/main/resources/static/docs/catalog/api/catalog.json
+++ b/src/main/resources/static/docs/catalog/api/catalog.json
@@ -92,7 +92,7 @@
     "role": "비밀번호 자격증명 최초 등록",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 45,
+    "line": 47,
     "operationId": null
   },
   {
@@ -104,7 +104,7 @@
     "role": "비밀번호 변경",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 58,
+    "line": 60,
     "operationId": null
   },
   {
@@ -116,7 +116,7 @@
     "role": "이메일 사용 가능 여부 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 87,
+    "line": 89,
     "operationId": null
   },
   {
@@ -128,7 +128,7 @@
     "role": "비밀번호 초기화",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 71,
+    "line": 73,
     "operationId": null
   },
   {
@@ -224,7 +224,7 @@
     "role": "이메일/PW 로그인",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java",
-    "line": 98,
+    "line": 100,
     "operationId": null
   },
   {
@@ -344,7 +344,7 @@
     "role": "챌린저 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 40,
+    "line": 46,
     "operationId": null
   },
   {
@@ -356,7 +356,7 @@
     "role": "챌린저 batch 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 52,
+    "line": 58,
     "operationId": null
   },
   {
@@ -368,7 +368,7 @@
     "role": "챌린저 비활성화 (제명/탈부 처리)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 70,
+    "line": 76,
     "operationId": null
   },
   {
@@ -380,7 +380,7 @@
     "role": "챌린저 파트 변경",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 83,
+    "line": 89,
     "operationId": null
   },
   {
@@ -392,7 +392,7 @@
     "role": "[주의] 챌린저 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java",
-    "line": 99,
+    "line": 105,
     "operationId": null
   },
   {
@@ -464,7 +464,7 @@
     "role": "6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 36,
+    "line": 42,
     "operationId": null
   },
   {
@@ -476,7 +476,7 @@
     "role": "[ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 89,
+    "line": 95,
     "operationId": null
   },
   {
@@ -488,7 +488,7 @@
     "role": "[ADMIN] 챌린저 기록용 코드 벌크 추가",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 116,
+    "line": 122,
     "operationId": null
   },
   {
@@ -500,7 +500,7 @@
     "role": "코드로 ChallengerRecord 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 65,
+    "line": 71,
     "operationId": null
   },
   {
@@ -512,7 +512,7 @@
     "role": "ID로 ChallengerRecord 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java",
-    "line": 77,
+    "line": 83,
     "operationId": null
   },
   {
@@ -524,7 +524,7 @@
     "role": "챌린저 상벌점 부여",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 38,
+    "line": 41,
     "operationId": null
   },
   {
@@ -536,7 +536,7 @@
     "role": "챌린저 상벌점 사유 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 55,
+    "line": 58,
     "operationId": null
   },
   {
@@ -548,7 +548,7 @@
     "role": "챌린저 상벌점 삭제",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java",
-    "line": 70,
+    "line": 73,
     "operationId": null
   },
   {
@@ -1189,6 +1189,30 @@
   },
   {
     "sequence": 100,
+    "domain": "feedback",
+    "apiId": "<미지정>",
+    "endpoint": "/api/v1/user-feedbacks/responses",
+    "httpMethod": "POST",
+    "role": "사용자 피드백 응답 제출",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java",
+    "line": 58,
+    "operationId": null
+  },
+  {
+    "sequence": 101,
+    "domain": "feedback",
+    "apiId": "<미지정>",
+    "endpoint": "/api/v1/user-feedbacks/templates",
+    "httpMethod": "GET",
+    "role": "사용자 피드백 템플릿 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java",
+    "line": 34,
+    "operationId": null
+  },
+  {
+    "sequence": 102,
     "domain": "figma",
     "apiId": "FIGMA-001",
     "endpoint": "/api/v1/admin/figma/oauth",
@@ -1200,7 +1224,7 @@
     "operationId": null
   },
   {
-    "sequence": 101,
+    "sequence": 103,
     "domain": "figma",
     "apiId": "FIGMA-002",
     "endpoint": "/api/v1/admin/figma/oauth/callback",
@@ -1212,7 +1236,7 @@
     "operationId": null
   },
   {
-    "sequence": 102,
+    "sequence": 104,
     "domain": "figma",
     "apiId": "FIGMA-003",
     "endpoint": "/api/v1/admin/figma/watched-files",
@@ -1224,7 +1248,7 @@
     "operationId": null
   },
   {
-    "sequence": 103,
+    "sequence": 105,
     "domain": "figma",
     "apiId": "FIGMA-004",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}",
@@ -1236,7 +1260,7 @@
     "operationId": null
   },
   {
-    "sequence": 104,
+    "sequence": 106,
     "domain": "figma",
     "apiId": "FIGMA-005",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}/enable",
@@ -1248,7 +1272,7 @@
     "operationId": null
   },
   {
-    "sequence": 105,
+    "sequence": 107,
     "domain": "figma",
     "apiId": "FIGMA-006",
     "endpoint": "/api/v1/admin/figma/sync",
@@ -1260,7 +1284,7 @@
     "operationId": null
   },
   {
-    "sequence": 106,
+    "sequence": 108,
     "domain": "figma",
     "apiId": "FIGMA-007",
     "endpoint": "/api/v1/admin/figma/sync/watched-files/{watchedFileId}",
@@ -1272,7 +1296,7 @@
     "operationId": null
   },
   {
-    "sequence": 107,
+    "sequence": 109,
     "domain": "figma",
     "apiId": "FIGMA-008",
     "endpoint": "/api/v1/admin/figma/watched-files",
@@ -1284,7 +1308,7 @@
     "operationId": null
   },
   {
-    "sequence": 108,
+    "sequence": 110,
     "domain": "figma",
     "apiId": "FIGMA-009",
     "endpoint": "/api/v1/admin/figma/watched-files/{watchedFileId}",
@@ -1296,7 +1320,7 @@
     "operationId": null
   },
   {
-    "sequence": 109,
+    "sequence": 111,
     "domain": "figma",
     "apiId": "FIGMA-010",
     "endpoint": "/api/v1/admin/figma/preview",
@@ -1308,7 +1332,7 @@
     "operationId": null
   },
   {
-    "sequence": 110,
+    "sequence": 112,
     "domain": "figma",
     "apiId": "FIGMA-011",
     "endpoint": "/api/v1/admin/figma/routing-domains",
@@ -1320,7 +1344,7 @@
     "operationId": null
   },
   {
-    "sequence": 111,
+    "sequence": 113,
     "domain": "figma",
     "apiId": "FIGMA-012",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1332,7 +1356,7 @@
     "operationId": null
   },
   {
-    "sequence": 112,
+    "sequence": 114,
     "domain": "figma",
     "apiId": "FIGMA-013",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}/mentions",
@@ -1344,7 +1368,7 @@
     "operationId": null
   },
   {
-    "sequence": 113,
+    "sequence": 115,
     "domain": "figma",
     "apiId": "FIGMA-014",
     "endpoint": "/api/v1/admin/figma/routing-domains/mentions/{mentionId}",
@@ -1356,7 +1380,7 @@
     "operationId": null
   },
   {
-    "sequence": 114,
+    "sequence": 116,
     "domain": "figma",
     "apiId": "FIGMA-015",
     "endpoint": "/api/v1/admin/figma/digest",
@@ -1368,7 +1392,7 @@
     "operationId": null
   },
   {
-    "sequence": 115,
+    "sequence": 117,
     "domain": "figma",
     "apiId": "FIGMA-016",
     "endpoint": "/api/v1/admin/figma/routing-domains",
@@ -1380,7 +1404,7 @@
     "operationId": null
   },
   {
-    "sequence": 116,
+    "sequence": 118,
     "domain": "figma",
     "apiId": "FIGMA-017",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1392,7 +1416,7 @@
     "operationId": null
   },
   {
-    "sequence": 117,
+    "sequence": 119,
     "domain": "figma",
     "apiId": "FIGMA-018",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}/mentions",
@@ -1404,7 +1428,7 @@
     "operationId": null
   },
   {
-    "sequence": 118,
+    "sequence": 120,
     "domain": "figma",
     "apiId": "FIGMA-019",
     "endpoint": "/api/v1/admin/figma/routing-domains/{domainId}",
@@ -1416,7 +1440,7 @@
     "operationId": null
   },
   {
-    "sequence": 119,
+    "sequence": 121,
     "domain": "figma",
     "apiId": "FIGMA-020",
     "endpoint": "/api/v1/admin/figma/routing-domains/mentions/{mentionId}",
@@ -1428,7 +1452,7 @@
     "operationId": null
   },
   {
-    "sequence": 120,
+    "sequence": 122,
     "domain": "global",
     "apiId": "<미지정>",
     "endpoint": "/error",
@@ -1440,7 +1464,7 @@
     "operationId": null
   },
   {
-    "sequence": 121,
+    "sequence": 123,
     "domain": "maintenance",
     "apiId": "MAINT-001",
     "endpoint": "/api/v1/admin/maintenance",
@@ -1452,7 +1476,7 @@
     "operationId": null
   },
   {
-    "sequence": 122,
+    "sequence": 124,
     "domain": "maintenance",
     "apiId": "MAINT-002",
     "endpoint": "/api/v1/admin/maintenance/{windowId}/end",
@@ -1464,7 +1488,7 @@
     "operationId": null
   },
   {
-    "sequence": 123,
+    "sequence": 125,
     "domain": "maintenance",
     "apiId": "MAINT-003",
     "endpoint": "/api/v1/admin/maintenance",
@@ -1476,7 +1500,7 @@
     "operationId": null
   },
   {
-    "sequence": 124,
+    "sequence": 126,
     "domain": "maintenance",
     "apiId": "MAINT-004",
     "endpoint": "/api/v1/admin/maintenance/{windowId}",
@@ -1488,7 +1512,7 @@
     "operationId": null
   },
   {
-    "sequence": 125,
+    "sequence": 127,
     "domain": "maintenance",
     "apiId": "SYSTEM-001",
     "endpoint": "/api/v1/system/status",
@@ -1500,7 +1524,7 @@
     "operationId": null
   },
   {
-    "sequence": 126,
+    "sequence": 128,
     "domain": "member",
     "apiId": "MEMBER-001",
     "endpoint": "/api/v1/member",
@@ -1508,11 +1532,11 @@
     "role": "내 회원 정보 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 128,
+    "line": 130,
     "operationId": null
   },
   {
-    "sequence": 127,
+    "sequence": 129,
     "domain": "member",
     "apiId": "MEMBER-002",
     "endpoint": "/api/v1/member/profile/links",
@@ -1520,11 +1544,11 @@
     "role": "내 회원 프로필 링크 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 142,
+    "line": 144,
     "operationId": null
   },
   {
-    "sequence": 128,
+    "sequence": 130,
     "domain": "member",
     "apiId": "MEMBER-003",
     "endpoint": "/api/v1/member",
@@ -1532,11 +1556,11 @@
     "role": "회원 탈퇴",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 156,
+    "line": 158,
     "operationId": null
   },
   {
-    "sequence": 129,
+    "sequence": 131,
     "domain": "member",
     "apiId": "MEMBER-004",
     "endpoint": "/api/v1/member/{memberId}",
@@ -1544,11 +1568,11 @@
     "role": "관리자 권한으로 회원 게정 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 169,
+    "line": 171,
     "operationId": null
   },
   {
-    "sequence": 130,
+    "sequence": 132,
     "domain": "member",
     "apiId": "MEMBER-101",
     "endpoint": "/api/v1/member/profile/{memberId}",
@@ -1560,7 +1584,7 @@
     "operationId": null
   },
   {
-    "sequence": 131,
+    "sequence": 133,
     "domain": "member",
     "apiId": "MEMBER-102",
     "endpoint": "/api/v1/member/me",
@@ -1572,7 +1596,7 @@
     "operationId": null
   },
   {
-    "sequence": 132,
+    "sequence": 134,
     "domain": "member",
     "apiId": "MEMBER-103",
     "endpoint": "/api/v1/member/search",
@@ -1584,7 +1608,7 @@
     "operationId": null
   },
   {
-    "sequence": 133,
+    "sequence": 135,
     "domain": "member",
     "apiId": "MEMBER-201",
     "endpoint": "/api/v2/member/me",
@@ -1596,7 +1620,7 @@
     "operationId": null
   },
   {
-    "sequence": 134,
+    "sequence": 136,
     "domain": "member",
     "apiId": "MEMBER-202",
     "endpoint": "/api/v2/member/search",
@@ -1608,7 +1632,7 @@
     "operationId": null
   },
   {
-    "sequence": 135,
+    "sequence": 137,
     "domain": "member",
     "apiId": "REGISTER-001",
     "endpoint": "/api/v1/member/register",
@@ -1616,11 +1640,11 @@
     "role": "OAuth 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 59,
+    "line": 61,
     "operationId": null
   },
   {
-    "sequence": 136,
+    "sequence": 138,
     "domain": "member",
     "apiId": "REGISTER-003",
     "endpoint": "/api/v1/member/register/email",
@@ -1628,11 +1652,11 @@
     "role": "이메일/PW 이용 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 101,
+    "line": 103,
     "operationId": null
   },
   {
-    "sequence": 137,
+    "sequence": 139,
     "domain": "notice",
     "apiId": "NOTICE-001",
     "endpoint": "/api/v1/notices",
@@ -1644,7 +1668,7 @@
     "operationId": null
   },
   {
-    "sequence": 138,
+    "sequence": 140,
     "domain": "notice",
     "apiId": "NOTICE-002",
     "endpoint": "/api/v1/notices/search",
@@ -1656,7 +1680,7 @@
     "operationId": null
   },
   {
-    "sequence": 139,
+    "sequence": 141,
     "domain": "notice",
     "apiId": "NOTICE-003",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1668,7 +1692,7 @@
     "operationId": null
   },
   {
-    "sequence": 140,
+    "sequence": 142,
     "domain": "notice",
     "apiId": "NOTICE-004",
     "endpoint": "/api/v1/notices/{noticeId}/read-statics",
@@ -1680,7 +1704,7 @@
     "operationId": null
   },
   {
-    "sequence": 141,
+    "sequence": 143,
     "domain": "notice",
     "apiId": "NOTICE-005",
     "endpoint": "/api/v1/notices/{noticeId}/read-status",
@@ -1692,7 +1716,7 @@
     "operationId": null
   },
   {
-    "sequence": 142,
+    "sequence": 144,
     "domain": "notice",
     "apiId": "NOTICE-101",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -1704,7 +1728,7 @@
     "operationId": null
   },
   {
-    "sequence": 143,
+    "sequence": 145,
     "domain": "notice",
     "apiId": "NOTICE-102",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -1716,7 +1740,7 @@
     "operationId": null
   },
   {
-    "sequence": 144,
+    "sequence": 146,
     "domain": "notice",
     "apiId": "NOTICE-103",
     "endpoint": "/api/v1/notices/{noticeId}/votes",
@@ -1728,7 +1752,7 @@
     "operationId": null
   },
   {
-    "sequence": 145,
+    "sequence": 147,
     "domain": "notice",
     "apiId": "NOTICE-104",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -1740,7 +1764,7 @@
     "operationId": null
   },
   {
-    "sequence": 146,
+    "sequence": 148,
     "domain": "notice",
     "apiId": "NOTICE-105",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -1752,7 +1776,7 @@
     "operationId": null
   },
   {
-    "sequence": 147,
+    "sequence": 149,
     "domain": "notice",
     "apiId": "NOTICE-106",
     "endpoint": "/api/v1/notices/{noticeId}/vote",
@@ -1764,7 +1788,7 @@
     "operationId": null
   },
   {
-    "sequence": 148,
+    "sequence": 150,
     "domain": "notice",
     "apiId": "NOTICE-201",
     "endpoint": "/api/v1/notices",
@@ -1776,7 +1800,7 @@
     "operationId": null
   },
   {
-    "sequence": 149,
+    "sequence": 151,
     "domain": "notice",
     "apiId": "NOTICE-202",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1788,7 +1812,7 @@
     "operationId": null
   },
   {
-    "sequence": 150,
+    "sequence": 152,
     "domain": "notice",
     "apiId": "NOTICE-203",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -1800,7 +1824,7 @@
     "operationId": null
   },
   {
-    "sequence": 151,
+    "sequence": 153,
     "domain": "notice",
     "apiId": "NOTICE-204",
     "endpoint": "/api/v1/notices/{noticeId}/reminders",
@@ -1812,7 +1836,7 @@
     "operationId": null
   },
   {
-    "sequence": 152,
+    "sequence": 154,
     "domain": "notice",
     "apiId": "NOTICE-205",
     "endpoint": "/api/v1/notices/{noticeId}/read",
@@ -1824,7 +1848,7 @@
     "operationId": null
   },
   {
-    "sequence": 153,
+    "sequence": 155,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-001",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -1836,7 +1860,7 @@
     "operationId": null
   },
   {
-    "sequence": 154,
+    "sequence": 156,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-002",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -1848,7 +1872,7 @@
     "operationId": null
   },
   {
-    "sequence": 155,
+    "sequence": 157,
     "domain": "notification",
     "apiId": "FCM-001",
     "endpoint": "/api/v1/notification/fcm/token",
@@ -1860,7 +1884,7 @@
     "operationId": null
   },
   {
-    "sequence": 156,
+    "sequence": 158,
     "domain": "notification",
     "apiId": "FCM-002",
     "endpoint": "/api/v1/notification/fcm/topics/legacy",
@@ -1872,7 +1896,7 @@
     "operationId": null
   },
   {
-    "sequence": 157,
+    "sequence": 159,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -1884,7 +1908,7 @@
     "operationId": null
   },
   {
-    "sequence": 158,
+    "sequence": 160,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/schools/gisu/{gisuId}",
@@ -1896,7 +1920,7 @@
     "operationId": null
   },
   {
-    "sequence": 159,
+    "sequence": 161,
     "domain": "organization",
     "apiId": "CHAPTER-001",
     "endpoint": "/api/v1/chapters",
@@ -1908,7 +1932,7 @@
     "operationId": null
   },
   {
-    "sequence": 160,
+    "sequence": 162,
     "domain": "organization",
     "apiId": "CHAPTER-002",
     "endpoint": "/api/v1/chapters/bulk",
@@ -1920,7 +1944,7 @@
     "operationId": null
   },
   {
-    "sequence": 161,
+    "sequence": 163,
     "domain": "organization",
     "apiId": "CHAPTER-003",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -1932,7 +1956,7 @@
     "operationId": null
   },
   {
-    "sequence": 162,
+    "sequence": 164,
     "domain": "organization",
     "apiId": "CHAPTER-101",
     "endpoint": "/api/v1/chapters",
@@ -1944,7 +1968,7 @@
     "operationId": null
   },
   {
-    "sequence": 163,
+    "sequence": 165,
     "domain": "organization",
     "apiId": "CHAPTER-102",
     "endpoint": "/api/v1/chapters/with-schools",
@@ -1956,7 +1980,7 @@
     "operationId": null
   },
   {
-    "sequence": 164,
+    "sequence": 166,
     "domain": "organization",
     "apiId": "CHAPTER-103",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -1968,7 +1992,7 @@
     "operationId": null
   },
   {
-    "sequence": 165,
+    "sequence": 167,
     "domain": "organization",
     "apiId": "GISU-001",
     "endpoint": "/api/v1/gisu",
@@ -1980,7 +2004,7 @@
     "operationId": null
   },
   {
-    "sequence": 166,
+    "sequence": 168,
     "domain": "organization",
     "apiId": "GISU-002",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -1992,7 +2016,7 @@
     "operationId": null
   },
   {
-    "sequence": 167,
+    "sequence": 169,
     "domain": "organization",
     "apiId": "GISU-003",
     "endpoint": "/api/v1/gisu/{gisuId}/active",
@@ -2004,7 +2028,7 @@
     "operationId": null
   },
   {
-    "sequence": 168,
+    "sequence": 170,
     "domain": "organization",
     "apiId": "GISU-101",
     "endpoint": "/api/v1/gisu",
@@ -2016,7 +2040,7 @@
     "operationId": null
   },
   {
-    "sequence": 169,
+    "sequence": 171,
     "domain": "organization",
     "apiId": "GISU-102",
     "endpoint": "/api/v1/gisu/all",
@@ -2028,7 +2052,7 @@
     "operationId": null
   },
   {
-    "sequence": 170,
+    "sequence": 172,
     "domain": "organization",
     "apiId": "GISU-103",
     "endpoint": "/api/v1/gisu/active",
@@ -2040,7 +2064,7 @@
     "operationId": null
   },
   {
-    "sequence": 171,
+    "sequence": 173,
     "domain": "organization",
     "apiId": "SCHOOL-001",
     "endpoint": "/api/v1/schools",
@@ -2052,7 +2076,7 @@
     "operationId": null
   },
   {
-    "sequence": 172,
+    "sequence": 174,
     "domain": "organization",
     "apiId": "SCHOOL-002",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2064,7 +2088,7 @@
     "operationId": null
   },
   {
-    "sequence": 173,
+    "sequence": 175,
     "domain": "organization",
     "apiId": "SCHOOL-003",
     "endpoint": "/api/v1/schools",
@@ -2076,7 +2100,7 @@
     "operationId": null
   },
   {
-    "sequence": 174,
+    "sequence": 176,
     "domain": "organization",
     "apiId": "SCHOOL-004",
     "endpoint": "/api/v1/schools/{schoolId}/assign",
@@ -2088,7 +2112,7 @@
     "operationId": null
   },
   {
-    "sequence": 175,
+    "sequence": 177,
     "domain": "organization",
     "apiId": "SCHOOL-005",
     "endpoint": "/api/v1/schools/{schoolId}/unassign",
@@ -2100,7 +2124,7 @@
     "operationId": null
   },
   {
-    "sequence": 176,
+    "sequence": 178,
     "domain": "organization",
     "apiId": "SCHOOL-101",
     "endpoint": "/api/v1/schools/all",
@@ -2112,7 +2136,7 @@
     "operationId": null
   },
   {
-    "sequence": 177,
+    "sequence": 179,
     "domain": "organization",
     "apiId": "SCHOOL-102",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2124,7 +2148,7 @@
     "operationId": null
   },
   {
-    "sequence": 178,
+    "sequence": 180,
     "domain": "organization",
     "apiId": "SCHOOL-103",
     "endpoint": "/api/v1/schools/unassigned",
@@ -2136,7 +2160,7 @@
     "operationId": null
   },
   {
-    "sequence": 179,
+    "sequence": 181,
     "domain": "organization",
     "apiId": "SCHOOL-104",
     "endpoint": "/api/v1/schools/link/{schoolId}",
@@ -2148,7 +2172,7 @@
     "operationId": null
   },
   {
-    "sequence": 180,
+    "sequence": 182,
     "domain": "organization",
     "apiId": "STUDY-GROUP-001",
     "endpoint": "/api/v1/study-groups",
@@ -2160,7 +2184,7 @@
     "operationId": null
   },
   {
-    "sequence": 181,
+    "sequence": 183,
     "domain": "organization",
     "apiId": "STUDY-GROUP-002",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2172,7 +2196,7 @@
     "operationId": null
   },
   {
-    "sequence": 182,
+    "sequence": 184,
     "domain": "organization",
     "apiId": "STUDY-GROUP-003",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2184,7 +2208,7 @@
     "operationId": null
   },
   {
-    "sequence": 183,
+    "sequence": 185,
     "domain": "organization",
     "apiId": "STUDY-GROUP-004",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2196,7 +2220,7 @@
     "operationId": null
   },
   {
-    "sequence": 184,
+    "sequence": 186,
     "domain": "organization",
     "apiId": "STUDY-GROUP-005",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2208,7 +2232,7 @@
     "operationId": null
   },
   {
-    "sequence": 185,
+    "sequence": 187,
     "domain": "organization",
     "apiId": "STUDY-GROUP-006",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2220,7 +2244,7 @@
     "operationId": null
   },
   {
-    "sequence": 186,
+    "sequence": 188,
     "domain": "organization",
     "apiId": "STUDY-GROUP-007",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2232,7 +2256,7 @@
     "operationId": null
   },
   {
-    "sequence": 187,
+    "sequence": 189,
     "domain": "organization",
     "apiId": "STUDY-GROUP-101",
     "endpoint": "/api/v1/study-groups/managed",
@@ -2244,7 +2268,7 @@
     "operationId": null
   },
   {
-    "sequence": 188,
+    "sequence": 190,
     "domain": "organization",
     "apiId": "STUDY-GROUP-102",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2256,7 +2280,7 @@
     "operationId": null
   },
   {
-    "sequence": 189,
+    "sequence": 191,
     "domain": "organization",
     "apiId": "STUDY-GROUP-SCHEDULE-001",
     "endpoint": "/api/v1/study-groups/schedules",
@@ -2268,7 +2292,7 @@
     "operationId": null
   },
   {
-    "sequence": 190,
+    "sequence": 192,
     "domain": "project",
     "apiId": "APPLY-001",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2280,7 +2304,7 @@
     "operationId": null
   },
   {
-    "sequence": 191,
+    "sequence": 193,
     "domain": "project",
     "apiId": "APPLY-002",
     "endpoint": "/api/v1/projects/{projectId}/applications/me",
@@ -2292,7 +2316,7 @@
     "operationId": null
   },
   {
-    "sequence": 192,
+    "sequence": 194,
     "domain": "project",
     "apiId": "APPLY-003",
     "endpoint": "/api/v1/projects/{projectId}/applications/me/submit",
@@ -2304,7 +2328,7 @@
     "operationId": null
   },
   {
-    "sequence": 193,
+    "sequence": 195,
     "domain": "project",
     "apiId": "APPLY-004",
     "endpoint": "/api/v1/projects/me/applications",
@@ -2316,7 +2340,7 @@
     "operationId": null
   },
   {
-    "sequence": 194,
+    "sequence": 196,
     "domain": "project",
     "apiId": "APPLY-005",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2328,7 +2352,7 @@
     "operationId": null
   },
   {
-    "sequence": 195,
+    "sequence": 197,
     "domain": "project",
     "apiId": "APPLY-101",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2340,7 +2364,7 @@
     "operationId": null
   },
   {
-    "sequence": 196,
+    "sequence": 198,
     "domain": "project",
     "apiId": "APPLY-102",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2352,7 +2376,7 @@
     "operationId": null
   },
   {
-    "sequence": 197,
+    "sequence": 199,
     "domain": "project",
     "apiId": "APPLY-103",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}/decision",
@@ -2364,7 +2388,7 @@
     "operationId": null
   },
   {
-    "sequence": 198,
+    "sequence": 200,
     "domain": "project",
     "apiId": "PROJECT-001",
     "endpoint": "/api/v1/projects",
@@ -2372,11 +2396,11 @@
     "role": "프로젝트 목록 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 43,
+    "line": 46,
     "operationId": null
   },
   {
-    "sequence": 199,
+    "sequence": 201,
     "domain": "project",
     "apiId": "PROJECT-002",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2384,11 +2408,11 @@
     "role": "프로젝트 상세 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 62,
+    "line": 65,
     "operationId": null
   },
   {
-    "sequence": 200,
+    "sequence": 202,
     "domain": "project",
     "apiId": "PROJECT-003",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -2396,23 +2420,11 @@
     "role": "프로젝트 팀원 구성 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 80,
+    "line": 83,
     "operationId": null
   },
   {
-    "sequence": 201,
-    "domain": "project",
-    "apiId": "PROJECT-004",
-    "endpoint": "/api/v1/projects/members",
-    "httpMethod": "GET",
-    "role": "프로젝트 팀원 구성 일괄 조회",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 98,
-    "operationId": null
-  },
-  {
-    "sequence": 202,
+    "sequence": 203,
     "domain": "project",
     "apiId": "PROJECT-004",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -2424,7 +2436,7 @@
     "operationId": null
   },
   {
-    "sequence": 203,
+    "sequence": 204,
     "domain": "project",
     "apiId": "PROJECT-005",
     "endpoint": "/api/v1/projects/{projectId}/members/{memberId}",
@@ -2436,7 +2448,7 @@
     "operationId": null
   },
   {
-    "sequence": 204,
+    "sequence": 205,
     "domain": "project",
     "apiId": "PROJECT-006",
     "endpoint": "/api/v1/projects/me/managed",
@@ -2444,11 +2456,23 @@
     "role": "내가 관리하는 프로젝트 목록",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 115,
+    "line": 118,
     "operationId": null
   },
   {
-    "sequence": 205,
+    "sequence": 206,
+    "domain": "project",
+    "apiId": "PROJECT-007",
+    "endpoint": "/api/v1/projects/members",
+    "httpMethod": "GET",
+    "role": "프로젝트 팀원 구성 일괄 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
+    "line": 101,
+    "operationId": null
+  },
+  {
+    "sequence": 207,
     "domain": "project",
     "apiId": "PROJECT-101",
     "endpoint": "/api/v1/projects",
@@ -2460,7 +2484,7 @@
     "operationId": null
   },
   {
-    "sequence": 206,
+    "sequence": 208,
     "domain": "project",
     "apiId": "PROJECT-102",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2472,7 +2496,7 @@
     "operationId": null
   },
   {
-    "sequence": 207,
+    "sequence": 209,
     "domain": "project",
     "apiId": "PROJECT-103",
     "endpoint": "/api/v1/projects/me/draft",
@@ -2480,11 +2504,11 @@
     "role": "내 Draft 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java",
-    "line": 134,
+    "line": 137,
     "operationId": null
   },
   {
-    "sequence": 208,
+    "sequence": 210,
     "domain": "project",
     "apiId": "PROJECT-104",
     "endpoint": "/api/v1/projects/{projectId}/transfer-ownership",
@@ -2496,7 +2520,7 @@
     "operationId": null
   },
   {
-    "sequence": 209,
+    "sequence": 211,
     "domain": "project",
     "apiId": "PROJECT-105",
     "endpoint": "/api/v1/projects/{projectId}/part-quotas",
@@ -2508,7 +2532,7 @@
     "operationId": null
   },
   {
-    "sequence": 210,
+    "sequence": 212,
     "domain": "project",
     "apiId": "PROJECT-106",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -2520,7 +2544,7 @@
     "operationId": null
   },
   {
-    "sequence": 211,
+    "sequence": 213,
     "domain": "project",
     "apiId": "PROJECT-106-GET",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -2532,7 +2556,7 @@
     "operationId": null
   },
   {
-    "sequence": 212,
+    "sequence": 214,
     "domain": "project",
     "apiId": "PROJECT-107",
     "endpoint": "/api/v1/projects/{projectId}/submit",
@@ -2544,7 +2568,7 @@
     "operationId": null
   },
   {
-    "sequence": 213,
+    "sequence": 215,
     "domain": "project",
     "apiId": "PROJECT-108",
     "endpoint": "/api/v1/projects/{projectId}/publish",
@@ -2556,7 +2580,7 @@
     "operationId": null
   },
   {
-    "sequence": 214,
+    "sequence": 216,
     "domain": "project",
     "apiId": "PROJECT-109",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -2568,7 +2592,7 @@
     "operationId": null
   },
   {
-    "sequence": 215,
+    "sequence": 217,
     "domain": "project",
     "apiId": "PROJECT-110",
     "endpoint": "/api/v1/projects/{projectId}/abort",
@@ -2580,7 +2604,7 @@
     "operationId": null
   },
   {
-    "sequence": 216,
+    "sequence": 218,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-001",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -2592,7 +2616,7 @@
     "operationId": null
   },
   {
-    "sequence": 217,
+    "sequence": 219,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-101",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -2604,7 +2628,7 @@
     "operationId": null
   },
   {
-    "sequence": 218,
+    "sequence": 220,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-102",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -2616,7 +2640,7 @@
     "operationId": null
   },
   {
-    "sequence": 219,
+    "sequence": 221,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-103",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -2628,7 +2652,7 @@
     "operationId": null
   },
   {
-    "sequence": 220,
+    "sequence": 222,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-201",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide",
@@ -2640,7 +2664,7 @@
     "operationId": null
   },
   {
-    "sequence": 221,
+    "sequence": 223,
     "domain": "project",
     "apiId": "PROJECT-STAT-001",
     "endpoint": "/api/v1/projects/{projectId}/statistics",
@@ -2652,7 +2676,7 @@
     "operationId": null
   },
   {
-    "sequence": 222,
+    "sequence": 224,
     "domain": "project",
     "apiId": "PROJECT-STAT-002",
     "endpoint": "/api/v1/projects/statistics",
@@ -2664,7 +2688,7 @@
     "operationId": null
   },
   {
-    "sequence": 223,
+    "sequence": 225,
     "domain": "schedule",
     "apiId": "SCHEDULE-C001",
     "endpoint": "/api/v2/schedules",
@@ -2676,7 +2700,7 @@
     "operationId": null
   },
   {
-    "sequence": 224,
+    "sequence": 226,
     "domain": "schedule",
     "apiId": "SCHEDULE-C002",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2688,7 +2712,7 @@
     "operationId": null
   },
   {
-    "sequence": 225,
+    "sequence": 227,
     "domain": "schedule",
     "apiId": "SCHEDULE-C003",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/request",
@@ -2700,7 +2724,7 @@
     "operationId": null
   },
   {
-    "sequence": 226,
+    "sequence": 228,
     "domain": "schedule",
     "apiId": "SCHEDULE-C004",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/excuse",
@@ -2712,7 +2736,7 @@
     "operationId": null
   },
   {
-    "sequence": 227,
+    "sequence": 229,
     "domain": "schedule",
     "apiId": "SCHEDULE-C005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/decide",
@@ -2724,7 +2748,7 @@
     "operationId": null
   },
   {
-    "sequence": 228,
+    "sequence": 230,
     "domain": "schedule",
     "apiId": "SCHEDULE-C006",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2736,7 +2760,7 @@
     "operationId": null
   },
   {
-    "sequence": 229,
+    "sequence": 231,
     "domain": "schedule",
     "apiId": "SCHEDULE-C007",
     "endpoint": "/api/v2/schedules/{scheduleId}/force",
@@ -2748,7 +2772,7 @@
     "operationId": null
   },
   {
-    "sequence": 230,
+    "sequence": 232,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q001",
     "endpoint": "/api/v2/schedules/capabilities",
@@ -2760,7 +2784,7 @@
     "operationId": null
   },
   {
-    "sequence": 231,
+    "sequence": 233,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q002",
     "endpoint": "/api/v2/schedules/me",
@@ -2772,7 +2796,7 @@
     "operationId": null
   },
   {
-    "sequence": 232,
+    "sequence": 234,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q003",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -2784,7 +2808,7 @@
     "operationId": null
   },
   {
-    "sequence": 233,
+    "sequence": 235,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q004",
     "endpoint": "/api/v2/schedules/attendance",
@@ -2796,7 +2820,7 @@
     "operationId": null
   },
   {
-    "sequence": 234,
+    "sequence": 236,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendance",
@@ -2808,7 +2832,7 @@
     "operationId": null
   },
   {
-    "sequence": 235,
+    "sequence": 237,
     "domain": "storage",
     "apiId": "STORAGE-001",
     "endpoint": "/api/v1/storage/prepare-upload",
@@ -2820,7 +2844,7 @@
     "operationId": null
   },
   {
-    "sequence": 236,
+    "sequence": 238,
     "domain": "storage",
     "apiId": "STORAGE-002",
     "endpoint": "/api/v1/storage/{fileId}/confirm",
@@ -2832,7 +2856,7 @@
     "operationId": null
   },
   {
-    "sequence": 237,
+    "sequence": 239,
     "domain": "storage",
     "apiId": "STORAGE-003",
     "endpoint": "/api/v1/storage/{fileId}",
@@ -2844,7 +2868,7 @@
     "operationId": null
   },
   {
-    "sequence": 238,
+    "sequence": 240,
     "domain": "term",
     "apiId": "TERM-001",
     "endpoint": "/api/v1/terms",
@@ -2852,11 +2876,11 @@
     "role": "약관 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 48,
+    "line": 71,
     "operationId": null
   },
   {
-    "sequence": 239,
+    "sequence": 241,
     "domain": "term",
     "apiId": "TERM-101",
     "endpoint": "/api/v1/terms/type/{termType}",
@@ -2864,11 +2888,11 @@
     "role": "약관 유형으로 약관 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 35,
+    "line": 50,
     "operationId": null
   },
   {
-    "sequence": 240,
+    "sequence": 242,
     "domain": "term",
     "apiId": "TERM-102",
     "endpoint": "/api/v1/terms/{termsId}",
@@ -2876,11 +2900,35 @@
     "role": "약관 ID로 약관 조회",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
-    "line": 42,
+    "line": 57,
     "operationId": null
   },
   {
-    "sequence": 241,
+    "sequence": 243,
+    "domain": "term",
+    "apiId": "TERM-103",
+    "endpoint": "/api/v1/terms/consent-status/me",
+    "httpMethod": "GET",
+    "role": "내 필수 약관 재동의 상태 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
+    "line": 63,
+    "operationId": null
+  },
+  {
+    "sequence": 244,
+    "domain": "term",
+    "apiId": "TERM-104",
+    "endpoint": "/api/v1/terms",
+    "httpMethod": "GET",
+    "role": "활성 약관 전체 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/term/adapter/in/web/TermController.java",
+    "line": 43,
+    "operationId": null
+  },
+  {
+    "sequence": 245,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/email/send-test",
@@ -2888,11 +2936,11 @@
     "role": "<요약 없음>",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 82,
+    "line": 85,
     "operationId": null
   },
   {
-    "sequence": 242,
+    "sequence": 246,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/log-test",
@@ -2900,11 +2948,11 @@
     "role": "<요약 없음>",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 209,
+    "line": 212,
     "operationId": null
   },
   {
-    "sequence": 243,
+    "sequence": 247,
     "domain": "test",
     "apiId": "SEED-001",
     "endpoint": "/test/seed/members",
@@ -2912,11 +2960,11 @@
     "role": "더미 멤버 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 57,
+    "line": 63,
     "operationId": "SEED-001"
   },
   {
-    "sequence": 244,
+    "sequence": 248,
     "domain": "test",
     "apiId": "SEED-002",
     "endpoint": "/test/seed/challengers",
@@ -2924,11 +2972,11 @@
     "role": "챌린저 분포 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 73,
+    "line": 79,
     "operationId": "SEED-002"
   },
   {
-    "sequence": 245,
+    "sequence": 249,
     "domain": "test",
     "apiId": "SEED-003",
     "endpoint": "/test/seed/projects",
@@ -2936,11 +2984,11 @@
     "role": "프로젝트 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 88,
+    "line": 94,
     "operationId": "SEED-003"
   },
   {
-    "sequence": 246,
+    "sequence": 250,
     "domain": "test",
     "apiId": "SEED-003-S",
     "endpoint": "/test/seed/projects/scenarios",
@@ -2948,11 +2996,11 @@
     "role": "프로젝트 시나리오 시딩",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 104,
+    "line": 110,
     "operationId": "SEED-003-S"
   },
   {
-    "sequence": 247,
+    "sequence": 251,
     "domain": "test",
     "apiId": "SEED-004",
     "endpoint": "/test/seed/curriculum",
@@ -2960,11 +3008,11 @@
     "role": "Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 125,
+    "line": 132,
     "operationId": "SEED-004"
   },
   {
-    "sequence": 248,
+    "sequence": 252,
     "domain": "test",
     "apiId": "SEED-005",
     "endpoint": "/test/seed/notice",
@@ -2972,11 +3020,23 @@
     "role": "Notice 시딩 (지부 · 학교 · 파트 분포)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
-    "line": 140,
+    "line": 147,
     "operationId": "SEED-005"
   },
   {
-    "sequence": 249,
+    "sequence": 253,
+    "domain": "test",
+    "apiId": "SEED-006",
+    "endpoint": "/test/seed/project-applications",
+    "httpMethod": "POST",
+    "role": "지원서 시나리오 시딩",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/test/adapter/in/web/SeedController.java",
+    "line": 166,
+    "operationId": null
+  },
+  {
+    "sequence": 254,
     "domain": "test",
     "apiId": "TEST-001",
     "endpoint": "/test/file/{fileId}",
@@ -2984,11 +3044,11 @@
     "role": "[개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 62,
+    "line": 65,
     "operationId": "TEST-001"
   },
   {
-    "sequence": 250,
+    "sequence": 255,
     "domain": "test",
     "apiId": "TEST-002",
     "endpoint": "/test/fcm/test-send",
@@ -2996,11 +3056,11 @@
     "role": "FCM 푸시 알림 테스트 전송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 74,
+    "line": 77,
     "operationId": "TEST-002"
   },
   {
-    "sequence": 251,
+    "sequence": 256,
     "domain": "test",
     "apiId": "TEST-003",
     "endpoint": "/test/webhook/aop-test",
@@ -3008,11 +3068,11 @@
     "role": "AOP로 전송하는 알람 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 101,
+    "line": 104,
     "operationId": "TEST-003"
   },
   {
-    "sequence": 252,
+    "sequence": 257,
     "domain": "test",
     "apiId": "TEST-004",
     "endpoint": "/test/webhook/alarm",
@@ -3020,11 +3080,11 @@
     "role": "웹훅 알람 전송 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 114,
+    "line": 117,
     "operationId": "TEST-004"
   },
   {
-    "sequence": 253,
+    "sequence": 258,
     "domain": "test",
     "apiId": "TEST-005",
     "endpoint": "/test/webhook/alarm/buffer",
@@ -3032,11 +3092,11 @@
     "role": "웹훅 알람 버퍼 전송 테스트",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 130,
+    "line": 133,
     "operationId": "TEST-005"
   },
   {
-    "sequence": 254,
+    "sequence": 259,
     "domain": "test",
     "apiId": "TEST-006",
     "endpoint": "/test/apple-client-secret",
@@ -3044,11 +3104,11 @@
     "role": "Apple Client Secret 생성",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 151,
+    "line": 154,
     "operationId": "TEST-006"
   },
   {
-    "sequence": 255,
+    "sequence": 260,
     "domain": "test",
     "apiId": "TEST-007",
     "endpoint": "/test/token/access",
@@ -3056,11 +3116,11 @@
     "role": "AccessToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 157,
+    "line": 160,
     "operationId": "TEST-007"
   },
   {
-    "sequence": 256,
+    "sequence": 261,
     "domain": "test",
     "apiId": "TEST-008",
     "endpoint": "/test/token/refresh",
@@ -3068,11 +3128,11 @@
     "role": "RefreshToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 170,
+    "line": 173,
     "operationId": "TEST-008"
   },
   {
-    "sequence": 257,
+    "sequence": 262,
     "domain": "test",
     "apiId": "TEST-009",
     "endpoint": "/test/token/email",
@@ -3080,11 +3140,11 @@
     "role": "EmailVerificationToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 177,
+    "line": 180,
     "operationId": "TEST-009"
   },
   {
-    "sequence": 258,
+    "sequence": 263,
     "domain": "test",
     "apiId": "TEST-010",
     "endpoint": "/test/token/oauth",
@@ -3092,11 +3152,11 @@
     "role": "oAuthVerificationToken 발급",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 187,
+    "line": 190,
     "operationId": "TEST-010"
   },
   {
-    "sequence": 259,
+    "sequence": 264,
     "domain": "test",
     "apiId": "TEST-011",
     "endpoint": "/test/health-check",
@@ -3104,11 +3164,11 @@
     "role": "헬스 체크 API",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 195,
+    "line": 198,
     "operationId": "TEST-011"
   },
   {
-    "sequence": 260,
+    "sequence": 265,
     "domain": "test",
     "apiId": "TEST-012",
     "endpoint": "/test/check-authenticated",
@@ -3116,7 +3176,7 @@
     "role": "인증된 사용자인지 여부를 확인합니다.",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/test/adapter/in/web/TestController.java",
-    "line": 202,
+    "line": 205,
     "operationId": "TEST-012"
   }
 ]

--- a/src/main/resources/static/docs/catalog/api/catalog.md
+++ b/src/main/resources/static/docs/catalog/api/catalog.md
@@ -25,10 +25,10 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 8 | authentication | CREDENTIAL-002 | POST | `/api/v1/auth/credentials` | 비밀번호 자격증명 최초 등록 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:45` |
-| 9 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:58` |
-| 10 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:87` |
-| 11 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:71` |
+| 8 | authentication | CREDENTIAL-002 | POST | `/api/v1/auth/credentials` | 비밀번호 자격증명 최초 등록 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:47` |
+| 9 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:60` |
+| 10 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:89` |
+| 11 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:73` |
 | 12 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:34` |
 | 13 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:60` |
 | 14 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:85` |
@@ -36,7 +36,7 @@
 | 16 | authentication | LOGIN-005 | POST | `/api/v1/auth/login/kakao` | Kakao 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:32` |
 | 17 | authentication | LOGIN-006 | POST | `/api/v1/auth/login/kakao/code` | Kakao 로그인 (Authorization Code 흐름) | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:50` |
 | 18 | authentication | LOGIN-010 | POST | `/api/v1/auth/login/apple` | Apple 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:68` |
-| 19 | authentication | LOGIN-011 | POST | `/api/v1/auth/login/email` | 이메일/PW 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:98` |
+| 19 | authentication | LOGIN-011 | POST | `/api/v1/auth/login/email` | 이메일/PW 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:100` |
 | 20 | authentication | OAUTH-001 | POST | `/api/v1/member-oauth` | 로그인용 OAuth 수단 추가 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:37` |
 | 21 | authentication | OAUTH-002 | DELETE | `/api/v1/member-oauth/{memberOAuthId}` | 로그인용 OAuth 수단 제거 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:58` |
 | 22 | authentication | OAUTH-101 | GET | `/api/v1/member-oauth/me` | 현재 회원 계정과 연동된 OAuth 정보 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/MemberOAuthController.java:81` |
@@ -56,24 +56,24 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 29 | challenger | CHALLENGER-001 | POST | `/api/v1/challenger` | 챌린저 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:40` |
-| 30 | challenger | CHALLENGER-002 | POST | `/api/v1/challenger/batch` | 챌린저 batch 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:52` |
-| 31 | challenger | CHALLENGER-003 | POST | `/api/v1/challenger/{challengerId}/deactivate` | 챌린저 비활성화 (제명/탈부 처리) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:70` |
-| 32 | challenger | CHALLENGER-004 | PATCH | `/api/v1/challenger/{challengerId}/part` | 챌린저 파트 변경 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:83` |
-| 33 | challenger | CHALLENGER-005 | DELETE | `/api/v1/challenger/{challengerId}` | [주의] 챌린저 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:99` |
+| 29 | challenger | CHALLENGER-001 | POST | `/api/v1/challenger` | 챌린저 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:46` |
+| 30 | challenger | CHALLENGER-002 | POST | `/api/v1/challenger/batch` | 챌린저 batch 생성 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:58` |
+| 31 | challenger | CHALLENGER-003 | POST | `/api/v1/challenger/{challengerId}/deactivate` | 챌린저 비활성화 (제명/탈부 처리) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:76` |
+| 32 | challenger | CHALLENGER-004 | PATCH | `/api/v1/challenger/{challengerId}/part` | 챌린저 파트 변경 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:89` |
+| 33 | challenger | CHALLENGER-005 | DELETE | `/api/v1/challenger/{challengerId}` | [주의] 챌린저 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java:105` |
 | 34 | challenger | CHALLENGER-101 | GET | `/api/v1/challenger/{challengerId}` | 챌린저 정보 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryController.java:44` |
 | 35 | challenger | CHALLENGER-102 | GET | `/api/v1/challenger/search/cursor` | 챌린저 검색 (Cursor 기반) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:29` |
 | 36 | challenger | CHALLENGER-103 | GET | `/api/v1/challenger/search/offset` | 챌린저 검색 (Offset 기반) | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:52` |
 | 37 | challenger | CHALLENGER-104 | GET | `/api/v1/challenger/search/global` | deprecated: 챌린저 전체 검색 (Cursor 기반, 일정 생성용) | O | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java:66` |
 | 38 | challenger | CHALLENGER-201 | GET | `/api/v2/challenger/search` | 챌린저 검색 v2 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/v2/ChallengerSearchV2Controller.java:31` |
-| 39 | challenger | CHALLENGER-RECORD-001 | POST | `/api/v1/challenger-record/member` | 6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:36` |
-| 40 | challenger | CHALLENGER-RECORD-002 | POST | `/api/v1/challenger-record` | [ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:89` |
-| 41 | challenger | CHALLENGER-RECORD-003 | POST | `/api/v1/challenger-record/bulk` | [ADMIN] 챌린저 기록용 코드 벌크 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:116` |
-| 42 | challenger | CHALLENGER-RECORD-101 | GET | `/api/v1/challenger-record/code/{code}` | 코드로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:65` |
-| 43 | challenger | CHALLENGER-RECORD-102 | GET | `/api/v1/challenger-record/id/{id}` | ID로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:77` |
-| 44 | challenger | POINT-001 | POST | `/api/v1/challenger/{challengerId}/points` | 챌린저 상벌점 부여 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:38` |
-| 45 | challenger | POINT-002 | PATCH | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 사유 수정 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:55` |
-| 46 | challenger | POINT-003 | DELETE | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 삭제 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:70` |
+| 39 | challenger | CHALLENGER-RECORD-001 | POST | `/api/v1/challenger-record/member` | 6자리 코드를 이용해서 회원(계정)에 챌린저 기록 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:42` |
+| 40 | challenger | CHALLENGER-RECORD-002 | POST | `/api/v1/challenger-record` | [ADMIN] 과거 챌린저 기록을 위한 코드 생성 기능 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:95` |
+| 41 | challenger | CHALLENGER-RECORD-003 | POST | `/api/v1/challenger-record/bulk` | [ADMIN] 챌린저 기록용 코드 벌크 추가 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:122` |
+| 42 | challenger | CHALLENGER-RECORD-101 | GET | `/api/v1/challenger-record/code/{code}` | 코드로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:71` |
+| 43 | challenger | CHALLENGER-RECORD-102 | GET | `/api/v1/challenger-record/id/{id}` | ID로 ChallengerRecord 조회 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java:83` |
+| 44 | challenger | POINT-001 | POST | `/api/v1/challenger/{challengerId}/points` | 챌린저 상벌점 부여 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:41` |
+| 45 | challenger | POINT-002 | PATCH | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 사유 수정 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:58` |
+| 46 | challenger | POINT-003 | DELETE | `/api/v1/challenger/points/{challengerPointId}` | 챌린저 상벌점 삭제 | X | `src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java:73` |
 
 ## community
 
@@ -138,224 +138,234 @@
 | 98 | curriculum | WORKBOOK-102 | GET | `/api/v2/curriculums/challenger-workbooks/{challengerWorkbookId}` | ChallengerWorkbook 상세 조회 | X | `src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java:38` |
 | 99 | curriculum | WORKBOOK-103 | GET | `/api/v2/curriculums/weekly-best-workbooks` | 베스트 워크북 조회 | X | `src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java:54` |
 
+## feedback
+
+| 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
+|---:|---|---|---|---|---|:---:|---|
+| 100 | feedback | <미지정> | POST | `/api/v1/user-feedbacks/responses` | 사용자 피드백 응답 제출 | X | `src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java:58` |
+| 101 | feedback | <미지정> | GET | `/api/v1/user-feedbacks/templates` | 사용자 피드백 템플릿 조회 | X | `src/main/java/com/umc/product/feedback/adapter/in/web/UserFeedbackController.java:34` |
+
 ## figma
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 100 | figma | FIGMA-001 | GET | `/api/v1/admin/figma/oauth` | Figma OAuth authorize URL 발급 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:32` |
-| 101 | figma | FIGMA-002 | GET | `/api/v1/admin/figma/oauth/callback` | Figma OAuth 콜백 처리 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:47` |
-| 102 | figma | FIGMA-003 | POST | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:37` |
-| 103 | figma | FIGMA-004 | DELETE | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 비활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:47` |
-| 104 | figma | FIGMA-005 | POST | `/api/v1/admin/figma/watched-files/{watchedFileId}/enable` | 폴링 대상 파일 활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:54` |
-| 105 | figma | FIGMA-006 | POST | `/api/v1/admin/figma/sync` | 활성 파일 전체 즉시 동기화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:52` |
-| 106 | figma | FIGMA-007 | POST | `/api/v1/admin/figma/sync/watched-files/{watchedFileId}` | 특정 파일 즉시 동기화 (enabled 무관) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:68` |
-| 107 | figma | FIGMA-008 | GET | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 목록 조회 (enabled 필터) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:61` |
-| 108 | figma | FIGMA-009 | GET | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 단건 조회 (sync 상태 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:72` |
-| 109 | figma | FIGMA-010 | GET | `/api/v1/admin/figma/preview` | 특정 시간대 미리보기 (Discord 발송 X, dispatch / cursor 비변경) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:100` |
-| 110 | figma | FIGMA-011 | POST | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:46` |
-| 111 | figma | FIGMA-012 | DELETE | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 삭제 (mention 도 cascade) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:67` |
-| 112 | figma | FIGMA-013 | POST | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인에 담당자 mention 추가 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:75` |
-| 113 | figma | FIGMA-014 | DELETE | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 삭제 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:97` |
-| 114 | figma | FIGMA-015 | POST | `/api/v1/admin/figma/digest` | 특정 시간대 catch-up | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:82` |
-| 115 | figma | FIGMA-016 | GET | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 목록 조회 (mention 본문 미포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:105` |
-| 116 | figma | FIGMA-017 | GET | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 단건 조회 (mention 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:114` |
-| 117 | figma | FIGMA-018 | GET | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인의 담당자 mention 목록 조회 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:121` |
-| 118 | figma | FIGMA-019 | PATCH | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 수정 (설명 · webhook URL · fallback) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:56` |
-| 119 | figma | FIGMA-020 | PATCH | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 수정 (Discord ID · 라벨) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:86` |
+| 102 | figma | FIGMA-001 | GET | `/api/v1/admin/figma/oauth` | Figma OAuth authorize URL 발급 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:32` |
+| 103 | figma | FIGMA-002 | GET | `/api/v1/admin/figma/oauth/callback` | Figma OAuth 콜백 처리 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaOAuthController.java:47` |
+| 104 | figma | FIGMA-003 | POST | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:37` |
+| 105 | figma | FIGMA-004 | DELETE | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 비활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:47` |
+| 106 | figma | FIGMA-005 | POST | `/api/v1/admin/figma/watched-files/{watchedFileId}/enable` | 폴링 대상 파일 활성화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:54` |
+| 107 | figma | FIGMA-006 | POST | `/api/v1/admin/figma/sync` | 활성 파일 전체 즉시 동기화 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:52` |
+| 108 | figma | FIGMA-007 | POST | `/api/v1/admin/figma/sync/watched-files/{watchedFileId}` | 특정 파일 즉시 동기화 (enabled 무관) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:68` |
+| 109 | figma | FIGMA-008 | GET | `/api/v1/admin/figma/watched-files` | 폴링 대상 파일 목록 조회 (enabled 필터) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:61` |
+| 110 | figma | FIGMA-009 | GET | `/api/v1/admin/figma/watched-files/{watchedFileId}` | 폴링 대상 파일 단건 조회 (sync 상태 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaWatchedFileController.java:72` |
+| 111 | figma | FIGMA-010 | GET | `/api/v1/admin/figma/preview` | 특정 시간대 미리보기 (Discord 발송 X, dispatch / cursor 비변경) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:100` |
+| 112 | figma | FIGMA-011 | POST | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 등록 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:46` |
+| 113 | figma | FIGMA-012 | DELETE | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 삭제 (mention 도 cascade) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:67` |
+| 114 | figma | FIGMA-013 | POST | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인에 담당자 mention 추가 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:75` |
+| 115 | figma | FIGMA-014 | DELETE | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 삭제 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:97` |
+| 116 | figma | FIGMA-015 | POST | `/api/v1/admin/figma/digest` | 특정 시간대 catch-up | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaSyncController.java:82` |
+| 117 | figma | FIGMA-016 | GET | `/api/v1/admin/figma/routing-domains` | 라우팅 도메인 목록 조회 (mention 본문 미포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:105` |
+| 118 | figma | FIGMA-017 | GET | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 단건 조회 (mention 포함) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:114` |
+| 119 | figma | FIGMA-018 | GET | `/api/v1/admin/figma/routing-domains/{domainId}/mentions` | 라우팅 도메인의 담당자 mention 목록 조회 | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:121` |
+| 120 | figma | FIGMA-019 | PATCH | `/api/v1/admin/figma/routing-domains/{domainId}` | 라우팅 도메인 수정 (설명 · webhook URL · fallback) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:56` |
+| 121 | figma | FIGMA-020 | PATCH | `/api/v1/admin/figma/routing-domains/mentions/{mentionId}` | 담당자 mention 수정 (Discord ID · 라벨) | X | `src/main/java/com/umc/product/figma/adapter/in/web/FigmaRoutingDomainController.java:86` |
 
 ## global
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 120 | global | <미지정> | REQUEST | `/error` | <요약 없음> | X | `src/main/java/com/umc/product/global/exception/CustomErrorController.java:27` |
+| 122 | global | <미지정> | REQUEST | `/error` | <요약 없음> | X | `src/main/java/com/umc/product/global/exception/CustomErrorController.java:27` |
 
 ## maintenance
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 121 | maintenance | MAINT-001 | POST | `/api/v1/admin/maintenance` | 점검 윈도우 생성 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:36` |
-| 122 | maintenance | MAINT-002 | PATCH | `/api/v1/admin/maintenance/{windowId}/end` | 점검 윈도우 강제 종료 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:50` |
-| 123 | maintenance | MAINT-003 | GET | `/api/v1/admin/maintenance` | 점검 윈도우 전체 목록 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:64` |
-| 124 | maintenance | MAINT-004 | GET | `/api/v1/admin/maintenance/{windowId}` | 점검 윈도우 단건 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:76` |
-| 125 | maintenance | SYSTEM-001 | GET | `/api/v1/system/status` | 시스템 점검 상태 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/SystemStatusController.java:23` |
+| 123 | maintenance | MAINT-001 | POST | `/api/v1/admin/maintenance` | 점검 윈도우 생성 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:36` |
+| 124 | maintenance | MAINT-002 | PATCH | `/api/v1/admin/maintenance/{windowId}/end` | 점검 윈도우 강제 종료 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:50` |
+| 125 | maintenance | MAINT-003 | GET | `/api/v1/admin/maintenance` | 점검 윈도우 전체 목록 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:64` |
+| 126 | maintenance | MAINT-004 | GET | `/api/v1/admin/maintenance/{windowId}` | 점검 윈도우 단건 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java:76` |
+| 127 | maintenance | SYSTEM-001 | GET | `/api/v1/system/status` | 시스템 점검 상태 조회 | X | `src/main/java/com/umc/product/maintenance/adapter/in/web/SystemStatusController.java:23` |
 
 ## member
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 126 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:128` |
-| 127 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:142` |
-| 128 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:156` |
-| 129 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:169` |
-| 130 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
-| 131 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
-| 132 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
-| 133 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
-| 134 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
-| 135 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:59` |
-| 136 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:101` |
+| 128 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:130` |
+| 129 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:144` |
+| 130 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:158` |
+| 131 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:171` |
+| 132 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
+| 133 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
+| 134 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
+| 135 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
+| 136 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
+| 137 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:61` |
+| 138 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:103` |
 
 ## notice
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 137 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
-| 138 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
-| 139 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
-| 140 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
-| 141 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
-| 142 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
-| 143 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
-| 144 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
-| 145 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
-| 146 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
-| 147 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
-| 148 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
-| 149 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
-| 150 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
-| 151 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
-| 152 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
-| 153 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
-| 154 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
+| 139 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
+| 140 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
+| 141 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
+| 142 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
+| 143 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
+| 144 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
+| 145 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
+| 146 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
+| 147 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
+| 148 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
+| 149 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
+| 150 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
+| 151 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
+| 152 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
+| 153 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
+| 154 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
+| 155 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
+| 156 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
 
 ## notification
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 155 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
-| 156 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
+| 157 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
+| 158 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
 
 ## organization
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 157 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
-| 158 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
-| 159 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
-| 160 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
-| 161 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
-| 162 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
-| 163 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
-| 164 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
-| 165 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
-| 166 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
-| 167 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
-| 168 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
-| 169 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
-| 170 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
-| 171 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
-| 172 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
-| 173 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
-| 174 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
-| 175 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
-| 176 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
-| 177 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
-| 178 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
-| 179 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
-| 180 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
-| 181 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
-| 182 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
-| 183 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
-| 184 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
-| 185 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
-| 186 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
-| 187 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
-| 188 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
-| 189 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 159 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
+| 160 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
+| 161 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
+| 162 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
+| 163 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
+| 164 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
+| 165 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
+| 166 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
+| 167 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
+| 168 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
+| 169 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
+| 170 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
+| 171 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
+| 172 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
+| 173 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
+| 174 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
+| 175 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
+| 176 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
+| 177 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
+| 178 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
+| 179 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
+| 180 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
+| 181 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
+| 182 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
+| 183 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
+| 184 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
+| 185 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
+| 186 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
+| 187 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
+| 188 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
+| 189 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
+| 190 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
+| 191 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
 
 ## project
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 190 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:47` |
-| 191 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:70` |
-| 192 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:93` |
-| 193 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:37` |
-| 194 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:147` |
-| 195 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:76` |
-| 196 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:127` |
-| 197 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:118` |
-| 198 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:43` |
-| 199 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:62` |
-| 200 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:80` |
-| 201 | project | PROJECT-004 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:98` |
-| 202 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:142` |
-| 203 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:244` |
-| 204 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:115` |
-| 205 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:62` |
-| 206 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:81` |
-| 207 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:134` |
-| 208 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:122` |
-| 209 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:184` |
-| 210 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:35` |
-| 211 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:56` |
-| 212 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:102` |
-| 213 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:162` |
-| 214 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:204` |
-| 215 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:225` |
-| 216 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
-| 217 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
-| 218 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
-| 219 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
-| 220 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
-| 221 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:30` |
-| 222 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:56` |
+| 192 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:47` |
+| 193 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:70` |
+| 194 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:93` |
+| 195 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:37` |
+| 196 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:147` |
+| 197 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:76` |
+| 198 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:127` |
+| 199 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:118` |
+| 200 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
+| 201 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
+| 202 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
+| 203 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:142` |
+| 204 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:244` |
+| 205 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
+| 206 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
+| 207 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:62` |
+| 208 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:81` |
+| 209 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
+| 210 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:122` |
+| 211 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:184` |
+| 212 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:35` |
+| 213 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:56` |
+| 214 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:102` |
+| 215 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:162` |
+| 216 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:204` |
+| 217 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:225` |
+| 218 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
+| 219 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
+| 220 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
+| 221 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
+| 222 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
+| 223 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:30` |
+| 224 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:56` |
 
 ## schedule
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 223 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:59` |
-| 224 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:125` |
-| 225 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:263` |
-| 226 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:312` |
-| 227 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:359` |
-| 228 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:186` |
-| 229 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:227` |
-| 230 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:42` |
-| 231 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:66` |
-| 232 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:103` |
-| 233 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:143` |
-| 234 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:206` |
+| 225 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:59` |
+| 226 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:125` |
+| 227 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:263` |
+| 228 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:312` |
+| 229 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:359` |
+| 230 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:186` |
+| 231 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:227` |
+| 232 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:42` |
+| 233 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:66` |
+| 234 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:103` |
+| 235 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:143` |
+| 236 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:206` |
 
 ## storage
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 235 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:35` |
-| 236 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:57` |
-| 237 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:67` |
+| 237 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:35` |
+| 238 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:57` |
+| 239 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:67` |
 
 ## term
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 238 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:48` |
-| 239 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:35` |
-| 240 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:42` |
+| 240 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
+| 241 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
+| 242 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
+| 243 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
+| 244 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
 
 ## test
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 241 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:82` |
-| 242 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:209` |
-| 243 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:57` |
-| 244 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:73` |
-| 245 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:88` |
-| 246 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:104` |
-| 247 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:125` |
-| 248 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:140` |
-| 249 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:62` |
-| 250 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:74` |
-| 251 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:101` |
-| 252 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:114` |
-| 253 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:130` |
-| 254 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:151` |
-| 255 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:157` |
-| 256 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:170` |
-| 257 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:177` |
-| 258 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:187` |
-| 259 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:195` |
-| 260 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:202` |
+| 245 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
+| 246 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
+| 247 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:63` |
+| 248 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:79` |
+| 249 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:94` |
+| 250 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:110` |
+| 251 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:132` |
+| 252 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:147` |
+| 253 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:166` |
+| 254 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
+| 255 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
+| 256 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
+| 257 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
+| 258 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
+| 259 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
+| 260 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
+| 261 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
+| 262 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
+| 263 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
+| 264 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
+| 265 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
 

--- a/src/main/resources/static/docs/catalog/api/index.html
+++ b/src/main/resources/static/docs/catalog/api/index.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="utf-8">
-    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>UMC PRODUCT API Catalog</title>
     <link href="/umc-logo.svg" rel="icon" type="image/svg+xml">
     <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet">
@@ -662,252 +662,253 @@
     </style>
 </head>
 <body class="api-catalog">
-<header>
-    <div class="brand">
-        <span aria-hidden="true" class="brand-mark"><img alt="" src="/umc-logo.svg"></span>
-        <div>
-            <h1>UMC PRODUCT Docs</h1>
+    <header>
+        <div class="brand">
+            <span class="brand-mark" aria-hidden="true"><img src="/umc-logo.svg" alt=""></span>
+            <div>
+                <h1>UMC PRODUCT Docs</h1>
+                <p>서버 계약을 소스에서 바로 읽어옵니다.</p>
+            </div>
         </div>
+        <nav aria-label="문서 이동">
+            <a href="/docs/catalog/api/" class="active">API</a>
+            <a href="/docs/catalog/error/" class="">ErrorCode</a>
+            <a href="catalog.md">Markdown</a>
+            <a href="catalog.json">JSON</a>
+        </nav>
+    </header>
+    <div class="page">
+        <section class="hero" aria-labelledby="catalog-title">
+            <div>
+                <p class="eyebrow">Endpoint Inventory</p>
+                <h2 id="catalog-title">API 카탈로그</h2>
+                <p class="hero-copy">API ID, endpoint, 역할, deprecated 상태를 한 곳에서 찾습니다.</p>
+            </div>
+            <aside class="hero-aside">
+                <strong>자동 생성 문서</strong>
+                <p>소스 변경 후 `./gradlew generateDocumentationCatalogs`로 갱신합니다.</p>
+            </aside>
+        </section>
+        <section class="stats" id="stats" aria-label="카탈로그 요약"></section>
+        <section class="toolbar" aria-label="카탈로그 검색">
+            <label class="search" for="catalog-search">
+                <input id="catalog-search" type="search" placeholder="도메인, API ID, endpoint, 역할로 검색" autocomplete="off">
+            </label>
+            <span class="result-count" id="result-count"></span>
+        </section>
+        <main id="content">
+            <p class="loading">카탈로그를 불러오는 중입니다.</p>
+        </main>
+        <p class="no-results" id="no-results">일치하는 API가 없습니다.</p>
     </div>
-    <nav aria-label="문서 이동">
-        <a class="active" href="/docs/catalog/api/">API</a>
-        <a class="" href="/docs/catalog/error/">ErrorCode</a>
-        <a href="catalog.md">Markdown</a>
-        <a href="catalog.json">JSON</a>
-    </nav>
-</header>
-<div class="page">
-    <section aria-labelledby="catalog-title" class="hero">
-        <div>
-            <p class="eyebrow">Endpoint Inventory</p>
-            <h2 id="catalog-title">API 카탈로그</h2>
-            <p class="hero-copy">API ID, endpoint, 역할, deprecated 상태를 한 곳에서 찾습니다.</p>
-        </div>
-        <aside class="hero-aside">
-            <strong>자동 생성 문서</strong>
-            <p>소스 변경 후 `./gradlew generateDocumentationCatalogs`로 갱신합니다.</p>
-        </aside>
-    </section>
-    <section aria-label="카탈로그 요약" class="stats" id="stats"></section>
-    <section aria-label="카탈로그 검색" class="toolbar">
-        <label class="search" for="catalog-search">
-            <input autocomplete="off" id="catalog-search" placeholder="도메인, API ID, endpoint, 역할로 검색" type="search">
-        </label>
-        <span class="result-count" id="result-count"></span>
-    </section>
-    <main id="content">
-        <p class="loading">카탈로그를 불러오는 중입니다.</p>
-    </main>
-    <p class="no-results" id="no-results">일치하는 API가 없습니다.</p>
-</div>
-<div aria-live="polite" class="copy-toast" id="copy-toast" role="status"></div>
-<script src="/webjars/markdown-it/14.1.0/dist/markdown-it.min.js"></script>
-<script>
-    const content = document.getElementById("content");
-    const stats = document.getElementById("stats");
-    const searchInput = document.getElementById("catalog-search");
-    const resultCount = document.getElementById("result-count");
-    const noResults = document.getElementById("no-results");
-    const copyToast = document.getElementById("copy-toast");
-    const markdownSource = "catalog.md";
-    const jsonSource = "catalog.json";
-    const pageKind = "api";
-    const md = window.markdownit({
-        html: false,
-        linkify: true,
-        typographer: false
-    });
-
-    function fetchText(path) {
-        return fetch(path, {cache: "no-cache"}).then((response) => {
-            if (!response.ok) {
-                throw new Error("HTTP " + response.status);
-            }
-            return response.text();
+    <div class="copy-toast" id="copy-toast" role="status" aria-live="polite"></div>
+    <script src="/webjars/markdown-it/14.1.0/dist/markdown-it.min.js"></script>
+    <script>
+        const content = document.getElementById("content");
+        const stats = document.getElementById("stats");
+        const searchInput = document.getElementById("catalog-search");
+        const resultCount = document.getElementById("result-count");
+        const noResults = document.getElementById("no-results");
+        const copyToast = document.getElementById("copy-toast");
+        const markdownSource = "catalog.md";
+        const jsonSource = "catalog.json";
+        const pageKind = "api";
+        const md = window.markdownit({
+            html: false,
+            linkify: true,
+            typographer: false
         });
-    }
 
-    function fetchJson(path) {
-        return fetch(path, {cache: "no-cache"}).then((response) => {
-            if (!response.ok) {
-                throw new Error("HTTP " + response.status);
-            }
-            return response.json();
-        });
-    }
-
-    function uniqueCount(rows, key) {
-        return new Set(rows.map((row) => row[key]).filter(Boolean)).size;
-    }
-
-    function renderStats(rows) {
-        const values = pageKind === "api"
-            ? [
-                ["등록된 API", rows.length],
-                ["도메인", uniqueCount(rows, "domain")],
-                ["ID 미지정", rows.filter((row) => row.apiId === "<미지정>").length],
-                ["Deprecated", rows.filter((row) => row.deprecated).length]
-            ]
-            : [
-                ["ErrorCode", rows.length],
-                ["도메인", uniqueCount(rows, "domain")],
-                ["HTTP Status", uniqueCount(rows, "httpStatus")],
-                ["Enum", uniqueCount(rows, "enumName")]
-            ];
-
-        stats.innerHTML = values.map((item) => (
-            '<article class="stat"><span>' + item[0] + '</span><strong>' + item[1].toLocaleString("ko-KR") + '</strong></article>'
-        )).join("");
-    }
-
-    function copyToClipboard(text) {
-        if (navigator.clipboard && window.isSecureContext) {
-            return navigator.clipboard.writeText(text);
-        }
-
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.setAttribute("readonly", "");
-        textarea.style.position = "fixed";
-        textarea.style.left = "-9999px";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        textarea.remove();
-        return Promise.resolve();
-    }
-
-    function markCopied(cell, value) {
-        cell.classList.add("copied");
-        window.setTimeout(() => cell.classList.remove("copied"), 900);
-        copyToast.textContent = "복사했습니다: " + value;
-        copyToast.classList.add("visible");
-        window.clearTimeout(copyToast.hideTimer);
-        copyToast.hideTimer = window.setTimeout(() => copyToast.classList.remove("visible"), 1400);
-    }
-
-    function bindCopyCell(cell, value) {
-        if (!value) {
-            return;
-        }
-
-        cell.classList.add("copy-cell");
-        cell.dataset.copyValue = value;
-        cell.tabIndex = 0;
-        cell.setAttribute("role", "button");
-        cell.setAttribute("aria-label", value + " 복사");
-        cell.title = value + " 복사";
-        if (!cell.querySelector(".copy-icon")) {
-            const icon = document.createElement("span");
-            icon.className = "copy-icon";
-            icon.setAttribute("aria-hidden", "true");
-            icon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 7.5h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2Z"/><path d="M5.5 14.5h-.5a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v.5"/></svg>';
-            cell.appendChild(icon);
-        }
-
-        const handleCopy = () => {
-            copyToClipboard(value).then(() => markCopied(cell, value));
-        };
-
-        cell.addEventListener("click", handleCopy);
-        cell.addEventListener("keydown", (event) => {
-            if (event.key === "Enter" || event.key === " ") {
-                event.preventDefault();
-                handleCopy();
-            }
-        });
-    }
-
-    function enhanceTables() {
-        const firstHeading = content.querySelector("h1");
-        if (firstHeading) {
-            firstHeading.remove();
-        }
-
-        content.querySelectorAll("table").forEach((table) => {
-            table.classList.add("catalog-table");
-            const headers = Array.from(table.querySelectorAll("thead th"))
-                .map((cell) => cell.textContent.trim().toLowerCase());
-            const copyHeaders = pageKind === "api"
-                ? ["api id", "endpoint", "source"]
-                : ["code", "constant"];
-            const copyColumnIndexes = headers
-                .map((header, index) => ({header, index}))
-                .filter(({header}) => copyHeaders.includes(header))
-                .map(({index}) => index);
-            const wrapper = document.createElement("div");
-            wrapper.className = "table-wrap";
-            table.parentNode.insertBefore(wrapper, table);
-            wrapper.appendChild(table);
-
-            table.querySelectorAll("tbody tr").forEach((row) => {
-                row.dataset.search = row.textContent.toLowerCase();
-                const sourceCell = row.cells[row.cells.length - 1];
-                const sourceCode = sourceCell?.querySelector("code");
-                if (sourceCell && sourceCode) {
-                    const fullSource = sourceCode.textContent.trim();
-                    sourceCell.classList.add("source-cell");
-                    sourceCode.title = fullSource;
-                    sourceCode.textContent = fullSource.split("/").pop() || fullSource;
+        function fetchText(path) {
+            return fetch(path, { cache: "no-cache" }).then((response) => {
+                if (!response.ok) {
+                    throw new Error("HTTP " + response.status);
                 }
+                return response.text();
+            });
+        }
 
-                copyColumnIndexes.forEach((index) => {
-                    const cell = row.cells[index];
-                    if (!cell) {
-                        return;
+        function fetchJson(path) {
+            return fetch(path, { cache: "no-cache" }).then((response) => {
+                if (!response.ok) {
+                    throw new Error("HTTP " + response.status);
+                }
+                return response.json();
+            });
+        }
+
+        function uniqueCount(rows, key) {
+            return new Set(rows.map((row) => row[key]).filter(Boolean)).size;
+        }
+
+        function renderStats(rows) {
+            const values = pageKind === "api"
+                ? [
+                    ["등록된 API", rows.length],
+                    ["도메인", uniqueCount(rows, "domain")],
+                    ["ID 미지정", rows.filter((row) => row.apiId === "<미지정>").length],
+                    ["Deprecated", rows.filter((row) => row.deprecated).length]
+                ]
+                : [
+                    ["ErrorCode", rows.length],
+                    ["도메인", uniqueCount(rows, "domain")],
+                    ["HTTP Status", uniqueCount(rows, "httpStatus")],
+                    ["Enum", uniqueCount(rows, "enumName")]
+                ];
+
+            stats.innerHTML = values.map((item) => (
+                '<article class="stat"><span>' + item[0] + '</span><strong>' + item[1].toLocaleString("ko-KR") + '</strong></article>'
+            )).join("");
+        }
+
+        function copyToClipboard(text) {
+            if (navigator.clipboard && window.isSecureContext) {
+                return navigator.clipboard.writeText(text);
+            }
+
+            const textarea = document.createElement("textarea");
+            textarea.value = text;
+            textarea.setAttribute("readonly", "");
+            textarea.style.position = "fixed";
+            textarea.style.left = "-9999px";
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand("copy");
+            textarea.remove();
+            return Promise.resolve();
+        }
+
+        function markCopied(cell, value) {
+            cell.classList.add("copied");
+            window.setTimeout(() => cell.classList.remove("copied"), 900);
+            copyToast.textContent = "복사했습니다: " + value;
+            copyToast.classList.add("visible");
+            window.clearTimeout(copyToast.hideTimer);
+            copyToast.hideTimer = window.setTimeout(() => copyToast.classList.remove("visible"), 1400);
+        }
+
+        function bindCopyCell(cell, value) {
+            if (!value) {
+                return;
+            }
+
+            cell.classList.add("copy-cell");
+            cell.dataset.copyValue = value;
+            cell.tabIndex = 0;
+            cell.setAttribute("role", "button");
+            cell.setAttribute("aria-label", value + " 복사");
+            cell.title = value + " 복사";
+            if (!cell.querySelector(".copy-icon")) {
+                const icon = document.createElement("span");
+                icon.className = "copy-icon";
+                icon.setAttribute("aria-hidden", "true");
+                icon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 7.5h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2Z"/><path d="M5.5 14.5h-.5a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v.5"/></svg>';
+                cell.appendChild(icon);
+            }
+
+            const handleCopy = () => {
+                copyToClipboard(value).then(() => markCopied(cell, value));
+            };
+
+            cell.addEventListener("click", handleCopy);
+            cell.addEventListener("keydown", (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleCopy();
+                }
+            });
+        }
+
+        function enhanceTables() {
+            const firstHeading = content.querySelector("h1");
+            if (firstHeading) {
+                firstHeading.remove();
+            }
+
+            content.querySelectorAll("table").forEach((table) => {
+                table.classList.add("catalog-table");
+                const headers = Array.from(table.querySelectorAll("thead th"))
+                    .map((cell) => cell.textContent.trim().toLowerCase());
+                const copyHeaders = pageKind === "api"
+                    ? ["api id", "endpoint", "source"]
+                    : ["code", "constant"];
+                const copyColumnIndexes = headers
+                    .map((header, index) => ({ header, index }))
+                    .filter(({ header }) => copyHeaders.includes(header))
+                    .map(({ index }) => index);
+                const wrapper = document.createElement("div");
+                wrapper.className = "table-wrap";
+                table.parentNode.insertBefore(wrapper, table);
+                wrapper.appendChild(table);
+
+                table.querySelectorAll("tbody tr").forEach((row) => {
+                    row.dataset.search = row.textContent.toLowerCase();
+                    const sourceCell = row.cells[row.cells.length - 1];
+                    const sourceCode = sourceCell?.querySelector("code");
+                    if (sourceCell && sourceCode) {
+                        const fullSource = sourceCode.textContent.trim();
+                        sourceCell.classList.add("source-cell");
+                        sourceCode.title = fullSource;
+                        sourceCode.textContent = fullSource.split("/").pop() || fullSource;
                     }
 
-                    const code = cell.querySelector("code");
-                    bindCopyCell(cell, code?.title || code?.textContent.trim() || cell.textContent.trim());
+                    copyColumnIndexes.forEach((index) => {
+                        const cell = row.cells[index];
+                        if (!cell) {
+                            return;
+                        }
+
+                        const code = cell.querySelector("code");
+                        bindCopyCell(cell, code?.title || code?.textContent.trim() || cell.textContent.trim());
+                    });
                 });
             });
-        });
-    }
+        }
 
-    function updateResultCount(visible, total) {
-        resultCount.textContent = visible.toLocaleString("ko-KR") + " / " + total.toLocaleString("ko-KR") + "개 표시";
-        noResults.style.display = visible === 0 ? "block" : "none";
-    }
+        function updateResultCount(visible, total) {
+            resultCount.textContent = visible.toLocaleString("ko-KR") + " / " + total.toLocaleString("ko-KR") + "개 표시";
+            noResults.style.display = visible === 0 ? "block" : "none";
+        }
 
-    function applyFilter() {
-        const query = searchInput.value.trim().toLowerCase();
-        let total = 0;
-        let visible = 0;
+        function applyFilter() {
+            const query = searchInput.value.trim().toLowerCase();
+            let total = 0;
+            let visible = 0;
 
-        content.querySelectorAll(".catalog-table tbody tr").forEach((row) => {
-            total += 1;
-            const matched = query === "" || row.dataset.search.includes(query);
-            row.classList.toggle("is-hidden", !matched);
-            if (matched) {
-                visible += 1;
-            }
-        });
+            content.querySelectorAll(".catalog-table tbody tr").forEach((row) => {
+                total += 1;
+                const matched = query === "" || row.dataset.search.includes(query);
+                row.classList.toggle("is-hidden", !matched);
+                if (matched) {
+                    visible += 1;
+                }
+            });
 
-        content.querySelectorAll(".table-wrap").forEach((wrapper) => {
-            const visibleRows = wrapper.querySelectorAll("tbody tr:not(.is-hidden)").length;
-            wrapper.classList.toggle("is-hidden", visibleRows === 0 && query !== "");
-            const heading = wrapper.previousElementSibling;
-            if (heading && heading.tagName === "H2") {
-                heading.classList.toggle("is-hidden", visibleRows === 0 && query !== "");
-            }
-        });
+            content.querySelectorAll(".table-wrap").forEach((wrapper) => {
+                const visibleRows = wrapper.querySelectorAll("tbody tr:not(.is-hidden)").length;
+                wrapper.classList.toggle("is-hidden", visibleRows === 0 && query !== "");
+                const heading = wrapper.previousElementSibling;
+                if (heading && heading.tagName === "H2") {
+                    heading.classList.toggle("is-hidden", visibleRows === 0 && query !== "");
+                }
+            });
 
-        updateResultCount(visible, total);
-    }
+            updateResultCount(visible, total);
+        }
 
-    Promise.all([fetchText(markdownSource), fetchJson(jsonSource)])
-        .then(([markdown, rows]) => {
-            content.innerHTML = md.render(markdown);
-            renderStats(rows);
-            enhanceTables();
-            applyFilter();
-            searchInput.addEventListener("input", applyFilter);
-        })
-        .catch((error) => {
-            content.innerHTML = '<p class="error">카탈로그를 불러오지 못했습니다. ' + error.message + '</p>';
-            stats.innerHTML = "";
-            updateResultCount(0, 0);
-        });
-</script>
+        Promise.all([fetchText(markdownSource), fetchJson(jsonSource)])
+            .then(([markdown, rows]) => {
+                content.innerHTML = md.render(markdown);
+                renderStats(rows);
+                enhanceTables();
+                applyFilter();
+                searchInput.addEventListener("input", applyFilter);
+            })
+            .catch((error) => {
+                content.innerHTML = '<p class="error">카탈로그를 불러오지 못했습니다. ' + error.message + '</p>';
+                stats.innerHTML = "";
+                updateResultCount(0, 0);
+            });
+    </script>
 </body>
 </html>

--- a/src/main/resources/static/docs/catalog/error/catalog.json
+++ b/src/main/resources/static/docs/catalog/error/catalog.json
@@ -1222,6 +1222,17 @@
   },
   {
     "sequence": 112,
+    "domain": "feedback",
+    "enumName": "FeedbackErrorCode",
+    "constantName": "USER_FEEDBACK_TEMPLATE_NOT_FOUND",
+    "httpStatus": "NOT_FOUND",
+    "code": "FEEDBACK-0001",
+    "message": "사용자 피드백 템플릿을 찾을 수 없습니다.",
+    "source": "src/main/java/com/umc/product/feedback/domain/exception/FeedbackErrorCode.java",
+    "line": 15
+  },
+  {
+    "sequence": 113,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "INTEGRATION_NOT_FOUND",
@@ -1232,7 +1243,7 @@
     "line": 12
   },
   {
-    "sequence": 113,
+    "sequence": 114,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_TOKEN_EXCHANGE_FAILED",
@@ -1243,7 +1254,7 @@
     "line": 13
   },
   {
-    "sequence": 114,
+    "sequence": 115,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_TOKEN_REFRESH_FAILED",
@@ -1254,7 +1265,7 @@
     "line": 14
   },
   {
-    "sequence": 115,
+    "sequence": 116,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "COMMENT_FETCH_FAILED",
@@ -1265,7 +1276,7 @@
     "line": 15
   },
   {
-    "sequence": 116,
+    "sequence": 117,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "FILE_METADATA_FETCH_FAILED",
@@ -1276,7 +1287,7 @@
     "line": 16
   },
   {
-    "sequence": 117,
+    "sequence": 118,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "WATCHED_FILE_NOT_FOUND",
@@ -1287,7 +1298,7 @@
     "line": 17
   },
   {
-    "sequence": 118,
+    "sequence": 119,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "WATCHED_FILE_ALREADY_EXISTS",
@@ -1298,7 +1309,7 @@
     "line": 18
   },
   {
-    "sequence": 119,
+    "sequence": 120,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "OAUTH_STATE_MISMATCH",
@@ -1309,7 +1320,7 @@
     "line": 19
   },
   {
-    "sequence": 120,
+    "sequence": 121,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "TOKEN_ENCRYPTION_FAILED",
@@ -1320,7 +1331,7 @@
     "line": 20
   },
   {
-    "sequence": 121,
+    "sequence": 122,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "DISCORD_MENTION_SEND_FAILED",
@@ -1331,7 +1342,7 @@
     "line": 21
   },
   {
-    "sequence": 122,
+    "sequence": 123,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_NOT_FOUND",
@@ -1342,7 +1353,7 @@
     "line": 22
   },
   {
-    "sequence": 123,
+    "sequence": 124,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_ALREADY_EXISTS",
@@ -1353,7 +1364,7 @@
     "line": 23
   },
   {
-    "sequence": 124,
+    "sequence": 125,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_MENTION_NOT_FOUND",
@@ -1364,7 +1375,7 @@
     "line": 24
   },
   {
-    "sequence": 125,
+    "sequence": 126,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "ROUTING_DOMAIN_NOT_REGISTERED",
@@ -1375,7 +1386,7 @@
     "line": 25
   },
   {
-    "sequence": 126,
+    "sequence": 127,
     "domain": "figma",
     "enumName": "FigmaErrorCode",
     "constantName": "DIGEST_RANGE_INVALID",
@@ -1386,7 +1397,7 @@
     "line": 26
   },
   {
-    "sequence": 127,
+    "sequence": 128,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "INTERNAL_SERVER_ERROR",
@@ -1397,7 +1408,7 @@
     "line": 24
   },
   {
-    "sequence": 128,
+    "sequence": 129,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "BAD_REQUEST",
@@ -1408,7 +1419,7 @@
     "line": 26
   },
   {
-    "sequence": 129,
+    "sequence": 130,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "UNAUTHORIZED",
@@ -1419,7 +1430,7 @@
     "line": 27
   },
   {
-    "sequence": 130,
+    "sequence": 131,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "FORBIDDEN",
@@ -1430,7 +1441,7 @@
     "line": 28
   },
   {
-    "sequence": 131,
+    "sequence": 132,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "NOT_FOUND",
@@ -1441,7 +1452,7 @@
     "line": 29
   },
   {
-    "sequence": 132,
+    "sequence": 133,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "NOT_IMPLEMENTED",
@@ -1452,7 +1463,7 @@
     "line": 30
   },
   {
-    "sequence": 133,
+    "sequence": 134,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "INVALID_ENV",
@@ -1463,7 +1474,7 @@
     "line": 37
   },
   {
-    "sequence": 134,
+    "sequence": 135,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "PERMISSION_TYPE_NOT_IMPLEMENTED",
@@ -1474,7 +1485,7 @@
     "line": 40
   },
   {
-    "sequence": 135,
+    "sequence": 136,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "SECURITY_NOT_GIVEN",
@@ -1485,7 +1496,7 @@
     "line": 33
   },
   {
-    "sequence": 136,
+    "sequence": 137,
     "domain": "global",
     "enumName": "CommonErrorCode",
     "constantName": "SECURITY_FORBIDDEN",
@@ -1496,7 +1507,7 @@
     "line": 34
   },
   {
-    "sequence": 137,
+    "sequence": 138,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "CHAT_COMPLETION_FAILED",
@@ -1507,7 +1518,7 @@
     "line": 12
   },
   {
-    "sequence": 138,
+    "sequence": 139,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "CHAT_COMPLETION_INVALID_RESPONSE",
@@ -1518,7 +1529,7 @@
     "line": 13
   },
   {
-    "sequence": 139,
+    "sequence": 140,
     "domain": "llm",
     "enumName": "LlmErrorCode",
     "constantName": "PROVIDER_NOT_CONFIGURED",
@@ -1529,7 +1540,7 @@
     "line": 14
   },
   {
-    "sequence": 140,
+    "sequence": 141,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "SERVICE_UNDER_MAINTENANCE",
@@ -1540,7 +1551,7 @@
     "line": 12
   },
   {
-    "sequence": 141,
+    "sequence": 142,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "MAINTENANCE_WINDOW_NOT_FOUND",
@@ -1551,7 +1562,7 @@
     "line": 13
   },
   {
-    "sequence": 142,
+    "sequence": 143,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "INVALID_TIME_RANGE",
@@ -1562,7 +1573,7 @@
     "line": 14
   },
   {
-    "sequence": 143,
+    "sequence": 144,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "START_AT_IN_PAST",
@@ -1573,7 +1584,7 @@
     "line": 15
   },
   {
-    "sequence": 144,
+    "sequence": 145,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "TARGET_DOMAINS_REQUIRED",
@@ -1584,7 +1595,7 @@
     "line": 16
   },
   {
-    "sequence": 145,
+    "sequence": 146,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "OVERLAPPING_WINDOW",
@@ -1595,7 +1606,7 @@
     "line": 17
   },
   {
-    "sequence": 146,
+    "sequence": 147,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "ALREADY_ENDED",
@@ -1606,7 +1617,7 @@
     "line": 18
   },
   {
-    "sequence": 147,
+    "sequence": 148,
     "domain": "maintenance",
     "enumName": "MaintenanceErrorCode",
     "constantName": "NOT_SUPER_ADMIN",
@@ -1617,7 +1628,7 @@
     "line": 19
   },
   {
-    "sequence": 148,
+    "sequence": 149,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_NOT_FOUND",
@@ -1628,7 +1639,7 @@
     "line": 12
   },
   {
-    "sequence": 149,
+    "sequence": 150,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_EXISTS",
@@ -1639,7 +1650,7 @@
     "line": 13
   },
   {
-    "sequence": 150,
+    "sequence": 151,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "EMAIL_ALREADY_EXISTS",
@@ -1650,7 +1661,7 @@
     "line": 14
   },
   {
-    "sequence": 151,
+    "sequence": 152,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_WITHDRAWN",
@@ -1661,7 +1672,7 @@
     "line": 15
   },
   {
-    "sequence": 152,
+    "sequence": 153,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_MEMBER_STATUS",
@@ -1672,7 +1683,7 @@
     "line": 16
   },
   {
-    "sequence": 153,
+    "sequence": 154,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_NOT_ACTIVE",
@@ -1683,7 +1694,7 @@
     "line": 17
   },
   {
-    "sequence": 154,
+    "sequence": 155,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_ALREADY_REGISTERED",
@@ -1694,7 +1705,7 @@
     "line": 18
   },
   {
-    "sequence": 155,
+    "sequence": 156,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_PROFILE_NOT_FOUND",
@@ -1705,7 +1716,7 @@
     "line": 19
   },
   {
-    "sequence": 156,
+    "sequence": 157,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "MEMBER_SCHOOL_NOT_ASSIGNED",
@@ -1716,7 +1727,7 @@
     "line": 20
   },
   {
-    "sequence": 157,
+    "sequence": 158,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "CREDENTIAL_ALREADY_REGISTERED",
@@ -1727,7 +1738,7 @@
     "line": 21
   },
   {
-    "sequence": 158,
+    "sequence": 159,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "CREDENTIAL_NOT_REGISTERED",
@@ -1738,7 +1749,7 @@
     "line": 22
   },
   {
-    "sequence": 159,
+    "sequence": 160,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_LOGIN_ID",
@@ -1749,7 +1760,7 @@
     "line": 23
   },
   {
-    "sequence": 160,
+    "sequence": 161,
     "domain": "member",
     "enumName": "MemberErrorCode",
     "constantName": "INVALID_PASSWORD",
@@ -1760,7 +1771,7 @@
     "line": 24
   },
   {
-    "sequence": 161,
+    "sequence": 162,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_NOT_FOUND",
@@ -1771,7 +1782,7 @@
     "line": 12
   },
   {
-    "sequence": 162,
+    "sequence": 163,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "ALREADY_PUBLISHED_NOTICE",
@@ -1782,7 +1793,7 @@
     "line": 13
   },
   {
-    "sequence": 163,
+    "sequence": 164,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_TITLE",
@@ -1793,7 +1804,7 @@
     "line": 14
   },
   {
-    "sequence": 164,
+    "sequence": 165,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_CONTENT",
@@ -1804,7 +1815,7 @@
     "line": 15
   },
   {
-    "sequence": 165,
+    "sequence": 166,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_NOTICE_STATUS_FOR_REMINDER",
@@ -1815,7 +1826,7 @@
     "line": 16
   },
   {
-    "sequence": 166,
+    "sequence": 167,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "AUTHOR_REQUIRED",
@@ -1826,7 +1837,7 @@
     "line": 17
   },
   {
-    "sequence": 167,
+    "sequence": 168,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_SCOPE_REQUIRED",
@@ -1837,7 +1848,7 @@
     "line": 18
   },
   {
-    "sequence": 168,
+    "sequence": 169,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_AUTHOR_MISMATCH",
@@ -1848,7 +1859,7 @@
     "line": 19
   },
   {
-    "sequence": 169,
+    "sequence": 170,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_WRITE_PERMISSION",
@@ -1859,7 +1870,7 @@
     "line": 20
   },
   {
-    "sequence": 170,
+    "sequence": 171,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_TARGET_SETTING",
@@ -1870,7 +1881,7 @@
     "line": 22
   },
   {
-    "sequence": 171,
+    "sequence": 172,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_TARGET_FOUND",
@@ -1881,7 +1892,7 @@
     "line": 23
   },
   {
-    "sequence": 172,
+    "sequence": 173,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NO_READ_PERMISSION",
@@ -1892,7 +1903,7 @@
     "line": 21
   },
   {
-    "sequence": 173,
+    "sequence": 174,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOT_IMPLEMENTED_YET",
@@ -1903,7 +1914,7 @@
     "line": 41
   },
   {
-    "sequence": 174,
+    "sequence": 175,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_IDS_REQUIRED",
@@ -1914,7 +1925,7 @@
     "line": 26
   },
   {
-    "sequence": 175,
+    "sequence": 176,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "IMAGE_URLS_REQUIRED",
@@ -1925,7 +1936,7 @@
     "line": 27
   },
   {
-    "sequence": 176,
+    "sequence": 177,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "LINK_URLS_REQUIRED",
@@ -1936,7 +1947,7 @@
     "line": 28
   },
   {
-    "sequence": 177,
+    "sequence": 178,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_VOTE_NOT_FOUND",
@@ -1947,7 +1958,7 @@
     "line": 29
   },
   {
-    "sequence": 178,
+    "sequence": 179,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_IMAGE_NOT_FOUND",
@@ -1958,7 +1969,7 @@
     "line": 30
   },
   {
-    "sequence": 179,
+    "sequence": 180,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "NOTICE_LINK_NOT_FOUND",
@@ -1969,7 +1980,7 @@
     "line": 31
   },
   {
-    "sequence": 180,
+    "sequence": 181,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "IMAGE_LIMIT_EXCEEDED",
@@ -1980,7 +1991,7 @@
     "line": 32
   },
   {
-    "sequence": 181,
+    "sequence": 182,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_ALREADY_EXISTS",
@@ -1991,7 +2002,7 @@
     "line": 33
   },
   {
-    "sequence": 182,
+    "sequence": 183,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_VOTE_OPTION_COUNT",
@@ -2002,7 +2013,7 @@
     "line": 34
   },
   {
-    "sequence": 183,
+    "sequence": 184,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "INVALID_VOTE_OPTION_CONTENT",
@@ -2013,7 +2024,7 @@
     "line": 35
   },
   {
-    "sequence": 184,
+    "sequence": 185,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_NOT_STARTED",
@@ -2024,7 +2035,7 @@
     "line": 36
   },
   {
-    "sequence": 185,
+    "sequence": 186,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "VOTE_CLOSED",
@@ -2035,7 +2046,7 @@
     "line": 37
   },
   {
-    "sequence": 186,
+    "sequence": 187,
     "domain": "notice",
     "enumName": "NoticeErrorCode",
     "constantName": "SELECTED_OPTION_IDS_REQUIRED",
@@ -2046,37 +2057,26 @@
     "line": 38
   },
   {
-    "sequence": 187,
-    "domain": "notification",
-    "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_GENERAL_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0001",
-    "message": "알 수 없는 사유로 이메일 전송에 실패했습니다.",
-    "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 11
-  },
-  {
     "sequence": 188,
     "domain": "notification",
     "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_ENCODING_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0002",
-    "message": "인코딩 과정에서 오류가 발생했습니다.",
+    "constantName": "EMAIL_TEMPLATE_RENDER_FAILED",
+    "httpStatus": "INTERNAL_SERVER_ERROR",
+    "code": "EMAIL-0004",
+    "message": "이메일 본문 템플릿 렌더링에 실패했습니다.",
     "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 12
+    "line": 11
   },
   {
     "sequence": 189,
     "domain": "notification",
     "enumName": "EmailErrorCode",
-    "constantName": "EMAIL_MESSAGING_ERROR",
-    "httpStatus": "BAD_REQUEST",
-    "code": "EMAIL-0003",
-    "message": "메일 전송 과정에서 오류가 발생했습니다.",
+    "constantName": "EMAIL_SEND_FAILED",
+    "httpStatus": "INTERNAL_SERVER_ERROR",
+    "code": "EMAIL-0005",
+    "message": "이메일 발송에 실패했습니다.",
     "source": "src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java",
-    "line": 13
+    "line": 12
   },
   {
     "sequence": 190,
@@ -2604,7 +2604,7 @@
     "code": "PROJECT-0001",
     "message": "프로젝트를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 13
+    "line": 15
   },
   {
     "sequence": 238,
@@ -2615,7 +2615,7 @@
     "code": "PROJECT-0002",
     "message": "이미 완료된 프로젝트입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 14
+    "line": 16
   },
   {
     "sequence": 239,
@@ -2626,7 +2626,7 @@
     "code": "PROJECT-0003",
     "message": "해당 프로젝트를 해산시킬 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 15
+    "line": 17
   },
   {
     "sequence": 240,
@@ -2637,7 +2637,7 @@
     "code": "PROJECT-0004",
     "message": "요청하신 조작은 지원서가 제출된 상태에서만 가능합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 18
+    "line": 20
   },
   {
     "sequence": 241,
@@ -2648,7 +2648,7 @@
     "code": "PROJECT-0005",
     "message": "이미 지원서가 제출되었거나 평가가 완료된 상태입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 19
+    "line": 21
   },
   {
     "sequence": 242,
@@ -2659,7 +2659,7 @@
     "code": "PROJECT-0006",
     "message": "프로젝트에서 해당 지원용 폼을 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 27
+    "line": 29
   },
   {
     "sequence": 243,
@@ -2670,7 +2670,7 @@
     "code": "PROJECT-0007",
     "message": "요청하신 지원용 폼 섹션에 접근 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 28
+    "line": 30
   },
   {
     "sequence": 244,
@@ -2681,7 +2681,7 @@
     "code": "PROJECT-0008",
     "message": "작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 37
+    "line": 39
   },
   {
     "sequence": 245,
@@ -2692,7 +2692,7 @@
     "code": "PROJECT-0009",
     "message": "현재 상태에서 수행할 수 없는 작업입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 38
+    "line": 40
   },
   {
     "sequence": 246,
@@ -2703,7 +2703,7 @@
     "code": "PROJECT-0010",
     "message": "프로젝트 PO는 PLAN 파트 챌린저여야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 39
+    "line": 41
   },
   {
     "sequence": 247,
@@ -2714,7 +2714,7 @@
     "code": "PROJECT-0011",
     "message": "제출에 필요한 필수 정보가 누락되었습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 40
+    "line": 42
   },
   {
     "sequence": 248,
@@ -2725,7 +2725,7 @@
     "code": "PROJECT-0012",
     "message": "해당 프로젝트에 대한 접근 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 41
+    "line": 43
   },
   {
     "sequence": 249,
@@ -2736,7 +2736,7 @@
     "code": "PROJECT-0013",
     "message": "PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 29
+    "line": 31
   },
   {
     "sequence": 250,
@@ -2747,7 +2747,7 @@
     "code": "PROJECT-0014",
     "message": "현재 폼에 존재하지 않는 sectionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 30
+    "line": 32
   },
   {
     "sequence": 251,
@@ -2758,7 +2758,7 @@
     "code": "PROJECT-0015",
     "message": "해당 섹션에 속하지 않는 questionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 31
+    "line": 33
   },
   {
     "sequence": 252,
@@ -2769,7 +2769,7 @@
     "code": "PROJECT-0016",
     "message": "해당 질문에 속하지 않는 optionId 입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 32
+    "line": 34
   },
   {
     "sequence": 253,
@@ -2780,7 +2780,7 @@
     "code": "PROJECT-0017",
     "message": "선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 33
+    "line": 35
   },
   {
     "sequence": 254,
@@ -2791,7 +2791,7 @@
     "code": "PROJECT-0018",
     "message": "선택지 타입 질문에는 1개 이상의 옵션이 필요합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 34
+    "line": 36
   },
   {
     "sequence": 255,
@@ -2802,7 +2802,7 @@
     "code": "PROJECT-0019",
     "message": "임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 20
+    "line": 22
   },
   {
     "sequence": 256,
@@ -2813,7 +2813,7 @@
     "code": "PROJECT-0020",
     "message": "임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 22
+    "line": 24
   },
   {
     "sequence": 257,
@@ -2824,7 +2824,7 @@
     "code": "PROJECT-0021",
     "message": "지원서를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 24
+    "line": 26
   },
   {
     "sequence": 258,
@@ -2835,7 +2835,7 @@
     "code": "PROJECT-0022",
     "message": "현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능)",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 42
+    "line": 44
   },
   {
     "sequence": 259,
@@ -2846,7 +2846,7 @@
     "code": "PROJECT-0023",
     "message": "프로젝트 중단 사유는 필수입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 44
+    "line": 46
   },
   {
     "sequence": 260,
@@ -2857,7 +2857,7 @@
     "code": "PROJECT-0100",
     "message": "프로젝트 멤버를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 47
+    "line": 49
   },
   {
     "sequence": 261,
@@ -2868,7 +2868,7 @@
     "code": "PROJECT-0101",
     "message": "이미 해당 프로젝트의 멤버입니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 48
+    "line": 50
   },
   {
     "sequence": 262,
@@ -2879,7 +2879,7 @@
     "code": "PROJECT-0102",
     "message": "메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 49
+    "line": 51
   },
   {
     "sequence": 263,
@@ -2890,7 +2890,7 @@
     "code": "PROJECT-0200",
     "message": "파트 정원은 1 이상이어야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 52
+    "line": 54
   },
   {
     "sequence": 264,
@@ -2901,7 +2901,7 @@
     "code": "PROJECT-0202",
     "message": "공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 53
+    "line": 55
   },
   {
     "sequence": 265,
@@ -2912,7 +2912,7 @@
     "code": "PROJECT-0203",
     "message": "동일 파트가 중복으로 입력되었습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 54
+    "line": 56
   },
   {
     "sequence": 266,
@@ -2923,7 +2923,7 @@
     "code": "PROJECT-0204",
     "message": "작성 중인 지원서를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 76
+    "line": 78
   },
   {
     "sequence": 267,
@@ -2934,7 +2934,7 @@
     "code": "PROJECT-0205",
     "message": "해당 프로젝트에 지원 가능한 파트가 아닙니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 77
+    "line": 79
   },
   {
     "sequence": 268,
@@ -2945,7 +2945,7 @@
     "code": "PROJECT-0206",
     "message": "이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 78
+    "line": 80
   },
   {
     "sequence": 269,
@@ -2956,7 +2956,7 @@
     "code": "PROJECT-0207",
     "message": "동일한 매칭 차수에 이미 제출된 지원서가 있습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 79
+    "line": 81
   },
   {
     "sequence": 270,
@@ -2967,7 +2967,7 @@
     "code": "PROJECT-0208",
     "message": "해당 매칭 차수의 지원 기간이 아닙니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 80
+    "line": 82
   },
   {
     "sequence": 271,
@@ -2978,7 +2978,7 @@
     "code": "PROJECT-0209",
     "message": "선택한 매칭 차수가 본인 파트에 해당하지 않습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 81
+    "line": 83
   },
   {
     "sequence": 272,
@@ -2989,7 +2989,7 @@
     "code": "PROJECT-0210",
     "message": "이미 작성 중인 지원서가 있습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 82
+    "line": 84
   },
   {
     "sequence": 273,
@@ -3000,7 +3000,7 @@
     "code": "PROJECT-0211",
     "message": "본인이 운영하는 프로젝트에는 지원할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 83
+    "line": 85
   },
   {
     "sequence": 274,
@@ -3011,7 +3011,7 @@
     "code": "PROJECT-0212",
     "message": "현재 상태에서는 합/불 결정을 변경할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 84
+    "line": 86
   },
   {
     "sequence": 275,
@@ -3022,7 +3022,7 @@
     "code": "PROJECT-0213",
     "message": "해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 86
+    "line": 88
   },
   {
     "sequence": 276,
@@ -3033,7 +3033,7 @@
     "code": "PROJECT-0214",
     "message": "이미 종결된 지원서는 철회할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 88
+    "line": 90
   },
   {
     "sequence": 277,
@@ -3044,7 +3044,7 @@
     "code": "PROJECT-0215",
     "message": "매칭 차수가 종료되어 지원서를 철회할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 89
+    "line": 91
   },
   {
     "sequence": 278,
@@ -3055,7 +3055,7 @@
     "code": "PROJECT-0300",
     "message": "매칭 차수를 찾을 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 57
+    "line": 59
   },
   {
     "sequence": 279,
@@ -3066,7 +3066,7 @@
     "code": "PROJECT-0301",
     "message": "매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 58
+    "line": 60
   },
   {
     "sequence": 280,
@@ -3077,7 +3077,7 @@
     "code": "PROJECT-0302",
     "message": "같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 60
+    "line": 62
   },
   {
     "sequence": 281,
@@ -3088,7 +3088,7 @@
     "code": "PROJECT-0303",
     "message": "해당 매칭 차수에 대한 관리 권한이 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 62
+    "line": 64
   },
   {
     "sequence": 282,
@@ -3099,7 +3099,7 @@
     "code": "PROJECT-0304",
     "message": "연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 64
+    "line": 66
   },
   {
     "sequence": 283,
@@ -3110,7 +3110,7 @@
     "code": "PROJECT-0305",
     "message": "time 기준 조회는 chapterId와 함께 요청해야 합니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 66
+    "line": 68
   },
   {
     "sequence": 284,
@@ -3121,7 +3121,7 @@
     "code": "PROJECT-0306",
     "message": "매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 68
+    "line": 70
   },
   {
     "sequence": 285,
@@ -3132,7 +3132,7 @@
     "code": "PROJECT-0307",
     "message": "결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 70
+    "line": 72
   },
   {
     "sequence": 286,
@@ -3143,7 +3143,7 @@
     "code": "PROJECT-0308",
     "message": "해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다.",
     "source": "src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java",
-    "line": 72
+    "line": 74
   },
   {
     "sequence": 287,

--- a/src/main/resources/static/docs/catalog/error/catalog.md
+++ b/src/main/resources/static/docs/catalog/error/catalog.md
@@ -145,118 +145,123 @@
 | 110 | curriculum | `CURRICULUM-0018` | 409 CONFLICT | 이미 동일한 주차와 부록 여부를 가진 주차별 커리큘럼이 존재합니다. | CurriculumErrorCode | `WEEKLY_CURRICULUM_ALREADY_EXISTS` | `src/main/java/com/umc/product/curriculum/domain/exception/CurriculumErrorCode.java:29` |
 | 111 | curriculum | `CURRICULUM-0019` | 400 BAD_REQUEST | 이미 종료된 기간으로 주차별 커리큘럼을 생성하거나 수정할 수 없습니다. | CurriculumErrorCode | `WEEKLY_CURRICULUM_PERIOD_ALREADY_ENDED` | `src/main/java/com/umc/product/curriculum/domain/exception/CurriculumErrorCode.java:30` |
 
+## feedback
+
+| 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
+|---:|---|---|---|---|---|---|---|
+| 112 | feedback | `FEEDBACK-0001` | 404 NOT_FOUND | 사용자 피드백 템플릿을 찾을 수 없습니다. | FeedbackErrorCode | `USER_FEEDBACK_TEMPLATE_NOT_FOUND` | `src/main/java/com/umc/product/feedback/domain/exception/FeedbackErrorCode.java:15` |
+
 ## figma
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 112 | figma | `FIGMA-0001` | 404 NOT_FOUND | Figma OAuth 통합 정보가 등록되어 있지 않습니다. | FigmaErrorCode | `INTEGRATION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:12` |
-| 113 | figma | `FIGMA-0002` | 502 BAD_GATEWAY | Figma OAuth 토큰 교환에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_EXCHANGE_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:13` |
-| 114 | figma | `FIGMA-0003` | 502 BAD_GATEWAY | Figma access token 갱신에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_REFRESH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:14` |
-| 115 | figma | `FIGMA-0004` | 502 BAD_GATEWAY | Figma 댓글 조회에 실패했습니다. | FigmaErrorCode | `COMMENT_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:15` |
-| 116 | figma | `FIGMA-0005` | 502 BAD_GATEWAY | Figma 파일 메타데이터 조회에 실패했습니다. | FigmaErrorCode | `FILE_METADATA_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:16` |
-| 117 | figma | `FIGMA-0006` | 404 NOT_FOUND | 등록된 Figma 폴링 대상 파일이 아닙니다. | FigmaErrorCode | `WATCHED_FILE_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:17` |
-| 118 | figma | `FIGMA-0007` | 409 CONFLICT | 이미 등록된 Figma 파일 키 입니다. | FigmaErrorCode | `WATCHED_FILE_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:18` |
-| 119 | figma | `FIGMA-0008` | 400 BAD_REQUEST | Figma OAuth state 값이 일치하지 않습니다. | FigmaErrorCode | `OAUTH_STATE_MISMATCH` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:19` |
-| 120 | figma | `FIGMA-0009` | 500 INTERNAL_SERVER_ERROR | Figma 토큰 암복호화에 실패했습니다. | FigmaErrorCode | `TOKEN_ENCRYPTION_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:20` |
-| 121 | figma | `FIGMA-0010` | 502 BAD_GATEWAY | Discord 멘션 전송에 실패했습니다. | FigmaErrorCode | `DISCORD_MENTION_SEND_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:21` |
-| 122 | figma | `FIGMA-0013` | 404 NOT_FOUND | 등록된 Figma 라우팅 도메인이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:22` |
-| 123 | figma | `FIGMA-0014` | 409 CONFLICT | 동일한 domain_key 의 라우팅 도메인이 이미 등록되어 있습니다. | FigmaErrorCode | `ROUTING_DOMAIN_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:23` |
-| 124 | figma | `FIGMA-0015` | 404 NOT_FOUND | 해당 라우팅 도메인의 mention 이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_MENTION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:24` |
-| 125 | figma | `FIGMA-0016` | 412 PRECONDITION_FAILED | 라우팅 도메인이 한 건도 등록되어 있지 않습니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_REGISTERED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:25` |
-| 126 | figma | `FIGMA-0017` | 400 BAD_REQUEST | digest 의 from/to 시간창이 유효하지 않습니다. | FigmaErrorCode | `DIGEST_RANGE_INVALID` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:26` |
+| 113 | figma | `FIGMA-0001` | 404 NOT_FOUND | Figma OAuth 통합 정보가 등록되어 있지 않습니다. | FigmaErrorCode | `INTEGRATION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:12` |
+| 114 | figma | `FIGMA-0002` | 502 BAD_GATEWAY | Figma OAuth 토큰 교환에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_EXCHANGE_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:13` |
+| 115 | figma | `FIGMA-0003` | 502 BAD_GATEWAY | Figma access token 갱신에 실패했습니다. | FigmaErrorCode | `OAUTH_TOKEN_REFRESH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:14` |
+| 116 | figma | `FIGMA-0004` | 502 BAD_GATEWAY | Figma 댓글 조회에 실패했습니다. | FigmaErrorCode | `COMMENT_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:15` |
+| 117 | figma | `FIGMA-0005` | 502 BAD_GATEWAY | Figma 파일 메타데이터 조회에 실패했습니다. | FigmaErrorCode | `FILE_METADATA_FETCH_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:16` |
+| 118 | figma | `FIGMA-0006` | 404 NOT_FOUND | 등록된 Figma 폴링 대상 파일이 아닙니다. | FigmaErrorCode | `WATCHED_FILE_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:17` |
+| 119 | figma | `FIGMA-0007` | 409 CONFLICT | 이미 등록된 Figma 파일 키 입니다. | FigmaErrorCode | `WATCHED_FILE_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:18` |
+| 120 | figma | `FIGMA-0008` | 400 BAD_REQUEST | Figma OAuth state 값이 일치하지 않습니다. | FigmaErrorCode | `OAUTH_STATE_MISMATCH` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:19` |
+| 121 | figma | `FIGMA-0009` | 500 INTERNAL_SERVER_ERROR | Figma 토큰 암복호화에 실패했습니다. | FigmaErrorCode | `TOKEN_ENCRYPTION_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:20` |
+| 122 | figma | `FIGMA-0010` | 502 BAD_GATEWAY | Discord 멘션 전송에 실패했습니다. | FigmaErrorCode | `DISCORD_MENTION_SEND_FAILED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:21` |
+| 123 | figma | `FIGMA-0013` | 404 NOT_FOUND | 등록된 Figma 라우팅 도메인이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:22` |
+| 124 | figma | `FIGMA-0014` | 409 CONFLICT | 동일한 domain_key 의 라우팅 도메인이 이미 등록되어 있습니다. | FigmaErrorCode | `ROUTING_DOMAIN_ALREADY_EXISTS` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:23` |
+| 125 | figma | `FIGMA-0015` | 404 NOT_FOUND | 해당 라우팅 도메인의 mention 이 아닙니다. | FigmaErrorCode | `ROUTING_DOMAIN_MENTION_NOT_FOUND` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:24` |
+| 126 | figma | `FIGMA-0016` | 412 PRECONDITION_FAILED | 라우팅 도메인이 한 건도 등록되어 있지 않습니다. | FigmaErrorCode | `ROUTING_DOMAIN_NOT_REGISTERED` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:25` |
+| 127 | figma | `FIGMA-0017` | 400 BAD_REQUEST | digest 의 from/to 시간창이 유효하지 않습니다. | FigmaErrorCode | `DIGEST_RANGE_INVALID` | `src/main/java/com/umc/product/figma/domain/exception/FigmaErrorCode.java:26` |
 
 ## global
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 127 | global | `COMMON-0001` | 500 INTERNAL_SERVER_ERROR | 알 수 없는 오류입니다. 관리자에게 문의해주세요. | CommonErrorCode | `INTERNAL_SERVER_ERROR` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:24` |
-| 128 | global | `COMMON-400` | 400 BAD_REQUEST | 잘못된 요청입니다. | CommonErrorCode | `BAD_REQUEST` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:26` |
-| 129 | global | `COMMON-401` | 401 UNAUTHORIZED | 인증이 필요합니다. | CommonErrorCode | `UNAUTHORIZED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:27` |
-| 130 | global | `COMMON-403` | 403 FORBIDDEN | 허용되지 않는 요청입니다. | CommonErrorCode | `FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:28` |
-| 131 | global | `COMMON-404` | 404 NOT_FOUND | 요청한 리소스를 찾을 수 없습니다. | CommonErrorCode | `NOT_FOUND` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:29` |
-| 132 | global | `COMMON-501` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. 서버팀에게 문의해주세요. | CommonErrorCode | `NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:30` |
-| 133 | global | `ENV-0001` | 400 BAD_REQUEST | 현재 실행 환경에서는 사용할 수 없는 기능입니다. | CommonErrorCode | `INVALID_ENV` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:37` |
-| 134 | global | `PE-0001` | 501 NOT_IMPLEMENTED | 요청하신 PE가 존재하지 않습니다. 관리자에게 문의해주세요. | CommonErrorCode | `PERMISSION_TYPE_NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:40` |
-| 135 | global | `SECURITY-0001` | 401 UNAUTHORIZED | 인증 정보가 전달되지 않았습니다. | CommonErrorCode | `SECURITY_NOT_GIVEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:33` |
-| 136 | global | `SECURITY-0002` | 403 FORBIDDEN | 권한이 부족합니다. | CommonErrorCode | `SECURITY_FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:34` |
+| 128 | global | `COMMON-0001` | 500 INTERNAL_SERVER_ERROR | 알 수 없는 오류입니다. 관리자에게 문의해주세요. | CommonErrorCode | `INTERNAL_SERVER_ERROR` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:24` |
+| 129 | global | `COMMON-400` | 400 BAD_REQUEST | 잘못된 요청입니다. | CommonErrorCode | `BAD_REQUEST` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:26` |
+| 130 | global | `COMMON-401` | 401 UNAUTHORIZED | 인증이 필요합니다. | CommonErrorCode | `UNAUTHORIZED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:27` |
+| 131 | global | `COMMON-403` | 403 FORBIDDEN | 허용되지 않는 요청입니다. | CommonErrorCode | `FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:28` |
+| 132 | global | `COMMON-404` | 404 NOT_FOUND | 요청한 리소스를 찾을 수 없습니다. | CommonErrorCode | `NOT_FOUND` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:29` |
+| 133 | global | `COMMON-501` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. 서버팀에게 문의해주세요. | CommonErrorCode | `NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:30` |
+| 134 | global | `ENV-0001` | 400 BAD_REQUEST | 현재 실행 환경에서는 사용할 수 없는 기능입니다. | CommonErrorCode | `INVALID_ENV` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:37` |
+| 135 | global | `PE-0001` | 501 NOT_IMPLEMENTED | 요청하신 PE가 존재하지 않습니다. 관리자에게 문의해주세요. | CommonErrorCode | `PERMISSION_TYPE_NOT_IMPLEMENTED` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:40` |
+| 136 | global | `SECURITY-0001` | 401 UNAUTHORIZED | 인증 정보가 전달되지 않았습니다. | CommonErrorCode | `SECURITY_NOT_GIVEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:33` |
+| 137 | global | `SECURITY-0002` | 403 FORBIDDEN | 권한이 부족합니다. | CommonErrorCode | `SECURITY_FORBIDDEN` | `src/main/java/com/umc/product/global/exception/constant/CommonErrorCode.java:34` |
 
 ## llm
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 137 | llm | `LLM-0001` | 502 BAD_GATEWAY | LLM 호출에 실패했습니다. | LlmErrorCode | `CHAT_COMPLETION_FAILED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:12` |
-| 138 | llm | `LLM-0002` | 502 BAD_GATEWAY | LLM 응답을 해석할 수 없습니다. | LlmErrorCode | `CHAT_COMPLETION_INVALID_RESPONSE` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:13` |
-| 139 | llm | `LLM-0003` | 500 INTERNAL_SERVER_ERROR | LLM provider 설정이 누락되었습니다. | LlmErrorCode | `PROVIDER_NOT_CONFIGURED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:14` |
+| 138 | llm | `LLM-0001` | 502 BAD_GATEWAY | LLM 호출에 실패했습니다. | LlmErrorCode | `CHAT_COMPLETION_FAILED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:12` |
+| 139 | llm | `LLM-0002` | 502 BAD_GATEWAY | LLM 응답을 해석할 수 없습니다. | LlmErrorCode | `CHAT_COMPLETION_INVALID_RESPONSE` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:13` |
+| 140 | llm | `LLM-0003` | 500 INTERNAL_SERVER_ERROR | LLM provider 설정이 누락되었습니다. | LlmErrorCode | `PROVIDER_NOT_CONFIGURED` | `src/main/java/com/umc/product/llm/domain/exception/LlmErrorCode.java:14` |
 
 ## maintenance
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 140 | maintenance | `MAINTENANCE-0001` | 503 SERVICE_UNAVAILABLE | 서비스 점검 중입니다. | MaintenanceErrorCode | `SERVICE_UNDER_MAINTENANCE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:12` |
-| 141 | maintenance | `MAINTENANCE-0002` | 404 NOT_FOUND | 점검 윈도우를 찾을 수 없습니다. | MaintenanceErrorCode | `MAINTENANCE_WINDOW_NOT_FOUND` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:13` |
-| 142 | maintenance | `MAINTENANCE-0003` | 400 BAD_REQUEST | 종료 시각은 시작 시각 이후여야 합니다. | MaintenanceErrorCode | `INVALID_TIME_RANGE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:14` |
-| 143 | maintenance | `MAINTENANCE-0004` | 400 BAD_REQUEST | 시작 시각은 현재 시각 이후여야 합니다. | MaintenanceErrorCode | `START_AT_IN_PAST` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:15` |
-| 144 | maintenance | `MAINTENANCE-0005` | 400 BAD_REQUEST | PER_DOMAIN 점검은 대상 도메인을 1개 이상 지정해야 합니다. | MaintenanceErrorCode | `TARGET_DOMAINS_REQUIRED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:16` |
-| 145 | maintenance | `MAINTENANCE-0006` | 409 CONFLICT | 다른 점검 윈도우와 시간이 겹칩니다. | MaintenanceErrorCode | `OVERLAPPING_WINDOW` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:17` |
-| 146 | maintenance | `MAINTENANCE-0007` | 400 BAD_REQUEST | 이미 종료된 점검 윈도우입니다. | MaintenanceErrorCode | `ALREADY_ENDED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:18` |
-| 147 | maintenance | `MAINTENANCE-0008` | 403 FORBIDDEN | 점검 관리 권한이 없습니다. | MaintenanceErrorCode | `NOT_SUPER_ADMIN` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:19` |
+| 141 | maintenance | `MAINTENANCE-0001` | 503 SERVICE_UNAVAILABLE | 서비스 점검 중입니다. | MaintenanceErrorCode | `SERVICE_UNDER_MAINTENANCE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:12` |
+| 142 | maintenance | `MAINTENANCE-0002` | 404 NOT_FOUND | 점검 윈도우를 찾을 수 없습니다. | MaintenanceErrorCode | `MAINTENANCE_WINDOW_NOT_FOUND` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:13` |
+| 143 | maintenance | `MAINTENANCE-0003` | 400 BAD_REQUEST | 종료 시각은 시작 시각 이후여야 합니다. | MaintenanceErrorCode | `INVALID_TIME_RANGE` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:14` |
+| 144 | maintenance | `MAINTENANCE-0004` | 400 BAD_REQUEST | 시작 시각은 현재 시각 이후여야 합니다. | MaintenanceErrorCode | `START_AT_IN_PAST` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:15` |
+| 145 | maintenance | `MAINTENANCE-0005` | 400 BAD_REQUEST | PER_DOMAIN 점검은 대상 도메인을 1개 이상 지정해야 합니다. | MaintenanceErrorCode | `TARGET_DOMAINS_REQUIRED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:16` |
+| 146 | maintenance | `MAINTENANCE-0006` | 409 CONFLICT | 다른 점검 윈도우와 시간이 겹칩니다. | MaintenanceErrorCode | `OVERLAPPING_WINDOW` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:17` |
+| 147 | maintenance | `MAINTENANCE-0007` | 400 BAD_REQUEST | 이미 종료된 점검 윈도우입니다. | MaintenanceErrorCode | `ALREADY_ENDED` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:18` |
+| 148 | maintenance | `MAINTENANCE-0008` | 403 FORBIDDEN | 점검 관리 권한이 없습니다. | MaintenanceErrorCode | `NOT_SUPER_ADMIN` | `src/main/java/com/umc/product/maintenance/exception/MaintenanceErrorCode.java:19` |
 
 ## member
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 148 | member | `MEMBER-0001` | 404 NOT_FOUND | 사용자를 찾을 수 없습니다. | MemberErrorCode | `MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:12` |
-| 149 | member | `MEMBER-0002` | 409 CONFLICT | 이미 등록된 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:13` |
-| 150 | member | `MEMBER-0003` | 409 CONFLICT | 이미 사용 중인 이메일입니다. | MemberErrorCode | `EMAIL_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:14` |
-| 151 | member | `MEMBER-0004` | 400 BAD_REQUEST | 이미 탈퇴한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_WITHDRAWN` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:15` |
-| 152 | member | `MEMBER-0005` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `INVALID_MEMBER_STATUS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:16` |
-| 153 | member | `MEMBER-0006` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `MEMBER_NOT_ACTIVE` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:17` |
-| 154 | member | `MEMBER-0007` | 400 BAD_REQUEST | 이미 회원가입을 완료한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:18` |
-| 155 | member | `MEMBER-0008` | 404 NOT_FOUND | 프로필을 찾을 수 없습니다. | MemberErrorCode | `MEMBER_PROFILE_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:19` |
-| 156 | member | `MEMBER-0009` | 400 BAD_REQUEST | 학교가 등록되지 않은 사용자입니다. | MemberErrorCode | `MEMBER_SCHOOL_NOT_ASSIGNED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:20` |
-| 157 | member | `MEMBER-0010` | 409 CONFLICT | 이미 ID/PW 자격증명이 등록된 사용자입니다. | MemberErrorCode | `CREDENTIAL_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:21` |
-| 158 | member | `MEMBER-0011` | 400 BAD_REQUEST | ID/PW 자격증명이 등록되지 않은 사용자입니다. | MemberErrorCode | `CREDENTIAL_NOT_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:22` |
-| 159 | member | `MEMBER-0012` | 400 BAD_REQUEST | 올바르지 않은 로그인 아이디입니다. | MemberErrorCode | `INVALID_LOGIN_ID` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:23` |
-| 160 | member | `MEMBER-0013` | 400 BAD_REQUEST | 올바르지 않은 비밀번호입니다. | MemberErrorCode | `INVALID_PASSWORD` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:24` |
+| 149 | member | `MEMBER-0001` | 404 NOT_FOUND | 사용자를 찾을 수 없습니다. | MemberErrorCode | `MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:12` |
+| 150 | member | `MEMBER-0002` | 409 CONFLICT | 이미 등록된 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:13` |
+| 151 | member | `MEMBER-0003` | 409 CONFLICT | 이미 사용 중인 이메일입니다. | MemberErrorCode | `EMAIL_ALREADY_EXISTS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:14` |
+| 152 | member | `MEMBER-0004` | 400 BAD_REQUEST | 이미 탈퇴한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_WITHDRAWN` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:15` |
+| 153 | member | `MEMBER-0005` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `INVALID_MEMBER_STATUS` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:16` |
+| 154 | member | `MEMBER-0006` | 400 BAD_REQUEST | 올바르지 않은 사용자 상태입니다. | MemberErrorCode | `MEMBER_NOT_ACTIVE` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:17` |
+| 155 | member | `MEMBER-0007` | 400 BAD_REQUEST | 이미 회원가입을 완료한 사용자입니다. | MemberErrorCode | `MEMBER_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:18` |
+| 156 | member | `MEMBER-0008` | 404 NOT_FOUND | 프로필을 찾을 수 없습니다. | MemberErrorCode | `MEMBER_PROFILE_NOT_FOUND` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:19` |
+| 157 | member | `MEMBER-0009` | 400 BAD_REQUEST | 학교가 등록되지 않은 사용자입니다. | MemberErrorCode | `MEMBER_SCHOOL_NOT_ASSIGNED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:20` |
+| 158 | member | `MEMBER-0010` | 409 CONFLICT | 이미 ID/PW 자격증명이 등록된 사용자입니다. | MemberErrorCode | `CREDENTIAL_ALREADY_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:21` |
+| 159 | member | `MEMBER-0011` | 400 BAD_REQUEST | ID/PW 자격증명이 등록되지 않은 사용자입니다. | MemberErrorCode | `CREDENTIAL_NOT_REGISTERED` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:22` |
+| 160 | member | `MEMBER-0012` | 400 BAD_REQUEST | 올바르지 않은 로그인 아이디입니다. | MemberErrorCode | `INVALID_LOGIN_ID` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:23` |
+| 161 | member | `MEMBER-0013` | 400 BAD_REQUEST | 올바르지 않은 비밀번호입니다. | MemberErrorCode | `INVALID_PASSWORD` | `src/main/java/com/umc/product/member/domain/exception/MemberErrorCode.java:24` |
 
 ## notice
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 161 | notice | `NOTICE-0001` | 404 NOT_FOUND | 공지사항을 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:12` |
-| 162 | notice | `NOTICE-0002` | 400 BAD_REQUEST | 이미 게시된 공지사항입니다. | NoticeErrorCode | `ALREADY_PUBLISHED_NOTICE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:13` |
-| 163 | notice | `NOTICE-0003` | 400 BAD_REQUEST | 공지사항 제목이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_TITLE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:14` |
-| 164 | notice | `NOTICE-0004` | 400 BAD_REQUEST | 공지사항 내용이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:15` |
-| 165 | notice | `NOTICE-0005` | 400 BAD_REQUEST | 공지사항 알림을 보낼 수 없는 상태입니다. | NoticeErrorCode | `INVALID_NOTICE_STATUS_FOR_REMINDER` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:16` |
-| 166 | notice | `NOTICE-0006` | 400 BAD_REQUEST | 공지사항 작성자는 필수입니다. | NoticeErrorCode | `AUTHOR_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:17` |
-| 167 | notice | `NOTICE-0007` | 400 BAD_REQUEST | 공지사항 대상 범위는 필수입니다. | NoticeErrorCode | `NOTICE_SCOPE_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:18` |
-| 168 | notice | `NOTICE-0008` | 403 FORBIDDEN | 공지사항 작성자가 아닙니다. | NoticeErrorCode | `NOTICE_AUTHOR_MISMATCH` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:19` |
-| 169 | notice | `NOTICE-0009` | 403 FORBIDDEN | 해당 공지사항을 작성할 권한이 없습니다. | NoticeErrorCode | `NO_WRITE_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:20` |
-| 170 | notice | `NOTICE-0010` | 400 BAD_REQUEST | 공지사항 수신자 설정이 잘못되었습니다. | NoticeErrorCode | `INVALID_TARGET_SETTING` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:22` |
-| 171 | notice | `NOTICE-0011` | 404 NOT_FOUND | 해당 공지사항에 설정된 수신 대상이 존재하지 않습니다. | NoticeErrorCode | `NO_TARGET_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:23` |
-| 172 | notice | `NOTICE-0012` | 403 FORBIDDEN | 해당 공지사항을 조회할 권한이 없습니다. | NoticeErrorCode | `NO_READ_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:21` |
-| 173 | notice | `NOTICE-9999` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. | NoticeErrorCode | `NOT_IMPLEMENTED_YET` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:41` |
-| 174 | notice | `NOTICE-CONTENTS-0001` | 400 BAD_REQUEST | 투표 ID 목록은 필수입니다. | NoticeErrorCode | `VOTE_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:26` |
-| 175 | notice | `NOTICE-CONTENTS-0002` | 400 BAD_REQUEST | 이미지 URL 목록은 필수입니다. | NoticeErrorCode | `IMAGE_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:27` |
-| 176 | notice | `NOTICE-CONTENTS-0003` | 400 BAD_REQUEST | 링크 URL 목록은 필수입니다. | NoticeErrorCode | `LINK_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:28` |
-| 177 | notice | `NOTICE-CONTENTS-0004` | 404 NOT_FOUND | 공지사항 투표를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_VOTE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:29` |
-| 178 | notice | `NOTICE-CONTENTS-0005` | 404 NOT_FOUND | 공지사항 이미지를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_IMAGE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:30` |
-| 179 | notice | `NOTICE-CONTENTS-0006` | 404 NOT_FOUND | 공지사항 링크를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_LINK_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:31` |
-| 180 | notice | `NOTICE-CONTENTS-0007` | 400 BAD_REQUEST | 공지사항 이미지는 최대 10장까지 등록할 수 있습니다. | NoticeErrorCode | `IMAGE_LIMIT_EXCEEDED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:32` |
-| 181 | notice | `NOTICE-CONTENTS-0008` | 409 CONFLICT | 해당 공지사항에 이미 투표가 존재합니다. | NoticeErrorCode | `VOTE_ALREADY_EXISTS` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:33` |
-| 182 | notice | `NOTICE-CONTENTS-0009` | 400 BAD_REQUEST | 투표 항목은 2개 이상 5개 이하여야 합니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_COUNT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:34` |
-| 183 | notice | `NOTICE-CONTENTS-0010` | 400 BAD_REQUEST | 투표 항목에 빈 값이 포함될 수 없습니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:35` |
-| 184 | notice | `NOTICE-CONTENTS-0011` | 400 BAD_REQUEST | 아직 투표 기간이 시작되지 않았습니다. | NoticeErrorCode | `VOTE_NOT_STARTED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:36` |
-| 185 | notice | `NOTICE-CONTENTS-0012` | 400 BAD_REQUEST | 이미 종료된 투표입니다. | NoticeErrorCode | `VOTE_CLOSED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:37` |
-| 186 | notice | `NOTICE-CONTENTS-0013` | 400 BAD_REQUEST | 선택한 투표 항목 ID 목록은 필수입니다. | NoticeErrorCode | `SELECTED_OPTION_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:38` |
+| 162 | notice | `NOTICE-0001` | 404 NOT_FOUND | 공지사항을 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:12` |
+| 163 | notice | `NOTICE-0002` | 400 BAD_REQUEST | 이미 게시된 공지사항입니다. | NoticeErrorCode | `ALREADY_PUBLISHED_NOTICE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:13` |
+| 164 | notice | `NOTICE-0003` | 400 BAD_REQUEST | 공지사항 제목이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_TITLE` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:14` |
+| 165 | notice | `NOTICE-0004` | 400 BAD_REQUEST | 공지사항 내용이 유효하지 않습니다. | NoticeErrorCode | `INVALID_NOTICE_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:15` |
+| 166 | notice | `NOTICE-0005` | 400 BAD_REQUEST | 공지사항 알림을 보낼 수 없는 상태입니다. | NoticeErrorCode | `INVALID_NOTICE_STATUS_FOR_REMINDER` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:16` |
+| 167 | notice | `NOTICE-0006` | 400 BAD_REQUEST | 공지사항 작성자는 필수입니다. | NoticeErrorCode | `AUTHOR_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:17` |
+| 168 | notice | `NOTICE-0007` | 400 BAD_REQUEST | 공지사항 대상 범위는 필수입니다. | NoticeErrorCode | `NOTICE_SCOPE_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:18` |
+| 169 | notice | `NOTICE-0008` | 403 FORBIDDEN | 공지사항 작성자가 아닙니다. | NoticeErrorCode | `NOTICE_AUTHOR_MISMATCH` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:19` |
+| 170 | notice | `NOTICE-0009` | 403 FORBIDDEN | 해당 공지사항을 작성할 권한이 없습니다. | NoticeErrorCode | `NO_WRITE_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:20` |
+| 171 | notice | `NOTICE-0010` | 400 BAD_REQUEST | 공지사항 수신자 설정이 잘못되었습니다. | NoticeErrorCode | `INVALID_TARGET_SETTING` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:22` |
+| 172 | notice | `NOTICE-0011` | 404 NOT_FOUND | 해당 공지사항에 설정된 수신 대상이 존재하지 않습니다. | NoticeErrorCode | `NO_TARGET_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:23` |
+| 173 | notice | `NOTICE-0012` | 403 FORBIDDEN | 해당 공지사항을 조회할 권한이 없습니다. | NoticeErrorCode | `NO_READ_PERMISSION` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:21` |
+| 174 | notice | `NOTICE-9999` | 501 NOT_IMPLEMENTED | 아직 구현되지 않은 기능입니다. | NoticeErrorCode | `NOT_IMPLEMENTED_YET` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:41` |
+| 175 | notice | `NOTICE-CONTENTS-0001` | 400 BAD_REQUEST | 투표 ID 목록은 필수입니다. | NoticeErrorCode | `VOTE_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:26` |
+| 176 | notice | `NOTICE-CONTENTS-0002` | 400 BAD_REQUEST | 이미지 URL 목록은 필수입니다. | NoticeErrorCode | `IMAGE_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:27` |
+| 177 | notice | `NOTICE-CONTENTS-0003` | 400 BAD_REQUEST | 링크 URL 목록은 필수입니다. | NoticeErrorCode | `LINK_URLS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:28` |
+| 178 | notice | `NOTICE-CONTENTS-0004` | 404 NOT_FOUND | 공지사항 투표를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_VOTE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:29` |
+| 179 | notice | `NOTICE-CONTENTS-0005` | 404 NOT_FOUND | 공지사항 이미지를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_IMAGE_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:30` |
+| 180 | notice | `NOTICE-CONTENTS-0006` | 404 NOT_FOUND | 공지사항 링크를 찾을 수 없습니다. | NoticeErrorCode | `NOTICE_LINK_NOT_FOUND` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:31` |
+| 181 | notice | `NOTICE-CONTENTS-0007` | 400 BAD_REQUEST | 공지사항 이미지는 최대 10장까지 등록할 수 있습니다. | NoticeErrorCode | `IMAGE_LIMIT_EXCEEDED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:32` |
+| 182 | notice | `NOTICE-CONTENTS-0008` | 409 CONFLICT | 해당 공지사항에 이미 투표가 존재합니다. | NoticeErrorCode | `VOTE_ALREADY_EXISTS` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:33` |
+| 183 | notice | `NOTICE-CONTENTS-0009` | 400 BAD_REQUEST | 투표 항목은 2개 이상 5개 이하여야 합니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_COUNT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:34` |
+| 184 | notice | `NOTICE-CONTENTS-0010` | 400 BAD_REQUEST | 투표 항목에 빈 값이 포함될 수 없습니다. | NoticeErrorCode | `INVALID_VOTE_OPTION_CONTENT` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:35` |
+| 185 | notice | `NOTICE-CONTENTS-0011` | 400 BAD_REQUEST | 아직 투표 기간이 시작되지 않았습니다. | NoticeErrorCode | `VOTE_NOT_STARTED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:36` |
+| 186 | notice | `NOTICE-CONTENTS-0012` | 400 BAD_REQUEST | 이미 종료된 투표입니다. | NoticeErrorCode | `VOTE_CLOSED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:37` |
+| 187 | notice | `NOTICE-CONTENTS-0013` | 400 BAD_REQUEST | 선택한 투표 항목 ID 목록은 필수입니다. | NoticeErrorCode | `SELECTED_OPTION_IDS_REQUIRED` | `src/main/java/com/umc/product/notice/domain/exception/NoticeErrorCode.java:38` |
 
 ## notification
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 187 | notification | `EMAIL-0001` | 400 BAD_REQUEST | 알 수 없는 사유로 이메일 전송에 실패했습니다. | EmailErrorCode | `EMAIL_GENERAL_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:11` |
-| 188 | notification | `EMAIL-0002` | 400 BAD_REQUEST | 인코딩 과정에서 오류가 발생했습니다. | EmailErrorCode | `EMAIL_ENCODING_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:12` |
-| 189 | notification | `EMAIL-0003` | 400 BAD_REQUEST | 메일 전송 과정에서 오류가 발생했습니다. | EmailErrorCode | `EMAIL_MESSAGING_ERROR` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:13` |
+| 188 | notification | `EMAIL-0004` | 500 INTERNAL_SERVER_ERROR | 이메일 본문 템플릿 렌더링에 실패했습니다. | EmailErrorCode | `EMAIL_TEMPLATE_RENDER_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:11` |
+| 189 | notification | `EMAIL-0005` | 500 INTERNAL_SERVER_ERROR | 이메일 발송에 실패했습니다. | EmailErrorCode | `EMAIL_SEND_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/EmailErrorCode.java:12` |
 | 190 | notification | `FCM-0001` | 404 NOT_FOUND | FCM 토큰을 찾을 수 없습니다. | FcmErrorCode | `FCM_NOT_FOUND` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:12` |
 | 191 | notification | `FCM-0002` | 404 NOT_FOUND | 해당 유저의 FCM 토큰을 찾을 수 없습니다. | FcmErrorCode | `USER_FCM_NOT_FOUND` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:13` |
 | 192 | notification | `FCM-0003` | 500 INTERNAL_SERVER_ERROR | FCM 메시지 전송에 실패했습니다. | FcmErrorCode | `FCM_SEND_FAILED` | `src/main/java/com/umc/product/notification/domain/exception/FcmErrorCode.java:14` |
@@ -314,56 +319,56 @@
 
 | 순번 | 도메인 | Code | HTTP Status | Message | Enum | Constant | Source |
 |---:|---|---|---|---|---|---|---|
-| 237 | project | `PROJECT-0001` | 404 NOT_FOUND | 프로젝트를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:13` |
-| 238 | project | `PROJECT-0002` | 400 BAD_REQUEST | 이미 완료된 프로젝트입니다. | ProjectErrorCode | `ALREADY_COMPLETED_PROJECT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:14` |
-| 239 | project | `PROJECT-0003` | 400 BAD_REQUEST | 해당 프로젝트를 해산시킬 수 없습니다. | ProjectErrorCode | `PROJECT_ABORT_UNAVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:15` |
-| 240 | project | `PROJECT-0004` | 400 BAD_REQUEST | 요청하신 조작은 지원서가 제출된 상태에서만 가능합니다. | ProjectErrorCode | `APPLICATION_NOT_SUBMITTED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:18` |
-| 241 | project | `PROJECT-0005` | 400 BAD_REQUEST | 이미 지원서가 제출되었거나 평가가 완료된 상태입니다. | ProjectErrorCode | `APPLICATION_SUBMIT_NOT_AVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:19` |
-| 242 | project | `PROJECT-0006` | 404 NOT_FOUND | 프로젝트에서 해당 지원용 폼을 찾을 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:27` |
-| 243 | project | `PROJECT-0007` | 403 FORBIDDEN | 요청하신 지원용 폼 섹션에 접근 권한이 없습니다. | ProjectErrorCode | `APPLICATION_FORM_ACCESS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:28` |
-| 244 | project | `PROJECT-0008` | 409 CONFLICT | 작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:37` |
-| 245 | project | `PROJECT-0009` | 400 BAD_REQUEST | 현재 상태에서 수행할 수 없는 작업입니다. | ProjectErrorCode | `PROJECT_INVALID_STATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:38` |
-| 246 | project | `PROJECT-0010` | 400 BAD_REQUEST | 프로젝트 PO는 PLAN 파트 챌린저여야 합니다. | ProjectErrorCode | `PROJECT_OWNER_NOT_PLAN_CHALLENGER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:39` |
-| 247 | project | `PROJECT-0011` | 400 BAD_REQUEST | 제출에 필요한 필수 정보가 누락되었습니다. | ProjectErrorCode | `PROJECT_SUBMIT_VALIDATION_FAILED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:40` |
-| 248 | project | `PROJECT-0012` | 403 FORBIDDEN | 해당 프로젝트에 대한 접근 권한이 없습니다. | ProjectErrorCode | `PROJECT_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:41` |
-| 249 | project | `PROJECT-0013` | 400 BAD_REQUEST | PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다. | ProjectErrorCode | `APPLICATION_FORM_POLICY_PARTS_EMPTY` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:29` |
-| 250 | project | `PROJECT-0014` | 400 BAD_REQUEST | 현재 폼에 존재하지 않는 sectionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_SECTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:30` |
-| 251 | project | `PROJECT-0015` | 400 BAD_REQUEST | 해당 섹션에 속하지 않는 questionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_QUESTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:31` |
-| 252 | project | `PROJECT-0016` | 400 BAD_REQUEST | 해당 질문에 속하지 않는 optionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_OPTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:32` |
-| 253 | project | `PROJECT-0017` | 400 BAD_REQUEST | 선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:33` |
-| 254 | project | `PROJECT-0018` | 400 BAD_REQUEST | 선택지 타입 질문에는 1개 이상의 옵션이 필요합니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:34` |
-| 255 | project | `PROJECT-0019` | 500 INTERNAL_SERVER_ERROR | 임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_NOT_EXPOSABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:20` |
-| 256 | project | `PROJECT-0020` | 400 BAD_REQUEST | 임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_FILTER_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:22` |
-| 257 | project | `PROJECT-0021` | 404 NOT_FOUND | 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:24` |
-| 258 | project | `PROJECT-0022` | 409 CONFLICT | 현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능) | ProjectErrorCode | `PROJECT_DELETE_NOT_ALLOWED_IN_STATUS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:42` |
-| 259 | project | `PROJECT-0023` | 400 BAD_REQUEST | 프로젝트 중단 사유는 필수입니다. | ProjectErrorCode | `PROJECT_ABORT_REASON_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:44` |
-| 260 | project | `PROJECT-0100` | 404 NOT_FOUND | 프로젝트 멤버를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:47` |
-| 261 | project | `PROJECT-0101` | 409 CONFLICT | 이미 해당 프로젝트의 멤버입니다. | ProjectErrorCode | `PROJECT_MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:48` |
-| 262 | project | `PROJECT-0102` | 400 BAD_REQUEST | 메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다. | ProjectErrorCode | `PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:49` |
-| 263 | project | `PROJECT-0200` | 400 BAD_REQUEST | 파트 정원은 1 이상이어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_INVALID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:52` |
-| 264 | project | `PROJECT-0202` | 400 BAD_REQUEST | 공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:53` |
-| 265 | project | `PROJECT-0203` | 400 BAD_REQUEST | 동일 파트가 중복으로 입력되었습니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_DUPLICATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:54` |
-| 266 | project | `PROJECT-0204` | 404 NOT_FOUND | 작성 중인 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:76` |
-| 267 | project | `PROJECT-0205` | 403 FORBIDDEN | 해당 프로젝트에 지원 가능한 파트가 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_PART_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:77` |
-| 268 | project | `PROJECT-0206` | 409 CONFLICT | 이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:78` |
-| 269 | project | `PROJECT-0207` | 409 CONFLICT | 동일한 매칭 차수에 이미 제출된 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DUPLICATE_SUBMISSION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:79` |
-| 270 | project | `PROJECT-0208` | 400 BAD_REQUEST | 해당 매칭 차수의 지원 기간이 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_NOT_OPEN` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:80` |
-| 271 | project | `PROJECT-0209` | 400 BAD_REQUEST | 선택한 매칭 차수가 본인 파트에 해당하지 않습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_TYPE_MISMATCH` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:81` |
-| 272 | project | `PROJECT-0210` | 409 CONFLICT | 이미 작성 중인 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:82` |
-| 273 | project | `PROJECT-0211` | 403 FORBIDDEN | 본인이 운영하는 프로젝트에는 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:83` |
-| 274 | project | `PROJECT-0212` | 400 BAD_REQUEST | 현재 상태에서는 합/불 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DECISION_INVALID_TRANSITION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:84` |
-| 275 | project | `PROJECT-0213` | 409 CONFLICT | 해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_QUOTA_EXCEEDED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:86` |
-| 276 | project | `PROJECT-0214` | 400 BAD_REQUEST | 이미 종결된 지원서는 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:88` |
-| 277 | project | `PROJECT-0215` | 400 BAD_REQUEST | 매칭 차수가 종료되어 지원서를 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_ROUND_CLOSED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:89` |
-| 278 | project | `PROJECT-0300` | 404 NOT_FOUND | 매칭 차수를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:57` |
-| 279 | project | `PROJECT-0301` | 400 BAD_REQUEST | 매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_INVALID_PERIOD` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:58` |
-| 280 | project | `PROJECT-0302` | 409 CONFLICT | 같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_PERIOD_OVERLAPPED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:60` |
-| 281 | project | `PROJECT-0303` | 403 FORBIDDEN | 해당 매칭 차수에 대한 관리 권한이 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:62` |
-| 282 | project | `PROJECT-0304` | 409 CONFLICT | 연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_DELETE_CONFLICT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:64` |
-| 283 | project | `PROJECT-0305` | 400 BAD_REQUEST | time 기준 조회는 chapterId와 함께 요청해야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:66` |
-| 284 | project | `PROJECT-0306` | 400 BAD_REQUEST | 매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_LOCKED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:68` |
-| 285 | project | `PROJECT-0307` | 400 BAD_REQUEST | 결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FINALIZABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:70` |
-| 286 | project | `PROJECT-0308` | 500 INTERNAL_SERVER_ERROR | 해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:72` |
+| 237 | project | `PROJECT-0001` | 404 NOT_FOUND | 프로젝트를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:15` |
+| 238 | project | `PROJECT-0002` | 400 BAD_REQUEST | 이미 완료된 프로젝트입니다. | ProjectErrorCode | `ALREADY_COMPLETED_PROJECT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:16` |
+| 239 | project | `PROJECT-0003` | 400 BAD_REQUEST | 해당 프로젝트를 해산시킬 수 없습니다. | ProjectErrorCode | `PROJECT_ABORT_UNAVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:17` |
+| 240 | project | `PROJECT-0004` | 400 BAD_REQUEST | 요청하신 조작은 지원서가 제출된 상태에서만 가능합니다. | ProjectErrorCode | `APPLICATION_NOT_SUBMITTED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:20` |
+| 241 | project | `PROJECT-0005` | 400 BAD_REQUEST | 이미 지원서가 제출되었거나 평가가 완료된 상태입니다. | ProjectErrorCode | `APPLICATION_SUBMIT_NOT_AVAILABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:21` |
+| 242 | project | `PROJECT-0006` | 404 NOT_FOUND | 프로젝트에서 해당 지원용 폼을 찾을 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:29` |
+| 243 | project | `PROJECT-0007` | 403 FORBIDDEN | 요청하신 지원용 폼 섹션에 접근 권한이 없습니다. | ProjectErrorCode | `APPLICATION_FORM_ACCESS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:30` |
+| 244 | project | `PROJECT-0008` | 409 CONFLICT | 작성 중인 DRAFT 프로젝트가 있어 새로 시작할 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_ALREADY_IN_PROGRESS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:39` |
+| 245 | project | `PROJECT-0009` | 400 BAD_REQUEST | 현재 상태에서 수행할 수 없는 작업입니다. | ProjectErrorCode | `PROJECT_INVALID_STATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:40` |
+| 246 | project | `PROJECT-0010` | 400 BAD_REQUEST | 프로젝트 PO는 PLAN 파트 챌린저여야 합니다. | ProjectErrorCode | `PROJECT_OWNER_NOT_PLAN_CHALLENGER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:41` |
+| 247 | project | `PROJECT-0011` | 400 BAD_REQUEST | 제출에 필요한 필수 정보가 누락되었습니다. | ProjectErrorCode | `PROJECT_SUBMIT_VALIDATION_FAILED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:42` |
+| 248 | project | `PROJECT-0012` | 403 FORBIDDEN | 해당 프로젝트에 대한 접근 권한이 없습니다. | ProjectErrorCode | `PROJECT_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:43` |
+| 249 | project | `PROJECT-0013` | 400 BAD_REQUEST | PART 타입 섹션은 1개 이상의 파트를 지정해야 합니다. | ProjectErrorCode | `APPLICATION_FORM_POLICY_PARTS_EMPTY` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:31` |
+| 250 | project | `PROJECT-0014` | 400 BAD_REQUEST | 현재 폼에 존재하지 않는 sectionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_SECTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:32` |
+| 251 | project | `PROJECT-0015` | 400 BAD_REQUEST | 해당 섹션에 속하지 않는 questionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_QUESTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:33` |
+| 252 | project | `PROJECT-0016` | 400 BAD_REQUEST | 해당 질문에 속하지 않는 optionId 입니다. | ProjectErrorCode | `APPLICATION_FORM_INVALID_OPTION_ID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:34` |
+| 253 | project | `PROJECT-0017` | 400 BAD_REQUEST | 선택지 타입(RADIO/CHECKBOX/DROPDOWN)이 아닌 질문에는 옵션을 지정할 수 없습니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:35` |
+| 254 | project | `PROJECT-0018` | 400 BAD_REQUEST | 선택지 타입 질문에는 1개 이상의 옵션이 필요합니다. | ProjectErrorCode | `APPLICATION_FORM_OPTIONS_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:36` |
+| 255 | project | `PROJECT-0019` | 500 INTERNAL_SERVER_ERROR | 임시저장 상태의 지원서는 PM/운영진 응답에 매핑할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_NOT_EXPOSABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:22` |
+| 256 | project | `PROJECT-0020` | 400 BAD_REQUEST | 임시저장(DRAFT)은 PM/운영진 지원자 목록 조회 필터로 사용할 수 없습니다. | ProjectErrorCode | `APPLICATION_DRAFT_FILTER_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:24` |
+| 257 | project | `PROJECT-0021` | 404 NOT_FOUND | 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:26` |
+| 258 | project | `PROJECT-0022` | 409 CONFLICT | 현재 상태에서는 프로젝트를 삭제할 수 없습니다. (DRAFT, PENDING_REVIEW 상태만 가능) | ProjectErrorCode | `PROJECT_DELETE_NOT_ALLOWED_IN_STATUS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:44` |
+| 259 | project | `PROJECT-0023` | 400 BAD_REQUEST | 프로젝트 중단 사유는 필수입니다. | ProjectErrorCode | `PROJECT_ABORT_REASON_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:46` |
+| 260 | project | `PROJECT-0100` | 404 NOT_FOUND | 프로젝트 멤버를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MEMBER_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:49` |
+| 261 | project | `PROJECT-0101` | 409 CONFLICT | 이미 해당 프로젝트의 멤버입니다. | ProjectErrorCode | `PROJECT_MEMBER_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:50` |
+| 262 | project | `PROJECT-0102` | 400 BAD_REQUEST | 메인 PM 은 팀원 제거가 아닌 소유권 양도 API 로 변경해야 합니다. | ProjectErrorCode | `PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:51` |
+| 263 | project | `PROJECT-0200` | 400 BAD_REQUEST | 파트 정원은 1 이상이어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_INVALID` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:54` |
+| 264 | project | `PROJECT-0202` | 400 BAD_REQUEST | 공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_REQUIRED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:55` |
+| 265 | project | `PROJECT-0203` | 400 BAD_REQUEST | 동일 파트가 중복으로 입력되었습니다. | ProjectErrorCode | `PROJECT_PART_QUOTA_DUPLICATE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:56` |
+| 266 | project | `PROJECT-0204` | 404 NOT_FOUND | 작성 중인 지원서를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_DRAFT_APPLICATION_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:78` |
+| 267 | project | `PROJECT-0205` | 403 FORBIDDEN | 해당 프로젝트에 지원 가능한 파트가 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_PART_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:79` |
+| 268 | project | `PROJECT-0206` | 409 CONFLICT | 이미 해당 기수에 소속된 팀이 있어 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_MEMBER_ALREADY_IN_TEAM` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:80` |
+| 269 | project | `PROJECT-0207` | 409 CONFLICT | 동일한 매칭 차수에 이미 제출된 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DUPLICATE_SUBMISSION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:81` |
+| 270 | project | `PROJECT-0208` | 400 BAD_REQUEST | 해당 매칭 차수의 지원 기간이 아닙니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_NOT_OPEN` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:82` |
+| 271 | project | `PROJECT-0209` | 400 BAD_REQUEST | 선택한 매칭 차수가 본인 파트에 해당하지 않습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ROUND_TYPE_MISMATCH` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:83` |
+| 272 | project | `PROJECT-0210` | 409 CONFLICT | 이미 작성 중인 지원서가 있습니다. | ProjectErrorCode | `PROJECT_APPLICATION_ALREADY_EXISTS` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:84` |
+| 273 | project | `PROJECT-0211` | 403 FORBIDDEN | 본인이 운영하는 프로젝트에는 지원할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_SELF_APPLY_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:85` |
+| 274 | project | `PROJECT-0212` | 400 BAD_REQUEST | 현재 상태에서는 합/불 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_DECISION_INVALID_TRANSITION` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:86` |
+| 275 | project | `PROJECT-0213` | 409 CONFLICT | 해당 파트의 남은 자리를 초과하여 합격 처리할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_QUOTA_EXCEEDED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:88` |
+| 276 | project | `PROJECT-0214` | 400 BAD_REQUEST | 이미 종결된 지원서는 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_NOT_ALLOWED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:90` |
+| 277 | project | `PROJECT-0215` | 400 BAD_REQUEST | 매칭 차수가 종료되어 지원서를 철회할 수 없습니다. | ProjectErrorCode | `PROJECT_APPLICATION_CANCEL_ROUND_CLOSED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:91` |
+| 278 | project | `PROJECT-0300` | 404 NOT_FOUND | 매칭 차수를 찾을 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:59` |
+| 279 | project | `PROJECT-0301` | 400 BAD_REQUEST | 매칭 차수 기간은 startsAt < endsAt < decisionDeadline 순서여야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_INVALID_PERIOD` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:60` |
+| 280 | project | `PROJECT-0302` | 409 CONFLICT | 같은 지부 내에서는 매칭 차수 기간이 중복될 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_PERIOD_OVERLAPPED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:62` |
+| 281 | project | `PROJECT-0303` | 403 FORBIDDEN | 해당 매칭 차수에 대한 관리 권한이 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_ACCESS_DENIED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:64` |
+| 282 | project | `PROJECT-0304` | 409 CONFLICT | 연관된 지원서가 있는 매칭 차수는 삭제할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_DELETE_CONFLICT` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:66` |
+| 283 | project | `PROJECT-0305` | 400 BAD_REQUEST | time 기준 조회는 chapterId와 함께 요청해야 합니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_TIME_REQUIRES_CHAPTER` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:68` |
+| 284 | project | `PROJECT-0306` | 400 BAD_REQUEST | 매칭 차수가 종료되어 더 이상 결정을 변경할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_LOCKED` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:70` |
+| 285 | project | `PROJECT-0307` | 400 BAD_REQUEST | 결정 마감 시각이 지나기 전에는 자동 선발을 실행할 수 없습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_NOT_FINALIZABLE` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:72` |
+| 286 | project | `PROJECT-0308` | 500 INTERNAL_SERVER_ERROR | 해당 매칭 종류에 대한 자동 선발 정책이 정의되지 않았습니다. | ProjectErrorCode | `PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND` | `src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java:74` |
 
 ## schedule
 

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
@@ -1,8 +1,27 @@
 package com.umc.product.project.adapter.in.web.assembler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
+import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.response.PageResponse;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -12,27 +31,22 @@ import com.umc.product.project.adapter.in.web.dto.response.DraftProjectResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ManagedProjectSummaryResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectDetailResponse;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectMembersResponse;
+import com.umc.product.project.application.port.in.query.GetProjectStatisticsUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectUseCase;
 import com.umc.product.project.application.port.in.query.SearchManagedProjectUseCase;
 import com.umc.product.project.application.port.in.query.SearchProjectUseCase;
 import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchManagedProjectQuery;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
+import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectResponseAssemblerTest {
@@ -44,11 +58,17 @@ class ProjectResponseAssemblerTest {
     @Mock
     SearchManagedProjectUseCase searchManagedProjectUseCase;
     @Mock
+    GetProjectStatisticsUseCase getProjectStatisticsUseCase;
+    @Mock
     GetMemberUseCase getMemberUseCase;
     @Mock
     LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     @Mock
+    LoadProjectApplicationPort loadProjectApplicationPort;
+    @Mock
     LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
+    CheckPermissionUseCase checkPermissionUseCase;
 
     @InjectMocks
     ProjectResponseAssembler sut;
@@ -126,6 +146,7 @@ class ProjectResponseAssemblerTest {
 
         assertThat(response.productOwner().memberId()).isEqualTo(99L);
         assertThat(response.productOwner().name()).isEqualTo("김메인");
+        assertThat(response.productOwner().matchedRoundInfo()).isNull();
         assertThat(response.coProductOwners()).hasSize(1);
         assertThat(response.coProductOwners().get(0).memberId()).isEqualTo(101L);
         assertThat(response.coProductOwners().get(0).name()).isEqualTo("박가나");
@@ -151,8 +172,90 @@ class ProjectResponseAssemblerTest {
 
         ProjectMembersResponse response = sut.membersFor(42L);
 
-        List<String> nicknames = response.coProductOwners().stream().map(MemberBrief::nickname).toList();
+        List<String> nicknames = response.coProductOwners().stream()
+            .map(ProjectMembersResponse.ProjectMemberBrief::nickname)
+            .toList();
         assertThat(nicknames).containsExactly("가람", "나무", "다람쥐");
+    }
+
+    @Test
+    @DisplayName("membersFor는 APPROVED 지원서의 최신 매칭차수를 프로젝트 멤버 응답에만 포함한다")
+    void membersForIncludesLatestApprovedMatchedRoundOnlyInProjectMemberResponse() {
+        ProjectInfo info = projectInfo(42L);
+        given(getProjectUseCase.getById(42L)).willReturn(info);
+        given(loadProjectMemberPort.listByProjectId(42L)).willReturn(List.of(
+            projectMember(101L, ChallengerPart.PLAN),
+            projectMember(102L, ChallengerPart.SPRINGBOOT)
+        ));
+        given(getMemberUseCase.findAllByIds(Set.of(99L, 101L, 102L))).willReturn(Map.of(
+            99L, memberInfoOf(99L, "메인", "김메인"),
+            101L, memberInfoOf(101L, "코PM", "박코피"),
+            102L, memberInfoOf(102L, "백엔드", "이다라")
+        ));
+        given(loadProjectApplicationPort.listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(any(), any()))
+            .willReturn(List.of(new ProjectMemberMatchedRoundInfo(
+                42L,
+                102L,
+                7L,
+                MatchingType.PLAN_DEVELOPER,
+                MatchingPhase.SECOND
+            )));
+
+        ProjectMembersResponse response = sut.membersFor(42L);
+
+        assertThat(response.coProductOwners().get(0).matchedRoundInfo()).isNull();
+        ProjectMembersResponse.ProjectMemberBrief springMember = response.partGroups().get(0).members().get(0);
+        assertThat(springMember.memberId()).isEqualTo(102L);
+        assertThat(springMember.matchedRoundInfo())
+            .isEqualTo(new ProjectMembersResponse.MatchedRoundInfo(
+                7L,
+                MatchingType.PLAN_DEVELOPER,
+                MatchingPhase.SECOND
+            ));
+
+        List<String> memberBriefFields = Arrays.stream(MemberBrief.class.getRecordComponents())
+            .map(RecordComponent::getName)
+            .toList();
+        assertThat(memberBriefFields).doesNotContain("matchedRoundInfo");
+    }
+
+    @Test
+    @DisplayName("listProjectMembers는 프로젝트와 멤버 쌍별로 APPROVED 매칭차수를 매핑한다")
+    void listProjectMembersMapsApprovedMatchedRoundByProjectAndMember() {
+        ProjectInfo project42 = projectInfo(42L);
+        ProjectInfo project43 = projectInfoWithOwner(43L, 199L);
+        given(checkPermissionUseCase.check(anyLong(), any(ResourcePermission.class))).willReturn(true);
+        given(getProjectUseCase.getById(42L)).willReturn(project42);
+        given(getProjectUseCase.getById(43L)).willReturn(project43);
+        given(loadProjectMemberPort.listByProjectIds(Set.of(42L, 43L))).willReturn(Map.of(
+            42L, List.of(projectMember(102L, ChallengerPart.SPRINGBOOT)),
+            43L, List.of(projectMember(102L, ChallengerPart.SPRINGBOOT))
+        ));
+        given(getMemberUseCase.findAllByIds(Set.of(99L, 199L, 102L))).willReturn(Map.of(
+            99L, memberInfoOf(99L, "메인42", "김메인"),
+            199L, memberInfoOf(199L, "메인43", "이메인"),
+            102L, memberInfoOf(102L, "백엔드", "이다라")
+        ));
+        given(loadProjectApplicationPort.listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(any(), any()))
+            .willReturn(List.of(
+                new ProjectMemberMatchedRoundInfo(42L, 102L, 7L, MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST),
+                new ProjectMemberMatchedRoundInfo(43L, 102L, 8L, MatchingType.PLAN_DEVELOPER, MatchingPhase.THIRD)
+            ));
+
+        Map<Long, ProjectMembersResponse> responses = sut.listProjectMembers(List.of(42L, 43L), 900L);
+
+        assertThat(responses.get(42L).partGroups().get(0).members().get(0).matchedRoundInfo())
+            .isEqualTo(new ProjectMembersResponse.MatchedRoundInfo(
+                7L,
+                MatchingType.PLAN_DEVELOPER,
+                MatchingPhase.FIRST
+            ));
+        assertThat(responses.get(43L).partGroups().get(0).members().get(0).matchedRoundInfo())
+            .isEqualTo(new ProjectMembersResponse.MatchedRoundInfo(
+                8L,
+                MatchingType.PLAN_DEVELOPER,
+                MatchingPhase.THIRD
+            ));
     }
 
     @Test
@@ -183,6 +286,20 @@ class ProjectResponseAssemblerTest {
             .gisuId(1L)
             .chapterId(1L)
             .productOwnerMemberId(99L)
+            .coProductOwnerMemberIds(List.of())
+            .partQuotas(List.of())
+            .build();
+    }
+
+    private ProjectInfo projectInfoWithOwner(Long projectId, Long ownerMemberId) {
+        return ProjectInfo.builder()
+            .id(projectId)
+            .status(ProjectStatus.DRAFT)
+            .name("Triple")
+            .description(null)
+            .gisuId(1L)
+            .chapterId(1L)
+            .productOwnerMemberId(ownerMemberId)
             .coProductOwnerMemberIds(List.of())
             .partQuotas(List.of())
             .build();

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
@@ -1,0 +1,163 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.TestContainersConfig;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, ProjectApplicationQueryRepository.class})
+class ProjectApplicationQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectApplicationQueryRepository sut;
+
+    private Project project;
+    private ProjectApplicationForm form;
+
+    @BeforeEach
+    void setUp() {
+        project = persistProject("프로젝트 알파", 10L);
+        form = ProjectApplicationForm.create(project, 500L);
+        em.persist(form);
+    }
+
+    @Test
+    @DisplayName("프로젝트_멤버별_APPROVED_지원서_중_최신_매칭차수만_반환한다")
+    void listLatestApprovedMatchedRoundsByProjectIdsAndMemberIdsReturnsLatestApprovedOnly() {
+        Long memberId = 200L;
+        ProjectMatchingRound oldApprovedRound = persistRound(
+            "1차",
+            MatchingType.PLAN_DEVELOPER,
+            MatchingPhase.FIRST,
+            Instant.parse("2026-05-01T00:00:00Z")
+        );
+        ProjectMatchingRound latestApprovedRound = persistRound(
+            "2차",
+            MatchingType.PLAN_DEVELOPER,
+            MatchingPhase.SECOND,
+            Instant.parse("2026-05-03T00:00:00Z")
+        );
+        ProjectMatchingRound tieApprovedRound = persistRound(
+            "디자인 1차",
+            MatchingType.PLAN_DESIGN,
+            MatchingPhase.FIRST,
+            Instant.parse("2026-05-03T00:00:00Z")
+        );
+        ProjectMatchingRound rejectedRound = persistRound(
+            "3차",
+            MatchingType.PLAN_DEVELOPER,
+            MatchingPhase.THIRD,
+            Instant.parse("2026-05-05T00:00:00Z")
+        );
+        ProjectMatchingRound submittedRound = persistRound(
+            "디자인 2차",
+            MatchingType.PLAN_DESIGN,
+            MatchingPhase.SECOND,
+            Instant.parse("2026-05-06T00:00:00Z")
+        );
+
+        persistApplication(memberId, oldApprovedRound, ProjectApplicationStatus.APPROVED);
+        ProjectApplication latestApproved = persistApplication(memberId, latestApprovedRound,
+            ProjectApplicationStatus.APPROVED);
+        ProjectApplication tieApproved = persistApplication(memberId, tieApprovedRound, ProjectApplicationStatus.APPROVED);
+        persistApplication(memberId, rejectedRound, ProjectApplicationStatus.REJECTED);
+        persistApplication(memberId, submittedRound, ProjectApplicationStatus.SUBMITTED);
+        persistApplication(201L, rejectedRound, ProjectApplicationStatus.REJECTED);
+        em.flush();
+        em.clear();
+
+        List<ProjectMemberMatchedRoundInfo> result = sut.listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
+            Set.of(project.getId()),
+            Set.of(memberId, 201L)
+        );
+
+        assertThat(result).containsExactly(new ProjectMemberMatchedRoundInfo(
+            project.getId(),
+            memberId,
+            tieApprovedRound.getId(),
+            MatchingType.PLAN_DESIGN,
+            MatchingPhase.FIRST
+        ));
+        assertThat(tieApproved.getId()).isGreaterThan(latestApproved.getId());
+    }
+
+    private Project persistProject(String name, Long ownerId) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
+        ReflectionTestUtils.setField(project, "productOwnerSchoolId", 1L);
+        ReflectionTestUtils.setField(project, "creatorMemberId", ownerId);
+        em.persist(project);
+        return project;
+    }
+
+    private ProjectMatchingRound persistRound(
+        String name,
+        MatchingType type,
+        MatchingPhase phase,
+        Instant startsAt
+    ) {
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            name,
+            null,
+            type,
+            phase,
+            1L,
+            startsAt,
+            startsAt.plusSeconds(3_600),
+            startsAt.plusSeconds(7_200)
+        );
+        em.persist(round);
+        return round;
+    }
+
+    private ProjectApplication persistApplication(
+        Long applicantMemberId,
+        ProjectMatchingRound round,
+        ProjectApplicationStatus status
+    ) {
+        ProjectApplication application = ProjectApplication.create(form, applicantMemberId * 10, applicantMemberId, round);
+        ReflectionTestUtils.setField(application, "status", status);
+        em.persist(application);
+        return application;
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
@@ -88,7 +88,8 @@ class ProjectApplicationQueryRepositoryTest {
         persistApplication(memberId, oldApprovedRound, ProjectApplicationStatus.APPROVED);
         ProjectApplication latestApproved = persistApplication(memberId, latestApprovedRound,
             ProjectApplicationStatus.APPROVED);
-        ProjectApplication tieApproved = persistApplication(memberId, tieApprovedRound, ProjectApplicationStatus.APPROVED);
+        ProjectApplication tieApproved = persistApplication(memberId, tieApprovedRound,
+            ProjectApplicationStatus.APPROVED);
         persistApplication(memberId, rejectedRound, ProjectApplicationStatus.REJECTED);
         persistApplication(memberId, submittedRound, ProjectApplicationStatus.SUBMITTED);
         persistApplication(201L, rejectedRound, ProjectApplicationStatus.REJECTED);
@@ -155,7 +156,8 @@ class ProjectApplicationQueryRepositoryTest {
         ProjectMatchingRound round,
         ProjectApplicationStatus status
     ) {
-        ProjectApplication application = ProjectApplication.create(form, applicantMemberId * 10, applicantMemberId, round);
+        ProjectApplication application = ProjectApplication.create(
+            form, applicantMemberId * 10, applicantMemberId, round);
         ReflectionTestUtils.setField(application, "status", status);
         em.persist(application);
         return application;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- project 도메인의 팀원 응답 DTO와 assembler, application out port, persistence QueryDSL 조회, 문서 카탈로그, 관련 테스트를 수정했어요.

### 작업 단위별 상세

1. **무엇을**: [PROJECT-003] GET /api/v1/projects/{projectId}/members 와 [PROJECT-007] GET /api/v1/projects/members 팀원 응답에 `matchedRoundInfo`를 추가했어요.
   - **어떻게**: 공용 `MemberBrief` 대신 `ProjectMembersResponse` 내부 전용 `ProjectMemberBrief`를 사용하고, `MatchedRoundInfo(id, type, phase)`를 함께 조립하도록 변경했어요.
   - **왜**: 수동 배정 멤버처럼 지원서가 없는 경우 현재 차수로 잘못 표시되는 문제를 막고, 공용 DTO 변경 영향은 팀원 조회 응답으로 제한하기 위해서예요.

2. **무엇을**: 프로젝트와 멤버 쌍별 최신 APPROVED 지원서의 매칭 차수를 batch로 조회하도록 추가했어요.
   - **어떻게**: `LoadProjectApplicationPort`에 batch 조회 메서드를 추가하고, QueryDSL에서 `projectId`, `applicantMemberId`, `APPROVED` 조건으로 조회한 뒤 `startsAt DESC`, `ProjectApplication.id DESC` 기준의 첫 row만 사용하도록 구성했어요.
   - **왜**: 단건 조회와 batch 조회 모두에서 N+1 없이 `(projectId, memberId)` 기준의 매칭 차수를 파생해야 해서예요.

3. **무엇을**: assembler 테스트와 repository 테스트, 문서 카탈로그를 보강했어요.
   - **어떻게**: `matchedRoundInfo`가 채워지는 케이스, 지원서가 없는 멤버가 `null`인 케이스, 공용 `MemberBrief`가 바뀌지 않는 케이스, batch 매핑 케이스, 최신 APPROVED 선정 기준을 테스트했어요.
   - **왜**: 응답 계약 변경과 최신 차수 선정 로직이 회귀 없이 유지되어야 해서예요.

## 💬 리뷰 중점사항

- `ProjectApplicationQueryRepository`의 최신 차수 선정 기준이 `startsAt DESC`, 동률 `ProjectApplication.id DESC`, `APPROVED`만 포함하는 정책과 맞는지 확인 부탁드려요.
- `matchedRoundInfo`가 공용 `MemberBrief`가 아니라 `ProjectMembersResponse` 전용 DTO에만 노출되는 구조가 FE 기대와 맞는지 확인 부탁드려요.
- POST /api/v1/projects/{projectId}/members 요청 body, DB 마이그레이션, 환경 설정, 인프라 설정 변경은 없어요.
- 검증은 `./gradlew test --tests '*ProjectResponseAssemblerTest' --tests '*ProjectApplicationQueryRepositoryTest'`, `./gradlew check -x test`, `./gradlew test`로 완료했어요.
