### PR TITLE
[Fix] 회원 탈퇴 요청 시 OAuth 측 access token 검증 추가

### DIFF
--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -1,6 +1,13 @@
 package com.umc.product.authentication.application.service;
 
-import com.umc.product.authentication.domain.OAuthAttributes;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authentication.application.port.in.command.OAuthAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.AccessTokenLoginCommand;
 import com.umc.product.authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand;
@@ -12,16 +19,13 @@ import com.umc.product.authentication.application.port.out.RevokeOAuthTokenPort;
 import com.umc.product.authentication.application.port.out.SaveMemberOAuthPort;
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
 import com.umc.product.authentication.domain.MemberOAuth;
+import com.umc.product.authentication.domain.OAuthAttributes;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.OAuthProvider;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * OAuth 인증 관련 비즈니스 로직을 처리하는 Service
@@ -214,6 +218,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             }
             case KAKAO -> {
                 if (command.kakaoAccessToken() != null) {
+                    validateAccessTokenOwner(memberOAuth, command.kakaoAccessToken());
                     revokeOAuthTokenPort.revokeKakaoToken(command.kakaoAccessToken());
                 } else {
                     log.warn("[Kakao 계정 연동 해제] access token이 전달되지 않아 revoke를 skip합니다: memberId={} memberOAuthId={}",
@@ -222,12 +227,25 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             }
             case GOOGLE -> {
                 if (command.googleAccessToken() != null) {
+                    validateAccessTokenOwner(memberOAuth, command.googleAccessToken());
                     revokeOAuthTokenPort.revokeGoogleToken(command.googleAccessToken());
                 } else {
                     log.warn("[Google 계정 연동 해제] access token이 전달되지 않아 revoke를 skip합니다: memberId={} memberOAuthId={}",
                         memberOAuth.getMemberId(), memberOAuth.getId());
                 }
             }
+        }
+    }
+
+    private void validateAccessTokenOwner(MemberOAuth memberOAuth, String accessToken) {
+        OAuthAttributes tokenAttributes = verifyIdTokenPort.verify(memberOAuth.getProvider(), accessToken);
+
+        if (tokenAttributes.provider() != memberOAuth.getProvider()
+            || !Objects.equals(tokenAttributes.providerId(), memberOAuth.getProviderId())) {
+            log.warn("[{} 계정 연동 해제] access token 소유자가 저장된 OAuth 계정과 일치하지 않습니다: "
+                    + "memberId={} memberOAuthId={}",
+                memberOAuth.getProvider(), memberOAuth.getMemberId(), memberOAuth.getId());
+            throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
         }
     }
 

