### PR TITLE
[Feat] 프로젝트 목록 정렬 순서 조정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -55,7 +55,8 @@ public class ProjectQueryController {
     public PageResponse<ProjectSummaryResponse> searchProjects(
         @CurrentMember MemberPrincipal memberPrincipal,
         @ParameterObject @Valid SearchProjectRequest request,
-        @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+        @ParameterObject @PageableDefault(size = 20, sort = {"createdAt", "name"}, direction = Sort.Direction.ASC)
+        Pageable pageable
     ) {
         SearchProjectQuery query = request.toQuery(pageable);
         return assembler.searchFor(query, memberPrincipal.getMemberId());
@@ -123,7 +124,8 @@ public class ProjectQueryController {
         @CurrentMember MemberPrincipal memberPrincipal,
         @RequestParam Long gisuId,
         @RequestParam(required = false) String keyword,
-        @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+        @ParameterObject @PageableDefault(size = 20, sort = {"createdAt", "name"}, direction = Sort.Direction.ASC)
+        Pageable pageable
     ) {
         SearchManagedProjectQuery query = SearchManagedProjectQuery.builder()
             .gisuId(gisuId)

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepository.java
@@ -215,11 +215,11 @@ public class ProjectQueryRepository {
 
     /**
      * Pageable의 Sort를 QueryDSL OrderSpecifier 배열로 변환합니다.
-     * 정렬 조건이 없으면 createdAt 내림차순을 기본으로 사용합니다.
+     * 정렬 조건이 없으면 createdAt 오름차순, name 오름차순을 기본으로 사용합니다.
      */
     private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
         if (sort == null || sort.isUnsorted()) {
-            return new OrderSpecifier<?>[]{project.createdAt.desc()};
+            return new OrderSpecifier<?>[]{project.createdAt.asc(), project.name.asc()};
         }
         PathBuilder<Project> path = new PathBuilder<>(Project.class, project.getMetadata());
         List<OrderSpecifier<?>> specifiers = new ArrayList<>();

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectQueryControllerTest.java
@@ -8,14 +8,8 @@ import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.response.PageResponse;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
-import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
-import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +22,14 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
 
 @WebMvcTest(controllers = ProjectQueryController.class)
 @Import(JacksonConfig.class)

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectQueryControllerTest.java
@@ -1,0 +1,77 @@
+package com.umc.product.project.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.response.PageResponse;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectSummaryResponse;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectQuery;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = ProjectQueryController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProjectQueryControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ProjectResponseAssembler assembler;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    void GET_프로젝트_목록_기본정렬은_createdAt_ASC_name_ASC() throws Exception {
+        given(assembler.searchFor(any(SearchProjectQuery.class), eq(TEST_MEMBER_ID)))
+            .willReturn(new PageResponse<ProjectSummaryResponse>(List.of(), 0, 20, 0, 0, false, false));
+
+        mockMvc.perform(get("/api/v1/projects")
+                .param("gisuId", "1"))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<SearchProjectQuery> captor = ArgumentCaptor.forClass(SearchProjectQuery.class);
+        then(assembler).should().searchFor(captor.capture(), eq(TEST_MEMBER_ID));
+
+        List<Sort.Order> orders = captor.getValue().pageable().getSort().stream().toList();
+        assertThat(orders)
+            .extracting(Sort.Order::getProperty)
+            .containsExactly("createdAt", "name");
+        assertThat(orders)
+            .allMatch(Sort.Order::isAscending);
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectQueryRepositoryTest.java
@@ -2,6 +2,8 @@ package com.umc.product.project.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -141,7 +143,7 @@ class ProjectQueryRepositoryTest {
     }
 
     @Test
-    void 정렬_createdAt_DESC() {
+    void 정렬_createdAt_ASC() {
         SearchProjectQuery query = SearchProjectQuery.forChallenger(
             gisuId, null, null, null, null, null, PageRequest.of(0, 20));
 
@@ -150,8 +152,33 @@ class ProjectQueryRepositoryTest {
         List<Project> content = result.getContent();
         for (int i = 0; i < content.size() - 1; i++) {
             assertThat(content.get(i).getCreatedAt())
-                .isAfterOrEqualTo(content.get(i + 1).getCreatedAt());
+                .isBeforeOrEqualTo(content.get(i + 1).getCreatedAt());
         }
+    }
+
+    @Test
+    void 정렬_createdAt이_같으면_이름_오름차순() {
+        Long targetGisuId = 77L;
+        Project charlie = persistProject("Charlie", ProjectStatus.IN_PROGRESS, targetGisuId, 1L, 301L);
+        Project alpha = persistProject("Alpha", ProjectStatus.IN_PROGRESS, targetGisuId, 1L, 302L);
+        Project bravo = persistProject("Bravo", ProjectStatus.IN_PROGRESS, targetGisuId, 1L, 303L);
+        em.flush();
+
+        Instant sameCreatedAt = Instant.parse("2026-01-01T00:00:00Z");
+        updateAuditTimestamp(charlie.getId(), sameCreatedAt);
+        updateAuditTimestamp(alpha.getId(), sameCreatedAt);
+        updateAuditTimestamp(bravo.getId(), sameCreatedAt);
+        em.flush();
+        em.clear();
+
+        SearchProjectQuery query = SearchProjectQuery.forChallenger(
+            targetGisuId, null, null, null, null, null, PageRequest.of(0, 20));
+
+        Page<Project> result = sut.search(query);
+
+        assertThat(result.getContent())
+            .extracting(Project::getName)
+            .containsExactly("Alpha", "Bravo", "Charlie");
     }
 
     @Test
@@ -486,5 +513,18 @@ class ProjectQueryRepositoryTest {
         ReflectionTestUtils.setField(pm, "part", part);
         ReflectionTestUtils.setField(pm, "status", ProjectMemberStatus.ACTIVE);
         em.persist(pm);
+    }
+
+    private void updateAuditTimestamp(Long projectId, Instant createdAt) {
+        em.getEntityManager()
+            .createNativeQuery("""
+                update project
+                set created_at = :createdAt,
+                    updated_at = :createdAt
+                where id = :id
+                """)
+            .setParameter("createdAt", Timestamp.from(createdAt))
+            .setParameter("id", projectId)
+            .executeUpdate();
     }
 }


### PR DESCRIPTION
## 대상 브랜치
- base: develop
- head: fix/project-list-sort-order

## 이슈
- 없음

## 작업 내용
- 프로젝트 목록과 내가 관리하는 프로젝트 목록의 기본 정렬을 createdAt ASC, name ASC로 변경했습니다.
- Pageable sort가 비어 있는 내부 조회 fallback도 동일한 정렬 정책으로 맞췄습니다.
- 컨트롤러 기본 Pageable 정렬과 QueryRepository 정렬 동작을 검증하는 테스트를 추가했습니다.

## 리뷰 중점사항
- 클라이언트가 sort 파라미터를 넘기지 않을 때 오래된 생성일 우선, 같은 생성일이면 이름 오름차순으로 노출되는지 확인 부탁드립니다.
- 명시적인 sort 요청은 기존처럼 요청값이 우선됩니다.

## 검증
- ./gradlew test