### PR TITLE
[Feat] 프로젝트 지원 현황 정렬 순서 변경

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -1,5 +1,13 @@
 package com.umc.product.project.adapter.in.web;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -14,16 +22,11 @@ import com.umc.product.project.application.port.in.query.dto.GetMyProjectApplica
 import com.umc.product.project.application.port.in.query.dto.GetProjectApplicationDetailQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/projects")

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -1,13 +1,5 @@
 package com.umc.product.project.adapter.in.web;
 
-import java.util.List;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
@@ -22,11 +14,16 @@ import com.umc.product.project.application.port.in.query.dto.GetMyProjectApplica
 import com.umc.product.project.application.port.in.query.dto.GetProjectApplicationDetailQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/projects")
@@ -81,7 +78,8 @@ public class ProjectApplicationQueryController {
         description = """
             단일 프로젝트의 지원자 목록을 조회한다. 임시저장(DRAFT) 지원서는 제외되며, SUBMITTED/APPROVED/REJECTED 만 노출.
 
-            정렬: matchingRound.phase ASC -> submittedAt ASC. 같은 파트끼리 묶기는 클라이언트가 처리한다.
+            정렬: matchingRound.phase ASC -> applicant.part ASC -> submittedAt ASC.
+            같은 차수 안에서 같은 파트끼리 묶은 뒤, 그 안에서 제출 시각 오름차순으로 노출된다.
             <p>
             필터:
             <ul>

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
@@ -1,5 +1,17 @@
 package com.umc.product.project.adapter.in.web.assembler;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -22,17 +34,8 @@ import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMemberInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * Project Application 관련 Response 조립기. Controller에서 여러 UseCase 를 조합하는 로직을 캡슐화한다.

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
@@ -1,16 +1,5 @@
 package com.umc.product.project.adapter.in.web.assembler;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
@@ -33,8 +22,17 @@ import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMemberInfo;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
-
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 /**
  * Project Application 관련 Response 조립기. Controller에서 여러 UseCase 를 조합하는 로직을 캡슐화한다.
@@ -119,6 +117,9 @@ public class ProjectApplicationResponseAssembler {
      * <p>
      * 파트(part) 필터도 챌린저 도메인 정보라 in-memory 로 적용한다. 권한 scope 결정은 Service 가 이미 처리했으니 (None 이면 빈 리스트 반환) 여기서는 그 결과를 그대로
      * 신뢰한다.
+     * <p>
+     * 정렬: 매칭 차수(phase) ASC -> 파트(part) ASC -> 제출 시각(submittedAt) ASC. phase 는 Service/Repository 가 보장하는 DB 정렬과 겹치지만,
+     * part 가 cross-domain enrichment 산물이라 파트별 묶음은 여기서 in-memory 로 한 번 더 정렬해야 한다.
      */
     public List<ProjectApplicantResponse> applicantsFor(SearchProjectApplicationsQuery query) {
         List<ProjectApplicationSummaryInfo> applications =
@@ -146,18 +147,35 @@ public class ProjectApplicationResponseAssembler {
             getProjectMatchingRoundUseCase.findAllByIds(roundIds);
         Map<Long, MemberInfo> memberMap = getMemberUseCase.findAllByIds(applicantMemberIds);
 
-        List<ProjectApplicantResponse> result = new ArrayList<>(applications.size());
-        for (ProjectApplicationSummaryInfo application : applications) {
-            ChallengerPart applicantPart = partsByMember.get(application.applicantMemberId());
-            // 파트 필터: 다른 파트는 건너뛴다.
-            if (query.part() != null && query.part() != applicantPart) {
-                continue;
-            }
-            ProjectMatchingRoundInfo round = rounds.get(application.matchingRoundId());
-            MemberBrief brief = toBrief(memberMap.get(application.applicantMemberId()));
-            result.add(ProjectApplicantResponse.from(application, applicantPart, round, brief));
-        }
-        return result;
+        return applications.stream()
+            .filter(application -> {
+                ChallengerPart applicantPart = partsByMember.get(application.applicantMemberId());
+                // 파트 필터: 다른 파트는 건너뛴다.
+                return query.part() == null || query.part() == applicantPart;
+            })
+            .sorted(applicantSortOrder(rounds, partsByMember))
+            .map(application -> {
+                ChallengerPart applicantPart = partsByMember.get(application.applicantMemberId());
+                ProjectMatchingRoundInfo round = rounds.get(application.matchingRoundId());
+                MemberBrief brief = toBrief(memberMap.get(application.applicantMemberId()));
+                return ProjectApplicantResponse.from(application, applicantPart, round, brief);
+            })
+            .toList();
+    }
+
+    /**
+     * APPLY-101 지원자 카드 정렬자: 매칭 차수(phase) ASC -> 파트(part) ASC -> 제출 시각(submittedAt) ASC.
+     */
+    private Comparator<ProjectApplicationSummaryInfo> applicantSortOrder(
+        Map<Long, ProjectMatchingRoundInfo> rounds,
+        Map<Long, ChallengerPart> partsByMember
+    ) {
+        return Comparator
+            .comparingInt((ProjectApplicationSummaryInfo application) ->
+                rounds.get(application.matchingRoundId()).phase().ordinal())
+            .thenComparingInt(application ->
+                partsByMember.get(application.applicantMemberId()).getSortOrder())
+            .thenComparing(ProjectApplicationSummaryInfo::submittedAt);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -5,15 +5,6 @@ import static com.umc.product.project.domain.QProjectApplication.projectApplicat
 import static com.umc.product.project.domain.QProjectApplicationForm.projectApplicationForm;
 import static com.umc.product.project.domain.QProjectMatchingRound.projectMatchingRound;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,8 +12,14 @@ import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoun
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 /**
  * ProjectApplication QueryDSL 동적 검색 구현.
@@ -122,7 +119,8 @@ public class ProjectApplicationQueryRepository {
      * 호출자({@code ProjectApplicationSummaryInfo#from})가 form.project.id 까지 접근하므로 N+1 방지를 위해 fetch join 이 필요하다.
      * 임시저장(DRAFT)은 항상 제외된다.
      * <p>
-     * 정렬: matchingRound.phase ASC -> projectApplication.submittedAt ASC.
+     * 정렬 (DB 단 baseline): matchingRound.phase ASC -> projectApplication.submittedAt ASC. 최종 화면 정렬(phase -> part ->
+     * submittedAt)은 part 가 cross-domain 정보라 Assembler 에서 in-memory 로 마무리한다.
      */
     public List<ProjectApplication> searchProjectApplications(
         Long projectId,

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -5,6 +5,15 @@ import static com.umc.product.project.domain.QProjectApplication.projectApplicat
 import static com.umc.product.project.domain.QProjectApplicationForm.projectApplicationForm;
 import static com.umc.product.project.domain.QProjectMatchingRound.projectMatchingRound;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -12,14 +21,8 @@ import com.umc.product.project.application.port.out.dto.ProjectMemberMatchedRoun
 import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 /**
  * ProjectApplication QueryDSL 동적 검색 구현.

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -1,5 +1,16 @@
 package com.umc.product.project.application.service.query;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -30,16 +41,8 @@ import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.AnswerInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Service

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -1,16 +1,5 @@
 package com.umc.product.project.application.service.query;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -41,8 +30,16 @@ import com.umc.product.survey.application.port.in.query.GetFormUseCase;
 import com.umc.product.survey.application.port.in.query.dto.AnswerInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormResponseWithAnswersInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
-
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -122,8 +119,8 @@ public class ProjectApplicationQueryService
      * 표준 view 로 반환한다.
      * <p>
      * 본 UseCase 는 자기 자원(ProjectApplication) 만 다룬다. 랜덤 매칭/운영진 강제 배정으로 합류한 {@code ProjectMember(application = null)} 는 별도
-     * UseCase ({@link com.umc.product.project.application.port.in.query.GetRandomMatchedProjectMemberUseCase}) 로
-     * 조회하며, 두 데이터원을 한 화면 카드 줄로 합성하는 책임은 Web Assembler 가 진다.
+     * UseCase ({@link com.umc.product.project.application.port.in.query.GetRandomMatchedProjectMemberUseCase}) 로 조회하며,
+     * 두 데이터원을 한 화면 카드 줄로 합성하는 책임은 Web Assembler 가 진다.
      * <p>
      * 사용자가 해당 기수의 챌린저가 아니거나 매칭 대상 파트가 아닌 경우(PLAN/ADMIN) 빈 리스트를 반환한다.
      */
@@ -145,17 +142,14 @@ public class ProjectApplicationQueryService
             .toList();
     }
 
-    // ==============================================================
-    //                      Helper Method
-    // ==============================================================
-
     /**
      * PM/운영진용 단일 프로젝트 지원자 목록 조회.
      * <p>
-     * 본 메서드는 자기 자원(ProjectApplication) 만 반환한다. 화면 카드에 들어가는 부가 정보 (지원자의 파트 / 매칭 라운드 / 닉네임 등) 는
-     * Web Assembler 가 다른 도메인에서 합쳐 붙인다. 그래서 파트(part) 필터도 챌린저 도메인이 필요한 정보라 Assembler 단계에서 적용한다.
+     * 본 메서드는 자기 자원(ProjectApplication) 만 반환한다. 화면 카드에 들어가는 부가 정보 (지원자의 파트 / 매칭 라운드 / 닉네임 등) 는 Web Assembler 가 다른 도메인에서
+     * 합쳐 붙인다. 그래서 파트(part) 필터도 챌린저 도메인이 필요한 정보라 Assembler 단계에서 적용한다.
      * <p>
-     * 권한이 없으면 (None scope) 존재 자체를 숨기려고 빈 리스트로 위장한다. 정렬은 repository 가 phase ASC → submittedAt ASC 로 보장한다.
+     * 권한이 없으면 (None scope) 존재 자체를 숨기려고 빈 리스트로 위장한다. 정렬: repository 가 phase ASC -> submittedAt ASC 의 DB baseline 만 보장하고,
+     * 최종 화면 정렬(phase -> part -> submittedAt)은 part 가 cross-domain 정보라 Assembler 에서 in-memory 로 마무리된다.
      */
     @Override
     public List<ProjectApplicationSummaryInfo> searchByProject(SearchProjectApplicationsQuery query) {
@@ -176,6 +170,10 @@ public class ProjectApplicationQueryService
             .map(ProjectApplicationSummaryInfo::from)
             .toList();
     }
+
+    // ==============================================================
+    //                      Helper Method
+    // ==============================================================
 
     /**
      * 요청자의 챌린저 파트로부터 매칭 종류를 결정한다.

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
@@ -8,19 +8,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -57,6 +44,17 @@ import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
 import com.umc.product.survey.domain.enums.FormResponseStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationResponseAssemblerTest {
@@ -391,6 +389,75 @@ class ProjectApplicationResponseAssemblerTest {
         assertThat(result.get(0).applicant().part()).isEqualTo(ChallengerPart.WEB);
     }
 
+    @Test
+    @DisplayName("applicantsFor_차수_파트_시간_순으로_정렬되어_반환된다")
+    void applicantsFor_정렬_순서() {
+        // given - 입력은 일부러 셔플된 순서.
+        // 차수(phase) ASC -> 파트(ChallengerPart#sortOrder) ASC -> 제출 시각(submittedAt) ASC 로 정렬되어야 한다.
+        // FIRST/SECOND/THIRD 세 차수, DESIGN(1)/WEB(2)/ANDROID(3)/IOS(4)/NODEJS(5) 다섯 파트, 같은 (차수,파트) 묶음에서 시간이 ASC 인지까지 검증.
+        Long roundFirstId = 11L;
+        Long roundSecondId = 22L;
+        Long roundThirdId = 33L;
+        Instant t06 = Instant.parse("2026-04-22T06:00:00Z");
+        Instant t07 = Instant.parse("2026-04-22T07:00:00Z");
+        Instant t08 = Instant.parse("2026-04-22T08:00:00Z");
+        Instant t09 = Instant.parse("2026-04-22T09:00:00Z");
+        Instant t10 = Instant.parse("2026-04-22T10:00:00Z");
+        Instant t11 = Instant.parse("2026-04-22T11:00:00Z");
+
+        ProjectApplicationSummaryInfo a = applicationSummaryOf(101L, 1L, roundSecondId, 300L, t10); // SECOND / DESIGN
+        ProjectApplicationSummaryInfo b = applicationSummaryOf(102L, 1L, roundFirstId, 301L, t09);  // FIRST / WEB
+        ProjectApplicationSummaryInfo c = applicationSummaryOf(103L, 1L, roundFirstId, 302L, t11);  // FIRST / DESIGN
+        ProjectApplicationSummaryInfo d = applicationSummaryOf(104L, 1L, roundFirstId, 303L, t08);  // FIRST / ANDROID
+        ProjectApplicationSummaryInfo e = applicationSummaryOf(105L, 1L, roundSecondId, 304L, t09); // SECOND / NODEJS
+        ProjectApplicationSummaryInfo f = applicationSummaryOf(106L, 1L, roundFirstId, 305L, t07);  // FIRST / WEB
+        ProjectApplicationSummaryInfo g = applicationSummaryOf(107L, 1L, roundThirdId, 306L, t06);  // THIRD / IOS
+        ProjectApplicationSummaryInfo h = applicationSummaryOf(108L, 1L, roundSecondId, 307L, t09); // SECOND / DESIGN
+
+        SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(100L)
+            .projectId(1L)
+            .build();
+        ProjectInfo project = projectInfoOf(1L, "프로젝트A", 99L);
+
+        given(searchProjectApplicationsUseCase.searchByProject(query))
+            .willReturn(List.of(a, b, c, d, e, f, g, h));
+        given(getProjectUseCase.getById(1L)).willReturn(project);
+        given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(any(), eq(GISU_ID)))
+            .willReturn(Map.of(
+                300L, challengerInfoOf(300L, ChallengerPart.DESIGN),
+                301L, challengerInfoOf(301L, ChallengerPart.WEB),
+                302L, challengerInfoOf(302L, ChallengerPart.DESIGN),
+                303L, challengerInfoOf(303L, ChallengerPart.ANDROID),
+                304L, challengerInfoOf(304L, ChallengerPart.NODEJS),
+                305L, challengerInfoOf(305L, ChallengerPart.WEB),
+                306L, challengerInfoOf(306L, ChallengerPart.IOS),
+                307L, challengerInfoOf(307L, ChallengerPart.DESIGN)
+            ));
+        given(getProjectMatchingRoundUseCase.findAllByIds(any()))
+            .willReturn(Map.of(
+                roundFirstId, roundInfoOf(roundFirstId, MatchingPhase.FIRST),
+                roundSecondId, roundInfoOf(roundSecondId, MatchingPhase.SECOND),
+                roundThirdId, roundInfoOf(roundThirdId, MatchingPhase.THIRD)
+            ));
+        given(getMemberUseCase.findAllByIds(any())).willReturn(Map.of());
+
+        // when
+        List<ProjectApplicantResponse> result = sut.applicantsFor(query);
+
+        // then - 기대 순서:
+        //   FIRST  / DESIGN(1)   / 11:00  -> c (103)
+        //   FIRST  / WEB(2)      / 07:00  -> f (106)
+        //   FIRST  / WEB(2)      / 09:00  -> b (102)
+        //   FIRST  / ANDROID(3)  / 08:00  -> d (104)
+        //   SECOND / DESIGN(1)   / 09:00  -> h (108)
+        //   SECOND / DESIGN(1)   / 10:00  -> a (101)
+        //   SECOND / NODEJS(5)   / 09:00  -> e (105)
+        //   THIRD  / IOS(4)      / 06:00  -> g (107)   // 시간이 가장 빨라도 차수가 가장 늦으면 마지막
+        assertThat(result).extracting(ProjectApplicantResponse::applicationId)
+            .containsExactly(103L, 106L, 102L, 104L, 108L, 101L, 105L, 107L);
+    }
+
     // ============================================================
     //                   detailFor (단건 상세) 테스트
     // ============================================================
@@ -459,6 +526,15 @@ class ProjectApplicationResponseAssemblerTest {
     private ProjectApplicationSummaryInfo applicationSummaryOf(
         Long applicationId, Long projectId, Long matchingRoundId, Long applicantMemberId
     ) {
+        return applicationSummaryOf(
+            applicationId, projectId, matchingRoundId, applicantMemberId,
+            Instant.parse("2026-04-22T01:30:00Z")
+        );
+    }
+
+    private ProjectApplicationSummaryInfo applicationSummaryOf(
+        Long applicationId, Long projectId, Long matchingRoundId, Long applicantMemberId, Instant submittedAt
+    ) {
         return ProjectApplicationSummaryInfo.builder()
             .id(applicationId)
             .applicantMemberId(applicantMemberId)
@@ -466,7 +542,7 @@ class ProjectApplicationResponseAssemblerTest {
             .projectId(projectId)
             .matchingRoundId(matchingRoundId)
             .status(ProjectApplicationStatus.SUBMITTED)
-            .submittedAt(Instant.parse("2026-04-22T01:30:00Z"))
+            .submittedAt(submittedAt)
             .build();
     }
 

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
@@ -8,6 +8,19 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -44,17 +57,6 @@ import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.survey.application.port.in.query.dto.FormResponseInfo;
 import com.umc.product.survey.domain.enums.FormResponseStatus;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationResponseAssemblerTest {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #991 

## 🚀 작업 내용

1. 단일 프로젝트에 대한 지원자 목록 조회 시, 응답 정렬 기준을 '(오름차순) 매칭 차수 -> 파트 -> 지원서 제출 시각' 으로 변경했습니다.
2. 관련 테스트코드를 작성했습니다.

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

