### PR TITLE
[Fix] 지원서 제출 시 비활성화된 질문이 필수 검증에 포함되는 문제 수정

### DIFF
--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
@@ -49,7 +49,7 @@ public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
     Optional<Question> findFirstByFormIdAndType(@Param("formId") Long formId, @Param("type") QuestionType type);
 
     /**
-     * 특정 폼의 모든 질문을 섹션 순서, 질문 순서대로 조회
+     * 특정 폼의 활성화된 질문을 섹션 순서, 질문 순서대로 조회
      */
     @Query("""
                 SELECT q
@@ -57,6 +57,7 @@ public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
                 JOIN q.formSection fs
                 JOIN fs.form f
                 WHERE f.id = :formId
+                  AND q.isActive = true
                 ORDER BY fs.orderNo ASC, q.orderNo ASC
             """)
     List<Question> findAllByFormId(@Param("formId") Long formId);

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
@@ -1,15 +1,17 @@
 package com.umc.product.survey.adapter.out.persistence;
 
-import com.umc.product.survey.domain.Question;
-import com.umc.product.survey.domain.enums.QuestionType;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.enums.QuestionType;
 
 public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
     /**

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionJpaRepository.java
@@ -62,7 +62,7 @@ public interface QuestionJpaRepository extends JpaRepository<Question, Long> {
                   AND q.isActive = true
                 ORDER BY fs.orderNo ASC, q.orderNo ASC
             """)
-    List<Question> findAllByFormId(@Param("formId") Long formId);
+    List<Question> findAllByFormIdAndIsActiveTrue(@Param("formId") Long formId);
 
     /**
      * 특정 폼에 속한 모든 질문 삭제 (deleteForm cascade 용)

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -1,17 +1,19 @@
 package com.umc.product.survey.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.survey.application.port.out.LoadQuestionPort;
 import com.umc.product.survey.application.port.out.SaveQuestionPort;
 import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -64,7 +64,7 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
 
     @Override
     public List<Question> listByFormId(Long formId) {
-        return questionJpaRepository.findAllByFormId(formId);
+        return questionJpaRepository.findAllByFormIdAndIsActiveTrue(formId);
     }
 
     @Override


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #959 

## 🚀 작업 내용

지원서 제출(POST `/projects/{projectId}/applications/me/submit`) 시 `SURVEY-0010` 에러가 발생하는 버그를 수정합니다.

폼 질문 수정 시 기존 질문이 `is_active = false`로 비활성화되고 새 버전이 생성되지만, 필수 질문 검증에 사용되는 `findAllByFormId` 쿼리에 `is_active` 필터가 없어 화면에 노출되지 않는 구버전 질문도 검증 대상에 포함되는 문제가 있었습니다.

-> `QuestionJpaRepository.findAllByFormId()` 쿼리에 `AND q.isActive = true` 조건을 추가하여 활성화된 질문만 필수 검증 대상에 포함되도록 수정했습니다.

## 💬 리뷰 중점사항
