### PR TITLE
[Feat] 이메일 변경 API 추가 및 인증 목적 enum 추가

### DIFF
--- a/docs/guides/API_목록.json
+++ b/docs/guides/API_목록.json
@@ -200,7 +200,7 @@
     "role": "6자리 인증코드로 이메일 인증",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 34,
+    "line": 36,
     "operationId": null
   },
   {
@@ -212,7 +212,7 @@
     "role": "이메일 인증 코드 발송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 60,
+    "line": 62,
     "operationId": null
   },
   {
@@ -224,7 +224,7 @@
     "role": "이메일 인증 코드 재전송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 85,
+    "line": 87,
     "operationId": null
   },
   {
@@ -1880,7 +1880,7 @@
     "role": "내 회원 정보 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 130,
+    "line": 134,
     "operationId": null
   },
   {
@@ -1892,7 +1892,7 @@
     "role": "내 회원 프로필 링크 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 144,
+    "line": 167,
     "operationId": null
   },
   {
@@ -1904,7 +1904,7 @@
     "role": "회원 탈퇴",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 158,
+    "line": 181,
     "operationId": null
   },
   {
@@ -1916,11 +1916,23 @@
     "role": "관리자 권한으로 회원 게정 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 171,
+    "line": 194,
     "operationId": null
   },
   {
     "sequence": 161,
+    "domain": "member",
+    "apiId": "MEMBER-005",
+    "endpoint": "/api/v1/member/email",
+    "httpMethod": "PATCH",
+    "role": "내 이메일 변경",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
+    "line": 148,
+    "operationId": null
+  },
+  {
+    "sequence": 162,
     "domain": "member",
     "apiId": "MEMBER-101",
     "endpoint": "/api/v1/member/profile/{memberId}",
@@ -1932,7 +1944,7 @@
     "operationId": null
   },
   {
-    "sequence": 162,
+    "sequence": 163,
     "domain": "member",
     "apiId": "MEMBER-102",
     "endpoint": "/api/v1/member/me",
@@ -1944,7 +1956,7 @@
     "operationId": null
   },
   {
-    "sequence": 163,
+    "sequence": 164,
     "domain": "member",
     "apiId": "MEMBER-103",
     "endpoint": "/api/v1/member/search",
@@ -1956,7 +1968,7 @@
     "operationId": null
   },
   {
-    "sequence": 164,
+    "sequence": 165,
     "domain": "member",
     "apiId": "MEMBER-201",
     "endpoint": "/api/v2/member/me",
@@ -1968,7 +1980,7 @@
     "operationId": null
   },
   {
-    "sequence": 165,
+    "sequence": 166,
     "domain": "member",
     "apiId": "MEMBER-202",
     "endpoint": "/api/v2/member/search",
@@ -1980,7 +1992,7 @@
     "operationId": null
   },
   {
-    "sequence": 166,
+    "sequence": 167,
     "domain": "member",
     "apiId": "REGISTER-001",
     "endpoint": "/api/v1/member/register",
@@ -1988,11 +2000,11 @@
     "role": "OAuth 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 61,
+    "line": 65,
     "operationId": null
   },
   {
-    "sequence": 167,
+    "sequence": 168,
     "domain": "member",
     "apiId": "REGISTER-003",
     "endpoint": "/api/v1/member/register/email",
@@ -2000,11 +2012,11 @@
     "role": "이메일/PW 이용 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 103,
+    "line": 107,
     "operationId": null
   },
   {
-    "sequence": 168,
+    "sequence": 169,
     "domain": "notice",
     "apiId": "NOTICE-001",
     "endpoint": "/api/v1/notices",
@@ -2016,7 +2028,7 @@
     "operationId": null
   },
   {
-    "sequence": 169,
+    "sequence": 170,
     "domain": "notice",
     "apiId": "NOTICE-002",
     "endpoint": "/api/v1/notices/search",
@@ -2028,7 +2040,7 @@
     "operationId": null
   },
   {
-    "sequence": 170,
+    "sequence": 171,
     "domain": "notice",
     "apiId": "NOTICE-003",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2040,7 +2052,7 @@
     "operationId": null
   },
   {
-    "sequence": 171,
+    "sequence": 172,
     "domain": "notice",
     "apiId": "NOTICE-004",
     "endpoint": "/api/v1/notices/{noticeId}/read-statics",
@@ -2052,7 +2064,7 @@
     "operationId": null
   },
   {
-    "sequence": 172,
+    "sequence": 173,
     "domain": "notice",
     "apiId": "NOTICE-005",
     "endpoint": "/api/v1/notices/{noticeId}/read-status",
@@ -2064,7 +2076,7 @@
     "operationId": null
   },
   {
-    "sequence": 173,
+    "sequence": 174,
     "domain": "notice",
     "apiId": "NOTICE-101",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -2076,7 +2088,7 @@
     "operationId": null
   },
   {
-    "sequence": 174,
+    "sequence": 175,
     "domain": "notice",
     "apiId": "NOTICE-102",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -2088,7 +2100,7 @@
     "operationId": null
   },
   {
-    "sequence": 175,
+    "sequence": 176,
     "domain": "notice",
     "apiId": "NOTICE-103",
     "endpoint": "/api/v1/notices/{noticeId}/votes",
@@ -2100,7 +2112,7 @@
     "operationId": null
   },
   {
-    "sequence": 176,
+    "sequence": 177,
     "domain": "notice",
     "apiId": "NOTICE-104",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -2112,7 +2124,7 @@
     "operationId": null
   },
   {
-    "sequence": 177,
+    "sequence": 178,
     "domain": "notice",
     "apiId": "NOTICE-105",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -2124,7 +2136,7 @@
     "operationId": null
   },
   {
-    "sequence": 178,
+    "sequence": 179,
     "domain": "notice",
     "apiId": "NOTICE-106",
     "endpoint": "/api/v1/notices/{noticeId}/vote",
@@ -2136,7 +2148,7 @@
     "operationId": null
   },
   {
-    "sequence": 179,
+    "sequence": 180,
     "domain": "notice",
     "apiId": "NOTICE-201",
     "endpoint": "/api/v1/notices",
@@ -2148,7 +2160,7 @@
     "operationId": null
   },
   {
-    "sequence": 180,
+    "sequence": 181,
     "domain": "notice",
     "apiId": "NOTICE-202",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2160,7 +2172,7 @@
     "operationId": null
   },
   {
-    "sequence": 181,
+    "sequence": 182,
     "domain": "notice",
     "apiId": "NOTICE-203",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2172,7 +2184,7 @@
     "operationId": null
   },
   {
-    "sequence": 182,
+    "sequence": 183,
     "domain": "notice",
     "apiId": "NOTICE-204",
     "endpoint": "/api/v1/notices/{noticeId}/reminders",
@@ -2184,7 +2196,7 @@
     "operationId": null
   },
   {
-    "sequence": 183,
+    "sequence": 184,
     "domain": "notice",
     "apiId": "NOTICE-205",
     "endpoint": "/api/v1/notices/{noticeId}/read",
@@ -2196,7 +2208,7 @@
     "operationId": null
   },
   {
-    "sequence": 184,
+    "sequence": 185,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-001",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -2208,7 +2220,7 @@
     "operationId": null
   },
   {
-    "sequence": 185,
+    "sequence": 186,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-002",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -2220,7 +2232,7 @@
     "operationId": null
   },
   {
-    "sequence": 186,
+    "sequence": 187,
     "domain": "notification",
     "apiId": "FCM-001",
     "endpoint": "/api/v1/notification/fcm/token",
@@ -2232,7 +2244,7 @@
     "operationId": null
   },
   {
-    "sequence": 187,
+    "sequence": 188,
     "domain": "notification",
     "apiId": "FCM-002",
     "endpoint": "/api/v1/notification/fcm/topics/legacy",
@@ -2244,7 +2256,7 @@
     "operationId": null
   },
   {
-    "sequence": 188,
+    "sequence": 189,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -2256,7 +2268,7 @@
     "operationId": null
   },
   {
-    "sequence": 189,
+    "sequence": 190,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/schools/gisu/{gisuId}",
@@ -2268,259 +2280,7 @@
     "operationId": null
   },
   {
-    "sequence": 190,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java",
-    "line": 24,
-    "operationId": null
-  },
-  {
     "sequence": 191,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 192,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 37,
-    "operationId": null
-  },
-  {
-    "sequence": 193,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 194,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
-    "line": 24,
-    "operationId": null
-  },
-  {
-    "sequence": 195,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 196,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 197,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 37,
-    "operationId": null
-  },
-  {
-    "sequence": 198,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 199,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 200,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 201,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
-    "line": 56,
-    "operationId": null
-  },
-  {
-    "sequence": 202,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 61,
-    "operationId": null
-  },
-  {
-    "sequence": 203,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships",
-    "httpMethod": "PUT",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 50,
-    "operationId": null
-  },
-  {
-    "sequence": 204,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/profile",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 39,
-    "operationId": null
-  },
-  {
-    "sequence": 205,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/organization-chart",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java",
-    "line": 23,
-    "operationId": null
-  },
-  {
-    "sequence": 206,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java",
-    "line": 23,
-    "operationId": null
-  },
-  {
-    "sequence": 207,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 208,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 39,
-    "operationId": null
-  },
-  {
-    "sequence": 209,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 210,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}/participants",
-    "httpMethod": "PUT",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 56,
-    "operationId": null
-  },
-  {
-    "sequence": 211,
     "domain": "organization",
     "apiId": "CHAPTER-001",
     "endpoint": "/api/v1/chapters",
@@ -2532,7 +2292,7 @@
     "operationId": null
   },
   {
-    "sequence": 212,
+    "sequence": 192,
     "domain": "organization",
     "apiId": "CHAPTER-002",
     "endpoint": "/api/v1/chapters/bulk",
@@ -2544,7 +2304,7 @@
     "operationId": null
   },
   {
-    "sequence": 213,
+    "sequence": 193,
     "domain": "organization",
     "apiId": "CHAPTER-003",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -2556,7 +2316,7 @@
     "operationId": null
   },
   {
-    "sequence": 214,
+    "sequence": 194,
     "domain": "organization",
     "apiId": "CHAPTER-101",
     "endpoint": "/api/v1/chapters",
@@ -2568,7 +2328,7 @@
     "operationId": null
   },
   {
-    "sequence": 215,
+    "sequence": 195,
     "domain": "organization",
     "apiId": "CHAPTER-102",
     "endpoint": "/api/v1/chapters/with-schools",
@@ -2580,7 +2340,7 @@
     "operationId": null
   },
   {
-    "sequence": 216,
+    "sequence": 196,
     "domain": "organization",
     "apiId": "CHAPTER-103",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -2592,7 +2352,7 @@
     "operationId": null
   },
   {
-    "sequence": 217,
+    "sequence": 197,
     "domain": "organization",
     "apiId": "GISU-001",
     "endpoint": "/api/v1/gisu",
@@ -2604,7 +2364,7 @@
     "operationId": null
   },
   {
-    "sequence": 218,
+    "sequence": 198,
     "domain": "organization",
     "apiId": "GISU-002",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -2616,7 +2376,7 @@
     "operationId": null
   },
   {
-    "sequence": 219,
+    "sequence": 199,
     "domain": "organization",
     "apiId": "GISU-003",
     "endpoint": "/api/v1/gisu/{gisuId}/active",
@@ -2628,7 +2388,7 @@
     "operationId": null
   },
   {
-    "sequence": 220,
+    "sequence": 200,
     "domain": "organization",
     "apiId": "GISU-101",
     "endpoint": "/api/v1/gisu",
@@ -2640,7 +2400,7 @@
     "operationId": null
   },
   {
-    "sequence": 221,
+    "sequence": 201,
     "domain": "organization",
     "apiId": "GISU-102",
     "endpoint": "/api/v1/gisu/all",
@@ -2652,7 +2412,7 @@
     "operationId": null
   },
   {
-    "sequence": 222,
+    "sequence": 202,
     "domain": "organization",
     "apiId": "GISU-103",
     "endpoint": "/api/v1/gisu/active",
@@ -2664,7 +2424,7 @@
     "operationId": null
   },
   {
-    "sequence": 223,
+    "sequence": 203,
     "domain": "organization",
     "apiId": "SCHOOL-001",
     "endpoint": "/api/v1/schools",
@@ -2676,7 +2436,7 @@
     "operationId": null
   },
   {
-    "sequence": 224,
+    "sequence": 204,
     "domain": "organization",
     "apiId": "SCHOOL-002",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2688,7 +2448,7 @@
     "operationId": null
   },
   {
-    "sequence": 225,
+    "sequence": 205,
     "domain": "organization",
     "apiId": "SCHOOL-003",
     "endpoint": "/api/v1/schools",
@@ -2700,7 +2460,7 @@
     "operationId": null
   },
   {
-    "sequence": 226,
+    "sequence": 206,
     "domain": "organization",
     "apiId": "SCHOOL-004",
     "endpoint": "/api/v1/schools/{schoolId}/assign",
@@ -2712,7 +2472,7 @@
     "operationId": null
   },
   {
-    "sequence": 227,
+    "sequence": 207,
     "domain": "organization",
     "apiId": "SCHOOL-005",
     "endpoint": "/api/v1/schools/{schoolId}/unassign",
@@ -2724,7 +2484,7 @@
     "operationId": null
   },
   {
-    "sequence": 228,
+    "sequence": 208,
     "domain": "organization",
     "apiId": "SCHOOL-101",
     "endpoint": "/api/v1/schools/all",
@@ -2736,7 +2496,7 @@
     "operationId": null
   },
   {
-    "sequence": 229,
+    "sequence": 209,
     "domain": "organization",
     "apiId": "SCHOOL-102",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2748,7 +2508,7 @@
     "operationId": null
   },
   {
-    "sequence": 230,
+    "sequence": 210,
     "domain": "organization",
     "apiId": "SCHOOL-103",
     "endpoint": "/api/v1/schools/unassigned",
@@ -2760,7 +2520,7 @@
     "operationId": null
   },
   {
-    "sequence": 231,
+    "sequence": 211,
     "domain": "organization",
     "apiId": "SCHOOL-104",
     "endpoint": "/api/v1/schools/link/{schoolId}",
@@ -2772,7 +2532,7 @@
     "operationId": null
   },
   {
-    "sequence": 232,
+    "sequence": 212,
     "domain": "organization",
     "apiId": "STUDY-GROUP-001",
     "endpoint": "/api/v1/study-groups",
@@ -2784,7 +2544,7 @@
     "operationId": null
   },
   {
-    "sequence": 233,
+    "sequence": 213,
     "domain": "organization",
     "apiId": "STUDY-GROUP-002",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2796,7 +2556,7 @@
     "operationId": null
   },
   {
-    "sequence": 234,
+    "sequence": 214,
     "domain": "organization",
     "apiId": "STUDY-GROUP-003",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2808,7 +2568,7 @@
     "operationId": null
   },
   {
-    "sequence": 235,
+    "sequence": 215,
     "domain": "organization",
     "apiId": "STUDY-GROUP-004",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2820,7 +2580,7 @@
     "operationId": null
   },
   {
-    "sequence": 236,
+    "sequence": 216,
     "domain": "organization",
     "apiId": "STUDY-GROUP-005",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2832,7 +2592,7 @@
     "operationId": null
   },
   {
-    "sequence": 237,
+    "sequence": 217,
     "domain": "organization",
     "apiId": "STUDY-GROUP-006",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2844,7 +2604,7 @@
     "operationId": null
   },
   {
-    "sequence": 238,
+    "sequence": 218,
     "domain": "organization",
     "apiId": "STUDY-GROUP-007",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2856,7 +2616,7 @@
     "operationId": null
   },
   {
-    "sequence": 239,
+    "sequence": 219,
     "domain": "organization",
     "apiId": "STUDY-GROUP-101",
     "endpoint": "/api/v1/study-groups/managed",
@@ -2868,7 +2628,7 @@
     "operationId": null
   },
   {
-    "sequence": 240,
+    "sequence": 220,
     "domain": "organization",
     "apiId": "STUDY-GROUP-102",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2880,7 +2640,7 @@
     "operationId": null
   },
   {
-    "sequence": 241,
+    "sequence": 221,
     "domain": "organization",
     "apiId": "STUDY-GROUP-SCHEDULE-001",
     "endpoint": "/api/v1/study-groups/schedules",
@@ -2892,7 +2652,259 @@
     "operationId": null
   },
   {
+    "sequence": 222,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-001",
+    "endpoint": "/api/v1/umc-product/functional-units",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 기능 조직 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 32,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-001"
+  },
+  {
+    "sequence": 223,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-002",
+    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 기능 조직 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 45,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-002"
+  },
+  {
+    "sequence": 224,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-003",
+    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 기능 조직 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-003"
+  },
+  {
+    "sequence": 225,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-101",
+    "endpoint": "/api/v1/umc-product/functional-units",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기능 조직 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java",
+    "line": 27,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-101"
+  },
+  {
+    "sequence": 226,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-001",
+    "endpoint": "/api/v1/umc-product/generations",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 기수 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 32,
+    "operationId": "UMC-PRODUCT-GENERATION-001"
+  },
+  {
+    "sequence": 227,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-002",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 기수 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 45,
+    "operationId": "UMC-PRODUCT-GENERATION-002"
+  },
+  {
+    "sequence": 228,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-003",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 기수 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-GENERATION-003"
+  },
+  {
+    "sequence": 229,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-101",
+    "endpoint": "/api/v1/umc-product/generations",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기수 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
+    "line": 27,
+    "operationId": "UMC-PRODUCT-GENERATION-101"
+  },
+  {
+    "sequence": 230,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-102",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기수 상세 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
+    "line": 37,
+    "operationId": "UMC-PRODUCT-GENERATION-102"
+  },
+  {
+    "sequence": 231,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-001",
+    "endpoint": "/api/v1/umc-product/members",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 멤버 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-MEMBER-001"
+  },
+  {
+    "sequence": 232,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-002",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/profile",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 멤버 프로필 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 47,
+    "operationId": "UMC-PRODUCT-MEMBER-002"
+  },
+  {
+    "sequence": 233,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-003",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships",
+    "httpMethod": "PUT",
+    "role": "UMC PRODUCT 멤버 기능 조직 소속 교체",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 63,
+    "operationId": "UMC-PRODUCT-MEMBER-003"
+  },
+  {
+    "sequence": 234,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-004",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 멤버 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 79,
+    "operationId": "UMC-PRODUCT-MEMBER-004"
+  },
+  {
+    "sequence": 235,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-101",
+    "endpoint": "/api/v1/umc-product/members",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 멤버 검색",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-MEMBER-101"
+  },
+  {
+    "sequence": 236,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-102",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 멤버 상세 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
+    "line": 64,
+    "operationId": "UMC-PRODUCT-MEMBER-102"
+  },
+  {
+    "sequence": 237,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-ORGANIZATION-CHART-101",
+    "endpoint": "/api/v1/umc-product/organization-chart",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 조직도 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java",
+    "line": 26,
+    "operationId": "UMC-PRODUCT-ORGANIZATION-CHART-101"
+  },
+  {
+    "sequence": 238,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-001",
+    "endpoint": "/api/v1/umc-product/squads",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 스쿼드 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-SQUAD-001"
+  },
+  {
+    "sequence": 239,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-002",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 스쿼드 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 47,
+    "operationId": "UMC-PRODUCT-SQUAD-002"
+  },
+  {
+    "sequence": 240,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-003",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 스쿼드 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-SQUAD-003"
+  },
+  {
+    "sequence": 241,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-004",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}/participants",
+    "httpMethod": "PUT",
+    "role": "UMC PRODUCT 스쿼드 참여자 교체",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 74,
+    "operationId": "UMC-PRODUCT-SQUAD-004"
+  },
+  {
     "sequence": 242,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-101",
+    "endpoint": "/api/v1/umc-product/squads",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 스쿼드 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java",
+    "line": 26,
+    "operationId": "UMC-PRODUCT-SQUAD-101"
+  },
+  {
+    "sequence": 243,
     "domain": "project",
     "apiId": "APPLY-001",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2904,7 +2916,7 @@
     "operationId": null
   },
   {
-    "sequence": 243,
+    "sequence": 244,
     "domain": "project",
     "apiId": "APPLY-002",
     "endpoint": "/api/v1/projects/{projectId}/applications/me",
@@ -2916,7 +2928,7 @@
     "operationId": null
   },
   {
-    "sequence": 244,
+    "sequence": 245,
     "domain": "project",
     "apiId": "APPLY-003",
     "endpoint": "/api/v1/projects/{projectId}/applications/me/submit",
@@ -2928,7 +2940,7 @@
     "operationId": null
   },
   {
-    "sequence": 245,
+    "sequence": 246,
     "domain": "project",
     "apiId": "APPLY-004",
     "endpoint": "/api/v1/projects/me/applications",
@@ -2940,7 +2952,7 @@
     "operationId": null
   },
   {
-    "sequence": 246,
+    "sequence": 247,
     "domain": "project",
     "apiId": "APPLY-005",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2952,7 +2964,7 @@
     "operationId": null
   },
   {
-    "sequence": 247,
+    "sequence": 248,
     "domain": "project",
     "apiId": "APPLY-101",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2964,7 +2976,7 @@
     "operationId": null
   },
   {
-    "sequence": 248,
+    "sequence": 249,
     "domain": "project",
     "apiId": "APPLY-102",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2976,7 +2988,7 @@
     "operationId": null
   },
   {
-    "sequence": 249,
+    "sequence": 250,
     "domain": "project",
     "apiId": "APPLY-103",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}/decision",
