### PR TITLE
[Feat] 지부 내 프로젝트 지원 현황을 교내 회장단도 조회할 수 있도록 변경

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -98,7 +98,7 @@ public class ProjectApplicationQueryController {
               <li>SUPER_ADMIN</li>
               <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
               <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
-              <li>해당 프로젝트 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+              <li>해당 프로젝트 지부에 속한 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
             </ul>
             """
     )

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -98,7 +98,7 @@ public class ProjectApplicationQueryController {
               <li>SUPER_ADMIN</li>
               <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
               <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
-              <li>해당 프로젝트 지부에 속한 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+              <li>해당 프로젝트 지부에 속한 학교 회장단 (SCHOOL_PRESIDENT/SCHOOL_VICE_PRESIDENT, 같은 기수)</li>
             </ul>
             """
     )

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -1,5 +1,13 @@
 package com.umc.product.project.application.access;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -13,13 +21,8 @@ import com.umc.product.project.application.access.ProjectApplicationAccessScope.
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.domain.Project;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * 호출 컨텍스트(본인 지원 내역 vs PO 검토 vs 운영진 모니터링) + 사용자 역할에 따라 {@link ProjectApplicationAccessScope} 를 결정한다.

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -47,7 +47,7 @@ public class ProjectApplicationAccessScopeResolver {
      *   <li>SUPER_ADMIN</li>
      *   <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
      *   <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
-     *   <li>해당 프로젝트 지부에 속한 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+     *   <li>해당 프로젝트 지부에 속한 학교 회장단 (SCHOOL_PRESIDENT/SCHOOL_VICE_PRESIDENT, 같은 기수)</li>
      * </ul>
      * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리하여 권한 부재를 '지원자 0건' 으로 위장한다.
      * <p>
@@ -76,16 +76,17 @@ public class ProjectApplicationAccessScopeResolver {
             return new ProjectScoped(projectId);
         }
 
-        if (isSchoolPresidentInProjectChapter(rolesInGisu, project)) {
+        if (isSchoolCoreInProjectChapter(rolesInGisu, project)) {
             return new ProjectScoped(projectId);
         }
 
         return new None();
     }
 
-    private boolean isSchoolPresidentInProjectChapter(List<ChallengerRoleInfo> rolesInGisu, Project project) {
+    private boolean isSchoolCoreInProjectChapter(List<ChallengerRoleInfo> rolesInGisu, Project project) {
         Set<Long> schoolIds = rolesInGisu.stream()
-            .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT)
+            .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                || r.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
             .map(ChallengerRoleInfo::organizationId)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -3,6 +3,8 @@ package com.umc.product.project.application.access;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.All;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.AllInGisu;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ChapterScoped;
@@ -12,7 +14,10 @@ import com.umc.product.project.application.access.ProjectApplicationAccessScope.
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.domain.Project;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +30,7 @@ public class ProjectApplicationAccessScopeResolver {
 
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final LoadProjectMemberPort loadProjectMemberPort;
+    private final GetChapterUseCase getChapterUseCase;
 
     /**
      * 본인 지원 내역 화면. 누구든지 본인 지원서만 본다.
@@ -41,7 +47,7 @@ public class ProjectApplicationAccessScopeResolver {
      *   <li>SUPER_ADMIN</li>
      *   <li>해당 프로젝트 기수의 Central Core (총괄/부총괄)</li>
      *   <li>해당 프로젝트 지부의 지부장 (같은 기수)</li>
-     *   <li>해당 프로젝트 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
+     *   <li>해당 프로젝트 지부에 속한 학교의 회장 (SCHOOL_PRESIDENT, 같은 기수)</li>
      * </ul>
      * 그 외엔 {@link None} 반환 — 호출 측이 빈 목록 처리하여 권한 부재를 '지원자 0건' 으로 위장한다.
      * <p>
@@ -66,13 +72,36 @@ public class ProjectApplicationAccessScopeResolver {
 
         if (rolesInGisu.stream().anyMatch(
             r -> r.roleType().isAtLeastCentralCore() || (r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
-                && Objects.equals(r.organizationId(), project.getChapterId())) || (
-                r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT && Objects.equals(r.organizationId(),
-                    project.getProductOwnerSchoolId())))) {
+                && Objects.equals(r.organizationId(), project.getChapterId())))) {
+            return new ProjectScoped(projectId);
+        }
+
+        if (isSchoolPresidentInProjectChapter(rolesInGisu, project)) {
             return new ProjectScoped(projectId);
         }
 
         return new None();
+    }
+
+    private boolean isSchoolPresidentInProjectChapter(List<ChallengerRoleInfo> rolesInGisu, Project project) {
+        Set<Long> schoolIds = rolesInGisu.stream()
+            .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        if (schoolIds.isEmpty()) {
+            return false;
+        }
+
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool =
+            getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(project.getGisuId()), schoolIds);
+        Map<Long, ChapterInfo> chapterBySchool =
+            chapterByGisuAndSchool.getOrDefault(project.getGisuId(), Map.of());
+
+        return chapterBySchool.values().stream()
+            .filter(Objects::nonNull)
+            .anyMatch(chapter -> Objects.equals(chapter.id(), project.getChapterId()));
     }
 
     /**

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -3,6 +3,18 @@ package com.umc.product.project.application.access;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -13,16 +25,6 @@ import com.umc.product.project.application.access.ProjectApplicationAccessScope.
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.domain.Project;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationAccessScopeResolverTest {

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -7,11 +7,15 @@ import com.umc.product.authorization.application.port.in.query.GetChallengerRole
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.None;
 import com.umc.product.project.application.access.ProjectApplicationAccessScope.ProjectScoped;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.domain.Project;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +41,8 @@ class ProjectApplicationAccessScopeResolverTest {
     GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock
     LoadProjectMemberPort loadProjectMemberPort;
+    @Mock
+    GetChapterUseCase getChapterUseCase;
 
     @InjectMocks
     ProjectApplicationAccessScopeResolver sut;
@@ -233,13 +239,15 @@ class ProjectApplicationAccessScopeResolverTest {
     }
 
     @Test
-    @DisplayName("projectApplicantList_같은_기수_학교의_회장이면_ProjectScoped")
-    void projectApplicantList_학교회장_통과() {
+    @DisplayName("projectApplicantList_같은_기수_같은_지부_학교_회장이면_ProjectScoped")
+    void projectApplicantList_같은지부_학교회장_통과() {
         Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
-            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
         ));
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(GISU_ID), Set.of(OTHER_SCHOOL_ID)))
+            .willReturn(Map.of(GISU_ID, Map.of(OTHER_SCHOOL_ID, new ChapterInfo(CHAPTER_ID, "서울"))));
 
         ProjectApplicationAccessScope scope =
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
@@ -268,13 +276,15 @@ class ProjectApplicationAccessScopeResolverTest {
     // --- helpers ---
 
     @Test
-    @DisplayName("projectApplicantList_타_학교_회장이면_None")
-    void projectApplicantList_타학교_회장_거부() {
+    @DisplayName("projectApplicantList_타_지부_학교_회장이면_None")
+    void projectApplicantList_타지부_학교회장_거부() {
         Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
         ));
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(GISU_ID), Set.of(OTHER_SCHOOL_ID)))
+            .willReturn(Map.of(GISU_ID, Map.of(OTHER_SCHOOL_ID, new ChapterInfo(OTHER_CHAPTER_ID, "인천"))));
 
         ProjectApplicationAccessScope scope =
             sut.resolveForProjectApplicantList(MEMBER_ID, project);

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -191,7 +191,7 @@ class ProjectApplicationAccessScopeResolverTest {
         assertThat(scope).isInstanceOf(None.class);
     }
 
-    // --- 학교 회장 (SCHOOL_PRESIDENT 만 통과, 부회장 제외) ---
+    // --- 학교 회장단 (SCHOOL_PRESIDENT / SCHOOL_VICE_PRESIDENT) ---
 
     @Test
     @DisplayName("projectApplicantList_같은_기수_지부의_지부장이면_ProjectScoped")
@@ -258,19 +258,20 @@ class ProjectApplicationAccessScopeResolverTest {
     // --- 권한 없음 (역할 0건) ---
 
     @Test
-    @DisplayName("projectApplicantList_학교_부회장은_권한_없음_None")
-    void projectApplicantList_학교_부회장_거부() {
-        // SCHOOL_VICE_PRESIDENT 는 명시적으로 제외됨 (회장만 통과)
+    @DisplayName("projectApplicantList_같은_기수_같은_지부_학교_부회장이면_ProjectScoped")
+    void projectApplicantList_같은지부_학교부회장_통과() {
         Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, GISU_ID)
         ));
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(GISU_ID), Set.of(SCHOOL_ID)))
+            .willReturn(Map.of(GISU_ID, Map.of(SCHOOL_ID, new ChapterInfo(CHAPTER_ID, "서울"))));
 
         ProjectApplicationAccessScope scope =
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
-        assertThat(scope).isInstanceOf(None.class);
+        assertThat(scope).isInstanceOf(ProjectScoped.class);
     }
 
     // --- helpers ---
@@ -282,6 +283,23 @@ class ProjectApplicationAccessScopeResolverTest {
         given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
         given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
+        ));
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(GISU_ID), Set.of(OTHER_SCHOOL_ID)))
+            .willReturn(Map.of(GISU_ID, Map.of(OTHER_SCHOOL_ID, new ChapterInfo(OTHER_CHAPTER_ID, "인천"))));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
+
+        assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantList_타_지부_학교_부회장이면_None")
+    void projectApplicantList_타지부_학교부회장_거부() {
+        Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, OTHER_SCHOOL_ID, GISU_ID)
         ));
         given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(GISU_ID), Set.of(OTHER_SCHOOL_ID)))
             .willReturn(Map.of(GISU_ID, Map.of(OTHER_SCHOOL_ID, new ChapterInfo(OTHER_CHAPTER_ID, "인천"))));


### PR DESCRIPTION
## 작업 내용
- 단일 프로젝트 지원자 목록 조회에서 SCHOOL_PRESIDENT 권한을 프로젝트 학교 기준에서 프로젝트 지부 기준으로 확장했습니다.
- SCHOOL_VICE_PRESIDENT도 동일하게 같은 기수, 같은 지부 학교 회장단 권한으로 지원자 목록을 조회할 수 있게 했습니다.
- 권한 설명과 resolver 단위 테스트를 갱신했습니다.

## 검증
- ./gradlew test --tests com.umc.product.project.application.access.ProjectApplicationAccessScopeResolverTest --tests com.umc.product.project.application.service.query.ProjectApplicationQueryServiceTest
- git diff --check