### PR TITLE
[Docs] 프로덕트팀 관련 API 설명 추가

### DIFF
--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java
@@ -15,17 +15,25 @@ import com.umc.product.organization.adapter.in.web.dto.request.CreateUmcProductF
 import com.umc.product.organization.adapter.in.web.dto.request.UpdateUmcProductFunctionalUnitRequest;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductFunctionalUnitUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/umc-product/functional-units")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 기능 조직 Command", description = "UMC Product 기능 조직 생성, 수정, 삭제")
 public class UmcProductFunctionalUnitCommandController {
 
     private final ManageUmcProductFunctionalUnitUseCase manageUmcProductFunctionalUnitUseCase;
 
     @PostMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-001",
+        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-001] UMC Product 기능 조직 생성",
+        description = "UMC Product 기수에 속한 기능 조직을 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 상위 기능 조직을 지정하는 경우 같은 기수 안의 조직이어야 합니다."
+    )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
         @RequestBody @Valid CreateUmcProductFunctionalUnitRequest request
@@ -34,6 +42,11 @@ public class UmcProductFunctionalUnitCommandController {
     }
 
     @PatchMapping("/{functionalUnitId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-002",
+        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-002] UMC Product 기능 조직 수정",
+        description = "UMC Product 기능 조직의 상위 조직, 유형, 코드, 이름, 설명, 정렬 순서, 활성 여부를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
+    )
     public void update(
         @PathVariable Long functionalUnitId,
         @CurrentMember MemberPrincipal currentMember,
@@ -45,6 +58,11 @@ public class UmcProductFunctionalUnitCommandController {
     }
 
     @DeleteMapping("/{functionalUnitId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-003",
+        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-003] UMC Product 기능 조직 삭제",
+        description = "UMC Product 기능 조직을 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
+    )
     public void delete(
         @PathVariable Long functionalUnitId,
         @CurrentMember MemberPrincipal currentMember

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/functional-units")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 기능 조직 Command", description = "UMC Product 기능 조직 생성, 수정, 삭제")
+@Tag(name = "Organization | UMC PRODUCT 기능 조직 Command", description = "UMC PRODUCT 기능 조직 생성, 수정, 삭제")
 public class UmcProductFunctionalUnitCommandController {
 
     private final ManageUmcProductFunctionalUnitUseCase manageUmcProductFunctionalUnitUseCase;
@@ -31,8 +31,8 @@ public class UmcProductFunctionalUnitCommandController {
     @PostMapping
     @Operation(
         operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-001",
-        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-001] UMC Product 기능 조직 생성",
-        description = "UMC Product 기수에 속한 기능 조직을 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 상위 기능 조직을 지정하는 경우 같은 기수 안의 조직이어야 합니다."
+        summary = "UMC PRODUCT 기능 조직 생성",
+        description = "UMC PRODUCT 기수에 속한 기능 조직을 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 상위 기능 조직을 지정하는 경우 같은 기수 안의 조직이어야 합니다."
     )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
@@ -44,8 +44,8 @@ public class UmcProductFunctionalUnitCommandController {
     @PatchMapping("/{functionalUnitId}")
     @Operation(
         operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-002",
-        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-002] UMC Product 기능 조직 수정",
-        description = "UMC Product 기능 조직의 상위 조직, 유형, 코드, 이름, 설명, 정렬 순서, 활성 여부를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
+        summary = "UMC PRODUCT 기능 조직 수정",
+        description = "UMC PRODUCT 기능 조직의 상위 조직, 유형, 코드, 이름, 설명, 정렬 순서, 활성 여부를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
     )
     public void update(
         @PathVariable Long functionalUnitId,
@@ -60,8 +60,8 @@ public class UmcProductFunctionalUnitCommandController {
     @DeleteMapping("/{functionalUnitId}")
     @Operation(
         operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-003",
-        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-003] UMC Product 기능 조직 삭제",
-        description = "UMC Product 기능 조직을 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
+        summary = "UMC PRODUCT 기능 조직 삭제",
+        description = "UMC PRODUCT 기능 조직을 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있습니다."
     )
     public void delete(
         @PathVariable Long functionalUnitId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/functional-units")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 기능 조직 Query", description = "UMC Product 기능 조직 목록 조회")
+@Tag(name = "Organization | UMC PRODUCT 기능 조직 Query", description = "UMC PRODUCT 기능 조직 목록 조회")
 public class UmcProductFunctionalUnitQueryController {
 
     private final GetUmcProductFunctionalUnitUseCase getUmcProductFunctionalUnitUseCase;
@@ -26,8 +26,8 @@ public class UmcProductFunctionalUnitQueryController {
     @GetMapping
     @Operation(
         operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-101",
-        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-101] UMC Product 기능 조직 목록 조회",
-        description = "기수별 UMC Product 기능 조직 목록을 조회합니다. type 값을 전달하면 기능 조직 유형별로 필터링할 수 있습니다."
+        summary = "UMC PRODUCT 기능 조직 목록 조회",
+        description = "기수별 UMC PRODUCT 기능 조직 목록을 조회합니다. type 값을 전달하면 기능 조직 유형별로 필터링할 수 있습니다."
     )
     public UmcProductFunctionalUnitListResponse list(
         @RequestParam Long umcProductGenerationId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java
@@ -10,17 +10,25 @@ import com.umc.product.organization.adapter.in.web.dto.response.umcproduct.UmcPr
 import com.umc.product.organization.application.port.in.query.GetUmcProductFunctionalUnitUseCase;
 import com.umc.product.organization.domain.enums.UmcProductFunctionalUnitType;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Public
 @RestController
 @RequestMapping("/api/v1/umc-product/functional-units")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 기능 조직 Query", description = "UMC Product 기능 조직 목록 조회")
 public class UmcProductFunctionalUnitQueryController {
 
     private final GetUmcProductFunctionalUnitUseCase getUmcProductFunctionalUnitUseCase;
 
     @GetMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-FUNCTIONAL-UNIT-101",
+        summary = "[UMC-PRODUCT-FUNCTIONAL-UNIT-101] UMC Product 기능 조직 목록 조회",
+        description = "기수별 UMC Product 기능 조직 목록을 조회합니다. type 값을 전달하면 기능 조직 유형별로 필터링할 수 있습니다."
+    )
     public UmcProductFunctionalUnitListResponse list(
         @RequestParam Long umcProductGenerationId,
         @RequestParam(required = false) UmcProductFunctionalUnitType type

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java
@@ -15,17 +15,25 @@ import com.umc.product.organization.adapter.in.web.dto.request.CreateUmcProductG
 import com.umc.product.organization.adapter.in.web.dto.request.UpdateUmcProductGenerationRequest;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductGenerationUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/umc-product/generations")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 기수 Command", description = "UMC Product 기수 생성, 수정, 삭제")
 public class UmcProductGenerationCommandController {
 
     private final ManageUmcProductGenerationUseCase manageUmcProductGenerationUseCase;
 
     @PostMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-GENERATION-001",
+        summary = "[UMC-PRODUCT-GENERATION-001] UMC Product 기수 생성",
+        description = "UMC Product 기수를 생성합니다. 기수 생성 권한을 가진 요청자만 호출할 수 있으며, 동일한 기수 번호는 중복 등록할 수 없습니다. active=true로 생성하면 기존 활성 기수는 비활성화됩니다."
+    )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
         @RequestBody @Valid CreateUmcProductGenerationRequest request
@@ -34,6 +42,11 @@ public class UmcProductGenerationCommandController {
     }
 
     @PatchMapping("/{umcProductGenerationId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-GENERATION-002",
+        summary = "[UMC-PRODUCT-GENERATION-002] UMC Product 기수 수정",
+        description = "UMC Product 기수의 번호, 운영 기간, 활성 여부를 수정합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있으며, active=true로 수정하면 기존 활성 기수는 비활성화됩니다."
+    )
     public void update(
         @PathVariable Long umcProductGenerationId,
         @CurrentMember MemberPrincipal currentMember,
@@ -45,6 +58,11 @@ public class UmcProductGenerationCommandController {
     }
 
     @DeleteMapping("/{umcProductGenerationId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-GENERATION-003",
+        summary = "[UMC-PRODUCT-GENERATION-003] UMC Product 기수 삭제",
+        description = "UMC Product 기수를 삭제합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있습니다."
+    )
     public void delete(
         @PathVariable Long umcProductGenerationId,
         @CurrentMember MemberPrincipal currentMember

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/generations")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 기수 Command", description = "UMC Product 기수 생성, 수정, 삭제")
+@Tag(name = "Organization | UMC PRODUCT 기수 Command", description = "UMC PRODUCT 기수 생성, 수정, 삭제")
 public class UmcProductGenerationCommandController {
 
     private final ManageUmcProductGenerationUseCase manageUmcProductGenerationUseCase;
@@ -31,8 +31,8 @@ public class UmcProductGenerationCommandController {
     @PostMapping
     @Operation(
         operationId = "UMC-PRODUCT-GENERATION-001",
-        summary = "[UMC-PRODUCT-GENERATION-001] UMC Product 기수 생성",
-        description = "UMC Product 기수를 생성합니다. 기수 생성 권한을 가진 요청자만 호출할 수 있으며, 동일한 기수 번호는 중복 등록할 수 없습니다. active=true로 생성하면 기존 활성 기수는 비활성화됩니다."
+        summary = "UMC PRODUCT 기수 생성",
+        description = "UMC PRODUCT 기수를 생성합니다. 기수 생성 권한을 가진 요청자만 호출할 수 있으며, 동일한 기수 번호는 중복 등록할 수 없습니다. active=true로 생성하면 기존 활성 기수는 비활성화됩니다."
     )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
@@ -44,8 +44,8 @@ public class UmcProductGenerationCommandController {
     @PatchMapping("/{umcProductGenerationId}")
     @Operation(
         operationId = "UMC-PRODUCT-GENERATION-002",
-        summary = "[UMC-PRODUCT-GENERATION-002] UMC Product 기수 수정",
-        description = "UMC Product 기수의 번호, 운영 기간, 활성 여부를 수정합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있으며, active=true로 수정하면 기존 활성 기수는 비활성화됩니다."
+        summary = "UMC PRODUCT 기수 수정",
+        description = "UMC PRODUCT 기수의 번호, 운영 기간, 활성 여부를 수정합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있으며, active=true로 수정하면 기존 활성 기수는 비활성화됩니다."
     )
     public void update(
         @PathVariable Long umcProductGenerationId,
@@ -60,8 +60,8 @@ public class UmcProductGenerationCommandController {
     @DeleteMapping("/{umcProductGenerationId}")
     @Operation(
         operationId = "UMC-PRODUCT-GENERATION-003",
-        summary = "[UMC-PRODUCT-GENERATION-003] UMC Product 기수 삭제",
-        description = "UMC Product 기수를 삭제합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있습니다."
+        summary = "UMC PRODUCT 기수 삭제",
+        description = "UMC PRODUCT 기수를 삭제합니다. 해당 기수 관리 권한을 가진 요청자만 호출할 수 있습니다."
     )
     public void delete(
         @PathVariable Long umcProductGenerationId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java
@@ -10,22 +10,35 @@ import com.umc.product.organization.adapter.in.web.dto.response.umcproduct.UmcPr
 import com.umc.product.organization.adapter.in.web.dto.response.umcproduct.UmcProductGenerationResponse;
 import com.umc.product.organization.application.port.in.query.GetUmcProductGenerationUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Public
 @RestController
 @RequestMapping("/api/v1/umc-product/generations")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 기수 Query", description = "UMC Product 기수 목록 및 상세 조회")
 public class UmcProductGenerationQueryController {
 
     private final GetUmcProductGenerationUseCase getUmcProductGenerationUseCase;
 
     @GetMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-GENERATION-101",
+        summary = "[UMC-PRODUCT-GENERATION-101] UMC Product 기수 목록 조회",
+        description = "등록된 UMC Product 기수 목록을 조회합니다. 각 기수의 번호, 운영 기간, 활성 여부를 반환합니다."
+    )
     public UmcProductGenerationListResponse list() {
         return UmcProductGenerationListResponse.from(getUmcProductGenerationUseCase.listAll());
     }
 
     @GetMapping("/{umcProductGenerationId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-GENERATION-102",
+        summary = "[UMC-PRODUCT-GENERATION-102] UMC Product 기수 상세 조회",
+        description = "UMC Product 기수 ID로 단건 상세 정보를 조회합니다. 기수 번호, 운영 기간, 활성 여부를 반환합니다."
+    )
     public UmcProductGenerationResponse get(@PathVariable Long umcProductGenerationId) {
         return UmcProductGenerationResponse.from(getUmcProductGenerationUseCase.getById(umcProductGenerationId));
     }

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/generations")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 기수 Query", description = "UMC Product 기수 목록 및 상세 조회")
+@Tag(name = "Organization | UMC PRODUCT 기수 Query", description = "UMC PRODUCT 기수 목록 및 상세 조회")
 public class UmcProductGenerationQueryController {
 
     private final GetUmcProductGenerationUseCase getUmcProductGenerationUseCase;
@@ -26,8 +26,8 @@ public class UmcProductGenerationQueryController {
     @GetMapping
     @Operation(
         operationId = "UMC-PRODUCT-GENERATION-101",
-        summary = "[UMC-PRODUCT-GENERATION-101] UMC Product 기수 목록 조회",
-        description = "등록된 UMC Product 기수 목록을 조회합니다. 각 기수의 번호, 운영 기간, 활성 여부를 반환합니다."
+        summary = "UMC PRODUCT 기수 목록 조회",
+        description = "등록된 UMC PRODUCT 기수 목록을 조회합니다. 각 기수의 번호, 운영 기간, 활성 여부를 반환합니다."
     )
     public UmcProductGenerationListResponse list() {
         return UmcProductGenerationListResponse.from(getUmcProductGenerationUseCase.listAll());
@@ -36,8 +36,8 @@ public class UmcProductGenerationQueryController {
     @GetMapping("/{umcProductGenerationId}")
     @Operation(
         operationId = "UMC-PRODUCT-GENERATION-102",
-        summary = "[UMC-PRODUCT-GENERATION-102] UMC Product 기수 상세 조회",
-        description = "UMC Product 기수 ID로 단건 상세 정보를 조회합니다. 기수 번호, 운영 기간, 활성 여부를 반환합니다."
+        summary = "UMC PRODUCT 기수 상세 조회",
+        description = "UMC PRODUCT 기수 ID로 단건 상세 정보를 조회합니다. 기수 번호, 운영 기간, 활성 여부를 반환합니다."
     )
     public UmcProductGenerationResponse get(@PathVariable Long umcProductGenerationId) {
         return UmcProductGenerationResponse.from(getUmcProductGenerationUseCase.getById(umcProductGenerationId));

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java
@@ -17,17 +17,25 @@ import com.umc.product.organization.adapter.in.web.dto.request.ReplaceUmcProduct
 import com.umc.product.organization.adapter.in.web.dto.request.UpdateUmcProductMemberProfileRequest;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductMemberUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/umc-product/members")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 멤버 Command", description = "UMC Product 멤버 생성, 프로필 수정, 소속 관리, 삭제")
 public class UmcProductMemberCommandController {
 
     private final ManageUmcProductMemberUseCase manageUmcProductMemberUseCase;
 
     @PostMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-001",
+        summary = "[UMC-PRODUCT-MEMBER-001] UMC Product 멤버 생성",
+        description = "UMC Product 조직에 멤버를 등록합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기본 프로필과 기능 조직 소속, 스쿼드 참여 정보를 함께 저장합니다."
+    )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
         @RequestBody @Valid CreateUmcProductMemberRequest request
@@ -36,6 +44,11 @@ public class UmcProductMemberCommandController {
     }
 
     @PatchMapping("/{umcProductMemberId}/profile")
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-002",
+        summary = "[UMC-PRODUCT-MEMBER-002] UMC Product 멤버 프로필 수정",
+        description = "UMC Product 멤버의 소개와 Product 전용 프로필 이미지를 수정합니다. 본인 또는 멤버 프로필 관리 권한을 가진 요청자만 호출할 수 있습니다."
+    )
     public void updateProfile(
         @PathVariable Long umcProductMemberId,
         @CurrentMember MemberPrincipal currentMember,
@@ -47,6 +60,11 @@ public class UmcProductMemberCommandController {
     }
 
     @PutMapping("/{umcProductMemberId}/functional-memberships")
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-003",
+        summary = "[UMC-PRODUCT-MEMBER-003] UMC Product 멤버 기능 조직 소속 교체",
+        description = "UMC Product 멤버의 기능 조직 소속 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 소속은 삭제 후 새 소속으로 저장됩니다."
+    )
     public void replaceFunctionalMemberships(
         @PathVariable Long umcProductMemberId,
         @CurrentMember MemberPrincipal currentMember,
@@ -58,6 +76,11 @@ public class UmcProductMemberCommandController {
     }
 
     @DeleteMapping("/{umcProductMemberId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-004",
+        summary = "[UMC-PRODUCT-MEMBER-004] UMC Product 멤버 삭제",
+        description = "UMC Product 멤버를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 기능 조직 소속과 스쿼드 참여 정보도 함께 삭제됩니다."
+    )
     public void delete(
         @PathVariable Long umcProductMemberId,
         @CurrentMember MemberPrincipal currentMember

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/members")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 멤버 Command", description = "UMC Product 멤버 생성, 프로필 수정, 소속 관리, 삭제")
+@Tag(name = "Organization | UMC PRODUCT 멤버 Command", description = "UMC PRODUCT 멤버 생성, 프로필 수정, 소속 관리, 삭제")
 public class UmcProductMemberCommandController {
 
     private final ManageUmcProductMemberUseCase manageUmcProductMemberUseCase;
@@ -33,8 +33,8 @@ public class UmcProductMemberCommandController {
     @PostMapping
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-001",
-        summary = "[UMC-PRODUCT-MEMBER-001] UMC Product 멤버 생성",
-        description = "UMC Product 조직에 멤버를 등록합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기본 프로필과 기능 조직 소속, 스쿼드 참여 정보를 함께 저장합니다."
+        summary = "UMC PRODUCT 멤버 생성",
+        description = "UMC PRODUCT 조직에 멤버를 등록합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기본 프로필과 기능 조직 소속, 스쿼드 참여 정보를 함께 저장합니다."
     )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
@@ -46,8 +46,8 @@ public class UmcProductMemberCommandController {
     @PatchMapping("/{umcProductMemberId}/profile")
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-002",
-        summary = "[UMC-PRODUCT-MEMBER-002] UMC Product 멤버 프로필 수정",
-        description = "UMC Product 멤버의 소개와 Product 전용 프로필 이미지를 수정합니다. 본인 또는 멤버 프로필 관리 권한을 가진 요청자만 호출할 수 있습니다."
+        summary = "UMC PRODUCT 멤버 프로필 수정",
+        description = "UMC PRODUCT 멤버의 소개와 UMC PRODUCT 전용 프로필 이미지를 수정합니다. 본인 또는 멤버 프로필 관리 권한을 가진 요청자만 호출할 수 있습니다."
     )
     public void updateProfile(
         @PathVariable Long umcProductMemberId,
@@ -62,8 +62,8 @@ public class UmcProductMemberCommandController {
     @PutMapping("/{umcProductMemberId}/functional-memberships")
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-003",
-        summary = "[UMC-PRODUCT-MEMBER-003] UMC Product 멤버 기능 조직 소속 교체",
-        description = "UMC Product 멤버의 기능 조직 소속 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 소속은 삭제 후 새 소속으로 저장됩니다."
+        summary = "UMC PRODUCT 멤버 기능 조직 소속 교체",
+        description = "UMC PRODUCT 멤버의 기능 조직 소속 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 소속은 삭제 후 새 소속으로 저장됩니다."
     )
     public void replaceFunctionalMemberships(
         @PathVariable Long umcProductMemberId,
@@ -78,8 +78,8 @@ public class UmcProductMemberCommandController {
     @DeleteMapping("/{umcProductMemberId}")
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-004",
-        summary = "[UMC-PRODUCT-MEMBER-004] UMC Product 멤버 삭제",
-        description = "UMC Product 멤버를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 기능 조직 소속과 스쿼드 참여 정보도 함께 삭제됩니다."
+        summary = "UMC PRODUCT 멤버 삭제",
+        description = "UMC PRODUCT 멤버를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 기능 조직 소속과 스쿼드 참여 정보도 함께 삭제됩니다."
     )
     public void delete(
         @PathVariable Long umcProductMemberId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java
@@ -17,17 +17,25 @@ import com.umc.product.organization.domain.enums.UmcProductFunctionalRole;
 import com.umc.product.organization.domain.enums.UmcProductFunctionalUnitType;
 import com.umc.product.organization.domain.enums.UmcProductPosition;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Public
 @RestController
 @RequestMapping("/api/v1/umc-product/members")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 멤버 Query", description = "UMC Product 멤버 목록 및 상세 조회")
 public class UmcProductMemberQueryController {
 
     private final GetUmcProductMemberUseCase getUmcProductMemberUseCase;
 
     @GetMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-101",
+        summary = "[UMC-PRODUCT-MEMBER-101] UMC Product 멤버 검색",
+        description = "기수, 기능 조직, 역할, 포지션, 스쿼드 조건으로 UMC Product 멤버를 페이지 조회합니다. 멤버 기본 정보와 기능 조직 소속, 스쿼드 참여 정보를 함께 반환합니다."
+    )
     public UmcProductMemberPageResponse search(
         @RequestParam(required = false) Long umcProductGenerationId,
         @RequestParam(required = false) Long functionalUnitId,
@@ -53,6 +61,11 @@ public class UmcProductMemberQueryController {
     }
 
     @GetMapping("/{umcProductMemberId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-MEMBER-102",
+        summary = "[UMC-PRODUCT-MEMBER-102] UMC Product 멤버 상세 조회",
+        description = "UMC Product 멤버 ID로 단건 상세 정보를 조회합니다. 멤버 기본 정보, Product 전용 프로필, 기능 조직 소속, 스쿼드 참여 정보를 반환합니다."
+    )
     public UmcProductMemberResponse get(@PathVariable Long umcProductMemberId) {
         return UmcProductMemberResponse.from(getUmcProductMemberUseCase.getById(umcProductMemberId));
     }

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/members")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 멤버 Query", description = "UMC Product 멤버 목록 및 상세 조회")
+@Tag(name = "Organization | UMC PRODUCT 멤버 Query", description = "UMC PRODUCT 멤버 목록 및 상세 조회")
 public class UmcProductMemberQueryController {
 
     private final GetUmcProductMemberUseCase getUmcProductMemberUseCase;
@@ -33,8 +33,8 @@ public class UmcProductMemberQueryController {
     @GetMapping
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-101",
-        summary = "[UMC-PRODUCT-MEMBER-101] UMC Product 멤버 검색",
-        description = "기수, 기능 조직, 역할, 포지션, 스쿼드 조건으로 UMC Product 멤버를 페이지 조회합니다. 멤버 기본 정보와 기능 조직 소속, 스쿼드 참여 정보를 함께 반환합니다."
+        summary = "UMC PRODUCT 멤버 검색",
+        description = "기수, 기능 조직, 역할, 포지션, 스쿼드 조건으로 UMC PRODUCT 멤버를 페이지 조회합니다. 멤버 기본 정보와 기능 조직 소속, 스쿼드 참여 정보를 함께 반환합니다."
     )
     public UmcProductMemberPageResponse search(
         @RequestParam(required = false) Long umcProductGenerationId,
@@ -63,8 +63,8 @@ public class UmcProductMemberQueryController {
     @GetMapping("/{umcProductMemberId}")
     @Operation(
         operationId = "UMC-PRODUCT-MEMBER-102",
-        summary = "[UMC-PRODUCT-MEMBER-102] UMC Product 멤버 상세 조회",
-        description = "UMC Product 멤버 ID로 단건 상세 정보를 조회합니다. 멤버 기본 정보, Product 전용 프로필, 기능 조직 소속, 스쿼드 참여 정보를 반환합니다."
+        summary = "UMC PRODUCT 멤버 상세 조회",
+        description = "UMC PRODUCT 멤버 ID로 단건 상세 정보를 조회합니다. 멤버 기본 정보, UMC PRODUCT 전용 프로필, 기능 조직 소속, 스쿼드 참여 정보를 반환합니다."
     )
     public UmcProductMemberResponse get(@PathVariable Long umcProductMemberId) {
         return UmcProductMemberResponse.from(getUmcProductMemberUseCase.getById(umcProductMemberId));

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java
@@ -9,17 +9,25 @@ import com.umc.product.global.security.annotation.Public;
 import com.umc.product.organization.adapter.in.web.dto.response.umcproduct.UmcProductOrganizationChartResponse;
 import com.umc.product.organization.application.port.in.query.GetUmcProductOrganizationChartUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Public
 @RestController
 @RequestMapping("/api/v1/umc-product/organization-chart")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 조직도 Query", description = "UMC Product 기수별 조직도 조회")
 public class UmcProductOrganizationChartQueryController {
 
     private final GetUmcProductOrganizationChartUseCase getUmcProductOrganizationChartUseCase;
 
     @GetMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-ORGANIZATION-CHART-101",
+        summary = "[UMC-PRODUCT-ORGANIZATION-CHART-101] UMC Product 조직도 조회",
+        description = "기수 ID 기준으로 UMC Product 조직도를 조회합니다. 기수 정보, 해당 기수의 기능 조직 목록, 운영 기간과 겹치는 스쿼드 목록을 함께 반환합니다."
+    )
     public UmcProductOrganizationChartResponse get(@RequestParam Long umcProductGenerationId) {
         return UmcProductOrganizationChartResponse.from(
             getUmcProductOrganizationChartUseCase.getByGenerationId(umcProductGenerationId)

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/organization-chart")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 조직도 Query", description = "UMC Product 기수별 조직도 조회")
+@Tag(name = "Organization | UMC PRODUCT 조직도 Query", description = "UMC PRODUCT 기수별 조직도 조회")
 public class UmcProductOrganizationChartQueryController {
 
     private final GetUmcProductOrganizationChartUseCase getUmcProductOrganizationChartUseCase;
@@ -25,8 +25,8 @@ public class UmcProductOrganizationChartQueryController {
     @GetMapping
     @Operation(
         operationId = "UMC-PRODUCT-ORGANIZATION-CHART-101",
-        summary = "[UMC-PRODUCT-ORGANIZATION-CHART-101] UMC Product 조직도 조회",
-        description = "기수 ID 기준으로 UMC Product 조직도를 조회합니다. 기수 정보, 해당 기수의 기능 조직 목록, 운영 기간과 겹치는 스쿼드 목록을 함께 반환합니다."
+        summary = "UMC PRODUCT 조직도 조회",
+        description = "기수 ID 기준으로 UMC PRODUCT 조직도를 조회합니다. 기수 정보, 해당 기수의 기능 조직 목록, 운영 기간과 겹치는 스쿼드 목록을 함께 반환합니다."
     )
     public UmcProductOrganizationChartResponse get(@RequestParam Long umcProductGenerationId) {
         return UmcProductOrganizationChartResponse.from(

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/squads")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 스쿼드 Command", description = "UMC Product 스쿼드 생성, 수정, 삭제, 참여자 관리")
+@Tag(name = "Organization | UMC PRODUCT 스쿼드 Command", description = "UMC PRODUCT 스쿼드 생성, 수정, 삭제, 참여자 관리")
 public class UmcProductSquadCommandController {
 
     private final ManageUmcProductSquadUseCase manageUmcProductSquadUseCase;
@@ -33,8 +33,8 @@ public class UmcProductSquadCommandController {
     @PostMapping
     @Operation(
         operationId = "UMC-PRODUCT-SQUAD-001",
-        summary = "[UMC-PRODUCT-SQUAD-001] UMC Product 스쿼드 생성",
-        description = "UMC Product 스쿼드를 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 코드, 이름, 운영 기간, 정렬 순서, 활성 여부를 저장합니다."
+        summary = "UMC PRODUCT 스쿼드 생성",
+        description = "UMC PRODUCT 스쿼드를 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 코드, 이름, 운영 기간, 정렬 순서, 활성 여부를 저장합니다."
     )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
@@ -46,8 +46,8 @@ public class UmcProductSquadCommandController {
     @PatchMapping("/{squadId}")
     @Operation(
         operationId = "UMC-PRODUCT-SQUAD-002",
-        summary = "[UMC-PRODUCT-SQUAD-002] UMC Product 스쿼드 수정",
-        description = "UMC Product 스쿼드의 기본 정보를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 요청 본문의 값으로 코드, 이름, 설명, 운영 기간, 정렬 순서, 활성 여부를 갱신합니다."
+        summary = "UMC PRODUCT 스쿼드 수정",
+        description = "UMC PRODUCT 스쿼드의 기본 정보를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 요청 본문의 값으로 코드, 이름, 설명, 운영 기간, 정렬 순서, 활성 여부를 갱신합니다."
     )
     public void update(
         @PathVariable Long squadId,
@@ -60,8 +60,8 @@ public class UmcProductSquadCommandController {
     @DeleteMapping("/{squadId}")
     @Operation(
         operationId = "UMC-PRODUCT-SQUAD-003",
-        summary = "[UMC-PRODUCT-SQUAD-003] UMC Product 스쿼드 삭제",
-        description = "UMC Product 스쿼드를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 스쿼드 참여자 정보도 함께 삭제됩니다."
+        summary = "UMC PRODUCT 스쿼드 삭제",
+        description = "UMC PRODUCT 스쿼드를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 스쿼드 참여자 정보도 함께 삭제됩니다."
     )
     public void delete(
         @PathVariable Long squadId,
@@ -73,8 +73,8 @@ public class UmcProductSquadCommandController {
     @PutMapping("/{squadId}/participants")
     @Operation(
         operationId = "UMC-PRODUCT-SQUAD-004",
-        summary = "[UMC-PRODUCT-SQUAD-004] UMC Product 스쿼드 참여자 교체",
-        description = "UMC Product 스쿼드 참여자 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 참여자는 삭제 후 새 참여자로 저장됩니다."
+        summary = "UMC PRODUCT 스쿼드 참여자 교체",
+        description = "UMC PRODUCT 스쿼드 참여자 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 참여자는 삭제 후 새 참여자로 저장됩니다."
     )
     public void replaceParticipants(
         @PathVariable Long squadId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java
@@ -17,17 +17,25 @@ import com.umc.product.organization.adapter.in.web.dto.request.ReplaceUmcProduct
 import com.umc.product.organization.adapter.in.web.dto.request.UpdateUmcProductSquadRequest;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductSquadUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/umc-product/squads")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 스쿼드 Command", description = "UMC Product 스쿼드 생성, 수정, 삭제, 참여자 관리")
 public class UmcProductSquadCommandController {
 
     private final ManageUmcProductSquadUseCase manageUmcProductSquadUseCase;
 
     @PostMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-SQUAD-001",
+        summary = "[UMC-PRODUCT-SQUAD-001] UMC Product 스쿼드 생성",
+        description = "UMC Product 스쿼드를 생성합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 코드, 이름, 운영 기간, 정렬 순서, 활성 여부를 저장합니다."
+    )
     public Long create(
         @CurrentMember MemberPrincipal currentMember,
         @RequestBody @Valid CreateUmcProductSquadRequest request
@@ -36,6 +44,11 @@ public class UmcProductSquadCommandController {
     }
 
     @PatchMapping("/{squadId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-SQUAD-002",
+        summary = "[UMC-PRODUCT-SQUAD-002] UMC Product 스쿼드 수정",
+        description = "UMC Product 스쿼드의 기본 정보를 수정합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 요청 본문의 값으로 코드, 이름, 설명, 운영 기간, 정렬 순서, 활성 여부를 갱신합니다."
+    )
     public void update(
         @PathVariable Long squadId,
         @CurrentMember MemberPrincipal currentMember,
@@ -45,6 +58,11 @@ public class UmcProductSquadCommandController {
     }
 
     @DeleteMapping("/{squadId}")
+    @Operation(
+        operationId = "UMC-PRODUCT-SQUAD-003",
+        summary = "[UMC-PRODUCT-SQUAD-003] UMC Product 스쿼드 삭제",
+        description = "UMC Product 스쿼드를 삭제합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 연결된 스쿼드 참여자 정보도 함께 삭제됩니다."
+    )
     public void delete(
         @PathVariable Long squadId,
         @CurrentMember MemberPrincipal currentMember
@@ -53,6 +71,11 @@ public class UmcProductSquadCommandController {
     }
 
     @PutMapping("/{squadId}/participants")
+    @Operation(
+        operationId = "UMC-PRODUCT-SQUAD-004",
+        summary = "[UMC-PRODUCT-SQUAD-004] UMC Product 스쿼드 참여자 교체",
+        description = "UMC Product 스쿼드 참여자 목록을 요청 본문 기준으로 전체 교체합니다. 운영 권한을 가진 요청자만 호출할 수 있으며, 기존 참여자는 삭제 후 새 참여자로 저장됩니다."
+    )
     public void replaceParticipants(
         @PathVariable Long squadId,
         @CurrentMember MemberPrincipal currentMember,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/umc-product/squads")
 @RequiredArgsConstructor
-@Tag(name = "Organization | UMC Product 스쿼드 Query", description = "UMC Product 스쿼드 목록 조회")
+@Tag(name = "Organization | UMC PRODUCT 스쿼드 Query", description = "UMC PRODUCT 스쿼드 목록 조회")
 public class UmcProductSquadQueryController {
 
     private final GetUmcProductSquadUseCase getUmcProductSquadUseCase;
@@ -25,8 +25,8 @@ public class UmcProductSquadQueryController {
     @GetMapping
     @Operation(
         operationId = "UMC-PRODUCT-SQUAD-101",
-        summary = "[UMC-PRODUCT-SQUAD-101] UMC Product 스쿼드 목록 조회",
-        description = "UMC Product 스쿼드 목록을 조회합니다. 기수 ID를 전달하면 해당 기수 운영 기간과 겹치는 스쿼드를 조회하고, active 값으로 활성 여부를 필터링할 수 있습니다."
+        summary = "UMC PRODUCT 스쿼드 목록 조회",
+        description = "UMC PRODUCT 스쿼드 목록을 조회합니다. 기수 ID를 전달하면 해당 기수 운영 기간과 겹치는 스쿼드를 조회하고, active 값으로 활성 여부를 필터링할 수 있습니다."
     )
     public UmcProductSquadListResponse list(
         @RequestParam(required = false) Long umcProductGenerationId,

--- a/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java
@@ -9,17 +9,25 @@ import com.umc.product.global.security.annotation.Public;
 import com.umc.product.organization.adapter.in.web.dto.response.umcproduct.UmcProductSquadListResponse;
 import com.umc.product.organization.application.port.in.query.GetUmcProductSquadUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Public
 @RestController
 @RequestMapping("/api/v1/umc-product/squads")
 @RequiredArgsConstructor
+@Tag(name = "Organization | UMC Product 스쿼드 Query", description = "UMC Product 스쿼드 목록 조회")
 public class UmcProductSquadQueryController {
 
     private final GetUmcProductSquadUseCase getUmcProductSquadUseCase;
 
     @GetMapping
+    @Operation(
+        operationId = "UMC-PRODUCT-SQUAD-101",
+        summary = "[UMC-PRODUCT-SQUAD-101] UMC Product 스쿼드 목록 조회",
+        description = "UMC Product 스쿼드 목록을 조회합니다. 기수 ID를 전달하면 해당 기수 운영 기간과 겹치는 스쿼드를 조회하고, active 값으로 활성 여부를 필터링할 수 있습니다."
+    )
     public UmcProductSquadListResponse list(
         @RequestParam(required = false) Long umcProductGenerationId,
         @RequestParam(required = false) Boolean active


### PR DESCRIPTION
## 대상 브랜치
- `develop`

## 관련 이슈
- 없음

## 작업 내용
- UMC PRODUCT 멤버, 스쿼드, 기수, 기능 조직, 조직도 컨트롤러에 Swagger `@Tag`를 추가했습니다.
- 각 API에 고유 `operationId`와 description을 추가했습니다.
- Swagger summary에서는 API ID를 제거하고, UMC PRODUCT 표기를 대문자로 통일했습니다.
- 설명은 실제 UseCase 동작 기준으로 권한 조건, 전체 교체 동작, 조회 필터 의미가 드러나도록 작성했습니다.

## 리뷰 중점사항
- Swagger tag 명칭이 기존 Organization API 분류와 자연스럽게 맞는지 확인 부탁드립니다.
- `operationId` 코드 체계와 summary 분리 방식이 문서 사용자 관점에서 충분히 명확한지 확인 부탁드립니다.

## 검증
- `./gradlew compileJava` 성공
- `git diff --check` 및 staged diff whitespace check 통과

## 비고
- 컴파일 중 기존 deprecated API 관련 warning이 출력되었지만, 이번 변경과 직접 관련된 오류는 없습니다.