### PR TITLE
[Feat] 테스트용 프로젝트 관련 데이터 초기화 API 추가

### DIFF
--- a/src/main/java/com/umc/product/survey/domain/AnswerChoice.java
+++ b/src/main/java/com/umc/product/survey/domain/AnswerChoice.java
@@ -1,12 +1,22 @@
 package com.umc.product.survey.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import com.umc.product.common.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * 객관식 응답에서 사용자가 '선택한 하나의 보기'를 나타낸다.
@@ -62,6 +72,10 @@ public class AnswerChoice extends BaseEntity {
     @JoinColumn(name = "question_option_id")
     @OnDelete(action = OnDeleteAction.SET_NULL)
     private QuestionOption questionOption;
+
+    public static AnswerChoice create(Answer answer, QuestionOption questionOption) {
+        return new AnswerChoice(answer, questionOption);
+    }
 
     public AnswerChoice(Answer answer, QuestionOption questionOption) {
         this.answer = answer;

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -2,6 +2,7 @@ package com.umc.product.test.adapter.in.web;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,8 @@ import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleRequest;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleResponse;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberRequest;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberResponse;
+import com.umc.product.test.adapter.in.web.dto.DeleteSeedProjectDataRequest;
+import com.umc.product.test.adapter.in.web.dto.DeleteSeedProjectDataResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengersResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedCurriculumRequest;
@@ -31,6 +34,7 @@ import com.umc.product.test.adapter.in.web.dto.SeedProjectsResponse;
 import com.umc.product.test.application.port.in.command.CreateSeedChallengerRoleUseCase;
 import com.umc.product.test.application.port.in.command.CreateSeedChallengerUseCase;
 import com.umc.product.test.application.port.in.command.CreateSeedMemberUseCase;
+import com.umc.product.test.application.port.in.command.DeleteSeedProjectDataUseCase;
 import com.umc.product.test.application.port.in.command.SeedChallengersUseCase;
 import com.umc.product.test.application.port.in.command.SeedCurriculumUseCase;
 import com.umc.product.test.application.port.in.command.SeedMembersUseCase;
@@ -38,6 +42,7 @@ import com.umc.product.test.application.port.in.command.SeedNoticeUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectApplicationsUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectScenariosUseCase;
 import com.umc.product.test.application.port.in.command.SeedProjectsUseCase;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,6 +72,7 @@ public class SeedController {
     private final CreateSeedChallengerUseCase createSeedChallengerUseCase;
     private final CreateSeedChallengerRoleUseCase createSeedChallengerRoleUseCase;
     private final SeedProjectsUseCase seedProjectsUseCase;
+    private final DeleteSeedProjectDataUseCase deleteSeedProjectDataUseCase;
     private final SeedProjectScenariosUseCase seedProjectScenariosUseCase;
     private final SeedProjectApplicationsUseCase seedProjectApplicationsUseCase;
     private final SeedCurriculumUseCase seedCurriculumUseCase;
@@ -160,6 +166,28 @@ public class SeedController {
     @PostMapping("/projects")
     public SeedProjectsResponse seedProjects(@RequestBody @Valid SeedProjectsRequest request) {
         return SeedProjectsResponse.from(seedProjectsUseCase.seed(request.toCommand()));
+    }
+
+    @Operation(
+        operationId = "SEED-003-D",
+        summary = "프로젝트 시딩 데이터 삭제",
+        description = """
+            특정 기수의 프로젝트 관련 데이터를 물리 삭제합니다.
+            삭제 범위는 Project, ProjectMember, ProjectPartQuota, ProjectApplication,
+            ProjectApplicationForm/Policy, 해당 기수 Chapter 의 ProjectMatchingRound,
+            그리고 프로젝트 지원 폼이 생성한 survey Form/FormSection/Question/QuestionOption/
+            FormResponse/Answer/AnswerChoice/legacy SingleAnswer 입니다.
+            gisuId 가 null 이면 활성 기수를 대상으로 합니다. prod 환경에서는 노출되지 않습니다.
+            """
+    )
+    @DeleteMapping("/projects")
+    public DeleteSeedProjectDataResponse deleteProjectData(
+        @RequestBody(required = false) @Valid DeleteSeedProjectDataRequest request
+    ) {
+        DeleteSeedProjectDataCommand command = request == null
+            ? DeleteSeedProjectDataCommand.of(null)
+            : request.toCommand();
+        return DeleteSeedProjectDataResponse.from(deleteSeedProjectDataUseCase.delete(command));
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/DeleteSeedProjectDataRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/DeleteSeedProjectDataRequest.java
@@ -1,0 +1,12 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
+
+public record DeleteSeedProjectDataRequest(
+    Long gisuId
+) {
+
+    public DeleteSeedProjectDataCommand toCommand() {
+        return DeleteSeedProjectDataCommand.of(gisuId);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/DeleteSeedProjectDataResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/DeleteSeedProjectDataResponse.java
@@ -1,0 +1,44 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
+
+public record DeleteSeedProjectDataResponse(
+    Long gisuId,
+    int deletedProjects,
+    int deletedProjectMembers,
+    int deletedProjectApplications,
+    int deletedProjectApplicationForms,
+    int deletedProjectApplicationFormPolicies,
+    int deletedProjectPartQuotas,
+    int deletedProjectMatchingRounds,
+    int deletedSurveyForms,
+    int deletedSurveyFormSections,
+    int deletedSurveyQuestions,
+    int deletedSurveyQuestionOptions,
+    int deletedSurveyFormResponses,
+    int deletedSurveyAnswers,
+    int deletedSurveyAnswerChoices,
+    int deletedSurveySingleAnswers
+) {
+
+    public static DeleteSeedProjectDataResponse from(DeleteSeedProjectDataResult result) {
+        return new DeleteSeedProjectDataResponse(
+            result.gisuId(),
+            result.deletedProjects(),
+            result.deletedProjectMembers(),
+            result.deletedProjectApplications(),
+            result.deletedProjectApplicationForms(),
+            result.deletedProjectApplicationFormPolicies(),
+            result.deletedProjectPartQuotas(),
+            result.deletedProjectMatchingRounds(),
+            result.deletedSurveyForms(),
+            result.deletedSurveyFormSections(),
+            result.deletedSurveyQuestions(),
+            result.deletedSurveyQuestionOptions(),
+            result.deletedSurveyFormResponses(),
+            result.deletedSurveyAnswers(),
+            result.deletedSurveyAnswerChoices(),
+            result.deletedSurveySingleAnswers()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
@@ -16,6 +16,36 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProjectSeedDataCleanupPersistenceAdapter implements DeleteSeedProjectDataPort {
 
+    /*
+     * 대상 Project 관련 데이터:
+     * - project: 프로젝트 루트. gisu_id로 대상 기수를 판별한다.
+     * - project_member: project, project_application을 참조하는 프로젝트 멤버.
+     * - project_part_quota: project를 참조하는 파트별 TO.
+     * - project_matching_round: chapter_id를 통해 대상 기수 chapter의 매칭 차수를 판별한다.
+     * - project_application: project_application_form, project_matching_round를 참조하는 지원서 메타데이터.
+     * - project_application_form: project와 survey form을 연결한다. form_id는 현재 DB FK가 아닌 스칼라 ID다.
+     * - project_application_form_policy: project_application_form과 form_section_id를 연결하는 섹션 노출 정책.
+     * - form, form_section, question, question_option: 프로젝트 지원 폼의 설문 구조.
+     * - form_response, answer, answer_choice: 프로젝트 지원 폼에 제출된 신규 설문 응답 구조.
+     * - single_answer: answer/answer_choice로 이관된 뒤에도 남아 있는 레거시 설문 응답 테이블.
+     *
+     * FK 안전 삭제 순서:
+     * 1. project_member: project_application, project보다 먼저 삭제한다.
+     * 2. answer_choice: answer, question_option보다 먼저 삭제한다.
+     * 3. single_answer: form_response, question보다 먼저 삭제한다.
+     * 4. answer: form_response, question보다 먼저 삭제한다.
+     * 5. project_application: project_application_form, project_matching_round보다 먼저 삭제한다.
+     * 6. project_application_form_policy: project_application_form보다 먼저 삭제한다.
+     * 7. question_option: question보다 먼저 삭제한다.
+     * 8. question: form_section보다 먼저 삭제한다.
+     * 9. form_section: form보다 먼저 삭제한다.
+     * 10. form_response: form보다 먼저 삭제한다.
+     * 11. form: project_application_form.form_id가 FK가 아니므로 연결 행보다 먼저 삭제할 수 있다.
+     * 12. project_application_form: project보다 먼저 삭제한다.
+     * 13. project_part_quota: project보다 먼저 삭제한다.
+     * 14. project_matching_round: project_application 삭제 이후 대상 기수 chapter 기준으로 삭제한다.
+     * 15. project: 모든 하위 프로젝트 데이터를 제거한 뒤 마지막에 삭제한다.
+     */
     private final EntityManager entityManager;
 
     @Override

--- a/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
@@ -1,0 +1,193 @@
+package com.umc.product.test.adapter.out.persistence;
+
+import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class ProjectSeedDataCleanupPersistenceAdapter implements DeleteSeedProjectDataPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public ProjectDataDeletionCounts deleteByGisuId(Long gisuId) {
+        int deletedProjectMembers = execute("""
+            DELETE FROM project_member pm
+            WHERE pm.project_id IN (
+                SELECT p.id
+                FROM project p
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyAnswerChoices = execute("""
+            DELETE FROM answer_choice ac
+            WHERE ac.answer_id IN (
+                SELECT a.id
+                FROM answer a
+                JOIN form_response fr ON fr.id = a.form_response_id
+                JOIN project_application_form paf ON paf.form_id = fr.form_id
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveySingleAnswers = execute("""
+            DELETE FROM single_answer sa
+            WHERE sa.response_id IN (
+                SELECT fr.id
+                FROM form_response fr
+                JOIN project_application_form paf ON paf.form_id = fr.form_id
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyAnswers = execute("""
+            DELETE FROM answer a
+            WHERE a.form_response_id IN (
+                SELECT fr.id
+                FROM form_response fr
+                JOIN project_application_form paf ON paf.form_id = fr.form_id
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjectApplications = execute("""
+            DELETE FROM project_application pa
+            WHERE pa.project_application_form_id IN (
+                SELECT paf.id
+                FROM project_application_form paf
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjectApplicationFormPolicies = execute("""
+            DELETE FROM project_application_form_policy pfp
+            WHERE pfp.project_application_form_id IN (
+                SELECT paf.id
+                FROM project_application_form paf
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyQuestionOptions = execute("""
+            DELETE FROM question_option qo
+            WHERE qo.question_id IN (
+                SELECT q.id
+                FROM question q
+                JOIN form_section fs ON fs.id = q.form_section_id
+                JOIN project_application_form paf ON paf.form_id = fs.form_id
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyQuestions = execute("""
+            DELETE FROM question q
+            WHERE q.form_section_id IN (
+                SELECT fs.id
+                FROM form_section fs
+                JOIN project_application_form paf ON paf.form_id = fs.form_id
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyFormSections = execute("""
+            DELETE FROM form_section fs
+            WHERE fs.form_id IN (
+                SELECT paf.form_id
+                FROM project_application_form paf
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyFormResponses = execute("""
+            DELETE FROM form_response fr
+            WHERE fr.form_id IN (
+                SELECT paf.form_id
+                FROM project_application_form paf
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedSurveyForms = execute("""
+            DELETE FROM form f
+            WHERE f.id IN (
+                SELECT paf.form_id
+                FROM project_application_form paf
+                JOIN project p ON p.id = paf.project_id
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjectApplicationForms = execute("""
+            DELETE FROM project_application_form paf
+            WHERE paf.project_id IN (
+                SELECT p.id
+                FROM project p
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjectPartQuotas = execute("""
+            DELETE FROM project_part_quota ppq
+            WHERE ppq.project_id IN (
+                SELECT p.id
+                FROM project p
+                WHERE p.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjectMatchingRounds = execute("""
+            DELETE FROM project_matching_round pmr
+            WHERE pmr.chapter_id IN (
+                SELECT c.id
+                FROM chapter c
+                WHERE c.gisu_id = :gisuId
+            )
+            """, gisuId);
+
+        int deletedProjects = execute("""
+            DELETE FROM project p
+            WHERE p.gisu_id = :gisuId
+            """, gisuId);
+
+        return ProjectDataDeletionCounts.builder()
+            .deletedProjects(deletedProjects)
+            .deletedProjectMembers(deletedProjectMembers)
+            .deletedProjectApplications(deletedProjectApplications)
+            .deletedProjectApplicationForms(deletedProjectApplicationForms)
+            .deletedProjectApplicationFormPolicies(deletedProjectApplicationFormPolicies)
+            .deletedProjectPartQuotas(deletedProjectPartQuotas)
+            .deletedProjectMatchingRounds(deletedProjectMatchingRounds)
+            .deletedSurveyForms(deletedSurveyForms)
+            .deletedSurveyFormSections(deletedSurveyFormSections)
+            .deletedSurveyQuestions(deletedSurveyQuestions)
+            .deletedSurveyQuestionOptions(deletedSurveyQuestionOptions)
+            .deletedSurveyFormResponses(deletedSurveyFormResponses)
+            .deletedSurveyAnswers(deletedSurveyAnswers)
+            .deletedSurveyAnswerChoices(deletedSurveyAnswerChoices)
+            .deletedSurveySingleAnswers(deletedSurveySingleAnswers)
+            .build();
+    }
+
+    private int execute(String sql, Long gisuId) {
+        return entityManager.createNativeQuery(sql)
+            .setParameter("gisuId", gisuId)
+            .executeUpdate();
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapter.java
@@ -1,12 +1,14 @@
 package com.umc.product.test.adapter.out.persistence;
 
-import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
-import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @Profile("!prod")

--- a/src/main/java/com/umc/product/test/application/port/in/command/DeleteSeedProjectDataUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/DeleteSeedProjectDataUseCase.java
@@ -1,0 +1,15 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
+
+/**
+ * 테스트 환경 프로젝트 관련 데이터 hard delete UseCase.
+ * <p>
+ * 운영 프로젝트 삭제 정책과 달리, 테스트 데이터 재시딩을 위해 지정 기수의 프로젝트·지원서·지원 폼·매칭 차수와
+ * 연결된 survey 데이터를 물리 삭제한다.
+ */
+public interface DeleteSeedProjectDataUseCase {
+
+    DeleteSeedProjectDataResult delete(DeleteSeedProjectDataCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataCommand.java
@@ -1,0 +1,15 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+/**
+ * 테스트 프로젝트 데이터 삭제 Command.
+ *
+ * @param gisuId 대상 기수 ID. null 이면 활성 기수를 사용한다.
+ */
+public record DeleteSeedProjectDataCommand(
+    Long gisuId
+) {
+
+    public static DeleteSeedProjectDataCommand of(Long gisuId) {
+        return new DeleteSeedProjectDataCommand(gisuId);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataResult.java
@@ -1,6 +1,7 @@
 package com.umc.product.test.application.port.in.command.dto;
 
 import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/DeleteSeedProjectDataResult.java
@@ -1,0 +1,49 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+import lombok.Builder;
+
+/**
+ * 테스트 프로젝트 데이터 삭제 결과.
+ */
+@Builder
+public record DeleteSeedProjectDataResult(
+    Long gisuId,
+    int deletedProjects,
+    int deletedProjectMembers,
+    int deletedProjectApplications,
+    int deletedProjectApplicationForms,
+    int deletedProjectApplicationFormPolicies,
+    int deletedProjectPartQuotas,
+    int deletedProjectMatchingRounds,
+    int deletedSurveyForms,
+    int deletedSurveyFormSections,
+    int deletedSurveyQuestions,
+    int deletedSurveyQuestionOptions,
+    int deletedSurveyFormResponses,
+    int deletedSurveyAnswers,
+    int deletedSurveyAnswerChoices,
+    int deletedSurveySingleAnswers
+) {
+
+    public static DeleteSeedProjectDataResult from(Long gisuId, ProjectDataDeletionCounts counts) {
+        return DeleteSeedProjectDataResult.builder()
+            .gisuId(gisuId)
+            .deletedProjects(counts.deletedProjects())
+            .deletedProjectMembers(counts.deletedProjectMembers())
+            .deletedProjectApplications(counts.deletedProjectApplications())
+            .deletedProjectApplicationForms(counts.deletedProjectApplicationForms())
+            .deletedProjectApplicationFormPolicies(counts.deletedProjectApplicationFormPolicies())
+            .deletedProjectPartQuotas(counts.deletedProjectPartQuotas())
+            .deletedProjectMatchingRounds(counts.deletedProjectMatchingRounds())
+            .deletedSurveyForms(counts.deletedSurveyForms())
+            .deletedSurveyFormSections(counts.deletedSurveyFormSections())
+            .deletedSurveyQuestions(counts.deletedSurveyQuestions())
+            .deletedSurveyQuestionOptions(counts.deletedSurveyQuestionOptions())
+            .deletedSurveyFormResponses(counts.deletedSurveyFormResponses())
+            .deletedSurveyAnswers(counts.deletedSurveyAnswers())
+            .deletedSurveyAnswerChoices(counts.deletedSurveyAnswerChoices())
+            .deletedSurveySingleAnswers(counts.deletedSurveySingleAnswers())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/out/DeleteSeedProjectDataPort.java
+++ b/src/main/java/com/umc/product/test/application/port/out/DeleteSeedProjectDataPort.java
@@ -1,0 +1,8 @@
+package com.umc.product.test.application.port.out;
+
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+
+public interface DeleteSeedProjectDataPort {
+
+    ProjectDataDeletionCounts deleteByGisuId(Long gisuId);
+}

--- a/src/main/java/com/umc/product/test/application/port/out/dto/ProjectDataDeletionCounts.java
+++ b/src/main/java/com/umc/product/test/application/port/out/dto/ProjectDataDeletionCounts.java
@@ -1,0 +1,23 @@
+package com.umc.product.test.application.port.out.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProjectDataDeletionCounts(
+    int deletedProjects,
+    int deletedProjectMembers,
+    int deletedProjectApplications,
+    int deletedProjectApplicationForms,
+    int deletedProjectApplicationFormPolicies,
+    int deletedProjectPartQuotas,
+    int deletedProjectMatchingRounds,
+    int deletedSurveyForms,
+    int deletedSurveyFormSections,
+    int deletedSurveyQuestions,
+    int deletedSurveyQuestionOptions,
+    int deletedSurveyFormResponses,
+    int deletedSurveyAnswers,
+    int deletedSurveyAnswerChoices,
+    int deletedSurveySingleAnswers
+) {
+}

--- a/src/main/java/com/umc/product/test/application/service/ProjectSeedDataCleanupService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectSeedDataCleanupService.java
@@ -1,17 +1,19 @@
 package com.umc.product.test.application.service;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.test.application.port.in.command.DeleteSeedProjectDataUseCase;
 import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
 import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
 import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
 import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/umc/product/test/application/service/ProjectSeedDataCleanupService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectSeedDataCleanupService.java
@@ -1,0 +1,44 @@
+package com.umc.product.test.application.service;
+
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.test.application.port.in.command.DeleteSeedProjectDataUseCase;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
+import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Transactional
+public class ProjectSeedDataCleanupService implements DeleteSeedProjectDataUseCase {
+
+    private final GetGisuUseCase getGisuUseCase;
+    private final DeleteSeedProjectDataPort deleteSeedProjectDataPort;
+
+    @Override
+    public DeleteSeedProjectDataResult delete(DeleteSeedProjectDataCommand command) {
+        Long gisuId = command.gisuId() != null ? command.gisuId() : getGisuUseCase.getActiveGisuId();
+        getGisuUseCase.getById(gisuId);
+
+        log.warn("seed project data cleanup start: gisuId={}", gisuId);
+        ProjectDataDeletionCounts counts = deleteSeedProjectDataPort.deleteByGisuId(gisuId);
+        DeleteSeedProjectDataResult result = DeleteSeedProjectDataResult.from(gisuId, counts);
+        log.warn(
+            "seed project data cleanup completed: gisuId={}, projects={}, applications={}, members={}",
+            gisuId,
+            result.deletedProjects(),
+            result.deletedProjectApplications(),
+            result.deletedProjectMembers()
+        );
+        return result;
+    }
+}

--- a/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
+++ b/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
@@ -17,6 +17,7 @@ import com.umc.product.test.application.service.MemberSeedService;
 import com.umc.product.test.application.service.NoticeSeedService;
 import com.umc.product.test.application.service.PartAssignmentPolicy;
 import com.umc.product.test.application.service.ProjectApplicationSeedService;
+import com.umc.product.test.application.service.ProjectSeedDataCleanupService;
 import com.umc.product.test.application.service.ProjectSeedService;
 import com.umc.product.test.application.service.SeedProperties;
 
@@ -35,6 +36,7 @@ class SeedControllerBeanRegistrationTest {
         MemberSeedService.class,
         ChallengerSeedService.class,
         ProjectSeedService.class,
+        ProjectSeedDataCleanupService.class,
         ProjectApplicationSeedService.class,
         CurriculumSeedService.class,
         NoticeSeedService.class,
@@ -45,7 +47,7 @@ class SeedControllerBeanRegistrationTest {
         SeedProperties.class
     })
     @DisplayName("모든 시딩 빈은 @Profile(!prod) + @ConditionalOnProperty(app.seed.enabled=true) 가드를 가진다")
-    void 시딩_빈_가드_어노테이션_보유(Class<?> seedBeanClass) {
+    void seedBeanGuardAnnotationsExist(Class<?> seedBeanClass) {
         Profile profile = seedBeanClass.getAnnotation(Profile.class);
         assertThat(profile)
             .as("%s 는 @Profile 가드가 있어야 한다", seedBeanClass.getSimpleName())

--- a/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
@@ -1,0 +1,415 @@
+package com.umc.product.test.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.support.TestContainersConfig;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = "app.seed.enabled=true")
+@Import({
+    JpaConfig.class,
+    QueryDslConfig.class,
+    TestContainersConfig.class,
+    ProjectSeedDataCleanupPersistenceAdapter.class
+})
+class ProjectSeedDataCleanupPersistenceAdapterTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectSeedDataCleanupPersistenceAdapter sut;
+
+    @Test
+    @DisplayName("대상 기수의 프로젝트 관련 데이터만 모두 삭제한다")
+    void 대상_기수_프로젝트_관련_데이터만_삭제() {
+        // Given
+        Long targetGisuId = insertGisu(11L);
+        Long otherGisuId = insertGisu(12L);
+        Long targetChapterId = insertChapter(targetGisuId, "target");
+        Long otherChapterId = insertChapter(otherGisuId, "other");
+        ProjectGraph target = insertProjectGraph(targetGisuId, targetChapterId, 100L);
+        ProjectGraph other = insertProjectGraph(otherGisuId, otherChapterId, 200L);
+        em.flush();
+        em.clear();
+
+        // When
+        ProjectDataDeletionCounts result = sut.deleteByGisuId(targetGisuId);
+        em.flush();
+        em.clear();
+
+        // Then
+        assertThat(result.deletedProjects()).isEqualTo(1);
+        assertThat(result.deletedProjectMembers()).isEqualTo(1);
+        assertThat(result.deletedProjectApplications()).isEqualTo(1);
+        assertThat(result.deletedProjectApplicationForms()).isEqualTo(1);
+        assertThat(result.deletedProjectApplicationFormPolicies()).isEqualTo(1);
+        assertThat(result.deletedProjectPartQuotas()).isEqualTo(1);
+        assertThat(result.deletedProjectMatchingRounds()).isEqualTo(1);
+        assertThat(result.deletedSurveyForms()).isEqualTo(1);
+        assertThat(result.deletedSurveyFormSections()).isEqualTo(1);
+        assertThat(result.deletedSurveyQuestions()).isEqualTo(1);
+        assertThat(result.deletedSurveyQuestionOptions()).isEqualTo(1);
+        assertThat(result.deletedSurveyFormResponses()).isEqualTo(1);
+        assertThat(result.deletedSurveyAnswers()).isEqualTo(1);
+        assertThat(result.deletedSurveyAnswerChoices()).isEqualTo(1);
+        assertThat(result.deletedSurveySingleAnswers()).isEqualTo(1);
+
+        assertGraphDeleted(target);
+        assertGraphExists(other);
+    }
+
+    private ProjectGraph insertProjectGraph(Long gisuId, Long chapterId, Long seed) {
+        Long projectId = insertProject(gisuId, chapterId, seed);
+        Long roundId = insertMatchingRound(chapterId, seed);
+        Long formId = insertForm(seed);
+        Long sectionId = insertFormSection(formId, seed);
+        Long questionId = insertQuestion(sectionId, seed);
+        Long optionId = insertQuestionOption(questionId, seed);
+        Long formResponseId = insertFormResponse(formId, seed);
+        Long answerId = insertAnswer(formResponseId, questionId);
+        Long answerChoiceId = insertAnswerChoice(answerId, optionId);
+        Long singleAnswerId = insertSingleAnswer(formResponseId, questionId, optionId);
+        Long applicationFormId = insertProjectApplicationForm(projectId, formId);
+        Long policyId = insertProjectApplicationFormPolicy(applicationFormId, sectionId);
+        Long applicationId = insertProjectApplication(applicationFormId, formResponseId, roundId, seed);
+        Long memberId = insertProjectMember(projectId, applicationId, seed);
+        Long quotaId = insertProjectPartQuota(projectId, seed);
+
+        return new ProjectGraph(
+            projectId,
+            memberId,
+            quotaId,
+            roundId,
+            applicationId,
+            applicationFormId,
+            policyId,
+            formId,
+            sectionId,
+            questionId,
+            optionId,
+            formResponseId,
+            answerId,
+            answerChoiceId,
+            singleAnswerId
+        );
+    }
+
+    private Long insertGisu(Long generation) {
+        return insertReturningId("""
+            INSERT INTO gisu (created_at, updated_at, generation, start_at, end_at, is_active)
+            VALUES (now(), now(), :generation, :startAt, :endAt, false)
+            RETURNING id
+            """, query -> {
+            query.setParameter("generation", generation);
+            query.setParameter("startAt", Instant.parse("2026-01-01T00:00:00Z"));
+            query.setParameter("endAt", Instant.parse("2026-12-31T00:00:00Z"));
+        });
+    }
+
+    private Long insertChapter(Long gisuId, String suffix) {
+        return insertReturningId("""
+            INSERT INTO chapter (created_at, updated_at, gisu_id, name)
+            VALUES (now(), now(), :gisuId, :name)
+            RETURNING id
+            """, query -> {
+            query.setParameter("gisuId", gisuId);
+            query.setParameter("name", "chapter-" + suffix);
+        });
+    }
+
+    private Long insertProject(Long gisuId, Long chapterId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO project (
+                created_at, updated_at, gisu_id, chapter_id, status, name,
+                product_owner_member_id, product_owner_school_id, created_by_member_id
+            )
+            VALUES (
+                now(), now(), :gisuId, :chapterId, 'IN_PROGRESS', :name,
+                :ownerId, :schoolId, :ownerId
+            )
+            RETURNING id
+            """, query -> {
+            query.setParameter("gisuId", gisuId);
+            query.setParameter("chapterId", chapterId);
+            query.setParameter("name", "project-" + seed);
+            query.setParameter("ownerId", seed);
+            query.setParameter("schoolId", seed);
+        });
+    }
+
+    private Long insertMatchingRound(Long chapterId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO project_matching_round (
+                created_at, updated_at, name, description, type, phase, chapter_id,
+                starts_at, ends_at, decision_deadline
+            )
+            VALUES (
+                now(), now(), :name, null, 'PLAN_DESIGN', 'FIRST', :chapterId,
+                now() - interval '1 hour', now() + interval '1 hour', now() + interval '2 hours'
+            )
+            RETURNING id
+            """, query -> {
+            query.setParameter("chapterId", chapterId);
+            query.setParameter("name", "round-" + seed);
+        });
+    }
+
+    private Long insertForm(Long seed) {
+        return insertReturningId("""
+            INSERT INTO form (created_at, updated_at, created_member_id, title, status, is_anonymous)
+            VALUES (now(), now(), :memberId, :title, 'PUBLISHED', false)
+            RETURNING id
+            """, query -> {
+            query.setParameter("memberId", seed);
+            query.setParameter("title", "form-" + seed);
+        });
+    }
+
+    private Long insertFormSection(Long formId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO form_section (created_at, updated_at, form_id, title, description, order_no)
+            VALUES (now(), now(), :formId, :title, null, 1)
+            RETURNING id
+            """, query -> {
+            query.setParameter("formId", formId);
+            query.setParameter("title", "section-" + seed);
+        });
+    }
+
+    private Long insertQuestion(Long sectionId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO question (
+                created_at, updated_at, form_section_id, title, description, type,
+                is_required, order_no, parent_question_id, is_active
+            )
+            VALUES (now(), now(), :sectionId, :title, null, 'RADIO', true, 1, null, true)
+            RETURNING id
+            """, query -> {
+            query.setParameter("sectionId", sectionId);
+            query.setParameter("title", "question-" + seed);
+        });
+    }
+
+    private Long insertQuestionOption(Long questionId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO question_option (created_at, updated_at, question_id, content, order_no, is_other)
+            VALUES (now(), now(), :questionId, :content, 1, false)
+            RETURNING id
+            """, query -> {
+            query.setParameter("questionId", questionId);
+            query.setParameter("content", "option-" + seed);
+        });
+    }
+
+    private Long insertFormResponse(Long formId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO form_response (
+                created_at, updated_at, form_id, respondent_member_id, status, last_saved_at
+            )
+            VALUES (now(), now(), :formId, :memberId, 'SUBMITTED', now())
+            RETURNING id
+            """, query -> {
+            query.setParameter("formId", formId);
+            query.setParameter("memberId", seed + 1000);
+        });
+    }
+
+    private Long insertAnswer(Long formResponseId, Long questionId) {
+        return insertReturningId("""
+            INSERT INTO answer (
+                created_at, updated_at, form_response_id, question_id, answered_as_type
+            )
+            VALUES (now(), now(), :formResponseId, :questionId, 'RADIO')
+            RETURNING id
+            """, query -> {
+            query.setParameter("formResponseId", formResponseId);
+            query.setParameter("questionId", questionId);
+        });
+    }
+
+    private Long insertAnswerChoice(Long answerId, Long optionId) {
+        return insertReturningId("""
+            INSERT INTO answer_choice (
+                created_at, updated_at, answer_id, answered_as_content, question_option_id
+            )
+            VALUES (now(), now(), :answerId, '선택지', :optionId)
+            RETURNING id
+            """, query -> {
+            query.setParameter("answerId", answerId);
+            query.setParameter("optionId", optionId);
+        });
+    }
+
+    private Long insertSingleAnswer(Long responseId, Long questionId, Long optionId) {
+        return insertReturningId("""
+            INSERT INTO single_answer (
+                created_at, updated_at, response_id, question_id, answered_as_type, value
+            )
+            VALUES (
+                now(), now(), :responseId, :questionId, 'RADIO',
+                jsonb_build_object('selectedOptionId', :optionId)
+            )
+            RETURNING id
+            """, query -> {
+            query.setParameter("responseId", responseId);
+            query.setParameter("questionId", questionId);
+            query.setParameter("optionId", optionId);
+        });
+    }
+
+    private Long insertProjectApplicationForm(Long projectId, Long formId) {
+        return insertReturningId("""
+            INSERT INTO project_application_form (created_at, updated_at, project_id, form_id)
+            VALUES (now(), now(), :projectId, :formId)
+            RETURNING id
+            """, query -> {
+            query.setParameter("projectId", projectId);
+            query.setParameter("formId", formId);
+        });
+    }
+
+    private Long insertProjectApplicationFormPolicy(Long applicationFormId, Long sectionId) {
+        return insertReturningId("""
+            INSERT INTO project_application_form_policy (
+                created_at, updated_at, project_application_form_id, form_section_id, type, allowed_parts
+            )
+            VALUES (now(), now(), :applicationFormId, :sectionId, 'COMMON', null)
+            RETURNING id
+            """, query -> {
+            query.setParameter("applicationFormId", applicationFormId);
+            query.setParameter("sectionId", sectionId);
+        });
+    }
+
+    private Long insertProjectApplication(
+        Long applicationFormId, Long formResponseId, Long roundId, Long seed
+    ) {
+        return insertReturningId("""
+            INSERT INTO project_application (
+                created_at, updated_at, project_application_form_id, form_response_id,
+                applicant_member_id, applied_matching_round_id, status, submitted_at, status_changed_at
+            )
+            VALUES (
+                now(), now(), :applicationFormId, :formResponseId,
+                :memberId, :roundId, 'APPROVED', now(), now()
+            )
+            RETURNING id
+            """, query -> {
+            query.setParameter("applicationFormId", applicationFormId);
+            query.setParameter("formResponseId", formResponseId);
+            query.setParameter("memberId", seed + 1000);
+            query.setParameter("roundId", roundId);
+        });
+    }
+
+    private Long insertProjectMember(Long projectId, Long applicationId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO project_member (
+                created_at, updated_at, project_id, project_application_id, member_id,
+                part, is_leader, decided_member_id, decided_at, status
+            )
+            VALUES (
+                now(), now(), :projectId, :applicationId, :memberId,
+                'WEB', false, :decidedMemberId, now(), 'ACTIVE'
+            )
+            RETURNING id
+            """, query -> {
+            query.setParameter("projectId", projectId);
+            query.setParameter("applicationId", applicationId);
+            query.setParameter("memberId", seed + 1000);
+            query.setParameter("decidedMemberId", seed);
+        });
+    }
+
+    private Long insertProjectPartQuota(Long projectId, Long seed) {
+        return insertReturningId("""
+            INSERT INTO project_part_quota (
+                created_at, updated_at, project_id, part, quota, last_edited_member_id
+            )
+            VALUES (now(), now(), :projectId, 'WEB', 3, :memberId)
+            RETURNING id
+            """, query -> {
+            query.setParameter("projectId", projectId);
+            query.setParameter("memberId", seed);
+        });
+    }
+
+    private Long insertReturningId(String sql, QueryBinder binder) {
+        var query = em.getEntityManager().createNativeQuery(sql);
+        binder.bind(query);
+        return ((Number) query.getSingleResult()).longValue();
+    }
+
+    private boolean existsById(String tableName, Long id) {
+        Object result = em.getEntityManager()
+            .createNativeQuery("SELECT EXISTS (SELECT 1 FROM " + tableName + " WHERE id = :id)")
+            .setParameter("id", id)
+            .getSingleResult();
+        return (Boolean) result;
+    }
+
+    private void assertGraphDeleted(ProjectGraph graph) {
+        assertGraphState(graph, false);
+    }
+
+    private void assertGraphExists(ProjectGraph graph) {
+        assertGraphState(graph, true);
+    }
+
+    private void assertGraphState(ProjectGraph graph, boolean expected) {
+        assertThat(existsById("project", graph.projectId())).isEqualTo(expected);
+        assertThat(existsById("project_member", graph.memberId())).isEqualTo(expected);
+        assertThat(existsById("project_part_quota", graph.quotaId())).isEqualTo(expected);
+        assertThat(existsById("project_matching_round", graph.roundId())).isEqualTo(expected);
+        assertThat(existsById("project_application", graph.applicationId())).isEqualTo(expected);
+        assertThat(existsById("project_application_form", graph.applicationFormId())).isEqualTo(expected);
+        assertThat(existsById("project_application_form_policy", graph.policyId())).isEqualTo(expected);
+        assertThat(existsById("form", graph.formId())).isEqualTo(expected);
+        assertThat(existsById("form_section", graph.sectionId())).isEqualTo(expected);
+        assertThat(existsById("question", graph.questionId())).isEqualTo(expected);
+        assertThat(existsById("question_option", graph.optionId())).isEqualTo(expected);
+        assertThat(existsById("form_response", graph.formResponseId())).isEqualTo(expected);
+        assertThat(existsById("answer", graph.answerId())).isEqualTo(expected);
+        assertThat(existsById("answer_choice", graph.answerChoiceId())).isEqualTo(expected);
+        assertThat(existsById("single_answer", graph.singleAnswerId())).isEqualTo(expected);
+    }
+
+    private interface QueryBinder {
+        void bind(jakarta.persistence.Query query);
+    }
+
+    private record ProjectGraph(
+        Long projectId,
+        Long memberId,
+        Long quotaId,
+        Long roundId,
+        Long applicationId,
+        Long applicationFormId,
+        Long policyId,
+        Long formId,
+        Long sectionId,
+        Long questionId,
+        Long optionId,
+        Long formResponseId,
+        Long answerId,
+        Long answerChoiceId,
+        Long singleAnswerId
+    ) {
+    }
+}

--- a/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
@@ -2,11 +2,8 @@ package com.umc.product.test.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.support.TestContainersConfig;
-import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
 import java.time.Instant;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +13,33 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
+import com.umc.product.project.domain.ProjectMatchingRound;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.MatchingPhase;
+import com.umc.product.project.domain.enums.MatchingType;
+import com.umc.product.support.TestContainersConfig;
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
+import com.umc.product.survey.domain.enums.QuestionType;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+
+import jakarta.persistence.Query;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -29,6 +53,12 @@ import org.springframework.test.context.TestPropertySource;
 })
 class ProjectSeedDataCleanupPersistenceAdapterTest {
 
+    private static final Instant GISU_START_AT = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant GISU_END_AT = Instant.parse("2026-12-31T00:00:00Z");
+    private static final Instant ROUND_STARTS_AT = Instant.parse("2026-03-01T00:00:00Z");
+    private static final Instant ROUND_ENDS_AT = Instant.parse("2026-03-02T00:00:00Z");
+    private static final Instant ROUND_DECISION_DEADLINE = Instant.parse("2026-03-03T00:00:00Z");
+
     @Autowired
     TestEntityManager em;
 
@@ -37,19 +67,19 @@ class ProjectSeedDataCleanupPersistenceAdapterTest {
 
     @Test
     @DisplayName("대상 기수의 프로젝트 관련 데이터만 모두 삭제한다")
-    void 대상_기수_프로젝트_관련_데이터만_삭제() {
+    void deleteOnlyTargetGisuProjectData() {
         // Given
-        Long targetGisuId = insertGisu(11L);
-        Long otherGisuId = insertGisu(12L);
-        Long targetChapterId = insertChapter(targetGisuId, "target");
-        Long otherChapterId = insertChapter(otherGisuId, "other");
-        ProjectGraph target = insertProjectGraph(targetGisuId, targetChapterId, 100L);
-        ProjectGraph other = insertProjectGraph(otherGisuId, otherChapterId, 200L);
+        Gisu targetGisu = persistGisu(11L);
+        Gisu otherGisu = persistGisu(12L);
+        Chapter targetChapter = persistChapter(targetGisu, "target");
+        Chapter otherChapter = persistChapter(otherGisu, "other");
+        ProjectGraph target = persistProjectGraph(targetGisu.getId(), targetChapter.getId(), 100L);
+        ProjectGraph other = persistProjectGraph(otherGisu.getId(), otherChapter.getId(), 200L);
         em.flush();
         em.clear();
 
         // When
-        ProjectDataDeletionCounts result = sut.deleteByGisuId(targetGisuId);
+        ProjectDataDeletionCounts result = sut.deleteByGisuId(targetGisu.getId());
         em.flush();
         em.clear();
 
@@ -74,190 +104,106 @@ class ProjectSeedDataCleanupPersistenceAdapterTest {
         assertGraphExists(other);
     }
 
-    private ProjectGraph insertProjectGraph(Long gisuId, Long chapterId, Long seed) {
-        Long projectId = insertProject(gisuId, chapterId, seed);
-        Long roundId = insertMatchingRound(chapterId, seed);
-        Long formId = insertForm(seed);
-        Long sectionId = insertFormSection(formId, seed);
-        Long questionId = insertQuestion(sectionId, seed);
-        Long optionId = insertQuestionOption(questionId, seed);
-        Long formResponseId = insertFormResponse(formId, seed);
-        Long answerId = insertAnswer(formResponseId, questionId);
-        Long answerChoiceId = insertAnswerChoice(answerId, optionId);
-        Long singleAnswerId = insertSingleAnswer(formResponseId, questionId, optionId);
-        Long applicationFormId = insertProjectApplicationForm(projectId, formId);
-        Long policyId = insertProjectApplicationFormPolicy(applicationFormId, sectionId);
-        Long applicationId = insertProjectApplication(applicationFormId, formResponseId, roundId, seed);
-        Long memberId = insertProjectMember(projectId, applicationId, seed);
-        Long quotaId = insertProjectPartQuota(projectId, seed);
+    private Gisu persistGisu(Long generation) {
+        Gisu gisu = Gisu.create(generation, GISU_START_AT, GISU_END_AT, false);
+        em.persist(gisu);
+        return gisu;
+    }
+
+    private Chapter persistChapter(Gisu gisu, String suffix) {
+        Chapter chapter = Chapter.create(gisu, "chapter-" + suffix);
+        em.persist(chapter);
+        return chapter;
+    }
+
+    private ProjectGraph persistProjectGraph(Long gisuId, Long chapterId, Long seed) {
+        Project project = Project.createDraft(gisuId, chapterId, seed, seed, seed);
+        em.persist(project);
+
+        ProjectMatchingRound round = ProjectMatchingRound.create(
+            "round-" + seed,
+            null,
+            MatchingType.PLAN_DESIGN,
+            MatchingPhase.FIRST,
+            chapterId,
+            ROUND_STARTS_AT,
+            ROUND_ENDS_AT,
+            ROUND_DECISION_DEADLINE
+        );
+        em.persist(round);
+
+        Form form = Form.createPublished(seed, "form-" + seed, false);
+        em.persist(form);
+
+        FormSection section = FormSection.create(form, "section-" + seed, null, 1L);
+        em.persist(section);
+
+        Question question = Question.create("question-" + seed, QuestionType.RADIO, true, 1L);
+        question.assignTo(section);
+        em.persist(question);
+
+        QuestionOption option = QuestionOption.create("option-" + seed, 1L, false);
+        option.assignTo(question);
+        em.persist(option);
+
+        FormResponse formResponse = FormResponse.createDraft(form, seed + 1000);
+        formResponse.submit(Instant.now(), "127.0.0.1");
+        em.persist(formResponse);
+
+        Answer answer = Answer.create(formResponse, question, QuestionType.RADIO, null, null);
+        em.persist(answer);
+
+        AnswerChoice answerChoice = AnswerChoice.create(answer, option);
+        em.persist(answerChoice);
+
+        em.flush();
+        Long singleAnswerId = insertLegacySingleAnswer(formResponse.getId(), question.getId(), option.getId());
+
+        ProjectApplicationForm applicationForm = ProjectApplicationForm.create(project, form.getId());
+        em.persist(applicationForm);
+
+        ProjectApplicationFormPolicy policy = ProjectApplicationFormPolicy.createCommon(
+            applicationForm,
+            section.getId()
+        );
+        em.persist(policy);
+
+        ProjectApplication application = ProjectApplication.create(
+            applicationForm,
+            formResponse.getId(),
+            seed + 1000,
+            round
+        );
+        em.persist(application);
+
+        ProjectMember member = ProjectMember.create(project, seed + 1000, ChallengerPart.WEB, seed);
+        em.persist(member);
+
+        ProjectPartQuota quota = ProjectPartQuota.create(project, ChallengerPart.WEB, 3L, seed);
+        em.persist(quota);
 
         return new ProjectGraph(
-            projectId,
-            memberId,
-            quotaId,
-            roundId,
-            applicationId,
-            applicationFormId,
-            policyId,
-            formId,
-            sectionId,
-            questionId,
-            optionId,
-            formResponseId,
-            answerId,
-            answerChoiceId,
+            project.getId(),
+            member.getId(),
+            quota.getId(),
+            round.getId(),
+            application.getId(),
+            applicationForm.getId(),
+            policy.getId(),
+            form.getId(),
+            section.getId(),
+            question.getId(),
+            option.getId(),
+            formResponse.getId(),
+            answer.getId(),
+            answerChoice.getId(),
             singleAnswerId
         );
     }
 
-    private Long insertGisu(Long generation) {
-        return insertReturningId("""
-            INSERT INTO gisu (created_at, updated_at, generation, start_at, end_at, is_active)
-            VALUES (now(), now(), :generation, :startAt, :endAt, false)
-            RETURNING id
-            """, query -> {
-            query.setParameter("generation", generation);
-            query.setParameter("startAt", Instant.parse("2026-01-01T00:00:00Z"));
-            query.setParameter("endAt", Instant.parse("2026-12-31T00:00:00Z"));
-        });
-    }
-
-    private Long insertChapter(Long gisuId, String suffix) {
-        return insertReturningId("""
-            INSERT INTO chapter (created_at, updated_at, gisu_id, name)
-            VALUES (now(), now(), :gisuId, :name)
-            RETURNING id
-            """, query -> {
-            query.setParameter("gisuId", gisuId);
-            query.setParameter("name", "chapter-" + suffix);
-        });
-    }
-
-    private Long insertProject(Long gisuId, Long chapterId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO project (
-                created_at, updated_at, gisu_id, chapter_id, status, name,
-                product_owner_member_id, product_owner_school_id, created_by_member_id
-            )
-            VALUES (
-                now(), now(), :gisuId, :chapterId, 'IN_PROGRESS', :name,
-                :ownerId, :schoolId, :ownerId
-            )
-            RETURNING id
-            """, query -> {
-            query.setParameter("gisuId", gisuId);
-            query.setParameter("chapterId", chapterId);
-            query.setParameter("name", "project-" + seed);
-            query.setParameter("ownerId", seed);
-            query.setParameter("schoolId", seed);
-        });
-    }
-
-    private Long insertMatchingRound(Long chapterId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO project_matching_round (
-                created_at, updated_at, name, description, type, phase, chapter_id,
-                starts_at, ends_at, decision_deadline
-            )
-            VALUES (
-                now(), now(), :name, null, 'PLAN_DESIGN', 'FIRST', :chapterId,
-                now() - interval '1 hour', now() + interval '1 hour', now() + interval '2 hours'
-            )
-            RETURNING id
-            """, query -> {
-            query.setParameter("chapterId", chapterId);
-            query.setParameter("name", "round-" + seed);
-        });
-    }
-
-    private Long insertForm(Long seed) {
-        return insertReturningId("""
-            INSERT INTO form (created_at, updated_at, created_member_id, title, status, is_anonymous)
-            VALUES (now(), now(), :memberId, :title, 'PUBLISHED', false)
-            RETURNING id
-            """, query -> {
-            query.setParameter("memberId", seed);
-            query.setParameter("title", "form-" + seed);
-        });
-    }
-
-    private Long insertFormSection(Long formId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO form_section (created_at, updated_at, form_id, title, description, order_no)
-            VALUES (now(), now(), :formId, :title, null, 1)
-            RETURNING id
-            """, query -> {
-            query.setParameter("formId", formId);
-            query.setParameter("title", "section-" + seed);
-        });
-    }
-
-    private Long insertQuestion(Long sectionId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO question (
-                created_at, updated_at, form_section_id, title, description, type,
-                is_required, order_no, parent_question_id, is_active
-            )
-            VALUES (now(), now(), :sectionId, :title, null, 'RADIO', true, 1, null, true)
-            RETURNING id
-            """, query -> {
-            query.setParameter("sectionId", sectionId);
-            query.setParameter("title", "question-" + seed);
-        });
-    }
-
-    private Long insertQuestionOption(Long questionId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO question_option (created_at, updated_at, question_id, content, order_no, is_other)
-            VALUES (now(), now(), :questionId, :content, 1, false)
-            RETURNING id
-            """, query -> {
-            query.setParameter("questionId", questionId);
-            query.setParameter("content", "option-" + seed);
-        });
-    }
-
-    private Long insertFormResponse(Long formId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO form_response (
-                created_at, updated_at, form_id, respondent_member_id, status, last_saved_at
-            )
-            VALUES (now(), now(), :formId, :memberId, 'SUBMITTED', now())
-            RETURNING id
-            """, query -> {
-            query.setParameter("formId", formId);
-            query.setParameter("memberId", seed + 1000);
-        });
-    }
-
-    private Long insertAnswer(Long formResponseId, Long questionId) {
-        return insertReturningId("""
-            INSERT INTO answer (
-                created_at, updated_at, form_response_id, question_id, answered_as_type
-            )
-            VALUES (now(), now(), :formResponseId, :questionId, 'RADIO')
-            RETURNING id
-            """, query -> {
-            query.setParameter("formResponseId", formResponseId);
-            query.setParameter("questionId", questionId);
-        });
-    }
-
-    private Long insertAnswerChoice(Long answerId, Long optionId) {
-        return insertReturningId("""
-            INSERT INTO answer_choice (
-                created_at, updated_at, answer_id, answered_as_content, question_option_id
-            )
-            VALUES (now(), now(), :answerId, '선택지', :optionId)
-            RETURNING id
-            """, query -> {
-            query.setParameter("answerId", answerId);
-            query.setParameter("optionId", optionId);
-        });
-    }
-
-    private Long insertSingleAnswer(Long responseId, Long questionId, Long optionId) {
-        return insertReturningId("""
+    private Long insertLegacySingleAnswer(Long responseId, Long questionId, Long optionId) {
+        // single_answer는 현재 JPA 엔티티가 없는 레거시 테이블이라 삭제 경로 검증에 필요한 행만 직접 삽입한다.
+        Query query = em.getEntityManager().createNativeQuery("""
             INSERT INTO single_answer (
                 created_at, updated_at, response_id, question_id, answered_as_type, value
             )
@@ -266,99 +212,20 @@ class ProjectSeedDataCleanupPersistenceAdapterTest {
                 jsonb_build_object('selectedOptionId', :optionId)
             )
             RETURNING id
-            """, query -> {
-            query.setParameter("responseId", responseId);
-            query.setParameter("questionId", questionId);
-            query.setParameter("optionId", optionId);
-        });
-    }
-
-    private Long insertProjectApplicationForm(Long projectId, Long formId) {
-        return insertReturningId("""
-            INSERT INTO project_application_form (created_at, updated_at, project_id, form_id)
-            VALUES (now(), now(), :projectId, :formId)
-            RETURNING id
-            """, query -> {
-            query.setParameter("projectId", projectId);
-            query.setParameter("formId", formId);
-        });
-    }
-
-    private Long insertProjectApplicationFormPolicy(Long applicationFormId, Long sectionId) {
-        return insertReturningId("""
-            INSERT INTO project_application_form_policy (
-                created_at, updated_at, project_application_form_id, form_section_id, type, allowed_parts
-            )
-            VALUES (now(), now(), :applicationFormId, :sectionId, 'COMMON', null)
-            RETURNING id
-            """, query -> {
-            query.setParameter("applicationFormId", applicationFormId);
-            query.setParameter("sectionId", sectionId);
-        });
-    }
-
-    private Long insertProjectApplication(
-        Long applicationFormId, Long formResponseId, Long roundId, Long seed
-    ) {
-        return insertReturningId("""
-            INSERT INTO project_application (
-                created_at, updated_at, project_application_form_id, form_response_id,
-                applicant_member_id, applied_matching_round_id, status, submitted_at, status_changed_at
-            )
-            VALUES (
-                now(), now(), :applicationFormId, :formResponseId,
-                :memberId, :roundId, 'APPROVED', now(), now()
-            )
-            RETURNING id
-            """, query -> {
-            query.setParameter("applicationFormId", applicationFormId);
-            query.setParameter("formResponseId", formResponseId);
-            query.setParameter("memberId", seed + 1000);
-            query.setParameter("roundId", roundId);
-        });
-    }
-
-    private Long insertProjectMember(Long projectId, Long applicationId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO project_member (
-                created_at, updated_at, project_id, project_application_id, member_id,
-                part, is_leader, decided_member_id, decided_at, status
-            )
-            VALUES (
-                now(), now(), :projectId, :applicationId, :memberId,
-                'WEB', false, :decidedMemberId, now(), 'ACTIVE'
-            )
-            RETURNING id
-            """, query -> {
-            query.setParameter("projectId", projectId);
-            query.setParameter("applicationId", applicationId);
-            query.setParameter("memberId", seed + 1000);
-            query.setParameter("decidedMemberId", seed);
-        });
-    }
-
-    private Long insertProjectPartQuota(Long projectId, Long seed) {
-        return insertReturningId("""
-            INSERT INTO project_part_quota (
-                created_at, updated_at, project_id, part, quota, last_edited_member_id
-            )
-            VALUES (now(), now(), :projectId, 'WEB', 3, :memberId)
-            RETURNING id
-            """, query -> {
-            query.setParameter("projectId", projectId);
-            query.setParameter("memberId", seed);
-        });
-    }
-
-    private Long insertReturningId(String sql, QueryBinder binder) {
-        var query = em.getEntityManager().createNativeQuery(sql);
-        binder.bind(query);
+            """);
+        query.setParameter("responseId", responseId);
+        query.setParameter("questionId", questionId);
+        query.setParameter("optionId", optionId);
         return ((Number) query.getSingleResult()).longValue();
     }
 
-    private boolean existsById(String tableName, Long id) {
+    private <T> boolean existsById(Class<T> entityClass, Long id) {
+        return em.find(entityClass, id) != null;
+    }
+
+    private boolean existsLegacySingleAnswerById(Long id) {
         Object result = em.getEntityManager()
-            .createNativeQuery("SELECT EXISTS (SELECT 1 FROM " + tableName + " WHERE id = :id)")
+            .createNativeQuery("SELECT EXISTS (SELECT 1 FROM single_answer WHERE id = :id)")
             .setParameter("id", id)
             .getSingleResult();
         return (Boolean) result;
@@ -373,25 +240,21 @@ class ProjectSeedDataCleanupPersistenceAdapterTest {
     }
 
     private void assertGraphState(ProjectGraph graph, boolean expected) {
-        assertThat(existsById("project", graph.projectId())).isEqualTo(expected);
-        assertThat(existsById("project_member", graph.memberId())).isEqualTo(expected);
-        assertThat(existsById("project_part_quota", graph.quotaId())).isEqualTo(expected);
-        assertThat(existsById("project_matching_round", graph.roundId())).isEqualTo(expected);
-        assertThat(existsById("project_application", graph.applicationId())).isEqualTo(expected);
-        assertThat(existsById("project_application_form", graph.applicationFormId())).isEqualTo(expected);
-        assertThat(existsById("project_application_form_policy", graph.policyId())).isEqualTo(expected);
-        assertThat(existsById("form", graph.formId())).isEqualTo(expected);
-        assertThat(existsById("form_section", graph.sectionId())).isEqualTo(expected);
-        assertThat(existsById("question", graph.questionId())).isEqualTo(expected);
-        assertThat(existsById("question_option", graph.optionId())).isEqualTo(expected);
-        assertThat(existsById("form_response", graph.formResponseId())).isEqualTo(expected);
-        assertThat(existsById("answer", graph.answerId())).isEqualTo(expected);
-        assertThat(existsById("answer_choice", graph.answerChoiceId())).isEqualTo(expected);
-        assertThat(existsById("single_answer", graph.singleAnswerId())).isEqualTo(expected);
-    }
-
-    private interface QueryBinder {
-        void bind(jakarta.persistence.Query query);
+        assertThat(existsById(Project.class, graph.projectId())).isEqualTo(expected);
+        assertThat(existsById(ProjectMember.class, graph.memberId())).isEqualTo(expected);
+        assertThat(existsById(ProjectPartQuota.class, graph.quotaId())).isEqualTo(expected);
+        assertThat(existsById(ProjectMatchingRound.class, graph.roundId())).isEqualTo(expected);
+        assertThat(existsById(ProjectApplication.class, graph.applicationId())).isEqualTo(expected);
+        assertThat(existsById(ProjectApplicationForm.class, graph.applicationFormId())).isEqualTo(expected);
+        assertThat(existsById(ProjectApplicationFormPolicy.class, graph.policyId())).isEqualTo(expected);
+        assertThat(existsById(Form.class, graph.formId())).isEqualTo(expected);
+        assertThat(existsById(FormSection.class, graph.sectionId())).isEqualTo(expected);
+        assertThat(existsById(Question.class, graph.questionId())).isEqualTo(expected);
+        assertThat(existsById(QuestionOption.class, graph.optionId())).isEqualTo(expected);
+        assertThat(existsById(FormResponse.class, graph.formResponseId())).isEqualTo(expected);
+        assertThat(existsById(Answer.class, graph.answerId())).isEqualTo(expected);
+        assertThat(existsById(AnswerChoice.class, graph.answerChoiceId())).isEqualTo(expected);
+        assertThat(existsLegacySingleAnswerById(graph.singleAnswerId())).isEqualTo(expected);
     }
 
     private record ProjectGraph(

--- a/src/test/java/com/umc/product/test/application/service/ProjectSeedDataCleanupServiceTest.java
+++ b/src/test/java/com/umc/product/test/application/service/ProjectSeedDataCleanupServiceTest.java
@@ -5,17 +5,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
-import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
-import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
-import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
-import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
-import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
+import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectSeedDataCleanupServiceTest {
@@ -34,7 +35,7 @@ class ProjectSeedDataCleanupServiceTest {
 
     @Test
     @DisplayName("gisuId가 지정되면 해당 기수 프로젝트 데이터를 삭제한다")
-    void 지정_기수_프로젝트_데이터_삭제() {
+    void deleteSpecifiedGisuProjectData() {
         // Given
         ProjectDataDeletionCounts counts = ProjectDataDeletionCounts.builder()
             .deletedProjects(2)
@@ -56,7 +57,7 @@ class ProjectSeedDataCleanupServiceTest {
 
     @Test
     @DisplayName("gisuId가 null이면 활성 기수 프로젝트 데이터를 삭제한다")
-    void 활성_기수_프로젝트_데이터_삭제() {
+    void deleteActiveGisuProjectData() {
         // Given
         given(getGisuUseCase.getActiveGisuId()).willReturn(10L);
         ProjectDataDeletionCounts counts = ProjectDataDeletionCounts.builder()

--- a/src/test/java/com/umc/product/test/application/service/ProjectSeedDataCleanupServiceTest.java
+++ b/src/test/java/com/umc/product/test/application/service/ProjectSeedDataCleanupServiceTest.java
@@ -1,0 +1,77 @@
+package com.umc.product.test.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataCommand;
+import com.umc.product.test.application.port.in.command.dto.DeleteSeedProjectDataResult;
+import com.umc.product.test.application.port.out.DeleteSeedProjectDataPort;
+import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectSeedDataCleanupServiceTest {
+
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+    @Mock
+    DeleteSeedProjectDataPort deleteSeedProjectDataPort;
+
+    ProjectSeedDataCleanupService sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new ProjectSeedDataCleanupService(getGisuUseCase, deleteSeedProjectDataPort);
+    }
+
+    @Test
+    @DisplayName("gisuId가 지정되면 해당 기수 프로젝트 데이터를 삭제한다")
+    void 지정_기수_프로젝트_데이터_삭제() {
+        // Given
+        ProjectDataDeletionCounts counts = ProjectDataDeletionCounts.builder()
+            .deletedProjects(2)
+            .deletedProjectMembers(20)
+            .build();
+        given(deleteSeedProjectDataPort.deleteByGisuId(9L)).willReturn(counts);
+
+        // When
+        DeleteSeedProjectDataResult result = sut.delete(DeleteSeedProjectDataCommand.of(9L));
+
+        // Then
+        assertThat(result.gisuId()).isEqualTo(9L);
+        assertThat(result.deletedProjects()).isEqualTo(2);
+        assertThat(result.deletedProjectMembers()).isEqualTo(20);
+        then(getGisuUseCase).should().getById(9L);
+        then(getGisuUseCase).should(never()).getActiveGisuId();
+        then(deleteSeedProjectDataPort).should().deleteByGisuId(9L);
+    }
+
+    @Test
+    @DisplayName("gisuId가 null이면 활성 기수 프로젝트 데이터를 삭제한다")
+    void 활성_기수_프로젝트_데이터_삭제() {
+        // Given
+        given(getGisuUseCase.getActiveGisuId()).willReturn(10L);
+        ProjectDataDeletionCounts counts = ProjectDataDeletionCounts.builder()
+            .deletedProjects(1)
+            .build();
+        given(deleteSeedProjectDataPort.deleteByGisuId(10L)).willReturn(counts);
+
+        // When
+        DeleteSeedProjectDataResult result = sut.delete(DeleteSeedProjectDataCommand.of(null));
+
+        // Then
+        assertThat(result.gisuId()).isEqualTo(10L);
+        assertThat(result.deletedProjects()).isEqualTo(1);
+        then(getGisuUseCase).should().getActiveGisuId();
+        then(getGisuUseCase).should().getById(10L);
+        then(deleteSeedProjectDataPort).should().deleteByGisuId(10L);
+    }
+}


### PR DESCRIPTION
## 대상 브랜치
- base: `develop`
- head: `feature/test-project-data-cleanup-api`

## 작업 내용
- `DELETE /test/seed/projects` 테스트 전용 API를 추가했습니다.
- `gisuId`가 주어지면 해당 기수, 생략되거나 `null`이면 활성 기수의 프로젝트 관련 데이터를 삭제합니다.
- Project, ProjectMember, ProjectPartQuota, ProjectApplication, ProjectApplicationForm/Policy, 해당 기수 Chapter의 ProjectMatchingRound를 정리합니다.
- 프로젝트 지원 폼이 생성한 survey Form/FormSection/Question/QuestionOption/FormResponse/Answer/AnswerChoice/legacy SingleAnswer까지 FK 순서대로 정리합니다.
- 삭제 건수를 응답으로 반환하도록 DTO를 추가했습니다.

## 리뷰 중점사항
- 테스트 전용 API의 삭제 범위가 기대하는 프로젝트 관련 데이터 범위와 맞는지 확인 부탁드립니다.
- `ProjectMatchingRound`는 `gisu_id`가 없어 `chapter.gisu_id` 기준으로 삭제합니다.
- 운영 삭제 유스케이스의 상태 제한과 분리하기 위해 test 도메인 전용 UseCase/Port/Adapter로 구성했습니다.

## 검증
- `./gradlew checkstyleMain checkstyleTest test --tests 'com.umc.product.test.*'`

## 이슈
- 별도 이슈 없음
