### PR TITLE
[Fix] 회장단이 특정파트의 지부 공지를 조회할 수 없는 문제 해결

### DIFF
--- a/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeQueryRepository.java
+++ b/src/main/java/com/umc/product/notice/adapter/out/persistence/NoticeQueryRepository.java
@@ -104,7 +104,7 @@ public class NoticeQueryRepository {
         NoticeViewerInfo viewerInfo
     ) {
         if (classification.isChallengerQuery()) {
-            return buildClassificationCondition(classification, viewerInfo.memberParts());
+            return buildClassificationCondition(classification, viewerInfo);
         }
         return buildStaffCondition(classification, viewerInfo);
     }
@@ -150,9 +150,21 @@ public class NoticeQueryRepository {
         return targetPartIsEmptyOrContainsAny(viewerInfo.memberParts());
     }
 
+    /**
+     * 챌린저 공지 파트 조건(파트 미지정 조회 시). - 회장단(SCHOOL_CORE)/중앙운영진(CENTRAL_MEMBER): 파트 무관 전체 열람 (본인 지부/학교 공지를 파트 상관없이
+     * 봐야 함, 상세 조회 권한과 동일 규칙) - 그 외(일반 챌린저/파트장): 본인 파트 + 파트 미지정 공지만
+     */
+    private BooleanExpression buildChallengerPartCondition(NoticeViewerInfo viewerInfo) {
+        NoticeTab viewerRole = viewerInfo.viewerRole();
+        if (viewerRole == NoticeTab.CENTRAL_MEMBER || viewerRole == NoticeTab.SCHOOL_CORE) {
+            return Expressions.TRUE;
+        }
+        return targetPartIsEmptyOrContainsAny(viewerInfo.memberParts());
+    }
+
     private BooleanExpression buildClassificationCondition(
         NoticeClassification classification,
-        Set<ChallengerPart> memberParts
+        NoticeViewerInfo viewerInfo
     ) {
         Long gisuId = classification.gisuId();
         Long chapterId = classification.chapterId();
@@ -167,8 +179,8 @@ public class NoticeQueryRepository {
             throw new NoticeDomainException(NoticeErrorCode.INVALID_TARGET_SETTING, "공지 대상을 설정하려면 기수를 선택해주세요.");
         }
 
-        log.debug("공지사항 조회 조건 제작: gisuId={}, chapterId={}, schoolId={}, part={}, memberParts={}",
-            gisuId, chapterId, schoolId, part, memberParts);
+        log.debug("공지사항 조회 조건 제작: gisuId={}, chapterId={}, schoolId={}, part={}, memberParts={}, viewerRole={}",
+            gisuId, chapterId, schoolId, part, viewerInfo.memberParts(), viewerInfo.viewerRole());
 
         BooleanExpression challengerNoticeOnly = isChallengerNotice();
         BooleanExpression gisuMatch = noticeTarget.targetGisuId.eq(gisuId)
@@ -187,7 +199,7 @@ public class NoticeQueryRepository {
                 .and(noticeTarget.targetGisuId.eq(gisuId))
                 .and(noticeTarget.targetChapterId.eq(chapterId))
                 .and(noticeTarget.targetSchoolId.isNull())
-                .and(targetPartIsEmptyOrContainsAny(memberParts));
+                .and(buildChallengerPartCondition(viewerInfo));
         }
 
         if (!hasChapter && hasSchool && !hasPart) {
@@ -195,7 +207,7 @@ public class NoticeQueryRepository {
                 .and(gisuMatch)
                 .and(noticeTarget.targetChapterId.isNull())
                 .and(noticeTarget.targetSchoolId.eq(schoolId))
-                .and(targetPartIsEmptyOrContainsAny(memberParts));
+                .and(buildChallengerPartCondition(viewerInfo));
         }
 
         if (hasPart) {

--- a/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
+++ b/src/main/java/com/umc/product/notice/application/service/NoticePermissionEvaluator.java
@@ -199,7 +199,9 @@ public class NoticePermissionEvaluator implements ResourcePermissionEvaluator {
         if (mySchoolId == null) {
             return false;
         }
-        if (!mySchoolId.equals(targetInfo.targetSchoolId())) {
+        // 학교 대상 공지는 본인 학교에 한정. 지부/전체 범위 공지(targetSchoolId == null)는
+        // 기수·지부 일치 여부로만 판정하여 회장단이 본인 지부공지를 파트 무관하게 읽을 수 있도록 함.
+        if (targetInfo.targetSchoolId() != null && !mySchoolId.equals(targetInfo.targetSchoolId())) {
             return false;
         }
         return isInGisuAndChapter(role, targetInfo, subject);

--- a/src/main/java/com/umc/product/notice/application/service/query/NoticeQueryService.java
+++ b/src/main/java/com/umc/product/notice/application/service/query/NoticeQueryService.java
@@ -289,7 +289,30 @@ public class NoticeQueryService implements GetNoticeUseCase {
     }
 
 
+    /**
+     * 조회 범위(지부/학교) 권한 검증.
+     * <p>
+     * 총괄/중앙운영진(CENTRAL_MEMBER)은 타 학교/지부 공지까지 자유롭게 조회할 수 있습니다. 그 외 역할(회장단/지부장/파트장/일반 챌린저)은 본인 소속 지부/학교 범위만 조회할 수
+     * 있습니다. 목록 조회와 상세 조회(@CheckAccess)의 접근 범위를 일치시켜, 임의의 학교/지부 ID를 넣어 타 범위 공지를 열람하는 우회를 차단합니다.
+     */
+    private void validateViewerScope(NoticeClassification classification, NoticeViewerInfo viewerInfo) {
+        if (viewerInfo.viewerRole() == NoticeTab.CENTRAL_MEMBER) {
+            return;
+        }
+        if (classification.chapterId() != null
+            && !classification.chapterId().equals(viewerInfo.chapterId())) {
+            throw new NoticeDomainException(NoticeErrorCode.NO_READ_PERMISSION,
+                "본인 소속 지부의 공지만 조회할 수 있습니다.");
+        }
+        if (classification.schoolId() != null
+            && !classification.schoolId().equals(viewerInfo.schoolId())) {
+            throw new NoticeDomainException(NoticeErrorCode.NO_READ_PERMISSION,
+                "본인 소속 학교의 공지만 조회할 수 있습니다.");
+        }
+    }
+
     private void validateClassification(NoticeClassification classification, NoticeViewerInfo viewerInfo) {
+        validateViewerScope(classification, viewerInfo);
         if (classification.isChallengerQuery()) {
             // 챌린저 공지: 필드 조합 유효성 검증 (지부+학교 동시 지정 등 불가 조합 차단)
             NoticeTargetPattern.from(classification.toTargetInfo());


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #997 

## 🚀 작업 내용
### 문제 상황

학교 회장단이 **파트별 공지(특히 지부+파트로 지정된 지부공지)를 보지 못하는** 문제가 있었습니다.
원인을 추적한 결과, 공지 **목록 조회**와 **상세 조회(@CheckAccess)**의 권한 규칙이 서로 따로 동작하는
3가지 불일치가 확인되었습니다.

1. **목록에서 회장단/중앙운영진이 본인 파트만 보임**
   - 챌린저 공지 목록 쿼리(`NoticeQueryRepository.buildClassificationCondition`)가 조회자의 역할(`viewerRole`)을
     보지 않고 본인 파트(`memberParts`)로만 파트 필터를 적용.
   - 회장단/중운은 전 파트를 봐야 하는데 본인 파트 + 파트 미지정 공지만 노출됨.

2. **상세에서 회장단이 지부 단위 파트 공지를 못 엶 -> 이제 현재 이슈의 근본 원인이었습니다.**
   - 지부공지는 `targetSchoolId == null`이라 회장단이 본인 지부공지를 열람 시 차단됨(본인 파트와 일치할 때만 열림).

3. **(추가 발견) 목록 조회에 소속 범위 검증 부재**
   - 목록 엔드포인트(`getAllNotices`/`searchNotices`)에는 `@CheckAccess`가 없고, 조회자의 실제 소속을
     검증하지 않은 채 `chapterId`/`schoolId` 파라미터를 그대로 신뢰.
   - 일반 챌린저가 임의의 학교/지부 ID를 넣어 **타 범위 공지의 본문까지 조회**할 수 있는 접근통제 우회 존재
     (목록 응답에 `content` 전문이 포함됨).

### 해결 방법

- 목록 파트 필터를 역할 기반으로 확장 — `NoticeQueryRepository`
  - `buildChallengerPartCondition` 헬퍼 추가. `viewerRole`이 `SCHOOL_CORE`(회장단/지부장) 또는
  `CENTRAL_MEMBER`(총괄/중앙운영진)이면 파트 제한 없이 전체, 그 외(일반 챌린저/파트장)는 기존대로
  본인 파트 + 파트 미지정만 노출.
  - 운영진 공지 경로(`buildStaffPartCondition`)가 이미 쓰던 원칙과 동일하게 정렬.

- 상세 권한에서 지부/전체 범위 공지 허용 — `NoticePermissionEvaluator.schoolCoreCanRead`
  - 학교 매칭은 `targetSchoolId`가 있을 때만 강제하고, 지부/전체 범위 공지(`targetSchoolId == null`)는
  `isInGisuAndChapter`(기수·지부 일치, 파트 무관)로 판정.
  - 회장단이 본인 지부공지·학교공지를 파트 무관하게 상세에서도 열람 가능 → 목록과 일치.

- 목록 조회 범위 가드 추가 — `NoticeQueryService.validateViewerScope`
  - `CENTRAL_MEMBER`(총괄/중앙운영진)은 타 학교/지부 자유 조회 허용(유연성 유지).
  - 그 외 역할은 요청 `chapterId`/`schoolId`가 본인 소속과 다르면 `NO_READ_PERMISSION`.
  - 임의 ID로 타 범위 공지 본문을 조회하던 우회 차단, 목록과 상세의 접근 범위 정렬.

**테스트**

한성대학교 회장이 제논지부 플랜파트 공지 조회
<img width="456" height="629" alt="image" src="https://github.com/user-attachments/assets/7e8a422f-7679-4258-960b-c1cc0253cdf8" />



## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.

