### PR TITLE
[Feat] Member, Challenger, ChallengerRole Seeding API 추가

### DIFF
--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -8,6 +8,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.global.security.annotation.Public;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRequest;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerResponse;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleRequest;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleResponse;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberRequest;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedCurriculumRequest;
@@ -22,6 +28,9 @@ import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectScenariosResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsResponse;
+import com.umc.product.test.application.port.in.command.CreateSeedChallengerRoleUseCase;
+import com.umc.product.test.application.port.in.command.CreateSeedChallengerUseCase;
+import com.umc.product.test.application.port.in.command.CreateSeedMemberUseCase;
 import com.umc.product.test.application.port.in.command.SeedChallengersUseCase;
 import com.umc.product.test.application.port.in.command.SeedCurriculumUseCase;
 import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
@@ -53,7 +62,10 @@ import lombok.extern.slf4j.Slf4j;
 public class SeedController {
 
     private final SeedMembersUseCase seedMembersUseCase;
+    private final CreateSeedMemberUseCase createSeedMemberUseCase;
     private final SeedChallengersUseCase seedChallengersUseCase;
+    private final CreateSeedChallengerUseCase createSeedChallengerUseCase;
+    private final CreateSeedChallengerRoleUseCase createSeedChallengerRoleUseCase;
     private final SeedProjectsUseCase seedProjectsUseCase;
     private final SeedProjectScenariosUseCase seedProjectScenariosUseCase;
     private final SeedProjectApplicationsUseCase seedProjectApplicationsUseCase;
@@ -77,6 +89,20 @@ public class SeedController {
     }
 
     @Operation(
+        operationId = "SEED-001-M",
+        summary = "테스트 멤버 단건 생성",
+        description = """
+            이름, 닉네임, 학교 ID, 이메일을 받아 ID/PW 멤버를 1명 생성합니다.
+            rawPassword 를 생략하거나 공백으로 보내면 app.seed.default-password 를 사용합니다.
+            활성 필수 약관은 모두 동의한 것으로 자동 처리합니다.
+            """
+    )
+    @PostMapping("/member")
+    public CreateSeedMemberResponse createMember(@RequestBody @Valid CreateSeedMemberRequest request) {
+        return CreateSeedMemberResponse.from(createSeedMemberUseCase.create(request.toCommand()));
+    }
+
+    @Operation(
         operationId = "SEED-002",
         summary = "챌린저 분포 시딩",
         description = """
@@ -89,6 +115,35 @@ public class SeedController {
     @PostMapping("/challengers")
     public SeedChallengersResponse seedChallengers(@RequestBody @Valid SeedChallengersRequest request) {
         return SeedChallengersResponse.from(seedChallengersUseCase.seed(request.toCommand()));
+    }
+
+    @Operation(
+        operationId = "SEED-002-C",
+        summary = "테스트 챌린저 단건 생성",
+        description = "memberId, gisuId, part 를 받아 챌린저를 1명 생성합니다."
+    )
+    @PostMapping("/challenger")
+    public CreateSeedChallengerResponse createChallenger(
+        @RequestBody @Valid CreateSeedChallengerRequest request
+    ) {
+        return CreateSeedChallengerResponse.from(createSeedChallengerUseCase.create(request.toCommand()));
+    }
+
+    @Operation(
+        operationId = "SEED-002-R",
+        summary = "테스트 챌린저 역할 단건 생성",
+        description = """
+            challengerId, roleType, gisuId 를 받아 운영진 역할을 1개 부여합니다.
+            SUPER_ADMIN 및 중앙 운영진 역할은 organizationId 없이 생성할 수 있고,
+            CHAPTER_PRESIDENT 는 organizationId 에 chapterId, SCHOOL_PRESIDENT 등 학교 역할은
+            organizationId 에 schoolId 를 전달합니다.
+            """
+    )
+    @PostMapping("/challenger-role")
+    public CreateSeedChallengerRoleResponse createChallengerRole(
+        @RequestBody @Valid CreateSeedChallengerRoleRequest request
+    ) {
+        return CreateSeedChallengerRoleResponse.from(createSeedChallengerRoleUseCase.create(request.toCommand()));
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRequest.java
@@ -1,0 +1,19 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerCommand;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateSeedChallengerRequest(
+    @NotNull(message = "회원 ID는 필수입니다") Long memberId,
+
+    @NotNull(message = "기수 ID는 필수입니다") Long gisuId,
+
+    @NotNull(message = "챌린저 파트는 필수입니다") ChallengerPart part
+) {
+
+    public CreateSeedChallengerCommand toCommand() {
+        return CreateSeedChallengerCommand.of(memberId, gisuId, part);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerResponse.java
@@ -1,0 +1,21 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerResult;
+
+public record CreateSeedChallengerResponse(
+    Long challengerId,
+    Long memberId,
+    Long gisuId,
+    ChallengerPart part
+) {
+
+    public static CreateSeedChallengerResponse from(CreateSeedChallengerResult result) {
+        return new CreateSeedChallengerResponse(
+            result.challengerId(),
+            result.memberId(),
+            result.gisuId(),
+            result.part()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRoleRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRoleRequest.java
@@ -1,0 +1,38 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleCommand;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateSeedChallengerRoleRequest(
+    @NotNull(message = "챌린저 ID는 필수입니다") Long challengerId,
+
+    @NotNull(message = "역할 타입은 필수입니다") ChallengerRoleType roleType,
+
+    Long organizationId,
+
+    ChallengerPart responsiblePart,
+
+    @NotNull(message = "기수 ID는 필수입니다") Long gisuId
+) {
+
+    public CreateSeedChallengerRoleCommand toCommand() {
+        return CreateSeedChallengerRoleCommand.of(
+            challengerId,
+            roleType,
+            organizationId,
+            responsiblePart,
+            gisuId
+        );
+    }
+
+    @AssertTrue(message = "중앙 조직이 아닌 역할은 organizationId가 필수입니다") public boolean isOrganizationIdValid() {
+        return roleType == null
+            || roleType.organizationType() == OrganizationType.CENTRAL
+            || organizationId != null;
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRoleResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedChallengerRoleResponse.java
@@ -1,0 +1,26 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleResult;
+
+public record CreateSeedChallengerRoleResponse(
+    Long challengerRoleId,
+    Long challengerId,
+    ChallengerRoleType roleType,
+    Long organizationId,
+    ChallengerPart responsiblePart,
+    Long gisuId
+) {
+
+    public static CreateSeedChallengerRoleResponse from(CreateSeedChallengerRoleResult result) {
+        return new CreateSeedChallengerRoleResponse(
+            result.challengerRoleId(),
+            result.challengerId(),
+            result.roleType(),
+            result.organizationId(),
+            result.responsiblePart(),
+            result.gisuId()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberRequest.java
@@ -1,0 +1,25 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberCommand;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateSeedMemberRequest(
+    @NotBlank(message = "이름은 필수입니다") @Size(max = 30, message = "이름은 30자 이하여야 합니다") String name,
+
+    @NotBlank(message = "닉네임은 필수입니다") @Size(max = 20, message = "닉네임은 20자 이하여야 합니다") String nickname,
+
+    @NotNull(message = "학교 ID는 필수입니다") Long schoolId,
+
+    @NotBlank(message = "이메일은 필수입니다") @Email(message = "이메일 형식이 올바르지 않습니다") @Size(max = 100, message = "이메일은 100자 이하여야 합니다") String email,
+
+    @Size(max = 100, message = "비밀번호는 100자 이하여야 합니다") String rawPassword
+) {
+
+    public CreateSeedMemberCommand toCommand() {
+        return CreateSeedMemberCommand.of(name, nickname, schoolId, email, rawPassword);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberResponse.java
@@ -1,0 +1,13 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberResult;
+
+public record CreateSeedMemberResponse(
+    Long memberId,
+    String email
+) {
+
+    public static CreateSeedMemberResponse from(CreateSeedMemberResult result) {
+        return new CreateSeedMemberResponse(result.memberId(), result.email());
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedChallengerRoleUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedChallengerRoleUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleResult;
+
+public interface CreateSeedChallengerRoleUseCase {
+
+    CreateSeedChallengerRoleResult create(CreateSeedChallengerRoleCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedChallengerUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedChallengerUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerResult;
+
+public interface CreateSeedChallengerUseCase {
+
+    CreateSeedChallengerResult create(CreateSeedChallengerCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedMemberUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedMemberUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberResult;
+
+public interface CreateSeedMemberUseCase {
+
+    CreateSeedMemberResult create(CreateSeedMemberCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerCommand.java
@@ -1,0 +1,14 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
+public record CreateSeedChallengerCommand(
+    Long memberId,
+    Long gisuId,
+    ChallengerPart part
+) {
+
+    public static CreateSeedChallengerCommand of(Long memberId, Long gisuId, ChallengerPart part) {
+        return new CreateSeedChallengerCommand(memberId, gisuId, part);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerResult.java
@@ -1,0 +1,20 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+
+public record CreateSeedChallengerResult(
+    Long challengerId,
+    Long memberId,
+    Long gisuId,
+    ChallengerPart part
+) {
+
+    public static CreateSeedChallengerResult of(
+        Long challengerId,
+        Long memberId,
+        Long gisuId,
+        ChallengerPart part
+    ) {
+        return new CreateSeedChallengerResult(challengerId, memberId, gisuId, part);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerRoleCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerRoleCommand.java
@@ -1,0 +1,23 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+
+public record CreateSeedChallengerRoleCommand(
+    Long challengerId,
+    ChallengerRoleType roleType,
+    Long organizationId,
+    ChallengerPart responsiblePart,
+    Long gisuId
+) {
+
+    public static CreateSeedChallengerRoleCommand of(
+        Long challengerId,
+        ChallengerRoleType roleType,
+        Long organizationId,
+        ChallengerPart responsiblePart,
+        Long gisuId
+    ) {
+        return new CreateSeedChallengerRoleCommand(challengerId, roleType, organizationId, responsiblePart, gisuId);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerRoleResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedChallengerRoleResult.java
@@ -1,0 +1,32 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+
+public record CreateSeedChallengerRoleResult(
+    Long challengerRoleId,
+    Long challengerId,
+    ChallengerRoleType roleType,
+    Long organizationId,
+    ChallengerPart responsiblePart,
+    Long gisuId
+) {
+
+    public static CreateSeedChallengerRoleResult of(
+        Long challengerRoleId,
+        Long challengerId,
+        ChallengerRoleType roleType,
+        Long organizationId,
+        ChallengerPart responsiblePart,
+        Long gisuId
+    ) {
+        return new CreateSeedChallengerRoleResult(
+            challengerRoleId,
+            challengerId,
+            roleType,
+            organizationId,
+            responsiblePart,
+            gisuId
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberCommand.java
@@ -1,0 +1,20 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+public record CreateSeedMemberCommand(
+    String name,
+    String nickname,
+    Long schoolId,
+    String email,
+    String rawPassword
+) {
+
+    public static CreateSeedMemberCommand of(
+        String name,
+        String nickname,
+        Long schoolId,
+        String email,
+        String rawPassword
+    ) {
+        return new CreateSeedMemberCommand(name, nickname, schoolId, email, rawPassword);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberResult.java
@@ -1,0 +1,11 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+public record CreateSeedMemberResult(
+    Long memberId,
+    String email
+) {
+
+    public static CreateSeedMemberResult of(Long memberId, String email) {
+        return new CreateSeedMemberResult(memberId, email);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/ChallengerRoleSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ChallengerRoleSeedService.java
@@ -1,0 +1,44 @@
+package com.umc.product.test.application.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
+import com.umc.product.test.application.port.in.command.CreateSeedChallengerRoleUseCase;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerRoleResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class ChallengerRoleSeedService implements CreateSeedChallengerRoleUseCase {
+
+    private final ManageChallengerRoleUseCase manageChallengerRoleUseCase;
+
+    @Override
+    @Transactional
+    public CreateSeedChallengerRoleResult create(CreateSeedChallengerRoleCommand command) {
+        Long challengerRoleId = manageChallengerRoleUseCase.createChallengerRole(CreateChallengerRoleCommand.builder()
+            .challengerId(command.challengerId())
+            .roleType(command.roleType())
+            .organizationId(command.organizationId())
+            .responsiblePart(command.responsiblePart())
+            .gisuId(command.gisuId())
+            .build());
+
+        return CreateSeedChallengerRoleResult.of(
+            challengerRoleId,
+            command.challengerId(),
+            command.roleType(),
+            command.organizationId(),
+            command.responsiblePart(),
+            command.gisuId()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/application/service/ChallengerSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ChallengerSeedService.java
@@ -1,5 +1,18 @@
 package com.umc.product.test.application.service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.command.ManageChallengerUseCase;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -9,22 +22,16 @@ import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterWithSchoolsInfo;
+import com.umc.product.test.application.port.in.command.CreateSeedChallengerUseCase;
 import com.umc.product.test.application.port.in.command.SeedChallengersUseCase;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedChallengerResult;
 import com.umc.product.test.application.port.in.command.dto.SeedChallengersCommand;
 import com.umc.product.test.application.port.in.command.dto.SeedChallengersResult;
 import com.umc.product.test.application.port.in.command.dto.SeedChallengersResult.PerCellSummary;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
 
 /**
  * 챌린저 분포 시딩 서비스. ADR-017 참조.
@@ -37,7 +44,7 @@ import org.springframework.stereotype.Service;
 @Profile("!prod")
 @ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
-public class ChallengerSeedService implements SeedChallengersUseCase {
+public class ChallengerSeedService implements SeedChallengersUseCase, CreateSeedChallengerUseCase {
 
     private static final Set<ChallengerPart> DEFAULT_PARTS = Arrays.stream(ChallengerPart.values())
         .filter(p -> p != ChallengerPart.ADMIN)
@@ -94,6 +101,23 @@ public class ChallengerSeedService implements SeedChallengersUseCase {
         );
 
         return new SeedChallengersResult(gisuId, totalCreated, totalFailed, summaries);
+    }
+
+    @Override
+    @Transactional
+    public CreateSeedChallengerResult create(CreateSeedChallengerCommand command) {
+        Long challengerId = manageChallengerUseCase.createChallenger(CreateChallengerCommand.builder()
+            .memberId(command.memberId())
+            .gisuId(command.gisuId())
+            .part(command.part())
+            .build());
+
+        return CreateSeedChallengerResult.of(
+            challengerId,
+            command.memberId(),
+            command.gisuId(),
+            command.part()
+        );
     }
 
     private Long resolveGisuId(Long gisuId) {

--- a/src/main/java/com/umc/product/test/application/service/MemberSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/MemberSeedService.java
@@ -1,21 +1,27 @@
 package com.umc.product.test.application.service;
 
-import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
-import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
-import com.umc.product.member.application.port.in.command.dto.TermConsents;
-import com.umc.product.member.application.port.in.query.GetMemberUseCase;
-import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
-import com.umc.product.test.application.port.in.command.dto.SeedMembersCommand;
-import com.umc.product.test.application.port.in.command.dto.SeedMembersResult;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
+import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
+import com.umc.product.member.application.port.in.command.dto.TermConsents;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.test.application.port.in.command.CreateSeedMemberUseCase;
+import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberResult;
+import com.umc.product.test.application.port.in.command.dto.SeedMembersCommand;
+import com.umc.product.test.application.port.in.command.dto.SeedMembersResult;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 멤버 시딩 서비스. ADR-017 참조.
@@ -33,7 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Profile("!prod")
 @ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
-public class MemberSeedService implements SeedMembersUseCase {
+public class MemberSeedService implements SeedMembersUseCase, CreateSeedMemberUseCase {
 
     private final SeedProperties properties;
     private final DummyMemberFactory dummyMemberFactory;
@@ -67,6 +73,22 @@ public class MemberSeedService implements SeedMembersUseCase {
         return SeedMembersResult.of(created);
     }
 
+    @Override
+    @Transactional
+    public CreateSeedMemberResult create(CreateSeedMemberCommand command) {
+        List<TermConsents> consents = dummyMemberFactory.snapshotMandatoryConsents();
+        Long memberId = registerEmailMemberUseCase.register(EmailRegisterMemberCommand.builder()
+            .rawPassword(resolveRawPassword(command.rawPassword()))
+            .name(command.name())
+            .nickname(command.nickname())
+            .email(command.email())
+            .schoolId(command.schoolId())
+            .termConsents(consents)
+            .build());
+
+        return CreateSeedMemberResult.of(memberId, command.email());
+    }
+
     /**
      * 이메일 회원을 target 만큼 등록한다. 약관 동의는 시딩 시작 시 1 회만 조회해 모든 Command 에
      * 재사용한다. 모든 Command 를 미리 만들어 {@link RegisterEmailMemberUseCase#batchRegister}
@@ -91,5 +113,12 @@ public class MemberSeedService implements SeedMembersUseCase {
             log.error("member seed batchRegister failed (target={}): {}", target, e.toString());
             return 0;
         }
+    }
+
+    private String resolveRawPassword(String rawPassword) {
+        if (rawPassword == null || rawPassword.isBlank()) {
+            return properties.defaultPassword();
+        }
+        return rawPassword;
     }
 }


### PR DESCRIPTION
## 대상 브랜치
- base: `develop`
- head: `feature/test-seed-single-api`

## 이슈
- 별도 이슈 없음

## 작업 내용
- `/test/seed/member` 단건 멤버 생성 API를 추가했습니다.
- `/test/seed/challenger` 단건 챌린저 생성 API를 추가했습니다.
- `/test/seed/challenger-role` 단건 챌린저 역할 생성 API를 추가했습니다.
- test 도메인 UseCase와 Command/Result DTO를 추가해 컨트롤러가 다른 도메인 UseCase를 직접 조합하지 않도록 유지했습니다.
- 멤버 단건 생성 시 필수 약관은 자동 동의 처리하고, 비밀번호가 없으면 `app.seed.default-password`를 사용하도록 했습니다.
- `scripts/create-test-seed-account.py`를 추가해 상단 변수만 바꿔 단건 member/challenger/challengerRole 생성 API를 쉽게 호출할 수 있게 했습니다.

## 리뷰 중점사항
- 운영 외 환경 전용 가드(`@Profile("!prod")`, `app.seed.enabled=true`)가 유지되는지 확인 부탁드립니다.
- `SUPER_ADMIN` 및 중앙 역할은 `organizationId` 없이 생성 가능하고, 지부/학교 역할은 `organizationId` 필수 검증이 적절한지 확인 부탁드립니다.
- Python 스크립트의 role case별 payload 매핑이 QA 시나리오에 충분한지 확인 부탁드립니다.

## 검증
- `./gradlew compileJava`
- `./gradlew spotlessCheck checkstyleMain`
- `./gradlew test --tests com.umc.product.test.application.service.MemberSeedServiceTest --tests com.umc.product.test.application.service.ChallengerSeedServiceTest`
- `python3 -m py_compile scripts/create-test-seed-account.py`
