### PR TITLE
[Perf] 테스트 실행 시간 최적화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -328,9 +328,43 @@ tasks.clean {
     }
 }
 
+val checkDuplicateFlywayMigrationVersions by tasks.registering {
+    group = "verification"
+    description = "Fails when two Flyway versioned migrations share the same version."
+
+    val migrationFiles = fileTree("src/main/resources/db/migration") {
+        include("V*__*.sql")
+    }
+    inputs.files(migrationFiles)
+
+    doLast {
+        val versionPattern = Regex("""^V(.+)__.+\.sql$""")
+        val duplicatedVersions = migrationFiles.files
+            .groupBy { migrationFile ->
+                versionPattern.matchEntire(migrationFile.name)?.groupValues?.get(1)
+                    ?: throw GradleException("Invalid Flyway migration filename: ${migrationFile.name}")
+            }
+            .filterValues { files -> files.size > 1 }
+
+        if (duplicatedVersions.isNotEmpty()) {
+            val details = duplicatedVersions.entries
+                .sortedBy { it.key }
+                .joinToString(System.lineSeparator()) { (version, files) ->
+                    val paths = files
+                        .sortedBy { it.name }
+                        .joinToString(", ") { it.relativeTo(projectDir).path }
+                    "  - $version: $paths"
+                }
+
+            throw GradleException("Duplicate Flyway migration versions found:${System.lineSeparator()}$details")
+        }
+    }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     maxHeapSize = "3g"
+    dependsOn(checkDuplicateFlywayMigrationVersions)
 }
 
 tasks.test {

--- a/docker/test/postgis/Dockerfile
+++ b/docker/test/postgis/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:18.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-18-postgis-3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminDashboardAnalyticsQueryRepositoryTest.java
@@ -2,6 +2,16 @@ package com.umc.product.analytics.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardActionQueueInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminDashboardSummaryInfo;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -12,8 +22,6 @@ import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.ChapterSchool;
@@ -24,21 +32,10 @@ import com.umc.product.schedule.domain.ScheduleParticipant;
 import com.umc.product.schedule.domain.ScheduleParticipantAttendance;
 import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import com.umc.product.schedule.domain.enums.ScheduleTag;
-import com.umc.product.support.TestContainersConfig;
-import java.time.Instant;
-import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminDashboardAnalyticsQueryRepository.class})
+@PersistenceAdapterTest
+@Import({AdminDashboardAnalyticsQueryRepository.class})
 @DisplayName("AdminDashboardAnalyticsQueryRepository")
 class AdminDashboardAnalyticsQueryRepositoryTest {
 

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminRiskChallengerAnalyticsQueryRepositoryTest.java
@@ -2,6 +2,17 @@ package com.umc.product.analytics.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminRiskChallengerQuery;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -11,29 +22,15 @@ import com.umc.product.challenger.domain.ChallengerPoint;
 import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.ChapterSchool;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.organization.domain.School;
-import com.umc.product.support.TestContainersConfig;
-import java.time.Instant;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminRiskChallengerAnalyticsQueryRepository.class})
+@PersistenceAdapterTest
+@Import({AdminRiskChallengerAnalyticsQueryRepository.class})
 @DisplayName("AdminRiskChallengerAnalyticsQueryRepository")
 class AdminRiskChallengerAnalyticsQueryRepositoryTest {
 

--- a/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/out/persistence/AdminSchoolAnalyticsQueryRepositoryTest.java
@@ -2,6 +2,17 @@ package com.umc.product.analytics.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
 import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryQuery;
 import com.umc.product.analytics.domain.AdminAnalyticsScope;
@@ -12,30 +23,15 @@ import com.umc.product.challenger.domain.ChallengerPoint;
 import com.umc.product.challenger.domain.enums.PointType;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.ChapterSchool;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.organization.domain.School;
-import com.umc.product.support.TestContainersConfig;
-import java.time.Instant;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, AdminSchoolAnalyticsQueryRepository.class})
+@PersistenceAdapterTest
+@Import({AdminSchoolAnalyticsQueryRepository.class})
 @DisplayName("AdminSchoolAnalyticsQueryRepository")
 class AdminSchoolAnalyticsQueryRepositoryTest {
 

--- a/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
@@ -5,27 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.domain.School;
-import com.umc.product.support.TestContainersConfig;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@PersistenceAdapterTest
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     MemberQueryRepository.class
 })
 @DisplayName("MemberQueryRepository 검색")

