### PR TITLE
[Fix] 지원서 합불 변경 시 매칭 선발 규정 적용 및 3차 매칭 종료 후 랜덤매칭 적용

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -121,8 +121,8 @@ public class ProjectApplicationController {
         description = """
             PM 이 지원서의 status 를 토글합니다.
             - 매칭 차수 진행 중에만 가능 (decisionDeadline 까지)
-            - SUBMITTED ↔ APPROVED ↔ REJECTED 자유 토글 (재토글 허용)
-            - PENDING 입력은 도메인의 SUBMITTED 로 매핑되어 결정을 "대기" 로 되돌림
+            - APPROVED ↔ REJECTED 재토글 허용
+            - REJECTED 처리 후 매칭 규칙의 최소선발 수를 만족하지 못하면 거절
             """
     )
     @CheckAccess(

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -101,6 +101,11 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     }
 
     @Override
+    public List<ProjectApplication> listDecidableByMatchingRoundIdAndProjectId(Long matchingRoundId, Long projectId) {
+        return projectApplicationQueryRepository.listDecidableByMatchingRoundIdAndProjectId(matchingRoundId, projectId);
+    }
+
+    @Override
     public Optional<ProjectApplication> findByIdWithDetails(Long applicationId) {
         return projectApplicationQueryRepository.findByIdWithDetails(applicationId);
     }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -144,6 +144,27 @@ public class ProjectApplicationQueryRepository {
     }
 
     /**
+     * 수동 상태 변경 시 최소선발 검증에 필요한 같은 차수/프로젝트의 결정 가능 지원서를 조회한다.
+     */
+    public List<ProjectApplication> listDecidableByMatchingRoundIdAndProjectId(Long matchingRoundId, Long projectId) {
+        return queryFactory
+            .selectFrom(projectApplication)
+            .innerJoin(projectApplication.applicationForm, projectApplicationForm).fetchJoin()
+            .innerJoin(projectApplicationForm.project, project).fetchJoin()
+            .innerJoin(projectApplication.appliedMatchingRound, projectMatchingRound).fetchJoin()
+            .where(
+                projectMatchingRound.id.eq(matchingRoundId),
+                project.id.eq(projectId),
+                projectApplication.status.in(List.of(
+                    ProjectApplicationStatus.SUBMITTED,
+                    ProjectApplicationStatus.APPROVED,
+                    ProjectApplicationStatus.REJECTED
+                ))
+            )
+            .fetch();
+    }
+
+    /**
      * 프로젝트/멤버 쌍별 APPROVED 지원서 중 가장 최신 매칭 차수를 반환한다.
      * <p>
      * DB 에서 최신 우선 정렬로 가져온 뒤, Java 에서 각 (projectId, memberId) 의 첫 row 만 남겨 DB 벤더별 window function 차이를 피한다.

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectJpaRepository.java
@@ -1,5 +1,6 @@
 package com.umc.product.project.adapter.out.persistence;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +14,8 @@ public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 
     Optional<Project> findByCreatorMemberIdAndGisuIdAndStatus(
         Long creatorMemberId, Long gisuId, ProjectStatus status);
+
+    List<Project> findByChapterIdAndStatus(Long chapterId, ProjectStatus status);
 
     boolean existsByCreatorMemberIdAndGisuIdAndStatus(
         Long creatorMemberId, Long gisuId, ProjectStatus status);

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectPersistenceAdapter.java
@@ -44,6 +44,11 @@ public class ProjectPersistenceAdapter implements LoadProjectPort, SaveProjectPo
     }
 
     @Override
+    public List<Project> listByChapterIdAndStatus(Long chapterId, ProjectStatus status) {
+        return jpaRepository.findByChapterIdAndStatus(chapterId, status);
+    }
+
+    @Override
     public boolean existsByOwnerAndGisu(Long productOwnerMemberId, Long gisuId) {
         return jpaRepository.existsByProductOwnerMemberIdAndGisuId(productOwnerMemberId, gisuId);
     }

--- a/src/main/java/com/umc/product/project/application/port/in/command/DecideApplicationUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/DecideApplicationUseCase.java
@@ -6,9 +6,9 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationI
 /**
  * 지원서 합/불 결정 UseCase (APPLY-103).
  * <p>
- * PM 이 매칭 차수 진행 중에 SUBMITTED ↔ APPROVED ↔ REJECTED 사이를 자유롭게 토글한다.
+ * PM 이 매칭 차수 진행 중에 APPROVED ↔ REJECTED 결정을 내린다.
  * 권한은 {@code @CheckAccess(PROJECT_APPLICATION, APPROVE)} 가 책임지고,
- * 차수 잠금 검증은 도메인 메서드({@code ProjectApplication.approve / reject / revertToPending}) 가 책임진다.
+ * 차수 잠금 검증은 도메인 메서드({@code ProjectApplication.approve / reject}) 가 책임진다.
  */
 public interface DecideApplicationUseCase {
 

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/ApplicationDecisionStatus.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/ApplicationDecisionStatus.java
@@ -3,17 +3,13 @@ package com.umc.product.project.application.port.in.command.dto;
 /**
  * PM 이 지원서에 내릴 수 있는 결정.
  * <p>
- * UI 의 "대기" 옵션은 {@code PENDING} 으로 표현하며, 도메인 레이어에서
- * {@link com.umc.product.project.domain.enums.ProjectApplicationStatus#SUBMITTED} 로 매핑된다.
- * <p>
  * 도메인 enum 을 직접 노출하지 않는 이유:
  * <ul>
- *   <li>DRAFT 등 결정 대상이 아닌 status 입력을 enum 자체로 차단</li>
+ *   <li>DRAFT, SUBMITTED 등 결정 대상이 아닌 status 입력을 enum 자체로 차단</li>
  *   <li>도메인 enum 변경이 API 계약 변경을 강제하지 않도록 결합 회피</li>
  * </ul>
  */
 public enum ApplicationDecisionStatus {
     APPROVED,
-    REJECTED,
-    PENDING
+    REJECTED
 }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -57,6 +57,14 @@ public interface LoadProjectApplicationPort {
     List<ProjectApplication> listByMatchingRoundId(Long matchingRoundId);
 
     /**
+     * 같은 매칭 차수와 프로젝트에 속한 결정 가능 지원서(SUBMITTED/APPROVED/REJECTED)를 조회합니다.
+     * <p>
+     * applicationForm -> project, appliedMatchingRound 를 fetch join 으로 함께 로드하여 최소선발 검증에서 lazy traversal
+     * 없이 프로젝트/차수 정보를 사용할 수 있게 합니다.
+     */
+    List<ProjectApplication> listDecidableByMatchingRoundIdAndProjectId(Long matchingRoundId, Long projectId);
+
+    /**
      * 지원서 단건을 fetch join 으로 조회한다.
      * <p>
      * applicationForm -> project, appliedMatchingRound 를 한 번에 로드하여 호출자가 lazy 프록시 traversal 없이

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectPort.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 
 import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.enums.ProjectStatus;
 
 /**
  * Project 조회 Port (Driven / Port Out).
@@ -33,6 +34,11 @@ public interface LoadProjectPort {
      * 여러 ID 에 대해 Project 를 한 번에 조회합니다. 누락된 ID 는 결과에서 빠집니다 (예외 없음).
      */
     List<Project> listByIds(Collection<Long> ids);
+
+    /**
+     * 특정 지부의 특정 상태 프로젝트 목록을 반환합니다.
+     */
+    List<Project> listByChapterIdAndStatus(Long chapterId, ProjectStatus status);
 
     /**
      * 특정 멤버가 특정 기수에 PO 인 프로젝트가 하나라도 존재하는지 확인합니다. Access scope 판정용 (OwnerOnly 부여 여부) — 동일 기수 내 PO 중복은 더 이상 차단되지 않으므로 다중

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -20,6 +20,7 @@ import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
@@ -60,6 +61,7 @@ public class ProjectApplicationCommandService implements
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
+    private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
 
     @Override
     public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
@@ -216,11 +218,13 @@ public class ProjectApplicationCommandService implements
             && application.getStatus() != ProjectApplicationStatus.APPROVED) {
             validateRemainingQuota(application);
         }
+        if (targetStatus == ApplicationDecisionStatus.REJECTED && isDecidableStatus(application.getStatus())) {
+            validateMinimumSelectionAfterRejection(application);
+        }
 
         switch (targetStatus) {
             case APPROVED -> application.approve(decidedByMemberId, reason);
             case REJECTED -> application.reject(decidedByMemberId, reason);
-            case PENDING -> application.revertToPending(decidedByMemberId);
         }
 
         saveProjectApplicationPort.save(application);
@@ -261,6 +265,78 @@ public class ProjectApplicationCommandService implements
         if (activeMemberCount + currentRoundApproved + 1 > totalQuota) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_QUOTA_EXCEEDED);
         }
+    }
+
+    /**
+     * REJECTED 결정 후에도 매칭 정책의 최소선발 인원을 만족하는지 검증한다.
+     */
+    private void validateMinimumSelectionAfterRejection(ProjectApplication application) {
+        Project project = application.getApplicationForm().getProject();
+        Long projectId = project.getId();
+        Long gisuId = project.getGisuId();
+        Long roundId = application.getAppliedMatchingRound().getId();
+        ChallengerPart targetPart = getChallengerUseCase
+            .getByMemberIdAndGisuId(application.getApplicantMemberId(), gisuId)
+            .part();
+
+        List<ProjectApplication> applicants = loadProjectApplicationPort
+            .listDecidableByMatchingRoundIdAndProjectId(roundId, projectId);
+        List<ProjectApplication> samePartApplicants = filterSamePartApplicants(applicants, targetPart, gisuId);
+
+        int required = resolvePolicy(application.getAppliedMatchingRound().getType())
+            .minimumRequired(samePartApplicants.size(), remainingQuota(projectId, targetPart));
+        int approvedAfterRejection = (int) samePartApplicants.stream()
+            .filter(a -> !a.getId().equals(application.getId()))
+            .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED)
+            .count();
+
+        if (approvedAfterRejection < required) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_MINIMUM_SELECTION_REQUIRED);
+        }
+    }
+
+    private List<ProjectApplication> filterSamePartApplicants(
+        List<ProjectApplication> applicants, ChallengerPart targetPart, Long gisuId
+    ) {
+        if (applicants.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> memberIds = applicants.stream()
+            .map(ProjectApplication::getApplicantMemberId)
+            .collect(Collectors.toSet());
+        Map<Long, ChallengerInfo> challengerByMember =
+            getChallengerUseCase.batchGetByMemberIdsAndGisuId(memberIds, gisuId);
+
+        return applicants.stream()
+            .filter(a -> challengerByMember.get(a.getApplicantMemberId()).part() == targetPart)
+            .toList();
+    }
+
+    private int remainingQuota(Long projectId, ChallengerPart part) {
+        int totalQuota = loadProjectPartQuotaPort.listByProjectId(projectId).stream()
+            .filter(q -> q.getPart() == part)
+            .findFirst()
+            .map(q -> q.getQuota().intValue())
+            .orElse(0);
+        int activeMemberCount = loadProjectMemberPort
+            .countByProjectIdGroupByPart(projectId)
+            .getOrDefault(part, 0L)
+            .intValue();
+
+        return Math.max(0, totalQuota - activeMemberCount);
+    }
+
+    private MatchingDecisionPolicy resolvePolicy(MatchingType type) {
+        return matchingDecisionPolicies.stream()
+            .filter(p -> p.supportedType() == type)
+            .findFirst()
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MATCHING_ROUND_POLICY_NOT_FOUND));
+    }
+
+    private boolean isDecidableStatus(ProjectApplicationStatus status) {
+        return status == ProjectApplicationStatus.SUBMITTED
+            || status == ProjectApplicationStatus.APPROVED
+            || status == ProjectApplicationStatus.REJECTED;
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -3,30 +3,44 @@ package com.umc.product.project.application.service.command;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.SearchChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerCursorResult;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerItemInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerQuery;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.service.policy.AutoDecisionResult;
 import com.umc.product.project.application.service.policy.MatchingDecisionPolicy;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,9 +63,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProjectMatchingRoundFinalizationCommandService implements
     AutoDecideProjectMatchingRoundUseCase {
 
+    private static final int RANDOM_ASSIGNMENT_SEARCH_PAGE_SIZE = 500;
+    private static final Set<ChallengerPart> DEVELOPER_PARTS = Set.of(
+        ChallengerPart.WEB,
+        ChallengerPart.ANDROID,
+        ChallengerPart.IOS,
+        ChallengerPart.NODEJS,
+        ChallengerPart.SPRINGBOOT
+    );
+
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final SaveProjectApplicationPort saveProjectApplicationPort;
+    private final LoadProjectPort loadProjectPort;
     private final LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
     private final SaveProjectMemberPort saveProjectMemberPort;
@@ -59,6 +83,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
     private final Random matchingRandom;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
+    private final SearchChallengerUseCase searchChallengerUseCase;
 
     @Override
     public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
@@ -83,29 +108,32 @@ public class ProjectMatchingRoundFinalizationCommandService implements
             .filter(a -> isDecidableStatus(a.getStatus()))
             .toList();
 
-        if (applicants.isEmpty()) {
-            round.executeAutoDecision(executedByMemberId);
-            return;
+        List<ProjectMember> membersToSave = new ArrayList<>();
+        if (!applicants.isEmpty()) {
+            Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
+            Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
+
+            Map<ProjectPartKey, Integer> remainingQuotaByKey = buildRemainingQuotaMap(grouped.keySet());
+
+            Set<Long> approvedIds = new HashSet<>();
+            Set<Long> rejectedIds = new HashSet<>();
+            for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
+                int quota = remainingQuotaByKey.getOrDefault(entry.getKey(), 0);
+                AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
+                approvedIds.addAll(result.approvedIds());
+                rejectedIds.addAll(result.rejectedIds());
+            }
+
+            applyDecisions(applicants, approvedIds, rejectedIds, executedByMemberId);
+            saveProjectApplicationPort.saveAll(applicants);
+            membersToSave.addAll(buildApprovedMembers(applicants, approvedIds, applicantPart, executedByMemberId));
         }
 
-        Map<Long, ChallengerPart> applicantPart = resolveApplicantParts(applicants);
-        Map<ProjectPartKey, List<ProjectApplication>> grouped = groupByProjectAndPart(applicants, applicantPart);
+        membersToSave.addAll(buildRandomAssignedMembersAfterThirdDeveloperRound(round, membersToSave, executedByMemberId));
 
-        Map<ProjectPartKey, Integer> remainingQuotaByKey = buildRemainingQuotaMap(grouped.keySet());
-
-        Set<Long> approvedIds = new HashSet<>();
-        Set<Long> rejectedIds = new HashSet<>();
-        for (Map.Entry<ProjectPartKey, List<ProjectApplication>> entry : grouped.entrySet()) {
-            int quota = remainingQuotaByKey.getOrDefault(entry.getKey(), 0);
-            AutoDecisionResult result = policy.decideAutomatically(entry.getValue(), quota, matchingRandom);
-            approvedIds.addAll(result.approvedIds());
-            rejectedIds.addAll(result.rejectedIds());
+        if (!membersToSave.isEmpty()) {
+            saveProjectMemberPort.saveAll(membersToSave);
         }
-
-        applyDecisions(applicants, approvedIds, rejectedIds, executedByMemberId);
-        saveProjectApplicationPort.saveAll(applicants);
-
-        registerApprovedMembers(applicants, approvedIds, applicantPart, executedByMemberId);
 
         round.executeAutoDecision(executedByMemberId);
     }
@@ -173,7 +201,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue().stream().collect(Collectors.toMap(
-                    com.umc.product.project.domain.ProjectPartQuota::getPart,
+                    ProjectPartQuota::getPart,
                     q -> q.getQuota().intValue()
                 ))
             ));
