### PR TITLE
[Fix] 프로젝트 매칭 자동 선발 스케쥴러 등록 버퍼 조정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,8 @@ APP_SEED_DEFAULT_PASSWORD=password12!
 # ------------------------------------------------------------------
 # FIRST, SECOND, THIRD 차수 사이 최소 간격. 단위: minute.
 PROJECT_MATCHING_ROUND_MIN_PHASE_INTERVAL_MINUTES=1
+# 자동 선발 스케줄러가 decisionDeadline 이후 대기하는 buffer. 단위: minute.
+PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES=1
 
 # ------------------------------------------------------------------
 # OAuth2 / Social Login

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
@@ -1,20 +1,23 @@
 package com.umc.product.project.adapter.out.scheduler;
 
-import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
-import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
-import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
-import com.umc.product.project.domain.ProjectMatchingRound;
-import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
+import com.umc.product.project.domain.ProjectMatchingRound;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * {@link ScheduleMatchingRoundDeadlinePort} 의 driven adapter 구현.
@@ -41,10 +44,10 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
      * 자동 선발 발화 시점을 deadline 정각이 아닌 buffer 만큼 뒤로 미룬다.
      * <p>
      * - 클럭 정밀도: deadline 정각에 발화 시 {@code isDecisionDeadlinePassed} 가 false 가 돼 NOT_FINALIZABLE 로 종료될 위험 회피
-     * - PM 마지막 토글과의 race 보호
+     * - PM 마지막 토글 커밋과의 짧은 race 보호
      * - 다른 도메인 자정 cron 부하와 분리
      */
-    static final Duration DEADLINE_BUFFER = Duration.ofMinutes(10);
+    private final Duration deadlineBuffer;
 
     private final TaskScheduler taskScheduler;
     private final MatchingRoundDeadlineHandler handler;
@@ -55,11 +58,13 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
     public MatchingRoundDeadlineScheduler(
         @Qualifier("matchingDeadlineTaskScheduler") TaskScheduler taskScheduler,
         MatchingRoundDeadlineHandler handler,
-        LoadProjectMatchingRoundPort loadProjectMatchingRoundPort
+        LoadProjectMatchingRoundPort loadProjectMatchingRoundPort,
+        MatchingRoundDeadlineSchedulerProperties properties
     ) {
         this.taskScheduler = taskScheduler;
         this.handler = handler;
         this.loadProjectMatchingRoundPort = loadProjectMatchingRoundPort;
+        this.deadlineBuffer = properties.deadlineBuffer();
     }
 
     @PostConstruct
@@ -72,7 +77,7 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
         Long roundId = round.getId();
         cancel(roundId);
 
