### PR TITLE
[Fix] 프로젝트 지원 통계 인원을 지부 단위가 아닌 기수 단위로 집계하는 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
@@ -1,5 +1,14 @@
 package com.umc.product.challenger.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerQuery;
 import com.umc.product.challenger.application.port.out.LoadChallengerPort;
 import com.umc.product.challenger.application.port.out.SaveChallengerPort;
@@ -9,14 +18,8 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -62,6 +65,11 @@ public class ChallengerPersistenceAdapter implements LoadChallengerPort, SaveCha
     @Override
     public List<Challenger> getAllByGisuIds(List<Long> gisuIds) {
         return repository.findByGisuIdIn(gisuIds);
+    }
+
+    @Override
+    public List<Challenger> listByChapterId(Long chapterId) {
+        return queryRepository.listByChapterId(chapterId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
@@ -9,6 +9,17 @@ import static com.umc.product.organization.domain.QGisu.gisu;
 import static com.umc.product.organization.domain.QSchool.school;
 import static java.util.Objects.requireNonNull;
 
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -29,22 +40,30 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.domain.QMember;
 import com.umc.product.organization.domain.QGisu;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ChallengerQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    /**
+     * 지부(chapterId)에 속한 챌린저 목록 조회.
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     */
+    public List<Challenger> listByChapterId(Long chapterId) {
+        if (chapterId == null) {
+            return List.of();
+        }
+        return queryFactory
+            .selectFrom(challenger)
+            .join(member).on(challenger.memberId.eq(member.id))
+            .where(chapterIdEq(chapterId))
+            .fetch();
+    }
 
     /**
      * 페이지네이션 검색 구현

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
@@ -1,12 +1,13 @@
 package com.umc.product.challenger.application.port.in.query;
 
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 
 public interface GetChallengerUseCase {
     // TODO: 챌린저에 대해서 public/private 정보 구분 필요 시 method 추가해서 진행하여야 함
@@ -104,6 +105,17 @@ public interface GetChallengerUseCase {
      * @return 해당 기수의 챌린저 정보 목록
      */
     List<ChallengerInfo> getAllByGisuId(Long gisuId);
+
+    /**
+     * 지부 ID로 해당 지부에 속한 모든 챌린저 정보 조회 (상벌점 제외)
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     * 모집단 집계 등 상벌점이 불필요한 경우 사용합니다.
+     *
+     * @param chapterId 지부 ID
+     * @return 해당 지부의 챌린저 정보 목록
+     */
+    List<ChallengerInfo> listByChapterId(Long chapterId);
 
     /**
      * memberId로 해당 사용자가 가지고 있는 가장 최근 챌린저 정보 조회

--- a/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
+++ b/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
@@ -1,9 +1,10 @@
 package com.umc.product.challenger.application.port.out;
 
-import com.umc.product.challenger.domain.Challenger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.challenger.domain.Challenger;
 
 public interface LoadChallengerPort {
 
@@ -43,6 +44,13 @@ public interface LoadChallengerPort {
      * 여러 gisuId로 챌린저 목록 조회
      */
     List<Challenger> getAllByGisuIds(List<Long> gisuIds);
+
+    /**
+     * 지부(chapterId)에 속한 챌린저 목록 조회.
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     */
+    List<Challenger> listByChapterId(Long chapterId);
 
     @Deprecated(since = "v1.5.0", forRemoval = true)
     Long countByIdIn(Set<Long> ids);

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
@@ -1,5 +1,14 @@
 package com.umc.product.challenger.application.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerPointUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
@@ -11,14 +20,8 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -191,6 +194,13 @@ public class ChallengerQueryService implements GetChallengerUseCase {
     @Override
     public List<ChallengerInfo> getAllByGisuId(Long gisuId) {
         return toChallengerInfoListBatch(loadChallengerPort.getAllByGisuId(gisuId));
+    }
+
+    @Override
+    public List<ChallengerInfo> listByChapterId(Long chapterId) {
+        return loadChallengerPort.listByChapterId(chapterId).stream()
+            .map(c -> ChallengerInfo.from(c, List.of()))
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -1,8 +1,26 @@
 package com.umc.product.project.application.service.query;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectStatisticsUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
@@ -23,22 +41,8 @@ import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchin
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -141,10 +145,10 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
     private StatisticsPopulation resolvePopulation(List<ProjectStatisticsProjectRow> projects) {
         Set<Long> eligibleMemberIds = projects.stream()
-            .map(ProjectStatisticsProjectRow::gisuId)
+            .map(ProjectStatisticsProjectRow::chapterId)
             .filter(Objects::nonNull)
             .distinct()
-            .flatMap(gisuId -> getChallengerUseCase.getAllByGisuId(gisuId).stream())
+            .flatMap(chapterId -> getChallengerUseCase.listByChapterId(chapterId).stream())
             .filter(this::isEligibleChallenger)
             .map(ChallengerInfo::memberId)
             .filter(Objects::nonNull)
@@ -158,7 +162,10 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     }
 
     private boolean isEligibleChallenger(ChallengerInfo challenger) {
-        return challenger.part() != ChallengerPart.ADMIN && challenger.part() != ChallengerPart.PLAN;
+        // 지원 가능 모집단(지부 인원)은 활동 중인 챌린저만 집계한다. 수료/제명 인원은 제외.
+        return challenger.challengerStatus() == ChallengerStatus.ACTIVE
+            && challenger.part() != ChallengerPart.ADMIN
+            && challenger.part() != ChallengerPart.PLAN;
     }
 
     private StatisticsContext buildContext(

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -5,9 +5,21 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectStatisticsInfo;
@@ -20,15 +32,6 @@ import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectStatisticsQueryServiceTest {
@@ -74,14 +77,17 @@ class ProjectStatisticsQueryServiceTest {
                 applicationRow(projectId, 1004L, 203L, ProjectApplicationStatus.SUBMITTED, 2L,
                     MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND)
             ));
-        given(getChallengerUseCase.getAllByGisuId(gisuId))
+        given(getChallengerUseCase.listByChapterId(chapterId))
             .willReturn(List.of(
                 challenger(1001L, gisuId, ChallengerPart.WEB),
                 challenger(1002L, gisuId, ChallengerPart.DESIGN),
                 challenger(1003L, gisuId, ChallengerPart.WEB),
                 challenger(1004L, gisuId, ChallengerPart.ANDROID),
                 challenger(9001L, gisuId, ChallengerPart.PLAN),
-                challenger(9002L, gisuId, ChallengerPart.ADMIN)
+                challenger(9002L, gisuId, ChallengerPart.ADMIN),
+                // 수료/제명 챌린저는 지부 모집단(지원 가능 인원)에서 제외되어야 한다.
+                challenger(1005L, gisuId, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
+                challenger(1006L, gisuId, ChallengerPart.SPRINGBOOT, ChallengerStatus.EXPELLED)
             ));
         given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L, 1002L, 1003L, 1004L)))
             .willReturn(Map.of(
@@ -173,7 +179,7 @@ class ProjectStatisticsQueryServiceTest {
                 applicationRow(10L, 9001L, 305L, ProjectApplicationStatus.SUBMITTED, 2L,
                     MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND)
             ));
-        given(getChallengerUseCase.getAllByGisuId(gisuId))
+        given(getChallengerUseCase.listByChapterId(chapterId))
             .willReturn(List.of(
                 challenger(1001L, gisuId, ChallengerPart.WEB),
                 challenger(1002L, gisuId, ChallengerPart.DESIGN),
@@ -297,10 +303,17 @@ class ProjectStatisticsQueryServiceTest {
     }
 
     private static ChallengerInfo challenger(Long memberId, Long gisuId, ChallengerPart part) {
+        return challenger(memberId, gisuId, part, ChallengerStatus.ACTIVE);
+    }
+
+    private static ChallengerInfo challenger(
+        Long memberId, Long gisuId, ChallengerPart part, ChallengerStatus status
+    ) {
         return ChallengerInfo.builder()
             .memberId(memberId)
             .gisuId(gisuId)
             .part(part)
+            .challengerStatus(status)
             .build();
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

## What
프로젝트 지원/매칭 현황 API(PROJECT-STAT-001/002)의 "지원 가능 인원(모집단)"이 실제 지부 인원과 일치하지 않던 문제를 수정했습니다.

## Why
지원률의 분모가 되는 모집단을 다음 두 가지 이유로 잘못 계산하고 있었습니다.

1. **기수 전체**를 모집단으로 집계 (지부 무관) : `getAllByGisuId`는 같은 기수의 모든 지부 챌린저를 반환함
2. 모집단에 **수료(GRADUATED)·제명(EXPELLED)** 챌린저까지 포함 : 매칭 가능 지부 인원을 ACTIVE 기준으로 집계되어야 함

## Where  
  - `ProjectStatisticsQueryService` (`resolvePopulation`, `isEligibleChallenger`)
  - `GetChallengerUseCase.listByChapterId` 신규 추가 (challenger 도메인)

## Who / When
사용자가 매칭 통계를 조회할 때 노출되는 수치에 영향을 줍니다.

## How
1. 모집단을 프로젝트가 속한 **지부(chapterId)로 한정** : 지부의 기수 및 소속 학교(`chapter_school`) 기준으로 챌린저를 조회하는 `listByChapterId`를 추가해 기존 `chapterIdEq` 필터 로직을 재사용
2. 모집단 적격 판정에 **ACTIVE 상태 조건 추가** (수료/제명 제외)
3. 부수 효과로 기존의 over-fetch 및 불필요한 상벌점 조회 제거







## 💬 리뷰 중점사항

<!--

수정사항과 관련된 담당자 및 랜덤으로 한 명의 리뷰어를 지정해주세요.
혹시 리뷰어가 신경써서 볼 부분이 있다면, 이 공간을 이용해서 명시해주세요.

-->
