### PR TITLE
[Feat] 프로젝트 지원 및 매칭 현황 조회 시 권한 검증 강화

### DIFF
--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.adapter.out.persistence.chapter;
 
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -56,6 +57,11 @@ public class ChapterSchoolPersistenceAdapter implements LoadChapterSchoolPort, S
     @Override
     public List<ChapterSchool> findBySchoolId(Long schoolId) {
         return chapterSchoolQueryRepository.findBySchoolId(schoolId);
+    }
+
+    @Override
+    public List<ChapterSchool> findBySchoolIds(Collection<Long> schoolIds) {
+        return chapterSchoolQueryRepository.findBySchoolIdIn(schoolIds);
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolQueryRepository.java
@@ -2,6 +2,7 @@ package com.umc.product.organization.adapter.out.persistence.chapter;
 
 import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -36,6 +37,13 @@ public class ChapterSchoolQueryRepository {
         return jpaQueryFactory
             .selectFrom(chapterSchool)
             .where(chapterSchool.school.id.eq(schoolId))
+            .fetch();
+    }
+
+    public List<ChapterSchool> findBySchoolIdIn(Collection<Long> schoolIds) {
+        return jpaQueryFactory
+            .selectFrom(chapterSchool)
+            .where(chapterSchool.school.id.in(schoolIds))
             .fetch();
     }
 

--- a/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.in.query;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +22,11 @@ public interface GetChapterUseCase {
     ChapterInfo byGisuAndSchool(Long gisuId, Long schoolId);
 
     List<ChapterInfo> getChaptersBySchool(Long schoolId);
+
+    /**
+     * 여러 학교가 속한 지부 정보를 1번 쿼리로 일괄 조회합니다. (학교 ↔ 지부 N:M)
+     */
+    List<ChapterInfo> getChaptersBySchoolIds(Collection<Long> schoolIds);
 
     List<ChapterWithSchoolsInfo> getChaptersWithSchoolsByGisuId(Long gisuId);
 

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadChapterSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadChapterSchoolPort.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.out.query;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -11,6 +12,8 @@ public interface LoadChapterSchoolPort {
     ChapterSchool findByChapterIdAndSchoolId(Long chapterId, Long schoolId);
 
     List<ChapterSchool> findBySchoolId(Long schoolId);
+
+    List<ChapterSchool> findBySchoolIds(Collection<Long> schoolIds);
     List<ChapterSchool> findByGisuId(Long gisuId);
 
     List<ChapterSchool> findByGisuIds(Set<Long> gisuIds);

--- a/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.service.query;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,6 +83,19 @@ public class ChapterQueryService implements GetChapterUseCase {
         return chapterSchools.stream()
             .map(ChapterSchool::getChapter)
             .map(ChapterInfo::from)
+            .toList();
+    }
+
+    @Override
+    public List<ChapterInfo> getChaptersBySchoolIds(Collection<Long> schoolIds) {
+        if (schoolIds == null || schoolIds.isEmpty()) {
+            return List.of();
+        }
+
+        return loadChapterSchoolPort.findBySchoolIds(schoolIds).stream()
+            .map(ChapterSchool::getChapter)
+            .map(ChapterInfo::from)
+            .distinct()
             .toList();
     }
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
@@ -6,9 +6,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
-import com.umc.product.authorization.domain.PermissionType;
-import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
@@ -39,19 +36,15 @@ public class ProjectStatisticsQueryController {
             없거나 (강제배정/랜덤매칭) 여러 건 (떨어지고 재 지원하는 경우) 이 존재할 수 있어 배열로 구성되어 있습니다.
 
             지원자 목록은(특정 프로젝트에 대한 지원서 조회) `/api/v1/projects/{projectId}/applications`를 호출하셔서 활용하셔야 합니다.
+
+            권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트) 또는 총괄단은 멤버 단위 상세까지, 해당 지부장·해당 지부 소속 학교 회장/부회장은 집계 숫자만 조회할 수 있습니다. 그 외에는 403.
             """
-    )
-    @CheckAccess(
-        resourceType = ResourceType.PROJECT,
-        resourceId = "#projectId",
-        permission = PermissionType.READ,
-        message = "프로젝트 지원/매칭 현황을 볼 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
     )
     public ProjectStatisticsResponse getProjectStatistics(
         @CurrentMember MemberPrincipal memberPrincipal,
         @Parameter(description = "프로젝트 ID", required = true) @PathVariable Long projectId
     ) {
-        return assembler.statisticsForProject(projectId);
+        return assembler.statisticsForProject(projectId, memberPrincipal.getMemberId());
     }
 
     @GetMapping("/statistics")
@@ -74,17 +67,14 @@ public class ProjectStatisticsQueryController {
             - roundSchoolRankings: N차 매칭 지원 Top N에 활용합니다. 각 차수별로, 각 학교별 지원자 수
             - schoolMatchingStatistics: 총원 N명 카드에 활용합니다. 차수와 무관하게, 각 학교별 총 매칭 완료 인원 & 지원 가능 총원
             - projectRoundStatistics: 프로젝트별 지원 현황 필드에 활용합니다. 각 프로젝트별로, 각 매칭 차수별 정보 (매칭 종류 & 차수) 와 지원자 수
+
+            권한: 총괄단은 모든 지부를 멤버 단위 상세까지, 해당 지부장·해당 지부 소속 학교 회장/부회장은 본인 지부를 집계 숫자만 조회할 수 있습니다. 그 외에는 403. (PO/Sub-PM 은 본인 프로젝트를 단건 조회 API로 확인합니다.)
             """
-    )
-    @CheckAccess(
-        resourceType = ResourceType.PROJECT,
-        permission = PermissionType.READ,
-        message = "프로젝트 지원/매칭 현황을 볼 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
     )
     public ChapterProjectStatisticsResponse listChapterProjectStatistics(
         @CurrentMember MemberPrincipal memberPrincipal,
         @Parameter(description = "지부 ID", required = true) @RequestParam Long chapterId
     ) {
-        return assembler.statisticsForChapter(chapterId);
+        return assembler.statisticsForChapter(chapterId, memberPrincipal.getMemberId());
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
@@ -37,7 +37,7 @@ public class ProjectStatisticsQueryController {
 
             지원자 목록은(특정 프로젝트에 대한 지원서 조회) `/api/v1/projects/{projectId}/applications`를 호출하셔서 활용하셔야 합니다.
 
-            권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트) 또는 총괄단은 멤버 단위 상세까지, 해당 지부장·해당 지부 소속 학교 회장/부회장은 집계 숫자만 조회할 수 있습니다. 그 외에는 403.
+            권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트), 총괄단, 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다. 그 외에는 403.
             """
     )
     public ProjectStatisticsResponse getProjectStatistics(
@@ -68,7 +68,7 @@ public class ProjectStatisticsQueryController {
             - schoolMatchingStatistics: 총원 N명 카드에 활용합니다. 차수와 무관하게, 각 학교별 총 매칭 완료 인원 & 지원 가능 총원
             - projectRoundStatistics: 프로젝트별 지원 현황 필드에 활용합니다. 각 프로젝트별로, 각 매칭 차수별 정보 (매칭 종류 & 차수) 와 지원자 수
 
-            권한: 총괄단은 모든 지부를 멤버 단위 상세까지, 해당 지부장·해당 지부 소속 학교 회장/부회장은 본인 지부를 집계 숫자만 조회할 수 있습니다. 그 외에는 403. (PO/Sub-PM 은 본인 프로젝트를 단건 조회 API로 확인합니다.)
+            권한: 총괄단(모든 지부), 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다. 그 외에는 403. (PO/Sub-PM 은 본인 프로젝트를 단건 조회 API로 확인합니다.)
             """
     )
     public ChapterProjectStatisticsResponse listChapterProjectStatistics(

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -234,15 +234,17 @@ public class ProjectResponseAssembler {
     /**
      * PROJECT-STAT-001 단건 프로젝트 지원/매칭 현황.
      */
-    public ProjectStatisticsResponse statisticsForProject(Long projectId) {
-        return ProjectStatisticsResponse.from(getProjectStatisticsUseCase.getByProjectId(projectId));
+    public ProjectStatisticsResponse statisticsForProject(Long projectId, Long requesterMemberId) {
+        return ProjectStatisticsResponse.from(
+            getProjectStatisticsUseCase.getByProjectId(projectId, requesterMemberId));
     }
 
     /**
      * PROJECT-STAT-002 지부 전체 프로젝트 지원/매칭 현황.
      */
-    public ChapterProjectStatisticsResponse statisticsForChapter(Long chapterId) {
-        return ChapterProjectStatisticsResponse.from(getProjectStatisticsUseCase.getByChapterId(chapterId));
+    public ChapterProjectStatisticsResponse statisticsForChapter(Long chapterId, Long requesterMemberId) {
+        return ChapterProjectStatisticsResponse.from(
+            getProjectStatisticsUseCase.getByChapterId(chapterId, requesterMemberId));
     }
 
     private ProjectMembersResponse buildMembersResponse(

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
@@ -11,15 +11,15 @@ public interface GetProjectStatisticsUseCase {
     /**
      * 단건 프로젝트의 활성 멤버와 해당 멤버들이 작성한 지원 이력을 조회합니다.
      * <p>
-     * 접근 권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트) 또는 총괄단 → 멤버 단위 상세 포함,
-     * 해당 지부장 / 해당 지부 소속 학교 회장·부회장 → 숫자(집계)만. 그 외는 {@code PROJECT_ACCESS_DENIED}.
+     * 접근 권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트), 총괄단, 해당 지부장, 해당 지부 소속 학교 회장·부회장만
+     * 조회할 수 있다. 그 외는 {@code PROJECT_ACCESS_DENIED}.
      */
     ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId);
 
     /**
      * 지부 내 전체 프로젝트의 활성 멤버와 BFF 요약 통계를 조회합니다.
      * <p>
-     * 접근 권한: 총괄단 → 멤버 단위 상세 포함, 해당 지부장 / 해당 지부 소속 학교 회장·부회장 → 숫자(집계)만.
+     * 접근 권한: 총괄단 / 해당 지부장 / 해당 지부 소속 학교 회장·부회장만 조회할 수 있다.
      * 그 외는 {@code PROJECT_ACCESS_DENIED}. (PO/Sub-PM 은 본인 프로젝트만 단건 조회로 본다.)
      */
     ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId);

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
@@ -10,11 +10,17 @@ public interface GetProjectStatisticsUseCase {
 
     /**
      * 단건 프로젝트의 활성 멤버와 해당 멤버들이 작성한 지원 이력을 조회합니다.
+     * <p>
+     * 접근 권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트) 또는 총괄단 → 멤버 단위 상세 포함,
+     * 해당 지부장 / 해당 지부 소속 학교 회장·부회장 → 숫자(집계)만. 그 외는 {@code PROJECT_ACCESS_DENIED}.
      */
-    ProjectStatisticsInfo getByProjectId(Long projectId);
+    ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId);
 
     /**
      * 지부 내 전체 프로젝트의 활성 멤버와 BFF 요약 통계를 조회합니다.
+     * <p>
+     * 접근 권한: 총괄단 → 멤버 단위 상세 포함, 해당 지부장 / 해당 지부 소속 학교 회장·부회장 → 숫자(집계)만.
+     * 그 외는 {@code PROJECT_ACCESS_DENIED}. (PO/Sub-PM 은 본인 프로젝트만 단건 조회로 본다.)
      */
-    ChapterProjectStatisticsInfo getByChapterId(Long chapterId);
+    ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId);
 }

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -17,11 +17,15 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectStatisticsUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsSummaryInfo;
@@ -35,12 +39,17 @@ import com.umc.product.project.application.port.in.query.dto.statistics.RoundApp
 import com.umc.product.project.application.port.in.query.dto.statistics.RoundSchoolApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolMatchingStatisticsInfo;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsApplicationRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchingRoundRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -52,9 +61,17 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     private final LoadProjectStatisticsPort loadProjectStatisticsPort;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetMemberUseCase getMemberUseCase;
+    private final LoadProjectPort loadProjectPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChapterUseCase getChapterUseCase;
 
     @Override
-    public ProjectStatisticsInfo getByProjectId(Long projectId) {
+    public ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId) {
+        Project target = loadProjectPort.findById(projectId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
+        StatisticsAccessLevel accessLevel = resolveProjectAccess(requesterMemberId, target);
+
         ProjectStatisticsProjectRow project = loadProjectStatisticsPort.getProjectById(projectId);
         List<ProjectStatisticsMatchingRoundRow> rounds =
             loadProjectStatisticsPort.listMatchingRoundsByChapterId(project.chapterId());
@@ -64,11 +81,14 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             sortApplications(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(projectId)));
         StatisticsPopulation population = resolvePopulation(List.of(project));
 
-        return assembleProject(project, rounds, members, applications, population);
+        ProjectStatisticsInfo info = assembleProject(project, rounds, members, applications, population);
+        return maskIfNumbersOnly(info, accessLevel);
     }
 
     @Override
-    public ChapterProjectStatisticsInfo getByChapterId(Long chapterId) {
+    public ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId) {
+        StatisticsAccessLevel accessLevel = resolveChapterAccess(requesterMemberId, chapterId);
+
         List<ProjectStatisticsProjectRow> projects = loadProjectStatisticsPort.listProjectsByChapterId(chapterId);
         if (projects.isEmpty()) {
             return new ChapterProjectStatisticsInfo(chapterId, List.of(), emptySummary());
@@ -106,6 +126,7 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
                 applicationsByProject.getOrDefault(project.projectId(), List.of()),
                 population
             ))
+            .map(info -> maskIfNumbersOnly(info, accessLevel))
             .toList();
 
         StatisticsContext chapterContext = buildContext(rounds, applications, members, population);
@@ -118,6 +139,74 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
                 buildSchoolMatchingStatistics(chapterContext),
                 buildProjectRoundStatistics(projects, chapterContext)
             )
+        );
+    }
+
+    /**
+     * 단건 프로젝트 통계 접근 권한 판정.
+     * <p>
+     * 본인 프로젝트의 PO/Sub-PM 이면 멤버 단위까지 노출(FULL). 그 외에는 지부 운영진 판정으로 위임한다.
+     */
+    private StatisticsAccessLevel resolveProjectAccess(Long memberId, Project project) {
+        boolean isOwner = Objects.equals(project.getProductOwnerMemberId(), memberId);
+        boolean isSubPm = loadProjectMemberPort.isActivePlanMember(project.getId(), memberId);
+        if (isOwner || isSubPm) {
+            return StatisticsAccessLevel.FULL;
+        }
+        return resolveChapterAccess(memberId, project.getChapterId());
+    }
+
+    /**
+     * 지부 단위 통계 접근 권한 판정.
+     * <ul>
+     *   <li>총괄단(SUPER_ADMIN 포함) → FULL (멤버 단위 포함)</li>
+     *   <li>해당 지부장 / 해당 지부 소속 학교 회장·부회장 → NUMBERS_ONLY (집계 숫자만)</li>
+     *   <li>그 외 → {@code PROJECT_ACCESS_DENIED}</li>
+     * </ul>
+     * 요청 chapterId 는 치환하지 않고 통과/거부만 판정한다(총괄단의 타 지부 조회 보장).
+     */
+    private StatisticsAccessLevel resolveChapterAccess(Long memberId, Long chapterId) {
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+        if (roles.stream().anyMatch(role -> role.roleType().isAtLeastCentralCore())) {
+            return StatisticsAccessLevel.FULL;
+        }
+        boolean isChapterStaff = roles.stream()
+            .anyMatch(role -> role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(role.organizationId(), chapterId))
+            || isSchoolCoreOfChapter(roles, chapterId);
+        if (isChapterStaff) {
+            return StatisticsAccessLevel.NUMBERS_ONLY;
+        }
+        throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+    }
+
+    private boolean isSchoolCoreOfChapter(List<ChallengerRoleInfo> roles, Long chapterId) {
+        Set<Long> schoolIds = roles.stream()
+            .filter(role -> role.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                || role.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        if (schoolIds.isEmpty()) {
+            return false;
+        }
+        return schoolIds.stream()
+            .flatMap(schoolId -> getChapterUseCase.getChaptersBySchool(schoolId).stream())
+            .anyMatch(chapter -> Objects.equals(chapter.id(), chapterId));
+    }
+
+    /**
+     * NUMBERS_ONLY 면 멤버 단위 데이터(projectMembers)를 제거해 집계 숫자만 남긴다.
+     */
+    private ProjectStatisticsInfo maskIfNumbersOnly(ProjectStatisticsInfo info, StatisticsAccessLevel accessLevel) {
+        if (accessLevel == StatisticsAccessLevel.FULL) {
+            return info;
+        }
+        return new ProjectStatisticsInfo(
+            info.projectId(),
+            List.of(),
+            info.roundApplicationStatistics(),
+            info.schoolApplicationStatistics()
         );
     }
 
@@ -392,6 +481,14 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
     private ChapterProjectStatisticsSummaryInfo emptySummary() {
         return new ChapterProjectStatisticsSummaryInfo(List.of(), List.of(), List.of(), List.of());
+    }
+
+    /**
+     * 통계 조회 시 노출 수준. FULL 은 멤버 단위 포함, NUMBERS_ONLY 는 집계 숫자만.
+     */
+    private enum StatisticsAccessLevel {
+        FULL,
+        NUMBERS_ONLY
     }
 
     private record StatisticsPopulation(

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -68,9 +68,8 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
     @Override
     public ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId) {
-        Project target = loadProjectPort.findById(projectId)
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND));
-        StatisticsAccessLevel accessLevel = resolveProjectAccess(requesterMemberId, target);
+        Project target = loadProjectPort.getById(projectId);
+        validateProjectAccess(requesterMemberId, target);
 
         ProjectStatisticsProjectRow project = loadProjectStatisticsPort.getProjectById(projectId);
         List<ProjectStatisticsMatchingRoundRow> rounds =
