### PR TITLE
[Fix] 프로젝트 지원서 중복 응답 정책 적용

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -67,48 +67,51 @@ public class ProjectApplicationController {
         );
     }
 
-    @PutMapping("/{projectId}/applications/me")
+    @PutMapping("/{projectId}/applications/{applicationId}")
     @Operation(
         summary = "[APPLY-002] 챌린저 지원서 임시저장",
         description = "본문이 곧 답변의 새 전체 상태가 된다. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT_APPLICATION,
-        resourceId = "#projectId",
-        permission = PermissionType.WRITE,
+        resourceId = "#applicationId",
+        permission = PermissionType.EDIT,
         message = "지원서를 임시저장할 권한이 없어요. 지원 가능한 프로젝트인지 확인해주세요."
     )
     public ProjectApplicationStatusResponse updateDraft(
         @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable Long projectId,
+        @PathVariable Long applicationId,
         @Valid @RequestBody UpdateApplicationAnswersRequest request
     ) {
         return ProjectApplicationStatusResponse.from(
             updateProjectApplicationDraftUseCase.update(
-                request.toCommand(projectId, memberPrincipal.getMemberId())
+                request.toCommand(projectId, applicationId, memberPrincipal.getMemberId())
             )
         );
     }
 
-    @PostMapping("/{projectId}/applications/me/submit")
+    @PostMapping("/{projectId}/applications/{applicationId}/submit")
     @Operation(
         summary = "[APPLY-003] 챌린저 지원서 최종 제출",
         description = "DRAFT -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 DRAFT 지원서에서만 호출 가능."
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT_APPLICATION,
-        resourceId = "#projectId",
-        permission = PermissionType.WRITE,
+        resourceId = "#applicationId",
+        permission = PermissionType.EDIT,
         message = "지원서를 제출할 권한이 없어요. 지원 가능한 프로젝트인지 확인해주세요."
     )
     public ProjectApplicationStatusResponse submit(
         @CurrentMember MemberPrincipal memberPrincipal,
-        @PathVariable Long projectId
+        @PathVariable Long projectId,
+        @PathVariable Long applicationId
     ) {
         return ProjectApplicationStatusResponse.from(
             submitProjectApplicationUseCase.submit(
                 SubmitProjectApplicationCommand.builder()
                     .projectId(projectId)
+                    .applicationId(applicationId)
                     .requesterMemberId(memberPrincipal.getMemberId())
                     .build()
             )

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
@@ -20,9 +20,14 @@ public record UpdateApplicationAnswersRequest(
     List<ApplicationAnswerItem> answers
 ) {
 
-    public UpdateProjectApplicationDraftCommand toCommand(Long projectId, Long requesterMemberId) {
+    public UpdateProjectApplicationDraftCommand toCommand(
+        Long projectId,
+        Long applicationId,
+        Long requesterMemberId
+    ) {
         return UpdateProjectApplicationDraftCommand.builder()
             .projectId(projectId)
+            .applicationId(applicationId)
             .requesterMemberId(requesterMemberId)
             .answers(answers.stream().map(ApplicationAnswerItem::toEntry).toList())
             .build();

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/UpdateApplicationAnswersRequest.java
@@ -1,10 +1,12 @@
 package com.umc.product.project.adapter.in.web.dto.request;
 
+import java.util.List;
+
 import com.umc.product.project.adapter.in.web.dto.common.ApplicationAnswerItem;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.Builder;
 
 /**
@@ -16,8 +18,7 @@ import lombok.Builder;
 @Builder
 public record UpdateApplicationAnswersRequest(
     @NotNull(message = "answers는 null 일 수 없습니다 (빈 리스트는 허용)")
-    @Valid
-    List<ApplicationAnswerItem> answers
+    @Valid List<ApplicationAnswerItem> answers
 ) {
 
     public UpdateProjectApplicationDraftCommand toCommand(

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/SubmitProjectApplicationCommand.java
@@ -1,17 +1,17 @@
 package com.umc.product.project.application.port.in.command.dto;
 
-import java.util.Objects;
 import lombok.Builder;
 
 /**
  * 챌린저 지원서 최종 제출 Command (APPLY-003).
  * <p>
- * (projectId, requesterMemberId) 로 본인의 DRAFT 지원서를 식별 — applicationId 를 path 에 노출하지 않는다.
+ * path의 applicationId로 본인의 DRAFT 지원서를 명시적으로 식별한다.
  * DRAFT -> SUBMITTED 전이. 필수 답변 누락 검증은 Survey {@code ManageFormResponseUseCase.submitDraft}가 담당.
  */
 @Builder
 public record SubmitProjectApplicationCommand(
     Long projectId,
+    Long applicationId,
     Long requesterMemberId
 ) {
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
@@ -1,19 +1,19 @@
 package com.umc.product.project.application.port.in.command.dto;
 
 import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 
 /**
  * 챌린저 지원서 임시저장 Command (APPLY-002).
  * <p>
- * (projectId, requesterMemberId)로 본인의 DRAFT 지원서를 식별 — applicationId 를 path에 노출하지 않는다.
+ * path의 applicationId로 본인의 DRAFT 지원서를 명시적으로 식별한다.
  * PUT 시멘틱 — {@code answers}가 곧 새 전체 상태이며, 빠진 questionId의 기존 답변은 삭제된다.
  * Survey의 {@code ManageFormResponseUseCase.updateDraft}에 위임된다.
  */
 @Builder
 public record UpdateProjectApplicationDraftCommand(
     Long projectId,
+    Long applicationId,
     Long requesterMemberId,
     List<AnswerEntry> answers
 ) {

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/UpdateProjectApplicationDraftCommand.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.application.port.in.command.dto;
 
 import java.util.List;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -39,8 +39,10 @@ public interface LoadProjectApplicationPort {
     );
 
     /**
-     * 본인의 DRAFT 지원서를 반드시 존재하는 것으로 조회합니다. 없으면 {@code PROJECT_DRAFT_APPLICATION_NOT_FOUND} 예외.
-     * update / submit 에서 사용합니다.
+     * (projectId, memberId) 로 단일 DRAFT 지원서를 조회합니다.
+     * <p>
+     * 같은 프로젝트/멤버에 여러 차수의 DRAFT가 공존할 수 있는 지원서 update/submit 흐름에서는 사용하지 않고,
+     * applicationId로 대상을 명시해야 합니다. 없으면 {@code PROJECT_DRAFT_APPLICATION_NOT_FOUND} 예외.
      */
     ProjectApplication getDraftByProjectAndMember(Long projectId, Long memberId);
 

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -1,5 +1,17 @@
 package com.umc.product.project.application.service.command;
 
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -8,8 +20,8 @@ import com.umc.product.project.application.port.in.command.CreateDraftProjectApp
 import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
-import com.umc.product.project.application.port.in.command.dto.CancelProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.command.dto.CancelProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
@@ -37,17 +49,8 @@ import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormRes
 import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -14,6 +14,7 @@ import com.umc.product.project.application.port.in.command.dto.CreateDraftProjec
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
@@ -23,6 +24,7 @@ import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
@@ -33,10 +35,15 @@ import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,11 +62,13 @@ public class ProjectApplicationCommandService implements
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectApplicationPort saveProjectApplicationPort;
     private final LoadProjectApplicationFormPort loadProjectApplicationFormPort;
+    private final LoadProjectApplicationFormPolicyPort loadProjectApplicationFormPolicyPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
+    private final GetFormUseCase getFormUseCase;
 
     @Override
     public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
@@ -137,8 +146,11 @@ public class ProjectApplicationCommandService implements
 
     @Override
     public ProjectApplicationInfo update(UpdateProjectApplicationDraftCommand command) {
-        ProjectApplication application = loadProjectApplicationPort
-            .getDraftByProjectAndMember(command.projectId(), command.requesterMemberId());
+        ProjectApplication application = loadDraftApplication(
+            command.projectId(), command.applicationId(), command.requesterMemberId()
+        );
+        VisibleQuestionScope questionScope = resolveVisibleQuestionScope(application);
+        validateAnswerQuestionIdsAllowed(command.answers(), questionScope.allowedQuestionIds());
 
         manageFormResponseUseCase.updateDraft(
             UpdateDraftFormResponseCommand.builder()
@@ -153,8 +165,9 @@ public class ProjectApplicationCommandService implements
 
     @Override
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
-        ProjectApplication application = loadProjectApplicationPort
-            .getDraftByProjectAndMember(command.projectId(), command.requesterMemberId());
+        ProjectApplication application = loadDraftApplication(
+            command.projectId(), command.applicationId(), command.requesterMemberId()
+        );
 
         // 차수 마감 여부 체크 - 제출 시점에 차수가 닫혀있으면 불가
         if (application.getAppliedMatchingRound() != null
@@ -171,11 +184,15 @@ public class ProjectApplicationCommandService implements
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DUPLICATE_SUBMISSION);
         }
 
-        // Survey submitDraft — 필수 답변 누락 검증 포함
+        VisibleQuestionScope questionScope = resolveVisibleQuestionScope(application);
+
+        // Survey submitDraft — Project 가 계산한 노출 질문 scope 안에서 필수 답변 누락 검증 포함
         manageFormResponseUseCase.submitDraft(
             SubmitDraftFormResponseCommand.builder()
                 .formResponseId(application.getFormResponseId())
                 .requesterMemberId(command.requesterMemberId())
+                .requiredQuestionIds(questionScope.requiredQuestionIds())
+                .allowedQuestionIds(questionScope.allowedQuestionIds())
                 .build()
         );
 
@@ -292,6 +309,78 @@ public class ProjectApplicationCommandService implements
             .count();
     }
 
+    private ProjectApplication loadDraftApplication(
+        Long projectId,
+        Long applicationId,
+        Long requesterMemberId
+    ) {
+        if (applicationId == null) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
+        }
+
+        ProjectApplication application = loadProjectApplicationPort.findByIdWithDetails(applicationId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
+
+        Long actualProjectId = application.getApplicationForm().getProject().getId();
+        if (!Objects.equals(actualProjectId, projectId)) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
+        }
+        if (!Objects.equals(application.getApplicantMemberId(), requesterMemberId) || !application.isDraft()) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_DRAFT_APPLICATION_NOT_FOUND);
+        }
+
+        return application;
+    }
+
+    private VisibleQuestionScope resolveVisibleQuestionScope(ProjectApplication application) {
+        ProjectApplicationForm applicationForm = application.getApplicationForm();
+        Project project = applicationForm.getProject();
+        ChallengerPart applicantPart = getChallengerUseCase
+            .getByMemberIdAndGisuId(application.getApplicantMemberId(), project.getGisuId())
+            .part();
+
+        Map<Long, ProjectApplicationFormPolicy> policyBySectionId =
+            loadProjectApplicationFormPolicyPort.listByApplicationFormId(applicationForm.getId()).stream()
+                .collect(Collectors.toMap(
+                    ProjectApplicationFormPolicy::getFormSectionId,
+                    Function.identity(),
+                    (first, second) -> second
+                ));
+
+        FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+        Set<Long> allowedQuestionIds = new HashSet<>();
+        Set<Long> requiredQuestionIds = new HashSet<>();
+        for (FormWithStructureInfo.SectionWithQuestions section : formStructure.sections()) {
+            ProjectApplicationFormPolicy policy = policyBySectionId.get(section.sectionId());
+            if (policy == null || !policy.canAccess(applicantPart)) {
+                continue;
+            }
+
+            for (FormWithStructureInfo.QuestionWithOptions question : section.questions()) {
+                allowedQuestionIds.add(question.questionId());
+                if (question.isRequired()) {
+                    requiredQuestionIds.add(question.questionId());
+                }
+            }
+        }
+        return new VisibleQuestionScope(allowedQuestionIds, requiredQuestionIds);
+    }
+
+    private void validateAnswerQuestionIdsAllowed(
+        List<UpdateProjectApplicationDraftCommand.AnswerEntry> answers,
+        Set<Long> allowedQuestionIds
+    ) {
+        if (answers == null) {
+            throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+        }
+
+        for (UpdateProjectApplicationDraftCommand.AnswerEntry answer : answers) {
+            if (answer.questionId() == null || !allowedQuestionIds.contains(answer.questionId())) {
+                throw new ProjectDomainException(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+            }
+        }
+    }
+
     private List<AnswerCommand> toAnswerCommands(List<UpdateProjectApplicationDraftCommand.AnswerEntry> entries) {
         return entries.stream()
             .map(e -> AnswerCommand.builder()
@@ -301,5 +390,11 @@ public class ProjectApplicationCommandService implements
                 .fileIds(e.fileIds() == null ? List.of() : e.fileIds())
                 .build())
             .toList();
+    }
+
+    private record VisibleQuestionScope(
+        Set<Long> allowedQuestionIds,
+        Set<Long> requiredQuestionIds
+    ) {
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -1,5 +1,18 @@
 package com.umc.product.project.application.service.command;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.project.application.port.in.command.UpsertProjectApplicationFormUseCase;
 import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
 import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand.ApplicationFormSectionEntry;
@@ -27,10 +40,10 @@ import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCom
 import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
-import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionOptionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderQuestionsCommand;
@@ -44,18 +57,8 @@ import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInf
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.QuestionWithOptions;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
 import com.umc.product.survey.domain.enums.QuestionType;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 지원 폼 upsert 서비스 (PROJECT-106).

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandService.java
@@ -135,6 +135,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
                 .title(resolveTitle(project, command))
                 .description(command.description())
                 .isAnonymous(false)
+                .allowDuplicateResponses(true)
                 .build()
         );
         return saveApplicationFormPort.save(ProjectApplicationForm.create(project, formId));
@@ -160,6 +161,7 @@ public class ProjectApplicationFormCommandService implements UpsertProjectApplic
                 .title(resolvedTitle)
                 .description(command.description())
                 .isAnonymous(existing.isAnonymous())
+                .allowDuplicateResponses(existing.allowDuplicateResponses())
                 .build()
         );
     }

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -55,7 +55,7 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
     }
 
     /**
-     * 지원서 생성/임시저장/제출 진입 권한. subject 가 부모 프로젝트의 기수에 챌린저 레코드를 가져야 한다.
+     * 지원서 생성 진입 권한. subject 가 부모 프로젝트의 기수에 챌린저 레코드를 가져야 한다.
      * <p>
      * IN_PROGRESS 검사 / 자기지원 차단 / 매칭 라운드 OPEN / 폼 정책 파트 / 기수 ACTIVE 멤버 / 중복 등은
      * 도메인 규칙으로 분류되어 {@code Project.validateApplicable()} 와 {@code ProjectApplicationCommandService} 가 검증한다.

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -1,5 +1,9 @@
 package com.umc.product.project.application.service.evaluator;
 
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
@@ -13,9 +17,8 @@ import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * ProjectApplication 도메인 단건 액션의 권한 판정 (L2). subject × resource 속성 매칭만 다룬다.

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateDraftFormCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateDraftFormCommand.java
@@ -7,12 +7,14 @@ import lombok.Builder;
  * {@code title}은 필수 (최초 생성 후 업데이트 가능). {@code description}은 선택.
  *      TODO: form.title가 nullable = false임. 최초 생성 시에 아무 값도 넘겨주고 싶지 않다면 nullable로 변경.
  * {@code isAnonymous}는 응답자 공개 여부 (true=익명).
+ * {@code allowDuplicateResponses}는 같은 폼에 같은 응답자가 여러 응답을 만들 수 있는지 여부.
  */
 @Builder
 public record CreateDraftFormCommand(
     Long createdMemberId,
     String title,
     String description,
-    boolean isAnonymous
+    boolean isAnonymous,
+    boolean allowDuplicateResponses
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/CreateDraftFormResponseCommand.java
@@ -7,7 +7,7 @@ import lombok.Builder;
  * <p>
  * 빈 draft 를 생성하고 ID를 반환한다. 이후 {@code updateDraft} 로 답변을 추가하며 {@code submitDraft} 로 최종 제출한다.
  * <p>
- * 같은 폼에 {@code respondentMemberId} 의 draft 가 이미 있으면 예외.
+ * 폼이 중복 응답을 허용하지 않으면 같은 폼에 {@code respondentMemberId} 의 응답이 이미 있을 때 예외.
  */
 @Builder
 public record CreateDraftFormResponseCommand(

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
@@ -1,6 +1,7 @@
 package com.umc.product.survey.application.port.in.command.dto;
 
 import java.util.Set;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
@@ -1,5 +1,6 @@
 package com.umc.product.survey.application.port.in.command.dto;
 
+import java.util.Set;
 import lombok.Builder;
 
 /**
@@ -9,11 +10,15 @@ import lombok.Builder;
  * 최종 제출 직전에 답변을 한 번 더 바꾸려면 {@code updateDraft} 를 먼저 호출한 뒤 submit.
  * <p>
  * draft 가 아닌 응답을 submit 시도하면 예외. {@code submittedIp} 는 감사/분석용 (선택, null 가능).
+ * {@code requiredQuestionIds} / {@code allowedQuestionIds} 는 특정 제품 흐름에서 제출 검증 범위를 좁힐 때 사용한다.
+ * 둘 다 {@code null} 이면 기존처럼 form 전체 기준으로 검증한다.
  */
 @Builder
 public record SubmitDraftFormResponseCommand(
     Long formResponseId,
     Long requesterMemberId,
-    String submittedIp
+    String submittedIp,
+    Set<Long> requiredQuestionIds,
+    Set<Long> allowedQuestionIds
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateFormCommand.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/command/dto/UpdateFormCommand.java
@@ -7,6 +7,7 @@ import lombok.Builder;
  * <p>
  * null 인 필드는 '변경 없음' 으로 처리 (PATCH 의미).
  * 임시저장 상태에서는 어느 필드든 부분 변경이 가능해야 하므로 모든 필드를 nullable 로 둔다.
+ * {@code allowDuplicateResponses}가 null이면 기존 중복 응답 정책을 유지한다.
  * <p>
  * {@code requesterMemberId} 는 리뷰 협의를 통해 권한 검증을 survey 측에서 하지 않는 것이 확정되면 삭제 예정 (권한 검증은 호출 측 책임).
  */
@@ -16,6 +17,7 @@ public record UpdateFormCommand(
     Long requesterMemberId,
     String title,
     String description,
-    Boolean isAnonymous
+    Boolean isAnonymous,
+    Boolean allowDuplicateResponses
 ) {
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
@@ -39,11 +39,15 @@ public interface GetFormResponseUseCase {
 
     /**
      * 특정 폼에 대한 특정 사용자의 draft 응답을 조회. 없으면 Optional.empty. "작성 중 응답 이어서 보기" 용도.
+     * <p>
+     * 중복 응답을 허용하지 않는 폼 전용 단건 조회다. 중복 허용 폼은 {@code formResponseId} 기준으로 조회해야 한다.
      */
     Optional<FormResponseInfo> findDraftByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 
     /**
      * 특정 폼에 대한 특정 사용자의 SUBMITTED 응답을 조회. 없으면 Optional.empty.
+     * <p>
+     * 중복 응답을 허용하지 않는 폼 전용 단건 조회다. 중복 허용 폼은 {@code formResponseId} 기준으로 조회해야 한다.
      */
     Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormResponseUseCase.java
@@ -1,9 +1,10 @@
 package com.umc.product.survey.application.port.in.query;
 
-import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
-import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 import java.util.List;
 import java.util.Optional;
+
+import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 
 /**
  * FormResponse 조회 UseCase.

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
@@ -1,8 +1,10 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
+import java.time.Instant;
+
 import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.enums.FormStatus;
-import java.time.Instant;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormInfo.java
@@ -16,6 +16,7 @@ public record FormInfo(
     String description,
     FormStatus status,
     boolean isAnonymous,
+    boolean allowDuplicateResponses,
     Instant createdAt,
     Instant updatedAt
 ) {
@@ -28,6 +29,7 @@ public record FormInfo(
             .description(form.getDescription())
             .status(form.getStatus())
             .isAnonymous(form.isAnonymous())
+            .allowDuplicateResponses(form.isAllowDuplicateResponses())
             .createdAt(form.getCreatedAt())
             .updatedAt(form.getUpdatedAt())
             .build();

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormWithStructureInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormWithStructureInfo.java
@@ -1,11 +1,12 @@
 package com.umc.product.survey.application.port.in.query.dto;
 
-import com.umc.product.survey.domain.enums.FormStatus;
-import com.umc.product.survey.domain.enums.QuestionType;
-import lombok.Builder;
-
 import java.time.Instant;
 import java.util.List;
+
+import com.umc.product.survey.domain.enums.FormStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
+
+import lombok.Builder;
 
 /**
  * 폼의 전체 구조(섹션 -> 질문 -> 옵션)를 중첩 포함한 DTO.

--- a/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormWithStructureInfo.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/dto/FormWithStructureInfo.java
@@ -19,6 +19,7 @@ public record FormWithStructureInfo(
     String description,
     FormStatus status,
     boolean isAnonymous,
+    boolean allowDuplicateResponses,
     Instant createdAt,
     Instant updatedAt,
     List<SectionWithQuestions> sections

--- a/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
@@ -34,7 +34,11 @@ public class FormCommandService implements ManageFormUseCase {
 
     @Override
     public Long createDraft(CreateDraftFormCommand command) {
-        Form form = Form.createDraft(command.title(), command.createdMemberId());
+        Form form = Form.createDraft(
+            command.title(),
+            command.createdMemberId(),
+            command.allowDuplicateResponses()
+        );
 
         return saveFormPort.save(form).getId();
     }
@@ -44,7 +48,12 @@ public class FormCommandService implements ManageFormUseCase {
         Form form = loadFormPort.findById(command.formId())
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
 
-        form.update(command.title(), command.description(), command.isAnonymous());
+        form.update(
+            command.title(),
+            command.description(),
+            command.isAnonymous(),
+            command.allowDuplicateResponses()
+        );
         saveFormPort.save(form);
     }
 

--- a/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
@@ -1,5 +1,8 @@
 package com.umc.product.survey.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
@@ -15,9 +18,8 @@ import com.umc.product.survey.application.port.out.SaveQuestionPort;
 import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -38,9 +38,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     public Long submitImmediately(SubmitFormResponseCommand command) {
         Form form = loadPublishedForm(command.formId());
 
-        if (loadFormResponsePort.existsByFormIdAndMemberId(command.formId(), command.respondentMemberId())) {
-            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
-        }
+        validateDuplicateResponsePolicy(form, command.respondentMemberId());
 
         validateAnswers(command.formId(), command.answers());
         validateAllRequiredAnswered(command.formId(), extractQuestionIds(command.answers()));
@@ -57,7 +55,8 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void updateResponse(UpdateFormResponseCommand command) {
-        loadPublishedForm(command.formId());
+        Form form = loadPublishedForm(command.formId());
+        validateSingleResponseLookupPolicy(form);
 
         FormResponse existing = loadFormResponsePort
             .findSubmittedByFormIdAndRespondentMemberId(command.formId(), command.respondentMemberId())
@@ -77,6 +76,9 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void deleteResponse(DeleteFormResponseCommand command) {
+        Form form = loadPublishedForm(command.formId());
+        validateSingleResponseLookupPolicy(form);
+
         FormResponse existing = loadFormResponsePort
             .findSubmittedByFormIdAndRespondentMemberId(command.formId(), command.respondentMemberId())
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_NOT_FOUND));
@@ -89,10 +91,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     public Long createDraft(CreateDraftFormResponseCommand command) {
         Form form = loadPublishedForm(command.formId());
 
-        // 같은 폼에 같은 멤버의 응답 (DRAFT/SUBMITTED) 이 이미 있으면 예외
-        if (loadFormResponsePort.existsByFormIdAndMemberId(command.formId(), command.respondentMemberId())) {
-            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
-        }
+        validateDuplicateResponsePolicy(form, command.respondentMemberId());
 
         FormResponse draft = FormResponse.createDraft(form, command.respondentMemberId());
         return saveFormResponsePort.save(draft).getId();
@@ -161,6 +160,21 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             throw new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_PUBLISHED);
         }
         return form;
+    }
+
+    private void validateDuplicateResponsePolicy(Form form, Long respondentMemberId) {
+        if (form.isAllowDuplicateResponses()) {
+            return;
+        }
+        if (loadFormResponsePort.existsByFormIdAndMemberId(form.getId(), respondentMemberId)) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
+        }
+    }
+
+    private static void validateSingleResponseLookupPolicy(Form form) {
+        if (form.isAllowDuplicateResponses()) {
+            throw new SurveyDomainException(SurveyErrorCode.FORM_RESPONSE_LOOKUP_AMBIGUOUS);
+        }
     }
 
     /**

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -117,11 +117,20 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     public void submitDraft(SubmitDraftFormResponseCommand command) {
         FormResponse draft = loadDraft(command.formResponseId());
 
-        // 저장된 답변에서 questionId 추출 -> 필수 누락 검증
-        Set<Long> answeredQuestionIds = loadAnswerPort.listByFormResponseId(draft.getId()).stream()
+        List<Answer> savedAnswers = loadAnswerPort.listByFormResponseId(draft.getId());
+        Set<Long> answeredQuestionIds = savedAnswers.stream()
             .map(answer -> answer.getQuestion().getId())
             .collect(Collectors.toSet());
-        validateAllRequiredAnswered(draft.getForm().getId(), answeredQuestionIds);
+
+        if (command.allowedQuestionIds() != null) {
+            validateAnsweredQuestionsAllowed(command.allowedQuestionIds(), answeredQuestionIds);
+        }
+
+        if (command.requiredQuestionIds() != null) {
+            validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
+        } else {
+            validateAllRequiredAnswered(draft.getForm().getId(), answeredQuestionIds);
+        }
 
         draft.submit(Instant.now(), command.submittedIp());
         saveFormResponsePort.save(draft);
@@ -215,6 +224,22 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         for (Question q : formQuestions) {
             if (Boolean.TRUE.equals(q.getIsRequired()) && !answeredQuestionIds.contains(q.getId())) {
                 throw new SurveyDomainException(SurveyErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
+            }
+        }
+    }
+
+    private void validateRequiredAnswered(Set<Long> requiredQuestionIds, Set<Long> answeredQuestionIds) {
+        for (Long questionId : requiredQuestionIds) {
+            if (!answeredQuestionIds.contains(questionId)) {
+                throw new SurveyDomainException(SurveyErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
+            }
+        }
+    }
+
+    private void validateAnsweredQuestionsAllowed(Set<Long> allowedQuestionIds, Set<Long> answeredQuestionIds) {
+        for (Long questionId : answeredQuestionIds) {
+            if (!allowedQuestionIds.contains(questionId)) {
+                throw new SurveyDomainException(SurveyErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
             }
         }
     }

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -1,24 +1,44 @@
 package com.umc.product.survey.application.service.command;
 
-import com.umc.product.storage.application.port.in.query.GetFileUseCase;
-import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
-import com.umc.product.survey.application.port.in.command.dto.*;
-import com.umc.product.survey.application.port.out.*;
-import com.umc.product.survey.domain.*;
-import com.umc.product.survey.domain.enums.FormResponseStatus;
-import com.umc.product.survey.domain.enums.QuestionType;
-import com.umc.product.survey.domain.exception.SurveyDomainException;
-import com.umc.product.survey.domain.exception.SurveyErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
+import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormResponseCommand;
+import com.umc.product.survey.application.port.out.LoadAnswerPort;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.LoadFormResponsePort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.application.port.out.SaveAnswerPort;
+import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.survey.domain.Answer;
+import com.umc.product.survey.domain.AnswerChoice;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.QuestionOption;
+import com.umc.product.survey.domain.enums.FormResponseStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional

--- a/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
@@ -97,6 +97,7 @@ public class FormQueryService implements GetFormUseCase {
             .description(form.getDescription())
             .status(form.getStatus())
             .isAnonymous(form.isAnonymous())
+            .allowDuplicateResponses(form.isAllowDuplicateResponses())
             .createdAt(form.getCreatedAt())
             .updatedAt(form.getUpdatedAt())
             .sections(sectionDtos)

--- a/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
@@ -1,5 +1,14 @@
 package com.umc.product.survey.application.service.query;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
@@ -16,15 +25,8 @@ import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/umc/product/survey/domain/Form.java
+++ b/src/main/java/com/umc/product/survey/domain/Form.java
@@ -46,25 +46,43 @@ public class Form extends BaseEntity {
     @Column(name = "is_anonymous", nullable = false)
     private boolean isAnonymous;
 
+    @Column(name = "allow_duplicate_responses", nullable = false)
+    private boolean allowDuplicateResponses;
+
     /**
      * Draft 생성을 위해서는 제목은 필수로 입력하여야 합니다.
      */
     public static Form createDraft(String title, Long createdMemberId) {
+        return createDraft(title, createdMemberId, false);
+    }
+
+    public static Form createDraft(String title, Long createdMemberId, boolean allowDuplicateResponses) {
         Form form = new Form();
 
         form.title = title;
         form.createdMemberId = createdMemberId;
         form.status = FormStatus.DRAFT;
+        form.allowDuplicateResponses = allowDuplicateResponses;
 
         return form;
     }
 
     public static Form createPublished(Long createdMemberId, String title, boolean isAnonymous) {
+        return createPublished(createdMemberId, title, isAnonymous, false);
+    }
+
+    public static Form createPublished(
+        Long createdMemberId,
+        String title,
+        boolean isAnonymous,
+        boolean allowDuplicateResponses
+    ) {
         Form form = new Form();
         form.createdMemberId = createdMemberId;
         form.title = title;
         form.isAnonymous = isAnonymous;
         form.status = FormStatus.PUBLISHED;
+        form.allowDuplicateResponses = allowDuplicateResponses;
 
         return form;
     }
@@ -86,8 +104,13 @@ public class Form extends BaseEntity {
      * null 인 필드는 기존 값 유지. 임시저장 단계에서 어느 필드든 부분 변경 가능하도록 모든 파라미터 nullable.
      */
     public void update(String title, String description, Boolean isAnonymous) {
+        update(title, description, isAnonymous, null);
+    }
+
+    public void update(String title, String description, Boolean isAnonymous, Boolean allowDuplicateResponses) {
         if (title != null) this.title = title;
         if (description != null) this.description = description;
         if (isAnonymous != null) this.isAnonymous = isAnonymous;
+        if (allowDuplicateResponses != null) this.allowDuplicateResponses = allowDuplicateResponses;
     }
 }

--- a/src/main/java/com/umc/product/survey/domain/Form.java
+++ b/src/main/java/com/umc/product/survey/domain/Form.java
@@ -4,6 +4,7 @@ import com.umc.product.common.BaseEntity;
 import com.umc.product.survey.domain.enums.FormStatus;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
+++ b/src/main/java/com/umc/product/survey/domain/exception/SurveyErrorCode.java
@@ -37,6 +37,8 @@ public enum SurveyErrorCode implements BaseCode {
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY-0030", "답변을 찾을 수 없어요. 응답 내용을 확인해주세요."),
     FORM_RESPONSE_NOT_DRAFT(HttpStatus.CONFLICT, "SURVEY-0031", "임시저장 상태의 응답에서만 할 수 있는 작업이에요. 응답 상태를 확인해주세요."),
     ANSWER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SURVEY-0032", "이미 해당 질문에 대한 답변이 있어요. 기존 답변을 수정해주세요."),
+    FORM_RESPONSE_LOOKUP_AMBIGUOUS(HttpStatus.CONFLICT, "SURVEY-0033",
+        "중복 응답을 허용하는 폼은 응답을 하나로 특정할 수 없어요. 응답 ID를 사용해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -257,6 +257,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
                 updateProjectApplicationDraftUseCase.update(
                     UpdateProjectApplicationDraftCommand.builder()
                         .projectId(projectId)
+                        .applicationId(applicationId)
                         .requesterMemberId(challenger.memberId())
                         .answers(answers)
                         .build()
@@ -273,6 +274,7 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             submitProjectApplicationUseCase.submit(
                 SubmitProjectApplicationCommand.builder()
                     .projectId(projectId)
+                    .applicationId(applicationId)
                     .requesterMemberId(challenger.memberId())
                     .build()
             );

--- a/src/main/resources/db/migration/V2026.06.13.10.00__add_form_allow_duplicate_responses.sql
+++ b/src/main/resources/db/migration/V2026.06.13.10.00__add_form_allow_duplicate_responses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.form
+    ADD COLUMN allow_duplicate_responses BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/main/resources/db/migration/V2026.06.13.10.00__add_form_allow_duplicate_responses.sql
+++ b/src/main/resources/db/migration/V2026.06.13.10.00__add_form_allow_duplicate_responses.sql
@@ -1,2 +1,10 @@
 ALTER TABLE public.form
     ADD COLUMN allow_duplicate_responses BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE public.form f
+SET allow_duplicate_responses = TRUE
+WHERE EXISTS (
+    SELECT 1
+    FROM public.project_application_form paf
+    WHERE paf.form_id = f.id
+);

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
@@ -12,6 +12,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -29,19 +43,6 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationI
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = ProjectApplicationController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
@@ -1,11 +1,14 @@
 package com.umc.product.project.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,6 +23,8 @@ import com.umc.product.project.application.port.in.command.DecideApplicationUseC
 import com.umc.product.project.application.port.in.command.SubmitProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectApplicationDraftUseCase;
 import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
@@ -27,6 +32,7 @@ import com.umc.product.project.domain.exception.ProjectErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -78,6 +84,82 @@ class ProjectApplicationControllerTest {
         SecurityContextHolder.getContext().setAuthentication(
             new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
         );
+    }
+
+    @Nested
+    class updateAndSubmit {
+
+        @Test
+        void PUT_applicationId_경로는_command에_applicationId를_전달한다() throws Exception {
+            given(updateProjectApplicationDraftUseCase.update(any()))
+                .willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.DRAFT));
+            String body = """
+                {
+                  "answers": [
+                    {
+                      "questionId": 10,
+                      "textValue": "답변"
+                    }
+                  ]
+                }
+                """;
+
+            mockMvc.perform(put("/api/v1/projects/{projectId}/applications/{applicationId}",
+                    PROJECT_ID, APPLICATION_ID)
+                    .content(body)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.applicationId").value(APPLICATION_ID))
+                .andExpect(jsonPath("$.result.status").value("DRAFT"));
+
+            ArgumentCaptor<UpdateProjectApplicationDraftCommand> captor =
+                ArgumentCaptor.forClass(UpdateProjectApplicationDraftCommand.class);
+            then(updateProjectApplicationDraftUseCase).should().update(captor.capture());
+            assertThat(captor.getValue().projectId()).isEqualTo(PROJECT_ID);
+            assertThat(captor.getValue().applicationId()).isEqualTo(APPLICATION_ID);
+            assertThat(captor.getValue().requesterMemberId()).isEqualTo(TEST_MEMBER_ID);
+        }
+
+        @Test
+        void POST_applicationId_submit_경로는_command에_applicationId를_전달한다() throws Exception {
+            given(submitProjectApplicationUseCase.submit(any()))
+                .willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.SUBMITTED));
+
+            mockMvc.perform(post("/api/v1/projects/{projectId}/applications/{applicationId}/submit",
+                    PROJECT_ID, APPLICATION_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.applicationId").value(APPLICATION_ID))
+                .andExpect(jsonPath("$.result.status").value("SUBMITTED"));
+
+            ArgumentCaptor<SubmitProjectApplicationCommand> captor =
+                ArgumentCaptor.forClass(SubmitProjectApplicationCommand.class);
+            then(submitProjectApplicationUseCase).should().submit(captor.capture());
+            assertThat(captor.getValue().projectId()).isEqualTo(PROJECT_ID);
+            assertThat(captor.getValue().applicationId()).isEqualTo(APPLICATION_ID);
+            assertThat(captor.getValue().requesterMemberId()).isEqualTo(TEST_MEMBER_ID);
+        }
+
+        @Test
+        void 기존_applications_me_update_경로는_usecase를_호출하지_않는다() throws Exception {
+            String body = """
+                { "answers": [] }
+                """;
+
+            mockMvc.perform(put("/api/v1/projects/{projectId}/applications/me", PROJECT_ID)
+                    .content(body)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError());
+
+            then(updateProjectApplicationDraftUseCase).should(never()).update(any());
+        }
+
+        @Test
+        void 기존_applications_me_submit_경로는_usecase를_호출하지_않는다() throws Exception {
+            mockMvc.perform(post("/api/v1/projects/{projectId}/applications/me/submit", PROJECT_ID))
+                .andExpect(status().is4xxClientError());
+
+            then(submitProjectApplicationUseCase).should(never()).submit(any());
+        }
     }
 
     @Nested

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.umc.product.project.application.service.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -15,7 +16,10 @@ import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.dto.ApplicationDecisionStatus;
 import com.umc.product.project.application.port.in.command.dto.CancelProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.SubmitProjectApplicationCommand;
+import com.umc.product.project.application.port.in.command.dto.UpdateProjectApplicationDraftCommand;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationInfo;
+import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
@@ -25,6 +29,7 @@ import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingPhase;
@@ -33,15 +38,25 @@ import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
+import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.query.GetFormUseCase;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.domain.enums.FormStatus;
+import com.umc.product.survey.domain.enums.QuestionType;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,9 +68,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ProjectApplicationCommandServiceTest {
 
+    private static final Long PROJECT_ID = 100L;
     private static final Long APPLICATION_ID = 500L;
+    private static final Long APPLICATION_FORM_ID = 600L;
+    private static final Long FORM_ID = 700L;
+    private static final Long FORM_RESPONSE_ID = 999L;
+    private static final Long MATCHING_ROUND_ID = 800L;
     private static final Long APPLICANT_MEMBER_ID = 100L;
     private static final Long DECIDER_MEMBER_ID = 200L;
+    private static final Long COMMON_SECTION_ID = 10L;
+    private static final Long WEB_SECTION_ID = 20L;
+    private static final Long DESIGN_SECTION_ID = 30L;
+    private static final Long COMMON_QUESTION_ID = 101L;
+    private static final Long WEB_QUESTION_ID = 201L;
+    private static final Long DESIGN_QUESTION_ID = 301L;
 
     private static final Instant NOW = Instant.now();
     private static final Instant ROUND_STARTS_AT = NOW.minusSeconds(86_400);
@@ -69,6 +95,8 @@ class ProjectApplicationCommandServiceTest {
     @Mock
     LoadProjectApplicationFormPort loadProjectApplicationFormPort;
     @Mock
+    LoadProjectApplicationFormPolicyPort loadProjectApplicationFormPolicyPort;
+    @Mock
     LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     @Mock
     LoadProjectMemberPort loadProjectMemberPort;
@@ -78,6 +106,8 @@ class ProjectApplicationCommandServiceTest {
     ManageFormResponseUseCase manageFormResponseUseCase;
     @Mock
     GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    GetFormUseCase getFormUseCase;
 
     @InjectMocks
     ProjectApplicationCommandService sut;
@@ -93,6 +123,122 @@ class ProjectApplicationCommandServiceTest {
             .willReturn(Map.of());
         given(loadProjectApplicationPort.listByMatchingRoundId(any()))
             .willReturn(List.of());
+    }
+
+    @Nested
+    class updateAndSubmit {
+
+        @Test
+        @DisplayName("update는 applicationId로 지정한 DRAFT만 수정한다")
+        void update는_applicationId로_지정한_DRAFT만_수정한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.DRAFT);
+            given(loadProjectApplicationPort.findByIdWithDetails(APPLICATION_ID))
+                .willReturn(Optional.of(application));
+            givenVisibleScope(application);
+
+            ProjectApplicationInfo result = sut.update(UpdateProjectApplicationDraftCommand.builder()
+                .projectId(PROJECT_ID)
+                .applicationId(APPLICATION_ID)
+                .requesterMemberId(APPLICANT_MEMBER_ID)
+                .answers(List.of(answerEntry(COMMON_QUESTION_ID)))
+                .build());
+
+            ArgumentCaptor<UpdateDraftFormResponseCommand> captor =
+                ArgumentCaptor.forClass(UpdateDraftFormResponseCommand.class);
+            then(manageFormResponseUseCase).should().updateDraft(captor.capture());
+            assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
+            assertThat(captor.getValue().formResponseId()).isEqualTo(FORM_RESPONSE_ID);
+            assertThat(captor.getValue().answers())
+                .extracting(AnswerCommand::questionId)
+                .containsExactly(COMMON_QUESTION_ID);
+            then(loadProjectApplicationPort).should(never()).getDraftByProjectAndMember(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("update 요청에 노출되지 않은 questionId가 있으면 실패한다")
+        void update_요청에_노출되지_않은_questionId가_있으면_실패한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.DRAFT);
+            given(loadProjectApplicationPort.findByIdWithDetails(APPLICATION_ID))
+                .willReturn(Optional.of(application));
+            givenVisibleScope(application);
+
+            assertThatThrownBy(() -> sut.update(UpdateProjectApplicationDraftCommand.builder()
+                .projectId(PROJECT_ID)
+                .applicationId(APPLICATION_ID)
+                .requesterMemberId(APPLICANT_MEMBER_ID)
+                .answers(List.of(answerEntry(DESIGN_QUESTION_ID)))
+                .build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.APPLICATION_FORM_INVALID_QUESTION_ID);
+
+            then(manageFormResponseUseCase).should(never()).updateDraft(any());
+        }
+
+        @Test
+        @DisplayName("submit은 지원자에게 노출되는 required question scope만 Survey에 전달한다")
+        void submit은_노출되는_required_question_scope만_Survey에_전달한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.DRAFT);
+            given(loadProjectApplicationPort.findByIdWithDetails(APPLICATION_ID))
+                .willReturn(Optional.of(application));
+            givenVisibleScope(application);
+
+            ProjectApplicationInfo result = sut.submit(SubmitProjectApplicationCommand.builder()
+                .projectId(PROJECT_ID)
+                .applicationId(APPLICATION_ID)
+                .requesterMemberId(APPLICANT_MEMBER_ID)
+                .build());
+
+            ArgumentCaptor<SubmitDraftFormResponseCommand> captor =
+                ArgumentCaptor.forClass(SubmitDraftFormResponseCommand.class);
+            then(manageFormResponseUseCase).should().submitDraft(captor.capture());
+            assertThat(result.status()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+            assertThat(captor.getValue().formResponseId()).isEqualTo(FORM_RESPONSE_ID);
+            assertThat(captor.getValue().requiredQuestionIds())
+                .containsExactlyInAnyOrder(COMMON_QUESTION_ID, WEB_QUESTION_ID);
+            assertThat(captor.getValue().allowedQuestionIds())
+                .containsExactlyInAnyOrder(COMMON_QUESTION_ID, WEB_QUESTION_ID);
+            then(loadProjectApplicationPort).should(never()).getDraftByProjectAndMember(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("path projectId와 application의 projectId가 다르면 PROJECT_APPLICATION_NOT_FOUND")
+        void path_projectId와_application_projectId가_다르면_NOT_FOUND() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.DRAFT);
+            given(loadProjectApplicationPort.findByIdWithDetails(APPLICATION_ID))
+                .willReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> sut.update(UpdateProjectApplicationDraftCommand.builder()
+                .projectId(PROJECT_ID + 1)
+                .applicationId(APPLICATION_ID)
+                .requesterMemberId(APPLICANT_MEMBER_ID)
+                .answers(List.of(answerEntry(COMMON_QUESTION_ID)))
+                .build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
+
+            then(manageFormResponseUseCase).should(never()).updateDraft(any());
+        }
+
+        @Test
+        @DisplayName("DRAFT가 아닌 applicationId로 submit하면 실패한다")
+        void DRAFT가_아닌_applicationId로_submit하면_실패한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findByIdWithDetails(APPLICATION_ID))
+                .willReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> sut.submit(SubmitProjectApplicationCommand.builder()
+                .projectId(PROJECT_ID)
+                .applicationId(APPLICATION_ID)
+                .requesterMemberId(APPLICANT_MEMBER_ID)
+                .build()))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_DRAFT_APPLICATION_NOT_FOUND);
+
+            then(manageFormResponseUseCase).should(never()).submitDraft(any());
+        }
     }
 
     @Nested
@@ -370,7 +516,7 @@ class ProjectApplicationCommandServiceTest {
 
     private ProjectApplication applicationWithStatus(ProjectApplicationStatus status) {
         ProjectApplication application = ProjectApplication.create(
-            applicationForm(), 999L, APPLICANT_MEMBER_ID, openRound()
+            applicationForm(), FORM_RESPONSE_ID, APPLICANT_MEMBER_ID, openRound()
         );
         ReflectionTestUtils.setField(application, "id", APPLICATION_ID);
         ReflectionTestUtils.setField(application, "status", status);
@@ -378,17 +524,21 @@ class ProjectApplicationCommandServiceTest {
     }
 
     private ProjectMatchingRound openRound() {
-        return ProjectMatchingRound.create(
+        ProjectMatchingRound round = ProjectMatchingRound.create(
             "기획-디자인 1차 매칭", null,
             MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
             ROUND_STARTS_AT, ROUND_ENDS_AT, ROUND_DECISION_DEADLINE
         );
+        ReflectionTestUtils.setField(round, "id", MATCHING_ROUND_ID);
+        return round;
     }
 
     private ProjectApplicationForm applicationForm() {
         Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
-        ReflectionTestUtils.setField(project, "id", 100L);
-        return ProjectApplicationForm.create(project, 500L);
+        ReflectionTestUtils.setField(project, "id", PROJECT_ID);
+        ProjectApplicationForm applicationForm = ProjectApplicationForm.create(project, FORM_ID);
+        ReflectionTestUtils.setField(applicationForm, "id", APPLICATION_FORM_ID);
+        return applicationForm;
     }
 
     private ChallengerInfo challengerWithPart(ChallengerPart part) {
@@ -422,6 +572,70 @@ class ProjectApplicationCommandServiceTest {
             .applicationId(APPLICATION_ID)
             .requesterMemberId(APPLICANT_MEMBER_ID)
             .reason(reason)
+            .build();
+    }
+
+    private void givenVisibleScope(ProjectApplication application) {
+        ProjectApplicationForm form = application.getApplicationForm();
+        given(getChallengerUseCase.getByMemberIdAndGisuId(APPLICANT_MEMBER_ID, form.getProject().getGisuId()))
+            .willReturn(challengerWithPart(ChallengerPart.WEB));
+        given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(APPLICATION_FORM_ID))
+            .willReturn(List.of(
+                ProjectApplicationFormPolicy.createCommon(form, COMMON_SECTION_ID),
+                ProjectApplicationFormPolicy.createForParts(form, WEB_SECTION_ID, Set.of(ChallengerPart.WEB)),
+                ProjectApplicationFormPolicy.createForParts(form, DESIGN_SECTION_ID, Set.of(ChallengerPart.DESIGN))
+            ));
+        given(getFormUseCase.getFormWithStructure(FORM_ID))
+            .willReturn(formStructure());
+    }
+
+    private FormWithStructureInfo formStructure() {
+        return FormWithStructureInfo.builder()
+            .formId(FORM_ID)
+            .createdMemberId(1L)
+            .title("프로젝트 지원서")
+            .description(null)
+            .status(FormStatus.PUBLISHED)
+            .isAnonymous(false)
+            .allowDuplicateResponses(true)
+            .sections(List.of(
+                section(COMMON_SECTION_ID, COMMON_QUESTION_ID, true),
+                section(WEB_SECTION_ID, WEB_QUESTION_ID, true),
+                section(DESIGN_SECTION_ID, DESIGN_QUESTION_ID, true)
+            ))
+            .build();
+    }
+
+    private FormWithStructureInfo.SectionWithQuestions section(
+        Long sectionId, Long questionId, boolean isRequired
+    ) {
+        return FormWithStructureInfo.SectionWithQuestions.builder()
+            .sectionId(sectionId)
+            .title("섹션")
+            .description(null)
+            .orderNo(sectionId)
+            .questions(List.of(question(questionId, isRequired)))
+            .build();
+    }
+
+    private FormWithStructureInfo.QuestionWithOptions question(Long questionId, boolean isRequired) {
+        return FormWithStructureInfo.QuestionWithOptions.builder()
+            .questionId(questionId)
+            .title("질문")
+            .description(null)
+            .type(QuestionType.SHORT_TEXT)
+            .isRequired(isRequired)
+            .orderNo(questionId)
+            .options(List.of())
+            .build();
+    }
+
+    private UpdateProjectApplicationDraftCommand.AnswerEntry answerEntry(Long questionId) {
+        return UpdateProjectApplicationDraftCommand.AnswerEntry.builder()
+            .questionId(questionId)
+            .textValue("답변")
+            .selectedOptionIds(List.of())
+            .fileIds(List.of())
             .build();
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -9,7 +9,26 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
@@ -45,24 +64,6 @@ import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 import com.umc.product.survey.domain.enums.FormStatus;
 import com.umc.product.survey.domain.enums.QuestionType;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -7,8 +7,26 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.dto.UpsertApplicationFormCommand;
@@ -37,10 +55,10 @@ import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCom
 import com.umc.product.survey.application.port.in.command.dto.CreateFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionOptionCommand;
-import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormSectionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionOptionCommand;
+import com.umc.product.survey.application.port.in.command.dto.ForkQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.ReorderFormSectionsCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormSectionCommand;
@@ -52,23 +70,6 @@ import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInf
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo.SectionWithQuestions;
 import com.umc.product.survey.domain.enums.FormStatus;
 import com.umc.product.survey.domain.enums.QuestionType;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationFormCommandServiceTest {

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationFormCommandServiceTest.java
@@ -128,6 +128,7 @@ class ProjectApplicationFormCommandServiceTest {
             ArgumentCaptor<CreateDraftFormCommand> captor = ArgumentCaptor.forClass(CreateDraftFormCommand.class);
             then(manageFormUseCase).should().createDraft(captor.capture());
             assertThat(captor.getValue().title()).isEqualTo("Triple");
+            assertThat(captor.getValue().allowDuplicateResponses()).isTrue();
             then(manageFormUseCase).should(never()).updateForm(any());
         }
 

--- a/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
@@ -8,6 +8,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormResponseCommand;
@@ -28,16 +40,6 @@ import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class FormResponseCommandServiceTest {

--- a/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.survey.application.port.out.LoadAnswerPort;
@@ -20,12 +21,16 @@ import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.survey.application.port.out.LoadQuestionPort;
 import com.umc.product.survey.application.port.out.SaveAnswerPort;
 import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.survey.domain.Answer;
 import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.enums.QuestionType;
 import com.umc.product.survey.domain.exception.SurveyDomainException;
 import com.umc.product.survey.domain.exception.SurveyErrorCode;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -172,10 +177,89 @@ class FormResponseCommandServiceTest {
         then(saveFormResponsePort).should(never()).deleteById(anyLong());
     }
 
+    @Test
+    @DisplayName("draft 제출 scope가 있으면 전달된 required question만 필수 응답 검증한다")
+    void draft_제출_scope가_있으면_전달된_required_question만_검증한다() {
+        FormResponse draft = draftResponse();
+        Question commonRequiredQuestion = question(10L, true);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, commonRequiredQuestion)));
+
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of(commonRequiredQuestion.getId()))
+            .allowedQuestionIds(Set.of(commonRequiredQuestion.getId()))
+            .build());
+
+        then(loadQuestionPort).should(never()).listByFormId(FORM_ID);
+        then(saveFormResponsePort).should().save(draft);
+    }
+
+    @Test
+    @DisplayName("draft 제출 scope가 없으면 기존처럼 form 전체 required question을 검증한다")
+    void draft_제출_scope가_없으면_form_전체_required_question을_검증한다() {
+        FormResponse draft = draftResponse();
+        Question answeredRequiredQuestion = question(10L, true);
+        Question missingRequiredQuestion = question(20L, true);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, answeredRequiredQuestion)));
+        given(loadQuestionPort.listByFormId(FORM_ID))
+            .willReturn(List.of(answeredRequiredQuestion, missingRequiredQuestion));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
+    }
+
+    @Test
+    @DisplayName("draft 제출 scope의 allowed question 밖에 저장된 답변이 있으면 실패한다")
+    void draft_제출_scope의_allowed_question_밖에_저장된_답변이면_실패한다() {
+        FormResponse draft = draftResponse();
+        Question hiddenQuestion = question(20L, false);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, hiddenQuestion)));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of())
+            .allowedQuestionIds(Set.of(10L))
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
     private Form publishedForm(boolean allowDuplicateResponses) {
         Form form = Form.createDraft("프로젝트 지원서", 1L, allowDuplicateResponses);
         ReflectionTestUtils.setField(form, "id", FORM_ID);
         form.publish();
         return form;
+    }
+
+    private FormResponse draftResponse() {
+        FormResponse response = FormResponse.createDraft(publishedForm(true), MEMBER_ID);
+        ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+        return response;
+    }
+
+    private Question question(Long questionId, boolean isRequired) {
+        Question question = Question.create("질문", QuestionType.SHORT_TEXT, isRequired, 1L);
+        ReflectionTestUtils.setField(question, "id", questionId);
+        return question;
+    }
+
+    private Answer answer(FormResponse formResponse, Question question) {
+        return Answer.create(formResponse, question, QuestionType.SHORT_TEXT, "답변", null);
     }
 }

--- a/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
@@ -1,0 +1,181 @@
+package com.umc.product.survey.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.SubmitFormResponseCommand;
+import com.umc.product.survey.application.port.in.command.dto.UpdateFormResponseCommand;
+import com.umc.product.survey.application.port.out.LoadAnswerPort;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.LoadFormResponsePort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.application.port.out.SaveAnswerPort;
+import com.umc.product.survey.application.port.out.SaveFormResponsePort;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormResponse;
+import com.umc.product.survey.domain.exception.SurveyDomainException;
+import com.umc.product.survey.domain.exception.SurveyErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class FormResponseCommandServiceTest {
+
+    private static final Long FORM_ID = 100L;
+    private static final Long MEMBER_ID = 200L;
+    private static final Long FORM_RESPONSE_ID = 300L;
+
+    @Mock
+    LoadFormPort loadFormPort;
+    @Mock
+    LoadQuestionPort loadQuestionPort;
+    @Mock
+    LoadQuestionOptionPort loadQuestionOptionPort;
+    @Mock
+    LoadFormResponsePort loadFormResponsePort;
+    @Mock
+    LoadAnswerPort loadAnswerPort;
+    @Mock
+    SaveFormResponsePort saveFormResponsePort;
+    @Mock
+    SaveAnswerPort saveAnswerPort;
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @InjectMocks
+    FormResponseCommandService sut;
+
+    @Test
+    @DisplayName("기본 폼은 같은 form/member의 draft 생성을 차단한다")
+    void 기본_폼은_중복_draft_생성을_차단한다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
+        given(loadFormResponsePort.existsByFormIdAndMemberId(FORM_ID, MEMBER_ID)).willReturn(true);
+
+        assertThatThrownBy(() -> sut.createDraft(CreateDraftFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("기본 폼은 같은 form/member의 즉시 제출을 차단한다")
+    void 기본_폼은_중복_즉시_제출을_차단한다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
+        given(loadFormResponsePort.existsByFormIdAndMemberId(FORM_ID, MEMBER_ID)).willReturn(true);
+
+        assertThatThrownBy(() -> sut.submitImmediately(SubmitFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("중복 허용 폼은 같은 form/member의 두 번째 draft도 새 응답으로 생성한다")
+    void 중복_허용_폼은_두번째_draft도_생성한다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(true)));
+        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
+            FormResponse response = invocation.getArgument(0);
+            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+            return response;
+        });
+
+        Long result = sut.createDraft(CreateDraftFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .build());
+
+        assertThat(result).isEqualTo(FORM_RESPONSE_ID);
+        then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(FORM_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("중복 허용 폼은 같은 form/member의 즉시 제출도 새 응답으로 생성한다")
+    void 중복_허용_폼은_두번째_즉시_제출도_생성한다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(true)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of());
+        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
+            FormResponse response = invocation.getArgument(0);
+            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+            return response;
+        });
+
+        Long result = sut.submitImmediately(SubmitFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .answers(List.of())
+            .build());
+
+        assertThat(result).isEqualTo(FORM_RESPONSE_ID);
+        then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(FORM_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("중복 허용 폼은 formId/memberId 기반 제출 응답 수정을 막는다")
+    void 중복_허용_폼은_단건_응답_수정을_막는다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(true)));
+
+        assertThatThrownBy(() -> sut.updateResponse(UpdateFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.FORM_RESPONSE_LOOKUP_AMBIGUOUS);
+
+        then(loadFormResponsePort).should(never())
+            .findSubmittedByFormIdAndRespondentMemberId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("중복 허용 폼은 formId/memberId 기반 제출 응답 삭제를 막는다")
+    void 중복_허용_폼은_단건_응답_삭제를_막는다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(true)));
+
+        assertThatThrownBy(() -> sut.deleteResponse(DeleteFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(MEMBER_ID)
+            .build()))
+            .isInstanceOf(SurveyDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(SurveyErrorCode.FORM_RESPONSE_LOOKUP_AMBIGUOUS);
+
+        then(loadFormResponsePort).should(never())
+            .findSubmittedByFormIdAndRespondentMemberId(anyLong(), anyLong());
+        then(saveFormResponsePort).should(never()).deleteById(anyLong());
+    }
+
+    private Form publishedForm(boolean allowDuplicateResponses) {
+        Form form = Form.createDraft("프로젝트 지원서", 1L, allowDuplicateResponses);
+        ReflectionTestUtils.setField(form, "id", FORM_ID);
+        form.publish();
+        return form;
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- Survey 도메인의 `Form` 모델, 응답 command service, command/query DTO와 Project 지원서 폼 생성 경로를 수정했어요.
- `form.allow_duplicate_responses` Flyway migration과 Survey/Project command 테스트를 추가했어요.

### 작업 단위별 상세

1. **무엇을**: Survey Form에 폼별 중복 응답 허용 정책을 추가했어요.
   - **어떻게**: `Form.allowDuplicateResponses` 필드와 `CreateDraftFormCommand`, `UpdateFormCommand`, `FormInfo`, `FormWithStructureInfo` 전달 필드를 추가하고 기본값은 false로 유지했어요.
   - **왜**: 기존 Notice 투표와 UserFeedback처럼 form/member 단위로 한 번만 응답해야 하는 Survey 사용처의 동작을 유지하면서, 프로젝트 지원서처럼 차수별로 같은 폼에 여러 응답이 필요할 수 있는 흐름을 분리하기 위해서예요.

2. **무엇을**: Survey 응답 생성 시 중복 검증을 폼 정책에 따라 수행하도록 수정했어요.
   - **어떻게**: `createDraft`와 `submitImmediately`는 중복 응답을 허용하지 않는 폼에서만 `existsByFormIdAndMemberId`를 검사하고, 중복 허용 폼의 `updateResponse`와 `deleteResponse`는 `SURVEY-0033` 예외로 차단했어요.
   - **왜**: 중복 허용 폼에서는 formId/memberId만으로 단일 FormResponse를 특정할 수 없어 조용히 최신 1건을 수정하거나 삭제하면 잘못된 응답이 변경될 수 있기 때문이에요.

3. **무엇을**: 프로젝트 지원서 폼은 생성과 backfill 모두 중복 응답 허용 정책을 사용하도록 변경했어요.
   - **어떻게**: `ProjectApplicationFormCommandService`에서 신규 지원서 폼 생성 시 `allowDuplicateResponses=true`를 넘기고, `project_application_form.form_id`가 참조하는 기존 `form` row만 migration에서 true로 업데이트했어요.
   - **왜**: 이전 매칭 차수의 DRAFT 또는 SUBMITTED FormResponse가 남아 있어도 새 매칭 차수에서 Survey 중복 응답 예외로 지원서 draft 생성이 막히지 않게 하기 위해서예요.

4. **무엇을**: 중복 응답 정책의 회귀 테스트를 추가했어요.
   - **어떻게**: 기본 폼의 draft/즉시 제출 중복 차단, 중복 허용 폼의 draft/즉시 제출 허용, 중복 허용 폼의 update/delete 차단, Project 지원서 폼 생성 command의 true 전달을 검증했어요.
   - **왜**: 기존 Survey 기본 플로우는 유지하고 Project 지원서 폼만 예외 정책을 타는지 명확히 보장하기 위해서예요.

## 💬 리뷰 중점사항

- `V2026.06.13.10.00__add_form_allow_duplicate_responses.sql`에서 전체 기본값은 false이고 `project_application_form`이 참조하는 form만 true로 backfill되는지 확인 부탁드려요.
- 중복 허용 폼에서 `updateResponse`와 `deleteResponse`를 막는 `SURVEY-0033` 정책이 기존 Notice 투표 수정/취소 흐름에는 적용되지 않는지 확인 부탁드려요.
- 검증은 `./gradlew test --tests 'com.umc.product.survey.application.service.command.FormResponseCommandServiceTest' --tests 'com.umc.product.project.application.service.command.ProjectApplicationFormCommandServiceTest' --tests 'com.umc.product.project.application.service.command.ProjectApplicationCommandServiceTest'`로 통과했어요. 전체 `./gradlew test`는 로컬 PostgreSQL SSL handshake/Flyway 연결 대기로 완료하지 못했어요.
