### PR TITLE
[Fix] 회원 keyword 검색 시 학교명으로도 검색되던 문제 해결

### DIFF
--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
@@ -12,7 +12,6 @@ import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.domain.Member;
 import com.umc.product.member.domain.QMember;
 import com.umc.product.organization.domain.QChapterSchool;
-import com.umc.product.organization.domain.QSchool;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
@@ -140,21 +139,9 @@ public class MemberQueryRepository {
             return null;
         }
 
-        QSchool school = QSchool.school;
-
-        BooleanExpression schoolNameExists = JPAExpressions
-            .selectOne()
-            .from(school)
-            .where(
-                school.id.eq(member.schoolId),
-                school.name.containsIgnoreCase(keyword)
-            )
-            .exists();
-
         return member.name.containsIgnoreCase(keyword)
             .or(member.nickname.containsIgnoreCase(keyword))
-            .or(member.email.containsIgnoreCase(keyword))
-            .or(schoolNameExists);
+            .or(member.email.containsIgnoreCase(keyword));
     }
 
     private BooleanExpression chapterIdExists(Long chapterId, QMember member) {

--- a/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.umc.product.member.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+import com.umc.product.member.domain.Member;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.TestContainersConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+    JpaConfig.class,
+    QueryDslConfig.class,
+    TestContainersConfig.class,
+    MemberQueryRepository.class
+})
+@DisplayName("MemberQueryRepository 검색")
+class MemberQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    MemberQueryRepository sut;
+
+    @Test
+    @DisplayName("keyword는 학교명만 일치하는 회원을 검색하지 않는다")
+    void keyword는_학교명만_일치하는_회원을_검색하지_않는다() {
+        // given
+        School school = persistSchool("한양대학교 ERICA");
+        Member member = persistMember("홍길동", "hong", "hong@test.com", school.getId());
+        Challenger challenger = persistChallenger(member.getId(), ChallengerPart.PLAN, 7L);
+        em.flush();
+        em.clear();
+
+        SearchMemberQuery query = new SearchMemberQuery("ERICA", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        var challengers = sut.searchBy(query, pageable);
+        var memberIds = sut.searchMemberIdsBy(query, pageable);
+
+        // then
+        assertThat(challengers.getContent())
+            .extracting(Challenger::getId)
+            .doesNotContain(challenger.getId());
+        assertThat(challengers.getTotalElements()).isZero();
+        assertThat(memberIds.getContent()).isEmpty();
+        assertThat(memberIds.getTotalElements()).isZero();
+    }
+
+    private School persistSchool(String name) {
+        School school = School.create(name, null);
+        em.persist(school);
+        return school;
+    }
+
+    private Member persistMember(String name, String nickname, String email, Long schoolId) {
+        Member member = Member.create(name, nickname, email, schoolId, null);
+        em.persist(member);
+        return member;
+    }
+
+    private Challenger persistChallenger(Long memberId, ChallengerPart part, Long gisuId) {
+        Challenger challenger = Challenger.builder()
+            .memberId(memberId)
+            .part(part)
+            .gisuId(gisuId)
+            .build();
+        em.persist(challenger);
+        return challenger;
+    }
+}


### PR DESCRIPTION
## 대상 브랜치
- base: `develop`
- head: `fix/member-search-keyword`

## 이슈
- 별도 연결 이슈 없음

## 작업 내용
- `member/search` keyword 조건에서 학교명 매칭을 제거했습니다.
- keyword가 학교명만 일치하는 경우 v1 챌린저 단위 검색과 v2 회원 단위 검색 모두 결과에 포함되지 않도록 회귀 테스트를 추가했습니다.

## 원인
- `MemberQueryRepository.keywordContains`가 `member.name`, `member.nickname`, `member.email` 외에 `school.name` 서브쿼리 조건까지 OR로 묶어 학교명 검색 결과를 반환하고 있었습니다.

## 검증
- `./gradlew test --tests com.umc.product.member.adapter.out.persistence.MemberQueryRepositoryTest`
- `./gradlew test`

## 리뷰 중점사항
- keyword 검색 범위가 회원 이름, 닉네임, 이메일로 제한되는 것이 API 의도와 맞는지 확인 부탁드립니다.