### PR TITLE
[Fix] 파일 삭제 시 권한 검증 추가

### DIFF
--- a/src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java
+++ b/src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java
@@ -1,5 +1,12 @@
 package com.umc.product.storage.adapter.in.web;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.global.response.ApiResponse;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
@@ -9,16 +16,11 @@ import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
 import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/storage")

--- a/src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java
+++ b/src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java
@@ -6,6 +6,7 @@ import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.storage.adapter.in.web.dto.PrepareUploadRequest;
 import com.umc.product.storage.adapter.in.web.dto.PrepareUploadResponse;
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
+import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -65,8 +66,14 @@ public class StorageController {
      */
     @DeleteMapping("/{fileId}")
     @Operation(summary = "[STORAGE-003] 파일 삭제")
-    public ApiResponse<Void> deleteFile(@PathVariable String fileId) {
-        manageFileUseCase.deleteFile(fileId);
+    public ApiResponse<Void> deleteFile(
+        @CurrentMember MemberPrincipal principal,
+        @PathVariable String fileId
+    ) {
+        manageFileUseCase.deleteFile(DeleteFileCommand.builder()
+            .fileId(fileId)
+            .requesterMemberId(principal.getMemberId())
+            .build());
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/umc/product/storage/adapter/out/persistence/FileMetadataPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/storage/adapter/out/persistence/FileMetadataPersistenceAdapter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -35,6 +36,7 @@ public class FileMetadataPersistenceAdapter implements LoadFileMetadataPort, Sav
     }
 
     @Override
+    @Transactional
     public void deleteByFileId(String fileId) {
         fileMetadataRepository.deleteById(fileId);
     }

--- a/src/main/java/com/umc/product/storage/adapter/out/persistence/FileMetadataPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/storage/adapter/out/persistence/FileMetadataPersistenceAdapter.java
@@ -1,13 +1,16 @@
 package com.umc.product.storage.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.storage.application.port.out.LoadFileMetadataPort;
 import com.umc.product.storage.application.port.out.SaveFileMetadataPort;
 import com.umc.product.storage.domain.FileMetadata;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/storage/application/port/in/command/ManageFileUseCase.java
+++ b/src/main/java/com/umc/product/storage/application/port/in/command/ManageFileUseCase.java
@@ -1,5 +1,6 @@
 package com.umc.product.storage.application.port.in.command;
 
+import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.in.command.dto.PrepareFileUploadCommand;
 
@@ -32,7 +33,7 @@ public interface ManageFileUseCase {
      * <p>
      * 메타데이터와 실제 스토리지의 파일을 모두 삭제합니다.
      *
-     * @param fileId 파일 ID
+     * @param command 파일 삭제 요청 정보
      */
-    void deleteFile(String fileId);
+    void deleteFile(DeleteFileCommand command);
 }

--- a/src/main/java/com/umc/product/storage/application/port/in/command/dto/DeleteFileCommand.java
+++ b/src/main/java/com/umc/product/storage/application/port/in/command/dto/DeleteFileCommand.java
@@ -1,6 +1,7 @@
 package com.umc.product.storage.application.port.in.command.dto;
 
 import java.util.Objects;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/storage/application/port/in/command/dto/DeleteFileCommand.java
+++ b/src/main/java/com/umc/product/storage/application/port/in/command/dto/DeleteFileCommand.java
@@ -1,0 +1,22 @@
+package com.umc.product.storage.application.port.in.command.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+
+/**
+ * 등록된 파일 삭제 Command.
+ */
+@Builder
+public record DeleteFileCommand(
+    String fileId,
+    Long requesterMemberId
+) {
+    public DeleteFileCommand {
+        Objects.requireNonNull(fileId, "fileId must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+
+        if (fileId.isBlank()) {
+            throw new IllegalArgumentException("fileId must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
+++ b/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
@@ -1,6 +1,9 @@
 package com.umc.product.storage.application.service;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
+import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.in.command.dto.PrepareFileUploadCommand;
 import com.umc.product.storage.application.port.out.LoadFileMetadataPort;
@@ -11,6 +14,7 @@ import com.umc.product.storage.domain.enums.FileCategory;
 import com.umc.product.storage.domain.enums.StorageProvider;
 import com.umc.product.storage.domain.exception.StorageErrorCode;
 import com.umc.product.storage.domain.exception.StorageException;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +32,7 @@ public class FileCommandService implements ManageFileUseCase {
     private final StoragePort storagePort;
     private final LoadFileMetadataPort loadFileMetadataPort;
     private final SaveFileMetadataPort saveFileMetadataPort;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @Override
     public FileUploadInfo getFileUploadUrl(PrepareFileUploadCommand command) {
@@ -100,17 +105,34 @@ public class FileCommandService implements ManageFileUseCase {
     }
 
     @Override
-    public void deleteFile(String fileId) {
-        FileMetadata metadata = loadFileMetadataPort.findByFileId(fileId)
+    public void deleteFile(DeleteFileCommand command) {
+        FileMetadata metadata = loadFileMetadataPort.findByFileId(command.fileId())
             .orElseThrow(() -> new StorageException(StorageErrorCode.FILE_NOT_FOUND));
+
+        validateDeletePermission(metadata, command.requesterMemberId());
 
         // 스토리지에서 파일 삭제
         storagePort.delete(metadata.getStorageKey());
 
         // 메타데이터 삭제
-        saveFileMetadataPort.deleteByFileId(fileId);
+        saveFileMetadataPort.deleteByFileId(command.fileId());
 
-        log.info("파일 삭제 완료: fileId={}", fileId);
+        log.info("파일 삭제 완료: fileId={}", command.fileId());
+    }
+
+    private void validateDeletePermission(FileMetadata metadata, Long requesterMemberId) {
+        if (Objects.equals(metadata.getUploadedMemberId(), requesterMemberId) || isSuperAdmin(requesterMemberId)) {
+            return;
+        }
+
+        throw new StorageException(StorageErrorCode.FILE_DELETE_FORBIDDEN);
+    }
+
+    private boolean isSuperAdmin(Long memberId) {
+        return getChallengerRoleUseCase.findAllByMemberId(memberId).stream()
+            .map(ChallengerRoleInfo::roleType)
+            .filter(Objects::nonNull)
+            .anyMatch(roleType -> roleType.isSuperAdmin());
     }
 
     private void validateFile(PrepareFileUploadCommand command) {

--- a/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
+++ b/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class FileCommandService implements ManageFileUseCase {
 
     private static final long UPLOAD_URL_DURATION_MINUTES = 15;
@@ -35,6 +34,7 @@ public class FileCommandService implements ManageFileUseCase {
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
     @Override
+    @Transactional
     public FileUploadInfo getFileUploadUrl(PrepareFileUploadCommand command) {
         // 파일 검증
         validateFile(command);
@@ -85,6 +85,7 @@ public class FileCommandService implements ManageFileUseCase {
     }
 
     @Override
+    @Transactional
     public void confirmUpload(String fileId) {
         FileMetadata metadata = loadFileMetadataPort.findByFileId(fileId)
             .orElseThrow(() -> new StorageException(StorageErrorCode.FILE_NOT_FOUND));

--- a/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
+++ b/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
@@ -1,5 +1,11 @@
 package com.umc.product.storage.application.service;
 
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
@@ -14,12 +20,9 @@ import com.umc.product.storage.domain.enums.FileCategory;
 import com.umc.product.storage.domain.enums.StorageProvider;
 import com.umc.product.storage.domain.exception.StorageErrorCode;
 import com.umc.product.storage.domain.exception.StorageException;
-import java.util.Objects;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/umc/product/storage/domain/exception/StorageErrorCode.java
+++ b/src/main/java/com/umc/product/storage/domain/exception/StorageErrorCode.java
@@ -13,6 +13,7 @@ public enum StorageErrorCode implements BaseCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORAGE-0001", "파일을 찾을 수 없습니다."),
     FILE_UPLOAD_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "STORAGE-0002", "파일 업로드가 완료되지 않았습니다."),
     FILE_ALREADY_UPLOADED(HttpStatus.BAD_REQUEST, "STORAGE-0003", "이미 업로드가 완료된 파일입니다."),
+    FILE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORAGE-0013", "파일 삭제 권한이 없습니다."),
 
     // 파일 검증 에러
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "STORAGE-0004", "허용되지 않는 파일 확장자입니다."),

--- a/src/main/java/com/umc/product/storage/domain/exception/StorageErrorCode.java
+++ b/src/main/java/com/umc/product/storage/domain/exception/StorageErrorCode.java
@@ -1,9 +1,11 @@
 package com.umc.product.storage.domain.exception;
 
+import org.springframework.http.HttpStatus;
+
 import com.umc.product.global.response.code.BaseCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor

--- a/src/test/java/com/umc/product/storage/application/service/FileCommandServiceTest.java
+++ b/src/test/java/com/umc/product/storage/application/service/FileCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
+import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.in.command.dto.PrepareFileUploadCommand;
 import com.umc.product.storage.application.port.out.LoadFileMetadataPort;
@@ -182,7 +183,7 @@ class FileCommandServiceTest extends UseCaseTestSupport {
         String fileId = metadata.getId();
 
         // when
-        manageFileUseCase.deleteFile(fileId);
+        manageFileUseCase.deleteFile(deleteCommand(fileId, 1L));
 
         // then: 스토리지에서 파일이 삭제되었는지 확인
         verify(storagePort).delete(metadata.getStorageKey());
@@ -197,8 +198,15 @@ class FileCommandServiceTest extends UseCaseTestSupport {
         String nonExistentFileId = "non-existent-id";
 
         // when & then
-        assertThatThrownBy(() -> manageFileUseCase.deleteFile(nonExistentFileId))
+        assertThatThrownBy(() -> manageFileUseCase.deleteFile(deleteCommand(nonExistentFileId, 1L)))
             .isInstanceOf(StorageException.class);
+    }
+
+    private DeleteFileCommand deleteCommand(String fileId, Long requesterMemberId) {
+        return DeleteFileCommand.builder()
+            .fileId(fileId)
+            .requesterMemberId(requesterMemberId)
+            .build();
     }
 
     /**

--- a/src/test/java/com/umc/product/storage/application/service/FileCommandServiceTest.java
+++ b/src/test/java/com/umc/product/storage/application/service/FileCommandServiceTest.java
@@ -8,6 +8,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
 import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
@@ -19,10 +25,6 @@ import com.umc.product.storage.domain.enums.FileCategory;
 import com.umc.product.storage.domain.enums.StorageProvider;
 import com.umc.product.storage.domain.exception.StorageException;
 import com.umc.product.support.UseCaseTestSupport;
-import java.time.LocalDateTime;
-import java.util.Map;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * FileCommandService 통합 테스트

--- a/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
+++ b/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.umc.product.storage.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -20,6 +21,7 @@ import com.umc.product.storage.domain.enums.FileCategory;
 import com.umc.product.storage.domain.enums.StorageProvider;
 import com.umc.product.storage.domain.exception.StorageErrorCode;
 import com.umc.product.storage.domain.exception.StorageException;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class FileCommandServiceUnitTest {
@@ -46,6 +49,24 @@ class FileCommandServiceUnitTest {
 
     @InjectMocks
     FileCommandService sut;
+
+    @Test
+    @DisplayName("파일 삭제는 클래스 공통 트랜잭션으로 외부 스토리지 I/O를 감싸지 않는다")
+    void 파일_삭제는_클래스_공통_트랜잭션으로_외부_스토리지_IO를_감싸지_않는다() throws NoSuchMethodException {
+        // when
+        Method getFileUploadUrl = FileCommandService.class.getMethod(
+            "getFileUploadUrl",
+            com.umc.product.storage.application.port.in.command.dto.PrepareFileUploadCommand.class
+        );
+        Method confirmUpload = FileCommandService.class.getMethod("confirmUpload", String.class);
+        Method deleteFile = FileCommandService.class.getMethod("deleteFile", DeleteFileCommand.class);
+
+        // then
+        assertThat(FileCommandService.class.getAnnotation(Transactional.class)).isNull();
+        assertThat(getFileUploadUrl.getAnnotation(Transactional.class)).isNotNull();
+        assertThat(confirmUpload.getAnnotation(Transactional.class)).isNotNull();
+        assertThat(deleteFile.getAnnotation(Transactional.class)).isNull();
+    }
 
     @Test
     @DisplayName("작성자가 아니어도 SUPER_ADMIN이면 파일을 삭제한다")

--- a/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
+++ b/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
@@ -1,0 +1,134 @@
+package com.umc.product.storage.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
+import com.umc.product.storage.application.port.out.LoadFileMetadataPort;
+import com.umc.product.storage.application.port.out.SaveFileMetadataPort;
+import com.umc.product.storage.application.port.out.StoragePort;
+import com.umc.product.storage.domain.FileMetadata;
+import com.umc.product.storage.domain.enums.FileCategory;
+import com.umc.product.storage.domain.enums.StorageProvider;
+import com.umc.product.storage.domain.exception.StorageErrorCode;
+import com.umc.product.storage.domain.exception.StorageException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FileCommandServiceUnitTest {
+
+    @Mock
+    StoragePort storagePort;
+
+    @Mock
+    LoadFileMetadataPort loadFileMetadataPort;
+
+    @Mock
+    SaveFileMetadataPort saveFileMetadataPort;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @InjectMocks
+    FileCommandService sut;
+
+    @Test
+    @DisplayName("작성자가 아니어도 SUPER_ADMIN이면 파일을 삭제한다")
+    void 작성자가_아니어도_SUPER_ADMIN이면_파일을_삭제한다() {
+        // given
+        FileMetadata metadata = uploadedFile("file-id", 1L);
+        given(loadFileMetadataPort.findByFileId("file-id")).willReturn(Optional.of(metadata));
+        given(getChallengerRoleUseCase.findAllByMemberId(2L)).willReturn(List.of(role(ChallengerRoleType.SUPER_ADMIN)));
+
+        // when
+        sut.deleteFile(deleteCommand("file-id", 2L));
+
+        // then
+        then(storagePort).should().delete(metadata.getStorageKey());
+        then(saveFileMetadataPort).should().deleteByFileId("file-id");
+    }
+
+    @Test
+    @DisplayName("작성자도 SUPER_ADMIN도 아니면 파일을 삭제할 수 없다")
+    void 작성자도_SUPER_ADMIN도_아니면_파일을_삭제할_수_없다() {
+        // given
+        FileMetadata metadata = uploadedFile("file-id", 1L);
+        given(loadFileMetadataPort.findByFileId("file-id")).willReturn(Optional.of(metadata));
+        given(getChallengerRoleUseCase.findAllByMemberId(2L)).willReturn(List.of(role(ChallengerRoleType.SCHOOL_PRESIDENT)));
+
+        // when & then
+        assertThatThrownBy(() -> sut.deleteFile(deleteCommand("file-id", 2L)))
+            .isInstanceOf(StorageException.class)
+            .extracting("baseCode")
+            .isEqualTo(StorageErrorCode.FILE_DELETE_FORBIDDEN);
+
+        then(storagePort).should(never()).delete(anyString());
+        then(saveFileMetadataPort).should(never()).deleteByFileId(anyString());
+    }
+
+    @Test
+    @DisplayName("S3 삭제가 실패하면 파일 메타데이터를 삭제하지 않는다")
+    void S3_삭제가_실패하면_파일_메타데이터를_삭제하지_않는다() {
+        // given
+        FileMetadata metadata = uploadedFile("file-id", 1L);
+        given(loadFileMetadataPort.findByFileId("file-id")).willReturn(Optional.of(metadata));
+        willThrow(new StorageException(StorageErrorCode.STORAGE_DELETE_FAILED))
+            .given(storagePort)
+            .delete(metadata.getStorageKey());
+
+        // when & then
+        assertThatThrownBy(() -> sut.deleteFile(deleteCommand("file-id", 1L)))
+            .isInstanceOf(StorageException.class)
+            .extracting("baseCode")
+            .isEqualTo(StorageErrorCode.STORAGE_DELETE_FAILED);
+
+        then(saveFileMetadataPort).should(never()).deleteByFileId(anyString());
+    }
+
+    private DeleteFileCommand deleteCommand(String fileId, Long requesterMemberId) {
+        return DeleteFileCommand.builder()
+            .fileId(fileId)
+            .requesterMemberId(requesterMemberId)
+            .build();
+    }
+
+    private ChallengerRoleInfo role(ChallengerRoleType roleType) {
+        return ChallengerRoleInfo.builder()
+            .id(1L)
+            .challengerId(1L)
+            .roleType(roleType)
+            .organizationType(OrganizationType.CENTRAL)
+            .gisuId(1L)
+            .build();
+    }
+
+    private FileMetadata uploadedFile(String fileId, Long uploadedMemberId) {
+        FileMetadata metadata = FileMetadata.builder()
+            .fileId(fileId)
+            .originalFileName("document.pdf")
+            .category(FileCategory.ETC)
+            .contentType("application/pdf")
+            .fileSize(1024L)
+            .storageProvider(StorageProvider.AWS_S3)
+            .storageKey("test/" + fileId + ".pdf")
+            .uploadedMemberId(uploadedMemberId)
+            .build();
+        metadata.markAsUploaded();
+        return metadata;
+    }
+}

--- a/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
+++ b/src/test/java/com/umc/product/storage/application/service/FileCommandServiceUnitTest.java
@@ -8,6 +8,18 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -21,16 +33,6 @@ import com.umc.product.storage.domain.enums.FileCategory;
 import com.umc.product.storage.domain.enums.StorageProvider;
 import com.umc.product.storage.domain.exception.StorageErrorCode;
 import com.umc.product.storage.domain.exception.StorageException;
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class FileCommandServiceUnitTest {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- storage 도메인의 파일 삭제 API 진입점, command usecase, command service, storage error code, 서비스 테스트를 수정했어요.

### 작업 단위별 상세

1. **무엇을**: [STORAGE-003] DELETE /api/v1/storage/{fileId} 요청에서 호출자 memberId를 application 계층으로 전달하도록 바꿨어요.
   - **어떻게**: `DeleteFileCommand`를 추가하고, `StorageController`가 `@CurrentMember`의 memberId와 fileId를 함께 `ManageFileUseCase`로 넘기도록 수정했어요.
   - **왜**: 파일 삭제 권한을 서비스에서 검증하려면 삭제 대상 fileId 외에 요청자 memberId가 필요해서예요.

2. **무엇을**: 등록한 파일은 작성자 본인이거나 SUPER_ADMIN 역할을 가진 사용자만 삭제할 수 있도록 검증을 추가했어요.
   - **어떻게**: `FileMetadata.uploadedMemberId`와 요청자 memberId를 먼저 비교하고, 작성자가 아니면 authorization 도메인의 공개 `GetChallengerRoleUseCase`로 SUPER_ADMIN 보유 여부를 확인하도록 구현했어요.
   - **왜**: 작성자가 아닌 사용자가 fileId만 알고 있으면 타인의 파일 메타데이터와 S3 객체를 삭제할 수 있는 권한 공백을 막기 위해서예요.

3. **무엇을**: S3 삭제가 성공적으로 수행된 뒤에만 DB 메타데이터를 삭제하는 동작을 테스트로 고정했어요.
   - **어떻게**: S3 삭제 실패 시 `SaveFileMetadataPort.deleteByFileId`가 호출되지 않는 단위 테스트를 추가하고, 기존 삭제 통합 테스트를 새 command 시그니처에 맞춰 갱신했어요.
   - **왜**: S3 삭제가 실패했는데 DB 메타데이터만 삭제되면 실제 파일이 스토리지에 남고 API 응답은 성공처럼 보일 수 있어서예요.

## 💬 리뷰 중점사항

- storage command service가 authorization 도메인의 공개 query usecase로 SUPER_ADMIN 여부를 확인하는 방향이 도메인 간 통신 규칙에 맞는지 확인 부탁드려요.
- `uploadedMemberId`가 없는 레거시 파일은 현재 작성자 매칭이 불가능하므로 SUPER_ADMIN만 삭제 가능한 형태예요. 이 정책이 운영 의도와 맞는지 확인 부탁드려요.
- 검증은 `./gradlew test --tests 'com.umc.product.storage.application.service.FileCommandServiceUnitTest' --tests 'com.umc.product.storage.application.service.FileCommandServiceTest'`로 수행했어요.