@@ -181,7 +209,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         Map<Long, Map<ChallengerPart, Long>> activeByProject = loadProjectMemberPort
             .countByProjectIdsGroupByProjectIdAndPart(projectIds);
 
-        Map<ProjectPartKey, Integer> result = new java.util.HashMap<>();
+        Map<ProjectPartKey, Integer> result = new HashMap<>();
         for (ProjectPartKey key : keys) {
             int total = totalQuotaByProject
                 .getOrDefault(key.projectId(), Map.of())
@@ -211,25 +239,178 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         }
     }
 
-    private void registerApprovedMembers(
+    private List<ProjectMember> buildApprovedMembers(
         List<ProjectApplication> applicants,
         Set<Long> approvedIds,
         Map<Long, ChallengerPart> applicantPart,
         Long executedByMemberId
     ) {
-        List<ProjectMember> membersToSave = applicants.stream()
+        return applicants.stream()
             .filter(app -> approvedIds.contains(app.getId()))
-            .map(app -> ProjectMember.create(
-                app.getApplicationForm().getProject(),
-                app.getApplicantMemberId(),
+            .map(app -> ProjectMember.createFromApplication(
+                app,
                 applicantPart.get(app.getId()),
                 executedByMemberId
             ))
             .toList();
+    }
 
-        if (!membersToSave.isEmpty()) {
-            saveProjectMemberPort.saveAll(membersToSave);
+    private List<ProjectMember> buildRandomAssignedMembersAfterThirdDeveloperRound(
+        ProjectMatchingRound round,
+        List<ProjectMember> plannedMembers,
+        Long executedByMemberId
+    ) {
+        if (round.getType() != MatchingType.PLAN_DEVELOPER || round.getPhase() != MatchingPhase.THIRD) {
+            return List.of();
         }
+
+        List<Project> projects = loadProjectPort.listByChapterIdAndStatus(
+            round.getChapterId(),
+            ProjectStatus.IN_PROGRESS
+        );
+        if (projects.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> projectIds = projects.stream()
+            .map(Project::getId)
+            .collect(Collectors.toSet());
+        Map<Long, Project> projectById = projects.stream()
+            .collect(Collectors.toMap(Project::getId, project -> project));
+        Long gisuId = projects.getFirst().getGisuId();
+
+        Map<ProjectPartKey, Integer> remainingByKey = buildRemainingDeveloperQuotaMap(projects, plannedMembers);
+        if (remainingByKey.values().stream().noneMatch(remaining -> remaining > 0)) {
+            return List.of();
+        }
+
+        Set<Long> alreadyMatchedMemberIds = loadProjectMemberPort.listByProjectIds(projectIds).values().stream()
+            .flatMap(List::stream)
+            .map(ProjectMember::getMemberId)
+            .collect(Collectors.toSet());
+        plannedMembers.stream()
+            .map(ProjectMember::getMemberId)
+            .forEach(alreadyMatchedMemberIds::add);
+
+        List<SearchChallengerItemInfo> candidates = new ArrayList<>(
+            listActiveChallengersInChapter(gisuId, round.getChapterId())
+        );
+        Collections.shuffle(candidates, matchingRandom);
+
+        List<ProjectMember> assignments = new ArrayList<>();
+        for (SearchChallengerItemInfo candidate : candidates) {
+            if (remainingByKey.values().stream().noneMatch(remaining -> remaining > 0)) {
+                break;
+            }
+            if (alreadyMatchedMemberIds.contains(candidate.memberId()) || !isDeveloperPart(candidate.part())) {
+                continue;
+            }
+
+            Optional<ProjectPartKey> targetKey = pickRandomRemainingProjectKey(candidate.part(), remainingByKey);
+            if (targetKey.isEmpty()) {
+                continue;
+            }
+
+            ProjectPartKey key = targetKey.get();
+            Project project = projectById.get(key.projectId());
+            assignments.add(ProjectMember.create(project, candidate.memberId(), candidate.part(), executedByMemberId));
+            alreadyMatchedMemberIds.add(candidate.memberId());
+            remainingByKey.computeIfPresent(key, (ignored, remaining) -> remaining - 1);
+        }
+
+        return assignments;
+    }
+
+    private Map<ProjectPartKey, Integer> buildRemainingDeveloperQuotaMap(
+        List<Project> projects,
+        List<ProjectMember> plannedMembers
+    ) {
+        Set<Long> projectIds = projects.stream()
+            .map(Project::getId)
+            .collect(Collectors.toSet());
+        Map<Long, Map<ChallengerPart, Long>> activeByProject = loadProjectMemberPort
+            .countByProjectIdsGroupByProjectIdAndPart(projectIds);
+        Map<ProjectPartKey, Long> plannedByKey = plannedMembers.stream()
+            .filter(member -> projectIds.contains(member.getProject().getId()))
+            .filter(member -> isDeveloperPart(member.getPart()))
+            .collect(Collectors.groupingBy(
+                member -> new ProjectPartKey(member.getProject().getId(), member.getPart()),
+                Collectors.counting()
+            ));
+
+        Map<ProjectPartKey, Integer> result = new HashMap<>();
+        Map<Long, List<ProjectPartQuota>> quotasByProject = loadProjectPartQuotaPort
+            .listByProjectIdsGroupedByProjectId(projectIds);
+        for (Project project : projects) {
+            Long projectId = project.getId();
+            for (ProjectPartQuota quota : quotasByProject.getOrDefault(projectId, List.of())) {
+                ChallengerPart part = quota.getPart();
+                if (!isDeveloperPart(part)) {
+                    continue;
+                }
+
+                ProjectPartKey key = new ProjectPartKey(projectId, part);
+                int active = activeByProject
+                    .getOrDefault(projectId, Map.of())
+                    .getOrDefault(part, 0L)
+                    .intValue();
+                int planned = plannedByKey.getOrDefault(key, 0L).intValue();
+                int remaining = Math.max(0, quota.getQuota().intValue() - active - planned);
+                if (remaining > 0) {
+                    result.put(key, remaining);
+                }
+            }
+        }
+        return result;
+    }
+
+    private List<SearchChallengerItemInfo> listActiveChallengersInChapter(Long gisuId, Long chapterId) {
+        SearchChallengerQuery query = new SearchChallengerQuery(
+            null,
+            null,
+            null,
+            null,
+            null,
+            chapterId,
+            null,
+            gisuId,
+            List.of(ChallengerStatus.ACTIVE)
+        );
+
+        List<SearchChallengerItemInfo> result = new ArrayList<>();
+        Long cursor = null;
+        boolean hasNext;
+        do {
+            SearchChallengerCursorResult page = searchChallengerUseCase.cursorSearch(
+                query,
+                cursor,
+                RANDOM_ASSIGNMENT_SEARCH_PAGE_SIZE
+            );
+            result.addAll(page.content());
+            cursor = page.nextCursor();
+            hasNext = page.hasNext() && cursor != null;
+        } while (hasNext);
+        return result;
+    }
+
+    private Optional<ProjectPartKey> pickRandomRemainingProjectKey(
+        ChallengerPart part,
+        Map<ProjectPartKey, Integer> remainingByKey
+    ) {
+        List<ProjectPartKey> availableKeys = remainingByKey.entrySet().stream()
+            .filter(entry -> entry.getValue() > 0)
+            .filter(entry -> entry.getKey().part() == part)
+            .map(Map.Entry::getKey)
+            .toList();
+
+        if (availableKeys.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(availableKeys.get(matchingRandom.nextInt(availableKeys.size())));
+    }
+
+    private boolean isDeveloperPart(ChallengerPart part) {
+        return DEVELOPER_PARTS.contains(part);
     }
 
     private void validateManageAccess(Long memberId, Long chapterId) {

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -157,25 +157,6 @@ public class ProjectApplication extends BaseEntity {
     }
 
     /**
-     * APPROVED / REJECTED 결정을 SUBMITTED ("대기") 로 되돌립니다.
-     * <p>
-     * UI 상의 "대기" 옵션이며, 차수 진행 중에만 호출 가능합니다.
-     *
-     * @param revertedByMemberId 되돌린 PO 또는 운영진 ID
-     */
-    public void revertToPending(Long revertedByMemberId) {
-        if (status != ProjectApplicationStatus.APPROVED && status != ProjectApplicationStatus.REJECTED) {
-            throw new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
-        }
-        appliedMatchingRound.validateIsMutableAt(Instant.now());
-
-        this.status = ProjectApplicationStatus.SUBMITTED;
-        this.statusChangedMemberId = revertedByMemberId;
-        this.statusChangeReason = null;
-        this.statusChangedAt = Instant.now();
-    }
-
-    /**
      * 합/불 결정 대상이 되는 status 인지 검증합니다. SUBMITTED / APPROVED / REJECTED 만 통과합니다.
      */
     private void validateCanBeDecided() {

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -103,6 +103,22 @@ public class ProjectMember extends BaseEntity {
     }
 
     /**
+     * 지원서 합격 결과로 활성 상태의 신규 멤버를 생성합니다.
+     */
+    public static ProjectMember createFromApplication(
+        ProjectApplication application, ChallengerPart part, Long decidedByMemberId
+    ) {
+        ProjectMember pm = create(
+            application.getApplicationForm().getProject(),
+            application.getApplicantMemberId(),
+            part,
+            decidedByMemberId
+        );
+        pm.application = application;
+        return pm;
+    }
+
+    /**
      * 멤버를 강제 퇴출 처리합니다 (soft delete).
      * status 를 {@link ProjectMemberStatus#DISMISSED} 로 바꾸고 변경 메타데이터를 기록합니다.
      */

--- a/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
+++ b/src/main/java/com/umc/product/project/domain/exception/ProjectErrorCode.java
@@ -93,6 +93,8 @@ public enum ProjectErrorCode implements BaseCode {
         "해당 파트의 남은 자리를 초과해 합격 처리할 수 없어요. 파트 정원을 확인해주세요."),
     PROJECT_APPLICATION_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PROJECT-0214", "이미 종결된 지원서는 철회할 수 없어요. 지원서 상태를 확인해주세요."),
     PROJECT_APPLICATION_CANCEL_ROUND_CLOSED(HttpStatus.BAD_REQUEST, "PROJECT-0215", "매칭 차수가 종료되어 지원서를 철회할 수 없어요. 차수 기간을 확인해주세요."),
+    PROJECT_APPLICATION_MINIMUM_SELECTION_REQUIRED(HttpStatus.CONFLICT, "PROJECT-0216",
+        "매칭 규칙의 최소 선발 인원을 충족하지 않아 불합격 처리할 수 없어요. 합격 인원을 확인해주세요."),
 
     ;
 

--- a/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/ProjectApplicationSeedService.java
@@ -282,8 +282,8 @@ public class ProjectApplicationSeedService implements SeedProjectApplicationsUse
             return ApplicationOutcome.fail("SUBMIT", e.toString(), applicationId);
         }
 
-        // 최종 상태 무작위 결정: SUBMITTED / APPROVED / REJECTED ≈ 1/3 분포
-        // 도메인이 상태 토글을 자유롭게 허용하므로 어떤 분포든 운영자가 화면에서 보정 가능 (revertToPending 등).
+        // 최종 상태 무작위 결정: SUBMITTED / APPROVED / REJECTED ≈ 1/3 분포.
+        // REJECTED 결정은 매칭 규칙의 최소선발 검증을 통과하는 경우에만 반영된다.
         int rand = ThreadLocalRandom.current().nextInt(3);
         if (rand == 0) {
             return ApplicationOutcome.success("SUBMITTED", applicationId);

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationControllerTest.java
@@ -119,20 +119,18 @@ class ProjectApplicationControllerTest {
         }
 
         @Test
-        void PENDING_요청시_도메인의_SUBMITTED로_매핑된_응답을_반환한다() throws Exception {
-            UpdateApplicationDecisionRequest request = new UpdateApplicationDecisionRequest(
-                ApplicationDecisionStatus.PENDING, null
-            );
-            given(decideApplicationUseCase.decide(
-                eq(APPLICATION_ID), eq(ApplicationDecisionStatus.PENDING), eq(null), eq(TEST_MEMBER_ID)
-            )).willReturn(ProjectApplicationInfo.of(APPLICATION_ID, ProjectApplicationStatus.SUBMITTED));
+        void PENDING_요청시_400_및_UseCase를_호출하지_않는다() throws Exception {
+            String body = """
+                { "status": "PENDING" }
+                """;
 
             mockMvc.perform(patch("/api/v1/projects/{projectId}/applications/{applicationId}/decision",
                     PROJECT_ID, APPLICATION_ID)
-                    .content(objectMapper.writeValueAsString(request))
+                    .content(body)
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.status").value("SUBMITTED"));
+                .andExpect(status().isBadRequest());
+
+            then(decideApplicationUseCase).should(never()).decide(any(), any(), any(), any());
         }
 
         @Test

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
@@ -22,6 +21,8 @@ import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
+import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
+import com.umc.product.project.application.service.policy.DeveloperMatchingPolicy;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -79,11 +79,22 @@ class ProjectApplicationCommandServiceTest {
     @Mock
     GetChallengerUseCase getChallengerUseCase;
 
-    @InjectMocks
     ProjectApplicationCommandService sut;
 
     @BeforeEach
     void setUpQuotaMocks() {
+        sut = new ProjectApplicationCommandService(
+            loadProjectApplicationPort,
+            saveProjectApplicationPort,
+            loadProjectApplicationFormPort,
+            loadProjectPartQuotaPort,
+            loadProjectMemberPort,
+            loadProjectMatchingRoundPort,
+            manageFormResponseUseCase,
+            getChallengerUseCase,
+            List.of(new DeveloperMatchingPolicy(), new DesignerMatchingPolicy())
+        );
+
         // 기본: quota 충분 (ChallengerPart.WEB, TO 6, active 0, 같은 차수 APPROVED 0)
         given(getChallengerUseCase.getByMemberIdAndGisuId(any(), any()))
             .willReturn(challengerWithPart(ChallengerPart.WEB));
@@ -93,6 +104,8 @@ class ProjectApplicationCommandServiceTest {
             .willReturn(Map.of());
         given(loadProjectApplicationPort.listByMatchingRoundId(any()))
             .willReturn(List.of());
+        given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+            .willReturn(Map.of(APPLICANT_MEMBER_ID, challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.WEB)));
     }
 
     @Nested
@@ -119,6 +132,8 @@ class ProjectApplicationCommandServiceTest {
         void REJECTED_입력시_도메인_reject_호출_후_저장한다() {
             ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
             given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(List.of(application));
 
             sut.decide(APPLICATION_ID, ApplicationDecisionStatus.REJECTED, "면접 결과", DECIDER_MEMBER_ID);
 
@@ -128,15 +143,119 @@ class ProjectApplicationCommandServiceTest {
         }
 
         @Test
-        void PENDING_입력시_도메인_revertToPending_호출하고_사유는_초기화된다() {
-            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
-            ReflectionTestUtils.setField(application, "statusChangeReason", "이전 사유");
+        void 디자이너_지원자_2명_승인_0명에서_SUBMITTED를_REJECTED로_변경하면_MINIMUM_SELECTION_REQUIRED() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            ProjectApplication otherSubmitted = otherApplication(
+                701L, 101L, application.getApplicationForm(), ProjectApplicationStatus.SUBMITTED
+            );
             given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(List.of(application, otherSubmitted));
+            given(loadProjectPartQuotaPort.listByProjectId(any()))
+                .willReturn(List.of(partQuotaFor(ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
+                .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+                .willReturn(Map.of(
+                    APPLICANT_MEMBER_ID, challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.DESIGN),
+                    101L, challengerWith(101L, ChallengerPart.DESIGN)
+                ));
 
-            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.PENDING, "무시되는 사유", DECIDER_MEMBER_ID);
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.REJECTED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_MINIMUM_SELECTION_REQUIRED);
 
             assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
-            assertThat(application.getStatusChangeReason()).isNull();
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        void 디자이너_최소_1명이_이미_APPROVED면_다른_SUBMITTED를_REJECTED로_변경할_수_있다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            ProjectApplication approved = otherApplication(
+                701L, 101L, application.getApplicationForm(), ProjectApplicationStatus.APPROVED
+            );
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(List.of(application, approved));
+            given(loadProjectPartQuotaPort.listByProjectId(any()))
+                .willReturn(List.of(partQuotaFor(ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
+                .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.DESIGN));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+                .willReturn(Map.of(
+                    APPLICANT_MEMBER_ID, challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.DESIGN),
+                    101L, challengerWith(101L, ChallengerPart.DESIGN)
+                ));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.REJECTED, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            then(saveProjectApplicationPort).should(times(1)).save(application);
+        }
+
+        @Test
+        void 개발자_TO6_지원자6명_승인3명에서_APPROVED를_REJECTED로_변경하면_MINIMUM_SELECTION_REQUIRED() {
+            ProjectMatchingRound developerRound = openRound(MatchingType.PLAN_DEVELOPER);
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED, developerRound);
+            List<ProjectApplication> applicants = List.of(
+                application,
+                otherApplication(701L, 101L, application.getApplicationForm(), ProjectApplicationStatus.APPROVED),
+                otherApplication(702L, 102L, application.getApplicationForm(), ProjectApplicationStatus.APPROVED),
+                otherApplication(703L, 103L, application.getApplicationForm(), ProjectApplicationStatus.SUBMITTED),
+                otherApplication(704L, 104L, application.getApplicationForm(), ProjectApplicationStatus.SUBMITTED),
+                otherApplication(705L, 105L, application.getApplicationForm(), ProjectApplicationStatus.SUBMITTED)
+            );
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(applicants);
+            given(loadProjectPartQuotaPort.listByProjectId(any()))
+                .willReturn(List.of(partQuotaFor(ChallengerPart.WEB, 6L)));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
+                .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.WEB));
+            given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), any()))
+                .willReturn(Map.of(
+                    APPLICANT_MEMBER_ID, challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.WEB),
+                    101L, challengerWith(101L, ChallengerPart.WEB),
+                    102L, challengerWith(102L, ChallengerPart.WEB),
+                    103L, challengerWith(103L, ChallengerPart.WEB),
+                    104L, challengerWith(104L, ChallengerPart.WEB),
+                    105L, challengerWith(105L, ChallengerPart.WEB)
+                ));
+
+            assertThatThrownBy(() -> sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.REJECTED, null, DECIDER_MEMBER_ID
+            ))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_MINIMUM_SELECTION_REQUIRED);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        void APPROVED_변경은_최소선발_미달_상태에서도_quota_검증만_통과하면_허용한다() {
+            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.SUBMITTED);
+            ProjectApplication otherSubmitted = otherApplication(
+                701L, 101L, application.getApplicationForm(), ProjectApplicationStatus.SUBMITTED
+            );
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(loadProjectApplicationPort.listByMatchingRoundId(any()))
+                .willReturn(List.of());
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(List.of(application, otherSubmitted));
+            given(loadProjectPartQuotaPort.listByProjectId(any()))
+                .willReturn(List.of(partQuotaFor(ChallengerPart.DESIGN, 1L)));
+            given(getChallengerUseCase.getByMemberIdAndGisuId(eq(APPLICANT_MEMBER_ID), any()))
+                .willReturn(challengerWith(APPLICANT_MEMBER_ID, ChallengerPart.DESIGN));
+
+            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.APPROVED, null, DECIDER_MEMBER_ID);
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
             then(saveProjectApplicationPort).should(times(1)).save(application);
         }
 
@@ -259,22 +378,12 @@ class ProjectApplicationCommandServiceTest {
             given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
             given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
                 .willReturn(Map.of(ChallengerPart.WEB, 99L));   // 초과 상황이지만 REJECTED 는 무관
+            given(loadProjectApplicationPort.listDecidableByMatchingRoundIdAndProjectId(any(), any()))
+                .willReturn(List.of(application));
 
             sut.decide(APPLICATION_ID, ApplicationDecisionStatus.REJECTED, null, DECIDER_MEMBER_ID);
 
             assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
-        }
-
-        @Test
-        void PENDING_토글은_quota_검증을_적용하지_않는다() {
-            ProjectApplication application = applicationWithStatus(ProjectApplicationStatus.APPROVED);
-            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
-            given(loadProjectMemberPort.countByProjectIdGroupByPart(any()))
-                .willReturn(Map.of(ChallengerPart.WEB, 99L));
-
-            sut.decide(APPLICATION_ID, ApplicationDecisionStatus.PENDING, null, DECIDER_MEMBER_ID);
-
-            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
         }
 
         @Test
@@ -369,8 +478,12 @@ class ProjectApplicationCommandServiceTest {
     }
 
     private ProjectApplication applicationWithStatus(ProjectApplicationStatus status) {
+        return applicationWithStatus(status, openRound());
+    }
+
+    private ProjectApplication applicationWithStatus(ProjectApplicationStatus status, ProjectMatchingRound round) {
         ProjectApplication application = ProjectApplication.create(
-            applicationForm(), 999L, APPLICANT_MEMBER_ID, openRound()
+            applicationForm(), 999L, APPLICANT_MEMBER_ID, round
         );
         ReflectionTestUtils.setField(application, "id", APPLICATION_ID);
         ReflectionTestUtils.setField(application, "status", status);
@@ -381,6 +494,14 @@ class ProjectApplicationCommandServiceTest {
         return ProjectMatchingRound.create(
             "기획-디자인 1차 매칭", null,
             MatchingType.PLAN_DESIGN, MatchingPhase.FIRST, 1L,
+            ROUND_STARTS_AT, ROUND_ENDS_AT, ROUND_DECISION_DEADLINE
+        );
+    }
+
+    private ProjectMatchingRound openRound(MatchingType matchingType) {
+        return ProjectMatchingRound.create(
+            "프로젝트 매칭", null,
+            matchingType, MatchingPhase.FIRST, 1L,
             ROUND_STARTS_AT, ROUND_ENDS_AT, ROUND_DECISION_DEADLINE
         );
     }
@@ -399,14 +520,27 @@ class ProjectApplicationCommandServiceTest {
     }
 
     private ProjectPartQuota partQuotaForWeb(Long quota) {
+        return partQuotaFor(ChallengerPart.WEB, quota);
+    }
+
+    private ProjectPartQuota partQuotaFor(ChallengerPart part, Long quota) {
         Project project = Project.createDraft(1L, 2L, 999L, 7L, 999L);
-        return ProjectPartQuota.create(project, ChallengerPart.WEB, quota, 999L);
+        return ProjectPartQuota.create(project, part, quota, 999L);
     }
 
     private ProjectApplication otherApprovedApplication(Long id, Long applicantMemberId, ProjectApplicationForm form) {
+        return otherApplication(id, applicantMemberId, form, ProjectApplicationStatus.APPROVED);
+    }
+
+    private ProjectApplication otherApplication(
+        Long id,
+        Long applicantMemberId,
+        ProjectApplicationForm form,
+        ProjectApplicationStatus status
+    ) {
         ProjectApplication app = ProjectApplication.create(form, 999L, applicantMemberId, openRound());
         ReflectionTestUtils.setField(app, "id", id);
-        ReflectionTestUtils.setField(app, "status", ProjectApplicationStatus.APPROVED);
+        ReflectionTestUtils.setField(app, "status", status);
         return app;
     }
 

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandServiceTest.java
@@ -3,7 +3,10 @@ package com.umc.product.project.application.service.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -11,14 +14,20 @@ import static org.mockito.Mockito.never;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.SearchChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerCursorResult;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerItemInfo;
+import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerQuery;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPartQuotaPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectApplicationPort;
 import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.application.service.policy.DesignerMatchingPolicy;
@@ -33,10 +42,12 @@ import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -69,6 +80,8 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
     @Mock
     SaveProjectApplicationPort saveProjectApplicationPort;
     @Mock
+    LoadProjectPort loadProjectPort;
+    @Mock
     LoadProjectPartQuotaPort loadProjectPartQuotaPort;
     @Mock
     LoadProjectMemberPort loadProjectMemberPort;
@@ -78,6 +91,8 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
     GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock
     GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    SearchChallengerUseCase searchChallengerUseCase;
 
     ProjectMatchingRoundFinalizationCommandService sut;
 
@@ -87,13 +102,15 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             loadProjectMatchingRoundPort,
             loadProjectApplicationPort,
             saveProjectApplicationPort,
+            loadProjectPort,
             loadProjectPartQuotaPort,
             loadProjectMemberPort,
             saveProjectMemberPort,
             List.<MatchingDecisionPolicy>of(new DesignerMatchingPolicy(), new DeveloperMatchingPolicy()),
             new Random(42L),
             getChallengerRoleUseCase,
-            getChallengerUseCase
+            getChallengerUseCase,
+            searchChallengerUseCase
         );
         given(getChallengerRoleUseCase.findAllByMemberId(EXECUTOR_MEMBER_ID))
             .willReturn(List.of(centralCoreRole()));
@@ -196,6 +213,7 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
             ArgumentCaptor<java.util.Collection<ProjectMember>> captor = ArgumentCaptor.forClass(java.util.Collection.class);
             then(saveProjectMemberPort).should().saveAll(captor.capture());
             assertThat(captor.getValue()).extracting(ProjectMember::getMemberId).containsExactly(11L);
+            assertThat(captor.getValue()).extracting(ProjectMember::getApplication).containsExactly(approved);
         }
 
         @Test
@@ -305,13 +323,15 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
                     loadProjectMatchingRoundPort,
                     loadProjectApplicationPort,
                     saveProjectApplicationPort,
+                    loadProjectPort,
                     loadProjectPartQuotaPort,
                     loadProjectMemberPort,
                     saveProjectMemberPort,
                     List.<MatchingDecisionPolicy>of(),
                     new Random(42L),
                     getChallengerRoleUseCase,
-                    getChallengerUseCase
+                    getChallengerUseCase,
+                    searchChallengerUseCase
                 );
             ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DESIGN);
             given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