@@ -81,13 +80,12 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             sortApplications(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(projectId)));
         StatisticsPopulation population = resolvePopulation(List.of(project));
 
-        ProjectStatisticsInfo info = assembleProject(project, rounds, members, applications, population);
-        return maskIfNumbersOnly(info, accessLevel);
+        return assembleProject(project, rounds, members, applications, population);
     }
 
     @Override
     public ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId) {
-        StatisticsAccessLevel accessLevel = resolveChapterAccess(requesterMemberId, chapterId);
+        validateChapterAccess(requesterMemberId, chapterId);
 
         List<ProjectStatisticsProjectRow> projects = loadProjectStatisticsPort.listProjectsByChapterId(chapterId);
         if (projects.isEmpty()) {
@@ -126,7 +124,6 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
                 applicationsByProject.getOrDefault(project.projectId(), List.of()),
                 population
             ))
-            .map(info -> maskIfNumbersOnly(info, accessLevel))
             .toList();
 
         StatisticsContext chapterContext = buildContext(rounds, applications, members, population);
@@ -143,41 +140,32 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     }
 
     /**
-     * 단건 프로젝트 통계 접근 권한 판정.
-     * <p>
-     * 본인 프로젝트의 PO/Sub-PM 이면 멤버 단위까지 노출(FULL). 그 외에는 지부 운영진 판정으로 위임한다.
+     * 단건 프로젝트 통계 접근 권한 검증. 본인 프로젝트의 PO/Sub-PM 이면 통과, 아니면 지부 운영진 판정으로 위임한다.
      */
