### PR TITLE
[Docs] 프로젝트 지원서 상태 변경 정책 문서화

### DIFF
--- a/docs/analysis/project-survey-user-flow-2026-05-12.md
+++ b/docs/analysis/project-survey-user-flow-2026-05-12.md
@@ -231,9 +231,10 @@ ProjectApplication:
    → 지원서 단건 상세 (폼 구조 + 답변 + 첨부 파일)
 
 3. [APPLY-103] PATCH /api/v1/projects/{projectId}/applications/{applicationId}/decision   ← PR #840
-   → ApplicationDecisionStatus = APPROVED | REJECTED | PENDING(=재토글)
-   → ProjectApplication.approve()/reject()/revertToPending()
+   → ApplicationDecisionStatus = APPROVED | REJECTED
+   → ProjectApplication.approve()/reject()
    → 잔여 quota 검증 (validateRemainingQuota) → QUOTA_EXCEEDED 시 409
+   → REJECTED 후 최소 선발 규정 미충족 시 → MINIMUM_SELECTION_REQUIRED 409, 기존 status 유지
    → 차수 종료 후 시도 시 → MATCHING_ROUND_LOCKED 400
 ```
 
@@ -598,7 +599,7 @@ PR 의존성을 고려한 추천 순서입니다. 상세 PR 묶음은 §6.5 (구
 | E1 | PO 가 SUBMITTED 지원서를 APPROVED 로 토글 | SUBMITTED + PO 인증 | PATCH /applications/{id}/decision (APPROVED) | 200, `status=APPROVED`, `status_changed_member_id=PO`, `status_changed_at` 기록 | QA-02 (positive) | ✅ |
 | E2 | 잔여 quota 초과 토글 → 409 | TO=2 + 이미 APPROVED 2건 | PATCH (APPROVED) | 409 `QUOTA_EXCEEDED` (PR #840 시나리오 C) | — | ✅ |
 | E3 | **PM 이 차수 종료 후 토글 → 400** | endsAt 경과 또는 auto-decide 완료 + PO 인증 | PATCH | 400 `MATCHING_ROUND_LOCKED` (PR #840 시나리오 D) | **QA-02** | ✅ |
-| E4 | APPROVED → PENDING 재토글 | E1 직후 | PATCH (PENDING) | 200, `status=SUBMITTED`, 사유 저장 | QA-18 | ✅ |
+| E4 | APPROVED → REJECTED 재토글, 단 최소 선발 규정 유지 필요 | E1 직후 + 최소 선발 인원 충족 | PATCH (REJECTED) | 200, `status=REJECTED`, 사유 저장 | QA-18 | ✅ |
 | E5 | 다른 프로젝트 PO 가 토글 시도 → 403 | 다른 PO 토큰 | PATCH | 403 | — | ✅ |
 | E6 | 일반 챌린저가 APPLY-101 로 다른 프로젝트 지원자 목록 조회 → 403 | — | 다른 프로젝트 GET | 403 (**현재는 통과해 버리는 보안 이슈 — RED 로 작성**) | — | 🟡 P1 #1 |
 | E7 | **Admin 이 차수 종료 후에도 합/불 토글 가능 (PM 잠금 우회)** | endsAt 경과 + 중앙 총괄단 / 지부장 인증 | PATCH (APPROVED) | 200, `status=APPROVED`, audit 사유 기록 (`Admin override`) | **QA-11** | 🔴 **미구현** |

--- a/docs/onboarding/domain/project-application-decision-access-analysis.md
+++ b/docs/onboarding/domain/project-application-decision-access-analysis.md
@@ -1,0 +1,92 @@
+# Project Application Decision Access Analysis
+
+작성일: 2026-06-15
+
+## 요약
+
+보고 내용은 다음 두 경우를 분리해서 봐야 한다.
+
+1. 지원자가 `CHAPTER_PRESIDENT`이면서 챌린저인 경우
+2. 상태 변경을 시도한 요청자가 `CHAPTER_PRESIDENT`인 경우
+
+현재 BE 코드 기준 결론은 다르다.
+
+- 지원자가 `CHAPTER_PRESIDENT`인 것만으로 상태 변경이 막히는 로직은 확인되지 않았다.
+- 상태 변경 요청자가 `CHAPTER_PRESIDENT`이지만 해당 프로젝트의 PO가 아니라면, 상태 변경이 막히는 것이 현재 정책상 정상이다.
+
+따라서 "지부장인 지원자의 지원서를 PO가 변경하지 못했다"는 보고라면 FE 처리, 요청 계정, applicationId, 일시적 오류 가능성을 확인해야 한다. 반대로 "지부장이 직접 상태 변경을 시도했다"는 보고라면 BE 정책과 일치한다.
+
+## 상태 변경 권한 경로
+
+지원서 상태 변경 API는 다음 컨트롤러 경로를 사용한다.
+
+```http
+PATCH /api/v1/projects/{projectId}/applications/{applicationId}/decision
+```
+
+컨트롤러는 `@CheckAccess(resourceType = PROJECT_APPLICATION, permission = APPROVE)`로 진입 전 권한을 검사한다.
+
+권한 평가는 `ProjectApplicationPermissionEvaluator.canApprove()`에서 처리된다. 현재 구현은 다음 조건만 통과시킨다.
+
+1. 지원서 상태가 `SUBMITTED`, `APPROVED`, `REJECTED` 중 하나여야 한다.
+2. 요청자 `memberId`가 부모 프로젝트의 `productOwnerMemberId`와 같아야 한다.
+
+즉 `APPROVE` 권한은 지부장, 총괄단, 보조 PM 권한을 보지 않는다. 실제 코드도 `return isOwner(subject, project);`로 끝난다.
+
+## 지원자가 CHAPTER_PRESIDENT인 경우
+
+상태 변경 서비스인 `ProjectApplicationCommandService.decide()`는 지원자의 역할을 확인하지 않는다.
+
+서비스가 확인하는 것은 다음이다.
+
+- 대상 지원서 존재 여부
+- `APPROVED` 변경 시 잔여 quota
+- `REJECTED` 변경 시 최소 선발 규정
+- 도메인 상태 전이 가능 여부
+- 매칭 차수 잠금 여부
+
+지원자의 `CHAPTER_PRESIDENT` 역할 여부는 이 흐름에 없다. 지원자가 지부장 역할을 가진 챌린저여도, 요청자가 프로젝트 PO이고 위 도메인 조건을 통과하면 상태 변경은 가능해야 한다.
+
+## 요청자가 CHAPTER_PRESIDENT인 경우
+
+요청자가 지부장이고 프로젝트 PO가 아니라면 현재 BE 정책상 상태 변경은 불가능하다.
+
+관련 테스트도 같은 방향이다.
+
+- 부모 PO의 `APPROVE`는 허용된다.
+- 보조 PM의 `APPROVE`는 거부된다.
+- 총괄단의 `APPROVE`도 거부된다.
+- 지부장은 지원서 `READ`에는 허용되지만 `APPROVE` 권한에는 포함되어 있지 않다.
+
+따라서 지부장이 운영진 화면에서 직접 합격/불합격을 누르는 UX가 필요하다면, 이는 클라이언트 오류가 아니라 BE 권한 정책 변경 요구사항이다.
+
+## 확인해야 할 로그/재현 조건
+
+보고를 확정하려면 다음 값을 확인해야 한다.
+
+- 상태 변경을 누른 요청자 `memberId`
+- 해당 프로젝트의 `productOwnerMemberId`
+- 대상 지원서의 `applicantMemberId`
+- 요청자의 `CHAPTER_PRESIDENT` 역할 `gisuId`, `organizationId(chapterId)`
+- 응답 HTTP status와 error code
+
+판정 기준은 다음이다.
+
+- 응답이 403 `RESOURCE_ACCESS_DENIED`이고 요청자가 PO가 아니면 BE 정책상 정상 차단이다.
+- 요청자가 PO인데 403이 발생했다면 권한 subject 생성, 토큰 계정, 프로젝트 PO 값, applicationId 매핑을 추가 조사해야 한다.
+- 응답이 409라면 권한 문제가 아니라 quota 또는 최소 선발 규정 문제일 가능성이 높다.
+- 응답이 400 `PROJECT_MATCHING_ROUND_LOCKED`라면 차수 결정 마감 이후 변경 시도다.
+
+## 검증
+
+다음 테스트를 실행해 현재 권한 정책과 상태 변경 서비스 동작을 확인했다.
+
+```bash
+./gradlew test --tests 'com.umc.product.project.application.service.evaluator.ProjectApplicationPermissionEvaluatorTest' --tests 'com.umc.product.project.application.service.command.ProjectApplicationCommandServiceTest'
+```
+
+결과:
+
+```text
+BUILD SUCCESSFUL in 11s
+```

--- a/docs/onboarding/domain/project.md
+++ b/docs/onboarding/domain/project.md
@@ -11,6 +11,45 @@
 - 지원 폼과 지원서를 생성, 임시저장, 제출, 평가한다.
 - 매칭 차수와 파트별 정원, 자동 선발을 관리한다.
 
+## 지원서 합/불 결정과 최소 선발 규정
+
+PM은 `PATCH /api/v1/projects/{projectId}/applications/{applicationId}/decision`으로 지원서를 `APPROVED` 또는 `REJECTED`로 변경한다. 요청 DTO는 `ApplicationDecisionStatus.APPROVED`, `ApplicationDecisionStatus.REJECTED`만 허용하며, 현재 단건 결정 API에는 `SUBMITTED`로 되돌리는 입력값이 없다.
+
+`APPROVED` 변경은 잔여 정원만 검증한다. 잔여 정원은 `파트별 TO - 기존 ACTIVE 멤버 수 - 현재 차수의 같은 프로젝트/파트 APPROVED 수`로 계산하며, 초과하면 `PROJECT_APPLICATION_QUOTA_EXCEEDED` 409를 반환한다.
+
+`REJECTED` 변경은 변경 후에도 매칭 정책의 최소 선발 인원을 만족하는지 먼저 검증한다. 검증은 현재 지원서를 제외한 같은 차수, 같은 프로젝트, 같은 파트의 `APPROVED` 수를 기준으로 한다.
+
+- `PLAN_DESIGN`: 지원자가 2명 이상이면 최소 1명 `APPROVED`가 필요하다. 지원자가 1명이면 최소 선발 의무가 없다.
+- `PLAN_DEVELOPER`: 지원자가 TO 이상이면 최소 `ceil(TO * 0.5)`명, 지원자가 TO의 50% 초과 100% 미만이면 최소 `ceil(TO * 0.25)`명, 지원자가 TO의 50% 이하면 최소 선발 의무가 없다.
+
+최소 선발 규정을 만족하지 못하면 `PROJECT_APPLICATION_MINIMUM_SELECTION_REQUIRED` 409를 반환한다. 이 예외는 `application.reject()` 호출 전에 발생하므로 BE 트랜잭션 안에서는 지원서 status를 변경하지 않고 저장도 수행하지 않는다. 예를 들어 `APPROVED`였던 지원자를 `REJECTED`로 바꾸면 최소 인원이 깨지는 상황에서는 DB 상태가 기존 `APPROVED`로 유지되어야 한다.
+
+응답 예시는 다음과 같다.
+
+```json
+{
+  "success": false,
+  "code": "PROJECT-0216",
+  "message": "매칭 규칙의 최소 선발 인원을 충족하지 않아 불합격 처리할 수 없어요. 합격 인원을 확인해주세요.",
+  "result": "매칭 규칙의 최소 선발 인원을 충족하지 않아 불합격 처리할 수 없어요. 합격 인원을 확인해주세요."
+}
+```
+
+## 상태 흔들림 분석 메모
+
+관측 증상: `APPROVED` 상태의 지원자를 `REJECTED`로 변경하려고 할 때 최소 선발 규정에 실패하면 기존 `APPROVED`가 유지되어야 하나, 화면에서는 시도할 때마다 `SUBMITTED`와 `APPROVED`가 번갈아 보일 수 있다.
+
+현재 BE 단건 결정 로직 기준으로는 실패 응답 이후 `SUBMITTED`로 전이되는 경로가 없다. `ApplicationDecisionStatus`는 `APPROVED`, `REJECTED`만 받고, 최소 선발 검증 실패는 `ProjectApplicationCommandService.validateMinimumSelectionAfterRejection()`에서 `ProjectApplication.reject()`보다 먼저 발생한다. 따라서 `PROJECT-0216`이 반환된 요청 하나만 놓고 보면 저장된 status는 기존 값, 보통 `APPROVED`, 그대로 남아야 한다.
+
+가능성이 높은 확인 지점은 다음과 같다.
+
+- FE가 409 실패 응답을 받은 뒤 요청 전 상태를 복원하지 않고 낙관적 업데이트나 기본 대기 상태를 적용하는지 확인한다.
+- FE가 실패 응답의 `success=false`와 HTTP 409를 성공 응답처럼 처리하면서 `result.status`가 없을 때 `SUBMITTED`를 fallback으로 넣는지 확인한다.
+- 실패 직후 재조회 API가 `status=SUBMITTED` 같은 필터를 붙여 호출되는지, 또는 이전 목록 응답 캐시가 섞이는지 확인한다.
+- 같은 매칭 차수의 `decisionDeadline` 경과 후 자동 선발이 실행되는 시점인지 확인한다. 자동 선발은 부족분을 `SUBMITTED` 풀에서 random 보충하고, 필요하면 `REJECTED` 풀도 override할 수 있어 화면에서 랜덤성이 보일 수 있다. 다만 자동 선발은 실행 완료 후 `autoDecisionExecutedAt`으로 멱등 처리되므로 같은 차수에서 계속 반복 실행되지는 않아야 한다.
+
+BE 확인 기준은 명확하다. `PATCH .../decision`이 `PROJECT-0216` 409를 반환한 직후 동일 `applicationId`를 DB 또는 `GET /api/v1/projects/{projectId}/applications/{applicationId}`로 재조회했을 때 status가 `APPROVED`라면 단건 결정 로직은 의도대로 동작한 것이다. 재조회 결과가 `SUBMITTED`라면 별도 BE 저장 경로, 테스트 seed, 자동 선발, 또는 조회 조건을 추가로 추적해야 한다.
+
 ## 경계
 
 프로젝트 참여자의 회원·챌린저·조직 정보는 다른 도메인에서 온다. project는 ID를 보관하고, 조회 응답 조립 시 필요한 정보만 공개 UseCase로 가져온다.


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- 없음

## 🚀 작업 내용

### 변경 범위 요약

- 프로젝트 도메인 온보딩 문서와 기존 지원서 플로우 분석 문서를 수정했어요.
- 지원서 상태 변경 실패 케이스, 최소 선발 규정, CHAPTER_PRESIDENT 권한 해석을 문서로 남겼어요.

### 작업 단위별 상세

1. **무엇을**: PM이 지원서 상태를 변경할 때 최소 선발 규정에 실패하는 동작을 문서화했어요.
   - **어떻게**: `docs/onboarding/domain/project.md`에 APPROVED, REJECTED 변경 검증 순서와 `PROJECT-0216` 응답 예시를 추가했어요.
   - **왜**: APPROVED였던 지원자를 REJECTED로 바꾸려다 최소 선발 규정에 걸리면 기존 APPROVED가 유지되어야 한다는 BE 계약을 명확히 하기 위해서예요.

2. **무엇을**: 지원서 상태가 SUBMITTED와 APPROVED로 흔들려 보이는 현상에 대한 분석 메모를 추가했어요.
   - **어떻게**: BE 단건 결정 API에는 SUBMITTED로 되돌리는 입력값이 없고, 실패 시 저장 전에 예외가 발생한다는 점을 기준으로 FE 낙관적 업데이트, 실패 응답 fallback, 재조회 필터, 자동 선발 시점을 확인 지점으로 정리했어요.
   - **왜**: 같은 증상이 재발했을 때 BE 저장 경로와 FE 표시 경로를 분리해서 빠르게 확인하기 위해서예요.

3. **무엇을**: CHAPTER_PRESIDENT이면서 챌린저인 회원의 지원서 상태 변경 보고를 별도 문서로 정리했어요.
   - **어떻게**: `docs/onboarding/domain/project-application-decision-access-analysis.md`를 추가해서 지원자가 지부장인 경우와 요청자가 지부장인 경우를 분리해 설명했어요.
   - **왜**: 지원자가 지부장이라는 이유만으로는 BE에서 차단하지 않지만, 상태 변경 요청자가 지부장이고 프로젝트 PO가 아니면 현재 권한 정책상 차단되는 점을 명확히 하기 위해서예요.

4. **무엇을**: 기존 플로우 문서의 오래된 PENDING 재토글 설명을 현재 API 계약에 맞게 수정했어요.
   - **어떻게**: APPLY-103의 `ApplicationDecisionStatus`를 APPROVED, REJECTED로 정리하고, APPROVED에서 REJECTED로 재토글할 때 최소 선발 규정 유지가 필요하다고 수정했어요.
   - **왜**: 현재 코드의 `ApplicationDecisionStatus`에는 PENDING이 없어서 문서와 실제 API 계약이 어긋나 있었기 때문이에요.

## 💬 리뷰 중점사항

- 문서화한 지원서 상태 변경 실패 시나리오가 현재 FE 처리 방식과 맞는지 확인 부탁드려요.
- CHAPTER_PRESIDENT 관련 분석에서 지부장의 상태 변경 권한을 열어야 하는 요구사항인지, 아니면 현재처럼 PO만 허용하는 정책을 유지할지 확인 부탁드려요.
- 코드 변경, DB migration, 환경 설정 변경은 없어요.

## ✅ 검증

- `./gradlew test --tests 'com.umc.product.project.application.service.command.ProjectApplicationCommandServiceTest' --tests 'com.umc.product.project.application.service.policy.DeveloperMatchingPolicyTest' --tests 'com.umc.product.project.application.service.policy.DesignerMatchingPolicyTest'` 통과했어요.
- `./gradlew test --tests 'com.umc.product.project.application.service.evaluator.ProjectApplicationPermissionEvaluatorTest' --tests 'com.umc.product.project.application.service.command.ProjectApplicationCommandServiceTest'` 통과했어요.