@@ -490,18 +510,105 @@ class ProjectMatchingRoundFinalizationCommandServiceTest {
                 .filter(a -> a.getStatus() == ProjectApplicationStatus.APPROVED).count();
             assertThat(approvedCount).isEqualTo(3);
         }
+
+        @Test
+        void PLAN_DEVELOPER_3차_종료_후_남은_TO를_ACTIVE_개발_챌린저로_랜덤_배정한다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER, MatchingPhase.THIRD);
+            Project project = projectWithId(PROJECT_ID);
+            ProjectMember existingMember = ProjectMember.create(project, 20L, ChallengerPart.WEB, EXECUTOR_MEMBER_ID);
+
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+            given(loadProjectPort.listByChapterIdAndStatus(1L, ProjectStatus.IN_PROGRESS))
+                .willReturn(List.of(project));
+            given(loadProjectPartQuotaPort.listByProjectIdsGroupedByProjectId(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(
+                    partQuota(project, ChallengerPart.WEB, 2L),
+                    partQuota(project, ChallengerPart.SPRINGBOOT, 1L)
+                )));
+            given(loadProjectMemberPort.countByProjectIdsGroupByProjectIdAndPart(any()))
+                .willReturn(Map.of(PROJECT_ID, Map.of(
+                    ChallengerPart.WEB, 1L,
+                    ChallengerPart.SPRINGBOOT, 1L
+                )));
+            given(loadProjectMemberPort.listByProjectIds(any()))
+                .willReturn(Map.of(PROJECT_ID, List.of(existingMember)));
+            given(searchChallengerUseCase.cursorSearch(any(SearchChallengerQuery.class), isNull(), eq(500)))
+                .willReturn(new SearchChallengerCursorResult(
+                    List.of(
+                        searchCandidate(20L, ChallengerPart.WEB),
+                        searchCandidate(31L, ChallengerPart.WEB),
+                        searchCandidate(32L, ChallengerPart.DESIGN),
+                        searchCandidate(33L, ChallengerPart.PLAN),
+                        searchCandidate(34L, ChallengerPart.SPRINGBOOT)
+                    ),
+                    null,
+                    false,
+                    Map.of()
+                ));
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Collection<ProjectMember>> membersCaptor = ArgumentCaptor.forClass(Collection.class);
+            then(saveProjectMemberPort).should().saveAll(membersCaptor.capture());
+            assertThat(membersCaptor.getValue())
+                .extracting(ProjectMember::getMemberId)
+                .containsExactly(31L);
+            assertThat(membersCaptor.getValue())
+                .extracting(ProjectMember::getPart)
+                .containsExactly(ChallengerPart.WEB);
+
+            ArgumentCaptor<SearchChallengerQuery> queryCaptor = ArgumentCaptor.forClass(SearchChallengerQuery.class);
+            then(searchChallengerUseCase).should().cursorSearch(queryCaptor.capture(), isNull(), eq(500));
+            assertThat(queryCaptor.getValue().statuses()).containsExactly(ChallengerStatus.ACTIVE);
+            assertThat(queryCaptor.getValue().chapterId()).isEqualTo(1L);
+        }
+
+        @Test
+        void PLAN_DEVELOPER_2차_종료_후에는_잔여_TO_랜덤_배정을_하지_않는다() {
+            ProjectMatchingRound round = expiredRound(MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND);
+            given(loadProjectMatchingRoundPort.getById(ROUND_ID)).willReturn(round);
+            given(loadProjectApplicationPort.listByMatchingRoundId(ROUND_ID)).willReturn(List.of());
+
+            sut.autoDecide(ROUND_ID, EXECUTOR_MEMBER_ID);
+
+            then(loadProjectPort).should(never()).listByChapterIdAndStatus(any(), any());
+            then(searchChallengerUseCase).should(never()).cursorSearch(any(), any(), anyInt());
+            then(saveProjectMemberPort).should(never()).saveAll(any());
+        }
     }
 
     private ProjectMatchingRound expiredRound(MatchingType type) {
+        return expiredRound(type, MatchingPhase.FIRST);
+    }
+
+    private ProjectMatchingRound expiredRound(MatchingType type, MatchingPhase phase) {
         ProjectMatchingRound round = ProjectMatchingRound.create(
             "테스트 매칭", null,
-            type, MatchingPhase.FIRST, 1L,
+            type, phase, 1L,
             Instant.now().minusSeconds(7_200),
             Instant.now().minusSeconds(3_600),
             ROUND_DECISION_DEADLINE
         );
         ReflectionTestUtils.setField(round, "id", ROUND_ID);
         return round;
+    }
+
+    private SearchChallengerItemInfo searchCandidate(Long memberId, ChallengerPart part) {
+        return new SearchChallengerItemInfo(
+            memberId * 10,
+            memberId,
+            GISU_ID,
+            6L,
+            part,
+            "이름" + memberId,
+            "닉네임" + memberId,
+            "학교",
+            0.0,
+            null,
+            List.of()
+        );
     }
 
     private ProjectMatchingRound futureDeadlineRound(MatchingType type) {

--- a/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
@@ -201,60 +201,6 @@ class ProjectApplicationTest {
     }
 
     @Nested
-    class revertToPending {
-
-        @Test
-        void APPROVED를_SUBMITTED로_되돌리고_사유는_초기화한다() {
-            setStatus(application, ProjectApplicationStatus.APPROVED);
-            ReflectionTestUtils.setField(application, "statusChangeReason", "이전 사유");
-
-            application.revertToPending(DECIDER_MEMBER_ID);
-
-            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
-            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
-            assertThat(application.getStatusChangeReason()).isNull();
-        }
-
-        @Test
-        void REJECTED를_SUBMITTED로_되돌린다() {
-            setStatus(application, ProjectApplicationStatus.REJECTED);
-
-            application.revertToPending(DECIDER_MEMBER_ID);
-
-            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
-        }
-
-        @Test
-        void SUBMITTED_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
-            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
-        }
-
-        @Test
-        void DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
-            setStatus(application, ProjectApplicationStatus.DRAFT);
-
-            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
-        }
-
-        @Test
-        void 차수_종료_후에는_PROJECT_MATCHING_ROUND_LOCKED() {
-            setStatus(application, ProjectApplicationStatus.APPROVED);
-            setRoundDeadline(round, NOW.minusSeconds(60));
-
-            assertThatThrownBy(() -> application.revertToPending(DECIDER_MEMBER_ID))
-                .isInstanceOf(ProjectDomainException.class)
-                .extracting("baseCode")
-                .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
-        }
-    }
-
-    @Nested
     class cancel {
 
         @Test


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- `project` 도메인의 지원서 결정 API, application service, outbound persistence query, 도메인 상태 전이, 관련 테스트를 수정했어요.

### 작업 단위별 상세

1. **무엇을**: APPLY-103 지원서 상태 변경 요청에서 `PENDING` 입력을 제거하고 `APPROVED`와 `REJECTED`만 허용하도록 수정했어요.
   - **어떻게**: `ApplicationDecisionStatus`에서 `PENDING`을 제거하고 `ProjectApplication.revertToPending` 경로와 API 설명을 정리했어요.
   - **왜**: 지원서 상태 변경은 다시 대기로 되돌릴 수 없다는 정책을 API 계약과 도메인 상태 머신 모두에서 보장하기 위해서예요.

2. **무엇을**: `REJECTED` 처리 시 매칭 규칙의 최소선발 수를 깨면 상태 변경을 거절하도록 추가했어요.
   - **어떻게**: `MatchingDecisionPolicy.minimumRequired`를 재사용하고 같은 매칭 차수/프로젝트/파트의 결정 가능 지원서를 fetch join으로 조회해 변경 후 승인 수를 계산했어요.
   - **왜**: PM 수동 처리에서도 자동 선발 정책과 같은 최소선발 규정을 유지해야 해서예요.

3. **무엇을**: 최소선발 검증과 `PENDING` 제거에 대한 단위 및 웹 계층 테스트를 보강했어요.
   - **어떻게**: 디자이너/개발자 최소선발 미달 거절 케이스, 최소선발 충족 상태의 `REJECTED` 허용 케이스, `PENDING` 요청 400 케이스를 추가했어요.
   - **왜**: 상태 변경 정책이 회귀하지 않도록 서비스와 컨트롤러 양쪽에서 검증하기 위해서예요.

## 💬 리뷰 중점사항

- 최소선발 검증에서 기존 활성 멤버 수를 차감한 `remainingQuota`를 정책 입력으로 사용하는 기준이 자동 선발 정책과 의도대로 맞는지 확인 부탁드려요.
- 같은 차수/프로젝트의 결정 가능 지원서를 fetch join으로 조회하는 방식이 APPLY-103 호출 규모에 적절한지 확인 부탁드려요.
- DB 마이그레이션과 환경 설정 변경은 없어요.