### PR TITLE
[Fix] 프로덕트팀 멤버 조회 시 NPE 수정

### DIFF
--- a/src/main/java/com/umc/product/organization/application/service/UmcProductMemberQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductMemberQueryService.java
@@ -72,7 +72,7 @@ public class UmcProductMemberQueryService implements GetUmcProductMemberUseCase 
             generationMapOf(functionalMemberships),
             functionalUnitMapOf(functionalMemberships),
             squadMapOf(squadParticipations),
-            productProfileLinks.get(member.getProfileImageId())
+            productProfileLinkOf(productProfileLinks, member)
         );
     }
 
@@ -119,7 +119,7 @@ public class UmcProductMemberQueryService implements GetUmcProductMemberUseCase 
                 generationMap,
                 functionalUnitMap,
                 squadMap,
-                productProfileLinks.get(member.getProfileImageId())
+                productProfileLinkOf(productProfileLinks, member)
             ))
             .toList();
 
@@ -242,5 +242,10 @@ public class UmcProductMemberQueryService implements GetUmcProductMemberUseCase 
             return Map.of();
         }
         return getFileUseCase.getFileLinks(new ArrayList<>(imageIds));
+    }
+
+    private String productProfileLinkOf(Map<String, String> productProfileLinks, UmcProductMember member) {
+        String profileImageId = member.getProfileImageId();
+        return profileImageId == null ? null : productProfileLinks.get(profileImageId);
     }
 }

--- a/src/test/java/com/umc/product/organization/application/service/UmcProductMemberQueryServiceTest.java
+++ b/src/test/java/com/umc/product/organization/application/service/UmcProductMemberQueryServiceTest.java
@@ -1,0 +1,103 @@
+package com.umc.product.organization.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.dto.umcproduct.UmcProductMemberInfo;
+import com.umc.product.organization.application.port.in.query.dto.umcproduct.UmcProductMemberSearchCondition;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductFunctionalMembershipPort;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductFunctionalUnitPort;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductGenerationPort;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductMemberPort;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductSquadParticipantPort;
+import com.umc.product.organization.application.port.out.query.LoadUmcProductSquadPort;
+import com.umc.product.organization.domain.UmcProductMember;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UmcProductMemberQueryService")
+class UmcProductMemberQueryServiceTest {
+
+    @Mock
+    LoadUmcProductMemberPort loadUmcProductMemberPort;
+    @Mock
+    LoadUmcProductFunctionalMembershipPort loadUmcProductFunctionalMembershipPort;
+    @Mock
+    LoadUmcProductSquadParticipantPort loadUmcProductSquadParticipantPort;
+    @Mock
+    LoadUmcProductGenerationPort loadUmcProductGenerationPort;
+    @Mock
+    LoadUmcProductFunctionalUnitPort loadUmcProductFunctionalUnitPort;
+    @Mock
+    LoadUmcProductSquadPort loadUmcProductSquadPort;
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @InjectMocks
+    UmcProductMemberQueryService sut;
+
+    @Test
+    @DisplayName("search는 프로덕트 프로필 이미지가 없는 멤버를 조회할 수 있다")
+    void search는_프로덕트_프로필_이미지가_없는_멤버를_조회할_수_있다() {
+        UmcProductMember member = umcProductMember(1L, 100L, null);
+        PageRequest pageable = PageRequest.of(0, 10);
+        UmcProductMemberSearchCondition condition = UmcProductMemberSearchCondition.of(
+            null, null, null, null, null, null
+        );
+        given(loadUmcProductMemberPort.searchIds(condition, pageable))
+            .willReturn(new PageImpl<>(List.of(1L), pageable, 1));
+        given(loadUmcProductMemberPort.listByIds(List.of(1L))).willReturn(List.of(member));
+        given(loadUmcProductFunctionalMembershipPort.listByUmcProductMemberIds(List.of(1L))).willReturn(List.of());
+        given(loadUmcProductSquadParticipantPort.listByUmcProductMemberIds(List.of(1L))).willReturn(List.of());
+        given(getMemberUseCase.findAllByIds(Set.of(100L))).willReturn(Map.of());
+
+        Page<UmcProductMemberInfo> result = sut.search(condition, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().umcProductProfileImageId()).isNull();
+        assertThat(result.getContent().getFirst().umcProductProfileImageUrl()).isNull();
+        then(getFileUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("getById는 프로덕트 프로필 이미지가 없는 멤버를 조회할 수 있다")
+    void getById는_프로덕트_프로필_이미지가_없는_멤버를_조회할_수_있다() {
+        UmcProductMember member = umcProductMember(1L, 100L, null);
+        given(loadUmcProductMemberPort.getById(1L)).willReturn(member);
+        given(loadUmcProductFunctionalMembershipPort.listByUmcProductMemberId(1L)).willReturn(List.of());
+        given(loadUmcProductSquadParticipantPort.listByUmcProductMemberId(1L)).willReturn(List.of());
+        given(getMemberUseCase.findById(100L)).willReturn(Optional.empty());
+
+        UmcProductMemberInfo result = sut.getById(1L);
+
+        assertThat(result.umcProductProfileImageId()).isNull();
+        assertThat(result.umcProductProfileImageUrl()).isNull();
+        then(getFileUseCase).shouldHaveNoInteractions();
+    }
+
+    private UmcProductMember umcProductMember(Long id, Long memberId, String profileImageId) {
+        UmcProductMember member = UmcProductMember.create(memberId, "소개", profileImageId);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

1. 프로덕트팀 멤버 조회 응답 조립 시 `profileImageId`가 `null`이면 파일 링크 Map 조회를 건너뛰도록 수정했습니다.
2. 기존에는 이미지가 없는 멤버에서 `Map.of().get(null)`이 호출되어 `ImmutableCollections$MapN.get` 내부에서 NPE가 발생했습니다.
3. 검색 조회와 단건 조회 모두 같은 null-safe 프로필 링크 조회 로직을 사용하도록 정리했습니다.
4. 프로필 이미지가 없는 프로덕트팀 멤버 검색 및 단건 조회 회귀 테스트를 추가했습니다.

## 💬 리뷰 중점사항

- `umcProductProfileImageId`가 없는 멤버의 응답에서 `umcProductProfileImageUrl`이 `null`로 내려가는 동작이 API 계약상 적절한지 확인 부탁드립니다.
- 파일 링크 조회는 이미지 ID가 있을 때만 수행되도록 유지했습니다.

## 검증

- `./gradlew test --tests com.umc.product.organization.application.service.UmcProductMemberQueryServiceTest`
- `./gradlew test`
- `git diff --check`
