### PR TITLE
[Chore] k6 공지사항 부하 테스트 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ docker/db/postgres
 logs/
 *.log
 
+loadtest/data/users.local.json
+loadtest/results/
+
 /.run/
 
 application-*.yml

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,121 @@
+# k6 공지사항 로그인 Flow 부하 테스트
+
+## 목적
+
+`notice-login-1000-vus.js`는 약 1000명의 사용자가 동시에 다음 흐름을 수행할 때 API와 DB가 SLO를 만족하는지 확인한다.
+
+1. 이메일/PW 로그인
+2. 공지사항 목록 조회
+3. 공지사항 상세 조회
+4. 공지사항 읽음 처리
+5. 공지사항 읽기 현황 조회
+6. 다시 공지사항 목록 조회
+
+기본 executor는 `ramping-vus`다. 즉 `TARGET_VUS`는 HTTP RPS가 아니라 동시에 flow를 수행하는 가상 사용자 수다.
+
+## 사전 조건
+
+- production 대상 실행 금지. staging 또는 local 부하 테스트 환경에서만 실행한다.
+- 테스트 대상 서버가 실행 중이어야 한다. 기본값은 `BASE_URL=http://localhost:8080`이다.
+- 공지 목록 조회에는 `GISU_ID`가 필요하다.
+- `INCLUDE_READ_STATUS=true`일 때는 대상 계정이 해당 공지의 `CHECK` 권한을 가져야 한다. 일반 챌린저 계정으로 실행하면 `GET /api/v1/notices/{noticeId}/read-status`가 403을 반환할 수 있다.
+- 1000 VU를 신뢰성 있게 검증하려면 서로 다른 로그인 계정 1000개를 준비한다.
+
+## 테스트 계정 파일
+
+로컬 계정 파일은 repository에 커밋하지 않는다. 다음 명령으로 `users.local.json`을 생성한다.
+
+```bash
+COUNT=1000 \
+EMAIL_DOMAIN=test.umc.it.kr \
+PASSWORD='password12!' \
+node loadtest/tools/generate-users.mjs > loadtest/data/users.local.json
+```
+
+시딩 API를 사용할 경우 non-prod profile에서 `APP_SEED_ENABLED=true`를 켜고 아래 순서로 데이터를 만든다.
+
+```bash
+curl -X POST "$BASE_URL/test/seed/members" \
+  -H 'Content-Type: application/json' \
+  -d '{"count":1000,"force":true}'
+
+curl -X POST "$BASE_URL/test/seed/challengers" \
+  -H 'Content-Type: application/json' \
+  -d '{"gisuId":1,"countPerPartPerSchool":10,"parts":null,"chapterIds":null}'
+
+curl -X POST "$BASE_URL/test/seed/notice" \
+  -H 'Content-Type: application/json' \
+  -d '{"gisuId":1,"authorMemberId":1,"globalCount":5,"perChapterCount":0,"perSchoolCount":0,"perPartCount":0,"parts":null}'
+```
+
+`authorMemberId`는 공지 생성 권한이 있는 멤버로 바꿔야 한다.
+
+## 실행
+
+지속 부하 기본 실행:
+
+```bash
+k6 run \
+  -e BASE_URL=http://localhost:8080 \
+  -e GISU_ID=1 \
+  -e TARGET_VUS=1000 \
+  -e RAMP_UP=5m \
+  -e HOLD=10m \
+  -e RAMP_DOWN=2m \
+  loadtest/scenarios/load/notice-login-1000-vus.js
+```
+
+1000명이 flow를 1회씩만 수행하는 동시성 점검:
+
+```bash
+k6 run \
+  -e BASE_URL=http://localhost:8080 \
+  -e GISU_ID=1 \
+  -e TARGET_VUS=1000 \
+  -e RUN_ONCE=true \
+  loadtest/scenarios/load/notice-login-1000-vus.js
+```
+
+Prometheus remote write로 Grafana에서 확인:
+
+```bash
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:19090/api/v1/write \
+K6_PROMETHEUS_RW_TREND_STATS=p(50),p(90),p(95),p(99),avg,min,max \
+k6 run -o experimental-prometheus-rw \
+  -e BASE_URL=http://localhost:8080 \
+  -e GISU_ID=1 \
+  -e TARGET_VUS=1000 \
+  --tag env=staging \
+  --tag service=umc-product-server \
+  --tag testid=notice-login-$(date +%Y%m%d-%H%M%S) \
+  loadtest/scenarios/load/notice-login-1000-vus.js
+```
+
+현재 `docker/monitoring`의 Prometheus는 OTLP receiver는 켜져 있지만 remote write receiver는 기본으로 열려 있지 않다. k6 remote write를 직접 받으려면 Prometheus 실행 옵션에 `--web.enable-remote-write-receiver`를 추가하거나, k6 결과 전용 Prometheus/Mimir tenant를 사용한다.
+
+## 주요 환경변수
+
+| 변수 | 기본값 | 설명 |
+|---|---:|---|
+| `BASE_URL` | `http://localhost:8080` | 테스트 대상 API 서버 |
+| `USERS_FILE` | `../../data/users.local.json` | k6 스크립트 기준 로그인 계정 파일 경로 |
+| `TARGET_VUS` | `1000` | 동시 사용자 수 |
+| `RUN_ONCE` | `false` | `true`면 각 VU가 flow를 1회만 수행 |
+| `ALLOW_USER_REUSE` | `false` | 계정 수가 VU보다 적을 때 재사용 허용 |
+| `GISU_ID` | 없음 | 공지 조회 필수 파라미터 |
+| `NOTICE_ID` | 없음 | 지정하면 목록 첫 항목 대신 해당 공지 상세 조회 |
+| `NOTICE_TAB` | `CHALLENGER` | 공지 탭 |
+| `INCLUDE_RECORD_READ` | `true` | 읽음 처리 포함 여부 |
+| `INCLUDE_READ_STATUS` | `true` | 읽기 현황 조회 포함 여부 |
+| `THINK_MIN_MS` / `THINK_MAX_MS` | `500` / `2000` | 사용자 행동 간 대기 시간 |
+
+## 해석 기준
+
+- `vus`가 1000까지 도달했는지 먼저 확인한다.
+- `http_reqs`는 실제 HTTP RPS이고, `iterations`는 전체 사용자 flow 반복 횟수다.
+- flow 하나가 최대 6개 요청을 보내므로, 대략 `HTTP RPS = iteration/s * flow당 요청 수`로 해석한다.
+- `notice_journey_duration` p95가 높아지면 사용자 여정 전체가 느려진 것이다.
+- `api` 태그별 `http_req_duration` p95/p99로 로그인, 목록, 상세, 읽음 처리, 읽기 현황 중 병목 endpoint를 분리한다.
+- Spring Boot 메트릭에서는 `http_server_requests_seconds`, HikariCP active/pending/timeout, JVM heap/GC pause를 함께 본다.
+
+상세 지표 요약은 [metrics.md](./metrics.md)를 참고한다.

