### PR TITLE
[Release] v2.1.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,12 @@ PROJECT_MATCHING_ROUND_MIN_PHASE_INTERVAL_MINUTES=1
 PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES=1
 
 # ------------------------------------------------------------------
+# Super Admin
+# ------------------------------------------------------------------
+# true 면 SUPER_ADMIN 이 DRAFT 프로젝트/지원서 단건을 조회할 수 있다. 초기 배포 모니터링용으로만 켜고 안정화 후 끈다.
+SUPER_ADMIN_ALLOW_DRAFT_READ=false
+
+# ------------------------------------------------------------------
 # OAuth2 / Social Login
 # ------------------------------------------------------------------
 GOOGLE_CLIENT_ID_LIST=

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerPersistenceAdapter.java
@@ -1,5 +1,14 @@
 package com.umc.product.challenger.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
 import com.umc.product.challenger.application.port.in.query.dto.SearchChallengerQuery;
 import com.umc.product.challenger.application.port.out.LoadChallengerPort;
 import com.umc.product.challenger.application.port.out.SaveChallengerPort;
@@ -9,14 +18,8 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -62,6 +65,11 @@ public class ChallengerPersistenceAdapter implements LoadChallengerPort, SaveCha
     @Override
     public List<Challenger> getAllByGisuIds(List<Long> gisuIds) {
         return repository.findByGisuIdIn(gisuIds);
+    }
+
+    @Override
+    public List<Challenger> listByChapterId(Long chapterId) {
+        return queryRepository.listByChapterId(chapterId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
+++ b/src/main/java/com/umc/product/challenger/adapter/out/persistence/ChallengerQueryRepository.java
@@ -9,6 +9,17 @@ import static com.umc.product.organization.domain.QGisu.gisu;
 import static com.umc.product.organization.domain.QSchool.school;
 import static java.util.Objects.requireNonNull;
 
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -29,22 +40,30 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.domain.QMember;
 import com.umc.product.organization.domain.QGisu;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ChallengerQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    /**
+     * 지부(chapterId)에 속한 챌린저 목록 조회.
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     */
+    public List<Challenger> listByChapterId(Long chapterId) {
+        if (chapterId == null) {
+            return List.of();
+        }
+        return queryFactory
+            .selectFrom(challenger)
+            .join(member).on(challenger.memberId.eq(member.id))
+            .where(chapterIdEq(chapterId))
+            .fetch();
+    }
 
     /**
      * 페이지네이션 검색 구현

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/GetChallengerUseCase.java
@@ -1,12 +1,13 @@
 package com.umc.product.challenger.application.port.in.query;
 
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
-import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfoWithStatus;
 
 public interface GetChallengerUseCase {
     // TODO: 챌린저에 대해서 public/private 정보 구분 필요 시 method 추가해서 진행하여야 함
@@ -104,6 +105,17 @@ public interface GetChallengerUseCase {
      * @return 해당 기수의 챌린저 정보 목록
      */
     List<ChallengerInfo> getAllByGisuId(Long gisuId);
+
+    /**
+     * 지부 ID로 해당 지부에 속한 모든 챌린저 정보 조회 (상벌점 제외)
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     * 모집단 집계 등 상벌점이 불필요한 경우 사용합니다.
+     *
+     * @param chapterId 지부 ID
+     * @return 해당 지부의 챌린저 정보 목록
+     */
+    List<ChallengerInfo> listByChapterId(Long chapterId);
 
     /**
      * memberId로 해당 사용자가 가지고 있는 가장 최근 챌린저 정보 조회

--- a/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
+++ b/src/main/java/com/umc/product/challenger/application/port/out/LoadChallengerPort.java
@@ -1,9 +1,10 @@
 package com.umc.product.challenger.application.port.out;
 
-import com.umc.product.challenger.domain.Challenger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.challenger.domain.Challenger;
 
 public interface LoadChallengerPort {
 
@@ -43,6 +44,13 @@ public interface LoadChallengerPort {
      * 여러 gisuId로 챌린저 목록 조회
      */
     List<Challenger> getAllByGisuIds(List<Long> gisuIds);
+
+    /**
+     * 지부(chapterId)에 속한 챌린저 목록 조회.
+     * <p>
+     * 지부의 기수와 일치하고, 회원의 학교가 해당 지부 소속 학교에 포함되는 챌린저를 반환합니다.
+     */
+    List<Challenger> listByChapterId(Long chapterId);
 
     @Deprecated(since = "v1.5.0", forRemoval = true)
     Long countByIdIn(Set<Long> ids);

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerQueryService.java
@@ -1,5 +1,14 @@
 package com.umc.product.challenger.application.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerPointUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
@@ -11,14 +20,8 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -191,6 +194,13 @@ public class ChallengerQueryService implements GetChallengerUseCase {
     @Override
     public List<ChallengerInfo> getAllByGisuId(Long gisuId) {
         return toChallengerInfoListBatch(loadChallengerPort.getAllByGisuId(gisuId));
+    }
+
+    @Override
+    public List<ChallengerInfo> listByChapterId(Long chapterId) {
+        return loadChallengerPort.listByChapterId(chapterId).stream()
+            .map(c -> ChallengerInfo.from(c, List.of()))
+            .toList();
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.adapter.out.persistence.chapter;
 
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -56,6 +57,11 @@ public class ChapterSchoolPersistenceAdapter implements LoadChapterSchoolPort, S
     @Override
     public List<ChapterSchool> findBySchoolId(Long schoolId) {
         return chapterSchoolQueryRepository.findBySchoolId(schoolId);
+    }
+
+    @Override
+    public List<ChapterSchool> findBySchoolIds(Collection<Long> schoolIds) {
+        return chapterSchoolQueryRepository.findBySchoolIdIn(schoolIds);
     }
 
     @Override

--- a/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolQueryRepository.java
+++ b/src/main/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterSchoolQueryRepository.java
@@ -2,6 +2,7 @@ package com.umc.product.organization.adapter.out.persistence.chapter;
 
 import static com.umc.product.organization.domain.QChapterSchool.chapterSchool;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -36,6 +37,13 @@ public class ChapterSchoolQueryRepository {
         return jpaQueryFactory
             .selectFrom(chapterSchool)
             .where(chapterSchool.school.id.eq(schoolId))
+            .fetch();
+    }
+
+    public List<ChapterSchool> findBySchoolIdIn(Collection<Long> schoolIds) {
+        return jpaQueryFactory
+            .selectFrom(chapterSchool)
+            .where(chapterSchool.school.id.in(schoolIds))
             .fetch();
     }
 

--- a/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.in.query;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +22,11 @@ public interface GetChapterUseCase {
     ChapterInfo byGisuAndSchool(Long gisuId, Long schoolId);
 
     List<ChapterInfo> getChaptersBySchool(Long schoolId);
+
+    /**
+     * 여러 학교가 속한 지부 정보를 1번 쿼리로 일괄 조회합니다. (학교 ↔ 지부 N:M)
+     */
+    List<ChapterInfo> getChaptersBySchoolIds(Collection<Long> schoolIds);
 
     List<ChapterWithSchoolsInfo> getChaptersWithSchoolsByGisuId(Long gisuId);
 

--- a/src/main/java/com/umc/product/organization/application/port/out/query/LoadChapterSchoolPort.java
+++ b/src/main/java/com/umc/product/organization/application/port/out/query/LoadChapterSchoolPort.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.out.query;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -11,6 +12,8 @@ public interface LoadChapterSchoolPort {
     ChapterSchool findByChapterIdAndSchoolId(Long chapterId, Long schoolId);
 
     List<ChapterSchool> findBySchoolId(Long schoolId);
+
+    List<ChapterSchool> findBySchoolIds(Collection<Long> schoolIds);
     List<ChapterSchool> findByGisuId(Long gisuId);
 
     List<ChapterSchool> findByGisuIds(Set<Long> gisuIds);

--- a/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
@@ -1,5 +1,6 @@
 package com.umc.product.organization.application.port.service.query;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,6 +83,19 @@ public class ChapterQueryService implements GetChapterUseCase {
         return chapterSchools.stream()
             .map(ChapterSchool::getChapter)
             .map(ChapterInfo::from)
+            .toList();
+    }
+
+    @Override
+    public List<ChapterInfo> getChaptersBySchoolIds(Collection<Long> schoolIds) {
+        if (schoolIds == null || schoolIds.isEmpty()) {
+            return List.of();
+        }
+
+        return loadChapterSchoolPort.findBySchoolIds(schoolIds).stream()
+            .map(ChapterSchool::getChapter)
+            .map(ChapterInfo::from)
+            .distinct()
             .toList();
     }
 

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectQueryController.java
@@ -118,7 +118,7 @@ public class ProjectQueryController {
     @GetMapping("/me/managed")
     @Operation(
         summary = "[PROJECT-006] 내가 관리하는 프로젝트 목록",
-        description = "역할별 자동 scope: 중앙 총괄단은 전체, 지부장은 본인 지부, 학교 회장단은 본인 학교, PM 챌린저는 본인 owner 프로젝트. 일반 챌린저는 빈 페이지."
+        description = "역할별 자동 scope: 중앙 총괄단은 전체, 지부장과 학교 회장단은 본인이 속한 지부 전체, PM 챌린저는 본인 owner 프로젝트. 일반 챌린저는 빈 페이지."
     )
     public PageResponse<ManagedProjectSummaryResponse> searchManaged(
         @CurrentMember MemberPrincipal memberPrincipal,

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
@@ -6,9 +6,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
-import com.umc.product.authorization.domain.PermissionType;
-import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.assembler.ProjectResponseAssembler;
@@ -39,19 +36,15 @@ public class ProjectStatisticsQueryController {
             없거나 (강제배정/랜덤매칭) 여러 건 (떨어지고 재 지원하는 경우) 이 존재할 수 있어 배열로 구성되어 있습니다.
 
             지원자 목록은(특정 프로젝트에 대한 지원서 조회) `/api/v1/projects/{projectId}/applications`를 호출하셔서 활용하셔야 합니다.
+
+            권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트), 총괄단, 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다. 그 외에는 403.
             """
-    )
-    @CheckAccess(
-        resourceType = ResourceType.PROJECT,
-        resourceId = "#projectId",
-        permission = PermissionType.READ,
-        message = "프로젝트 지원/매칭 현황을 볼 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
     )
     public ProjectStatisticsResponse getProjectStatistics(
         @CurrentMember MemberPrincipal memberPrincipal,
         @Parameter(description = "프로젝트 ID", required = true) @PathVariable Long projectId
     ) {
-        return assembler.statisticsForProject(projectId);
+        return assembler.statisticsForProject(projectId, memberPrincipal.getMemberId());
     }
 
     @GetMapping("/statistics")
@@ -74,17 +67,14 @@ public class ProjectStatisticsQueryController {
             - roundSchoolRankings: N차 매칭 지원 Top N에 활용합니다. 각 차수별로, 각 학교별 지원자 수
             - schoolMatchingStatistics: 총원 N명 카드에 활용합니다. 차수와 무관하게, 각 학교별 총 매칭 완료 인원 & 지원 가능 총원
             - projectRoundStatistics: 프로젝트별 지원 현황 필드에 활용합니다. 각 프로젝트별로, 각 매칭 차수별 정보 (매칭 종류 & 차수) 와 지원자 수
+
+            권한: 총괄단(모든 지부), 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다. 그 외에는 403. (PO/Sub-PM 은 본인 프로젝트를 단건 조회 API로 확인합니다.)
             """
-    )
-    @CheckAccess(
-        resourceType = ResourceType.PROJECT,
-        permission = PermissionType.READ,
-        message = "프로젝트 지원/매칭 현황을 볼 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
     )
     public ChapterProjectStatisticsResponse listChapterProjectStatistics(
         @CurrentMember MemberPrincipal memberPrincipal,
         @Parameter(description = "지부 ID", required = true) @RequestParam Long chapterId
     ) {
-        return assembler.statisticsForChapter(chapterId);
+        return assembler.statisticsForChapter(chapterId, memberPrincipal.getMemberId());
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectResponseAssembler.java
@@ -234,15 +234,17 @@ public class ProjectResponseAssembler {
     /**
      * PROJECT-STAT-001 단건 프로젝트 지원/매칭 현황.
      */
-    public ProjectStatisticsResponse statisticsForProject(Long projectId) {
-        return ProjectStatisticsResponse.from(getProjectStatisticsUseCase.getByProjectId(projectId));
+    public ProjectStatisticsResponse statisticsForProject(Long projectId, Long requesterMemberId) {
+        return ProjectStatisticsResponse.from(
+            getProjectStatisticsUseCase.getByProjectId(projectId, requesterMemberId));
     }
 
     /**
      * PROJECT-STAT-002 지부 전체 프로젝트 지원/매칭 현황.
      */
-    public ChapterProjectStatisticsResponse statisticsForChapter(Long chapterId) {
-        return ChapterProjectStatisticsResponse.from(getProjectStatisticsUseCase.getByChapterId(chapterId));
+    public ChapterProjectStatisticsResponse statisticsForChapter(Long chapterId, Long requesterMemberId) {
+        return ChapterProjectStatisticsResponse.from(
+            getProjectStatisticsUseCase.getByChapterId(chapterId, requesterMemberId));
     }
 
     private ProjectMembersResponse buildMembersResponse(

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -126,9 +126,16 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
         Long projectId,
         Long matchingRoundId,
         ProjectApplicationStatus status,
-        Instant now
+        Instant now,
+        boolean includeOngoingMatchingRounds
     ) {
-        return projectApplicationQueryRepository.searchProjectApplications(projectId, matchingRoundId, status, now);
+        return projectApplicationQueryRepository.searchProjectApplications(
+            projectId,
+            matchingRoundId,
+            status,
+            now,
+            includeOngoingMatchingRounds
+        );
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -126,14 +126,15 @@ public class ProjectApplicationQueryRepository {
      * 정렬 (DB 단 baseline): matchingRound.phase ASC -> projectApplication.submittedAt ASC. 최종 화면 정렬(phase -> part ->
      * submittedAt)은 part 가 cross-domain 정보라 Assembler 에서 in-memory 로 마무리한다.
      * <p>
-     * 지원(모집)이 끝난 차수({@code endsAt < now})의 지원서만 노출한다. matchingRoundId 미지정(전체 조회) 시에도 진행 중인 차수의
-     * 지원서는 자동으로 제외된다.
+     * 기본적으로 지원(모집)이 끝난 차수({@code endsAt < now})의 지원서만 노출한다. matchingRoundId 미지정(전체 조회) 시에도 진행 중인 차수의
+     * 지원서는 자동으로 제외된다. {@code includeOngoingMatchingRounds} 가 true 면 이 시간 조건을 적용하지 않는다.
      */
     public List<ProjectApplication> searchProjectApplications(
         Long projectId,
         Long matchingRoundId,
         ProjectApplicationStatus status,
-        Instant now
+        Instant now,
+        boolean includeOngoingMatchingRounds
     ) {
         return queryFactory
             .selectFrom(projectApplication)
@@ -144,10 +145,17 @@ public class ProjectApplicationQueryRepository {
                 projectApplicationForm.project.id.eq(projectId),
                 matchingRoundIdEq(matchingRoundId),
                 managedStatusCond(status),
-                projectMatchingRound.endsAt.before(now)
+                matchingRoundViewableCond(now, includeOngoingMatchingRounds)
             )
             .orderBy(projectMatchingRound.phase.asc(), projectApplication.submittedAt.asc())
             .fetch();
+    }
+
+    private BooleanExpression matchingRoundViewableCond(Instant now, boolean includeOngoingMatchingRounds) {
+        if (includeOngoingMatchingRounds) {
+            return null;
+        }
+        return projectMatchingRound.endsAt.before(now);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScope.java
@@ -16,11 +16,8 @@ public sealed interface ProjectAccessScope {
     /** 모든 프로젝트 노출 (Central Core). 상태 필터는 호출자가 요청한 그대로 통과. */
     record All(Set<ProjectStatus> visibleStatuses) implements ProjectAccessScope {}
 
-    /** 특정 지부의 프로젝트만 노출 (지부장). */
+    /** 특정 지부의 프로젝트만 노출 (지부장 / 학교 회장단 — 본인 학교가 속한 지부 전체). */
     record ChapterScoped(Long chapterId, Set<ProjectStatus> visibleStatuses) implements ProjectAccessScope {}
-
-    /** 특정 학교의 프로젝트만 노출 (학교 회장단). */
-    record SchoolScoped(Long schoolId, Set<ProjectStatus> visibleStatuses) implements ProjectAccessScope {}
 
     /** 본인이 PM 인 프로젝트만 노출 (PM 챌린저, 관리 화면). */
     record OwnerOnly(Long memberId, Set<ProjectStatus> visibleStatuses) implements ProjectAccessScope {}

--- a/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectAccessScopeResolver.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.project.application.access.ProjectAccessScope.All;
 import com.umc.product.project.application.access.ProjectAccessScope.ChapterScoped;
 import com.umc.product.project.application.access.ProjectAccessScope.None;
 import com.umc.product.project.application.access.ProjectAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.PublicOnly;
-import com.umc.product.project.application.access.ProjectAccessScope.SchoolScoped;
 import com.umc.product.project.application.access.ProjectAccessScope.WithOwnerIncluded;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
@@ -37,6 +37,7 @@ public class ProjectAccessScopeResolver {
 
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final LoadProjectPort loadProjectPort;
+    private final GetChapterUseCase getChapterUseCase;
 
     /**
      * 공개 검색(PROJECT-001) 컨텍스트.
@@ -79,7 +80,7 @@ public class ProjectAccessScopeResolver {
      * <ol>
      *   <li>Central Core → 전체 (DRAFT 제외)</li>
      *   <li>지부장 → 본인 지부 (DRAFT 제외)</li>
-     *   <li>학교 회장단 → 본인 학교 (DRAFT 제외)</li>
+     *   <li>학교 회장단 → 본인 학교가 속한 지부 전체 (DRAFT 제외) — 정책상 지부장과 동일 범위</li>
      *   <li>PM 챌린저 → 본인이 owner 인 프로젝트만 (DRAFT 포함)</li>
      *   <li>그 외 → 관리 대상 0건</li>
      * </ol>
@@ -105,7 +106,8 @@ public class ProjectAccessScopeResolver {
 
         Optional<Long> schoolId = schoolCoreOrgId(rolesInGisu);
         if (schoolId.isPresent()) {
-            return includeOwnerProjects(new SchoolScoped(schoolId.get(), requestedStatuses),
+            Long schoolChapterId = getChapterUseCase.byGisuAndSchool(gisuId, schoolId.get()).id();
+            return includeOwnerProjects(new ChapterScoped(schoolChapterId, requestedStatuses),
                 memberId, gisuId, requestedStatuses);
         }
 

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScope.java
@@ -19,7 +19,12 @@ public sealed interface ProjectApplicationAccessScope {
     /**
      * 특정 프로젝트의 지원서만 (PO/Sub-PM/CC/지부장/학교장의 "이 프로젝트 지원자 목록")
      */
-    record ProjectScoped(Long projectId) implements ProjectApplicationAccessScope {
+    record ProjectScoped(Long projectId, boolean includeOngoingMatchingRounds)
+        implements ProjectApplicationAccessScope {
+
+        public ProjectScoped(Long projectId) {
+            this(projectId, false);
+        }
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -66,16 +66,19 @@ public class ProjectApplicationAccessScopeResolver {
 
         List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
         if (roles.stream().anyMatch(r -> r.roleType().isSuperAdmin())) {
-            return new ProjectScoped(projectId);
+            return new ProjectScoped(projectId, true);
         }
 
         List<ChallengerRoleInfo> rolesInGisu = roles.stream()
             .filter(r -> Objects.equals(r.gisuId(), project.getGisuId()))
             .toList();
 
-        if (rolesInGisu.stream().anyMatch(
-            r -> r.roleType().isAtLeastCentralCore() || (r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
-                && Objects.equals(r.organizationId(), project.getChapterId())))) {
+        if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
+            return new ProjectScoped(projectId, true);
+        }
+
+        if (rolesInGisu.stream().anyMatch(r -> r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+            && Objects.equals(r.organizationId(), project.getChapterId()))) {
             return new ProjectScoped(projectId);
         }
 

--- a/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/GetProjectStatisticsUseCase.java
@@ -10,11 +10,17 @@ public interface GetProjectStatisticsUseCase {
 
     /**
      * 단건 프로젝트의 활성 멤버와 해당 멤버들이 작성한 지원 이력을 조회합니다.
+     * <p>
+     * 접근 권한: 해당 프로젝트의 PO/Sub-PM(본인 프로젝트), 총괄단, 해당 지부장, 해당 지부 소속 학교 회장·부회장만
+     * 조회할 수 있다. 그 외는 {@code PROJECT_ACCESS_DENIED}.
      */
-    ProjectStatisticsInfo getByProjectId(Long projectId);
+    ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId);
 
     /**
      * 지부 내 전체 프로젝트의 활성 멤버와 BFF 요약 통계를 조회합니다.
+     * <p>
+     * 접근 권한: 총괄단 / 해당 지부장 / 해당 지부 소속 학교 회장·부회장만 조회할 수 있다.
+     * 그 외는 {@code PROJECT_ACCESS_DENIED}. (PO/Sub-PM 은 본인 프로젝트만 단건 조회로 본다.)
      */
-    ChapterProjectStatisticsInfo getByChapterId(Long chapterId);
+    ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectQuery.java
@@ -21,7 +21,7 @@ import lombok.Builder;
  * Controller는 분기 로직을 가지지 않고, Request DTO의 {@code toQuery(...)}에서 팩토리를 선택합니다.
  * <p>
  * Service 계층에서 {@link com.umc.product.project.application.access.ProjectAccessScope} 적용 시
- * {@link #withStatuses}, {@link #withChapterFilter}, {@link #withSchoolFilter}, {@link #withOwnerFilter}
+ * {@link #withStatuses}, {@link #withChapterFilter}, {@link #withOwnerFilter}
  * 헬퍼로 새 인스턴스를 만들어 어댑터에 전달합니다.
  */
 @Builder
@@ -117,14 +117,6 @@ public record SearchProjectQuery(
     public SearchProjectQuery withChapterFilter(Long chapterId, Set<ProjectStatus> newStatuses) {
         return copyBuilder()
             .chapterId(chapterId)
-            .statuses(toList(newStatuses))
-            .build();
-    }
-
-    /** scope 적용 — 학교 한정 + 상태 교체. */
-    public SearchProjectQuery withSchoolFilter(Long schoolId, Set<ProjectStatus> newStatuses) {
-        return copyBuilder()
-            .productOwnerSchoolIds(List.of(schoolId))
             .statuses(toList(newStatuses))
             .build();
     }

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -108,19 +108,21 @@ public interface LoadProjectApplicationPort {
      * <p>
      * 파트 필터는 challenger 도메인 속성이라 본 port 에서 다루지 않는다 -- 호출자(Service) 가 challenger 정보를 enrich 한 뒤 in-memory 로 필터링한다.
      *
-     * 지원(모집)이 끝난 차수({@code endsAt < now})의 지원서만 반환한다. matchingRoundId 미지정(전체 조회) 시에도 진행 중인 차수의
-     * 지원서는 자동으로 제외된다.
+     * 기본적으로 지원(모집)이 끝난 차수({@code endsAt < now})의 지원서만 반환한다. matchingRoundId 미지정(전체 조회) 시에도 진행 중인 차수의
+     * 지원서는 자동으로 제외된다. 단, {@code includeOngoingMatchingRounds} 가 true 면 진행 중인 차수의 지원서도 함께 반환한다.
      *
      * @param projectId       대상 프로젝트 ID
      * @param matchingRoundId 매칭 차수 필터 (선택). null 이면 전체.
      * @param status          상태 필터 (선택). null 이면 DRAFT 제외 전체.
-     * @param now             조회 기준 시각. 이 시각보다 endsAt 이 이른 차수만 노출된다.
+     * @param now                           조회 기준 시각. 이 시각보다 endsAt 이 이른 차수만 노출된다.
+     * @param includeOngoingMatchingRounds 진행 중인 매칭 차수 포함 여부
      */
     List<ProjectApplication> searchProjectApplications(
         Long projectId,
         Long matchingRoundId,
         ProjectApplicationStatus status,
-        Instant now
+        Instant now,
+        boolean includeOngoingMatchingRounds
     );
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -39,6 +39,7 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
     private final LoadProjectPort loadProjectPort;
     private final LoadProjectApplicationPort loadProjectApplicationPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
+    private final SuperAdminProperties superAdminProperties;
 
     @Override
     public ResourceType supportedResourceType() {
@@ -80,7 +81,8 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
      *   <li>부모 프로젝트의 PO 또는 보조 PM (Sub-PM, ACTIVE PLAN 멤버)</li>
      *   <li>(SUBMITTED 이상) 해당 기수의 SUPER_ADMIN/총괄/부총괄 또는 해당 기수+해당 지부의 지부장</li>
      * </ul>
-     * DRAFT 는 본인만 노출 — 임시저장은 외부에 보이지 않는다.
+     * DRAFT 는 본인만 노출 — 임시저장은 외부에 보이지 않는다. 단, {@code app.super-admin.allow-draft-read} 가 켜진 동안은
+     * SUPER_ADMIN 도 DRAFT 단건을 조회할 수 있다 (초기 배포 모니터링용).
      */
     private boolean canRead(SubjectAttributes subject, ResourcePermission permission) {
         if (permission.resourceId() == null) {
@@ -93,7 +95,7 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
             return true;
         }
         if (application.getStatus() == ProjectApplicationStatus.DRAFT) {
-            return false;
+            return superAdminProperties.allowDraftRead() && isSuperAdmin(subject);
         }
         if (isOwner(subject, project) || isSubPm(subject, project)) {
             return true;
@@ -151,6 +153,11 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
 
     private boolean isSubPm(SubjectAttributes subject, Project project) {
         return loadProjectMemberPort.isActivePlanMember(project.getId(), subject.memberId());
+    }
+
+    private boolean isSuperAdmin(SubjectAttributes subject) {
+        return subject.roleAttributes().stream()
+            .anyMatch(role -> role.roleType().isSuperAdmin());
     }
 
     private boolean isCentralCoreInGisu(SubjectAttributes subject, Long gisuId) {

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -1,5 +1,9 @@
 package com.umc.product.project.application.service.evaluator;
 
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
@@ -10,9 +14,8 @@ import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * Project 도메인 단건 액션의 권한 판정 (L2). status × 역할 binary 매트릭스만 다룬다.
@@ -25,6 +28,7 @@ import org.springframework.stereotype.Component;
 public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
 
     private final LoadProjectPort loadProjectPort;
+    private final SuperAdminProperties superAdminProperties;
 
     @Override
     public ResourceType supportedResourceType() {
@@ -48,6 +52,9 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
      * <p>
      * 목록 조회는 {@code resourceId} 가 없어 이 분기를 타지 않고 단순 통과 후 L3-A scope 에서 거른다.
      * PR/ABORTED 는 PO + 해당 기수의 총괄단(SUPER_ADMIN 은 글로벌) ∪ 해당 기수의 지부장(chapter 무관).
+     * <p>
+     * DRAFT 는 PO 만 노출. 단, {@code app.super-admin.allow-draft-read} 가 켜진 동안은 SUPER_ADMIN 도 DRAFT 단건을
+     * 조회할 수 있다 (초기 배포 모니터링용).
      */
     private boolean canRead(SubjectAttributes subject, ResourcePermission permission) {
         if (permission.resourceId() == null) {
@@ -56,7 +63,8 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
         Project project = loadProject(permission);
         return switch (project.getStatus()) {
             case IN_PROGRESS, COMPLETED -> true;
-            case DRAFT -> isOwner(subject, project);
+            case DRAFT -> isOwner(subject, project)
+                || (superAdminProperties.allowDraftRead() && isSuperAdmin(subject));
             case PENDING_REVIEW, ABORTED -> isOwner(subject, project)
                 || isCentralCoreInGisu(subject, project.getGisuId())
                 || isChapterPresidentInGisu(subject, project.getGisuId());
@@ -156,10 +164,9 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
                 && Objects.equals(role.gisuId(), gisuId));
     }
 
-    @SuppressWarnings("unused")
-    private boolean isCentralCore(SubjectAttributes subject) {
+    private boolean isSuperAdmin(SubjectAttributes subject) {
         return subject.roleAttributes().stream()
-            .anyMatch(role -> role.roleType().isAtLeastCentralCore());
+            .anyMatch(role -> role.roleType().isSuperAdmin());
     }
 
     private boolean isCentralCoreInGisu(SubjectAttributes subject, Long gisuId) {

--- a/src/main/java/com/umc/product/project/application/service/evaluator/SuperAdminProperties.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/SuperAdminProperties.java
@@ -1,0 +1,14 @@
+package com.umc.product.project.application.service.evaluator;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * SUPER_ADMIN 전용 운영 토글.
+ * <p>
+ * {@code allowDraftRead} 가 true 면 SUPER_ADMIN 이 DRAFT 상태의 프로젝트/지원서 단건을 조회할 수 있다. 초기 배포 모니터링용으로만 켜고
+ * 안정화 후 끈다. 기본 false.
+ */
+@ConfigurationProperties(prefix = "app.super-admin")
+public record SuperAdminProperties(boolean allowDraftRead) {
+}

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -94,7 +94,7 @@ public class ProjectApplicationQueryService
 
         // 지원자 본인은 시점 제약 없이 조회 가능하며, PM/운영진 등 타인 조회만 지원 종료(endsAt) 이후로 제한한다.
         boolean isApplicantSelf = Objects.equals(application.getApplicantMemberId(), query.requesterMemberId());
-        if (!isApplicantSelf) {
+        if (!isApplicantSelf && !canViewOngoingMatchingRoundApplications(query.requesterMemberId(), project)) {
             application.getAppliedMatchingRound().validateIsViewableAt(Instant.now());
         }
 
@@ -170,12 +170,16 @@ public class ProjectApplicationQueryService
         if (scope instanceof ProjectApplicationAccessScope.None) {
             return List.of();
         }
+        boolean includeOngoingMatchingRounds =
+            scope instanceof ProjectApplicationAccessScope.ProjectScoped projectScoped
+                && projectScoped.includeOngoingMatchingRounds();
 
         List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplications(
             query.projectId(),
             query.matchingRoundId(),
             query.status(),
-            Instant.now()
+            Instant.now(),
+            includeOngoingMatchingRounds
         );
         return applications.stream()
             .map(ProjectApplicationSummaryInfo::from)
@@ -200,6 +204,13 @@ public class ProjectApplicationQueryService
             .findByMemberIdAndGisuId(query.requesterMemberId(), query.gisuId())
             .map(ChallengerInfo::part)
             .flatMap(MatchingType::fromPart);
+    }
+
+    private boolean canViewOngoingMatchingRoundApplications(Long requesterMemberId, Project project) {
+        ProjectApplicationAccessScope scope =
+            accessScopeResolver.resolveForProjectApplicantList(requesterMemberId, project);
+        return scope instanceof ProjectApplicationAccessScope.ProjectScoped projectScoped
+            && projectScoped.includeOngoingMatchingRounds();
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectQueryService.java
@@ -24,7 +24,6 @@ import com.umc.product.project.application.access.ProjectAccessScope.ChapterScop
 import com.umc.product.project.application.access.ProjectAccessScope.None;
 import com.umc.product.project.application.access.ProjectAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.PublicOnly;
-import com.umc.product.project.application.access.ProjectAccessScope.SchoolScoped;
 import com.umc.product.project.application.access.ProjectAccessScopeResolver;
 import com.umc.product.project.application.port.in.query.GetProjectUseCase;
 import com.umc.product.project.application.port.in.query.SearchManagedProjectUseCase;
@@ -152,8 +151,6 @@ public class ProjectQueryService implements
             case All(Set<ProjectStatus> statuses) -> loadProjectPort.search(query.withStatuses(statuses));
             case ChapterScoped(Long chapterId, Set<ProjectStatus> statuses) ->
                 loadProjectPort.search(query.withChapterFilter(chapterId, statuses));
-            case SchoolScoped(Long schoolId, Set<ProjectStatus> statuses) ->
-                loadProjectPort.search(query.withSchoolFilter(schoolId, statuses));
             case OwnerOnly(Long memberId, Set<ProjectStatus> statuses) ->
                 loadProjectPort.search(query.withOwnerFilter(memberId, statuses));
             case ProjectAccessScope.WithOwnerIncluded(
@@ -173,8 +170,6 @@ public class ProjectQueryService implements
             case All(Set<ProjectStatus> statuses) -> query.withStatuses(statuses);
             case ChapterScoped(Long chapterId, Set<ProjectStatus> statuses) ->
                 query.withChapterFilter(chapterId, statuses);
-            case SchoolScoped(Long schoolId, Set<ProjectStatus> statuses) ->
-                query.withSchoolFilter(schoolId, statuses);
             case OwnerOnly(Long memberId, Set<ProjectStatus> statuses) ->
                 query.withOwnerFilter(memberId, statuses);
             case PublicOnly() -> query.withStatuses(Set.of(ProjectStatus.IN_PROGRESS, ProjectStatus.COMPLETED));

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -17,11 +17,15 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectStatisticsUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsSummaryInfo;
@@ -35,12 +39,17 @@ import com.umc.product.project.application.port.in.query.dto.statistics.RoundApp
 import com.umc.product.project.application.port.in.query.dto.statistics.RoundSchoolApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolMatchingStatisticsInfo;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsApplicationRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchingRoundRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -52,9 +61,16 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     private final LoadProjectStatisticsPort loadProjectStatisticsPort;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetMemberUseCase getMemberUseCase;
+    private final LoadProjectPort loadProjectPort;
+    private final LoadProjectMemberPort loadProjectMemberPort;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChapterUseCase getChapterUseCase;
 
     @Override
-    public ProjectStatisticsInfo getByProjectId(Long projectId) {
+    public ProjectStatisticsInfo getByProjectId(Long projectId, Long requesterMemberId) {
+        Project target = loadProjectPort.getById(projectId);
+        validateProjectAccess(requesterMemberId, target);
+
         ProjectStatisticsProjectRow project = loadProjectStatisticsPort.getProjectById(projectId);
         List<ProjectStatisticsMatchingRoundRow> rounds =
             loadProjectStatisticsPort.listMatchingRoundsByChapterId(project.chapterId());
@@ -68,7 +84,9 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     }
 
     @Override
-    public ChapterProjectStatisticsInfo getByChapterId(Long chapterId) {
+    public ChapterProjectStatisticsInfo getByChapterId(Long chapterId, Long requesterMemberId) {
+        validateChapterAccess(requesterMemberId, chapterId);
+
         List<ProjectStatisticsProjectRow> projects = loadProjectStatisticsPort.listProjectsByChapterId(chapterId);
         if (projects.isEmpty()) {
             return new ChapterProjectStatisticsInfo(chapterId, List.of(), emptySummary());
@@ -119,6 +137,49 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
                 buildProjectRoundStatistics(projects, chapterContext)
             )
         );
+    }
+
+    /**
+     * 단건 프로젝트 통계 접근 권한 검증. 본인 프로젝트의 PO/Sub-PM 이면 통과, 아니면 지부 운영진 판정으로 위임한다.
+     */
+    private void validateProjectAccess(Long memberId, Project project) {
+        boolean isOwner = Objects.equals(project.getProductOwnerMemberId(), memberId);
+        boolean isSubPm = loadProjectMemberPort.isActivePlanMember(project.getId(), memberId);
+        if (isOwner || isSubPm) {
+            return;
+        }
+        validateChapterAccess(memberId, project.getChapterId());
+    }
+
+    /**
+     * 지부 단위 통계 접근 권한 검증. 총괄단(SUPER_ADMIN 포함) / 해당 지부장 / 해당 지부 소속 학교 회장·부회장이면 통과,
+     * 그 외에는 {@code PROJECT_ACCESS_DENIED}.
+     * <p>
+     * 요청 chapterId 는 치환하지 않고 통과/거부만 판정한다(총괄단의 타 지부 조회 보장).
+     */
+    private void validateChapterAccess(Long memberId, Long chapterId) {
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+        boolean allowed = roles.stream().anyMatch(role -> role.roleType().isAtLeastCentralCore()
+                || (role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                    && Objects.equals(role.organizationId(), chapterId)))
+            || isSchoolCoreOfChapter(roles, chapterId);
+        if (!allowed) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_ACCESS_DENIED);
+        }
+    }
+
+    private boolean isSchoolCoreOfChapter(List<ChallengerRoleInfo> roles, Long chapterId) {
+        Set<Long> schoolIds = roles.stream()
+            .filter(role -> role.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                || role.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        if (schoolIds.isEmpty()) {
+            return false;
+        }
+        return getChapterUseCase.getChaptersBySchoolIds(schoolIds).stream()
+            .anyMatch(chapter -> Objects.equals(chapter.id(), chapterId));
     }
 
     private ProjectStatisticsInfo assembleProject(

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -1,8 +1,26 @@
 package com.umc.product.project.application.service.query;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectStatisticsUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
@@ -23,22 +41,8 @@ import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchin
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -141,10 +145,10 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
     private StatisticsPopulation resolvePopulation(List<ProjectStatisticsProjectRow> projects) {
         Set<Long> eligibleMemberIds = projects.stream()
-            .map(ProjectStatisticsProjectRow::gisuId)
+            .map(ProjectStatisticsProjectRow::chapterId)
             .filter(Objects::nonNull)
             .distinct()
-            .flatMap(gisuId -> getChallengerUseCase.getAllByGisuId(gisuId).stream())
+            .flatMap(chapterId -> getChallengerUseCase.listByChapterId(chapterId).stream())
             .filter(this::isEligibleChallenger)
             .map(ChallengerInfo::memberId)
             .filter(Objects::nonNull)
@@ -158,7 +162,10 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     }
 
     private boolean isEligibleChallenger(ChallengerInfo challenger) {
-        return challenger.part() != ChallengerPart.ADMIN && challenger.part() != ChallengerPart.PLAN;
+        // 지원 가능 모집단(지부 인원)은 활동 중인 챌린저만 집계한다. 수료/제명 인원은 제외.
+        return challenger.challengerStatus() == ChallengerStatus.ACTIVE
+            && challenger.part() != ChallengerPart.ADMIN
+            && challenger.part() != ChallengerPart.PLAN;
     }
 
     private StatisticsContext buildContext(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -263,6 +263,10 @@ app:
       # 자동 선발 스케줄러가 decisionDeadline 이후 대기하는 buffer. 환경변수 단위는 minute.
       deadline-buffer-minutes: ${PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES:1}
 
+  super-admin:
+    # true 면 SUPER_ADMIN 이 DRAFT 프로젝트/지원서 단건을 조회할 수 있다. 초기 배포 모니터링용으로만 켜고 안정화 후 끈다.
+    allow-draft-read: ${SUPER_ADMIN_ALLOW_DRAFT_READ:false}
+
   observability:
     tracing:
       enabled: ${APP_OBSERVABILITY_TRACING_ENABLED:true}

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
@@ -5,6 +5,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -26,18 +40,6 @@ import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = ProjectStatisticsQueryController.class)
 @Import(JacksonConfig.class)
@@ -69,7 +71,7 @@ class ProjectStatisticsQueryControllerTest {
     @DisplayName("GET_projectId_statistics_단건_프로젝트_지원_매칭_현황을_반환한다")
     void 단건_프로젝트_통계_조회() throws Exception {
         // given
-        given(assembler.statisticsForProject(10L))
+        given(assembler.statisticsForProject(10L, TEST_MEMBER_ID))
             .willReturn(response(10L, 101L, 1001L, 201L));
 
         // when & then
@@ -91,7 +93,7 @@ class ProjectStatisticsQueryControllerTest {
     @DisplayName("GET_statistics_chapterId_지부_전체_프로젝트_지원_매칭_현황을_반환한다")
     void 지부_전체_통계_조회() throws Exception {
         // given
-        given(assembler.statisticsForChapter(3L))
+        given(assembler.statisticsForChapter(3L, TEST_MEMBER_ID))
             .willReturn(chapterResponse(3L, List.of(
                 response(10L, 101L, 1001L, 201L),
                 response(11L, 102L, 1002L, 202L)

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
@@ -125,7 +125,7 @@ class ProjectApplicationQueryRepositoryTest {
 
         // when - 전체 조회 (matchingRoundId = null)
         List<ProjectApplication> result = sut.searchProjectApplications(
-            project.getId(), null, null, now);
+            project.getId(), null, null, now, false);
 
         // then - 종료된 차수의 지원서만 반환
         assertThat(result)
@@ -147,10 +147,32 @@ class ProjectApplicationQueryRepositoryTest {
 
         // when
         List<ProjectApplication> result = sut.searchProjectApplications(
-            project.getId(), ongoingRound.getId(), null, now);
+            project.getId(), ongoingRound.getId(), null, now, false);
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("searchProjectApplications_includeOngoingMatchingRounds_true면_진행_중_차수의_지원서도_반환한다")
+    void searchProjectApplicationsReturnsOngoingRoundsWhenIncluded() {
+        // given
+        Instant now = Instant.parse("2026-05-10T00:00:00Z");
+        ProjectMatchingRound ongoingRound = persistRound(
+            "진행 차수", MatchingType.PLAN_DESIGN, MatchingPhase.FIRST,
+            now.minusSeconds(1_800)); // endsAt = now + 1800 (미래)
+        ProjectApplication ongoingApp = persistApplication(200L, ongoingRound, ProjectApplicationStatus.SUBMITTED);
+        em.flush();
+        em.clear();
+
+        // when
+        List<ProjectApplication> result = sut.searchProjectApplications(
+            project.getId(), ongoingRound.getId(), null, now, true);
+
+        // then
+        assertThat(result)
+            .extracting(ProjectApplication::getId)
+            .containsExactly(ongoingApp.getId());
     }
 
     private Project persistProject(String name, Long ownerId) {

--- a/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectAccessScopeResolverTest.java
@@ -17,12 +17,13 @@ import com.umc.product.authorization.application.port.in.query.GetChallengerRole
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.access.ProjectAccessScope.All;
 import com.umc.product.project.application.access.ProjectAccessScope.ChapterScoped;
 import com.umc.product.project.application.access.ProjectAccessScope.None;
 import com.umc.product.project.application.access.ProjectAccessScope.OwnerOnly;
 import com.umc.product.project.application.access.ProjectAccessScope.PublicOnly;
-import com.umc.product.project.application.access.ProjectAccessScope.SchoolScoped;
 import com.umc.product.project.application.access.ProjectAccessScope.WithOwnerIncluded;
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.enums.ProjectStatus;
@@ -34,6 +35,8 @@ class ProjectAccessScopeResolverTest {
     GetChallengerRoleUseCase getChallengerRoleUseCase;
     @Mock
     LoadProjectPort loadProjectPort;
+    @Mock
+    GetChapterUseCase getChapterUseCase;
 
     @InjectMocks
     ProjectAccessScopeResolver sut;
@@ -166,30 +169,35 @@ class ProjectAccessScopeResolverTest {
     }
 
     @Test
-    void management_은_학교_회장이면_SchoolScoped() {
+    void management_은_학교_회장이면_본인_학교가_속한_지부의_ChapterScoped() {
         Long memberId = 10L;
         Long gisuId = 1L;
         given(getChallengerRoleUseCase.findAllByMemberId(memberId)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, 7L, gisuId)
         ));
+        given(getChapterUseCase.byGisuAndSchool(gisuId, 7L))
+            .willReturn(new ChapterInfo(5L, "테스트 지부"));
 
         ProjectAccessScope scope = sut.resolveForManagement(memberId, gisuId, Set.of(ProjectStatus.IN_PROGRESS));
 
-        assertThat(scope).isInstanceOf(SchoolScoped.class);
-        assertThat(((SchoolScoped) scope).schoolId()).isEqualTo(7L);
+        assertThat(scope).isInstanceOf(ChapterScoped.class);
+        assertThat(((ChapterScoped) scope).chapterId()).isEqualTo(5L);
     }
 
     @Test
-    void management_은_학교_부회장도_SchoolScoped() {
+    void management_은_학교_부회장도_본인_학교가_속한_지부의_ChapterScoped() {
         Long memberId = 10L;
         Long gisuId = 1L;
         given(getChallengerRoleUseCase.findAllByMemberId(memberId)).willReturn(List.of(
             roleInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, 7L, gisuId)
         ));
+        given(getChapterUseCase.byGisuAndSchool(gisuId, 7L))
+            .willReturn(new ChapterInfo(5L, "테스트 지부"));
 
         ProjectAccessScope scope = sut.resolveForManagement(memberId, gisuId, Set.of(ProjectStatus.IN_PROGRESS));
 
-        assertThat(scope).isInstanceOf(SchoolScoped.class);
+        assertThat(scope).isInstanceOf(ChapterScoped.class);
+        assertThat(((ChapterScoped) scope).chapterId()).isEqualTo(5L);
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -100,6 +100,7 @@ class ProjectApplicationAccessScopeResolverTest {
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
         assertThat(((ProjectScoped) scope).projectId()).isEqualTo(PROJECT_ID);
+        assertThat(((ProjectScoped) scope).includeOngoingMatchingRounds()).isFalse();
     }
 
     @Test
@@ -128,6 +129,7 @@ class ProjectApplicationAccessScopeResolverTest {
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
+        assertThat(((ProjectScoped) scope).includeOngoingMatchingRounds()).isTrue();
     }
 
     @Test
@@ -143,6 +145,7 @@ class ProjectApplicationAccessScopeResolverTest {
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
+        assertThat(((ProjectScoped) scope).includeOngoingMatchingRounds()).isTrue();
     }
 
     // --- 지부장 ---
@@ -160,6 +163,7 @@ class ProjectApplicationAccessScopeResolverTest {
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(ProjectScoped.class);
+        assertThat(((ProjectScoped) scope).includeOngoingMatchingRounds()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -3,6 +3,16 @@ package com.umc.product.project.application.service.evaluator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
@@ -20,14 +30,6 @@ import com.umc.product.project.domain.ProjectApplication;
 import com.umc.product.project.domain.ProjectApplicationForm;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectApplicationPermissionEvaluatorTest {
@@ -46,8 +48,19 @@ class ProjectApplicationPermissionEvaluatorTest {
     @Mock
     LoadProjectMemberPort loadProjectMemberPort;
 
-    @InjectMocks
     ProjectApplicationPermissionEvaluator sut;
+
+    @BeforeEach
+    void setUp() {
+        // 기본은 플래그 OFF. DRAFT 단건 노출 플래그를 켜야 하는 테스트는 sutWithDraftRead() 로 별도 생성.
+        sut = newSut(false);
+    }
+
+    private ProjectApplicationPermissionEvaluator newSut(boolean allowDraftRead) {
+        return new ProjectApplicationPermissionEvaluator(
+            loadProjectPort, loadProjectApplicationPort, loadProjectMemberPort,
+            new SuperAdminProperties(allowDraftRead));
+    }
 
     @Test
     void supportedResourceType은_PROJECT_APPLICATION을_반환한다() {
@@ -119,6 +132,44 @@ class ProjectApplicationPermissionEvaluatorTest {
         SubjectAttributes subject = subjectWith(PO_MEMBER_ID, List.of(), List.of());
 
         assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_플래그_OFF면_SUPER_ADMIN도_거부() {
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(30L, List.of(),
+            List.of(superAdminRoleInGisu(99L)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_플래그_ON이면_SUPER_ADMIN_허용() {
+        sut = newSut(true);
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(30L, List.of(),
+            List.of(superAdminRoleInGisu(99L)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_플래그_ON이라도_비_SUPER_ADMIN_총괄단_거부() {
+        sut = newSut(true);
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(30L, List.of(),
+            List.of(centralCoreRoleInGisu(PROJECT_GISU_ID)));
+
+        assertThat(sut.evaluate(subject, readPermission())).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_지원서를_플래그_ON이라도_본인은_플래그_무관_허용() {
+        sut = newSut(true);
+        givenApplication(ProjectApplicationStatus.DRAFT);
+        SubjectAttributes subject = subjectWith(APPLICANT_MEMBER_ID, List.of(), List.of());
+
+        assertThat(sut.evaluate(subject, readPermission())).isTrue();
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -4,6 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
@@ -17,14 +27,6 @@ import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectPermissionEvaluatorTest {
@@ -32,8 +34,17 @@ class ProjectPermissionEvaluatorTest {
     @Mock
     LoadProjectPort loadProjectPort;
 
-    @InjectMocks
     ProjectPermissionEvaluator sut;
+
+    @BeforeEach
+    void setUp() {
+        // 기본은 플래그 OFF. DRAFT 단건 노출 플래그를 켜야 하는 테스트는 sut = newSut(true) 로 재생성.
+        sut = newSut(false);
+    }
+
+    private ProjectPermissionEvaluator newSut(boolean allowDraftRead) {
+        return new ProjectPermissionEvaluator(loadProjectPort, new SuperAdminProperties(allowDraftRead));
+    }
 
     @Test
     void supportedResourceType은_PROJECT를_반환한다() {
@@ -111,6 +122,58 @@ class ProjectPermissionEvaluatorTest {
         ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ);
 
         assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_프로젝트를_플래그_OFF면_SUPER_ADMIN도_거부() {
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(superAdminRoleInGisu(99L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_프로젝트를_플래그_ON이면_SUPER_ADMIN_허용() {
+        sut = newSut(true);
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(superAdminRoleInGisu(99L)));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void READ는_DRAFT_프로젝트를_플래그_ON이라도_비_SUPER_ADMIN_중앙총괄_거부() {
+        sut = newSut(true);
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, 10L, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void READ는_DRAFT_프로젝트를_플래그_ON이라도_작성자는_플래그_무관_허용() {
+        sut = newSut(true);
+        Long memberId = 10L;
+        Long projectId = 100L;
+        given(loadProjectPort.findById(projectId))
+            .willReturn(Optional.of(project(projectId, memberId, ProjectStatus.DRAFT)));
+
+        SubjectAttributes subject = subjectWith(memberId, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.READ);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.umc.product.project.application.service.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -286,7 +287,7 @@ class ProjectApplicationQueryServiceTest {
         // then
         assertThat(result).isEmpty();
         verify(loadProjectApplicationPort, never())
-            .searchProjectApplications(any(), any(), any(), any());
+            .searchProjectApplications(any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -300,7 +301,7 @@ class ProjectApplicationQueryServiceTest {
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
             .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
-        given(loadProjectApplicationPort.searchProjectApplications(eq(1L), isNull(), isNull(), any()))
+        given(loadProjectApplicationPort.searchProjectApplications(eq(1L), isNull(), isNull(), any(), eq(false)))
             .willReturn(List.of());
 
         // when
@@ -326,7 +327,7 @@ class ProjectApplicationQueryServiceTest {
         given(loadProjectPort.getById(1L)).willReturn(project);
         given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
             .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
-        given(loadProjectApplicationPort.searchProjectApplications(eq(1L), isNull(), isNull(), any()))
+        given(loadProjectApplicationPort.searchProjectApplications(eq(1L), isNull(), isNull(), any(), eq(false)))
             .willReturn(List.of(application));
 
         // when
@@ -340,6 +341,34 @@ class ProjectApplicationQueryServiceTest {
         assertThat(info.projectId()).isEqualTo(1L);
         assertThat(info.matchingRoundId()).isEqualTo(7L);
         assertThat(info.status()).isEqualTo(ProjectApplicationStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("searchByProject_중앙총괄단_scope면_진행_중_차수_지원서까지_조회")
+    void searchByProject_중앙총괄단은_진행중_차수까지_조회() {
+        // given
+        Project project = createProject(1L, "프로젝트A", null, 99L);
+        ProjectMatchingRound round = createMatchingRound(
+            7L, MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST);
+        ReflectionTestUtils.setField(round, "endsAt", java.time.Instant.now().plusSeconds(3_600));
+        ProjectApplication application = createSubmittedApplication(
+            55L, project, round, 200L, ProjectApplicationStatus.SUBMITTED);
+
+        SearchProjectApplicationsQuery query = SearchProjectApplicationsQuery.builder()
+            .requesterMemberId(REQUESTER_ID).projectId(1L).build();
+
+        given(loadProjectPort.getById(1L)).willReturn(project);
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L, true));
+        given(loadProjectApplicationPort.searchProjectApplications(eq(1L), isNull(), isNull(), any(), eq(true)))
+            .willReturn(List.of(application));
+
+        // when
+        List<ProjectApplicationSummaryInfo> result = sut.searchByProject(query);
+
+        // then
+        assertThat(result).hasSize(1);
+        verify(loadProjectApplicationPort).searchProjectApplications(eq(1L), isNull(), isNull(), any(), eq(true));
     }
 
     @Test
@@ -358,7 +387,7 @@ class ProjectApplicationQueryServiceTest {
         given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
             .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L));
         given(loadProjectApplicationPort.searchProjectApplications(
-            eq(1L), eq(7L), eq(ProjectApplicationStatus.APPROVED), any()))
+            eq(1L), eq(7L), eq(ProjectApplicationStatus.APPROVED), any(), eq(false)))
             .willReturn(List.of());
 
         // when
@@ -366,7 +395,7 @@ class ProjectApplicationQueryServiceTest {
 
         // then
         verify(loadProjectApplicationPort).searchProjectApplications(
-            eq(1L), eq(7L), eq(ProjectApplicationStatus.APPROVED), any());
+            eq(1L), eq(7L), eq(ProjectApplicationStatus.APPROVED), any(), eq(false));
     }
 
     // ============================================================
@@ -429,6 +458,42 @@ class ProjectApplicationQueryServiceTest {
             .hasFieldOrPropertyWithValue("baseCode",
                 ProjectErrorCode.PROJECT_MATCHING_ROUND_APPLICANTS_NOT_VIEWABLE);
         verify(getChallengerUseCase, never()).findByMemberIdAndGisuId(any(), any());
+    }
+
+    @Test
+    @DisplayName("getDetail_중앙총괄단_scope면_지원_진행_중인_차수도_조회")
+    void getDetail_중앙총괄단은_지원_진행_중에도_조회() {
+        // given - endsAt 이 미래라 아직 지원 기간 중이지만 중앙 총괄단 scope 로 통과
+        Project project = createProject(1L, "프로젝트A", null, 99L);
+        ProjectMatchingRound round = createMatchingRound(
+            7L, MatchingType.PLAN_DESIGN, MatchingPhase.FIRST);
+        ReflectionTestUtils.setField(round, "endsAt", java.time.Instant.now().plusSeconds(3_600));
+        ProjectApplication application = createApplicationWithFormResponse(
+            55L, project, round, 200L, ProjectApplicationStatus.SUBMITTED, 123L);
+
+        GetProjectApplicationDetailQuery query = detailQuery(1L, 55L);
+        given(loadProjectApplicationPort.findByIdWithDetails(55L))
+            .willReturn(Optional.of(application));
+        given(accessScopeResolver.resolveForProjectApplicantList(REQUESTER_ID, project))
+            .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L, true));
+        given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
+            .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
+        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
+            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
+        given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
+            .willReturn(List.of());
+        given(getFormResponseUseCase.findResponseWithAnswers(123L))
+            .willReturn(Optional.of(FormResponseWithAnswersInfo.builder()
+                .id(123L).formId(7L).respondentMemberId(200L)
+                .status(FormResponseStatus.SUBMITTED)
+                .answers(List.of())
+                .build()));
+
+        // when
+        ProjectApplicationDetailInfo result = sut.getDetail(query);
+
+        // then
+        assertThat(result.applicationId()).isEqualTo(55L);
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.umc.product.project.application.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -15,23 +16,34 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.OrganizationType;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectStatisticsInfo;
+import com.umc.product.project.application.port.out.LoadProjectMemberPort;
+import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.LoadProjectStatisticsPort;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsApplicationRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMatchingRoundRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsMemberRow;
 import com.umc.product.project.application.port.out.dto.ProjectStatisticsProjectRow;
+import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectStatisticsQueryServiceTest {
@@ -44,6 +56,18 @@ class ProjectStatisticsQueryServiceTest {
 
     @Mock
     GetMemberUseCase getMemberUseCase;
+
+    @Mock
+    LoadProjectPort loadProjectPort;
+
+    @Mock
+    LoadProjectMemberPort loadProjectMemberPort;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @Mock
+    GetChapterUseCase getChapterUseCase;
 
     @InjectMocks
     ProjectStatisticsQueryService sut;
@@ -96,9 +120,13 @@ class ProjectStatisticsQueryServiceTest {
                 1003L, 502L,
                 1004L, 501L
             ));
+        // 요청자가 해당 프로젝트의 PO → FULL (멤버 단위 포함)
+        Long requesterMemberId = 7000L;
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, requesterMemberId, chapterId));
 
         // when
-        ProjectStatisticsInfo result = sut.getByProjectId(projectId);
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
 
         // then
         assertThat(result.projectId()).isEqualTo(projectId);
@@ -195,9 +223,13 @@ class ProjectStatisticsQueryServiceTest {
                 1003L, 502L,
                 1004L, 501L
             ));
+        // 요청자가 총괄단 → FULL (멤버 단위 포함)
+        Long requesterMemberId = 7000L;
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, gisuId)));
 
         // when
-        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId);
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
 
         // then
         assertThat(result.chapterId()).isEqualTo(chapterId);
@@ -262,6 +294,174 @@ class ProjectStatisticsQueryServiceTest {
 
         verify(loadProjectStatisticsPort).listProjectsByChapterId(chapterId);
         verify(loadProjectStatisticsPort).listActiveMembersByChapterId(chapterId);
+    }
+
+    @Test
+    @DisplayName("getByChapterId_지부장이면_조회_가능하다")
+    void 지부_지부장이면_조회_가능() {
+        // given
+        Long chapterId = 3L;
+        Long gisuId = 1L;
+        Long requesterMemberId = 8000L;
+        givenSingleProjectChapter(chapterId, gisuId);
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER,
+                chapterId, gisuId)));
+
+        // when
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
+
+        // then — 권한 통과: 프로젝트 멤버까지 그대로 노출
+        assertThat(result.projects()).hasSize(1);
+        assertThat(result.projects().get(0).projectMembers()).hasSize(1);
+        assertThat(result.summary()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getByChapterId_해당_지부_소속_학교_회장이면_조회_가능하다")
+    void 지부_학교_회장이면_조회_가능() {
+        // given
+        Long chapterId = 3L;
+        Long gisuId = 1L;
+        Long schoolId = 7L;
+        Long requesterMemberId = 8100L;
+        givenSingleProjectChapter(chapterId, gisuId);
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL,
+                schoolId, gisuId)));
+        given(getChapterUseCase.getChaptersBySchoolIds(Set.of(schoolId)))
+            .willReturn(List.of(new ChapterInfo(chapterId, "테스트 지부")));
+
+        // when
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
+
+        // then
+        assertThat(result.projects()).hasSize(1);
+        assertThat(result.projects().get(0).projectMembers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getByChapterId_권한이_없으면_PROJECT_ACCESS_DENIED")
+    void 지부_권한없으면_거부() {
+        // given
+        Long chapterId = 3L;
+        Long requesterMemberId = 8200L;
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> sut.getByChapterId(chapterId, requesterMemberId))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    @Test
+    @DisplayName("getByProjectId_보조PM이면_FULL로_멤버_단위를_포함한다")
+    void 단건_보조PM이면_FULL() {
+        // given
+        Long projectId = 10L;
+        Long gisuId = 1L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8300L;
+        givenSingleProject(projectId, gisuId, chapterId);
+        // PO 는 아니지만 ACTIVE PLAN 멤버(Sub-PM)
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
+        given(loadProjectMemberPort.isActivePlanMember(projectId, requesterMemberId)).willReturn(true);
+
+        // when
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
+
+        // then
+        assertThat(result.projectMembers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getByProjectId_지부장이면_조회_가능하다")
+    void 단건_지부장이면_조회_가능() {
+        // given
+        Long projectId = 10L;
+        Long gisuId = 1L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8400L;
+        givenSingleProject(projectId, gisuId, chapterId);
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId))
+            .willReturn(List.of(roleInfo(ChallengerRoleType.CHAPTER_PRESIDENT, OrganizationType.CHAPTER,
+                chapterId, gisuId)));
+
+        // when
+        ProjectStatisticsInfo result = sut.getByProjectId(projectId, requesterMemberId);
+
+        // then — 권한 통과: 프로젝트 멤버까지 그대로 노출
+        assertThat(result.projectMembers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getByProjectId_권한이_없으면_PROJECT_ACCESS_DENIED")
+    void 단건_권한없으면_거부() {
+        // given
+        Long projectId = 10L;
+        Long chapterId = 3L;
+        Long requesterMemberId = 8500L;
+        given(loadProjectPort.getById(projectId))
+            .willReturn(project(projectId, 9999L, chapterId));
+        given(getChallengerRoleUseCase.findAllByMemberId(requesterMemberId)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> sut.getByProjectId(projectId, requesterMemberId))
+            .isInstanceOf(ProjectDomainException.class);
+    }
+
+    /** 멤버 1명짜리 단일 프로젝트 지부 통계 데이터 stub (집계 경로 통과용). */
+    private void givenSingleProjectChapter(Long chapterId, Long gisuId) {
+        given(loadProjectStatisticsPort.listProjectsByChapterId(chapterId))
+            .willReturn(List.of(projectRow(10L, gisuId, chapterId)));
+        given(loadProjectStatisticsPort.listMatchingRoundsByChapterId(chapterId)).willReturn(List.of());
+        given(loadProjectStatisticsPort.listActiveMembersByChapterId(chapterId))
+            .willReturn(List.of(memberRow(10L, 101L, 1001L, ChallengerPart.WEB)));
+        given(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(10L))).willReturn(List.of());
+        given(getChallengerUseCase.listByChapterId(chapterId))
+            .willReturn(List.of(challenger(1001L, gisuId, ChallengerPart.WEB)));
+        given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L))).willReturn(Map.of(1001L, 501L));
+    }
+
+    /** 멤버 1명짜리 단건 프로젝트 통계 데이터 stub (집계 경로 통과용). */
+    private void givenSingleProject(Long projectId, Long gisuId, Long chapterId) {
+        given(loadProjectStatisticsPort.getProjectById(projectId))
+            .willReturn(projectRow(projectId, gisuId, chapterId));
+        given(loadProjectStatisticsPort.listMatchingRoundsByChapterId(chapterId)).willReturn(List.of());
+        given(loadProjectStatisticsPort.listActiveMembersByProjectId(projectId))
+            .willReturn(List.of(memberRow(projectId, 101L, 1001L, ChallengerPart.WEB)));
+        given(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(projectId)))
+            .willReturn(List.of());
+        given(getChallengerUseCase.listByChapterId(chapterId))
+            .willReturn(List.of(challenger(1001L, gisuId, ChallengerPart.WEB)));
+        given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L))).willReturn(Map.of(1001L, 501L));
+    }
+
+    private static ChallengerRoleInfo roleInfo(
+        ChallengerRoleType roleType, OrganizationType organizationType, Long organizationId, Long gisuId
+    ) {
+        return ChallengerRoleInfo.builder()
+            .roleType(roleType)
+            .organizationType(organizationType)
+            .organizationId(organizationId)
+            .gisuId(gisuId)
+            .build();
+    }
+
+    private static Project project(Long id, Long ownerMemberId, Long chapterId) {
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Project project = constructor.newInstance();
+            ReflectionTestUtils.setField(project, "id", id);
+            ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerMemberId);
+            ReflectionTestUtils.setField(project, "chapterId", chapterId);
+            return project;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static ProjectStatisticsProjectRow projectRow(Long projectId, Long gisuId, Long chapterId) {

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -5,9 +5,21 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.project.application.port.in.query.dto.statistics.ChapterProjectStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectStatisticsInfo;
@@ -20,15 +32,6 @@ import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectStatisticsQueryServiceTest {
@@ -74,14 +77,17 @@ class ProjectStatisticsQueryServiceTest {
                 applicationRow(projectId, 1004L, 203L, ProjectApplicationStatus.SUBMITTED, 2L,
                     MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND)
             ));
-        given(getChallengerUseCase.getAllByGisuId(gisuId))
+        given(getChallengerUseCase.listByChapterId(chapterId))
             .willReturn(List.of(
                 challenger(1001L, gisuId, ChallengerPart.WEB),
                 challenger(1002L, gisuId, ChallengerPart.DESIGN),
                 challenger(1003L, gisuId, ChallengerPart.WEB),
                 challenger(1004L, gisuId, ChallengerPart.ANDROID),
                 challenger(9001L, gisuId, ChallengerPart.PLAN),
-                challenger(9002L, gisuId, ChallengerPart.ADMIN)
+                challenger(9002L, gisuId, ChallengerPart.ADMIN),
+                // 수료/제명 챌린저는 지부 모집단(지원 가능 인원)에서 제외되어야 한다.
+                challenger(1005L, gisuId, ChallengerPart.WEB, ChallengerStatus.GRADUATED),
+                challenger(1006L, gisuId, ChallengerPart.SPRINGBOOT, ChallengerStatus.EXPELLED)
             ));
         given(getMemberUseCase.findAllSchoolIdsByIds(Set.of(1001L, 1002L, 1003L, 1004L)))
             .willReturn(Map.of(
@@ -173,7 +179,7 @@ class ProjectStatisticsQueryServiceTest {
                 applicationRow(10L, 9001L, 305L, ProjectApplicationStatus.SUBMITTED, 2L,
                     MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND)
             ));
-        given(getChallengerUseCase.getAllByGisuId(gisuId))
+        given(getChallengerUseCase.listByChapterId(chapterId))
             .willReturn(List.of(
                 challenger(1001L, gisuId, ChallengerPart.WEB),
                 challenger(1002L, gisuId, ChallengerPart.DESIGN),
@@ -297,10 +303,17 @@ class ProjectStatisticsQueryServiceTest {
     }
 
     private static ChallengerInfo challenger(Long memberId, Long gisuId, ChallengerPart part) {
+        return challenger(memberId, gisuId, part, ChallengerStatus.ACTIVE);
+    }
+
+    private static ChallengerInfo challenger(
+        Long memberId, Long gisuId, ChallengerPart part, ChallengerStatus status
+    ) {
         return ChallengerInfo.builder()
             .memberId(memberId)
             .gisuId(gisuId)
             .part(part)
+            .challengerStatus(status)
             .build();
     }
 }


### PR DESCRIPTION
## Release Note

### 🎉 새로 추가된 것들
- 교내 회장의 프로젝트 관리 권한을 지부장 권한과 일치하도록 변경했어요. (#1019)
- 프로젝트 지원 및 매칭 현황을 조회할 때 권한 검증 로직을 더욱 강화했어요. (#1025)
- 시스템 관리자(Super Admin)를 위한 프로젝트 관련 권한 우회(Bypass) 플래그 기능을 제작하고 관련 환경 변수(`SUPER_ADMIN_ALLOW_DRAFT_READ`)를 추가했어요. (#1008)

### ♻️ 변경된 동작
- 프로젝트 지원 통계 인원을 집계할 때, 지부 단위가 아닌 기수 단위로 잘못 집계되던 오류를 수정했어요. (#1021)