--- a/src/test/java/com/umc/product/organization/adapter/out/persistence/StudyGroupSchedulePersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/out/persistence/StudyGroupSchedulePersistenceAdapterTest.java
@@ -2,25 +2,19 @@ package com.umc.product.organization.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.organization.domain.StudyGroupSchedule;
-import com.umc.product.support.TestContainersConfig;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+import com.umc.product.organization.domain.StudyGroupSchedule;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     StudyGroupSchedulePersistenceAdapter.class
 })
 class StudyGroupSchedulePersistenceAdapterTest {

--- a/src/test/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupPersistenceAdapterTest.java
@@ -3,29 +3,23 @@ package com.umc.product.organization.adapter.out.persistence.studygroup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.organization.domain.StudyGroup;
 import com.umc.product.organization.domain.StudyGroupMember;
 import com.umc.product.organization.domain.StudyGroupMentor;
 import com.umc.product.organization.exception.OrganizationDomainException;
 import com.umc.product.organization.exception.OrganizationErrorCode;
-import com.umc.product.support.TestContainersConfig;
-import java.util.Set;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@PersistenceAdapterTest
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     StudyGroupQueryRepository.class,
     StudyGroupPersistenceAdapter.class
 })

--- a/src/test/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/out/persistence/studygroup/StudyGroupQueryRepositoryTest.java
@@ -2,35 +2,29 @@ package com.umc.product.organization.adapter.out.persistence.studygroup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupHeaderInfo;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsPartLeader;
-import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsSchoolCore;
-import com.umc.product.organization.domain.StudyGroup;
-import com.umc.product.organization.domain.StudyGroupMember;
-import com.umc.product.organization.domain.StudyGroupMentor;
-import com.umc.product.support.TestContainersConfig;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsPartLeader;
+import com.umc.product.organization.application.port.in.query.dto.OrganizationRoleScope.AsSchoolCore;
+import com.umc.product.organization.application.port.in.query.dto.studygroup.StudyGroupHeaderInfo;
+import com.umc.product.organization.domain.StudyGroup;
+import com.umc.product.organization.domain.StudyGroupMember;
+import com.umc.product.organization.domain.StudyGroupMentor;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     StudyGroupQueryRepository.class
 })
 class StudyGroupQueryRepositoryTest {

--- a/src/test/java/com/umc/product/organization/adapter/out/persistence/umcproduct/UmcProductPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/out/persistence/umcproduct/UmcProductPersistenceAdapterTest.java
@@ -8,16 +8,12 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.organization.application.port.in.query.dto.umcproduct.UmcProductMemberSearchCondition;
 import com.umc.product.organization.domain.UmcProductFunctionalMembership;
 import com.umc.product.organization.domain.UmcProductFunctionalUnit;
@@ -29,15 +25,11 @@ import com.umc.product.organization.domain.enums.UmcProductFunctionalRole;
 import com.umc.product.organization.domain.enums.UmcProductFunctionalUnitType;
 import com.umc.product.organization.domain.enums.UmcProductPosition;
 import com.umc.product.organization.domain.enums.UmcProductSquadRole;
-import com.umc.product.support.TestContainersConfig;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
+@PersistenceAdapterTest
 @ActiveProfiles("test")
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     UmcProductMemberQueryRepository.class,
     UmcProductGenerationPersistenceAdapter.class,
     UmcProductMemberPersistenceAdapter.class,

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPersistenceAdapterTest.java
@@ -2,25 +2,22 @@ package com.umc.product.project.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.ProjectApplicationForm;
-import com.umc.product.project.domain.enums.ProjectStatus;
-import com.umc.product.support.TestContainersConfig;
 import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplicationForm;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@Import({
     ProjectApplicationFormPersistenceAdapter.class})
 class ProjectApplicationFormPersistenceAdapterTest {
 

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationFormPolicyPersistenceAdapterTest.java
@@ -2,29 +2,26 @@ package com.umc.product.project.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.ProjectApplicationFormPolicy;
 import com.umc.product.project.domain.enums.FormSectionType;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import com.umc.product.support.TestContainersConfig;
-import java.util.List;
-import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+@PersistenceAdapterTest
+@Import({
     ProjectApplicationFormPolicyPersistenceAdapter.class})
 class ProjectApplicationFormPolicyPersistenceAdapterTest {
 

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
@@ -10,14 +10,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoundInfo;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectApplication;
@@ -27,11 +23,10 @@ import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import com.umc.product.support.TestContainersConfig;
+import com.umc.product.support.PersistenceAdapterTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, ProjectApplicationQueryRepository.class})
+@PersistenceAdapterTest
+@Import({ProjectApplicationQueryRepository.class})
 class ProjectApplicationQueryRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -2,23 +2,11 @@ package com.umc.product.project.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
-import com.umc.product.project.domain.Project;
-import com.umc.product.project.domain.ProjectMember;
-import com.umc.product.project.domain.ProjectPartQuota;
-import com.umc.product.project.domain.enums.PartQuotaStatus;
-import com.umc.product.project.domain.enums.ProjectMemberStatus;
-import com.umc.product.project.domain.enums.ProjectStatus;
-import com.umc.product.support.TestContainersConfig;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -26,9 +14,18 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class, ProjectQueryRepository.class})
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.ProjectPartQuota;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@Import({ProjectQueryRepository.class})
 class ProjectQueryRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/umc/product/support/PersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/support/PersistenceAdapterTest.java