-    private StatisticsAccessLevel resolveProjectAccess(Long memberId, Project project) {
+    private void validateProjectAccess(Long memberId, Project project) {
         boolean isOwner = Objects.equals(project.getProductOwnerMemberId(), memberId);
         boolean isSubPm = loadProjectMemberPort.isActivePlanMember(project.getId(), memberId);
         if (isOwner || isSubPm) {
-            return StatisticsAccessLevel.FULL;
+            return;
         }
-        return resolveChapterAccess(memberId, project.getChapterId());
+        validateChapterAccess(memberId, project.getChapterId());
     }
 
     /**
-     * 지부 단위 통계 접근 권한 판정.
-     * <ul>
-     *   <li>총괄단(SUPER_ADMIN 포함) → FULL (멤버 단위 포함)</li>
-     *   <li>해당 지부장 / 해당 지부 소속 학교 회장·부회장 → NUMBERS_ONLY (집계 숫자만)</li>
-     *   <li>그 외 → {@code PROJECT_ACCESS_DENIED}</li>
-     * </ul>
+     * 지부 단위 통계 접근 권한 검증. 총괄단(SUPER_ADMIN 포함) / 해당 지부장 / 해당 지부 소속 학교 회장·부회장이면 통과,
+     * 그 외에는 {@code PROJECT_ACCESS_DENIED}.
+     * <p>
      * 요청 chapterId 는 치환하지 않고 통과/거부만 판정한다(총괄단의 타 지부 조회 보장).
      */
-    private StatisticsAccessLevel resolveChapterAccess(Long memberId, Long chapterId) {
+    private void validateChapterAccess(Long memberId, Long chapterId) {
         List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
-        if (roles.stream().anyMatch(role -> role.roleType().isAtLeastCentralCore())) {
-            return StatisticsAccessLevel.FULL;
-        }
-        boolean isChapterStaff = roles.stream()
-            .anyMatch(role -> role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
-                && Objects.equals(role.organizationId(), chapterId))
+        boolean allowed = roles.stream().anyMatch(role -> role.roleType().isAtLeastCentralCore()
+                || (role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                    && Objects.equals(role.organizationId(), chapterId)))
             || isSchoolCoreOfChapter(roles, chapterId);
-        if (isChapterStaff) {
-            return StatisticsAccessLevel.NUMBERS_ONLY;
+        if (!allowed) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
         }
-        throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
     }
 
     private boolean isSchoolCoreOfChapter(List<ChallengerRoleInfo> roles, Long chapterId) {
@@ -190,24 +178,8 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
         if (schoolIds.isEmpty()) {
             return false;
         }
-        return schoolIds.stream()
-            .flatMap(schoolId -> getChapterUseCase.getChaptersBySchool(schoolId).stream())
+        return getChapterUseCase.getChaptersBySchoolIds(schoolIds).stream()
             .anyMatch(chapter -> Objects.equals(chapter.id(), chapterId));
-    }
-
-    /**
-     * NUMBERS_ONLY 면 멤버 단위 데이터(projectMembers)를 제거해 집계 숫자만 남긴다.
-     */
-    private ProjectStatisticsInfo maskIfNumbersOnly(ProjectStatisticsInfo info, StatisticsAccessLevel accessLevel) {
-        if (accessLevel == StatisticsAccessLevel.FULL) {
-            return info;
-        }
-        return new ProjectStatisticsInfo(
-            info.projectId(),
-            List.of(),
-            info.roundApplicationStatistics(),
-            info.schoolApplicationStatistics()
-        );
     }
 
     private ProjectStatisticsInfo assembleProject(
@@ -481,14 +453,6 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
     private ChapterProjectStatisticsSummaryInfo emptySummary() {
         return new ChapterProjectStatisticsSummaryInfo(List.of(), List.of(), List.of(), List.of());
-    }
-
-    /**
-     * 통계 조회 시 노출 수준. FULL 은 멤버 단위 포함, NUMBERS_ONLY 는 집계 숫자만.
-     */
-    private enum StatisticsAccessLevel {
-        FULL,
-        NUMBERS_ONLY
     }
 
     private record StatisticsPopulation(

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
@@ -5,6 +5,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -26,18 +40,6 @@ import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = ProjectStatisticsQueryController.class)
 @Import(JacksonConfig.class)
@@ -69,7 +71,7 @@ class ProjectStatisticsQueryControllerTest {
     @DisplayName("GET_projectId_statistics_단건_프로젝트_지원_매칭_현황을_반환한다")
     void 단건_프로젝트_통계_조회() throws Exception {
         // given
-        given(assembler.statisticsForProject(10L))
+        given(assembler.statisticsForProject(10L, TEST_MEMBER_ID))
             .willReturn(response(10L, 101L, 1001L, 201L));
 
         // when & then
@@ -91,7 +93,7 @@ class ProjectStatisticsQueryControllerTest {
     @DisplayName("GET_statistics_chapterId_지부_전체_프로젝트_지원_매칭_현황을_반환한다")
     void 지부_전체_통계_조회() throws Exception {
         // given
-        given(assembler.statisticsForChapter(3L))
+        given(assembler.statisticsForChapter(3L, TEST_MEMBER_ID))
             .willReturn(chapterResponse(3L, List.of(
                 response(10L, 101L, 1001L, 201L),
                 response(11L, 102L, 1002L, 202L)

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -123,8 +122,8 @@ class ProjectStatisticsQueryServiceTest {
             ));
         // 요청자가 해당 프로젝트의 PO → FULL (멤버 단위 포함)
         Long requesterMemberId = 7000L;
-        given(loadProjectPort.findById(projectId))
-            .willReturn(Optional.of(project(projectId, requesterMemberId, chapterId)));
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, requesterMemberId, chapterId));
 
         // when
         ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
@@ -298,8 +297,8 @@ class ProjectStatisticsQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getByChapterId_지부장이면_숫자만_반환하고_멤버_단위를_숨긴다")
-    void 지부_지부장이면_숫자만() {
+    @DisplayName("getByChapterId_지부장이면_조회_가능하다")
+    void 지부_지부장이면_조회_가능() {
         // given
         Long chapterId = 3L;
         Long gisuId = 1L;
@@ -312,16 +311,15 @@ class ProjectStatisticsQueryServiceTest {
         // when
         ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
 
-        // then — 멤버 단위(projectMembers)는 비워지고, 집계 숫자(summary)는 그대로
+        // then — 권한 통과: 프로젝트 멤버까지 그대로 노출
         assertThat(result.projects()).hasSize(1);
-        assertThat(result.projects().get(0).projectMembers()).isEmpty();
-        assertThat(result.projects().get(0).roundApplicationStatistics()).isNotNull();
+        assertThat(result.projects().get(0).projectMembers()).hasSize(1);
         assertThat(result.summary()).isNotNull();
     }
 
     @Test
-    @DisplayName("getByChapterId_해당_지부_소속_학교_회장이면_숫자만_반환한다")
-    void 지부_학교_회장이면_숫자만() {
+    @DisplayName("getByChapterId_해당_지부_소속_학교_회장이면_조회_가능하다")
+    void 지부_학교_회장이면_조회_가능() {
         // given
         Long chapterId = 3L;
         Long gisuId = 1L;
@@ -331,7 +329,7 @@ class ProjectStatisticsQueryServiceTest {
         given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
             .willReturn(List.of(roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL,
                 schoolId, gisuId)));
-        given(getChapterUseCase.getChaptersBySchool(schoolId))
+        given(getChapterUseCase.getChaptersBySchoolIds(Set.of(schoolId)))
             .willReturn(List.of(new ChapterInfo(chapterId, "테스트 지부")));
 
         // when
@@ -339,7 +337,7 @@ class ProjectStatisticsQueryServiceTest {
 
         // then
         assertThat(result.projects()).hasSize(1);
-        assertThat(result.projects().get(0).projectMembers()).isEmpty();
+        assertThat(result.projects().get(0).projectMembers()).hasSize(1);
     }
 
     @Test
@@ -365,8 +363,8 @@ class ProjectStatisticsQueryServiceTest {
         Long requesterMemberId = 8300L;
         givenSingleProject(projectId, gisuId, chapterId);
         // PO 는 아니지만 ACTIVE PLAN 멤버(Sub-PM)
-        given(loadProjectPort.findById(projectId))
-            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
         given(loadProjectMemberPort.isActivePlanMember(projectId, requesterMemberId)).willReturn(true);
 
         // when
@@ -377,16 +375,16 @@ class ProjectStatisticsQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getByProjectId_지부장이면_숫자만_반환한다")
-    void 단건_지부장이면_숫자만() {
+    @DisplayName("getByProjectId_지부장이면_조회_가능하다")
+    void 단건_지부장이면_조회_가능() {
         // given
         Long projectId = 10L;
         Long gisuId = 1L;
         Long chapterId = 3L;
         Long requesterMemberId = 8400L;
         givenSingleProject(projectId, gisuId, chapterId);
-        given(loadProjectPort.findById(projectId))
-            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
         given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
             .willReturn(List.of(roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER,
                 chapterId, gisuId)));
@@ -394,9 +392,8 @@ class ProjectStatisticsQueryServiceTest {
         // when
         ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
 
-        // then
-        assertThat(result.projectMembers()).isEmpty();
-        assertThat(result.roundApplicationStatistics()).isNotNull();
+        // then — 권한 통과: 프로젝트 멤버까지 그대로 노출
+        assertThat(result.projectMembers()).hasSize(1);
     }
 
     @Test
@@ -406,8 +403,8 @@ class ProjectStatisticsQueryServiceTest {
         Long projectId = 10L;
         Long chapterId = 3L;
         Long requesterMemberId = 8500L;
-        given(loadProjectPort.findById(projectId))
-            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
         given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId)).willReturn(List.of());
 
         // when & then

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -1,12 +1,14 @@
 package com.umc.product.project.application.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,23 +17,34 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectStatisticsInfo;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsApplicationRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchingRoundRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectStatisticsQueryServiceTest {
@@ -44,6 +57,18 @@ class ProjectStatisticsQueryServiceTest {
 
     @Mock
     GetMemberUseCase getMemberUseCase;
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @Mock
+    GetChapterUseCase getChapterUseCase;
 
     @InjectMocks
     ProjectStatisticsQueryService sut;
@@ -96,9 +121,13 @@ class ProjectStatisticsQueryServiceTest {
                 1003L, 502L,
                 1004L, 501L
             ));
+        // 요청자가 해당 프로젝트의 PO → FULL (멤버 단위 포함)
+        Long requesterMemberId = 7000L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, requesterMemberId, chapterId)));
 
         // when
-        ProjectStatisticsInfo result = sut.getByProjectId(projectId);
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
 
         // then
         assertThat(result.projectId()).isEqualTo(projectId);
@@ -195,9 +224,13 @@ class ProjectStatisticsQueryServiceTest {
                 1003L, 502L,
                 1004L, 501L
             ));
+        // 요청자가 총괄단 → FULL (멤버 단위 포함)
+        Long requesterMemberId = 7000L;
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, gisuId)));
 
         // when
-        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId);
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
 
         // then
         assertThat(result.chapterId()).isEqualTo(chapterId);
@@ -262,6 +295,176 @@ class ProjectStatisticsQueryServiceTest {
 
         verify(loadProjectStatisticsPort).listProjectsByChapterId(chapterId);
         verify(loadProjectStatisticsPort).listActiveMembersByChapterId(chapterId);
+    }
+
+    @Test
+    @DisplayName("getByChapterId_지부장이면_숫자만_반환하고_멤버_단위를_숨긴다")
+    void 지부_지부장이면_숫자만() {
+        // given
+        Long chapterId = 3L;
+        Long gisuId = 1L;
+        Long requesterMemberId = 8000L;
+        givenSingleProjectChapter(chapterId, gisuId);
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER,
+                chapterId, gisuId)));
+
+        // when
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
+
+        // then — 멤버 단위(projectMembers)는 비워지고, 집계 숫자(summary)는 그대로
+        assertThat(result.projects()).hasSize(1);
+        assertThat(result.projects().get(0).projectMembers()).isEmpty();
+        assertThat(result.projects().get(0).roundApplicationStatistics()).isNotNull();
+        assertThat(result.summary()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getByChapterId_해당_지부_소속_학교_회장이면_숫자만_반환한다")
+    void 지부_학교_회장이면_숫자만() {
+        // given
+        Long chapterId = 3L;
+        Long gisuId = 1L;
+        Long schoolId = 7L;
+        Long requesterMemberId = 8100L;
+        givenSingleProjectChapter(chapterId, gisuId);
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL,
+                schoolId, gisuId)));
+        given(getChapterUseCase.getChaptersBySchool(schoolId))
+            .willReturn(List.of(new ChapterInfo(chapterId, "테스트 지부")));
+
+        // when
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
+
+        // then
+        assertThat(result.projects()).hasSize(1);
+        assertThat(result.projects().get(0).projectMembers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getByChapterId_권한이_없으면_PROJECT_ACCESS_DENIED")
+    void 지부_권한없으면_거부() {
+        // given
+        Long chapterId = 3L;
+        Long requesterMemberId = 8200L;
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> sut.getByChapterId(chapterId, requesterMemberId))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    @Test
+    @DisplayName("getByProjectId_보조PM이면_FULL로_멤버_단위를_포함한다")
+    void 단건_보조PM이면_FULL() {
+        // given
+        Long projectId = 10L;
+        Long gisuId = 1L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8300L;
+        givenSingleProject(projectId, gisuId, chapterId);
+        // PO 는 아니지만 ACTIVE PLAN 멤버(Sub-PM)
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(loadProjectMemberPort.isActivePlanMember(projectId, requesterMemberId)).willReturn(true);
+
+        // when
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
+
+        // then
+        assertThat(result.projectMembers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getByProjectId_지부장이면_숫자만_반환한다")
+    void 단건_지부장이면_숫자만() {
+        // given
+        Long projectId = 10L;
+        Long gisuId = 1L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8400L;
+        givenSingleProject(projectId, gisuId, chapterId);
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER,
+                chapterId, gisuId)));
+
+        // when
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
+
+        // then
+        assertThat(result.projectMembers()).isEmpty();
+        assertThat(result.roundApplicationStatistics()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getByProjectId_권한이_없으면_PROJECT_ACCESS_DENIED")
+    void 단건_권한없으면_거부() {
+        // given
+        Long projectId = 10L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8500L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 9999L, chapterId)));
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> sut.getByProjectId(projectId, requesterMemberId))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    /** 멤버 1명짜리 단일 프로젝트 지부 통계 데이터 stub (집계 경로 통과용). */
+    private void givenSingleProjectChapter(Long chapterId, Long gisuId) {
+        given(loadProjectStatisticsPort.listProjectsByChapterId(chapterId))
+            .willReturn(List.of(projectRow(10L, gisuId, chapterId)));
+        given(loadProjectStatisticsPort.listMatchingRoundsByChapterId(chapterId)).willReturn(List.of());
+        given(loadProjectStatisticsPort.listActiveMembersByChapterId(chapterId))
+            .willReturn(List.of(memberRow(10L, 101L, 1001L, ChallengerPart.WEB)));
+        given(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(10L))).willReturn(List.of());
+        given(getChallengerUseCase.listByChapterId(chapterId))
+            .willReturn(List.of(challenger(1001L, gisuId, ChallengerPart.WEB)));
+        given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L))).willReturn(Map.of(1001L, 501L));
+    }
+
+    /** 멤버 1명짜리 단건 프로젝트 통계 데이터 stub (집계 경로 통과용). */
+    private void givenSingleProject(Long projectId, Long gisuId, Long chapterId) {
+        given(loadProjectStatisticsPort.getProjectById(projectId))
+            .willReturn(projectRow(projectId, gisuId, chapterId));
+        given(loadProjectStatisticsPort.listMatchingRoundsByChapterId(chapterId)).willReturn(List.of());
+        given(loadProjectStatisticsPort.listActiveMembersByProjectId(projectId))
+            .willReturn(List.of(memberRow(projectId, 101L, 1001L, ChallengerPart.WEB)));
+        given(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(projectId)))
+            .willReturn(List.of());
+        given(getChallengerUseCase.listByChapterId(chapterId))
+            .willReturn(List.of(challenger(1001L, gisuId, ChallengerPart.WEB)));
+        given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L))).willReturn(Map.of(1001L, 501L));
+    }
+
+    private static ChallengerRoleInfo roleInfo(
+        ChallengerRoleType roleType, OrganizationType organizationType, Long organizationId, Long gisuId
+    ) {
+        return ChallengerRoleInfo.builder()
+            .roleType(roleType)
+            .organizationType(organizationType)
+            .organizationId(organizationId)
+            .gisuId(gisuId)
+            .build();
+    }
+
+    private static Project project(Long id, Long ownerMemberId, Long chapterId) {
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Project project = constructor.newInstance();
+            ReflectionTestUtils.setField(project, "id", id);
+            ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "chapterId", chapterId);
+            return project;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static ProjectStatisticsProjectRow projectRow(Long projectId, Long gisuId, Long chapterId) {


### PR DESCRIPTION
## 🚀 작업 내용
### 변경 사항

권한 검증을 **서비스 레벨**(`ProjectStatisticsQueryService`)로 일원화하고, 역할에 따라 응답을 차등 노출합니다.

- 요청자 `memberId`를 UseCase까지 전달 (`getByProjectId`, `getByChapterId` 시그니처 변경)
- 노출 수준 2단계: `FULL`(멤버 단위 포함) / `NUMBERS_ONLY`(집계 숫자만, projectMembers 제외)
- 무력했던 STAT-002의 `@CheckAccess` 제거 (실제 검증은 서비스로 이동)

### 권한 정책

| 호출자 | STAT-001 (단건) | STAT-002 (지부 전체) |
|---|---|---|
| 본인 프로젝트 PO / Sub-PM | FULL | 403 (본인 프로젝트는 단건으로) |
| 총괄단(SUPER_ADMIN 포함) | FULL | FULL |
| 해당 지부장 | 숫자만 | 숫자만 |
| 해당 지부 소속 학교 회장/부회장 | 숫자만 | 숫자만 |
| 그 외 / 타 지부 | 403 | 403 |

- 권한 없음 → `PROJECT_ACCESS_DENIED`(PROJECT-0012, 403)

###  테스트

- `ProjectStatisticsQueryServiceTest`: PO/Sub-PM·총괄단 FULL, 지부장·학교 회장단 숫자만(멤버 마스킹), 무권한 403 — STAT-001/002 각각
- `ProjectStatisticsQueryControllerTest`: 어셈블러 호출 시 요청자 memberId 전달 검증
- 단위 테스트 전체 통과 (`./gradlew test --tests "*ProjectStatistics*"`)


## 💬 리뷰 중점사항
