### PR TITLE
[Fix] 운영진 권한이 있는 경우 본인의 프로젝트를 관리 목록에서 조회할 수 없는 문제 수정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -68,22 +68,34 @@ public class ProjectQueryRepository {
     }
 
     private BooleanBuilder buildCondition(SearchProjectQuery query) {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        builder
+        BooleanBuilder common = new BooleanBuilder()
             .and(gisuIdEq(query.gisuId()))
             .and(keywordContains(query.keyword()))
+            .and(partAndQuotaFilter(query.parts(), query.partQuotaStatus()));
+
+        BooleanBuilder scoped = new BooleanBuilder()
             .and(chapterIdEq(query.chapterId()))
             .and(productOwnerSchoolIdsIn(query.productOwnerSchoolIds()))
             .and(productOwnerMemberIdEq(query.productOwnerMemberId()))
-            .and(partAndQuotaFilter(query.parts(), query.partQuotaStatus()))
             .and(statusIn(query.statuses()));
 
-        return builder;
+        BooleanExpression includedOwner = includedOwnerCond(query);
+        if (includedOwner != null) {
+            scoped.or(includedOwner);
+        }
+
+        return common.and(scoped);
     }
 
     private BooleanExpression productOwnerMemberIdEq(Long memberId) {
         return memberId != null ? project.productOwnerMemberId.eq(memberId) : null;
+    }
+
+    private BooleanExpression includedOwnerCond(SearchProjectQuery query) {
+        return query.includedOwnerMemberId() != null
+            ? project.productOwnerMemberId.eq(query.includedOwnerMemberId())
+                .and(project.status.in(query.includedOwnerStatuses()))
+            : null;
     }
 
     private BooleanExpression gisuIdEq(Long gisuId) {

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -4,6 +4,15 @@ import static com.umc.product.project.domain.QProject.project;
 import static com.umc.product.project.domain.QProjectMember.projectMember;
 import static com.umc.product.project.domain.QProjectPartQuota.projectPartQuota;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -18,14 +27,8 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.PartQuotaStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
 
 /**
  * Project QueryDSL 동적 검색 구현 (PROJECT-001).

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
@@ -1,7 +1,8 @@
 package com.umc.product.project.application.access;
 
-import com.umc.product.project.domain.enums.ProjectStatus;
 import java.util.Set;
+
+import com.umc.product.project.domain.enums.ProjectStatus;
 
 /**
  * 프로젝트 조회 시 적용되는 가시 범위(scope) typed value.

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
@@ -24,6 +24,17 @@ public sealed interface ProjectAccessScope {
     /** 본인이 PM 인 프로젝트만 노출 (PM 챌린저, 관리 화면). */
     record OwnerOnly(Long memberId, Set<ProjectStatus> visibleStatuses) implements ProjectAccessScope {}
 
+    /**
+     * 상위 권한 scope 결과에 본인 PO 프로젝트를 추가 포함한다.
+     * <p>
+     * 운영진/지부장/학교 회장단 scope 에서 DRAFT 를 전체 공개하지 않으면서, 본인이 PO 인 프로젝트만 별도 OR 조건으로 노출하기 위한 값 객체.
+     */
+    record WithOwnerIncluded(
+        ProjectAccessScope baseScope,
+        Long ownerMemberId,
+        Set<ProjectStatus> ownerVisibleStatuses
+    ) implements ProjectAccessScope {}
+
     /** 일반 챌린저용 공개 목록 ({@link ProjectStatus#IN_PROGRESS} / {@link ProjectStatus#COMPLETED}). */
     record PublicOnly() implements ProjectAccessScope {}
 

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
@@ -1,5 +1,13 @@
 package com.umc.product.project.application.access;
 
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -14,13 +22,8 @@ import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * 호출 컨텍스트(공개 검색 vs 관리 화면) + 사용자 역할에 따라 {@link ProjectAccessScope} 를 결정한다.

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
@@ -9,6 +9,7 @@ import com.umc.product.project.application.access.ProjectAccessScope.None;
 import com.umc.product.project.application.access.ProjectAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.PublicOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.SchoolScoped;
+import com.umc.product.project.application.access.ProjectAccessScope.WithOwnerIncluded;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
@@ -90,17 +91,19 @@ public class ProjectAccessScopeResolver {
             .toList();
 
         if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
-            return new All(requestedStatuses);
+            return includeOwnerProjects(new All(requestedStatuses), memberId, gisuId, requestedStatuses);
         }
 
         Optional<Long> chapterId = chapterPresidentOrgId(rolesInGisu);
         if (chapterId.isPresent()) {
-            return new ChapterScoped(chapterId.get(), requestedStatuses);
+            return includeOwnerProjects(new ChapterScoped(chapterId.get(), requestedStatuses),
+                memberId, gisuId, requestedStatuses);
         }
 
         Optional<Long> schoolId = schoolCoreOrgId(rolesInGisu);
         if (schoolId.isPresent()) {
-            return new SchoolScoped(schoolId.get(), requestedStatuses);
+            return includeOwnerProjects(new SchoolScoped(schoolId.get(), requestedStatuses),
+                memberId, gisuId, requestedStatuses);
         }
 
         if (loadProjectPort.existsByOwnerAndGisu(memberId, gisuId)) {
@@ -112,6 +115,23 @@ public class ProjectAccessScopeResolver {
         }
 
         return new None();
+    }
+
+    private ProjectAccessScope includeOwnerProjects(
+        ProjectAccessScope baseScope,
+        Long memberId,
+        Long gisuId,
+        Set<ProjectStatus> requestedStatuses
+    ) {
+        if (!loadProjectPort.existsByOwnerAndGisu(memberId, gisuId)) {
+            return baseScope;
+        }
+
+        Set<ProjectStatus> ownerStatuses = requestedStatuses.isEmpty()
+            ? EnumSet.allOf(ProjectStatus.class)
+            : EnumSet.copyOf(requestedStatuses);
+        ownerStatuses.add(ProjectStatus.DRAFT);
+        return new WithOwnerIncluded(baseScope, memberId, ownerStatuses);
     }
 
     private Optional<Long> chapterPresidentOrgId(List<ChallengerRoleInfo> rolesInGisu) {

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
@@ -1,14 +1,17 @@
 package com.umc.product.project.application.port.in.query.dto;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
-import com.umc.product.project.domain.enums.PartQuotaStatus;
-import com.umc.product.project.domain.enums.ProjectStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import lombok.Builder;
+
 import org.springframework.data.domain.Pageable;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.PartQuotaStatus;
+import com.umc.product.project.domain.enums.ProjectStatus;
+
+import lombok.Builder;
 
 /**
  * 프로젝트 목록 검색 Query (PROJECT-001).

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
@@ -28,9 +28,11 @@ public record SearchProjectQuery(
     Long chapterId,
     List<Long> productOwnerSchoolIds,
     Long productOwnerMemberId,
+    Long includedOwnerMemberId,
     List<ChallengerPart> parts,
     PartQuotaStatus partQuotaStatus,
     List<ProjectStatus> statuses,
+    List<ProjectStatus> includedOwnerStatuses,
     Pageable pageable
 ) {
     public SearchProjectQuery {
@@ -38,6 +40,12 @@ public record SearchProjectQuery(
         Objects.requireNonNull(pageable, "pageable must not be null");
         if (statuses == null || statuses.isEmpty()) {
             throw new IllegalArgumentException("statuses must contain at least one ProjectStatus");
+        }
+        if (includedOwnerMemberId == null && includedOwnerStatuses != null && !includedOwnerStatuses.isEmpty()) {
+            throw new IllegalArgumentException("includedOwnerMemberId must not be null when includedOwnerStatuses exists");
+        }
+        if (includedOwnerMemberId != null && (includedOwnerStatuses == null || includedOwnerStatuses.isEmpty())) {
+            throw new IllegalArgumentException("includedOwnerStatuses must contain at least one ProjectStatus");
         }
     }
 
@@ -126,6 +134,15 @@ public record SearchProjectQuery(
             .build();
     }
 
+    /** scope 적용 — 기존 scope 조건에 본인 PO 프로젝트를 OR 로 추가 포함. */
+    public SearchProjectQuery withIncludedOwner(Long memberId, Set<ProjectStatus> ownerStatuses) {
+        Objects.requireNonNull(memberId, "memberId must not be null");
+        return copyBuilder()
+            .includedOwnerMemberId(memberId)
+            .includedOwnerStatuses(toRequiredList(ownerStatuses))
+            .build();
+    }
+
     private SearchProjectQueryBuilder copyBuilder() {
         return SearchProjectQuery.builder()
             .gisuId(gisuId)
@@ -133,15 +150,24 @@ public record SearchProjectQuery(
             .chapterId(chapterId)
             .productOwnerSchoolIds(productOwnerSchoolIds)
             .productOwnerMemberId(productOwnerMemberId)
+            .includedOwnerMemberId(includedOwnerMemberId)
             .parts(parts)
             .partQuotaStatus(partQuotaStatus)
             .statuses(statuses)
+            .includedOwnerStatuses(includedOwnerStatuses)
             .pageable(pageable);
     }
 
     private static List<ProjectStatus> toList(Set<ProjectStatus> set) {
         if (set == null || set.isEmpty()) {
             return List.of(ProjectStatus.IN_PROGRESS);
+        }
+        return new ArrayList<>(set);
+    }
+
+    private static List<ProjectStatus> toRequiredList(Set<ProjectStatus> set) {
+        if (set == null || set.isEmpty()) {
+            throw new IllegalArgumentException("ownerStatuses must contain at least one ProjectStatus");
         }
         return new ArrayList<>(set);
     }

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -156,9 +156,34 @@ public class ProjectQueryService implements
                 loadProjectPort.search(query.withSchoolFilter(schoolId, statuses));
             case OwnerOnly(Long memberId, Set<ProjectStatus> statuses) ->
                 loadProjectPort.search(query.withOwnerFilter(memberId, statuses));
+            case ProjectAccessScope.WithOwnerIncluded(
+                ProjectAccessScope baseScope,
+                Long ownerMemberId,
+                Set<ProjectStatus> ownerStatuses
+            ) -> loadProjectPort.search(toScopedQuery(baseScope, query)
+                .withIncludedOwner(ownerMemberId, ownerStatuses));
             case PublicOnly() -> loadProjectPort.search(query.withStatuses(
                 Set.of(ProjectStatus.IN_PROGRESS, ProjectStatus.COMPLETED)));
             case None() -> new PageImpl<>(List.of(), query.pageable(), 0L);
+        };
+    }
+
+    private SearchProjectQuery toScopedQuery(ProjectAccessScope scope, SearchProjectQuery query) {
+        return switch (scope) {
+            case All(Set<ProjectStatus> statuses) -> query.withStatuses(statuses);
+            case ChapterScoped(Long chapterId, Set<ProjectStatus> statuses) ->
+                query.withChapterFilter(chapterId, statuses);
+            case SchoolScoped(Long schoolId, Set<ProjectStatus> statuses) ->
+                query.withSchoolFilter(schoolId, statuses);
+            case OwnerOnly(Long memberId, Set<ProjectStatus> statuses) ->
+                query.withOwnerFilter(memberId, statuses);
+            case PublicOnly() -> query.withStatuses(Set.of(ProjectStatus.IN_PROGRESS, ProjectStatus.COMPLETED));
+            case None() -> query.withStatuses(Set.of(ProjectStatus.IN_PROGRESS));
+            case ProjectAccessScope.WithOwnerIncluded(
+                ProjectAccessScope baseScope,
+                Long ownerMemberId,
+                Set<ProjectStatus> ownerStatuses
+            ) -> toScopedQuery(baseScope, query).withIncludedOwner(ownerMemberId, ownerStatuses);
         };
     }
 

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -404,6 +404,30 @@ class ProjectQueryRepositoryTest {
         assertThat(result.getContent().get(0).getName()).isEqualTo("한양대 프로젝트");
     }
 
+    @Test
+    void 상위_scope_검색에서도_본인_PO_DRAFT는_추가_포함한다() {
+        persistProject("내 초안", ProjectStatus.DRAFT, gisuId, 2L, 99L, 9L);
+        persistProject("다른 사람 초안", ProjectStatus.DRAFT, gisuId, 2L, 100L, 9L);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.builder()
+            .gisuId(gisuId)
+            .chapterId(1L)
+            .statuses(List.of(ProjectStatus.PENDING_REVIEW, ProjectStatus.IN_PROGRESS,
+                ProjectStatus.COMPLETED, ProjectStatus.ABORTED))
+            .pageable(PageRequest.of(0, 20))
+            .build()
+            .withIncludedOwner(99L, java.util.EnumSet.allOf(ProjectStatus.class));
+
+        Page<Project> result = sut.search(query);
+
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .contains("내 초안")
+            .doesNotContain("다른 사람 초안");
+    }
+
     // ========== Helper ==========
 
     private Project persistProject(String name, ProjectStatus status, Long gisuId, Long chapterId, Long ownerId) {

--- a/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
@@ -4,6 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -17,13 +26,6 @@ import com.umc.product.project.application.access.ProjectAccessScope.SchoolScope
 import com.umc.product.project.application.access.ProjectAccessScope.WithOwnerIncluded;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import java.util.List;
-import java.util.Set;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectAccessScopeResolverTest {

--- a/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
@@ -14,6 +14,7 @@ import com.umc.product.project.application.access.ProjectAccessScope.None;
 import com.umc.product.project.application.access.ProjectAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.PublicOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.SchoolScoped;
+import com.umc.product.project.application.access.ProjectAccessScope.WithOwnerIncluded;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import java.util.List;
@@ -225,6 +226,27 @@ class ProjectAccessScopeResolverTest {
         assertThat(scope).isInstanceOf(ChapterScoped.class);
         assertThat(((ChapterScoped) scope).visibleStatuses())
             .doesNotContain(ProjectStatus.DRAFT);
+    }
+
+    @Test
+    void management_은_상위_권한자라도_PO_프로젝트가_있으면_본인_PO_프로젝트를_추가_포함한다() {
+        Long memberId = 10L;
+        Long gisuId = 1L;
+        given(getChallengerRoleUseCase.findAllByMemberId(memberId)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER, 5L, gisuId)
+        ));
+        given(loadProjectPort.existsByOwnerAndGisu(memberId, gisuId)).willReturn(true);
+
+        Set<ProjectStatus> requested = Set.of(ProjectStatus.PENDING_REVIEW, ProjectStatus.IN_PROGRESS);
+        ProjectAccessScope scope = sut.resolveForManagement(memberId, gisuId, requested);
+
+        assertThat(scope).isInstanceOf(WithOwnerIncluded.class);
+        WithOwnerIncluded withOwner = (WithOwnerIncluded) scope;
+        assertThat(withOwner.baseScope()).isInstanceOf(ChapterScoped.class);
+        assertThat(withOwner.ownerMemberId()).isEqualTo(memberId);
+        assertThat(withOwner.ownerVisibleStatuses())
+            .contains(ProjectStatus.DRAFT)
+            .containsAll(requested);
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -8,6 +8,21 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.access.ProjectAccessScope;
 import com.umc.product.project.application.access.ProjectAccessScopeResolver;
@@ -22,19 +37,6 @@ import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectQueryServiceTest {

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectQueryServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -281,6 +282,39 @@ class ProjectQueryServiceTest {
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
         verify(loadProjectMemberPort, never()).listByProjectIdsAndPartGroupedByProjectId(anySet(), any());
+    }
+
+    @Test
+    void searchManaged_상위_scope에서도_본인_PO_프로젝트를_추가_포함하는_query를_전달한다() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchManagedProjectQuery query = SearchManagedProjectQuery.builder()
+            .gisuId(1L).keyword(null).pageable(pageable).build();
+        java.util.Set<ProjectStatus> requested = java.util.Set.of(
+            ProjectStatus.PENDING_REVIEW,
+            ProjectStatus.IN_PROGRESS,
+            ProjectStatus.COMPLETED,
+            ProjectStatus.ABORTED
+        );
+        java.util.Set<ProjectStatus> ownerStatuses = java.util.EnumSet.copyOf(requested);
+        ownerStatuses.add(ProjectStatus.DRAFT);
+
+        given(scopeResolver.resolveForManagement(any(), any(), anySet()))
+            .willReturn(new ProjectAccessScope.WithOwnerIncluded(
+                new ProjectAccessScope.ChapterScoped(5L, requested),
+                99L,
+                ownerStatuses
+            ));
+        given(loadProjectPort.search(any(SearchProjectQuery.class)))
+            .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        sut.searchManaged(query, 99L);
+
+        ArgumentCaptor<SearchProjectQuery> captor = ArgumentCaptor.forClass(SearchProjectQuery.class);
+        verify(loadProjectPort).search(captor.capture());
+        SearchProjectQuery actual = captor.getValue();
+        assertThat(actual.chapterId()).isEqualTo(5L);
+        assertThat(actual.includedOwnerMemberId()).isEqualTo(99L);
+        assertThat(actual.includedOwnerStatuses()).contains(ProjectStatus.DRAFT);
     }
 
     // ========== Helper Methods ==========


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 병합 대상 브랜치가 올바른지 확인했어요. (Production: `main`, Development: `develop`)
- [x] PR 제목을 컨벤션에 맞게 작성했어요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

- resolves #

## 🚀 작업 내용

### 변경 범위 요약

- project 도메인의 관리 프로젝트 조회 scope 계산과 QueryDSL 검색 조건을 수정했어요.
- [PROJECT-006] GET /api/v1/projects/me/managed 기존 API의 응답 범위를 보정하고, 관련 단위 테스트와 persistence 테스트를 추가했어요.

### 작업 단위별 상세

1. **무엇을**: 상위 권한자가 본인 PO 프로젝트를 함께 관리 목록에서 볼 수 있도록 수정했어요.
   - **어떻게**: `ProjectAccessScope.WithOwnerIncluded`를 추가하고, 중앙 총괄단·지부장·학교 회장단 scope에 해당해도 같은 기수에 본인 PO 프로젝트가 있으면 owner 조건을 추가로 전달하도록 구성했어요.
   - **왜**: 상위 권한 분기가 먼저 적용되면 본인이 PO인 DRAFT 프로젝트가 `/me/managed` 응답에서 빠지는 문제가 있었기 때문이에요.

2. **무엇을**: 본인 PO 프로젝트만 추가 포함되도록 QueryDSL 조건을 분리했어요.
   - **어떻게**: 공통 조건은 `gisuId`, `keyword`, quota 필터로 유지하고, scope 조건과 본인 owner 조건을 `OR`로 묶어 `공통 조건 AND (scope 조건 OR owner 조건)` 형태로 검색하도록 수정했어요.
   - **왜**: DRAFT를 상위 권한 전체 scope에 섞으면 다른 사람의 DRAFT까지 노출될 수 있어서, 본인 PO 프로젝트만 제한적으로 포함해야 했기 때문이에요.

3. **무엇을**: 상위 권한자와 PO 역할이 겹치는 케이스의 회귀 테스트를 추가했어요.
   - **어떻게**: scope resolver, query service, QueryDSL repository 테스트에 각각 본인 PO DRAFT 포함과 타인 DRAFT 제외 검증을 추가했어요.
   - **왜**: 역할 우선순위와 DRAFT 노출 범위가 다시 깨지지 않도록 계층별로 기대 동작을 고정하기 위해서예요.

## 💬 리뷰 중점사항

- `DRAFT`가 상위 권한 전체에 노출되지 않고 본인 PO 프로젝트에만 추가되는지 확인 부탁드려요.
- QueryDSL 조건이 `공통 조건 AND (scope 조건 OR owner 조건)`으로 적용되어 pagination과 total count가 같은 조건을 쓰는지 확인 부탁드려요.
- 검증은 `./gradlew test --tests 'com.umc.product.project.application.access.ProjectAccessScopeResolverTest' --tests 'com.umc.product.project.application.service.query.ProjectQueryServiceTest' --tests 'com.umc.product.project.adapter.out.persistence.ProjectQueryRepositoryTest'`로 수행했어요.
