### PR TITLE
[Fix] CI에서 테스트 실행 시 OOM이 발생하던 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -330,6 +330,7 @@ tasks.clean {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxHeapSize = "3g"
 }
 
 tasks.test {

--- a/src/main/java/com/umc/product/global/config/SchedulingConfig.java
+++ b/src/main/java/com/umc/product/global/config/SchedulingConfig.java
@@ -1,9 +1,11 @@
 package com.umc.product.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@Profile("!test")
 public class SchedulingConfig {
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,6 +29,18 @@ jwt:
 
 
 management:
+  tracing:
+    enabled: false
+  otlp:
+    tracing:
+      export:
+        enabled: false
+    logging:
+      export:
+        enabled: false
+    metrics:
+      export:
+        enabled: false
   health:
     mail:
       enabled: false
@@ -45,6 +57,12 @@ logging:
 
 app:
   base-url: http://localhost:8080
+  observability:
+    tracing:
+      enabled: false
+      use-case-spans: false
+      adapter-spans: false
+      db-spans: false
   cors:
     allowed-origin-patterns: ""
   llm:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,6 +63,16 @@ app:
       use-case-spans: false
       adapter-spans: false
       db-spans: false
+  webhook:
+    buffer:
+      enabled: false
+    telegram:
+      bot-token: "false"
+      chat-id: "false"
+    slack:
+      url: "false"
+    discord:
+      url: "false"
   cors:
     allowed-origin-patterns: ""
   llm:


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- 관련 이슈는 없어요.

## 🚀 작업 내용

### 변경 범위 요약

- CI 테스트 실행 환경과 test profile 설정만 수정했어요.
- 운영 profile의 tracing, scheduling, webhook 동작은 변경하지 않았어요.

### 작업 단위별 상세

1. **무엇을**: GitHub Actions 전체 테스트에서 사용하는 JVM heap을 3g로 명시했어요.
   - **어떻게**: Gradle `Test` 태스크의 `maxHeapSize`를 설정했어요.
   - **왜**: GitHub hosted runner에서 전체 테스트 후반부에 classpath scanning 중 `OutOfMemoryError`가 발생해 CI가 실패했기 때문이에요.

2. **무엇을**: test profile에서 tracing, OTLP export, scheduling, webhook 외부 호출을 비활성화했어요.
   - **어떻게**: `application-test.yml`에 테스트 전용 설정을 추가하고, `SchedulingConfig`는 `test` profile에서 제외했어요.
   - **왜**: 테스트 중 불필요한 background 작업과 외부 export가 메모리와 네트워크 자원을 소모하지 않게 하기 위해서예요.

## 💬 리뷰 중점사항

- `@Profile("!test")`로 스케줄링 전체를 test profile에서 제외해도 통합 테스트 의도와 충돌하지 않는지 봐주세요.
- `maxHeapSize = "3g"`가 GitHub hosted runner 기준으로 적절한지 봐주세요.
- 운영 profile에는 영향이 없도록 test profile 설정에만 외부 export와 webhook 비활성화가 들어갔는지 봐주세요.