-        Instant runAt = round.getDecisionDeadline().plus(DEADLINE_BUFFER);
+        Instant runAt = round.getDecisionDeadline().plus(deadlineBuffer);
         ScheduledFuture<?> future = taskScheduler.schedule(
             () -> {
                 try {

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerProperties.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerProperties.java
@@ -1,0 +1,31 @@
+package com.umc.product.project.adapter.out.scheduler;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 매칭 차수 자동 선발 스케줄러 설정.
+ *
+ * @param deadlineBufferMinutes 자동 선발 task 를 decisionDeadline 이후로 지연할 시간. 환경변수 단위는 minute.
+ */
+@ConfigurationProperties(prefix = "app.project.matching-round")
+public record MatchingRoundDeadlineSchedulerProperties(
+    Long deadlineBufferMinutes
+) {
+
+    private static final long DEFAULT_DEADLINE_BUFFER_MINUTES = 1L;
+
+    public MatchingRoundDeadlineSchedulerProperties {
+        if (deadlineBufferMinutes == null) {
+            deadlineBufferMinutes = DEFAULT_DEADLINE_BUFFER_MINUTES;
+        }
+        if (deadlineBufferMinutes < 1) {
+            throw new IllegalArgumentException("deadlineBufferMinutes must be greater than or equal to 1");
+        }
+    }
+
+    public Duration deadlineBuffer() {
+        return Duration.ofMinutes(deadlineBufferMinutes);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -260,6 +260,8 @@ app:
     matching-round:
       # FIRST, SECOND, THIRD 차수 사이 최소 간격. 환경변수 단위는 minute.
       min-phase-interval-minutes: ${PROJECT_MATCHING_ROUND_MIN_PHASE_INTERVAL_MINUTES:1}
+      # 자동 선발 스케줄러가 decisionDeadline 이후 대기하는 buffer. 환경변수 단위는 minute.
+      deadline-buffer-minutes: ${PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES:1}
 
   observability:
     tracing:

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerPropertiesTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerPropertiesTest.java
@@ -1,0 +1,37 @@
+package com.umc.product.project.adapter.out.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MatchingRoundDeadlineSchedulerPropertiesTest {
+
+    @Test
+    @DisplayName("deadline buffer 설정이 없으면 기본값 1분을 사용한다")
+    void deadline_buffer_설정이_없으면_기본값_1분을_사용한다() {
+        MatchingRoundDeadlineSchedulerProperties properties =
+            new MatchingRoundDeadlineSchedulerProperties(null);
+
+        assertThat(properties.deadlineBuffer()).isEqualTo(Duration.ofMinutes(1));
+    }
+
+    @Test
+    @DisplayName("deadline buffer 설정은 분 단위 Duration으로 변환한다")
+    void deadline_buffer_설정은_분_단위_Duration으로_변환한다() {
+        MatchingRoundDeadlineSchedulerProperties properties =
+            new MatchingRoundDeadlineSchedulerProperties(5L);
+
+        assertThat(properties.deadlineBuffer()).isEqualTo(Duration.ofMinutes(5));
+    }
+
+    @Test
+    @DisplayName("deadline buffer 설정은 1분 이상이어야 한다")
+    void deadline_buffer_설정은_1분_이상이어야_한다() {
+        assertThatThrownBy(() -> new MatchingRoundDeadlineSchedulerProperties(0L))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
@@ -9,14 +9,11 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
-import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
-import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
-import com.umc.product.project.domain.ProjectMatchingRound;
-import com.umc.product.project.domain.enums.MatchingPhase;
-import com.umc.product.project.domain.enums.MatchingType;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,8 +24,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
+import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+
 @ExtendWith(MockitoExtension.class)
 class MatchingRoundDeadlineSchedulerTest {
+
+    private static final Duration TEST_DEADLINE_BUFFER = Duration.ofMinutes(3);
 
     @Mock
     TaskScheduler taskScheduler;
@@ -46,7 +51,10 @@ class MatchingRoundDeadlineSchedulerTest {
     @BeforeEach
     void setUp() {
         sut = new MatchingRoundDeadlineScheduler(
-            taskScheduler, handler, loadProjectMatchingRoundPort
+            taskScheduler,
+            handler,
+            loadProjectMatchingRoundPort,
+            new MatchingRoundDeadlineSchedulerProperties(TEST_DEADLINE_BUFFER.toMinutes())
         );
     }
 
@@ -62,7 +70,7 @@ class MatchingRoundDeadlineSchedulerTest {
             sut.schedule(round);
 
             assertThat(sut.isScheduled(1L)).isTrue();
-            Instant expectedRunAt = round.getDecisionDeadline().plus(MatchingRoundDeadlineScheduler.DEADLINE_BUFFER);
+            Instant expectedRunAt = round.getDecisionDeadline().plus(TEST_DEADLINE_BUFFER);
             then(taskScheduler).should().schedule(any(Runnable.class), eq(expectedRunAt));
         }
 


### PR DESCRIPTION
## 대상 브랜치
- `develop`

## 이슈
- 별도 이슈 없음

## 작업 내용
- 매칭 차수 autoDecide 스케줄러의 deadline buffer 기본값을 10분에서 1분으로 단축했습니다.
- `PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES` 환경변수로 deadline buffer를 조정할 수 있도록 설정화했습니다.
- 최신 `origin/develop`의 `app.project.matching-round.*` 설정 패턴에 맞춰 `application.yml`과 `@ConfigurationProperties`를 추가했습니다.
- scheduler 테스트가 하드코딩 상수 대신 주입된 buffer 값을 검증하도록 수정했습니다.

## 작업 근거
- 현재 스케줄러는 주기 실행이 아니라 `decisionDeadline + buffer` 시점의 1회성 task로 동작합니다.
- 기존 10분 buffer는 다음 차수가 바로 시작되는 운영 플로우에서 이전 차수 autoDecide와 `ProjectMember` 등록을 지연시킬 수 있습니다.
- 운영 환경에서는 race/부하 상황에 따라 애플리케이션 재빌드 없이 buffer를 조정할 수 있어야 합니다.

## 검증
- PASS: `./gradlew test --tests MatchingRoundDeadlineSchedulerTest --tests MatchingRoundDeadlineSchedulerPropertiesTest`

## 리뷰 중점사항
- `PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES` 기본값 1분과 최소값 1분 정책이 운영 플로우에 적절한지 확인 부탁드립니다.