--- a/src/test/java/com/umc/product/authentication/application/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/OAuthAuthenticationServiceTest.java
@@ -1,0 +1,108 @@
+package com.umc.product.authentication.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.umc.product.authentication.application.port.in.command.dto.UnlinkOAuthCommand;
+import com.umc.product.authentication.application.port.out.LoadMemberOAuthPort;
+import com.umc.product.authentication.application.port.out.RevokeOAuthTokenPort;
+import com.umc.product.authentication.application.port.out.SaveMemberOAuthPort;
+import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
+import com.umc.product.authentication.domain.MemberOAuth;
+import com.umc.product.authentication.domain.OAuthAttributes;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.common.domain.enums.OAuthProvider;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthAuthenticationServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long MEMBER_OAUTH_ID = 10L;
+    private static final String STORED_GOOGLE_PROVIDER_ID = "google-user-1";
+    private static final String OTHER_GOOGLE_PROVIDER_ID = "google-user-2";
+    private static final String GOOGLE_ACCESS_TOKEN = "google-access-token";
+
+    @Mock
+    VerifyOAuthTokenPort verifyOAuthTokenPort;
+
+    @Mock
+    LoadMemberOAuthPort loadMemberOAuthPort;
+
+    @Mock
+    SaveMemberOAuthPort saveMemberOAuthPort;
+
+    @Mock
+    RevokeOAuthTokenPort revokeOAuthTokenPort;
+
+    @InjectMocks
+    OAuthAuthenticationService service;
+
+    @Nested
+    @DisplayName("unlinkOAuth")
+    class UnlinkOAuth {
+
+        @Test
+        @DisplayName("Google access token의 providerId가 연동 계정과 다르면 연동 해제를 거부한다")
+        void google_access_token_providerId_불일치_거부() {
+            // given
+            MemberOAuth memberOAuth = memberOAuth(
+                MEMBER_OAUTH_ID,
+                MEMBER_ID,
+                OAuthProvider.GOOGLE,
+                STORED_GOOGLE_PROVIDER_ID
+            );
+            given(loadMemberOAuthPort.findByMemberOAuthId(MEMBER_OAUTH_ID))
+                .willReturn(Optional.of(memberOAuth));
+            given(verifyOAuthTokenPort.verify(OAuthProvider.GOOGLE, GOOGLE_ACCESS_TOKEN))
+                .willReturn(googleAttributes(OTHER_GOOGLE_PROVIDER_ID));
+
+            UnlinkOAuthCommand command = UnlinkOAuthCommand.builder()
+                .memberId(MEMBER_ID)
+                .memberOAuthId(MEMBER_OAUTH_ID)
+                .isWithdrawal(true)
+                .googleAccessToken(GOOGLE_ACCESS_TOKEN)
+                .build();
+
+            // when & then
+            assertThatThrownBy(() -> service.unlinkOAuth(command))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
+
+            then(revokeOAuthTokenPort).should(never()).revokeGoogleToken(anyString());
+            then(saveMemberOAuthPort).should(never()).delete(any());
+        }
+    }
+
+    private MemberOAuth memberOAuth(Long id, Long memberId, OAuthProvider provider, String providerId) {
+        MemberOAuth memberOAuth = MemberOAuth.builder()
+            .memberId(memberId)
+            .provider(provider)
+            .providerId(providerId)
+            .build();
+        ReflectionTestUtils.setField(memberOAuth, "id", id);
+        return memberOAuth;
+    }
+
+    private OAuthAttributes googleAttributes(String providerId) {
+        return OAuthAttributes.of("google", Map.of(
+            "sub", providerId,
+            "email", "google@example.com"
+        ));
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- authentication 도메인의 OAuth 연동 해제 application service와 해당 단위 테스트를 수정했어요.

### 작업 단위별 상세

1. **무엇을**: Google/Kakao OAuth 연동 해제 전에 access token 소유자 검증을 추가했어요.
   - **어떻게**: `VerifyOAuthTokenPort.verify(...)`로 token을 검증한 뒤, 반환된 `provider`와 `providerId`를 저장된 `MemberOAuth`와 비교했어요.
   - **왜**: 회원 탈퇴나 OAuth 연동 해제 시 다른 계정의 access token으로 provider revoke와 로컬 연동 삭제가 성공하지 않도록 막기 위해서예요.

2. **무엇을**: Google access token providerId 불일치 회귀 테스트를 추가했어요.
   - **어떻게**: 검증 포트가 다른 `providerId`를 반환하도록 구성하고, `OAUTH_INVALID_ACCESS_TOKEN` 예외와 revoke/delete 미호출을 검증했어요.
   - **왜**: 탈퇴 대상 계정과 토큰 소유자가 다를 때 요청이 성공하던 오류가 다시 생기지 않도록 하기 위해서예요.

## 💬 리뷰 중점사항

- 보안/인증 흐름 변경이라 `unlinkOAuth`에서 외부 revoke 전에 소유자 검증을 수행하는 위치가 적절한지 확인 부탁드려요.
- 전체 `./gradlew test`는 PostgreSQL Testcontainers 시작 대기에서 5분 이상 진행되지 않아 중단했어요. 대신 `./gradlew test --tests 'com.umc.product.authentication.application.service.OAuthAuthenticationServiceTest' checkstyleMain checkstyleTest`는 통과했어요.