--- a/loadtest/data/users.sample.json
+++ b/loadtest/data/users.sample.json
@@ -1,0 +1,17 @@
+[
+  {
+    "email": "alpha_user_0001@test.umc.it.kr",
+    "password": "password12!",
+    "clientType": "WEB"
+  },
+  {
+    "email": "alpha_user_0002@test.umc.it.kr",
+    "password": "password12!",
+    "clientType": "WEB"
+  },
+  {
+    "email": "alpha_user_0003@test.umc.it.kr",
+    "password": "password12!",
+    "clientType": "WEB"
+  }
+]

--- a/loadtest/metrics.md
+++ b/loadtest/metrics.md
@@ -1,0 +1,58 @@
+# k6 지표 요약
+
+## 내장 지표
+
+| 지표 | 타입 | 의미 | Grafana에서 보는 방법 |
+|---|---|---|---|
+| `http_reqs` | Counter | 발생한 HTTP 요청 수 | 초당 요청 수(RPS), API별 요청량 |
+| `http_req_duration` | Trend | 요청 전체 시간. sending + waiting + receiving 포함 | p50/p95/p99 latency |
+| `http_req_failed` | Rate | k6 기준 실패한 HTTP 요청 비율 | 전체/endpoint별 실패율 |
+| `http_req_blocked` | Trend | TCP 연결 슬롯 대기, DNS 등 요청 전 대기 시간 | 부하 생성기/네트워크 병목 의심 |
+| `http_req_connecting` | Trend | TCP 연결 시간 | 연결 재사용/네트워크 문제 확인 |
+| `http_req_tls_handshaking` | Trend | TLS handshake 시간 | HTTPS 부하 시 인증서/네트워크 비용 확인 |
+| `http_req_sending` | Trend | 요청 바디 전송 시간 | 큰 payload 또는 네트워크 병목 확인 |
+| `http_req_waiting` | Trend | 서버 첫 byte 대기 시간(TTFB) | 서버 처리 시간에 가장 가까운 HTTP 지표 |
+| `http_req_receiving` | Trend | 응답 바디 수신 시간 | 큰 응답/네트워크 병목 확인 |
+| `checks` | Rate | `check()` 성공률 | 기능 검증 실패율 |
+| `iterations` | Counter | default/exec 함수 완료 횟수 | 사용자 flow 처리량 |
+| `iteration_duration` | Trend | iteration 1회 총 수행 시간 | flow 전체 latency |
+| `vus` | Gauge | 현재 활성 VU 수 | 목표 동시 사용자 도달 여부 |
+| `vus_max` | Gauge | 사용 가능한 최대 VU 수 | VU capacity 확인 |
+| `data_received` | Counter | 받은 데이터 크기 | 응답 payload 비용 |
+| `data_sent` | Counter | 보낸 데이터 크기 | 요청 payload 비용 |
+| `dropped_iterations` | Counter | arrival-rate executor에서 시작하지 못한 iteration 수 | k6 VU 부족 또는 SUT 지연 악화 |
+
+## 스크립트 커스텀 지표
+
+| 지표 | 타입 | 의미 | 기본 threshold |
+|---|---|---|---|
+| `notice_journey_duration` | Trend | 로그인 이후 공지 flow 1회 전체 시간 | `p(95)<5000` |
+| `notice_login_success` | Rate | 이메일 로그인 성공률 | `rate>0.99` |
+| `notice_list_success` | Rate | 공지 목록/복귀 목록 성공률 | `rate>0.99` |
+| `notice_detail_success` | Rate | 공지 상세 조회 성공률 | `rate>0.99` |
+| `notice_record_read_success` | Rate | 읽음 처리 성공률 | `rate>0.99` |
+| `notice_read_status_success` | Rate | 읽기 현황 조회 성공률 | `rate>0.99` |
+| `notice_list_empty_total` | Counter | 공지 목록이 비어 상세 조회를 못 한 횟수 | 별도 threshold 없음 |
+
+## 자주 설정하는 옵션
+
+| 설정 | 예시 | 용도 |
+|---|---|---|
+| `scenarios` | `ramping-vus`, `per-vu-iterations`, `constant-arrival-rate` | 동시 사용자 수 또는 처리량 모델 선택 |
+| `thresholds` | `http_req_failed: ["rate<0.01"]` | 성능/SLO 실패 기준 선언 |
+| `summaryTrendStats` | `["p(90)", "p(95)", "p(99)"]` | CLI summary에 표시할 percentile 선택 |
+| `tags` | `api=notice_list`, `flow=notice_login_1000_vus` | Grafana 필터링과 threshold 범위 지정 |
+| `userAgent` | `umc-product-k6-notice-login/1.0` | 서버 로그에서 k6 트래픽 식별 |
+| `noConnectionReuse` | `true` | connection reuse를 끄고 최악 조건 확인 |
+| `discardResponseBodies` | `true` | body가 필요 없는 테스트에서 k6 메모리 사용량 감소 |
+
+## VU와 RPS 해석
+
+| 개념 | 의미 | 이 스크립트 기준 |
+|---|---|---|
+| VU | 동시에 행동 중인 가상 사용자 수 | `TARGET_VUS=1000`이면 최대 1000명이 flow 반복 |
+| iteration/s | 사용자 flow 시작/완료 처리량 | `noticeJourney()` 완료 횟수 |
+| HTTP RPS | 실제 초당 HTTP 요청 수 | `iteration/s * flow당 요청 수`에 가까움 |
+| think time | 사용자가 화면을 읽거나 다음 행동까지 기다리는 시간 | `THINK_MIN_MS`, `THINK_MAX_MS` |
+
+따라서 `TARGET_VUS=1000`은 `1000 RPS`가 아니다. 평균 flow 시간이 10초이고 flow당 요청이 6개라면, 이론상 대략 `1000 / 10 * 6 = 600 HTTP RPS` 수준이 된다.

