### PR TITLE
[Fix] API 에러 응답 처리 표준화

### DIFF
--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -28,11 +28,11 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.global.security.ApiAccessDeniedHandler;
 import com.umc.product.global.security.ApiAuthenticationEntryPoint;
 import com.umc.product.global.security.JwtAuthenticationFilter;
 import com.umc.product.global.security.util.PublicEndpointCollector;
+import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.maintenance.adapter.in.web.filter.MaintenanceFilter;
 import com.umc.product.maintenance.application.port.out.MaintenanceBypassPolicy;
 import com.umc.product.maintenance.application.service.MaintenanceStateHolder;
@@ -65,9 +65,9 @@ public class SecurityConfig {
     public MaintenanceFilter maintenanceFilter(
         MaintenanceStateHolder stateHolder,
         MaintenanceBypassPolicy bypassPolicy,
-        ObjectMapper objectMapper
+        ApiErrorResponseWriter errorResponseWriter
     ) {
-        return new MaintenanceFilter(stateHolder, bypassPolicy, objectMapper);
+        return new MaintenanceFilter(stateHolder, bypassPolicy, errorResponseWriter);
     }
 
     /**

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -28,11 +28,11 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.global.security.ApiAccessDeniedHandler;
 import com.umc.product.global.security.ApiAuthenticationEntryPoint;
 import com.umc.product.global.security.JwtAuthenticationFilter;
 import com.umc.product.global.security.util.PublicEndpointCollector;
-import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.maintenance.adapter.in.web.filter.MaintenanceFilter;
 import com.umc.product.maintenance.application.port.out.MaintenanceBypassPolicy;
 import com.umc.product.maintenance.application.service.MaintenanceStateHolder;

--- a/src/main/java/com/umc/product/global/exception/BusinessExceptionResponseResolver.java
+++ b/src/main/java/com/umc/product/global/exception/BusinessExceptionResponseResolver.java
@@ -1,0 +1,37 @@
+package com.umc.product.global.exception;
+
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.response.ApiErrorResponseFactory;
+import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.code.BaseCode;
+
+final class BusinessExceptionResponseResolver {
+
+    private BusinessExceptionResponseResolver() {
+    }
+
+    static ApiResponse<Object> toApiResponse(BusinessException exception) {
+        BaseCode code = exception.getBaseCode();
+        return ApiErrorResponseFactory.from(code, resolveMessage(exception), resolveDetail(exception));
+    }
+
+    private static String resolveMessage(BusinessException exception) {
+        if (requiresDefaultMessageFallback(exception)) {
+            return ApiErrorResponseFactory.resolveMessage(exception.getBaseCode(), exception.getMessage());
+        }
+        return exception.getBaseCode().getMessage();
+    }
+
+    private static Object resolveDetail(BusinessException exception) {
+        if (requiresDefaultMessageFallback(exception)) {
+            return ApiErrorResponseFactory.resolveMessage(exception.getBaseCode(), exception.getMessage());
+        }
+        return exception.getMessage();
+    }
+
+    private static boolean requiresDefaultMessageFallback(BusinessException exception) {
+        return exception instanceof AuthorizationDomainException
+            && exception.getBaseCode().equals(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/umc/product/global/exception/CustomErrorController.java
+++ b/src/main/java/com/umc/product/global/exception/CustomErrorController.java
@@ -1,18 +1,20 @@
 package com.umc.product.global.exception;
 
-import com.umc.product.global.exception.constant.CommonErrorCode;
-import com.umc.product.global.response.ApiErrorResponseFactory;
-import com.umc.product.global.response.ApiResponse;
-import com.umc.product.global.response.code.BaseCode;
-import io.swagger.v3.oas.annotations.Hidden;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiErrorResponseFactory;
+import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.code.BaseCode;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * GlobalExceptionHandler가 처리하지 못하는 에러를 처리하는 fallback 컨트롤러 - 404 Not Found (존재하지 않는 URL) - Filter에서 발생한 예외 - Servlet 레벨

--- a/src/main/java/com/umc/product/global/exception/CustomErrorController.java
+++ b/src/main/java/com/umc/product/global/exception/CustomErrorController.java
@@ -42,7 +42,7 @@ public class CustomErrorController implements ErrorController {
 
                 return ResponseEntity
                     .status(code.getHttpStatus())
-                    .body(ApiErrorResponseFactory.from(code));
+                    .body(BusinessExceptionResponseResolver.toApiResponse(businessException));
             }
         }
 

--- a/src/main/java/com/umc/product/global/exception/CustomErrorController.java
+++ b/src/main/java/com/umc/product/global/exception/CustomErrorController.java
@@ -1,6 +1,7 @@
 package com.umc.product.global.exception;
 
 import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiErrorResponseFactory;
 import com.umc.product.global.response.ApiResponse;
 import com.umc.product.global.response.code.BaseCode;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -39,7 +40,7 @@ public class CustomErrorController implements ErrorController {
 
                 return ResponseEntity
                     .status(code.getHttpStatus())
-                    .body(ApiResponse.onFailure(code.getCode(), code.getMessage(), null));
+                    .body(ApiErrorResponseFactory.from(code));
             }
         }
 
@@ -53,11 +54,7 @@ public class CustomErrorController implements ErrorController {
 
         CommonErrorCode errorCode = resolveErrorCode(status);
 
-        ApiResponse<Object> body = ApiResponse.onFailure(
-            errorCode.getCode(),
-            errorCode.getMessage(),
-            null
-        );
+        ApiResponse<Object> body = ApiErrorResponseFactory.from(errorCode);
 
         return ResponseEntity.status(status).body(body);
     }

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -106,15 +106,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("JSON 파싱 에러: {}", e.getMessage());
 
         String errorMessage = e.getMessage();
-        String simplifiedMessage = "잘못된 요청 형식입니다";
+        String simplifiedMessage = "요청 형식이 올바르지 않아요. 입력한 값을 확인해주세요.";
 
         if (errorMessage != null) {
             if (errorMessage.contains("Cannot deserialize")) {
-                simplifiedMessage = "요청 데이터 타입이 올바르지 않습니다";
+                simplifiedMessage = "요청 값의 형식이 올바르지 않아요. 입력한 값을 확인해주세요.";
             } else if (errorMessage.contains("Required request body is missing")) {
-                simplifiedMessage = "요청 본문이 필요합니다";
+                simplifiedMessage = "요청 내용이 비어 있어요. 입력한 값을 확인해주세요.";
             } else if (errorMessage.contains("JSON parse error")) {
-                simplifiedMessage = "JSON 형식이 올바르지 않습니다";
+                simplifiedMessage = "요청 형식이 올바르지 않아요. 입력한 값을 확인해주세요.";
             }
         }
 
@@ -131,7 +131,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpStatusCode status,
         WebRequest request
     ) {
-        String detail = String.format("필수 요청 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+        String detail = String.format("필수 요청 값 '%s'가 없어요. 입력한 값을 확인해주세요.", e.getParameterName());
         log.warn("[MISSING REQUEST PARAMETER] {}", detail);
 
         return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, detail);
@@ -149,7 +149,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         log.warn("[REQUEST PARAMETER TYPE MISMATCH] {}", e.getMessage());
 
-        return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, "요청 파라미터 값이 올바르지 않습니다.");
+        return buildResponse(
+            e,
+            CommonErrorCode.BAD_REQUEST,
+            headers,
+            request,
+            "요청 값의 형식이 올바르지 않아요. 입력한 값을 확인해주세요."
+        );
     }
 
 
@@ -161,7 +167,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.error("[UNHANDLED EXCEPTION] {}", e.getMessage(), e);
 
         String errorDetail = isProductionProfile()
-            ? "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+            ? CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage()
             : e.getMessage();
 
         return buildResponse(e, CommonErrorCode.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, request, errorDetail);

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -21,8 +21,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
-import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.response.ApiErrorResponseFactory;
 import com.umc.product.global.response.ApiResponse;
@@ -174,14 +172,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("[BUSINESS EXCEPTION] domain={}, code={}, message={}", e.getDomain(), e.getBaseCode().getCode(),
             e.getMessage(), e);
 
-        if (e instanceof AuthorizationDomainException) {
-            if (e.getBaseCode().equals(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)) {
-                String message = ApiErrorResponseFactory.resolveMessage(e.getBaseCode(), e.getMessage());
-                return buildResponse(e, e.getBaseCode(), HttpHeaders.EMPTY, request, message, message);
-            }
-        }
-
-        return buildResponse(e, e.getBaseCode(), HttpHeaders.EMPTY, request, e.getMessage());
+        ApiResponse<Object> body = BusinessExceptionResponseResolver.toApiResponse(e);
+        return super.handleExceptionInternal(
+            e,
+            body,
+            HttpHeaders.EMPTY,
+            e.getBaseCode().getHttpStatus(),
+            request
+        );
     }
 
     /**

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,20 +42,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private String activeProfile;
 
     /**
-     * Spring Security 권한 거부 예외 처리 - AuthorizationDeniedException: @PreAuthorize 등 메서드 레벨 보안
-     */
-    @ExceptionHandler(AuthorizationDeniedException.class)
-    public ResponseEntity<Object> handleAccessDenied(AuthorizationDeniedException e, WebRequest request) {
-        log.warn("[ACCESS DENIED] {}", e.getMessage());
-
-        return buildResponse(e, CommonErrorCode.FORBIDDEN, HttpHeaders.EMPTY, request, null);
-    }
-
-    /**
-     * Spring Security 표준 AccessDeniedException 처리 - 커스텀 Aspect 등 MVC 내부에서 발생하는 인가 실패
+     * Spring Security 권한 거부 예외 처리 - 메서드 레벨 보안 및 MVC 내부 인가 실패
      */
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<Object> handleSpringAccessDenied(AccessDeniedException e, WebRequest request) {
+    public ResponseEntity<Object> handleAccessDenied(AccessDeniedException e, WebRequest request) {
         log.warn("[ACCESS DENIED] {}", e.getMessage());
 
         return buildResponse(e, CommonErrorCode.FORBIDDEN, HttpHeaders.EMPTY, request, null);

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ package com.umc.product.global.exception;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiErrorResponseFactory;
 import com.umc.product.global.response.ApiResponse;
 import com.umc.product.global.response.code.BaseCode;
 import jakarta.validation.ConstraintViolation;
@@ -20,6 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -41,10 +43,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * Spring Security 권한 거부 예외 처리 - AuthorizationDeniedException: @PreAuthorize 등 메서드 레벨 보안
      */
     @ExceptionHandler(AuthorizationDeniedException.class)
-    public ResponseEntity<Object> handleAccessDenied(Exception e, WebRequest request) {
+    public ResponseEntity<Object> handleAccessDenied(AuthorizationDeniedException e, WebRequest request) {
         log.warn("[ACCESS DENIED] {}", e.getMessage());
 
-        return buildResponse(e, CommonErrorCode.FORBIDDEN, HttpHeaders.EMPTY, request, e.getMessage());
+        return buildResponse(e, CommonErrorCode.FORBIDDEN, HttpHeaders.EMPTY, request, null);
+    }
+
+    /**
+     * Spring Security 표준 AccessDeniedException 처리 - 커스텀 Aspect 등 MVC 내부에서 발생하는 인가 실패
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleSpringAccessDenied(AccessDeniedException e, WebRequest request) {
+        log.warn("[ACCESS DENIED] {}", e.getMessage());
+
+        return buildResponse(e, CommonErrorCode.FORBIDDEN, HttpHeaders.EMPTY, request, null);
     }
 
     /**
@@ -101,7 +113,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         WebRequest request
     ) {
 
-        log.error("JSON 파싱 에러: {}", e.getMessage());
+        log.warn("JSON 파싱 에러: {}", e.getMessage());
 
         String errorMessage = e.getMessage();
         String simplifiedMessage = "잘못된 요청 형식입니다";
@@ -116,8 +128,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             }
         }
 
-        String detail = simplifiedMessage + " - " + e.getMostSpecificCause().getMessage();
-        return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, detail);
+        return buildResponse(e, CommonErrorCode.BAD_REQUEST, headers, request, simplifiedMessage);
     }
 
     /**
@@ -173,7 +184,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         if (e instanceof AuthorizationDomainException) {
             if (e.getBaseCode().equals(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED)) {
-                return buildResponse(e, e.getBaseCode(), HttpHeaders.EMPTY, request, e.getMessage(), e.getMessage());
+                String message = ApiErrorResponseFactory.resolveMessage(e.getBaseCode(), e.getMessage());
+                return buildResponse(e, e.getBaseCode(), HttpHeaders.EMPTY, request, message, message);
             }
         }
 
@@ -187,7 +199,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         Exception e, BaseCode code,
         HttpHeaders headers, WebRequest request, Object detail
     ) {
-        ApiResponse<Object> body = ApiResponse.onFailure(code.getCode(), code.getMessage(), detail);
+        ApiResponse<Object> body = ApiErrorResponseFactory.from(code, detail);
         return super.handleExceptionInternal(e, body, headers, code.getHttpStatus(), request);
     }
 
@@ -196,7 +208,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpHeaders headers, WebRequest request, Object detail,
         String message
     ) {
-        ApiResponse<Object> body = ApiResponse.onFailure(code.getCode(), message, detail);
+        ApiResponse<Object> body = ApiErrorResponseFactory.from(code, message, detail);
         return super.handleExceptionInternal(e, body, headers, code.getHttpStatus(), request);
     }
 

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -1,20 +1,11 @@
 package com.umc.product.global.exception;
 
 
-import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
-import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
-import com.umc.product.global.exception.constant.CommonErrorCode;
-import com.umc.product.global.response.ApiErrorResponseFactory;
-import com.umc.product.global.response.ApiResponse;
-import com.umc.product.global.response.code.BaseCode;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -30,6 +21,18 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiErrorResponseFactory;
+import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.code.BaseCode;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice(annotations = {RestController.class})

--- a/src/main/java/com/umc/product/global/response/ApiErrorResponseFactory.java
+++ b/src/main/java/com/umc/product/global/response/ApiErrorResponseFactory.java
@@ -1,7 +1,8 @@
 package com.umc.product.global.response;
 
-import com.umc.product.global.response.code.BaseCode;
 import org.springframework.util.StringUtils;
+
+import com.umc.product.global.response.code.BaseCode;
 
 public final class ApiErrorResponseFactory {
 

--- a/src/main/java/com/umc/product/global/response/ApiErrorResponseFactory.java
+++ b/src/main/java/com/umc/product/global/response/ApiErrorResponseFactory.java
@@ -1,0 +1,29 @@
+package com.umc.product.global.response;
+
+import com.umc.product.global.response.code.BaseCode;
+import org.springframework.util.StringUtils;
+
+public final class ApiErrorResponseFactory {
+
+    private ApiErrorResponseFactory() {
+    }
+
+    public static ApiResponse<Object> from(BaseCode code) {
+        return from(code, null);
+    }
+
+    public static ApiResponse<Object> from(BaseCode code, Object detail) {
+        return from(code, code.getMessage(), detail);
+    }
+
+    public static ApiResponse<Object> from(BaseCode code, String message, Object detail) {
+        return ApiResponse.onFailure(code.getCode(), resolveMessage(code, message), detail);
+    }
+
+    public static String resolveMessage(BaseCode code, String message) {
+        if (StringUtils.hasText(message)) {
+            return message;
+        }
+        return code.getMessage();
+    }
+}

--- a/src/main/java/com/umc/product/global/response/ApiErrorResponseWriter.java
+++ b/src/main/java/com/umc/product/global/response/ApiErrorResponseWriter.java
@@ -1,0 +1,32 @@
+package com.umc.product.global.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.response.code.BaseCode;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApiErrorResponseWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public void write(HttpServletResponse response, BaseCode code) throws IOException {
+        write(response, code, code.getMessage(), null);
+    }
+
+    public void write(HttpServletResponse response, BaseCode code, Object detail) throws IOException {
+        write(response, code, code.getMessage(), detail);
+    }
+
+    public void write(HttpServletResponse response, BaseCode code, String message, Object detail) throws IOException {
+        response.setStatus(code.getHttpStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiErrorResponseFactory.from(code, message, detail));
+    }
+}

--- a/src/main/java/com/umc/product/global/response/ApiErrorResponseWriter.java
+++ b/src/main/java/com/umc/product/global/response/ApiErrorResponseWriter.java
@@ -1,13 +1,16 @@
 package com.umc.product.global.response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.product.global.response.code.BaseCode;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.response.code.BaseCode;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/global/security/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/umc/product/global/security/ApiAccessDeniedHandler.java
@@ -1,14 +1,11 @@
 package com.umc.product.global.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.global.exception.constant.CommonErrorCode;
-import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.ApiErrorResponseWriter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -17,24 +14,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ApiAccessDeniedHandler implements AccessDeniedHandler {
 
-    private final ObjectMapper objectMapper;
+    private final ApiErrorResponseWriter errorResponseWriter;
 
     @Override
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
 
-        CommonErrorCode status = CommonErrorCode.FORBIDDEN;
-
-        ApiResponse<Object> body = ApiResponse.onFailure(
-                status.getCode(),
-                status.getMessage(),
-                accessDeniedException.getMessage()
-        );
-
-        response.setStatus(status.getHttpStatus().value());
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+        errorResponseWriter.write(response, CommonErrorCode.FORBIDDEN);
     }
 }

--- a/src/main/java/com/umc/product/global/security/ApiAccessDeniedHandler.java
+++ b/src/main/java/com/umc/product/global/security/ApiAccessDeniedHandler.java
@@ -1,14 +1,17 @@
 package com.umc.product.global.security;
 
-import com.umc.product.global.exception.constant.CommonErrorCode;
-import com.umc.product.global.response.ApiErrorResponseWriter;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.response.ApiErrorResponseWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/global/security/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/product/global/security/ApiAuthenticationEntryPoint.java
@@ -3,18 +3,21 @@ package com.umc.product.global.security;
 import static com.umc.product.global.security.JwtAuthenticationFilter.JWT_ERROR_ATTRIBUTE;
 import static com.umc.product.global.security.JwtAuthenticationFilter.JWT_UNKNOWN_ERROR_ATTRIBUTE;
 
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.global.response.code.BaseCode;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/global/security/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/product/global/security/ApiAuthenticationEntryPoint.java
@@ -3,18 +3,15 @@ package com.umc.product.global.security;
 import static com.umc.product.global.security.JwtAuthenticationFilter.JWT_ERROR_ATTRIBUTE;
 import static com.umc.product.global.security.JwtAuthenticationFilter.JWT_UNKNOWN_ERROR_ATTRIBUTE;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.global.exception.constant.CommonErrorCode;
-import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.global.response.code.BaseCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -24,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
+    private final ApiErrorResponseWriter errorResponseWriter;
 
     @Override
     public void commence(HttpServletRequest req, HttpServletResponse res, AuthenticationException ex)
@@ -38,16 +35,7 @@ public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
             errorCode.getMessage(),
             ex);
 
-        ApiResponse<Object> body = ApiResponse.onFailure(
-            errorCode.getCode(),
-            errorCode.getMessage(),
-            null
-        );
-
-        res.setStatus(errorCode.getHttpStatus().value());
-        res.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        res.getWriter().write(objectMapper.writeValueAsString(body));
+        errorResponseWriter.write(res, errorCode);
     }
 
     private BaseCode resolveErrorCode(HttpServletRequest req, AuthenticationException ex) {

--- a/src/main/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilter.java
+++ b/src/main/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilter.java
@@ -1,22 +1,19 @@
 package com.umc.product.maintenance.adapter.in.web.filter;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.global.config.SecurityPathConfig;
-import com.umc.product.global.response.ApiResponse;
+import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.maintenance.adapter.in.web.dto.response.MaintenanceWindowResponse;
 import com.umc.product.maintenance.application.port.in.query.dto.MaintenanceWindowInfo;
@@ -53,26 +50,26 @@ public class MaintenanceFilter extends OncePerRequestFilter {
 
     private final MaintenanceStateHolder stateHolder;
     private final MaintenanceBypassPolicy bypassPolicy;
-    private final ObjectMapper objectMapper;
+    private final ApiErrorResponseWriter errorResponseWriter;
     private final Clock clock;
 
     public MaintenanceFilter(
         MaintenanceStateHolder stateHolder,
         MaintenanceBypassPolicy bypassPolicy,
-        ObjectMapper objectMapper
+        ApiErrorResponseWriter errorResponseWriter
     ) {
-        this(stateHolder, bypassPolicy, objectMapper, Clock.systemUTC());
+        this(stateHolder, bypassPolicy, errorResponseWriter, Clock.systemUTC());
     }
 
     MaintenanceFilter(
         MaintenanceStateHolder stateHolder,
         MaintenanceBypassPolicy bypassPolicy,
-        ObjectMapper objectMapper,
+        ApiErrorResponseWriter errorResponseWriter,
         Clock clock
     ) {
         this.stateHolder = stateHolder;
         this.bypassPolicy = bypassPolicy;
-        this.objectMapper = objectMapper;
+        this.errorResponseWriter = errorResponseWriter;
         this.clock = clock;
     }
 
@@ -152,14 +149,8 @@ public class MaintenanceFilter extends OncePerRequestFilter {
         Instant now = clock.instant();
         long retryAfterSeconds = Math.max(1L, Duration.between(now, snapshot.endAt()).getSeconds());
 
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
 
-        ApiResponse<MaintenanceWindowResponse> payload =
-            ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), body);
-
-        objectMapper.writeValue(response.getWriter(), payload);
+        errorResponseWriter.write(response, errorCode, body);
     }
 }

--- a/src/test/java/com/umc/product/global/exception/CustomErrorControllerTest.java
+++ b/src/test/java/com/umc/product/global/exception/CustomErrorControllerTest.java
@@ -1,0 +1,61 @@
+package com.umc.product.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.response.ApiResponse;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+
+class CustomErrorControllerTest {
+
+    private final CustomErrorController controller = new CustomErrorController();
+
+    @Test
+    @DisplayName("fallback error controller도 BusinessException 상세 메시지를 유지한다")
+    void businessExceptionDetailIsPreserved() {
+        AuthorizationDomainException exception = new AuthorizationDomainException(
+            AuthorizationErrorCode.PERMISSION_DENIED,
+            "학교 운영진만 수정할 수 있습니다."
+        );
+
+        ResponseEntity<ApiResponse<Object>> response = controller.handleError(errorRequest(exception));
+
+        assertThat(response.getStatusCode()).isEqualTo(AuthorizationErrorCode.PERMISSION_DENIED.getHttpStatus());
+        assertThat(response.getBody()).satisfies(body -> {
+            assertThat(body.getCode()).isEqualTo(AuthorizationErrorCode.PERMISSION_DENIED.getCode());
+            assertThat(body.getMessage()).isEqualTo(AuthorizationErrorCode.PERMISSION_DENIED.getMessage());
+            assertThat(body.getResult()).isEqualTo("학교 운영진만 수정할 수 있습니다.");
+        });
+    }
+
+    @Test
+    @DisplayName("fallback error controller도 RESOURCE_ACCESS_DENIED 기본 메시지를 detail로 내려준다")
+    void resourceAccessDeniedDefaultDetailFallsBackToErrorCodeMessage() {
+        AuthorizationDomainException exception =
+            new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+
+        ResponseEntity<ApiResponse<Object>> response = controller.handleError(errorRequest(exception));
+
+        assertThat(response.getStatusCode()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getHttpStatus());
+        assertThat(response.getBody()).satisfies(body -> {
+            assertThat(body.getCode()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getCode());
+            assertThat(body.getMessage()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getMessage());
+            assertThat(body.getResult()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getMessage());
+        });
+    }
+
+    private MockHttpServletRequest errorRequest(Throwable exception) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, "/error-path");
+        request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, new ServletException(exception));
+        return request;
+    }
+}

--- a/src/test/java/com/umc/product/global/exception/CustomErrorControllerTest.java
+++ b/src/test/java/com/umc/product/global/exception/CustomErrorControllerTest.java
@@ -23,7 +23,7 @@ class CustomErrorControllerTest {
     void businessExceptionDetailIsPreserved() {
         AuthorizationDomainException exception = new AuthorizationDomainException(
             AuthorizationErrorCode.PERMISSION_DENIED,
-            "학교 운영진만 수정할 수 있습니다."
+            "학교 운영진만 수정할 수 있어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
         );
 
         ResponseEntity<ApiResponse<Object>> response = controller.handleError(errorRequest(exception));
@@ -32,7 +32,8 @@ class CustomErrorControllerTest {
         assertThat(response.getBody()).satisfies(body -> {
             assertThat(body.getCode()).isEqualTo(AuthorizationErrorCode.PERMISSION_DENIED.getCode());
             assertThat(body.getMessage()).isEqualTo(AuthorizationErrorCode.PERMISSION_DENIED.getMessage());
-            assertThat(body.getResult()).isEqualTo("학교 운영진만 수정할 수 있습니다.");
+            assertThat(body.getResult())
+                .isEqualTo("학교 운영진만 수정할 수 있어요. 필요한 권한이 있다면 운영진에게 문의해주세요.");
         });
     }
 

--- a/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
@@ -24,6 +24,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.response.ApiResponse;
 
 class GlobalExceptionHandlerTest {
@@ -44,9 +45,9 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getHttpStatus());
         assertThat(response.getBody())
             .isInstanceOfSatisfying(ApiResponse.class, body -> {
-                assertThat(body.getCode()).isEqualTo("AUTHORIZATION-0002");
-                assertThat(body.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
-                assertThat(body.getResult()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+                assertThat(body.getCode()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getCode());
+                assertThat(body.getMessage()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getMessage());
+                assertThat(body.getResult()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getMessage());
             });
     }
 
@@ -62,8 +63,8 @@ class GlobalExceptionHandlerTest {
         mockMvc.perform(get("/access-denied"))
             .andExpect(status().isForbidden())
             .andExpect(jsonPath("$.success").value(false))
-            .andExpect(jsonPath("$.code").value("COMMON-403"))
-            .andExpect(jsonPath("$.message").value("허용되지 않는 요청입니다."))
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.FORBIDDEN.getCode()))
+            .andExpect(jsonPath("$.message").value(CommonErrorCode.FORBIDDEN.getMessage()))
             .andExpect(jsonPath("$.result").doesNotExist());
     }
 

--- a/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
@@ -6,14 +6,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
-import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
-import com.umc.product.global.response.ApiResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -23,7 +21,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.ServletWebRequest;
-import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.response.ApiResponse;
 
 class GlobalExceptionHandlerTest {
 

--- a/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,109 @@
+package com.umc.product.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
+import com.umc.product.global.response.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("RESOURCE_ACCESS_DENIED 기본 예외도 message가 null로 내려가지 않는다")
+    void resourceAccessDeniedDefaultMessageFallback() {
+        AuthorizationDomainException exception =
+            new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
+
+        ResponseEntity<Object> response = handler.onThrowException(
+            exception,
+            new ServletWebRequest(new MockHttpServletRequest())
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED.getHttpStatus());
+        assertThat(response.getBody())
+            .isInstanceOfSatisfying(ApiResponse.class, body -> {
+                assertThat(body.getCode()).isEqualTo("AUTHORIZATION-0002");
+                assertThat(body.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+                assertThat(body.getResult()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+            });
+    }
+
+    @Test
+    @DisplayName("Spring Security AccessDeniedException은 MVC 경로에서도 403으로 응답한다")
+    void accessDeniedExceptionReturnsForbidden() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new ExceptionController())
+            .setControllerAdvice(handler)
+            .setMessageConverters(new MappingJackson2HttpMessageConverter())
+            .build();
+
+        mockMvc.perform(get("/access-denied"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-403"))
+            .andExpect(jsonPath("$.message").value("허용되지 않는 요청입니다."))
+            .andExpect(jsonPath("$.result").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 오류는 내부 파서 상세 메시지를 응답에 노출하지 않는다")
+    void jsonParseErrorDoesNotExposeParserDetail() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new ExceptionController())
+            .setControllerAdvice(handler)
+            .setMessageConverters(new MappingJackson2HttpMessageConverter())
+            .build();
+
+        MvcResult result = mockMvc.perform(post("/body")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON-400"))
+            .andExpect(jsonPath("$.result").value("JSON 형식이 올바르지 않습니다"))
+            .andReturn();
+
+        assertThat(result.getResponse().getContentAsString())
+            .doesNotContain("JsonParseException")
+            .doesNotContain("Unexpected")
+            .doesNotContain("com.fasterxml");
+    }
+
+    @RestController
+    private static class ExceptionController {
+
+        @GetMapping("/access-denied")
+        String accessDenied() {
+            throw new AccessDeniedException("ROLE_ADMIN required for internal policy");
+        }
+
+        @PostMapping("/body")
+        String body(@RequestBody TestRequest request) {
+            return request.name();
+        }
+    }
+
+    private record TestRequest(String name) {
+    }
+}

--- a/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/umc/product/global/exception/GlobalExceptionHandlerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.ServletWebRequest;
 
@@ -83,13 +84,46 @@ class GlobalExceptionHandlerTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.code").value("COMMON-400"))
-            .andExpect(jsonPath("$.result").value("JSON 형식이 올바르지 않습니다"))
+            .andExpect(jsonPath("$.result").value("요청 형식이 올바르지 않아요. 입력한 값을 확인해주세요."))
             .andReturn();
 
         assertThat(result.getResponse().getContentAsString())
             .doesNotContain("JsonParseException")
             .doesNotContain("Unexpected")
             .doesNotContain("com.fasterxml");
+    }
+
+    @Test
+    @DisplayName("요청 본문이 없으면 사용자가 이해할 수 있는 다음 행동을 안내한다")
+    void missingRequestBodyReturnsActionableMessage() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new ExceptionController())
+            .setControllerAdvice(handler)
+            .setMessageConverters(new MappingJackson2HttpMessageConverter())
+            .build();
+
+        mockMvc.perform(post("/body")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCode()))
+            .andExpect(jsonPath("$.result").value("요청 내용이 비어 있어요. 입력한 값을 확인해주세요."));
+    }
+
+    @Test
+    @DisplayName("요청 값 형식이 맞지 않으면 사용자가 확인할 값을 안내한다")
+    void requestTypeMismatchReturnsActionableMessage() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new ExceptionController())
+            .setControllerAdvice(handler)
+            .setMessageConverters(new MappingJackson2HttpMessageConverter())
+            .build();
+
+        mockMvc.perform(get("/number").param("value", "not-number"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.BAD_REQUEST.getCode()))
+            .andExpect(jsonPath("$.result").value("요청 값의 형식이 올바르지 않아요. 입력한 값을 확인해주세요."));
     }
 
     @RestController
@@ -103,6 +137,11 @@ class GlobalExceptionHandlerTest {
         @PostMapping("/body")
         String body(@RequestBody TestRequest request) {
             return request.name();
+        }
+
+        @GetMapping("/number")
+        String number(@RequestParam Integer value) {
+            return value.toString();
         }
     }
 

--- a/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
+++ b/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
@@ -1,0 +1,38 @@
+package com.umc.product.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.response.ApiErrorResponseWriter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+class ApiAccessDeniedHandlerTest {
+
+    private final ApiAccessDeniedHandler handler =
+        new ApiAccessDeniedHandler(new ApiErrorResponseWriter(new ObjectMapper()));
+
+    @Test
+    @DisplayName("인가 실패 응답은 내부 AccessDeniedException 메시지를 노출하지 않는다")
+    void accessDeniedResponseDoesNotExposeExceptionMessage() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(
+            new MockHttpServletRequest(),
+            response,
+            new AccessDeniedException("ROLE_ADMIN required for internal policy")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString())
+            .contains("\"success\":false")
+            .contains("\"code\":\"COMMON-403\"")
+            .contains("\"message\":\"허용되지 않는 요청입니다.\"")
+            .doesNotContain("ROLE_ADMIN")
+            .doesNotContain("internal policy")
+            .doesNotContain("\"result\"");
+    }
+}

--- a/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
+++ b/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
@@ -9,6 +9,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.response.ApiErrorResponseWriter;
 
 class ApiAccessDeniedHandlerTest {
@@ -30,8 +31,8 @@ class ApiAccessDeniedHandlerTest {
         assertThat(response.getStatus()).isEqualTo(403);
         assertThat(response.getContentAsString())
             .contains("\"success\":false")
-            .contains("\"code\":\"COMMON-403\"")
-            .contains("\"message\":\"허용되지 않는 요청입니다.\"")
+            .contains("\"code\":\"" + CommonErrorCode.FORBIDDEN.getCode() + "\"")
+            .contains("\"message\":\"" + CommonErrorCode.FORBIDDEN.getMessage() + "\"")
             .doesNotContain("ROLE_ADMIN")
             .doesNotContain("internal policy")
             .doesNotContain("\"result\"");

--- a/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
+++ b/src/test/java/com/umc/product/global/security/ApiAccessDeniedHandlerTest.java
@@ -2,13 +2,14 @@ package com.umc.product.global.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.product.global.response.ApiErrorResponseWriter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.response.ApiErrorResponseWriter;
 
 class ApiAccessDeniedHandlerTest {
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- 연관 이슈는 없어요.

## 🚀 작업 내용

### 변경 범위 요약

- 전역 예외 처리, Spring Security 인증/인가 실패 처리, 점검 모드 필터의 실패 응답 생성 경로를 표준화했어요.
- 신규 API, DB migration, 환경 변수 변경은 없어요. 기존 API 실패 응답 envelope인 `success`, `code`, `message`, `result` 구조를 유지해요.
- 사용자에게 노출되는 오류 문구는 [UX Writing Guidelines](docs/onboarding/ux-writing-guidelines.md)에 맞춰 쉬운 말, 다음 행동 안내, 내부 구현명 비노출 기준을 반영했어요.

### 작업 배경

- 실패 응답 생성 로직이 `GlobalExceptionHandler`, `/error` fallback controller, Spring Security handler, 점검 필터에 각각 흩어져 있었어요.
- 일부 경로는 `ApiResponse.onFailure`를 직접 호출하고, 일부 servlet handler는 status, content type, charset, JSON 직렬화를 직접 처리하고 있었어요.
- JSON 파싱 실패나 인가 실패 상황에서 Jackson 내부 메시지, Spring Security 내부 정책 문구 같은 서버 구현 detail이 `result`로 내려갈 수 있었어요.
- `BusinessException`이 필터나 servlet fallback 경로에서 처리될 때 controller advice 경로와 다른 응답 detail을 만들 수 있었고, 기본 메시지가 비어 있는 예외는 null에 가까운 응답이 될 위험이 있었어요.

### 작업 단위별 상세

1. **무엇을**: API 실패 응답 생성 로직을 공통 factory와 writer로 모았어요.
   - **어떻게**: `ApiErrorResponseFactory`를 추가해 `BaseCode`, 커스텀 message, detail 조합을 한 곳에서 `ApiResponse.onFailure`로 변환하도록 했어요.
   - **어떻게**: `ApiErrorResponseWriter`를 추가해 servlet response의 status, charset, content type, JSON body 작성을 공통화했어요.
   - **왜**: handler마다 응답 body와 HTTP response 설정을 직접 만들면 같은 에러여도 경로별 포맷이 달라질 수 있어서, 실패 응답의 기본 생성 규칙을 한곳에 두기 위해서예요.

2. **무엇을**: Spring Security 인증/인가 실패 응답을 표준 응답 writer 경로로 통일했어요.
   - **어떻게**: `ApiAuthenticationEntryPoint`와 `ApiAccessDeniedHandler`에서 직접 `ObjectMapper`로 응답을 쓰던 코드를 `ApiErrorResponseWriter` 호출로 바꿨어요.
   - **어떻게**: `SecurityConfig`의 `MaintenanceFilter` 생성 의존성도 `ObjectMapper`에서 `ApiErrorResponseWriter`로 바꿨어요.
   - **왜**: Security filter chain에서 발생하는 401, 403 응답도 controller advice 경로와 같은 JSON 구조와 charset, content type 설정을 사용하도록 맞추기 위해서예요.

3. **무엇을**: MVC 내부에서 발생하는 Spring Security 인가 실패를 403으로 명확히 처리했어요.
   - **어떻게**: `GlobalExceptionHandler`의 handler를 `AuthorizationDeniedException` 전용에서 상위 `AccessDeniedException` handler로 정리했어요.
   - **어떻게**: `AccessDeniedException#getMessage()`는 로그에는 남기되, API 응답의 `result`에는 싣지 않도록 했어요.
   - **왜**: `@PreAuthorize`나 커스텀 권한 검증 흐름에서 발생한 인가 실패가 500 fallback으로 떨어지는 일을 막고, 내부 권한 정책 문구가 클라이언트에 노출되지 않도록 하기 위해서예요.

4. **무엇을**: JSON 파싱 실패와 요청 값 오류 문구를 사용자-facing 문구로 정리했어요.
   - **어떻게**: `HttpMessageNotReadableException` 응답에서 Jackson 내부 cause 메시지를 제거하고, 상황별로 단순한 안내 문구만 `result`에 담도록 했어요.
   - **어떻게**: 필수 요청 값 누락과 타입 변환 실패 문구를 `~요` 톤과 “입력한 값을 확인해주세요” 안내로 바꿨어요.
   - **왜**: 에러 응답이 상태 보고나 내부 구현 detail에 머물지 않고, 사용자가 다음에 무엇을 확인해야 하는지 알려주도록 맞추기 위해서예요.

5. **무엇을**: `BusinessException` 응답 detail을 controller advice와 `/error` fallback 경로에서 일관되게 만들었어요.
   - **어떻게**: `BusinessExceptionResponseResolver`를 추가하고 `GlobalExceptionHandler`와 `CustomErrorController`가 같은 resolver를 사용하도록 했어요.
   - **어떻게**: 기존 `BusinessException#getMessage()` 동작은 바꾸지 않고, 응답 생성 단계에서 필요한 경우 `BaseCode.message`로 fallback하도록 했어요.
   - **왜**: 예외 클래스의 기존 동작을 건드리지 않으면서 `RESOURCE_ACCESS_DENIED` 같은 기본 도메인 예외가 null 메시지로 내려가는 문제를 막기 위해서예요.

6. **무엇을**: 점검 모드 실패 응답도 공통 writer를 사용하도록 정리했어요.
   - **어떻게**: `MaintenanceFilter`에서 직접 status, charset, content type, JSON body를 쓰던 로직을 `ApiErrorResponseWriter`로 대체했어요.
   - **어떻게**: 기존 `Retry-After` header와 `MaintenanceWindowResponse` detail은 유지했어요.
   - **왜**: 점검 모드 503 응답도 전역 실패 응답 규칙을 따르면서, 프론트엔드가 쓰는 점검 상세 정보와 재시도 안내 header는 그대로 보존하기 위해서예요.

7. **무엇을**: 리뷰 반영과 회귀 테스트를 추가했어요.
   - **어떻게**: PR 리뷰에서 제안된 `AuthorizationDeniedException`/`AccessDeniedException` handler 중복을 상위 handler 하나로 정리했어요.
   - **어떻게**: PR 리뷰에서 제안된 `/error` fallback의 `BusinessException` detail 보존 문제를 resolver 공유 방식으로 반영했어요.
   - **어떻게**: `CommonErrorCode`, `AuthorizationErrorCode` 메시지를 테스트 기대값에 직접 사용해 base branch 문구 변경에 덜 깨지도록 조정했어요.
   - **왜**: 에러 핸들러는 여러 진입 경로가 얽혀 있어서, PR 리뷰로 확인된 경로 차이를 테스트와 구현 양쪽에서 고정하기 위해서예요.

### 클라이언트 영향 정리

- 401, 403, 400, 500, 503 응답의 기본 envelope 구조는 바뀌지 않아요.
- 403 인가 실패 응답에서는 내부 `AccessDeniedException` 메시지가 더 이상 `result`로 내려가지 않아요. 클라이언트는 `result`보다 `code`와 `message`를 기준으로 처리하는 것이 안전해요.
- 잘못된 JSON, 요청 본문 누락, 요청 값 타입 불일치 응답의 `result`는 내부 파서 메시지 대신 사용자가 이해할 수 있는 문구로 내려가요.
- 점검 모드 503 응답은 기존처럼 점검 상세 정보를 `result`에 담고, `Retry-After` header를 유지해요.

### 검증 내용

- `./gradlew test --tests 'com.umc.product.global.exception.GlobalExceptionHandlerTest' --tests 'com.umc.product.global.exception.CustomErrorControllerTest' --tests 'com.umc.product.global.security.ApiAccessDeniedHandlerTest'`를 통과했어요.
- `./gradlew spotlessCheck`를 통과했어요.
- `git diff --check`를 통과했어요.
- 최신 문구 반영 전 기준으로는 전체 `./gradlew test`를 통과했어요. 최신 문구 반영 후 전체 `./gradlew test`는 로컬 세션이 종료 출력을 반환하지 않아 중단했고, 변경 범위와 직접 관련된 테스트는 별도로 통과시켰어요.

## 💬 리뷰 중점사항

- Security filter chain, MVC exception handler, `/error` fallback controller, 점검 필터가 같은 실패 응답 구조를 유지하는지 봐 주세요.
- 403 응답에서 내부 권한 정책 메시지를 숨기고 `result`를 비워두는 정책이 프론트엔드 처리 방식과 맞는지 봐 주세요.
- JSON 파싱 실패와 요청 값 오류 문구가 `docs/onboarding/ux-writing-guidelines.md` 기준에 맞게 충분히 이해 가능한지 봐 주세요.
- `BusinessException#getMessage()` 자체는 변경하지 않고 응답 resolver에서만 fallback을 적용했어요. 예외 클래스 동작을 근본적으로 정리할지는 별도 작업으로 보는 것이 안전해요.
- DB migration, 환경 설정, 외부 API 연동 변경은 없어요.
