### PR TITLE
[Feat] 프로젝트 멤버 목록 응답을 추가된 시점을 기준으로 정렬 고정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -136,7 +136,7 @@ public class ProjectResponseAssembler {
     /**
      * PROJECT-003 프로젝트 팀원 구성 조회.
      * <p>
-     * 메인 PM 별도 노출 + 보조 PM(PLAN 파트의 다른 멤버) + 그 외 파트별 그룹. 각 그룹은 닉네임 가나다순 정렬.
+     * 메인 PM 별도 노출 + 보조 PM(PLAN 파트의 다른 멤버) + 그 외 파트별 그룹. 각 그룹은 ProjectMember 생성일 오름차순 정렬.
      */
     public ProjectMembersResponse membersFor(Long projectId) {
         ProjectInfo info = getProjectUseCase.getById(projectId);
@@ -258,7 +258,12 @@ public class ProjectResponseAssembler {
         );
 
         Map<ChallengerPart, List<ProjectMemberBrief>> partToMembers = new EnumMap<>(ChallengerPart.class);
-        for (ProjectMember m : members) {
+        List<ProjectMember> orderedMembers = members.stream()
+            .sorted(Comparator.comparing(ProjectMember::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(ProjectMember::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+            .toList();
+
+        for (ProjectMember m : orderedMembers) {
             ProjectMemberBrief brief = toProjectMemberBrief(
                 memberMap.get(m.getMemberId()),
                 matchedRoundMap.get(ProjectMemberKey.of(projectId, m.getMemberId()))
@@ -269,18 +274,14 @@ public class ProjectResponseAssembler {
             partToMembers.computeIfAbsent(m.getPart(), p -> new ArrayList<>()).add(brief);
         }
 
-        Comparator<ProjectMemberBrief> byNickname = Comparator.comparing(
-            ProjectMemberBrief::nickname, Comparator.nullsLast(Comparator.naturalOrder()));
-
         List<ProjectMemberBrief> coProductOwners = partToMembers.getOrDefault(ChallengerPart.PLAN, List.of()).stream()
             .filter(b -> !Objects.equals(b.memberId(), info.productOwnerMemberId()))
-            .sorted(byNickname)
             .toList();
 
         List<PartGroup> partGroups = Arrays.stream(ChallengerPart.values())
             .filter(p -> p != ChallengerPart.PLAN)
             .map(p -> new PartGroup(p,
-                partToMembers.getOrDefault(p, List.of()).stream().sorted(byNickname).toList()))
+                partToMembers.getOrDefault(p, List.of())))
             .filter(g -> !g.members().isEmpty())
             .toList();
 

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -1,15 +1,17 @@
 package com.umc.product.project.adapter.out.persistence;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
 
 // TODO: 프로젝트 전반의 QueryDSL 일관성을 위해 ProjectMemberQueryRepository로 마이그레이션 필요.
 public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember, Long> {

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberJpaRepository.java
@@ -14,11 +14,15 @@ import org.springframework.data.repository.query.Param;
 // TODO: 프로젝트 전반의 QueryDSL 일관성을 위해 ProjectMemberQueryRepository로 마이그레이션 필요.
 public interface ProjectMemberJpaRepository extends JpaRepository<ProjectMember, Long> {
 
-    List<ProjectMember> findByProjectIdAndPartAndStatus(Long projectId, ChallengerPart part, ProjectMemberStatus status);
+    List<ProjectMember> findByProjectIdAndPartAndStatusOrderByCreatedAtAscIdAsc(
+        Long projectId, ChallengerPart part, ProjectMemberStatus status
+    );
 
-    List<ProjectMember> findByProjectIdAndStatus(Long projectId, ProjectMemberStatus status);
+    List<ProjectMember> findByProjectIdAndStatusOrderByCreatedAtAscIdAsc(Long projectId, ProjectMemberStatus status);
 
-    List<ProjectMember> findByProjectIdInAndStatus(Collection<Long> projectIds, ProjectMemberStatus status);
+    List<ProjectMember> findByProjectIdInAndStatusOrderByCreatedAtAscIdAsc(
+        Collection<Long> projectIds, ProjectMemberStatus status
+    );
 
     Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId);
 

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -1,19 +1,22 @@
 package com.umc.product.project.adapter.out.persistence;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.project.application.port.out.LoadProjectMemberPort;
-import com.umc.product.project.application.port.out.SaveProjectMemberPort;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.enums.MatchingType;
-import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.SaveProjectMemberPort;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -44,19 +44,20 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
 
     @Override
     public List<ProjectMember> listByProjectId(Long projectId) {
-        return repository.findByProjectIdAndStatus(projectId, ProjectMemberStatus.ACTIVE);
+        return repository.findByProjectIdAndStatusOrderByCreatedAtAscIdAsc(projectId, ProjectMemberStatus.ACTIVE);
     }
 
     @Override
     public Map<Long, List<ProjectMember>> listByProjectIds(Collection<Long> projectIds) {
-        return repository.findByProjectIdInAndStatus(projectIds, ProjectMemberStatus.ACTIVE)
+        return repository.findByProjectIdInAndStatusOrderByCreatedAtAscIdAsc(projectIds, ProjectMemberStatus.ACTIVE)
             .stream()
             .collect(Collectors.groupingBy(pm -> pm.getProject().getId()));
     }
 
     @Override
     public List<ProjectMember> listByProjectIdAndPart(Long projectId, ChallengerPart part) {
-        return repository.findByProjectIdAndPartAndStatus(projectId, part, ProjectMemberStatus.ACTIVE);
+        return repository.findByProjectIdAndPartAndStatusOrderByCreatedAtAscIdAsc(
+            projectId, part, ProjectMemberStatus.ACTIVE);
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
@@ -2,12 +2,6 @@ package com.umc.product.project.adapter.out.persistence;
 
 import static com.umc.product.project.domain.QProjectMember.projectMember;
 
-import com.querydsl.core.Tuple;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.enums.MatchingType;
-import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -17,8 +11,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * ProjectMember QueryDSL 기반 조회 구현.

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
@@ -94,6 +94,7 @@ public class ProjectMemberQueryRepository {
                 projectMember.part.eq(part),
                 projectMember.status.eq(ProjectMemberStatus.ACTIVE)
             )
+            .orderBy(projectMember.createdAt.asc(), projectMember.id.asc())
             .fetch();
 
         Map<Long, List<ProjectMember>> result = new HashMap<>();

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssemblerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import java.lang.reflect.RecordComponent;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -155,13 +156,13 @@ class ProjectResponseAssemblerTest {
     }
 
     @Test
-    void membersFor_보조PM_가나다순_정렬() {
+    void membersFor_보조PM_createdAt_오름차순_정렬() {
         ProjectInfo info = projectInfo(42L);
         given(getProjectUseCase.getById(42L)).willReturn(info);
         given(loadProjectMemberPort.listByProjectId(42L)).willReturn(List.of(
-            projectMember(101L, ChallengerPart.PLAN),
-            projectMember(102L, ChallengerPart.PLAN),
-            projectMember(103L, ChallengerPart.PLAN)
+            projectMember(101L, ChallengerPart.PLAN, Instant.parse("2026-01-01T00:00:00Z")),
+            projectMember(102L, ChallengerPart.PLAN, Instant.parse("2026-01-03T00:00:00Z")),
+            projectMember(103L, ChallengerPart.PLAN, Instant.parse("2026-01-02T00:00:00Z"))
         ));
         given(getMemberUseCase.findAllByIds(Set.of(99L, 101L, 102L, 103L))).willReturn(Map.of(
             99L, memberInfoOf(99L, "메인", "김메인"),
@@ -175,7 +176,30 @@ class ProjectResponseAssemblerTest {
         List<String> nicknames = response.coProductOwners().stream()
             .map(ProjectMembersResponse.ProjectMemberBrief::nickname)
             .toList();
-        assertThat(nicknames).containsExactly("가람", "나무", "다람쥐");
+        assertThat(nicknames).containsExactly("다람쥐", "나무", "가람");
+    }
+
+    @Test
+    @DisplayName("membersFor는 파트별 멤버를 ProjectMember createdAt 오름차순으로 응답한다")
+    void membersFor_파트별_멤버_createdAt_오름차순_정렬() {
+        ProjectInfo info = projectInfo(42L);
+        given(getProjectUseCase.getById(42L)).willReturn(info);
+        given(loadProjectMemberPort.listByProjectId(42L)).willReturn(List.of(
+            projectMember(101L, ChallengerPart.SPRINGBOOT, Instant.parse("2026-01-02T00:00:00Z")),
+            projectMember(102L, ChallengerPart.SPRINGBOOT, Instant.parse("2026-01-01T00:00:00Z"))
+        ));
+        given(getMemberUseCase.findAllByIds(Set.of(99L, 101L, 102L))).willReturn(Map.of(
+            99L, memberInfoOf(99L, "메인", "김메인"),
+            101L, memberInfoOf(101L, "가람", "이가람"),
+            102L, memberInfoOf(102L, "다람쥐", "박다람")
+        ));
+
+        ProjectMembersResponse response = sut.membersFor(42L);
+
+        List<Long> memberIds = response.partGroups().get(0).members().stream()
+            .map(ProjectMembersResponse.ProjectMemberBrief::memberId)
+            .toList();
+        assertThat(memberIds).containsExactly(102L, 101L);
     }
 
     @Test
@@ -315,12 +339,17 @@ class ProjectResponseAssemblerTest {
     }
 
     private ProjectMember projectMember(Long memberId, ChallengerPart part) {
+        return projectMember(memberId, part, null);
+    }
+
+    private ProjectMember projectMember(Long memberId, ChallengerPart part, Instant createdAt) {
         try {
             var c = ProjectMember.class.getDeclaredConstructor();
             c.setAccessible(true);
             ProjectMember pm = c.newInstance();
             ReflectionTestUtils.setField(pm, "memberId", memberId);
             ReflectionTestUtils.setField(pm, "part", part);
+            ReflectionTestUtils.setField(pm, "createdAt", createdAt);
             return pm;
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## 대상 브랜치
- base: `develop`
- head: `feature/project-member-created-at-order`

## 이슈
- 별도 이슈 번호 없음

## 작업 내용
- 프로젝트 멤버 조회 응답에서 보조 PM 및 파트별 멤버 배열을 `ProjectMember.createdAt` 오름차순으로 정렬하도록 변경했습니다.
- `LoadProjectMemberPort` 구현에서 사용하는 JPA repository 조회 메서드에 `createdAt ASC, id ASC` 정렬을 명시했습니다.
- QueryDSL 기반 프로젝트/파트별 멤버 조회에도 동일한 정렬을 추가했습니다.
- 기존 닉네임 가나다순 정렬 테스트를 새 정책에 맞춰 수정하고, 파트별 멤버 정렬 회귀 테스트를 추가했습니다.

## 리뷰 중점사항
- 응답 구조상 전체 멤버를 하나의 배열로 내려주지 않고 `coProductOwners`, `partGroups[].members`로 나뉘므로, 각 배열 내부 순서를 `ProjectMember.createdAt` 기준으로 고정했습니다.
- 동일 `createdAt` 값에 대해서는 응답 흔들림을 줄이기 위해 `id ASC`를 보조 정렬로 사용했습니다.

## 검증
- ✅ `./gradlew compileJava compileTestJava test --tests com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssemblerTest`
- ⚠️ `./gradlew test`는 5분 이상 종료되지 않아 테스트 실행 프로세스를 정리했습니다. 중단 과정에서 shutdown hook의 로컬 웹훅 설정 관련 오류 로그가 출력됐고, 완료/통과 결과는 확인하지 못했습니다.