--- a/loadtest/scenarios/load/notice-login-1000-vus.js
+++ b/loadtest/scenarios/load/notice-login-1000-vus.js
@@ -1,0 +1,343 @@
+import http from "k6/http";
+import {check, fail, group, sleep} from "k6";
+import {Counter, Rate, Trend} from "k6/metrics";
+import {SharedArray} from "k6/data";
+
+const BASE_URL = (__ENV.BASE_URL || "http://localhost:8080").replace(/\/$/, "");
+const USERS_FILE = __ENV.USERS_FILE || "../../data/users.local.json";
+const TARGET_VUS = Number(__ENV.TARGET_VUS || 1000);
+const RAMP_UP = __ENV.RAMP_UP || "5m";
+const HOLD = __ENV.HOLD || "10m";
+const RAMP_DOWN = __ENV.RAMP_DOWN || "2m";
+const RUN_ONCE = (__ENV.RUN_ONCE || "false").toLowerCase() === "true";
+const ALLOW_USER_REUSE = (__ENV.ALLOW_USER_REUSE || "false").toLowerCase() === "true";
+
+const CLIENT_TYPE = __ENV.CLIENT_TYPE || "WEB";
+const GISU_ID = __ENV.GISU_ID;
+const NOTICE_ID = __ENV.NOTICE_ID;
+const NOTICE_TAB = __ENV.NOTICE_TAB || "CHALLENGER";
+const PAGE_SIZE = __ENV.PAGE_SIZE || "20";
+const INCLUDE_RECORD_READ = (__ENV.INCLUDE_RECORD_READ || "true").toLowerCase() === "true";
+const INCLUDE_READ_STATUS = (__ENV.INCLUDE_READ_STATUS || "true").toLowerCase() === "true";
+const READ_STATUS = __ENV.READ_STATUS || "UNREAD";
+const READ_STATUS_FILTER_TYPE = __ENV.READ_STATUS_FILTER_TYPE || "ALL";
+const THINK_MIN_MS = Number(__ENV.THINK_MIN_MS || 500);
+const THINK_MAX_MS = Number(__ENV.THINK_MAX_MS || 2000);
+
+const LOGIN_P95_MS = Number(__ENV.LOGIN_P95_MS || 800);
+const NOTICE_LIST_P95_MS = Number(__ENV.NOTICE_LIST_P95_MS || 500);
+const NOTICE_DETAIL_P95_MS = Number(__ENV.NOTICE_DETAIL_P95_MS || 500);
+const NOTICE_READ_P95_MS = Number(__ENV.NOTICE_READ_P95_MS || 500);
+const NOTICE_READ_STATUS_P95_MS = Number(__ENV.NOTICE_READ_STATUS_P95_MS || 800);
+const JOURNEY_P95_MS = Number(__ENV.JOURNEY_P95_MS || 5000);
+
+const users = new SharedArray("notice-login-users", () => {
+  const parsed = JSON.parse(open(USERS_FILE));
+  const dataset = Array.isArray(parsed) ? parsed : parsed.users;
+  if (!Array.isArray(dataset)) {
+    throw new Error(`${USERS_FILE}은 배열 또는 { "users": [...] } 형식이어야 합니다.`);
+  }
+  return dataset;
+});
+
+const noticeJourneyDuration = new Trend("notice_journey_duration", true);
+const noticeLoginSuccess = new Rate("notice_login_success");
+const noticeListSuccess = new Rate("notice_list_success");
+const noticeDetailSuccess = new Rate("notice_detail_success");
+const noticeRecordReadSuccess = new Rate("notice_record_read_success");
+const noticeReadStatusSuccess = new Rate("notice_read_status_success");
+const noticeListEmptyTotal = new Counter("notice_list_empty_total");
+
+export const options = {
+  scenarios: RUN_ONCE ? {
+    notice_login_once: {
+      executor: "per-vu-iterations",
+      vus: TARGET_VUS,
+      iterations: 1,
+      maxDuration: __ENV.MAX_DURATION || "20m",
+      exec: "noticeJourney",
+      tags: {flow: "notice_login_1000_vus", mode: "once"},
+    },
+  } : {
+    notice_login_1000_vus: {
+      executor: "ramping-vus",
+      stages: [
+        {duration: RAMP_UP, target: TARGET_VUS},
+        {duration: HOLD, target: TARGET_VUS},
+        {duration: RAMP_DOWN, target: 0},
+      ],
+      gracefulRampDown: "30s",
+      exec: "noticeJourney",
+      tags: {flow: "notice_login_1000_vus", mode: "sustained"},
+    },
+  },
+  thresholds: {
+    "checks{flow:notice_login_1000_vus}": ["rate>0.99"],
+    "http_req_failed{flow:notice_login_1000_vus}": ["rate<0.01"],
+    "http_req_duration{api:login_email}": [`p(95)<${LOGIN_P95_MS}`],
+    "http_req_duration{api:notice_list}": [`p(95)<${NOTICE_LIST_P95_MS}`],
+    "http_req_duration{api:notice_list_back}": [`p(95)<${NOTICE_LIST_P95_MS}`],
+    "http_req_duration{api:notice_detail}": [`p(95)<${NOTICE_DETAIL_P95_MS}`],
+    "http_req_duration{api:notice_record_read}": [`p(95)<${NOTICE_READ_P95_MS}`],
+    "http_req_duration{api:notice_read_status}": [`p(95)<${NOTICE_READ_STATUS_P95_MS}`],
+    notice_journey_duration: [`p(95)<${JOURNEY_P95_MS}`],
+    notice_login_success: ["rate>0.99"],
+    notice_list_success: ["rate>0.99"],
+    notice_detail_success: ["rate>0.99"],
+    notice_record_read_success: ["rate>0.99"],
+    notice_read_status_success: ["rate>0.99"],
+  },
+  summaryTrendStats: ["min", "avg", "med", "p(90)", "p(95)", "p(99)", "max"],
+  userAgent: "umc-product-k6-notice-login/1.0",
+};
+
+let accessToken;
+let memberId;
+
+export function setup() {
+  if (!users || users.length === 0) {
+    throw new Error(`${USERS_FILE}에 로그인 계정이 없습니다.`);
+  }
+
+  if (users.length < TARGET_VUS && !ALLOW_USER_REUSE) {
+    throw new Error(
+      `TARGET_VUS=${TARGET_VUS}인데 계정은 ${users.length}개입니다. ` +
+      "계정 재사용은 결과를 왜곡할 수 있으므로, 필요하면 ALLOW_USER_REUSE=true를 명시하세요."
+    );
+  }
+
+  if (!GISU_ID) {
+    throw new Error("공지 목록 조회에는 GISU_ID가 필요합니다.");
+  }
+
+  return {
+    startedAt: new Date().toISOString(),
+    targetVus: TARGET_VUS,
+  };
+}
+
+export function noticeJourney() {
+  const startedAt = Date.now();
+  const user = pickUser();
+
+  group("login", () => {
+    ensureLoggedIn(user);
+  });
+
+  let noticeId = NOTICE_ID;
+
+  group("notice list", () => {
+    const listResponse = listNotices("notice_list");
+    const listOk = isSuccess(listResponse);
+    noticeListSuccess.add(listOk);
+    check(listResponse, {
+      "notice list status is 2xx": (response) => response.status >= 200 && response.status < 300,
+      "notice list api success": isSuccess,
+    }, {flow: "notice_login_1000_vus"});
+
+    if (!noticeId) {
+      noticeId = extractFirstNoticeId(listResponse);
+    }
+
+    if (!noticeId) {
+      noticeListEmptyTotal.add(1);
+      fail("공지 목록에서 상세 조회할 noticeId를 찾지 못했습니다. NOTICE_ID를 직접 지정하거나 시딩 데이터를 확인하세요.");
+    }
+  });
+
+  randomThinkTime();
+
+  group("notice detail", () => {
+    const detailResponse = http.get(`${BASE_URL}/api/v1/notices/${noticeId}`, authParams("notice_detail"));
+    const detailOk = isSuccess(detailResponse);
+    noticeDetailSuccess.add(detailOk);
+    check(detailResponse, {
+      "notice detail status is 2xx": (response) => response.status >= 200 && response.status < 300,
+      "notice detail api success": isSuccess,
+    }, {flow: "notice_login_1000_vus"});
+  });
+
+  if (INCLUDE_RECORD_READ) {
+    randomThinkTime();
+    group("notice record read", () => {
+      const readResponse = http.post(`${BASE_URL}/api/v1/notices/${noticeId}/read`, null, authParams("notice_record_read"));
+      const readOk = isSuccess(readResponse);
+      noticeRecordReadSuccess.add(readOk);
+      check(readResponse, {
+        "notice record read status is 2xx": (response) => response.status >= 200 && response.status < 300,
+        "notice record read api success": isSuccess,
+      }, {flow: "notice_login_1000_vus"});
+    });
+  } else {
+    noticeRecordReadSuccess.add(true);
+  }
+
+  if (INCLUDE_READ_STATUS) {
+    randomThinkTime();
+    group("notice read status", () => {
+      const readStatusResponse = http.get(noticeReadStatusUrl(noticeId), authParams("notice_read_status"));
+      const readStatusOk = isSuccess(readStatusResponse);
+      noticeReadStatusSuccess.add(readStatusOk);
+      check(readStatusResponse, {
+        "notice read status status is 2xx": (response) => response.status >= 200 && response.status < 300,
+        "notice read status api success": isSuccess,
+      }, {flow: "notice_login_1000_vus"});
+    });
+  } else {
+    noticeReadStatusSuccess.add(true);
+  }
+
+  randomThinkTime();
+
+  group("notice list back", () => {
+    const backResponse = listNotices("notice_list_back");
+    const backOk = isSuccess(backResponse);
+    noticeListSuccess.add(backOk);
+    check(backResponse, {
+      "notice list back status is 2xx": (response) => response.status >= 200 && response.status < 300,
+      "notice list back api success": isSuccess,
+    }, {flow: "notice_login_1000_vus"});
+  });
+
+  noticeJourneyDuration.add(Date.now() - startedAt, {flow: "notice_login_1000_vus"});
+}
+
+function ensureLoggedIn(user) {
+  if (accessToken) {
+    return;
+  }
+
+  const response = http.post(`${BASE_URL}/api/v1/auth/login/email`, JSON.stringify({
+    email: user.email,
+    password: user.password,
+    clientType: user.clientType || CLIENT_TYPE,
+  }), {
+    headers: {"Content-Type": "application/json"},
+    tags: {api: "login_email", flow: "notice_login_1000_vus"},
+  });
+
+  const loginOk = isSuccess(response) && !!jsonValue(response, "result.accessToken");
+  noticeLoginSuccess.add(loginOk);
+  check(response, {
+    "login status is 2xx": (res) => res.status >= 200 && res.status < 300,
+    "login api success": isSuccess,
+    "login access token exists": (res) => !!jsonValue(res, "result.accessToken"),
+  }, {flow: "notice_login_1000_vus"});
+
+  if (!loginOk) {
+    fail(`로그인 실패: status=${response.status}, email=${maskEmail(user.email)}`);
+  }
+
+  accessToken = jsonValue(response, "result.accessToken");
+  memberId = jsonValue(response, "result.memberId");
+}
+
+function pickUser() {
+  const index = ALLOW_USER_REUSE ? (__VU - 1) % users.length : __VU - 1;
+  const user = users[index];
+  if (!user || !user.email || !user.password) {
+    fail(`VU ${__VU}에 매핑할 로그인 계정이 없습니다.`);
+  }
+  return user;
+}
+
+function listNotices(apiTag) {
+  return http.get(noticeListUrl(), authParams(apiTag));
+}
+
+function authParams(apiTag) {
+  return {
+    headers: {Authorization: `Bearer ${accessToken}`},
+    tags: {
+      api: apiTag,
+      flow: "notice_login_1000_vus",
+      member_id_bucket: memberId ? String(Number(memberId) % 10) : "unknown",
+    },
+  };
+}
+
+function noticeListUrl() {
+  return `${BASE_URL}/api/v1/notices?${queryString({
+    gisuId: GISU_ID,
+    noticeTab: NOTICE_TAB,
+    page: "0",
+    size: PAGE_SIZE,
+    sort: "createdAt,DESC",
+    chapterId: __ENV.CHAPTER_ID,
+    schoolId: __ENV.SCHOOL_ID,
+    part: __ENV.PART,
+  })}`;
+}
+
+function noticeReadStatusUrl(noticeId) {
+  return `${BASE_URL}/api/v1/notices/${noticeId}/read-status?${queryString({
+    filterType: READ_STATUS_FILTER_TYPE,
+    status: READ_STATUS,
+    cursorId: __ENV.READ_STATUS_CURSOR_ID,
+    organizationIds: __ENV.ORGANIZATION_IDS,
+  })}`;
+}
+
+function extractFirstNoticeId(response) {
+  const content = jsonValue(response, "result.content") || jsonValue(response, "content") || [];
+  if (!Array.isArray(content) || content.length === 0) {
+    return undefined;
+  }
+  return content[0].id || content[0].noticeId;
+}
+
+function isSuccess(response) {
+  if (response.status < 200 || response.status >= 300) {
+    return false;
+  }
+  const wrappedSuccess = jsonValue(response, "success");
+  return wrappedSuccess === undefined || wrappedSuccess === true;
+}
+
+function jsonValue(response, path) {
+  try {
+    return response.json(path);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function queryString(params) {
+  const pairs = [];
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+
+    if (key === "organizationIds") {
+      String(value)
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((item) => pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(item)}`));
+      continue;
+    }
+
+    pairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+  }
+
+  return pairs.join("&");
+}
+
+function randomThinkTime() {
+  if (THINK_MAX_MS <= 0) {
+    return;
+  }
+  const min = Math.max(0, THINK_MIN_MS);
+  const max = Math.max(min, THINK_MAX_MS);
+  sleep((Math.random() * (max - min) + min) / 1000);
+}
+
+function maskEmail(email) {
+  const [local, domain] = String(email).split("@");
+  if (!domain) {
+    return "***";
+  }
+  return `${local.slice(0, 3)}***@${domain}`;
+}

--- a/loadtest/tools/generate-users.mjs
+++ b/loadtest/tools/generate-users.mjs
@@ -1,0 +1,16 @@
+const count = Number(process.env.COUNT || process.argv[2] || 1000);
+const start = Number(process.env.START || process.argv[3] || 1);
+const emailDomain = process.env.EMAIL_DOMAIN || "test.umc.it.kr";
+const password = process.env.PASSWORD || "password12!";
+const clientType = process.env.CLIENT_TYPE || "WEB";
+
+const users = Array.from({length: count}, (_, index) => {
+  const sequence = String(start + index).padStart(4, "0");
+  return {
+    email: `alpha_user_${sequence}@${emailDomain}`,
+    password,
+    clientType,
+  };
+});
+
+process.stdout.write(`${JSON.stringify(users, null, 2)}\n`);


### PR DESCRIPTION
## 대상 브랜치

- base: `develop`
- head: `feature/k6-notice-loadtest`

## 이슈

- 별도 이슈 없음

## 작업 내용

- `loadtest/scenarios/load/notice-login-1000-vus.js` 추가
  - 이메일 로그인 후 발급 토큰으로 공지 목록, 상세, 읽음 처리, 읽기 현황, 목록 복귀 flow를 수행합니다.
  - 기본 `ramping-vus`로 1000명 동시 사용자 흐름을 점검하고, `RUN_ONCE=true`로 1회성 동시성 점검도 지원합니다.
- `loadtest/README.md` 추가
  - 계정 파일 생성, 시딩 API 사용, k6 실행, Prometheus remote write 실행 방법을 정리했습니다.
- `loadtest/metrics.md` 추가
  - k6 내장 지표와 커스텀 지표를 표로 정리했습니다.
- `loadtest/tools/generate-users.mjs` 및 `users.sample.json` 추가
  - 시딩 기본 이메일 패턴에 맞춘 로컬 계정 파일 생성을 지원합니다.
- 실제 계정 파일과 결과 디렉터리는 `.gitignore`에 추가했습니다.

## 검증

- `git diff --check`
- `node --check loadtest/tools/generate-users.mjs`
- `k6 inspect -e USERS_FILE=../../data/users.sample.json -e GISU_ID=1 -e TARGET_VUS=3 loadtest/scenarios/load/notice-login-1000-vus.js`
- `k6 inspect -e USERS_FILE=../../data/users.sample.json -e GISU_ID=1 -e TARGET_VUS=3 -e RUN_ONCE=true loadtest/scenarios/load/notice-login-1000-vus.js`

## 리뷰 중점사항

- 실제 스테이징 권한 모델에서 `read-status` flow를 기본 포함할지 여부
- 1000 VU 검증 시 계정 재사용을 금지한 기본 정책이 적절한지
- Prometheus remote write receiver를 별도 성능 테스트용 인스턴스로 분리할지 여부