@@ -1,0 +1,21 @@
+package com.umc.product.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.umc.product.global.config.JpaConfig;
+import com.umc.product.global.config.QueryDslConfig;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class})
+public @interface PersistenceAdapterTest {
+}

--- a/src/test/java/com/umc/product/support/TestContainersConfig.java
+++ b/src/test/java/com/umc/product/support/TestContainersConfig.java
@@ -11,12 +11,15 @@ import org.testcontainers.utility.DockerImageName;
 @TestConfiguration
 public class TestContainersConfig {
 
-    @Bean
+    private static final DockerImageName POSTGIS_IMAGE = DockerImageName.parse("postgis/postgis:18-3.6")
+        .asCompatibleSubstituteFor("postgres");
+
+    private static final PostgreSQLContainer<?> POSTGIS_CONTAINER = new PostgreSQLContainer<>(POSTGIS_IMAGE);
+
+    @Bean(destroyMethod = "")
     @ServiceConnection
     PostgreSQLContainer<?> postgisContainer() {
-        return new PostgreSQLContainer<>(
-                DockerImageName.parse("postgis/postgis:18-3.6").asCompatibleSubstituteFor("postgres")
-        );
+        return POSTGIS_CONTAINER;
     }
 
     // 컨테이너가 뜬 뒤, 확장 1회 생성

--- a/src/test/java/com/umc/product/support/TestContainersConfig.java
+++ b/src/test/java/com/umc/product/support/TestContainersConfig.java
@@ -1,7 +1,9 @@
 package com.umc.product.support;
 
 import java.nio.file.Path;
+
 import javax.sql.DataSource;
+
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;

--- a/src/test/java/com/umc/product/support/TestContainersConfig.java
+++ b/src/test/java/com/umc/product/support/TestContainersConfig.java
@@ -1,12 +1,15 @@
 package com.umc.product.support;
 
 import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -23,15 +26,38 @@ public class TestContainersConfig {
 
     private static final DockerImageName POSTGIS_IMAGE = resolvePostgisImage();
 
-    private static final PostgreSQLContainer<?> POSTGIS_CONTAINER = new PostgreSQLContainer<>(POSTGIS_IMAGE);
+    private static final PostgreSQLContainer<?> POSTGIS_CONTAINER = startPostgisContainer();
 
-    @Bean(destroyMethod = "")
-    @ServiceConnection
-    PostgreSQLContainer<?> postgisContainer() {
-        return POSTGIS_CONTAINER;
+    private static final AtomicInteger DATABASE_SEQUENCE = new AtomicInteger();
+
+    @Bean
+    JdbcConnectionDetails postgisConnectionDetails() {
+        String databaseName = "test_" + DATABASE_SEQUENCE.incrementAndGet();
+        createDatabase(databaseName);
+        String jdbcUrl = "jdbc:postgresql://%s:%d/%s?loggerLevel=OFF".formatted(
+            POSTGIS_CONTAINER.getHost(),
+            POSTGIS_CONTAINER.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+            databaseName
+        );
+        return new JdbcConnectionDetails() {
+            @Override
+            public String getUsername() {
+                return POSTGIS_CONTAINER.getUsername();
+            }
+
+            @Override
+            public String getPassword() {
+                return POSTGIS_CONTAINER.getPassword();
+            }
+
+            @Override
+            public String getJdbcUrl() {
+                return jdbcUrl;
+            }
+        };
     }
 
-    // 컨테이너가 뜬 뒤, 확장 1회 생성
+    // 각 테스트 데이터베이스에 PostGIS 확장을 생성한다.
     @Bean
     ApplicationRunner init(DataSource ds) {
         return args -> {
@@ -65,6 +91,12 @@ public class TestContainersConfig {
         return "aarch64".equals(osArch) || "arm64".equals(osArch);
     }
 
+    private static PostgreSQLContainer<?> startPostgisContainer() {
+        PostgreSQLContainer<?> container = new PostgreSQLContainer<>(POSTGIS_IMAGE);
+        container.start();
+        return container;
+    }
+
     private static DockerImageName buildArm64PostgisImage() {
         try {
             String imageName = new ImageFromDockerfile(LOCAL_ARM64_POSTGIS_IMAGE, false)
@@ -78,5 +110,20 @@ public class TestContainersConfig {
 
     private static DockerImageName postgresCompatibleImage(String imageName) {
         return DockerImageName.parse(imageName).asCompatibleSubstituteFor("postgres");
+    }
+
+    private static void createDatabase(String databaseName) {
+        try (
+            var connection = DriverManager.getConnection(
+                POSTGIS_CONTAINER.getJdbcUrl(),
+                POSTGIS_CONTAINER.getUsername(),
+                POSTGIS_CONTAINER.getPassword()
+            );
+            var statement = connection.createStatement()
+        ) {
+            statement.execute("CREATE DATABASE " + databaseName);
+        } catch (SQLException e) {
+            throw new IllegalStateException("테스트 데이터베이스를 생성하지 못했습니다: " + databaseName, e);
+        }
     }
 }

--- a/src/test/java/com/umc/product/support/TestContainersConfig.java
+++ b/src/test/java/com/umc/product/support/TestContainersConfig.java
@@ -1,18 +1,25 @@
 package com.umc.product.support;
 
+import java.nio.file.Path;
 import javax.sql.DataSource;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration
 public class TestContainersConfig {
 
-    private static final DockerImageName POSTGIS_IMAGE = DockerImageName.parse("postgis/postgis:18-3.6")
-        .asCompatibleSubstituteFor("postgres");
+    private static final String TEST_POSTGIS_IMAGE_PROPERTY = "umc.test.postgis.image";
+    private static final String TEST_POSTGIS_IMAGE_ENV = "UMC_TEST_POSTGIS_IMAGE";
+    private static final String OFFICIAL_POSTGIS_IMAGE = "postgis/postgis:18-3.6";
+    private static final String LOCAL_ARM64_POSTGIS_IMAGE = "umc-product-postgis-test:18.2-postgis";
+    private static final Path ARM64_POSTGIS_DOCKERFILE = Path.of("docker/test/postgis/Dockerfile");
+
+    private static final DockerImageName POSTGIS_IMAGE = resolvePostgisImage();
 
     private static final PostgreSQLContainer<?> POSTGIS_CONTAINER = new PostgreSQLContainer<>(POSTGIS_IMAGE);
 
@@ -30,5 +37,44 @@ public class TestContainersConfig {
                 st.execute("CREATE EXTENSION IF NOT EXISTS postgis");
             }
         };
+    }
+
+    private static DockerImageName resolvePostgisImage() {
+        String configuredImage = configuredPostgisImage();
+        if (configuredImage != null) {
+            return postgresCompatibleImage(configuredImage);
+        }
+        if (isArm64()) {
+            return buildArm64PostgisImage();
+        }
+        return postgresCompatibleImage(OFFICIAL_POSTGIS_IMAGE);
+    }
+
+    private static String configuredPostgisImage() {
+        String image = System.getProperty(TEST_POSTGIS_IMAGE_PROPERTY);
+        if (image == null || image.isBlank()) {
+            image = System.getenv(TEST_POSTGIS_IMAGE_ENV);
+        }
+        return image == null || image.isBlank() ? null : image.trim();
+    }
+
+    private static boolean isArm64() {
+        String osArch = System.getProperty("os.arch");
+        return "aarch64".equals(osArch) || "arm64".equals(osArch);
+    }
+
+    private static DockerImageName buildArm64PostgisImage() {
+        try {
+            String imageName = new ImageFromDockerfile(LOCAL_ARM64_POSTGIS_IMAGE, false)
+                .withDockerfile(ARM64_POSTGIS_DOCKERFILE)
+                .get();
+            return postgresCompatibleImage(imageName);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("arm64 테스트 환경용 PostGIS 이미지를 빌드하지 못했습니다.", e);
+        }
+    }
+
+    private static DockerImageName postgresCompatibleImage(String imageName) {
+        return DockerImageName.parse(imageName).asCompatibleSubstituteFor("postgres");
     }
 }

--- a/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/term/adapter/out/persistence/TermPersistenceAdapterTest.java
@@ -8,20 +8,15 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
-import com.umc.product.support.TestContainersConfig;
+import com.umc.product.support.PersistenceAdapterTest;
 import com.umc.product.term.domain.Term;
 import com.umc.product.term.domain.enums.TermType;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, QueryDslConfig.class, TestContainersConfig.class,
+@PersistenceAdapterTest
+@Import({
     TermPersistenceAdapter.class, TermQueryRepository.class})
 @DisplayName("TermPersistenceAdapter")
 class TermPersistenceAdapterTest {

--- a/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/test/adapter/out/persistence/ProjectSeedDataCleanupPersistenceAdapterTest.java
@@ -7,16 +7,12 @@ import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.global.config.JpaConfig;
-import com.umc.product.global.config.QueryDslConfig;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.project.domain.Project;
@@ -28,7 +24,7 @@ import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
-import com.umc.product.support.TestContainersConfig;
+import com.umc.product.support.PersistenceAdapterTest;
 import com.umc.product.survey.domain.Answer;
 import com.umc.product.survey.domain.AnswerChoice;
 import com.umc.product.survey.domain.Form;
@@ -41,14 +37,10 @@ import com.umc.product.test.application.port.out.dto.ProjectDataDeletionCounts;
 
 import jakarta.persistence.Query;
 
-@DataJpaTest
+@PersistenceAdapterTest
 @ActiveProfiles("test")
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestPropertySource(properties = "app.seed.enabled=true")
 @Import({
-    JpaConfig.class,
-    QueryDslConfig.class,
-    TestContainersConfig.class,
     ProjectSeedDataCleanupPersistenceAdapter.class
 })
 class ProjectSeedDataCleanupPersistenceAdapterTest {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- 없음

## 🚀 작업 내용

### 변경 범위 요약

- 전체 테스트가 5분 이상 걸리던 원인을 Flyway 중복 버전 실패, amd64 전용 PostGIS 이미지 에뮬레이션, Spring 컨텍스트별 Testcontainer 재기동으로 분리해 해결했어요.
- `./gradlew cleanTest test --profile --console=plain` 기준으로 기존 `7m 15s / 실패`에서 `1m 48s / 성공`까지 개선했어요.
- 별도 외부 문서는 없고, 로컬 Gradle profile/test-results와 Docker image manifest 확인 결과를 근거로 반영했어요.

### 작업 단위별 상세

1. **무엇을**: Flyway migration 중복 버전을 해소했어요.
   - **어떻게**: `V2026.06.13.10.00__add_change_email_purpose_to_email_verification.sql`을 `V2026.06.13.10.01__add_change_email_purpose_to_email_verification.sql`로 변경했어요.
   - **왜**: 동일 버전 migration 2개 때문에 테스트가 실제 실행 전에 Flyway validation 단계에서 실패하고 있었어요.

2. **무엇을**: Flyway 중복 버전을 빠르게 잡는 Gradle 검증 태스크를 추가했어요.
   - **어떻게**: `checkDuplicateFlywayMigrationVersions`를 추가하고 `Test` 태스크가 실행 전 의존하도록 연결했어요.
   - **왜**: 같은 문제가 재발해도 Testcontainers를 띄우기 전에 수백 ms 수준으로 실패시키기 위해서예요.

3. **무엇을**: PostGIS Testcontainer를 테스트 JVM 안에서 재사용하도록 바꿨어요.
   - **어떻게**: `TestContainersConfig`에서 컨테이너를 static singleton으로 관리하고, Spring에는 JDBC connection details만 노출하도록 조정했어요.
   - **왜**: Spring test context가 여러 개 생성될 때마다 PostgreSQL/PostGIS 컨테이너가 반복 기동되던 비용을 제거하기 위해서예요.

4. **무엇을**: Apple Silicon 환경에서 amd64 에뮬레이션을 피하도록 arm64 PostGIS 테스트 이미지를 추가했어요.
   - **어떻게**: `postgres:18.2` 기반 `docker/test/postgis/Dockerfile`을 추가하고, `os.arch`가 `arm64/aarch64`면 로컬 `umc-product-postgis-test:18.2-postgis` 이미지를 사용하게 했어요.
   - **왜**: `postgis/postgis:18-3.6`이 amd64-only라 arm64 Docker에서 QEMU 에뮬레이션으로 컨테이너 시작 시간이 크게 늘어났어요.

5. **무엇을**: persistence adapter JPA slice 테스트의 공통 설정을 메타 애너테이션으로 묶었어요.
   - **어떻게**: `@PersistenceAdapterTest`를 추가하고 반복되던 `@DataJpaTest`, `@AutoConfigureTestDatabase`, `JpaConfig`, `QueryDslConfig`, `TestContainersConfig` import를 정리했어요.
   - **왜**: 테스트 슬라이스의 공통 컨텍스트 구성을 명확히 하고, 향후 context cache 튜닝 포인트를 한곳으로 모으기 위해서예요.

6. **무엇을**: 공유 컨테이너 내부에서 Spring ApplicationContext별 DB를 분리했어요.
   - **어떻게**: 컨테이너는 worker JVM당 1회만 시작하되, 각 컨텍스트에는 `test_1`, `test_2`처럼 별도 PostgreSQL database를 생성해 Flyway를 독립 실행하도록 했어요.
   - **왜**: 기존 통합 테스트의 `DatabaseIsolation`이 seed 테이블까지 TRUNCATE하므로, 하나의 DB를 모든 컨텍스트가 공유하면 뒤쪽 JPA 테스트가 seed를 잃는 문제가 생겼기 때문이에요.

## 💬 리뷰 중점사항

- `TestContainersConfig`에서 `@ServiceConnection` 대신 직접 시작한 컨테이너 + `JdbcConnectionDetails` bean을 쓰는 구조가 Spring 테스트 컨텍스트 lifecycle과 맞는지 봐 주세요.
- arm64 로컬 PostGIS 이미지는 테스트 전용 Dockerfile이므로 CI/개발 환경에서 `UMC_TEST_POSTGIS_IMAGE` 또는 `umc.test.postgis.image`로 오버라이드할 필요가 있는지 확인 부탁드려요.
- Flyway migration rename은 SQL 내용 변경 없이 버전만 조정했으니 배포된 DB migration 이력과 충돌 가능성이 없는지 확인 부탁드려요.

## ✅ 검증

- `./gradlew compileTestJava --console=plain` 통과
- `./gradlew test --tests "com.umc.product.organization.adapter.out.persistence.studygroup.StudyGroupPersistenceAdapterTest" --tests "com.umc.product.organization.adapter.out.persistence.studygroup.StudyGroupQueryRepositoryTest" --tests "com.umc.product.test.adapter.out.persistence.ProjectSeedDataCleanupPersistenceAdapterTest" --console=plain` 통과
- `./gradlew cleanTest test --profile --console=plain` 통과
  - `1475 tests, 0 failures, 0 errors, 40 skipped`
  - `BUILD SUCCESSFUL in 1m 48s`
- PostGIS 컨테이너 생성 로그: 전체 테스트 JVM에서 `umc-product-postgis-test:18.2-postgis` 1회 생성 확인