@@ -2988,7 +3000,7 @@
     "operationId": null
   },
   {
-    "sequence": 250,
+    "sequence": 251,
     "domain": "project",
     "apiId": "PROJECT-001",
     "endpoint": "/api/v1/projects",
@@ -3000,7 +3012,7 @@
     "operationId": null
   },
   {
-    "sequence": 251,
+    "sequence": 252,
     "domain": "project",
     "apiId": "PROJECT-002",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3012,7 +3024,7 @@
     "operationId": null
   },
   {
-    "sequence": 252,
+    "sequence": 253,
     "domain": "project",
     "apiId": "PROJECT-003",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -3024,7 +3036,7 @@
     "operationId": null
   },
   {
-    "sequence": 253,
+    "sequence": 254,
     "domain": "project",
     "apiId": "PROJECT-004",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -3036,7 +3048,7 @@
     "operationId": null
   },
   {
-    "sequence": 254,
+    "sequence": 255,
     "domain": "project",
     "apiId": "PROJECT-005",
     "endpoint": "/api/v1/projects/{projectId}/members/{memberId}",
@@ -3048,7 +3060,7 @@
     "operationId": null
   },
   {
-    "sequence": 255,
+    "sequence": 256,
     "domain": "project",
     "apiId": "PROJECT-006",
     "endpoint": "/api/v1/projects/me/managed",
@@ -3060,7 +3072,7 @@
     "operationId": null
   },
   {
-    "sequence": 256,
+    "sequence": 257,
     "domain": "project",
     "apiId": "PROJECT-007",
     "endpoint": "/api/v1/projects/members",
@@ -3072,7 +3084,7 @@
     "operationId": null
   },
   {
-    "sequence": 257,
+    "sequence": 258,
     "domain": "project",
     "apiId": "PROJECT-101",
     "endpoint": "/api/v1/projects",
@@ -3084,7 +3096,7 @@
     "operationId": null
   },
   {
-    "sequence": 258,
+    "sequence": 259,
     "domain": "project",
     "apiId": "PROJECT-102",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3096,7 +3108,7 @@
     "operationId": null
   },
   {
-    "sequence": 259,
+    "sequence": 260,
     "domain": "project",
     "apiId": "PROJECT-103",
     "endpoint": "/api/v1/projects/me/draft",
@@ -3108,7 +3120,7 @@
     "operationId": null
   },
   {
-    "sequence": 260,
+    "sequence": 261,
     "domain": "project",
     "apiId": "PROJECT-104",
     "endpoint": "/api/v1/projects/{projectId}/transfer-ownership",
@@ -3120,7 +3132,7 @@
     "operationId": null
   },
   {
-    "sequence": 261,
+    "sequence": 262,
     "domain": "project",
     "apiId": "PROJECT-105",
     "endpoint": "/api/v1/projects/{projectId}/part-quotas",
@@ -3132,7 +3144,7 @@
     "operationId": null
   },
   {
-    "sequence": 262,
+    "sequence": 263,
     "domain": "project",
     "apiId": "PROJECT-106",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -3144,7 +3156,7 @@
     "operationId": null
   },
   {
-    "sequence": 263,
+    "sequence": 264,
     "domain": "project",
     "apiId": "PROJECT-106-GET",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -3156,7 +3168,7 @@
     "operationId": null
   },
   {
-    "sequence": 264,
+    "sequence": 265,
     "domain": "project",
     "apiId": "PROJECT-107",
     "endpoint": "/api/v1/projects/{projectId}/submit",
@@ -3168,7 +3180,7 @@
     "operationId": null
   },
   {
-    "sequence": 265,
+    "sequence": 266,
     "domain": "project",
     "apiId": "PROJECT-108",
     "endpoint": "/api/v1/projects/{projectId}/publish",
@@ -3180,7 +3192,7 @@
     "operationId": null
   },
   {
-    "sequence": 266,
+    "sequence": 267,
     "domain": "project",
     "apiId": "PROJECT-109",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3192,7 +3204,7 @@
     "operationId": null
   },
   {
-    "sequence": 267,
+    "sequence": 268,
     "domain": "project",
     "apiId": "PROJECT-110",
     "endpoint": "/api/v1/projects/{projectId}/abort",
@@ -3204,7 +3216,7 @@
     "operationId": null
   },
   {
-    "sequence": 268,
+    "sequence": 269,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-001",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -3216,7 +3228,7 @@
     "operationId": null
   },
   {
-    "sequence": 269,
+    "sequence": 270,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-101",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -3228,7 +3240,7 @@
     "operationId": null
   },
   {
-    "sequence": 270,
+    "sequence": 271,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-102",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -3240,7 +3252,7 @@
     "operationId": null
   },
   {
-    "sequence": 271,
+    "sequence": 272,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-103",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -3252,7 +3264,7 @@
     "operationId": null
   },
   {
-    "sequence": 272,
+    "sequence": 273,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-201",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide",
@@ -3264,7 +3276,7 @@
     "operationId": null
   },
   {
-    "sequence": 273,
+    "sequence": 274,
     "domain": "project",
     "apiId": "PROJECT-STAT-001",
     "endpoint": "/api/v1/projects/{projectId}/statistics",
@@ -3276,7 +3288,7 @@
     "operationId": null
   },
   {
-    "sequence": 274,
+    "sequence": 275,
     "domain": "project",
     "apiId": "PROJECT-STAT-002",
     "endpoint": "/api/v1/projects/statistics",
@@ -3288,7 +3300,7 @@
     "operationId": null
   },
   {
-    "sequence": 275,
+    "sequence": 276,
     "domain": "schedule",
     "apiId": "SCHEDULE-C001",
     "endpoint": "/api/v2/schedules",
@@ -3300,7 +3312,7 @@
     "operationId": null
   },
   {
-    "sequence": 276,
+    "sequence": 277,
     "domain": "schedule",
     "apiId": "SCHEDULE-C002",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3312,7 +3324,7 @@
     "operationId": null
   },
   {
-    "sequence": 277,
+    "sequence": 278,
     "domain": "schedule",
     "apiId": "SCHEDULE-C003",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/request",
@@ -3324,7 +3336,7 @@
     "operationId": null
   },
   {
-    "sequence": 278,
+    "sequence": 279,
     "domain": "schedule",
     "apiId": "SCHEDULE-C004",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/excuse",
@@ -3336,7 +3348,7 @@
     "operationId": null
   },
   {
-    "sequence": 279,
+    "sequence": 280,
     "domain": "schedule",
     "apiId": "SCHEDULE-C005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/decide",
@@ -3348,7 +3360,7 @@
     "operationId": null
   },
   {
-    "sequence": 280,
+    "sequence": 281,
     "domain": "schedule",
     "apiId": "SCHEDULE-C006",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3360,7 +3372,7 @@
     "operationId": null
   },
   {
-    "sequence": 281,
+    "sequence": 282,
     "domain": "schedule",
     "apiId": "SCHEDULE-C007",
     "endpoint": "/api/v2/schedules/{scheduleId}/force",
@@ -3372,7 +3384,7 @@
     "operationId": null
   },
   {
-    "sequence": 282,
+    "sequence": 283,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q001",
     "endpoint": "/api/v2/schedules/capabilities",
@@ -3384,7 +3396,7 @@
     "operationId": null
   },
   {
-    "sequence": 283,
+    "sequence": 284,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q002",
     "endpoint": "/api/v2/schedules/me",
@@ -3396,7 +3408,7 @@
     "operationId": null
   },
   {
-    "sequence": 284,
+    "sequence": 285,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q003",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3408,7 +3420,7 @@
     "operationId": null
   },
   {
-    "sequence": 285,
+    "sequence": 286,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q004",
     "endpoint": "/api/v2/schedules/attendance",
@@ -3420,7 +3432,7 @@
     "operationId": null
   },
   {
-    "sequence": 286,
+    "sequence": 287,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendance",
@@ -3432,7 +3444,7 @@
     "operationId": null
   },
   {
-    "sequence": 287,
+    "sequence": 288,
     "domain": "storage",
     "apiId": "STORAGE-001",
     "endpoint": "/api/v1/storage/prepare-upload",
@@ -3444,7 +3456,7 @@
     "operationId": null
   },
   {
-    "sequence": 288,
+    "sequence": 289,
     "domain": "storage",
     "apiId": "STORAGE-002",
     "endpoint": "/api/v1/storage/{fileId}/confirm",
@@ -3456,7 +3468,7 @@
     "operationId": null
   },
   {
-    "sequence": 289,
+    "sequence": 290,
     "domain": "storage",
     "apiId": "STORAGE-003",
     "endpoint": "/api/v1/storage/{fileId}",
@@ -3468,7 +3480,7 @@
     "operationId": null
   },
   {
-    "sequence": 290,
+    "sequence": 291,
     "domain": "term",
     "apiId": "TERM-001",
     "endpoint": "/api/v1/terms",
@@ -3480,7 +3492,7 @@
     "operationId": null
   },
   {
-    "sequence": 291,
+    "sequence": 292,
     "domain": "term",
     "apiId": "TERM-101",
     "endpoint": "/api/v1/terms/type/{termType}",
@@ -3492,7 +3504,7 @@
     "operationId": null
   },
   {
-    "sequence": 292,
+    "sequence": 293,
     "domain": "term",
     "apiId": "TERM-102",
     "endpoint": "/api/v1/terms/{termsId}",
@@ -3504,7 +3516,7 @@
     "operationId": null
   },
   {
-    "sequence": 293,
+    "sequence": 294,
     "domain": "term",
     "apiId": "TERM-103",
     "endpoint": "/api/v1/terms/consent-status/me",
@@ -3516,7 +3528,7 @@
     "operationId": null
   },
   {
-    "sequence": 294,
+    "sequence": 295,
     "domain": "term",
     "apiId": "TERM-104",
     "endpoint": "/api/v1/terms",
@@ -3528,7 +3540,7 @@
     "operationId": null
   },
   {
-    "sequence": 295,
+    "sequence": 296,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/email/send-test",
@@ -3540,7 +3552,7 @@
     "operationId": null
   },
   {
-    "sequence": 296,
+    "sequence": 297,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/log-test",
@@ -3552,7 +3564,7 @@
     "operationId": null
   },
   {
-    "sequence": 297,
+    "sequence": 298,
     "domain": "test",
     "apiId": "SEED-001",
     "endpoint": "/test/seed/members",
@@ -3564,7 +3576,7 @@
     "operationId": "SEED-001"
   },
   {
-    "sequence": 298,
+    "sequence": 299,
     "domain": "test",
     "apiId": "SEED-001-M",
     "endpoint": "/test/seed/member",
@@ -3576,7 +3588,7 @@
     "operationId": "SEED-001-M"
   },
   {
-    "sequence": 299,
+    "sequence": 300,
     "domain": "test",
     "apiId": "SEED-002",
     "endpoint": "/test/seed/challengers",
@@ -3588,7 +3600,7 @@
     "operationId": "SEED-002"
   },
   {
-    "sequence": 300,
+    "sequence": 301,
     "domain": "test",
     "apiId": "SEED-002-C",
     "endpoint": "/test/seed/challenger",
@@ -3600,7 +3612,7 @@
     "operationId": "SEED-002-C"
   },
   {
-    "sequence": 301,
+    "sequence": 302,
     "domain": "test",
     "apiId": "SEED-002-R",
     "endpoint": "/test/seed/challenger-role",
@@ -3612,7 +3624,7 @@
     "operationId": "SEED-002-R"
   },
   {
-    "sequence": 302,
+    "sequence": 303,
     "domain": "test",
     "apiId": "SEED-003",
     "endpoint": "/test/seed/projects",
@@ -3624,7 +3636,7 @@
     "operationId": "SEED-003"
   },
   {
-    "sequence": 303,
+    "sequence": 304,
     "domain": "test",
     "apiId": "SEED-003-D",
     "endpoint": "/test/seed/projects",
@@ -3636,7 +3648,7 @@
     "operationId": "SEED-003-D"
   },
   {
-    "sequence": 304,
+    "sequence": 305,
     "domain": "test",
     "apiId": "SEED-003-S",
     "endpoint": "/test/seed/projects/scenarios",
@@ -3648,7 +3660,7 @@
     "operationId": "SEED-003-S"
   },
   {
-    "sequence": 305,
+    "sequence": 306,
     "domain": "test",
     "apiId": "SEED-004",
     "endpoint": "/test/seed/curriculum",
@@ -3660,7 +3672,7 @@
     "operationId": "SEED-004"
   },
   {
-    "sequence": 306,
+    "sequence": 307,
     "domain": "test",
     "apiId": "SEED-005",
     "endpoint": "/test/seed/notice",
@@ -3672,7 +3684,7 @@
     "operationId": "SEED-005"
   },
   {
-    "sequence": 307,
+    "sequence": 308,
     "domain": "test",
     "apiId": "SEED-006",
     "endpoint": "/test/seed/project-applications",
@@ -3684,7 +3696,7 @@
     "operationId": null
   },
   {
-    "sequence": 308,
+    "sequence": 309,
     "domain": "test",
     "apiId": "TEST-001",
     "endpoint": "/test/file/{fileId}",
@@ -3696,7 +3708,7 @@
     "operationId": "TEST-001"
   },
   {
-    "sequence": 309,
+    "sequence": 310,
     "domain": "test",
     "apiId": "TEST-002",
     "endpoint": "/test/fcm/test-send",
@@ -3708,7 +3720,7 @@
     "operationId": "TEST-002"
   },
   {
-    "sequence": 310,
+    "sequence": 311,
     "domain": "test",
     "apiId": "TEST-003",
     "endpoint": "/test/webhook/aop-test",
@@ -3720,7 +3732,7 @@
     "operationId": "TEST-003"
   },
   {
-    "sequence": 311,
+    "sequence": 312,
     "domain": "test",
     "apiId": "TEST-004",
     "endpoint": "/test/webhook/alarm",
@@ -3732,7 +3744,7 @@
     "operationId": "TEST-004"
   },
   {
-    "sequence": 312,
+    "sequence": 313,
     "domain": "test",
     "apiId": "TEST-005",
     "endpoint": "/test/webhook/alarm/buffer",
@@ -3744,7 +3756,7 @@
     "operationId": "TEST-005"
   },
   {
-    "sequence": 313,
+    "sequence": 314,
     "domain": "test",
     "apiId": "TEST-006",
     "endpoint": "/test/apple-client-secret",
@@ -3756,7 +3768,7 @@
     "operationId": "TEST-006"
   },
   {
-    "sequence": 314,
+    "sequence": 315,
     "domain": "test",
     "apiId": "TEST-007",
     "endpoint": "/test/token/access",
@@ -3768,7 +3780,7 @@
     "operationId": "TEST-007"
   },
   {
-    "sequence": 315,
+    "sequence": 316,
     "domain": "test",
     "apiId": "TEST-008",
     "endpoint": "/test/token/refresh",
@@ -3780,7 +3792,7 @@
     "operationId": "TEST-008"
   },
   {
-    "sequence": 316,
+    "sequence": 317,
     "domain": "test",
     "apiId": "TEST-009",
     "endpoint": "/test/token/email",
@@ -3792,7 +3804,7 @@
     "operationId": "TEST-009"
   },
   {
-    "sequence": 317,
+    "sequence": 318,
     "domain": "test",
     "apiId": "TEST-010",
     "endpoint": "/test/token/oauth",
@@ -3804,7 +3816,7 @@
     "operationId": "TEST-010"
   },
   {
-    "sequence": 318,
+    "sequence": 319,
     "domain": "test",
     "apiId": "TEST-011",
     "endpoint": "/test/health-check",
@@ -3816,7 +3828,7 @@
     "operationId": "TEST-011"
   },
   {
-    "sequence": 319,
+    "sequence": 320,
     "domain": "test",
     "apiId": "TEST-012",
     "endpoint": "/test/check-authenticated",

--- a/docs/guides/API_목록.md
+++ b/docs/guides/API_목록.md
@@ -34,9 +34,9 @@
 | 14 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:60` |
 | 15 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:89` |
 | 16 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:73` |
-| 17 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:34` |
-| 18 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:60` |
-| 19 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:85` |
+| 17 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:36` |
+| 18 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:62` |
+| 19 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:87` |
 | 20 | authentication | LOGIN-001 | POST | `/api/v1/auth/login/google` | Google 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:14` |
 | 21 | authentication | LOGIN-005 | POST | `/api/v1/auth/login/kakao` | Kakao 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:32` |
 | 22 | authentication | LOGIN-006 | POST | `/api/v1/auth/login/kakao/code` | Kakao 로그인 (Authorization Code 흐름) | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:50` |
@@ -224,207 +224,208 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 157 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:130` |
-| 158 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:144` |
-| 159 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:158` |
-| 160 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:171` |
-| 161 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
-| 162 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
-| 163 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
-| 164 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
-| 165 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
-| 166 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:61` |
-| 167 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:103` |
+| 157 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:134` |
+| 158 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:167` |
+| 159 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:181` |
+| 160 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:194` |
+| 161 | member | MEMBER-005 | PATCH | `/api/v1/member/email` | 내 이메일 변경 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:148` |
+| 162 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
+| 163 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
+| 164 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
+| 165 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
+| 166 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
+| 167 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:65` |
+| 168 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:107` |
 
 ## notice
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 168 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
-| 169 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
-| 170 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
-| 171 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
-| 172 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
-| 173 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
-| 174 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
-| 175 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
-| 176 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
-| 177 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
-| 178 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
-| 179 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
-| 180 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
-| 181 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
-| 182 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
-| 183 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
-| 184 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
-| 185 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
+| 169 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
+| 170 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
+| 171 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
+| 172 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
+| 173 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
+| 174 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
+| 175 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
+| 176 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
+| 177 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
+| 178 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
+| 179 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
+| 180 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
+| 181 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
+| 182 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
+| 183 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
+| 184 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
+| 185 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
+| 186 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
 
 ## notification
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 186 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
-| 187 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
+| 187 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
+| 188 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
 
 ## organization
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 188 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
-| 189 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
-| 190 | organization | <미지정> | GET | `/api/v1/umc-product/functional-units` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java:24` |
-| 191 | organization | <미지정> | POST | `/api/v1/umc-product/functional-units` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:29` |
-| 192 | organization | <미지정> | PATCH | `/api/v1/umc-product/functional-units/{functionalUnitId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:37` |
-| 193 | organization | <미지정> | DELETE | `/api/v1/umc-product/functional-units/{functionalUnitId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:48` |
-| 194 | organization | <미지정> | GET | `/api/v1/umc-product/generations` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:24` |
-| 195 | organization | <미지정> | POST | `/api/v1/umc-product/generations` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:29` |
-| 196 | organization | <미지정> | GET | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:29` |
-| 197 | organization | <미지정> | PATCH | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:37` |
-| 198 | organization | <미지정> | DELETE | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:48` |
-| 199 | organization | <미지정> | GET | `/api/v1/umc-product/members` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:31` |
-| 200 | organization | <미지정> | POST | `/api/v1/umc-product/members` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:31` |
-| 201 | organization | <미지정> | GET | `/api/v1/umc-product/members/{umcProductMemberId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:56` |
-| 202 | organization | <미지정> | DELETE | `/api/v1/umc-product/members/{umcProductMemberId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:61` |
-| 203 | organization | <미지정> | PUT | `/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:50` |
-| 204 | organization | <미지정> | PATCH | `/api/v1/umc-product/members/{umcProductMemberId}/profile` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:39` |
-| 205 | organization | <미지정> | GET | `/api/v1/umc-product/organization-chart` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java:23` |
-| 206 | organization | <미지정> | GET | `/api/v1/umc-product/squads` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java:23` |
-| 207 | organization | <미지정> | POST | `/api/v1/umc-product/squads` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:31` |
-| 208 | organization | <미지정> | PATCH | `/api/v1/umc-product/squads/{squadId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:39` |
-| 209 | organization | <미지정> | DELETE | `/api/v1/umc-product/squads/{squadId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:48` |
-| 210 | organization | <미지정> | PUT | `/api/v1/umc-product/squads/{squadId}/participants` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:56` |
-| 211 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
-| 212 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
-| 213 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
-| 214 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
-| 215 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
-| 216 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
-| 217 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
-| 218 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
-| 219 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
-| 220 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
-| 221 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
-| 222 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
-| 223 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
-| 224 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
-| 225 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
-| 226 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
-| 227 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
-| 228 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
-| 229 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
-| 230 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
-| 231 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
-| 232 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
-| 233 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
-| 234 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
-| 235 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
-| 236 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
-| 237 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
-| 238 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
-| 239 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
-| 240 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
-| 241 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 189 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
+| 190 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
+| 191 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
+| 192 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
+| 193 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
+| 194 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
+| 195 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
+| 196 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
+| 197 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
+| 198 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
+| 199 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
+| 200 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
+| 201 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
+| 202 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
+| 203 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
+| 204 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
+| 205 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
+| 206 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
+| 207 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
+| 208 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
+| 209 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
+| 210 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
+| 211 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
+| 212 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
+| 213 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
+| 214 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
+| 215 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
+| 216 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
+| 217 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
+| 218 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
+| 219 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
+| 220 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
+| 221 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 222 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-001 | POST | `/api/v1/umc-product/functional-units` | UMC PRODUCT 기능 조직 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:32` |
+| 223 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-002 | PATCH | `/api/v1/umc-product/functional-units/{functionalUnitId}` | UMC PRODUCT 기능 조직 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:45` |
+| 224 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-003 | DELETE | `/api/v1/umc-product/functional-units/{functionalUnitId}` | UMC PRODUCT 기능 조직 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:61` |
+| 225 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-101 | GET | `/api/v1/umc-product/functional-units` | UMC PRODUCT 기능 조직 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java:27` |
+| 226 | organization | UMC-PRODUCT-GENERATION-001 | POST | `/api/v1/umc-product/generations` | UMC PRODUCT 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:32` |
+| 227 | organization | UMC-PRODUCT-GENERATION-002 | PATCH | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:45` |
+| 228 | organization | UMC-PRODUCT-GENERATION-003 | DELETE | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:61` |
+| 229 | organization | UMC-PRODUCT-GENERATION-101 | GET | `/api/v1/umc-product/generations` | UMC PRODUCT 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:27` |
+| 230 | organization | UMC-PRODUCT-GENERATION-102 | GET | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:37` |
+| 231 | organization | UMC-PRODUCT-MEMBER-001 | POST | `/api/v1/umc-product/members` | UMC PRODUCT 멤버 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:34` |
+| 232 | organization | UMC-PRODUCT-MEMBER-002 | PATCH | `/api/v1/umc-product/members/{umcProductMemberId}/profile` | UMC PRODUCT 멤버 프로필 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:47` |
+| 233 | organization | UMC-PRODUCT-MEMBER-003 | PUT | `/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships` | UMC PRODUCT 멤버 기능 조직 소속 교체 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:63` |
+| 234 | organization | UMC-PRODUCT-MEMBER-004 | DELETE | `/api/v1/umc-product/members/{umcProductMemberId}` | UMC PRODUCT 멤버 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:79` |
+| 235 | organization | UMC-PRODUCT-MEMBER-101 | GET | `/api/v1/umc-product/members` | UMC PRODUCT 멤버 검색 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:34` |
+| 236 | organization | UMC-PRODUCT-MEMBER-102 | GET | `/api/v1/umc-product/members/{umcProductMemberId}` | UMC PRODUCT 멤버 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:64` |
+| 237 | organization | UMC-PRODUCT-ORGANIZATION-CHART-101 | GET | `/api/v1/umc-product/organization-chart` | UMC PRODUCT 조직도 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java:26` |
+| 238 | organization | UMC-PRODUCT-SQUAD-001 | POST | `/api/v1/umc-product/squads` | UMC PRODUCT 스쿼드 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:34` |
+| 239 | organization | UMC-PRODUCT-SQUAD-002 | PATCH | `/api/v1/umc-product/squads/{squadId}` | UMC PRODUCT 스쿼드 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:47` |
+| 240 | organization | UMC-PRODUCT-SQUAD-003 | DELETE | `/api/v1/umc-product/squads/{squadId}` | UMC PRODUCT 스쿼드 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:61` |
+| 241 | organization | UMC-PRODUCT-SQUAD-004 | PUT | `/api/v1/umc-product/squads/{squadId}/participants` | UMC PRODUCT 스쿼드 참여자 교체 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:74` |
+| 242 | organization | UMC-PRODUCT-SQUAD-101 | GET | `/api/v1/umc-product/squads` | UMC PRODUCT 스쿼드 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java:26` |
 
 ## project
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 242 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:48` |
-| 243 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:71` |
-| 244 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:94` |
-| 245 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:40` |
-| 246 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:148` |
-| 247 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:79` |
-| 248 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:130` |
-| 249 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:119` |
-| 250 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
-| 251 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
-| 252 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
-| 253 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:144` |
-| 254 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:246` |
-| 255 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
-| 256 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
-| 257 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:64` |
-| 258 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:83` |
-| 259 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
-| 260 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:124` |
-| 261 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:186` |
-| 262 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:37` |
-| 263 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:58` |
-| 264 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:104` |
-| 265 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:164` |
-| 266 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:206` |
-| 267 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:227` |
-| 268 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
-| 269 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
-| 270 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
-| 271 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
-| 272 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
-| 273 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:32` |
-| 274 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:58` |
+| 243 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:48` |
+| 244 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:71` |
+| 245 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:94` |
+| 246 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:40` |
+| 247 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:148` |
+| 248 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:79` |
+| 249 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:130` |
+| 250 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:119` |
+| 251 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
+| 252 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
+| 253 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
+| 254 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:144` |
+| 255 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:246` |
+| 256 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
+| 257 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
+| 258 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:64` |
+| 259 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:83` |
+| 260 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
+| 261 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:124` |
+| 262 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:186` |
+| 263 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:37` |
+| 264 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:58` |
+| 265 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:104` |
+| 266 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:164` |
+| 267 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:206` |
+| 268 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:227` |
+| 269 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
+| 270 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
+| 271 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
+| 272 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
+| 273 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
+| 274 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:32` |
+| 275 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:58` |
 
 ## schedule
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 275 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:62` |
-| 276 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:128` |
-| 277 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:266` |
-| 278 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:315` |
-| 279 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:362` |
-| 280 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:189` |
-| 281 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:230` |
-| 282 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:45` |
-| 283 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:69` |
-| 284 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:106` |
-| 285 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:146` |
-| 286 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:209` |
+| 276 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:62` |
+| 277 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:128` |
+| 278 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:266` |
+| 279 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:315` |
+| 280 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:362` |
+| 281 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:189` |
+| 282 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:230` |
+| 283 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:45` |
+| 284 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:69` |
+| 285 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:106` |
+| 286 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:146` |
+| 287 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:209` |
 
 ## storage
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 287 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:38` |
-| 288 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:60` |
-| 289 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:70` |
+| 288 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:38` |
+| 289 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:60` |
+| 290 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:70` |
 
 ## term
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 290 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
-| 291 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
-| 292 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
-| 293 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
-| 294 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
+| 291 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
+| 292 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
+| 293 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
+| 294 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
+| 295 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
 
 ## test
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 295 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
-| 296 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
-| 297 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:81` |
-| 298 | test | SEED-001-M | POST | `/test/seed/member` | 테스트 멤버 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:97` |
-| 299 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:111` |
-| 300 | test | SEED-002-C | POST | `/test/seed/challenger` | 테스트 챌린저 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:126` |
-| 301 | test | SEED-002-R | POST | `/test/seed/challenger-role` | 테스트 챌린저 역할 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:138` |
-| 302 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:155` |
-| 303 | test | SEED-003-D | DELETE | `/test/seed/projects` | 프로젝트 시딩 데이터 삭제 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:171` |
-| 304 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:193` |
-| 305 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:215` |
-| 306 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:230` |
-| 307 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:249` |
-| 308 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
-| 309 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
-| 310 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
-| 311 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
-| 312 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
-| 313 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
-| 314 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
-| 315 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
-| 316 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
-| 317 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
-| 318 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
-| 319 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
+| 296 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
+| 297 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
+| 298 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:81` |
+| 299 | test | SEED-001-M | POST | `/test/seed/member` | 테스트 멤버 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:97` |
+| 300 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:111` |
+| 301 | test | SEED-002-C | POST | `/test/seed/challenger` | 테스트 챌린저 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:126` |
+| 302 | test | SEED-002-R | POST | `/test/seed/challenger-role` | 테스트 챌린저 역할 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:138` |
+| 303 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:155` |
+| 304 | test | SEED-003-D | DELETE | `/test/seed/projects` | 프로젝트 시딩 데이터 삭제 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:171` |
+| 305 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:193` |
+| 306 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:215` |
+| 307 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:230` |
+| 308 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:249` |
+| 309 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
+| 310 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
+| 311 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
+| 312 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
+| 313 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
+| 314 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
+| 315 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
+| 316 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
+| 317 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
+| 318 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
+| 319 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
+| 320 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
 

--- a/docs/guides/ErrorCode_목록.json
+++ b/docs/guides/ErrorCode_목록.json
@@ -523,7 +523,7 @@
     "constantName": "INVALID_SLUG",
     "httpStatus": "BAD_REQUEST",
     "code": "BLOG-0004",
-    "message": "주소 slug를 확인해주세요.",
+    "message": "주소는 영문 소문자, 숫자, 하이픈만 사용할 수 있어요.",
     "source": "src/main/java/com/umc/product/blog/domain/BlogErrorCode.java",
     "line": 16
   },

--- a/docs/guides/ErrorCode_목록.md
+++ b/docs/guides/ErrorCode_목록.md
@@ -70,7 +70,7 @@
 | 45 | blog | `BLOG-0001` | 404 NOT_FOUND | 글을 찾지 못했어요. 주소를 확인해주세요. | BlogErrorCode | `CONTENT_NOT_FOUND` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:13` |
 | 46 | blog | `BLOG-0002` | 404 NOT_FOUND | 댓글을 찾지 못했어요. 새로고침 후 다시 시도해주세요. | BlogErrorCode | `COMMENT_NOT_FOUND` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:14` |
 | 47 | blog | `BLOG-0003` | 400 BAD_REQUEST | 카테고리를 확인해주세요. | BlogErrorCode | `INVALID_CONTENT_TYPE` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:15` |
-| 48 | blog | `BLOG-0004` | 400 BAD_REQUEST | 주소 slug를 확인해주세요. | BlogErrorCode | `INVALID_SLUG` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:16` |
+| 48 | blog | `BLOG-0004` | 400 BAD_REQUEST | 주소는 영문 소문자, 숫자, 하이픈만 사용할 수 있어요. | BlogErrorCode | `INVALID_SLUG` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:16` |
 | 49 | blog | `BLOG-0005` | 400 BAD_REQUEST | ID는 1 이상이어야 해요. | BlogErrorCode | `INVALID_ID` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:17` |
 | 50 | blog | `BLOG-0006` | 400 BAD_REQUEST | 댓글은 1자 이상 1,000자 이하로 입력해주세요. | BlogErrorCode | `INVALID_COMMENT_CONTENT` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:18` |
 | 51 | blog | `BLOG-0007` | 400 BAD_REQUEST | 닉네임은 1자 이상 20자 이하로 입력해주세요. | BlogErrorCode | `INVALID_NICKNAME` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:19` |

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java
@@ -1,5 +1,10 @@
 package com.umc.product.authentication.adapter.in.web;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authentication.adapter.in.web.dto.request.CompleteEmailVerificationRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.ResendEmailVerificationRequest;
 import com.umc.product.authentication.adapter.in.web.dto.request.SendEmailVerificationRequest;
@@ -11,14 +16,11 @@ import com.umc.product.authentication.application.port.in.command.dto.ValidateEm
 import com.umc.product.authentication.application.port.out.VerifyOAuthTokenPort;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.annotation.Public;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -63,7 +65,7 @@ public class EmailAuthenticationController {
 
             이메일 인증코드는 6자리의 숫자로만 구성되어 있습니다.
 
-            purpose 는 회원가입(REGISTER) 또는 비밀번호 초기화(PASSWORD_RESET) 중 하나여야 하며,
+            purpose 는 회원가입(REGISTER), 비밀번호 초기화(PASSWORD_RESET), 이메일 변경(CHANGE_EMAIL) 중 하나여야 하며,
             cross-purpose 공격 방어를 위해 세션 단위로 고정됩니다.
             """)
     @PostMapping("email-verification")

--- a/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/web/dto/request/SendEmailVerificationRequest.java
@@ -1,22 +1,19 @@
 package com.umc.product.authentication.adapter.in.web.dto.request;
 
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SendEmailVerificationRequest(
-    @NotBlank
-    @Email
-    @Size(max = 100)
-    String email,
+    @NotBlank @Email @Size(max = 100) String email,
 
     /**
-     * 인증 세션 용도. 회원가입(REGISTER) / 비밀번호 초기화(PASSWORD_RESET).
+     * 인증 세션 용도. 회원가입(REGISTER) / 비밀번호 초기화(PASSWORD_RESET) / 이메일 변경(CHANGE_EMAIL).
      * cross-purpose 공격 방어를 위해 세션 단위로 고정한다.
      */
-    @NotNull
-    EmailVerificationPurpose purpose
+    @NotNull EmailVerificationPurpose purpose
 ) {
 }

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -1,5 +1,11 @@
 package com.umc.product.authentication.application.service;
 
+import java.security.SecureRandom;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authentication.application.event.SendVerificationEmailEvent;
 import com.umc.product.authentication.application.port.in.command.ManageAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.NewTokens;
@@ -15,12 +21,9 @@ import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
-import java.security.SecureRandom;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -49,7 +52,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
 
             이는 네트워크 이슈로 인해서 Server에 요청이 접수되었지만 클라이언트에게는 응답이 가지 않은 경우를 대비하기 위함임
          */
-        
+
         Long memberId = jwtTokenProvider.parseRefreshToken(command.refreshToken());
 
         return NewTokens.builder()
@@ -65,13 +68,13 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         CredentialPolicy.validateEmail(email);
 
         // purpose 별 가입 여부 분기 검증.
-        // - REGISTER: 이미 가입된 이메일이면 인증 진행 자체를 차단 (가입 마지막 단계의 UNIQUE 충돌로 인한
-        //   "인증 다 했는데 실패" UX 방지). 회원가입 흐름에서는 이미 가입 여부 노출이 자연스러움.
+        // - REGISTER / CHANGE_EMAIL: 이미 가입된 이메일이면 인증 진행 자체를 차단 (가입/변경 마지막 단계의
+        //   UNIQUE 충돌로 인한 "인증 다 했는데 실패" UX 방지). 두 흐름에서는 이메일 사용 여부 노출이 자연스러움.
         // - PASSWORD_RESET: 미가입 / 자격증명 미등록 이메일에 대해서는 user enumeration 방어를 위해
         //   응답은 동일하게 내려보내되 실제 메일 발송만 건너뛴다. 후속 reset 흐름에서도 INVALID_LOGIN_CREDENTIAL
         //   단일 메시지로 응답하므로 끝까지 가입 여부가 노출되지 않는다.
         boolean shouldSendEmail = switch (purpose) {
-            case REGISTER -> {
+            case REGISTER, CHANGE_EMAIL -> {
                 if (getMemberCredentialUseCase.existsByEmail(email)) {
                     throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
                 }

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -1,8 +1,11 @@
 package com.umc.product.authentication.domain;
 
+import java.time.Instant;
+
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,7 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -71,7 +73,7 @@ public class EmailVerification extends BaseEntity {
     private Instant expiresAt;
 
     /**
-     * 인증 세션의 용도 (REGISTER / PASSWORD_RESET). cross-purpose 공격 방어를 위해 세션 단위로 고정한다.
+     * 인증 세션의 용도. cross-purpose 공격 방어를 위해 세션 단위로 고정한다.
      */
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose", nullable = false, length = 20)

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerificationPurpose.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerificationPurpose.java
@@ -15,5 +15,10 @@ public enum EmailVerificationPurpose {
     /**
      * 가입된 회원의 비밀번호 초기화를 위한 이메일 인증.
      */
-    PASSWORD_RESET
+    PASSWORD_RESET,
+
+    /**
+     * 기존 회원의 이메일 변경을 위한 새 이메일 소유 인증.
+     */
+    CHANGE_EMAIL
 }

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -1,24 +1,28 @@
 package com.umc.product.global.security;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.ClientType;
 import com.umc.product.common.domain.enums.OAuthProvider;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
@@ -78,7 +82,7 @@ public class JwtTokenProvider {
     /**
      * emailVerificationToken 발급
      * <p>
-     * purpose claim 으로 회원가입(REGISTER) 과 비밀번호 초기화(PASSWORD_RESET) 흐름을 구분한다.
+     * purpose claim 으로 회원가입(REGISTER), 비밀번호 초기화(PASSWORD_RESET), 이메일 변경(CHANGE_EMAIL) 흐름을 구분한다.
      * 한 흐름에서 발급된 토큰이 다른 흐름에 재사용되지 않도록, 파싱 시 expectedPurpose 와 비교한다.
      */
     public String createEmailVerificationToken(String email, EmailVerificationPurpose purpose) {
@@ -260,7 +264,7 @@ public class JwtTokenProvider {
      * emailVerificationToken 파싱 및 검증
      * <p>
      * 토큰의 purpose claim 이 expectedPurpose 와 일치하지 않으면 INVALID_EMAIL_VERIFICATION 예외를 던진다.
-     * 예) 회원가입(REGISTER) 흐름에서 발급된 토큰을 비밀번호 초기화에 사용하려는 cross-purpose 공격 방어.
+     * 예) 회원가입(REGISTER) 흐름에서 발급된 토큰을 비밀번호 초기화나 이메일 변경에 사용하려는 cross-purpose 공격 방어.
      */
     public String parseEmailVerificationToken(String token, EmailVerificationPurpose expectedPurpose) {
         validateToken(token, emailVerificationTokenSecret);

--- a/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java
@@ -18,6 +18,7 @@ import com.umc.product.global.security.OAuthVerificationClaims;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.global.security.annotation.Public;
 import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
+import com.umc.product.member.adapter.in.web.dto.request.ChangeMemberEmailRequest;
 import com.umc.product.member.adapter.in.web.dto.request.DeleteMemberRequest;
 import com.umc.product.member.adapter.in.web.dto.request.EditMemberInfoRequest;
 import com.umc.product.member.adapter.in.web.dto.request.EditMemberProfileRequest;
@@ -25,10 +26,12 @@ import com.umc.product.member.adapter.in.web.dto.request.EmailRegisterMemberRequ
 import com.umc.product.member.adapter.in.web.dto.request.OAuthRegisterMemberRequest;
 import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
 import com.umc.product.member.adapter.in.web.dto.response.RegisterResponse;
+import com.umc.product.member.application.port.in.command.ChangeMemberEmailUseCase;
 import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
 import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
 import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
 import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
 import com.umc.product.member.application.port.in.command.dto.DeleteMemberCommand;
 import com.umc.product.member.application.port.in.command.dto.OAuthRegisterMemberCommand;
 import com.umc.product.member.application.port.in.command.dto.TermConsents;
@@ -51,6 +54,7 @@ public class MemberCommandController {
     private final JwtTokenProvider jwtTokenProvider;
 
     private final ManageMemberUseCase manageMemberUseCase;
+    private final ChangeMemberEmailUseCase changeMemberEmailUseCase;
     private final ManageMemberProfileUseCase manageMemberProfileUseCase;
 
     private final RegisterOAuthMemberUseCase registerOAuthMemberUseCase;
@@ -136,6 +140,25 @@ public class MemberCommandController {
         manageMemberUseCase.updateMember(UpdateMemberCommand.forProfileUpdate(
             memberPrincipal.getMemberId(),
             request.profileImageId())
+        );
+
+        return assembler.fromMemberId(memberPrincipal.getMemberId());
+    }
+
+    @Operation(summary = "[MEMBER-005] 내 이메일 변경",
+        description = "CHANGE_EMAIL 용도로 발급된 emailVerificationToken 으로 새 이메일 소유를 확인한 뒤 회원 이메일을 변경합니다.")
+    @PatchMapping("/email")
+    MemberInfoResponse changeMemberEmail(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @Valid @RequestBody ChangeMemberEmailRequest request
+    ) {
+        String email = jwtTokenProvider.parseEmailVerificationToken(
+            request.emailVerificationToken(),
+            EmailVerificationPurpose.CHANGE_EMAIL
+        );
+
+        changeMemberEmailUseCase.changeEmail(
+            ChangeMemberEmailCommand.of(memberPrincipal.getMemberId(), email)
         );
 
         return assembler.fromMemberId(memberPrincipal.getMemberId());

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/ChangeMemberEmailRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/ChangeMemberEmailRequest.java
@@ -1,0 +1,8 @@
+package com.umc.product.member.adapter.in.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangeMemberEmailRequest(
+    @NotBlank String emailVerificationToken
+) {
+}

--- a/src/main/java/com/umc/product/member/application/port/in/command/ChangeMemberEmailUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/command/ChangeMemberEmailUseCase.java
@@ -1,0 +1,11 @@
+package com.umc.product.member.application.port.in.command;
+
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
+
+/**
+ * 회원의 이메일을 변경하는 UseCase.
+ */
+public interface ChangeMemberEmailUseCase {
+
+    void changeEmail(ChangeMemberEmailCommand command);
+}

--- a/src/main/java/com/umc/product/member/application/port/in/command/dto/ChangeMemberEmailCommand.java
+++ b/src/main/java/com/umc/product/member/application/port/in/command/dto/ChangeMemberEmailCommand.java
@@ -1,0 +1,13 @@
+package com.umc.product.member.application.port.in.command.dto;
+
+/**
+ * 이메일 인증 토큰으로 검증된 새 이메일을 현재 회원에게 반영하는 커맨드.
+ */
+public record ChangeMemberEmailCommand(
+    Long memberId,
+    String email
+) {
+    public static ChangeMemberEmailCommand of(Long memberId, String email) {
+        return new ChangeMemberEmailCommand(memberId, email);
+    }
+}

--- a/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
@@ -1,0 +1,37 @@
+package com.umc.product.member.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.member.application.port.in.command.ChangeMemberEmailUseCase;
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberEmailCommandService implements ChangeMemberEmailUseCase {
+
+    private final LoadMemberPort loadMemberPort;
+
+    @Override
+    public void changeEmail(ChangeMemberEmailCommand command) {
+        Member member = loadMemberPort.findByIdForUpdate(command.memberId())
+            .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getEmail().equals(command.email())) {
+            return;
+        }
+
+        if (loadMemberPort.existsByEmail(command.email())) {
+            throw new MemberDomainException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        member.changeEmail(command.email());
+    }
+}

--- a/src/main/java/com/umc/product/member/domain/Member.java
+++ b/src/main/java/com/umc/product/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.umc.product.common.BaseEntity;
 import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -96,6 +97,11 @@ public class Member extends BaseEntity {
     public void updateProfile(String profileImageId) {
         validateActive();
         this.profileImageId = profileImageId;
+    }
+
+    public void changeEmail(String email) {
+        validateActive();
+        this.email = email;
     }
 
     /**

--- a/src/main/resources/db/migration/V2026.06.13.10.00__add_change_email_purpose_to_email_verification.sql
+++ b/src/main/resources/db/migration/V2026.06.13.10.00__add_change_email_purpose_to_email_verification.sql
@@ -1,0 +1,8 @@
+-- 이메일 변경 화면에서 이메일 인증 세션을 분리하기 위해 CHANGE_EMAIL purpose 를 허용한다.
+-- 기존 REGISTER / PASSWORD_RESET 토큰과 섞이지 않도록 purpose check constraint 를 함께 갱신한다.
+ALTER TABLE email_verification
+    DROP CONSTRAINT IF EXISTS email_verification_purpose_check;
+
+ALTER TABLE email_verification
+    ADD CONSTRAINT email_verification_purpose_check
+        CHECK (purpose IN ('REGISTER', 'PASSWORD_RESET', 'CHANGE_EMAIL'));

--- a/src/main/resources/static/docs/catalog/api/catalog.json
+++ b/src/main/resources/static/docs/catalog/api/catalog.json
@@ -200,7 +200,7 @@
     "role": "6자리 인증코드로 이메일 인증",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 34,
+    "line": 36,
     "operationId": null
   },
   {
@@ -212,7 +212,7 @@
     "role": "이메일 인증 코드 발송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 60,
+    "line": 62,
     "operationId": null
   },
   {
@@ -224,7 +224,7 @@
     "role": "이메일 인증 코드 재전송",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java",
-    "line": 85,
+    "line": 87,
     "operationId": null
   },
   {
@@ -1880,7 +1880,7 @@
     "role": "내 회원 정보 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 130,
+    "line": 134,
     "operationId": null
   },
   {
@@ -1892,7 +1892,7 @@
     "role": "내 회원 프로필 링크 수정",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 144,
+    "line": 167,
     "operationId": null
   },
   {
@@ -1904,7 +1904,7 @@
     "role": "회원 탈퇴",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 158,
+    "line": 181,
     "operationId": null
   },
   {
@@ -1916,11 +1916,23 @@
     "role": "관리자 권한으로 회원 게정 삭제 (Hard Delete)",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 171,
+    "line": 194,
     "operationId": null
   },
   {
     "sequence": 161,
+    "domain": "member",
+    "apiId": "MEMBER-005",
+    "endpoint": "/api/v1/member/email",
+    "httpMethod": "PATCH",
+    "role": "내 이메일 변경",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
+    "line": 148,
+    "operationId": null
+  },
+  {
+    "sequence": 162,
     "domain": "member",
     "apiId": "MEMBER-101",
     "endpoint": "/api/v1/member/profile/{memberId}",
@@ -1932,7 +1944,7 @@
     "operationId": null
   },
   {
-    "sequence": 162,
+    "sequence": 163,
     "domain": "member",
     "apiId": "MEMBER-102",
     "endpoint": "/api/v1/member/me",
@@ -1944,7 +1956,7 @@
     "operationId": null
   },
   {
-    "sequence": 163,
+    "sequence": 164,
     "domain": "member",
     "apiId": "MEMBER-103",
     "endpoint": "/api/v1/member/search",
@@ -1956,7 +1968,7 @@
     "operationId": null
   },
   {
-    "sequence": 164,
+    "sequence": 165,
     "domain": "member",
     "apiId": "MEMBER-201",
     "endpoint": "/api/v2/member/me",
@@ -1968,7 +1980,7 @@
     "operationId": null
   },
   {
-    "sequence": 165,
+    "sequence": 166,
     "domain": "member",
     "apiId": "MEMBER-202",
     "endpoint": "/api/v2/member/search",
@@ -1980,7 +1992,7 @@
     "operationId": null
   },
   {
-    "sequence": 166,
+    "sequence": 167,
     "domain": "member",
     "apiId": "REGISTER-001",
     "endpoint": "/api/v1/member/register",
@@ -1988,11 +2000,11 @@
     "role": "OAuth 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 61,
+    "line": 65,
     "operationId": null
   },
   {
-    "sequence": 167,
+    "sequence": 168,
     "domain": "member",
     "apiId": "REGISTER-003",
     "endpoint": "/api/v1/member/register/email",
@@ -2000,11 +2012,11 @@
     "role": "이메일/PW 이용 회원가입",
     "deprecated": false,
     "source": "src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java",
-    "line": 103,
+    "line": 107,
     "operationId": null
   },
   {
-    "sequence": 168,
+    "sequence": 169,
     "domain": "notice",
     "apiId": "NOTICE-001",
     "endpoint": "/api/v1/notices",
@@ -2016,7 +2028,7 @@
     "operationId": null
   },
   {
-    "sequence": 169,
+    "sequence": 170,
     "domain": "notice",
     "apiId": "NOTICE-002",
     "endpoint": "/api/v1/notices/search",
@@ -2028,7 +2040,7 @@
     "operationId": null
   },
   {
-    "sequence": 170,
+    "sequence": 171,
     "domain": "notice",
     "apiId": "NOTICE-003",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2040,7 +2052,7 @@
     "operationId": null
   },
   {
-    "sequence": 171,
+    "sequence": 172,
     "domain": "notice",
     "apiId": "NOTICE-004",
     "endpoint": "/api/v1/notices/{noticeId}/read-statics",
@@ -2052,7 +2064,7 @@
     "operationId": null
   },
   {
-    "sequence": 172,
+    "sequence": 173,
     "domain": "notice",
     "apiId": "NOTICE-005",
     "endpoint": "/api/v1/notices/{noticeId}/read-status",
@@ -2064,7 +2076,7 @@
     "operationId": null
   },
   {
-    "sequence": 173,
+    "sequence": 174,
     "domain": "notice",
     "apiId": "NOTICE-101",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -2076,7 +2088,7 @@
     "operationId": null
   },
   {
-    "sequence": 174,
+    "sequence": 175,
     "domain": "notice",
     "apiId": "NOTICE-102",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -2088,7 +2100,7 @@
     "operationId": null
   },
   {
-    "sequence": 175,
+    "sequence": 176,
     "domain": "notice",
     "apiId": "NOTICE-103",
     "endpoint": "/api/v1/notices/{noticeId}/votes",
@@ -2100,7 +2112,7 @@
     "operationId": null
   },
   {
-    "sequence": 176,
+    "sequence": 177,
     "domain": "notice",
     "apiId": "NOTICE-104",
     "endpoint": "/api/v1/notices/{noticeId}/images",
@@ -2112,7 +2124,7 @@
     "operationId": null
   },
   {
-    "sequence": 177,
+    "sequence": 178,
     "domain": "notice",
     "apiId": "NOTICE-105",
     "endpoint": "/api/v1/notices/{noticeId}/links",
@@ -2124,7 +2136,7 @@
     "operationId": null
   },
   {
-    "sequence": 178,
+    "sequence": 179,
     "domain": "notice",
     "apiId": "NOTICE-106",
     "endpoint": "/api/v1/notices/{noticeId}/vote",
@@ -2136,7 +2148,7 @@
     "operationId": null
   },
   {
-    "sequence": 179,
+    "sequence": 180,
     "domain": "notice",
     "apiId": "NOTICE-201",
     "endpoint": "/api/v1/notices",
@@ -2148,7 +2160,7 @@
     "operationId": null
   },
   {
-    "sequence": 180,
+    "sequence": 181,
     "domain": "notice",
     "apiId": "NOTICE-202",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2160,7 +2172,7 @@
     "operationId": null
   },
   {
-    "sequence": 181,
+    "sequence": 182,
     "domain": "notice",
     "apiId": "NOTICE-203",
     "endpoint": "/api/v1/notices/{noticeId}",
@@ -2172,7 +2184,7 @@
     "operationId": null
   },
   {
-    "sequence": 182,
+    "sequence": 183,
     "domain": "notice",
     "apiId": "NOTICE-204",
     "endpoint": "/api/v1/notices/{noticeId}/reminders",
@@ -2184,7 +2196,7 @@
     "operationId": null
   },
   {
-    "sequence": 183,
+    "sequence": 184,
     "domain": "notice",
     "apiId": "NOTICE-205",
     "endpoint": "/api/v1/notices/{noticeId}/read",
@@ -2196,7 +2208,7 @@
     "operationId": null
   },
   {
-    "sequence": 184,
+    "sequence": 185,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-001",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -2208,7 +2220,7 @@
     "operationId": null
   },
   {
-    "sequence": 185,
+    "sequence": 186,
     "domain": "notice",
     "apiId": "NOTICE-VOTE-002",
     "endpoint": "/api/v1/notices/{noticeId}/votes/responses",
@@ -2220,7 +2232,7 @@
     "operationId": null
   },
   {
-    "sequence": 186,
+    "sequence": 187,
     "domain": "notification",
     "apiId": "FCM-001",
     "endpoint": "/api/v1/notification/fcm/token",
@@ -2232,7 +2244,7 @@
     "operationId": null
   },
   {
-    "sequence": 187,
+    "sequence": 188,
     "domain": "notification",
     "apiId": "FCM-002",
     "endpoint": "/api/v1/notification/fcm/topics/legacy",
@@ -2244,7 +2256,7 @@
     "operationId": null
   },
   {
-    "sequence": 188,
+    "sequence": 189,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -2256,7 +2268,7 @@
     "operationId": null
   },
   {
-    "sequence": 189,
+    "sequence": 190,
     "domain": "organization",
     "apiId": "<미지정>",
     "endpoint": "/api/v1/schools/gisu/{gisuId}",
@@ -2268,259 +2280,7 @@
     "operationId": null
   },
   {
-    "sequence": 190,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java",
-    "line": 24,
-    "operationId": null
-  },
-  {
     "sequence": 191,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 192,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 37,
-    "operationId": null
-  },
-  {
-    "sequence": 193,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 194,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
-    "line": 24,
-    "operationId": null
-  },
-  {
-    "sequence": 195,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 196,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
-    "line": 29,
-    "operationId": null
-  },
-  {
-    "sequence": 197,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 37,
-    "operationId": null
-  },
-  {
-    "sequence": 198,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 199,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 200,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 201,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
-    "line": 56,
-    "operationId": null
-  },
-  {
-    "sequence": 202,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 61,
-    "operationId": null
-  },
-  {
-    "sequence": 203,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships",
-    "httpMethod": "PUT",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 50,
-    "operationId": null
-  },
-  {
-    "sequence": 204,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/profile",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
-    "line": 39,
-    "operationId": null
-  },
-  {
-    "sequence": 205,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/organization-chart",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java",
-    "line": 23,
-    "operationId": null
-  },
-  {
-    "sequence": 206,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads",
-    "httpMethod": "GET",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java",
-    "line": 23,
-    "operationId": null
-  },
-  {
-    "sequence": 207,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads",
-    "httpMethod": "POST",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 31,
-    "operationId": null
-  },
-  {
-    "sequence": 208,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}",
-    "httpMethod": "PATCH",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 39,
-    "operationId": null
-  },
-  {
-    "sequence": 209,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}",
-    "httpMethod": "DELETE",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 48,
-    "operationId": null
-  },
-  {
-    "sequence": 210,
-    "domain": "organization",
-    "apiId": "<미지정>",
-    "endpoint": "/api/v1/umc-product/squads/{squadId}/participants",
-    "httpMethod": "PUT",
-    "role": "<요약 없음>",
-    "deprecated": false,
-    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
-    "line": 56,
-    "operationId": null
-  },
-  {
-    "sequence": 211,
     "domain": "organization",
     "apiId": "CHAPTER-001",
     "endpoint": "/api/v1/chapters",
@@ -2532,7 +2292,7 @@
     "operationId": null
   },
   {
-    "sequence": 212,
+    "sequence": 192,
     "domain": "organization",
     "apiId": "CHAPTER-002",
     "endpoint": "/api/v1/chapters/bulk",
@@ -2544,7 +2304,7 @@
     "operationId": null
   },
   {
-    "sequence": 213,
+    "sequence": 193,
     "domain": "organization",
     "apiId": "CHAPTER-003",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -2556,7 +2316,7 @@
     "operationId": null
   },
   {
-    "sequence": 214,
+    "sequence": 194,
     "domain": "organization",
     "apiId": "CHAPTER-101",
     "endpoint": "/api/v1/chapters",
@@ -2568,7 +2328,7 @@
     "operationId": null
   },
   {
-    "sequence": 215,
+    "sequence": 195,
     "domain": "organization",
     "apiId": "CHAPTER-102",
     "endpoint": "/api/v1/chapters/with-schools",
@@ -2580,7 +2340,7 @@
     "operationId": null
   },
   {
-    "sequence": 216,
+    "sequence": 196,
     "domain": "organization",
     "apiId": "CHAPTER-103",
     "endpoint": "/api/v1/chapters/{chapterId}",
@@ -2592,7 +2352,7 @@
     "operationId": null
   },
   {
-    "sequence": 217,
+    "sequence": 197,
     "domain": "organization",
     "apiId": "GISU-001",
     "endpoint": "/api/v1/gisu",
@@ -2604,7 +2364,7 @@
     "operationId": null
   },
   {
-    "sequence": 218,
+    "sequence": 198,
     "domain": "organization",
     "apiId": "GISU-002",
     "endpoint": "/api/v1/gisu/{gisuId}",
@@ -2616,7 +2376,7 @@
     "operationId": null
   },
   {
-    "sequence": 219,
+    "sequence": 199,
     "domain": "organization",
     "apiId": "GISU-003",
     "endpoint": "/api/v1/gisu/{gisuId}/active",
@@ -2628,7 +2388,7 @@
     "operationId": null
   },
   {
-    "sequence": 220,
+    "sequence": 200,
     "domain": "organization",
     "apiId": "GISU-101",
     "endpoint": "/api/v1/gisu",
@@ -2640,7 +2400,7 @@
     "operationId": null
   },
   {
-    "sequence": 221,
+    "sequence": 201,
     "domain": "organization",
     "apiId": "GISU-102",
     "endpoint": "/api/v1/gisu/all",
@@ -2652,7 +2412,7 @@
     "operationId": null
   },
   {
-    "sequence": 222,
+    "sequence": 202,
     "domain": "organization",
     "apiId": "GISU-103",
     "endpoint": "/api/v1/gisu/active",
@@ -2664,7 +2424,7 @@
     "operationId": null
   },
   {
-    "sequence": 223,
+    "sequence": 203,
     "domain": "organization",
     "apiId": "SCHOOL-001",
     "endpoint": "/api/v1/schools",
@@ -2676,7 +2436,7 @@
     "operationId": null
   },
   {
-    "sequence": 224,
+    "sequence": 204,
     "domain": "organization",
     "apiId": "SCHOOL-002",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2688,7 +2448,7 @@
     "operationId": null
   },
   {
-    "sequence": 225,
+    "sequence": 205,
     "domain": "organization",
     "apiId": "SCHOOL-003",
     "endpoint": "/api/v1/schools",
@@ -2700,7 +2460,7 @@
     "operationId": null
   },
   {
-    "sequence": 226,
+    "sequence": 206,
     "domain": "organization",
     "apiId": "SCHOOL-004",
     "endpoint": "/api/v1/schools/{schoolId}/assign",
@@ -2712,7 +2472,7 @@
     "operationId": null
   },
   {
-    "sequence": 227,
+    "sequence": 207,
     "domain": "organization",
     "apiId": "SCHOOL-005",
     "endpoint": "/api/v1/schools/{schoolId}/unassign",
@@ -2724,7 +2484,7 @@
     "operationId": null
   },
   {
-    "sequence": 228,
+    "sequence": 208,
     "domain": "organization",
     "apiId": "SCHOOL-101",
     "endpoint": "/api/v1/schools/all",
@@ -2736,7 +2496,7 @@
     "operationId": null
   },
   {
-    "sequence": 229,
+    "sequence": 209,
     "domain": "organization",
     "apiId": "SCHOOL-102",
     "endpoint": "/api/v1/schools/{schoolId}",
@@ -2748,7 +2508,7 @@
     "operationId": null
   },
   {
-    "sequence": 230,
+    "sequence": 210,
     "domain": "organization",
     "apiId": "SCHOOL-103",
     "endpoint": "/api/v1/schools/unassigned",
@@ -2760,7 +2520,7 @@
     "operationId": null
   },
   {
-    "sequence": 231,
+    "sequence": 211,
     "domain": "organization",
     "apiId": "SCHOOL-104",
     "endpoint": "/api/v1/schools/link/{schoolId}",
@@ -2772,7 +2532,7 @@
     "operationId": null
   },
   {
-    "sequence": 232,
+    "sequence": 212,
     "domain": "organization",
     "apiId": "STUDY-GROUP-001",
     "endpoint": "/api/v1/study-groups",
@@ -2784,7 +2544,7 @@
     "operationId": null
   },
   {
-    "sequence": 233,
+    "sequence": 213,
     "domain": "organization",
     "apiId": "STUDY-GROUP-002",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2796,7 +2556,7 @@
     "operationId": null
   },
   {
-    "sequence": 234,
+    "sequence": 214,
     "domain": "organization",
     "apiId": "STUDY-GROUP-003",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2808,7 +2568,7 @@
     "operationId": null
   },
   {
-    "sequence": 235,
+    "sequence": 215,
     "domain": "organization",
     "apiId": "STUDY-GROUP-004",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2820,7 +2580,7 @@
     "operationId": null
   },
   {
-    "sequence": 236,
+    "sequence": 216,
     "domain": "organization",
     "apiId": "STUDY-GROUP-005",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/members/{memberId}",
@@ -2832,7 +2592,7 @@
     "operationId": null
   },
   {
-    "sequence": 237,
+    "sequence": 217,
     "domain": "organization",
     "apiId": "STUDY-GROUP-006",
     "endpoint": "/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}",
@@ -2844,7 +2604,7 @@
     "operationId": null
   },
   {
-    "sequence": 238,
+    "sequence": 218,
     "domain": "organization",
     "apiId": "STUDY-GROUP-007",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2856,7 +2616,7 @@
     "operationId": null
   },
   {
-    "sequence": 239,
+    "sequence": 219,
     "domain": "organization",
     "apiId": "STUDY-GROUP-101",
     "endpoint": "/api/v1/study-groups/managed",
@@ -2868,7 +2628,7 @@
     "operationId": null
   },
   {
-    "sequence": 240,
+    "sequence": 220,
     "domain": "organization",
     "apiId": "STUDY-GROUP-102",
     "endpoint": "/api/v1/study-groups/{studyGroupId}",
@@ -2880,7 +2640,7 @@
     "operationId": null
   },
   {
-    "sequence": 241,
+    "sequence": 221,
     "domain": "organization",
     "apiId": "STUDY-GROUP-SCHEDULE-001",
     "endpoint": "/api/v1/study-groups/schedules",
@@ -2892,7 +2652,259 @@
     "operationId": null
   },
   {
+    "sequence": 222,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-001",
+    "endpoint": "/api/v1/umc-product/functional-units",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 기능 조직 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 32,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-001"
+  },
+  {
+    "sequence": 223,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-002",
+    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 기능 조직 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 45,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-002"
+  },
+  {
+    "sequence": 224,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-003",
+    "endpoint": "/api/v1/umc-product/functional-units/{functionalUnitId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 기능 조직 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-003"
+  },
+  {
+    "sequence": 225,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-FUNCTIONAL-UNIT-101",
+    "endpoint": "/api/v1/umc-product/functional-units",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기능 조직 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java",
+    "line": 27,
+    "operationId": "UMC-PRODUCT-FUNCTIONAL-UNIT-101"
+  },
+  {
+    "sequence": 226,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-001",
+    "endpoint": "/api/v1/umc-product/generations",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 기수 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 32,
+    "operationId": "UMC-PRODUCT-GENERATION-001"
+  },
+  {
+    "sequence": 227,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-002",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 기수 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 45,
+    "operationId": "UMC-PRODUCT-GENERATION-002"
+  },
+  {
+    "sequence": 228,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-003",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 기수 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-GENERATION-003"
+  },
+  {
+    "sequence": 229,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-101",
+    "endpoint": "/api/v1/umc-product/generations",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기수 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
+    "line": 27,
+    "operationId": "UMC-PRODUCT-GENERATION-101"
+  },
+  {
+    "sequence": 230,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-GENERATION-102",
+    "endpoint": "/api/v1/umc-product/generations/{umcProductGenerationId}",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 기수 상세 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java",
+    "line": 37,
+    "operationId": "UMC-PRODUCT-GENERATION-102"
+  },
+  {
+    "sequence": 231,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-001",
+    "endpoint": "/api/v1/umc-product/members",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 멤버 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-MEMBER-001"
+  },
+  {
+    "sequence": 232,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-002",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/profile",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 멤버 프로필 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 47,
+    "operationId": "UMC-PRODUCT-MEMBER-002"
+  },
+  {
+    "sequence": 233,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-003",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships",
+    "httpMethod": "PUT",
+    "role": "UMC PRODUCT 멤버 기능 조직 소속 교체",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 63,
+    "operationId": "UMC-PRODUCT-MEMBER-003"
+  },
+  {
+    "sequence": 234,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-004",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 멤버 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java",
+    "line": 79,
+    "operationId": "UMC-PRODUCT-MEMBER-004"
+  },
+  {
+    "sequence": 235,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-101",
+    "endpoint": "/api/v1/umc-product/members",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 멤버 검색",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-MEMBER-101"
+  },
+  {
+    "sequence": 236,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-MEMBER-102",
+    "endpoint": "/api/v1/umc-product/members/{umcProductMemberId}",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 멤버 상세 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java",
+    "line": 64,
+    "operationId": "UMC-PRODUCT-MEMBER-102"
+  },
+  {
+    "sequence": 237,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-ORGANIZATION-CHART-101",
+    "endpoint": "/api/v1/umc-product/organization-chart",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 조직도 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java",
+    "line": 26,
+    "operationId": "UMC-PRODUCT-ORGANIZATION-CHART-101"
+  },
+  {
+    "sequence": 238,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-001",
+    "endpoint": "/api/v1/umc-product/squads",
+    "httpMethod": "POST",
+    "role": "UMC PRODUCT 스쿼드 생성",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 34,
+    "operationId": "UMC-PRODUCT-SQUAD-001"
+  },
+  {
+    "sequence": 239,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-002",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}",
+    "httpMethod": "PATCH",
+    "role": "UMC PRODUCT 스쿼드 수정",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 47,
+    "operationId": "UMC-PRODUCT-SQUAD-002"
+  },
+  {
+    "sequence": 240,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-003",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}",
+    "httpMethod": "DELETE",
+    "role": "UMC PRODUCT 스쿼드 삭제",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 61,
+    "operationId": "UMC-PRODUCT-SQUAD-003"
+  },
+  {
+    "sequence": 241,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-004",
+    "endpoint": "/api/v1/umc-product/squads/{squadId}/participants",
+    "httpMethod": "PUT",
+    "role": "UMC PRODUCT 스쿼드 참여자 교체",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java",
+    "line": 74,
+    "operationId": "UMC-PRODUCT-SQUAD-004"
+  },
+  {
     "sequence": 242,
+    "domain": "organization",
+    "apiId": "UMC-PRODUCT-SQUAD-101",
+    "endpoint": "/api/v1/umc-product/squads",
+    "httpMethod": "GET",
+    "role": "UMC PRODUCT 스쿼드 목록 조회",
+    "deprecated": false,
+    "source": "src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java",
+    "line": 26,
+    "operationId": "UMC-PRODUCT-SQUAD-101"
+  },
+  {
+    "sequence": 243,
     "domain": "project",
     "apiId": "APPLY-001",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2904,7 +2916,7 @@
     "operationId": null
   },
   {
-    "sequence": 243,
+    "sequence": 244,
     "domain": "project",
     "apiId": "APPLY-002",
     "endpoint": "/api/v1/projects/{projectId}/applications/me",
@@ -2916,7 +2928,7 @@
     "operationId": null
   },
   {
-    "sequence": 244,
+    "sequence": 245,
     "domain": "project",
     "apiId": "APPLY-003",
     "endpoint": "/api/v1/projects/{projectId}/applications/me/submit",
@@ -2928,7 +2940,7 @@
     "operationId": null
   },
   {
-    "sequence": 245,
+    "sequence": 246,
     "domain": "project",
     "apiId": "APPLY-004",
     "endpoint": "/api/v1/projects/me/applications",
@@ -2940,7 +2952,7 @@
     "operationId": null
   },
   {
-    "sequence": 246,
+    "sequence": 247,
     "domain": "project",
     "apiId": "APPLY-005",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2952,7 +2964,7 @@
     "operationId": null
   },
   {
-    "sequence": 247,
+    "sequence": 248,
     "domain": "project",
     "apiId": "APPLY-101",
     "endpoint": "/api/v1/projects/{projectId}/applications",
@@ -2964,7 +2976,7 @@
     "operationId": null
   },
   {
-    "sequence": 248,
+    "sequence": 249,
     "domain": "project",
     "apiId": "APPLY-102",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}",
@@ -2976,7 +2988,7 @@
     "operationId": null
   },
   {
-    "sequence": 249,
+    "sequence": 250,
     "domain": "project",
     "apiId": "APPLY-103",
     "endpoint": "/api/v1/projects/{projectId}/applications/{applicationId}/decision",
@@ -2988,7 +3000,7 @@
     "operationId": null
   },
   {
-    "sequence": 250,
+    "sequence": 251,
     "domain": "project",
     "apiId": "PROJECT-001",
     "endpoint": "/api/v1/projects",
@@ -3000,7 +3012,7 @@
     "operationId": null
   },
   {
-    "sequence": 251,
+    "sequence": 252,
     "domain": "project",
     "apiId": "PROJECT-002",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3012,7 +3024,7 @@
     "operationId": null
   },
   {
-    "sequence": 252,
+    "sequence": 253,
     "domain": "project",
     "apiId": "PROJECT-003",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -3024,7 +3036,7 @@
     "operationId": null
   },
   {
-    "sequence": 253,
+    "sequence": 254,
     "domain": "project",
     "apiId": "PROJECT-004",
     "endpoint": "/api/v1/projects/{projectId}/members",
@@ -3036,7 +3048,7 @@
     "operationId": null
   },
   {
-    "sequence": 254,
+    "sequence": 255,
     "domain": "project",
     "apiId": "PROJECT-005",
     "endpoint": "/api/v1/projects/{projectId}/members/{memberId}",
@@ -3048,7 +3060,7 @@
     "operationId": null
   },
   {
-    "sequence": 255,
+    "sequence": 256,
     "domain": "project",
     "apiId": "PROJECT-006",
     "endpoint": "/api/v1/projects/me/managed",
@@ -3060,7 +3072,7 @@
     "operationId": null
   },
   {
-    "sequence": 256,
+    "sequence": 257,
     "domain": "project",
     "apiId": "PROJECT-007",
     "endpoint": "/api/v1/projects/members",
@@ -3072,7 +3084,7 @@
     "operationId": null
   },
   {
-    "sequence": 257,
+    "sequence": 258,
     "domain": "project",
     "apiId": "PROJECT-101",
     "endpoint": "/api/v1/projects",
@@ -3084,7 +3096,7 @@
     "operationId": null
   },
   {
-    "sequence": 258,
+    "sequence": 259,
     "domain": "project",
     "apiId": "PROJECT-102",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3096,7 +3108,7 @@
     "operationId": null
   },
   {
-    "sequence": 259,
+    "sequence": 260,
     "domain": "project",
     "apiId": "PROJECT-103",
     "endpoint": "/api/v1/projects/me/draft",
@@ -3108,7 +3120,7 @@
     "operationId": null
   },
   {
-    "sequence": 260,
+    "sequence": 261,
     "domain": "project",
     "apiId": "PROJECT-104",
     "endpoint": "/api/v1/projects/{projectId}/transfer-ownership",
@@ -3120,7 +3132,7 @@
     "operationId": null
   },
   {
-    "sequence": 261,
+    "sequence": 262,
     "domain": "project",
     "apiId": "PROJECT-105",
     "endpoint": "/api/v1/projects/{projectId}/part-quotas",
@@ -3132,7 +3144,7 @@
     "operationId": null
   },
   {
-    "sequence": 262,
+    "sequence": 263,
     "domain": "project",
     "apiId": "PROJECT-106",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -3144,7 +3156,7 @@
     "operationId": null
   },
   {
-    "sequence": 263,
+    "sequence": 264,
     "domain": "project",
     "apiId": "PROJECT-106-GET",
     "endpoint": "/api/v1/projects/{projectId}/application-form",
@@ -3156,7 +3168,7 @@
     "operationId": null
   },
   {
-    "sequence": 264,
+    "sequence": 265,
     "domain": "project",
     "apiId": "PROJECT-107",
     "endpoint": "/api/v1/projects/{projectId}/submit",
@@ -3168,7 +3180,7 @@
     "operationId": null
   },
   {
-    "sequence": 265,
+    "sequence": 266,
     "domain": "project",
     "apiId": "PROJECT-108",
     "endpoint": "/api/v1/projects/{projectId}/publish",
@@ -3180,7 +3192,7 @@
     "operationId": null
   },
   {
-    "sequence": 266,
+    "sequence": 267,
     "domain": "project",
     "apiId": "PROJECT-109",
     "endpoint": "/api/v1/projects/{projectId}",
@@ -3192,7 +3204,7 @@
     "operationId": null
   },
   {
-    "sequence": 267,
+    "sequence": 268,
     "domain": "project",
     "apiId": "PROJECT-110",
     "endpoint": "/api/v1/projects/{projectId}/abort",
@@ -3204,7 +3216,7 @@
     "operationId": null
   },
   {
-    "sequence": 268,
+    "sequence": 269,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-001",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -3216,7 +3228,7 @@
     "operationId": null
   },
   {
-    "sequence": 269,
+    "sequence": 270,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-101",
     "endpoint": "/api/v1/project/matching-rounds",
@@ -3228,7 +3240,7 @@
     "operationId": null
   },
   {
-    "sequence": 270,
+    "sequence": 271,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-102",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -3240,7 +3252,7 @@
     "operationId": null
   },
   {
-    "sequence": 271,
+    "sequence": 272,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-103",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}",
@@ -3252,7 +3264,7 @@
     "operationId": null
   },
   {
-    "sequence": 272,
+    "sequence": 273,
     "domain": "project",
     "apiId": "PROJECT-MATCHING-201",
     "endpoint": "/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide",
@@ -3264,7 +3276,7 @@
     "operationId": null
   },
   {
-    "sequence": 273,
+    "sequence": 274,
     "domain": "project",
     "apiId": "PROJECT-STAT-001",
     "endpoint": "/api/v1/projects/{projectId}/statistics",
@@ -3276,7 +3288,7 @@
     "operationId": null
   },
   {
-    "sequence": 274,
+    "sequence": 275,
     "domain": "project",
     "apiId": "PROJECT-STAT-002",
     "endpoint": "/api/v1/projects/statistics",
@@ -3288,7 +3300,7 @@
     "operationId": null
   },
   {
-    "sequence": 275,
+    "sequence": 276,
     "domain": "schedule",
     "apiId": "SCHEDULE-C001",
     "endpoint": "/api/v2/schedules",
@@ -3300,7 +3312,7 @@
     "operationId": null
   },
   {
-    "sequence": 276,
+    "sequence": 277,
     "domain": "schedule",
     "apiId": "SCHEDULE-C002",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3312,7 +3324,7 @@
     "operationId": null
   },
   {
-    "sequence": 277,
+    "sequence": 278,
     "domain": "schedule",
     "apiId": "SCHEDULE-C003",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/request",
@@ -3324,7 +3336,7 @@
     "operationId": null
   },
   {
-    "sequence": 278,
+    "sequence": 279,
     "domain": "schedule",
     "apiId": "SCHEDULE-C004",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/excuse",
@@ -3336,7 +3348,7 @@
     "operationId": null
   },
   {
-    "sequence": 279,
+    "sequence": 280,
     "domain": "schedule",
     "apiId": "SCHEDULE-C005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendances/decide",
@@ -3348,7 +3360,7 @@
     "operationId": null
   },
   {
-    "sequence": 280,
+    "sequence": 281,
     "domain": "schedule",
     "apiId": "SCHEDULE-C006",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3360,7 +3372,7 @@
     "operationId": null
   },
   {
-    "sequence": 281,
+    "sequence": 282,
     "domain": "schedule",
     "apiId": "SCHEDULE-C007",
     "endpoint": "/api/v2/schedules/{scheduleId}/force",
@@ -3372,7 +3384,7 @@
     "operationId": null
   },
   {
-    "sequence": 282,
+    "sequence": 283,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q001",
     "endpoint": "/api/v2/schedules/capabilities",
@@ -3384,7 +3396,7 @@
     "operationId": null
   },
   {
-    "sequence": 283,
+    "sequence": 284,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q002",
     "endpoint": "/api/v2/schedules/me",
@@ -3396,7 +3408,7 @@
     "operationId": null
   },
   {
-    "sequence": 284,
+    "sequence": 285,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q003",
     "endpoint": "/api/v2/schedules/{scheduleId}",
@@ -3408,7 +3420,7 @@
     "operationId": null
   },
   {
-    "sequence": 285,
+    "sequence": 286,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q004",
     "endpoint": "/api/v2/schedules/attendance",
@@ -3420,7 +3432,7 @@
     "operationId": null
   },
   {
-    "sequence": 286,
+    "sequence": 287,
     "domain": "schedule",
     "apiId": "SCHEDULE-Q005",
     "endpoint": "/api/v2/schedules/{scheduleId}/attendance",
@@ -3432,7 +3444,7 @@
     "operationId": null
   },
   {
-    "sequence": 287,
+    "sequence": 288,
     "domain": "storage",
     "apiId": "STORAGE-001",
     "endpoint": "/api/v1/storage/prepare-upload",
@@ -3444,7 +3456,7 @@
     "operationId": null
   },
   {
-    "sequence": 288,
+    "sequence": 289,
     "domain": "storage",
     "apiId": "STORAGE-002",
     "endpoint": "/api/v1/storage/{fileId}/confirm",
@@ -3456,7 +3468,7 @@
     "operationId": null
   },
   {
-    "sequence": 289,
+    "sequence": 290,
     "domain": "storage",
     "apiId": "STORAGE-003",
     "endpoint": "/api/v1/storage/{fileId}",
@@ -3468,7 +3480,7 @@
     "operationId": null
   },
   {
-    "sequence": 290,
+    "sequence": 291,
     "domain": "term",
     "apiId": "TERM-001",
     "endpoint": "/api/v1/terms",
@@ -3480,7 +3492,7 @@
     "operationId": null
   },
   {
-    "sequence": 291,
+    "sequence": 292,
     "domain": "term",
     "apiId": "TERM-101",
     "endpoint": "/api/v1/terms/type/{termType}",
@@ -3492,7 +3504,7 @@
     "operationId": null
   },
   {
-    "sequence": 292,
+    "sequence": 293,
     "domain": "term",
     "apiId": "TERM-102",
     "endpoint": "/api/v1/terms/{termsId}",
@@ -3504,7 +3516,7 @@
     "operationId": null
   },
   {
-    "sequence": 293,
+    "sequence": 294,
     "domain": "term",
     "apiId": "TERM-103",
     "endpoint": "/api/v1/terms/consent-status/me",
@@ -3516,7 +3528,7 @@
     "operationId": null
   },
   {
-    "sequence": 294,
+    "sequence": 295,
     "domain": "term",
     "apiId": "TERM-104",
     "endpoint": "/api/v1/terms",
@@ -3528,7 +3540,7 @@
     "operationId": null
   },
   {
-    "sequence": 295,
+    "sequence": 296,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/email/send-test",
@@ -3540,7 +3552,7 @@
     "operationId": null
   },
   {
-    "sequence": 296,
+    "sequence": 297,
     "domain": "test",
     "apiId": "<미지정>",
     "endpoint": "/test/log-test",
@@ -3552,7 +3564,7 @@
     "operationId": null
   },
   {
-    "sequence": 297,
+    "sequence": 298,
     "domain": "test",
     "apiId": "SEED-001",
     "endpoint": "/test/seed/members",
@@ -3564,7 +3576,7 @@
     "operationId": "SEED-001"
   },
   {
-    "sequence": 298,
+    "sequence": 299,
     "domain": "test",
     "apiId": "SEED-001-M",
     "endpoint": "/test/seed/member",
@@ -3576,7 +3588,7 @@
     "operationId": "SEED-001-M"
   },
   {
-    "sequence": 299,
+    "sequence": 300,
     "domain": "test",
     "apiId": "SEED-002",
     "endpoint": "/test/seed/challengers",
@@ -3588,7 +3600,7 @@
     "operationId": "SEED-002"
   },
   {
-    "sequence": 300,
+    "sequence": 301,
     "domain": "test",
     "apiId": "SEED-002-C",
     "endpoint": "/test/seed/challenger",
@@ -3600,7 +3612,7 @@
     "operationId": "SEED-002-C"
   },
   {
-    "sequence": 301,
+    "sequence": 302,
     "domain": "test",
     "apiId": "SEED-002-R",
     "endpoint": "/test/seed/challenger-role",
@@ -3612,7 +3624,7 @@
     "operationId": "SEED-002-R"
   },
   {
-    "sequence": 302,
+    "sequence": 303,
     "domain": "test",
     "apiId": "SEED-003",
     "endpoint": "/test/seed/projects",
@@ -3624,7 +3636,7 @@
     "operationId": "SEED-003"
   },
   {
-    "sequence": 303,
+    "sequence": 304,
     "domain": "test",
     "apiId": "SEED-003-D",
     "endpoint": "/test/seed/projects",
@@ -3636,7 +3648,7 @@
     "operationId": "SEED-003-D"
   },
   {
-    "sequence": 304,
+    "sequence": 305,
     "domain": "test",
     "apiId": "SEED-003-S",
     "endpoint": "/test/seed/projects/scenarios",
@@ -3648,7 +3660,7 @@
     "operationId": "SEED-003-S"
   },
   {
-    "sequence": 305,
+    "sequence": 306,
     "domain": "test",
     "apiId": "SEED-004",
     "endpoint": "/test/seed/curriculum",
@@ -3660,7 +3672,7 @@
     "operationId": "SEED-004"
   },
   {
-    "sequence": 306,
+    "sequence": 307,
     "domain": "test",
     "apiId": "SEED-005",
     "endpoint": "/test/seed/notice",
@@ -3672,7 +3684,7 @@
     "operationId": "SEED-005"
   },
   {
-    "sequence": 307,
+    "sequence": 308,
     "domain": "test",
     "apiId": "SEED-006",
     "endpoint": "/test/seed/project-applications",
@@ -3684,7 +3696,7 @@
     "operationId": null
   },
   {
-    "sequence": 308,
+    "sequence": 309,
     "domain": "test",
     "apiId": "TEST-001",
     "endpoint": "/test/file/{fileId}",
@@ -3696,7 +3708,7 @@
     "operationId": "TEST-001"
   },
   {
-    "sequence": 309,
+    "sequence": 310,
     "domain": "test",
     "apiId": "TEST-002",
     "endpoint": "/test/fcm/test-send",
@@ -3708,7 +3720,7 @@
     "operationId": "TEST-002"
   },
   {
-    "sequence": 310,
+    "sequence": 311,
     "domain": "test",
     "apiId": "TEST-003",
     "endpoint": "/test/webhook/aop-test",
@@ -3720,7 +3732,7 @@
     "operationId": "TEST-003"
   },
   {
-    "sequence": 311,
+    "sequence": 312,
     "domain": "test",
     "apiId": "TEST-004",
     "endpoint": "/test/webhook/alarm",
@@ -3732,7 +3744,7 @@
     "operationId": "TEST-004"
   },
   {
-    "sequence": 312,
+    "sequence": 313,
     "domain": "test",
     "apiId": "TEST-005",
     "endpoint": "/test/webhook/alarm/buffer",
@@ -3744,7 +3756,7 @@
     "operationId": "TEST-005"
   },
   {
-    "sequence": 313,
+    "sequence": 314,
     "domain": "test",
     "apiId": "TEST-006",
     "endpoint": "/test/apple-client-secret",
@@ -3756,7 +3768,7 @@
     "operationId": "TEST-006"
   },
   {
-    "sequence": 314,
+    "sequence": 315,
     "domain": "test",
     "apiId": "TEST-007",
     "endpoint": "/test/token/access",
@@ -3768,7 +3780,7 @@
     "operationId": "TEST-007"
   },
   {
-    "sequence": 315,
+    "sequence": 316,
     "domain": "test",
     "apiId": "TEST-008",
     "endpoint": "/test/token/refresh",
@@ -3780,7 +3792,7 @@
     "operationId": "TEST-008"
   },
   {
-    "sequence": 316,
+    "sequence": 317,
     "domain": "test",
     "apiId": "TEST-009",
     "endpoint": "/test/token/email",
@@ -3792,7 +3804,7 @@
     "operationId": "TEST-009"
   },
   {
-    "sequence": 317,
+    "sequence": 318,
     "domain": "test",
     "apiId": "TEST-010",
     "endpoint": "/test/token/oauth",
@@ -3804,7 +3816,7 @@
     "operationId": "TEST-010"
   },
   {
-    "sequence": 318,
+    "sequence": 319,
     "domain": "test",
     "apiId": "TEST-011",
     "endpoint": "/test/health-check",
@@ -3816,7 +3828,7 @@
     "operationId": "TEST-011"
   },
   {
-    "sequence": 319,
+    "sequence": 320,
     "domain": "test",
     "apiId": "TEST-012",
     "endpoint": "/test/check-authenticated",

--- a/src/main/resources/static/docs/catalog/api/catalog.md
+++ b/src/main/resources/static/docs/catalog/api/catalog.md
@@ -34,9 +34,9 @@
 | 14 | authentication | CREDENTIAL-003 | PATCH | `/api/v1/auth/password` | 비밀번호 변경 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:60` |
 | 15 | authentication | CREDENTIAL-005 | GET | `/api/v1/auth/email/availability` | 이메일 사용 가능 여부 조회 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:89` |
 | 16 | authentication | CREDENTIAL-007 | PATCH | `/api/v1/auth/password/reset` | 비밀번호 초기화 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/CredentialAuthenticationController.java:73` |
-| 17 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:34` |
-| 18 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:60` |
-| 19 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:85` |
+| 17 | authentication | EMAIL-001 | POST | `/api/v1/auth/email-verification/code` | 6자리 인증코드로 이메일 인증 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:36` |
+| 18 | authentication | EMAIL-002 | POST | `/api/v1/auth/email-verification` | 이메일 인증 코드 발송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:62` |
+| 19 | authentication | EMAIL-003 | POST | `/api/v1/auth/email-verification/resend` | 이메일 인증 코드 재전송 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/EmailAuthenticationController.java:87` |
 | 20 | authentication | LOGIN-001 | POST | `/api/v1/auth/login/google` | Google 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:14` |
 | 21 | authentication | LOGIN-005 | POST | `/api/v1/auth/login/kakao` | Kakao 로그인 | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:32` |
 | 22 | authentication | LOGIN-006 | POST | `/api/v1/auth/login/kakao/code` | Kakao 로그인 (Authorization Code 흐름) | X | `src/main/java/com/umc/product/authentication/adapter/in/web/swagger/AuthenticationControllerInterface.java:50` |
@@ -224,207 +224,208 @@
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 157 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:130` |
-| 158 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:144` |
-| 159 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:158` |
-| 160 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:171` |
-| 161 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
-| 162 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
-| 163 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
-| 164 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
-| 165 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
-| 166 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:61` |
-| 167 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:103` |
+| 157 | member | MEMBER-001 | PATCH | `/api/v1/member` | 내 회원 정보 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:134` |
+| 158 | member | MEMBER-002 | PATCH | `/api/v1/member/profile/links` | 내 회원 프로필 링크 수정 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:167` |
+| 159 | member | MEMBER-003 | DELETE | `/api/v1/member` | 회원 탈퇴 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:181` |
+| 160 | member | MEMBER-004 | DELETE | `/api/v1/member/{memberId}` | 관리자 권한으로 회원 게정 삭제 (Hard Delete) | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:194` |
+| 161 | member | MEMBER-005 | PATCH | `/api/v1/member/email` | 내 이메일 변경 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:148` |
+| 162 | member | MEMBER-101 | GET | `/api/v1/member/profile/{memberId}` | memberId로 회원 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:32` |
+| 163 | member | MEMBER-102 | GET | `/api/v1/member/me` | 내 프로필 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:44` |
+| 164 | member | MEMBER-103 | GET | `/api/v1/member/search` | 회원 검색 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java:50` |
+| 165 | member | MEMBER-201 | GET | `/api/v2/member/me` | 내 종합 정보 조회 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:39` |
+| 166 | member | MEMBER-202 | GET | `/api/v2/member/search` | 회원 검색 v2 | X | `src/main/java/com/umc/product/member/adapter/in/web/v2/MemberQueryV2Controller.java:62` |
+| 167 | member | REGISTER-001 | POST | `/api/v1/member/register` | OAuth 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:65` |
+| 168 | member | REGISTER-003 | POST | `/api/v1/member/register/email` | 이메일/PW 이용 회원가입 | X | `src/main/java/com/umc/product/member/adapter/in/web/MemberCommandController.java:107` |
 
 ## notice
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 168 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
-| 169 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
-| 170 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
-| 171 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
-| 172 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
-| 173 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
-| 174 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
-| 175 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
-| 176 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
-| 177 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
-| 178 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
-| 179 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
-| 180 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
-| 181 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
-| 182 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
-| 183 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
-| 184 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
-| 185 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
+| 169 | notice | NOTICE-001 | GET | `/api/v1/notices` | 공지사항 전체 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:31` |
+| 170 | notice | NOTICE-002 | GET | `/api/v1/notices/search` | 공지사항 검색 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:79` |
+| 171 | notice | NOTICE-003 | GET | `/api/v1/notices/{noticeId}` | 공지사항 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:110` |
+| 172 | notice | NOTICE-004 | GET | `/api/v1/notices/{noticeId}/read-statics` | 공지사항 읽음 통계 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:134` |
+| 173 | notice | NOTICE-005 | GET | `/api/v1/notices/{noticeId}/read-status` | 공지사항 읽음 현황 상세 조회 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeQueryApi.java:143` |
+| 174 | notice | NOTICE-101 | POST | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:23` |
+| 175 | notice | NOTICE-102 | POST | `/api/v1/notices/{noticeId}/links` | 첫 공지 생성 시 공지사항 링크를 추가하는 API입니다. | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:36` |
+| 176 | notice | NOTICE-103 | POST | `/api/v1/notices/{noticeId}/votes` | 공지사항 투표 추가 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:48` |
+| 177 | notice | NOTICE-104 | PATCH | `/api/v1/notices/{noticeId}/images` | 공지사항 이미지 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:61` |
+| 178 | notice | NOTICE-105 | PATCH | `/api/v1/notices/{noticeId}/links` | 공지사항 링크 전체 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:74` |
+| 179 | notice | NOTICE-106 | DELETE | `/api/v1/notices/{noticeId}/vote` | 공지사항 투표 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeContentApi.java:87` |
+| 180 | notice | NOTICE-201 | POST | `/api/v1/notices` | 공지사항 생성 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:21` |
+| 181 | notice | NOTICE-202 | DELETE | `/api/v1/notices/{noticeId}` | 공지사항 삭제 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:71` |
+| 182 | notice | NOTICE-203 | PATCH | `/api/v1/notices/{noticeId}` | 공지사항 수정 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:93` |
+| 183 | notice | NOTICE-204 | POST | `/api/v1/notices/{noticeId}/reminders` | 공지사항 리마인더 발송 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:122` |
+| 184 | notice | NOTICE-205 | POST | `/api/v1/notices/{noticeId}/read` | 공지사항 읽음 처리 | X | `src/main/java/com/umc/product/notice/adapter/in/web/swagger/NoticeCommandControllerApi.java:152` |
+| 185 | notice | NOTICE-VOTE-001 | POST | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 제출 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:30` |
+| 186 | notice | NOTICE-VOTE-002 | PUT | `/api/v1/notices/{noticeId}/votes/responses` | 공지사항 투표 응답 수정/취소 | X | `src/main/java/com/umc/product/notice/adapter/in/web/NoticeVoteResponseController.java:50` |
 
 ## notification
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 186 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
-| 187 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
+| 187 | notification | FCM-001 | PUT | `/api/v1/notification/fcm/token` | FCM 토큰 등록 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:15` |
+| 188 | notification | FCM-002 | DELETE | `/api/v1/notification/fcm/topics/legacy` | Legacy 토픽 구독 해제 | X | `src/main/java/com/umc/product/notification/adapter/in/web/swagger/FcmControllerApi.java:30` |
 
 ## organization
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 188 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
-| 189 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
-| 190 | organization | <미지정> | GET | `/api/v1/umc-product/functional-units` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java:24` |
-| 191 | organization | <미지정> | POST | `/api/v1/umc-product/functional-units` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:29` |
-| 192 | organization | <미지정> | PATCH | `/api/v1/umc-product/functional-units/{functionalUnitId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:37` |
-| 193 | organization | <미지정> | DELETE | `/api/v1/umc-product/functional-units/{functionalUnitId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:48` |
-| 194 | organization | <미지정> | GET | `/api/v1/umc-product/generations` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:24` |
-| 195 | organization | <미지정> | POST | `/api/v1/umc-product/generations` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:29` |
-| 196 | organization | <미지정> | GET | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:29` |
-| 197 | organization | <미지정> | PATCH | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:37` |
-| 198 | organization | <미지정> | DELETE | `/api/v1/umc-product/generations/{umcProductGenerationId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:48` |
-| 199 | organization | <미지정> | GET | `/api/v1/umc-product/members` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:31` |
-| 200 | organization | <미지정> | POST | `/api/v1/umc-product/members` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:31` |
-| 201 | organization | <미지정> | GET | `/api/v1/umc-product/members/{umcProductMemberId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:56` |
-| 202 | organization | <미지정> | DELETE | `/api/v1/umc-product/members/{umcProductMemberId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:61` |
-| 203 | organization | <미지정> | PUT | `/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:50` |
-| 204 | organization | <미지정> | PATCH | `/api/v1/umc-product/members/{umcProductMemberId}/profile` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:39` |
-| 205 | organization | <미지정> | GET | `/api/v1/umc-product/organization-chart` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java:23` |
-| 206 | organization | <미지정> | GET | `/api/v1/umc-product/squads` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java:23` |
-| 207 | organization | <미지정> | POST | `/api/v1/umc-product/squads` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:31` |
-| 208 | organization | <미지정> | PATCH | `/api/v1/umc-product/squads/{squadId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:39` |
-| 209 | organization | <미지정> | DELETE | `/api/v1/umc-product/squads/{squadId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:48` |
-| 210 | organization | <미지정> | PUT | `/api/v1/umc-product/squads/{squadId}/participants` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:56` |
-| 211 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
-| 212 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
-| 213 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
-| 214 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
-| 215 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
-| 216 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
-| 217 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
-| 218 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
-| 219 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
-| 220 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
-| 221 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
-| 222 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
-| 223 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
-| 224 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
-| 225 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
-| 226 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
-| 227 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
-| 228 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
-| 229 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
-| 230 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
-| 231 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
-| 232 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
-| 233 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
-| 234 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
-| 235 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
-| 236 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
-| 237 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
-| 238 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
-| 239 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
-| 240 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
-| 241 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 189 | organization | <미지정> | GET | `/api/v1/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/GisuQueryController.java:28` |
+| 190 | organization | <미지정> | GET | `/api/v1/schools/gisu/{gisuId}` | <요약 없음> | X | `src/main/java/com/umc/product/organization/adapter/in/web/SchoolQueryController.java:36` |
+| 191 | organization | CHAPTER-001 | POST | `/api/v1/chapters` | 지부 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:16` |
+| 192 | organization | CHAPTER-002 | POST | `/api/v1/chapters/bulk` | 지부 일괄 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:25` |
+| 193 | organization | CHAPTER-003 | DELETE | `/api/v1/chapters/{chapterId}` | 지부 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminChapterControllerApi.java:28` |
+| 194 | organization | CHAPTER-101 | GET | `/api/v1/chapters` | 지부 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:18` |
+| 195 | organization | CHAPTER-102 | GET | `/api/v1/chapters/with-schools` | 기수별 지부 및 소속 학교 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:29` |
+| 196 | organization | CHAPTER-103 | GET | `/api/v1/chapters/{chapterId}` | 지부 ID로 지부 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/ChapterQueryControllerApi.java:41` |
+| 197 | organization | GISU-001 | POST | `/api/v1/gisu` | 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:13` |
+| 198 | organization | GISU-002 | DELETE | `/api/v1/gisu/{gisuId}` | 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:20` |
+| 199 | organization | GISU-003 | POST | `/api/v1/gisu/{gisuId}/active` | 활성 기수 변경 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java:28` |
+| 200 | organization | GISU-101 | GET | `/api/v1/gisu` | 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:25` |
+| 201 | organization | GISU-102 | GET | `/api/v1/gisu/all` | 기수 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:35` |
+| 202 | organization | GISU-103 | GET | `/api/v1/gisu/active` | 활성화된 기수 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuQueryControllerApi.java:46` |
+| 203 | organization | SCHOOL-001 | POST | `/api/v1/schools` | 학교 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:17` |
+| 204 | organization | SCHOOL-002 | PATCH | `/api/v1/schools/{schoolId}` | 학교 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:25` |
+| 205 | organization | SCHOOL-003 | DELETE | `/api/v1/schools` | 학교 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:35` |
+| 206 | organization | SCHOOL-004 | PATCH | `/api/v1/schools/{schoolId}/assign` | 학교 지부 배정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:42` |
+| 207 | organization | SCHOOL-005 | PATCH | `/api/v1/schools/{schoolId}/unassign` | 학교 지부 배정 해제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminSchoolControllerApi.java:53` |
+| 208 | organization | SCHOOL-101 | GET | `/api/v1/schools/all` | 학교 전체 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:18` |
+| 209 | organization | SCHOOL-102 | GET | `/api/v1/schools/{schoolId}` | 학교 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:28` |
+| 210 | organization | SCHOOL-103 | GET | `/api/v1/schools/unassigned` | 배정 대기 중인 학교 목록 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:41` |
+| 211 | organization | SCHOOL-104 | GET | `/api/v1/schools/link/{schoolId}` | 학교 링크 조회 | O | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/SchoolQueryControllerApi.java:53` |
+| 212 | organization | STUDY-GROUP-001 | POST | `/api/v1/study-groups` | 스터디 그룹 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:15` |
+| 213 | organization | STUDY-GROUP-002 | PATCH | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 수정 (이름만 가능) | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:29` |
+| 214 | organization | STUDY-GROUP-003 | PATCH | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:38` |
+| 215 | organization | STUDY-GROUP-004 | PATCH | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 추가 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:44` |
+| 216 | organization | STUDY-GROUP-005 | DELETE | `/api/v1/study-groups/{studyGroupId}/members/{memberId}` | 스터디 그룹에 스터디원 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:50` |
+| 217 | organization | STUDY-GROUP-006 | DELETE | `/api/v1/study-groups/{studyGroupId}/mentors/{mentorId}` | 스터디 그룹에 담당 파트장 제거 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:56` |
+| 218 | organization | STUDY-GROUP-007 | DELETE | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupCommandControllerApi.java:62` |
+| 219 | organization | STUDY-GROUP-101 | GET | `/api/v1/study-groups/managed` | 내가 관리하는 스터디 그룹 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:34` |
+| 220 | organization | STUDY-GROUP-102 | GET | `/api/v1/study-groups/{studyGroupId}` | 스터디 그룹 정보 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupQueryControllerApi.java:43` |
+| 221 | organization | STUDY-GROUP-SCHEDULE-001 | POST | `/api/v1/study-groups/schedules` | 스터디 그룹 일정 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/swagger/StudyGroupScheduleControllerApi.java:12` |
+| 222 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-001 | POST | `/api/v1/umc-product/functional-units` | UMC PRODUCT 기능 조직 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:32` |
+| 223 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-002 | PATCH | `/api/v1/umc-product/functional-units/{functionalUnitId}` | UMC PRODUCT 기능 조직 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:45` |
+| 224 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-003 | DELETE | `/api/v1/umc-product/functional-units/{functionalUnitId}` | UMC PRODUCT 기능 조직 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitCommandController.java:61` |
+| 225 | organization | UMC-PRODUCT-FUNCTIONAL-UNIT-101 | GET | `/api/v1/umc-product/functional-units` | UMC PRODUCT 기능 조직 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductFunctionalUnitQueryController.java:27` |
+| 226 | organization | UMC-PRODUCT-GENERATION-001 | POST | `/api/v1/umc-product/generations` | UMC PRODUCT 기수 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:32` |
+| 227 | organization | UMC-PRODUCT-GENERATION-002 | PATCH | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:45` |
+| 228 | organization | UMC-PRODUCT-GENERATION-003 | DELETE | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationCommandController.java:61` |
+| 229 | organization | UMC-PRODUCT-GENERATION-101 | GET | `/api/v1/umc-product/generations` | UMC PRODUCT 기수 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:27` |
+| 230 | organization | UMC-PRODUCT-GENERATION-102 | GET | `/api/v1/umc-product/generations/{umcProductGenerationId}` | UMC PRODUCT 기수 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductGenerationQueryController.java:37` |
+| 231 | organization | UMC-PRODUCT-MEMBER-001 | POST | `/api/v1/umc-product/members` | UMC PRODUCT 멤버 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:34` |
+| 232 | organization | UMC-PRODUCT-MEMBER-002 | PATCH | `/api/v1/umc-product/members/{umcProductMemberId}/profile` | UMC PRODUCT 멤버 프로필 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:47` |
+| 233 | organization | UMC-PRODUCT-MEMBER-003 | PUT | `/api/v1/umc-product/members/{umcProductMemberId}/functional-memberships` | UMC PRODUCT 멤버 기능 조직 소속 교체 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:63` |
+| 234 | organization | UMC-PRODUCT-MEMBER-004 | DELETE | `/api/v1/umc-product/members/{umcProductMemberId}` | UMC PRODUCT 멤버 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberCommandController.java:79` |
+| 235 | organization | UMC-PRODUCT-MEMBER-101 | GET | `/api/v1/umc-product/members` | UMC PRODUCT 멤버 검색 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:34` |
+| 236 | organization | UMC-PRODUCT-MEMBER-102 | GET | `/api/v1/umc-product/members/{umcProductMemberId}` | UMC PRODUCT 멤버 상세 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductMemberQueryController.java:64` |
+| 237 | organization | UMC-PRODUCT-ORGANIZATION-CHART-101 | GET | `/api/v1/umc-product/organization-chart` | UMC PRODUCT 조직도 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductOrganizationChartQueryController.java:26` |
+| 238 | organization | UMC-PRODUCT-SQUAD-001 | POST | `/api/v1/umc-product/squads` | UMC PRODUCT 스쿼드 생성 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:34` |
+| 239 | organization | UMC-PRODUCT-SQUAD-002 | PATCH | `/api/v1/umc-product/squads/{squadId}` | UMC PRODUCT 스쿼드 수정 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:47` |
+| 240 | organization | UMC-PRODUCT-SQUAD-003 | DELETE | `/api/v1/umc-product/squads/{squadId}` | UMC PRODUCT 스쿼드 삭제 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:61` |
+| 241 | organization | UMC-PRODUCT-SQUAD-004 | PUT | `/api/v1/umc-product/squads/{squadId}/participants` | UMC PRODUCT 스쿼드 참여자 교체 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadCommandController.java:74` |
+| 242 | organization | UMC-PRODUCT-SQUAD-101 | GET | `/api/v1/umc-product/squads` | UMC PRODUCT 스쿼드 목록 조회 | X | `src/main/java/com/umc/product/organization/adapter/in/web/UmcProductSquadQueryController.java:26` |
 
 ## project
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 242 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:48` |
-| 243 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:71` |
-| 244 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:94` |
-| 245 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:40` |
-| 246 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:148` |
-| 247 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:79` |
-| 248 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:130` |
-| 249 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:119` |
-| 250 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
-| 251 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
-| 252 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
-| 253 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:144` |
-| 254 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:246` |
-| 255 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
-| 256 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
-| 257 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:64` |
-| 258 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:83` |
-| 259 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
-| 260 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:124` |
-| 261 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:186` |
-| 262 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:37` |
-| 263 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:58` |
-| 264 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:104` |
-| 265 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:164` |
-| 266 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:206` |
-| 267 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:227` |
-| 268 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
-| 269 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
-| 270 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
-| 271 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
-| 272 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
-| 273 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:32` |
-| 274 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:58` |
+| 243 | project | APPLY-001 | POST | `/api/v1/projects/{projectId}/applications` | 챌린저 지원서 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:48` |
+| 244 | project | APPLY-002 | PUT | `/api/v1/projects/{projectId}/applications/me` | 챌린저 지원서 임시저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:71` |
+| 245 | project | APPLY-003 | POST | `/api/v1/projects/{projectId}/applications/me/submit` | 챌린저 지원서 최종 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:94` |
+| 246 | project | APPLY-004 | GET | `/api/v1/projects/me/applications` | 본인 지원 내역 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:40` |
+| 247 | project | APPLY-005 | DELETE | `/api/v1/projects/{projectId}/applications/{applicationId}` | 챌린저 지원서 철회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:148` |
+| 248 | project | APPLY-101 | GET | `/api/v1/projects/{projectId}/applications` | PM/운영진 단일 프로젝트 지원자 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:79` |
+| 249 | project | APPLY-102 | GET | `/api/v1/projects/{projectId}/applications/{applicationId}` | 지원서 단건 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java:130` |
+| 250 | project | APPLY-103 | PATCH | `/api/v1/projects/{projectId}/applications/{applicationId}/decision` | 지원서 합/불 결정 (단일 PATCH) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java:119` |
+| 251 | project | PROJECT-001 | GET | `/api/v1/projects` | 프로젝트 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:46` |
+| 252 | project | PROJECT-002 | GET | `/api/v1/projects/{projectId}` | 프로젝트 상세 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:65` |
+| 253 | project | PROJECT-003 | GET | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 구성 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:83` |
+| 254 | project | PROJECT-004 | POST | `/api/v1/projects/{projectId}/members` | 프로젝트 팀원 추가 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:144` |
+| 255 | project | PROJECT-005 | DELETE | `/api/v1/projects/{projectId}/members/{memberId}` | 프로젝트 팀원 제거 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:246` |
+| 256 | project | PROJECT-006 | GET | `/api/v1/projects/me/managed` | 내가 관리하는 프로젝트 목록 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:118` |
+| 257 | project | PROJECT-007 | GET | `/api/v1/projects/members` | 프로젝트 팀원 구성 일괄 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:101` |
+| 258 | project | PROJECT-101 | POST | `/api/v1/projects` | 프로젝트 Draft 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:64` |
+| 259 | project | PROJECT-102 | PATCH | `/api/v1/projects/{projectId}` | 프로젝트 기본정보 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:83` |
+| 260 | project | PROJECT-103 | GET | `/api/v1/projects/me/draft` | 내 Draft 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java:137` |
+| 261 | project | PROJECT-104 | POST | `/api/v1/projects/{projectId}/transfer-ownership` | 프로젝트 소유권 양도 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:124` |
+| 262 | project | PROJECT-105 | PUT | `/api/v1/projects/{projectId}/part-quotas` | 파트별 정원 일괄 갱신 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:186` |
+| 263 | project | PROJECT-106 | PUT | `/api/v1/projects/{projectId}/application-form` | 지원 폼 저장 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:37` |
+| 264 | project | PROJECT-106-GET | GET | `/api/v1/projects/{projectId}/application-form` | 지원 폼 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationFormController.java:58` |
+| 265 | project | PROJECT-107 | POST | `/api/v1/projects/{projectId}/submit` | 프로젝트 제출 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:104` |
+| 266 | project | PROJECT-108 | POST | `/api/v1/projects/{projectId}/publish` | 프로젝트 공개 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:164` |
+| 267 | project | PROJECT-109 | DELETE | `/api/v1/projects/{projectId}` | 프로젝트 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:206` |
+| 268 | project | PROJECT-110 | POST | `/api/v1/projects/{projectId}/abort` | 프로젝트 중단 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java:227` |
+| 269 | project | PROJECT-MATCHING-001 | GET | `/api/v1/project/matching-rounds` | 매칭 차수 목록 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:44` |
+| 270 | project | PROJECT-MATCHING-101 | POST | `/api/v1/project/matching-rounds` | 매칭 차수 생성 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:66` |
+| 271 | project | PROJECT-MATCHING-102 | PATCH | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 수정 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:87` |
+| 272 | project | PROJECT-MATCHING-103 | DELETE | `/api/v1/project/matching-rounds/{matchingRoundId}` | 매칭 차수 삭제 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:110` |
+| 273 | project | PROJECT-MATCHING-201 | POST | `/api/v1/project/matching-rounds/{matchingRoundId}/auto-decide` | 매칭 차수 자동 선발 실행 (운영진 수동 트리거) | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectMatchingRoundController.java:127` |
+| 274 | project | PROJECT-STAT-001 | GET | `/api/v1/projects/{projectId}/statistics` | 단건 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:32` |
+| 275 | project | PROJECT-STAT-002 | GET | `/api/v1/projects/statistics` | 지부 전체 프로젝트 지원/매칭 현황 조회 | X | `src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java:58` |
 
 ## schedule
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 275 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:62` |
-| 276 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:128` |
-| 277 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:266` |
-| 278 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:315` |
-| 279 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:362` |
-| 280 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:189` |
-| 281 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:230` |
-| 282 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:45` |
-| 283 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:69` |
-| 284 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:106` |
-| 285 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:146` |
-| 286 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:209` |
+| 276 | schedule | SCHEDULE-C001 | POST | `/api/v2/schedules` | 일정 생성 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:62` |
+| 277 | schedule | SCHEDULE-C002 | PATCH | `/api/v2/schedules/{scheduleId}` | 일정 수정 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:128` |
+| 278 | schedule | SCHEDULE-C003 | POST | `/api/v2/schedules/{scheduleId}/attendances/request` | 출석 요청하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:266` |
+| 279 | schedule | SCHEDULE-C004 | POST | `/api/v2/schedules/{scheduleId}/attendances/excuse` | 출석 요청이 불가능한 경우, 사유 제출하기 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:315` |
+| 280 | schedule | SCHEDULE-C005 | POST | `/api/v2/schedules/{scheduleId}/attendances/decide` | [운영진용] 출석 요청 승인/거절 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:362` |
+| 281 | schedule | SCHEDULE-C006 | DELETE | `/api/v2/schedules/{scheduleId}` | 일정 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:189` |
+| 282 | schedule | SCHEDULE-C007 | DELETE | `/api/v2/schedules/{scheduleId}/force` | 일정 강제 삭제 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleCommandV2Controller.java:230` |
+| 283 | schedule | SCHEDULE-Q001 | GET | `/api/v2/schedules/capabilities` | 일정 생성, 수정 관련 권한 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:45` |
+| 284 | schedule | SCHEDULE-Q002 | GET | `/api/v2/schedules/me` | 내 일정 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:69` |
+| 285 | schedule | SCHEDULE-Q003 | GET | `/api/v2/schedules/{scheduleId}` | 일정 상세 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:106` |
+| 286 | schedule | SCHEDULE-Q004 | GET | `/api/v2/schedules/attendance` | [운영진용] 일정들의 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:146` |
+| 287 | schedule | SCHEDULE-Q005 | GET | `/api/v2/schedules/{scheduleId}/attendance` | [운영진용] 단일 일정 출석 현황 조회 | X | `src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java:209` |
 
 ## storage
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 287 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:38` |
-| 288 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:60` |
-| 289 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:70` |
+| 288 | storage | STORAGE-001 | POST | `/api/v1/storage/prepare-upload` | 파일 업로드를 위한 Signed URL을 생성합니다. | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:38` |
+| 289 | storage | STORAGE-002 | POST | `/api/v1/storage/{fileId}/confirm` | 파일 업로드 완료 처리 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:60` |
+| 290 | storage | STORAGE-003 | DELETE | `/api/v1/storage/{fileId}` | 파일 삭제 | X | `src/main/java/com/umc/product/storage/adapter/in/web/StorageController.java:70` |
 
 ## term
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 290 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
-| 291 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
-| 292 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
-| 293 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
-| 294 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
+| 291 | term | TERM-001 | POST | `/api/v1/terms` | 약관 생성 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:71` |
+| 292 | term | TERM-101 | GET | `/api/v1/terms/type/{termType}` | 약관 유형으로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:50` |
+| 293 | term | TERM-102 | GET | `/api/v1/terms/{termsId}` | 약관 ID로 약관 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:57` |
+| 294 | term | TERM-103 | GET | `/api/v1/terms/consent-status/me` | 내 필수 약관 재동의 상태 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:63` |
+| 295 | term | TERM-104 | GET | `/api/v1/terms` | 활성 약관 전체 조회 | X | `src/main/java/com/umc/product/term/adapter/in/web/TermController.java:43` |
 
 ## test
 
 | 순번 | 도메인 | API ID | HTTP Method | Endpoint | 역할 | Deprecated | Source |
 |---:|---|---|---|---|---|:---:|---|
-| 295 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
-| 296 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
-| 297 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:81` |
-| 298 | test | SEED-001-M | POST | `/test/seed/member` | 테스트 멤버 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:97` |
-| 299 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:111` |
-| 300 | test | SEED-002-C | POST | `/test/seed/challenger` | 테스트 챌린저 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:126` |
-| 301 | test | SEED-002-R | POST | `/test/seed/challenger-role` | 테스트 챌린저 역할 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:138` |
-| 302 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:155` |
-| 303 | test | SEED-003-D | DELETE | `/test/seed/projects` | 프로젝트 시딩 데이터 삭제 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:171` |
-| 304 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:193` |
-| 305 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:215` |
-| 306 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:230` |
-| 307 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:249` |
-| 308 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
-| 309 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
-| 310 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
-| 311 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
-| 312 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
-| 313 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
-| 314 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
-| 315 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
-| 316 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
-| 317 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
-| 318 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
-| 319 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
+| 296 | test | <미지정> | POST | `/test/email/send-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:85` |
+| 297 | test | <미지정> | GET | `/test/log-test` | <요약 없음> | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:212` |
+| 298 | test | SEED-001 | POST | `/test/seed/members` | 더미 멤버 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:81` |
+| 299 | test | SEED-001-M | POST | `/test/seed/member` | 테스트 멤버 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:97` |
+| 300 | test | SEED-002 | POST | `/test/seed/challengers` | 챌린저 분포 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:111` |
+| 301 | test | SEED-002-C | POST | `/test/seed/challenger` | 테스트 챌린저 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:126` |
+| 302 | test | SEED-002-R | POST | `/test/seed/challenger-role` | 테스트 챌린저 역할 단건 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:138` |
+| 303 | test | SEED-003 | POST | `/test/seed/projects` | 프로젝트 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:155` |
+| 304 | test | SEED-003-D | DELETE | `/test/seed/projects` | 프로젝트 시딩 데이터 삭제 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:171` |
+| 305 | test | SEED-003-S | POST | `/test/seed/projects/scenarios` | 프로젝트 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:193` |
+| 306 | test | SEED-004 | POST | `/test/seed/curriculum` | Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:215` |
+| 307 | test | SEED-005 | POST | `/test/seed/notice` | Notice 시딩 (지부 · 학교 · 파트 분포) | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:230` |
+| 308 | test | SEED-006 | POST | `/test/seed/project-applications` | 지원서 시나리오 시딩 | X | `src/main/java/com/umc/product/test/adapter/in/web/SeedController.java:249` |
+| 309 | test | TEST-001 | GET | `/test/file/{fileId}` | [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:65` |
+| 310 | test | TEST-002 | POST | `/test/fcm/test-send` | FCM 푸시 알림 테스트 전송 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:77` |
+| 311 | test | TEST-003 | GET | `/test/webhook/aop-test` | AOP로 전송하는 알람 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:104` |
+| 312 | test | TEST-004 | POST | `/test/webhook/alarm` | 웹훅 알람 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:117` |
+| 313 | test | TEST-005 | POST | `/test/webhook/alarm/buffer` | 웹훅 알람 버퍼 전송 테스트 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:133` |
+| 314 | test | TEST-006 | GET | `/test/apple-client-secret` | Apple Client Secret 생성 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:154` |
+| 315 | test | TEST-007 | GET | `/test/token/access` | AccessToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:160` |
+| 316 | test | TEST-008 | GET | `/test/token/refresh` | RefreshToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:173` |
+| 317 | test | TEST-009 | GET | `/test/token/email` | EmailVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:180` |
+| 318 | test | TEST-010 | GET | `/test/token/oauth` | oAuthVerificationToken 발급 | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:190` |
+| 319 | test | TEST-011 | GET | `/test/health-check` | 헬스 체크 API | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:198` |
+| 320 | test | TEST-012 | GET | `/test/check-authenticated` | 인증된 사용자인지 여부를 확인합니다. | X | `src/main/java/com/umc/product/test/adapter/in/web/TestController.java:205` |
 

--- a/src/main/resources/static/docs/catalog/error/catalog.json
+++ b/src/main/resources/static/docs/catalog/error/catalog.json
@@ -523,7 +523,7 @@
     "constantName": "INVALID_SLUG",
     "httpStatus": "BAD_REQUEST",
     "code": "BLOG-0004",
-    "message": "주소 slug를 확인해주세요.",
+    "message": "주소는 영문 소문자, 숫자, 하이픈만 사용할 수 있어요.",
     "source": "src/main/java/com/umc/product/blog/domain/BlogErrorCode.java",
     "line": 16
   },

--- a/src/main/resources/static/docs/catalog/error/catalog.md
+++ b/src/main/resources/static/docs/catalog/error/catalog.md
@@ -70,7 +70,7 @@
 | 45 | blog | `BLOG-0001` | 404 NOT_FOUND | 글을 찾지 못했어요. 주소를 확인해주세요. | BlogErrorCode | `CONTENT_NOT_FOUND` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:13` |
 | 46 | blog | `BLOG-0002` | 404 NOT_FOUND | 댓글을 찾지 못했어요. 새로고침 후 다시 시도해주세요. | BlogErrorCode | `COMMENT_NOT_FOUND` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:14` |
 | 47 | blog | `BLOG-0003` | 400 BAD_REQUEST | 카테고리를 확인해주세요. | BlogErrorCode | `INVALID_CONTENT_TYPE` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:15` |
-| 48 | blog | `BLOG-0004` | 400 BAD_REQUEST | 주소 slug를 확인해주세요. | BlogErrorCode | `INVALID_SLUG` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:16` |
+| 48 | blog | `BLOG-0004` | 400 BAD_REQUEST | 주소는 영문 소문자, 숫자, 하이픈만 사용할 수 있어요. | BlogErrorCode | `INVALID_SLUG` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:16` |
 | 49 | blog | `BLOG-0005` | 400 BAD_REQUEST | ID는 1 이상이어야 해요. | BlogErrorCode | `INVALID_ID` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:17` |
 | 50 | blog | `BLOG-0006` | 400 BAD_REQUEST | 댓글은 1자 이상 1,000자 이하로 입력해주세요. | BlogErrorCode | `INVALID_COMMENT_CONTENT` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:18` |
 | 51 | blog | `BLOG-0007` | 400 BAD_REQUEST | 닉네임은 1자 이상 20자 이하로 입력해주세요. | BlogErrorCode | `INVALID_NICKNAME` | `src/main/java/com/umc/product/blog/domain/BlogErrorCode.java:19` |

--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -8,6 +8,17 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authentication.application.event.SendVerificationEmailEvent;
 import com.umc.product.authentication.application.port.in.command.dto.ValidateEmailVerificationSessionCommand;
 import com.umc.product.authentication.application.port.out.LoadEmailVerificationPort;
@@ -20,15 +31,6 @@ import com.umc.product.global.event.application.port.out.DomainEventPublisher;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.member.application.port.in.query.GetMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * AuthenticationService 단위 테스트.
@@ -143,6 +145,40 @@ class AuthenticationServiceTest {
             // then
             assertThat(sessionId).isEqualTo(SESSION_ID);
             then(eventPublisher).should().publish(any(SendVerificationEmailEvent.class));
+        }
+
+        @Test
+        @DisplayName("CHANGE_EMAIL + 미사용 이메일이면 세션을 저장하고 메일 발송 이벤트를 발행한다")
+        void changeEmailSessionCreated() {
+            // given
+            given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(false);
+            EmailVerification persisted = newSession(EmailVerificationPurpose.CHANGE_EMAIL);
+            ReflectionTestUtils.setField(persisted, "id", SESSION_ID);
+            given(saveEmailVerificationPort.save(any(EmailVerification.class))).willReturn(persisted);
+
+            // when
+            Long sessionId = service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.CHANGE_EMAIL);
+
+            // then
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            then(eventPublisher).should().publish(any(SendVerificationEmailEvent.class));
+        }
+
+        @Test
+        @DisplayName("CHANGE_EMAIL + 이미 사용 중인 이메일이면 EMAIL_ALREADY_EXISTS 예외, 저장/이벤트 발행 모두 차단")
+        void changeEmailDuplicateRejected() {
+            // given
+            given(getMemberCredentialUseCase.existsByEmail(EMAIL)).willReturn(true);
+
+            // when / then
+            assertThatThrownBy(() ->
+                service.createEmailVerificationSession(EMAIL, EmailVerificationPurpose.CHANGE_EMAIL))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(AuthenticationErrorCode.EMAIL_ALREADY_EXISTS);
+
+            then(saveEmailVerificationPort).should(never()).save(any());
+            then(eventPublisher).should(never()).publish(any(SendVerificationEmailEvent.class));
         }
 
         @Test

--- a/src/test/java/com/umc/product/global/security/JwtTokenProviderEmailVerificationTest.java
+++ b/src/test/java/com/umc/product/global/security/JwtTokenProviderEmailVerificationTest.java
@@ -3,17 +3,18 @@ package com.umc.product.global.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.umc.product.authentication.domain.EmailVerificationPurpose;
-import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
-import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+
 /**
  * JwtTokenProvider 의 emailVerificationToken purpose claim 검증 단위 테스트.
  * <p>
- * 회원가입(REGISTER) 흐름에서 발급된 토큰이 비밀번호 초기화(PASSWORD_RESET) 에 재사용되지
+ * 회원가입(REGISTER) 흐름에서 발급된 토큰이 비밀번호 초기화(PASSWORD_RESET) 나 이메일 변경(CHANGE_EMAIL) 에 재사용되지
  * 않도록, 발급 시 purpose 를 claim 으로 심고 파싱 시 expectedPurpose 와 일치해야만
  * 통과시키는 동작을 검증한다.
  */
@@ -69,6 +70,19 @@ class JwtTokenProviderEmailVerificationTest {
     }
 
     @Test
+    @DisplayName("CHANGE_EMAIL 로 발급한 토큰은 CHANGE_EMAIL 로 파싱 시 이메일을 반환한다")
+    void purposeMatchesChangeEmail() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.CHANGE_EMAIL);
+
+        // when
+        String parsedEmail = provider.parseEmailVerificationToken(token, EmailVerificationPurpose.CHANGE_EMAIL);
+
+        // then
+        assertThat(parsedEmail).isEqualTo(EMAIL);
+    }
+
+    @Test
     @DisplayName("REGISTER 토큰을 PASSWORD_RESET 로 파싱하면 INVALID_EMAIL_VERIFICATION 예외를 던진다")
     void cross_purpose_REGISTER_to_RESET_거부() {
         // given
@@ -91,6 +105,34 @@ class JwtTokenProviderEmailVerificationTest {
         // when / then
         assertThatThrownBy(() ->
             provider.parseEmailVerificationToken(token, EmailVerificationPurpose.REGISTER))
+            .isInstanceOf(AuthenticationDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+    }
+
+    @Test
+    @DisplayName("REGISTER 토큰을 CHANGE_EMAIL 로 파싱하면 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+    void registerTokenRejectedForChangeEmail() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.REGISTER);
+
+        // when / then
+        assertThatThrownBy(() ->
+            provider.parseEmailVerificationToken(token, EmailVerificationPurpose.CHANGE_EMAIL))
+            .isInstanceOf(AuthenticationDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);
+    }
+
+    @Test
+    @DisplayName("PASSWORD_RESET 토큰을 CHANGE_EMAIL 로 파싱하면 INVALID_EMAIL_VERIFICATION 예외를 던진다")
+    void passwordResetTokenRejectedForChangeEmail() {
+        // given
+        String token = provider.createEmailVerificationToken(EMAIL, EmailVerificationPurpose.PASSWORD_RESET);
+
+        // when / then
+        assertThatThrownBy(() ->
+            provider.parseEmailVerificationToken(token, EmailVerificationPurpose.CHANGE_EMAIL))
             .isInstanceOf(AuthenticationDomainException.class)
             .extracting("baseCode")
             .isEqualTo(AuthenticationErrorCode.INVALID_EMAIL_VERIFICATION);

--- a/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/web/MemberCommandControllerTest.java
@@ -1,5 +1,6 @@
 package com.umc.product.member.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,15 +25,18 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.authentication.domain.EmailVerificationPurpose;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.adapter.in.web.assembler.MemberInfoResponseAssembler;
 import com.umc.product.member.adapter.in.web.dto.response.MemberInfoResponse;
+import com.umc.product.member.application.port.in.command.ChangeMemberEmailUseCase;
 import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
 import com.umc.product.member.application.port.in.command.ManageMemberUseCase;
 import com.umc.product.member.application.port.in.command.RegisterEmailMemberUseCase;
 import com.umc.product.member.application.port.in.command.RegisterOAuthMemberUseCase;
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
 import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
 import com.umc.product.member.application.port.in.command.dto.UpdateMemberCommand;
 
@@ -57,6 +62,9 @@ class MemberCommandControllerTest {
 
     @MockitoBean
     ManageMemberUseCase manageMemberUseCase;
+
+    @MockitoBean
+    ChangeMemberEmailUseCase changeMemberEmailUseCase;
 
     @MockitoBean
     ManageMemberProfileUseCase manageMemberProfileUseCase;
@@ -142,5 +150,41 @@ class MemberCommandControllerTest {
             .andExpect(jsonPath("$.result.id").value(TEST_MEMBER_ID));
 
         then(manageMemberUseCase).should().updateMember(any(UpdateMemberCommand.class));
+    }
+
+    @Test
+    @DisplayName("내 이메일 변경은 CHANGE_EMAIL 토큰을 검증하고 로그인 회원 ID로 UseCase를 호출한다")
+    void changeEmail_usesChangeEmailPurpose() throws Exception {
+        // given
+        given(jwtTokenProvider.parseEmailVerificationToken(
+            "change-email-token",
+            EmailVerificationPurpose.CHANGE_EMAIL
+        )).willReturn("new@example.com");
+        given(assembler.fromMemberId(TEST_MEMBER_ID)).willReturn(MemberInfoResponse.builder()
+            .id(TEST_MEMBER_ID)
+            .email("new@example.com")
+            .build());
+
+        // when / then
+        mockMvc.perform(patch("/api/v1/member/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "emailVerificationToken": "change-email-token"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.id").value(TEST_MEMBER_ID))
+            .andExpect(jsonPath("$.result.email").value("new@example.com"));
+
+        then(jwtTokenProvider).should().parseEmailVerificationToken(
+            "change-email-token",
+            EmailVerificationPurpose.CHANGE_EMAIL
+        );
+
+        ArgumentCaptor<ChangeMemberEmailCommand> captor = ArgumentCaptor.forClass(ChangeMemberEmailCommand.class);
+        then(changeMemberEmailUseCase).should().changeEmail(captor.capture());
+        assertThat(captor.getValue().memberId()).isEqualTo(TEST_MEMBER_ID);
+        assertThat(captor.getValue().email()).isEqualTo("new@example.com");
     }
 }

--- a/src/test/java/com/umc/product/member/application/service/MemberEmailCommandServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberEmailCommandServiceTest.java
@@ -1,0 +1,106 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberEmailCommandService")
+class MemberEmailCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String OLD_EMAIL = "old@example.com";
+    private static final String NEW_EMAIL = "new@example.com";
+
+    @Mock
+    LoadMemberPort loadMemberPort;
+
+    @InjectMocks
+    MemberEmailCommandService service;
+
+    @Test
+    @DisplayName("새 이메일이 사용 가능하면 회원 이메일을 변경한다")
+    void changeEmail_success() {
+        // given
+        Member member = member(OLD_EMAIL);
+        given(loadMemberPort.findByIdForUpdate(MEMBER_ID)).willReturn(Optional.of(member));
+        given(loadMemberPort.existsByEmail(NEW_EMAIL)).willReturn(false);
+
+        // when
+        service.changeEmail(ChangeMemberEmailCommand.of(MEMBER_ID, NEW_EMAIL));
+
+        // then
+        assertThat(member.getEmail()).isEqualTo(NEW_EMAIL);
+    }
+
+    @Test
+    @DisplayName("현재 이메일과 새 이메일이 같으면 중복 조회 없이 성공 처리한다")
+    void changeEmail_sameEmail_noop() {
+        // given
+        Member member = member(OLD_EMAIL);
+        given(loadMemberPort.findByIdForUpdate(MEMBER_ID)).willReturn(Optional.of(member));
+
+        // when
+        service.changeEmail(ChangeMemberEmailCommand.of(MEMBER_ID, OLD_EMAIL));
+
+        // then
+        assertThat(member.getEmail()).isEqualTo(OLD_EMAIL);
+        then(loadMemberPort).should(never()).existsByEmail(OLD_EMAIL);
+    }
+
+    @Test
+    @DisplayName("새 이메일이 이미 사용 중이면 EMAIL_ALREADY_EXISTS 예외를 던지고 변경하지 않는다")
+    void changeEmail_duplicateEmail_rejected() {
+        // given
+        Member member = member(OLD_EMAIL);
+        given(loadMemberPort.findByIdForUpdate(MEMBER_ID)).willReturn(Optional.of(member));
+        given(loadMemberPort.existsByEmail(NEW_EMAIL)).willReturn(true);
+
+        // when / then
+        assertThatThrownBy(() -> service.changeEmail(ChangeMemberEmailCommand.of(MEMBER_ID, NEW_EMAIL)))
+            .isInstanceOf(MemberDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+
+        assertThat(member.getEmail()).isEqualTo(OLD_EMAIL);
+    }
+
+    @Test
+    @DisplayName("회원이 없으면 MEMBER_NOT_FOUND 예외를 던진다")
+    void changeEmail_memberNotFound_rejected() {
+        // given
+        given(loadMemberPort.findByIdForUpdate(MEMBER_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> service.changeEmail(ChangeMemberEmailCommand.of(MEMBER_ID, NEW_EMAIL)))
+            .isInstanceOf(MemberDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
+
+        then(loadMemberPort).should(never()).existsByEmail(NEW_EMAIL);
+    }
+
+    private Member member(String email) {
+        Member member = Member.create("홍길동", "길동", email, 1L, null);
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
+        return member;
+    }
+}

--- a/src/test/java/com/umc/product/member/domain/MemberTest.java
+++ b/src/test/java/com/umc/product/member/domain/MemberTest.java
@@ -29,6 +29,33 @@ class MemberTest {
     }
 
     @Nested
+    @DisplayName("changeEmail")
+    class ChangeEmail {
+
+        @Test
+        @DisplayName("활성 회원은 이메일을 변경할 수 있다")
+        void changeEmail_activeMember_success() {
+            Member member = Member.create("홍길동", "길동", "old@example.com", 1L, null);
+
+            member.changeEmail("new@example.com");
+
+            assertThat(member.getEmail()).isEqualTo("new@example.com");
+        }
+
+        @Test
+        @DisplayName("비활성 회원은 이메일을 변경할 수 없다")
+        void changeEmail_inactiveMember_rejected() {
+            Member member = Member.create("홍길동", "길동", "old@example.com", 1L, null);
+            ReflectionTestUtils.setField(member, "status", MemberStatus.INACTIVE);
+
+            assertThatThrownBy(() -> member.changeEmail("new@example.com"))
+                .isInstanceOf(MemberDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(MemberErrorCode.MEMBER_NOT_ACTIVE);
+        }
+    }
+
+    @Nested
     @DisplayName("updateProfile")
     class UpdateProfile {
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- authentication 도메인의 이메일 인증 purpose와 member 도메인의 이메일 변경 Command/Web 흐름을 추가했어요.
- DB migration, API catalog, 단위/웹 테스트를 함께 갱신했어요.
- 검증은 `./gradlew test`, `./gradlew checkDocumentationCatalogs`, `./gradlew spotlessJavaCheck checkstyleMain checkstyleTest`, `git diff --check`로 수행했어요.

### 작업 단위별 상세

1. **무엇을**: EMAIL-002 이메일 인증 요청에서 CHANGE_EMAIL purpose를 사용할 수 있게 했어요.
   - **어떻게**: `EmailVerificationPurpose`에 `CHANGE_EMAIL`을 추가하고, `AuthenticationService`에서 `REGISTER`와 같은 중복 이메일 차단 정책으로 처리했어요.
   - **왜**: 회원가입/비밀번호 초기화 토큰을 이메일 변경 화면에서 재사용하지 않도록 cross-purpose 공격 방어 경계를 유지하기 위해서예요.

2. **무엇을**: [MEMBER-005] PATCH /api/v1/member/email API를 추가했어요.
   - **어떻게**: `CHANGE_EMAIL` emailVerificationToken에서 새 이메일을 파싱하고, `ChangeMemberEmailUseCase`가 현재 회원 row를 잠근 뒤 중복 검사를 거쳐 `Member.changeEmail()`로 상태를 변경해요.
   - **왜**: 로컬 로그인 이메일과 OAuth 회원의 저장 이메일을 같은 검증 절차로 안전하게 변경할 수 있게 하기 위해서예요.

3. **무엇을**: email_verification purpose DB 제약과 API catalog, 테스트를 갱신했어요.
   - **어떻게**: Flyway migration으로 `email_verification_purpose_check`에 `CHANGE_EMAIL`을 추가하고, documentation catalog를 재생성했어요.
   - **왜**: enum, DB 제약, Swagger/API 문서, JWT 검증 테스트가 같은 공개 계약을 바라보도록 맞추기 위해서예요.

## 💬 리뷰 중점사항

- `CHANGE_EMAIL`이 `REGISTER`와 동일하게 이미 사용 중인 이메일을 차단하는 정책이 요구사항과 맞는지 확인 부탁드려요.
- 새 migration이 기존 `email_verification_purpose_check`를 drop 후 재생성하므로 운영 DB 제약 반영 순서를 확인 부탁드려요.
- 이메일 변경 후 기존 AccessToken/RefreshToken은 폐기하지 않는 정책이 현재 인증 구조와 맞는지 확인 부탁드려요.
