### PR TITLE
[Refactor] 서비스 및 감사 로그 개선

### DIFF
--- a/onboarding/log/README.md
+++ b/onboarding/log/README.md
@@ -15,44 +15,73 @@
 - 외부 API 호출 결과와 지연 시간은 `ExternalApiCallLogger`의 `external_api_called` 구조화 이벤트로 남긴다.
 - 생성/수정/삭제처럼 추적 책임이 필요한 사용자/관리자 작업은 일반 로그만으로 끝내지 않고 audit log 대상인지 검토한다.
 - 반복적으로 집계해야 하는 성공률, 실패율, 지연 시간, 처리량은 로그보다 metric 후보로 본다.
+- 운영 metric은 `OperationalMetrics`를 통해 남긴다. 허용 tag는 `domain`, `operation`, `result`, `provider`, `jobName` 계열로 제한하고, URL/email/긴 식별자처럼 cardinality가 높은 값은 `other`로 축약한다.
 
-## 추가 로깅 계획
+## 적용 현황
+
+### 1. 과도한 INFO와 민감 가능 로그 정리
+
+- `AuthorizationService`의 요청별 권한 평가 시작/subject 상세 로그는 DEBUG로 낮췄고, 접근 거부만 WARN과 security metric으로 남긴다.
+- JWT 검증 실패 로그는 반복 발생 가능성을 고려해 DEBUG로 낮췄다.
+- Firebase 초기화 로그에서 service account email, private key algorithm/format, credential 길이/접두어를 제거했다.
+- FCM/webhook 로그에서 title/content/to 원문을 제거하고 대상 수, token 수, platform 수, content length 중심으로 바꿨다.
+- S3/CloudFront 로그에서 signed URL, signature, final URL 원문이 남지 않도록 정리했다.
+
+### 2. Audit action과 command audit 보강
+
+- `AuditAction`에 `LOGIN`, `LINK`, `UNLINK`, `ACCESS_DENIED`, `PUBLISH`, `CANCEL`, `REMIND`, `REORDER`, `FINALIZE`를 추가했다.
+- 인증/인가: 이메일 로그인 성공, OAuth 로그인 성공/회원가입 필요 흐름, OAuth 연결/해제, ChallengerRole 생성/수정/삭제를 audit 대상으로 선언했다.
+- 회원/약관/조직/챌린저: 이메일 변경, 비밀번호 변경, 프로필 수정/삭제, 약관 생성/동의, 기수/조직 멤버/스쿼드/챌린저 기록 변경을 audit 대상으로 선언했다.
+- 커리큘럼/일정/커뮤니티/블로그/공지/설문/피드백/프로젝트/스토리지의 주요 생성, 수정, 삭제, 제출, 배포, 리마인드, 재정렬, 확정 작업을 audit 대상으로 선언했다.
+- audit target/description에는 email, providerId, OAuth subject, command 객체 전체, 사용자 입력 본문을 넣지 않는다.
+
+### 3. Metric 보강
+
+- `OperationalMetrics`를 추가해 외부 호출, batch job, notification, security event metric을 표준화했다.
+- `ExternalApiCallLogger`는 기존 structured log schema를 유지하면서 provider/operation/result/latency metric을 함께 기록한다.
+- email verification retention, workbook auto release, figma dispatch retention, matching round deadline은 `jobName`, `processed`, `durationMs`, `result` 기반 batch metric을 기록한다.
+- FCM audience 발송과 webhook 발송은 provider/operation/result/count 기반 notification metric을 기록한다.
+- S3 upload URL 생성, object metadata 조회, object delete, CloudFront signed URL 생성은 storage external metric을 기록한다.
+- 로그인 실패, 비밀번호 재설정 실패, 접근 거부는 audit log가 아니라 security event metric으로 집계한다.
+
+### 4. 정책 테스트
+
+- 민감 필드 로그 금지 테스트: `email={}`, `body={}`, `providerId={}`, `sub={}`, `signedUrl={}`, `signature={}`, notification title/content/to, storage URL 원문을 검출한다.
+- command 객체 전체 로그 금지 테스트: `command={}`, `commands={}` 직접 로깅을 검출한다.
+- audit coverage 테스트: 주요 CommandService 상태 변경 메서드가 `@Audited`인지 검증한다.
+- metric recorder 테스트: 허용 tag schema와 high-cardinality 값 축약을 검증한다.
+
+## 남은 개선 계획
 
 ### 1. 인증과 인가 audit 보강
 
-- 대상: 로그인 성공/실패, OAuth 계정 연결/해제, 비밀번호 재설정 요청, 접근 거부.
-- 방식: 개인 식별 원문은 제외하고 `actorMemberId`, `provider`, `clientType`, `result`, `reasonCode` 중심으로 audit event 또는 security event를 남긴다.
-- 주의: 사용자 존재 여부를 노출하지 않는 enumeration 방어 흐름은 결과 문구와 필드를 더 엄격히 제한한다.
+- 실패 로그인/접근 거부는 현재 security metric으로 집계한다. 실패까지 audit log에 저장하려면 `@Audited`와 별도로 실패 이벤트 발행 API가 필요하다.
+- 사용자 존재 여부를 노출하지 않는 enumeration 방어 흐름은 audit description에도 reason 원문을 넣지 않는다.
 
 ### 2. 외부 연동 metric 분리
 
-- 대상: OAuth provider, Figma, Discord, Slack, Telegram, SES, S3/CloudFront, LLM provider.
-- 현재: 일부는 `ExternalApiCallLogger`로 `provider`, `operation`, `result`, `durationMs`, `errorClass`를 남긴다.
-- 추가: Micrometer `Timer`/`Counter`로 `provider`, `operation`, `result` 태그를 남겨 대시보드와 알람에 사용한다.
+- OAuth provider, Figma, Discord, Slack, Telegram, SES는 `ExternalApiCallLogger`를 통해 metric까지 기록한다.
+- LLM은 기존 `LlmMetrics`를 유지한다. 필요하면 provider별 latency/token/failure를 `OperationalMetrics`와 같은 naming policy로 맞춘다.
 
 ### 3. 스토리지 audit와 metric 보강
 
-- 대상: 업로드 URL 발급, 업로드 완료 확인, 파일 삭제, 다운로드 URL 발급 실패.
-- audit 후보: 파일 생성/삭제는 actor와 fileId를 남긴다.
-- metric 후보: presigned URL 발급 실패율, S3/CloudFront 호출 지연 시간, 삭제 실패 건수.
-- 보안 기준: signed URL, signature, private key, storage object URL 원문은 로그 금지.
+- 파일 upload URL 발급, upload confirm, delete는 audit 대상으로 선언했다.
+- S3/CloudFront 호출 metric은 어댑터에서 기록한다.
 
 ### 4. 알림 발송 관측성 개선
 
-- 대상: FCM audience 발송, invalid token 비활성화, webhook flush, SES 발송.
-- 추가: 성공/실패 건수를 metric으로 분리하고, 로그에는 batch size와 실패 reason class만 남긴다.
-- 주의: 알림 title/content는 사용자 입력 또는 운영 메시지를 포함할 수 있으므로 장기적으로 원문 로그를 줄인다.
+- FCM과 webhook 성공/실패 건수 metric은 추가했다.
+- invalid token 비활성화와 SES template rendering 실패는 후속으로 별도 counter를 둘 수 있다.
 
 ### 5. 배치와 스케줄러 표준화
 
-- 대상: email verification retention, figma dispatch retention, workbook auto release, matching round deadline.
-- 표준 필드: `jobName`, `trigger`, `threshold`, `processed`, `deleted`, `durationMs`, `result`, `errorClass`.
-- 추가: batch job 공통 helper를 두면 시작/종료/실패 로그와 metric을 일관되게 남길 수 있다.
+- 주요 scheduler/handler는 `jobName`, `processed`, `durationMs`, `result`, `errorClass` 기반 로그와 metric을 사용한다.
+- scheduler가 더 늘어나면 공통 helper로 시작/종료/실패 로그와 metric 호출을 묶는다.
 
 ### 6. 과도한 INFO 정리
 
-- 후보: `AuthorizationService`의 권한 평가 시작/subject attribute, JWT 검증 실패 INFO, Firebase 초기화 세부 로그, FCM topic deprecated warning.
-- 방향: 요청마다 반복되는 진단 로그는 DEBUG로 내리고, 운영자가 즉시 알아야 하는 상태 변화만 INFO/WARN으로 유지한다.
+- 이번 변경에서 주요 후보는 정리했다.
+- 남은 4xx/business exception WARN 과다는 request summary와 통합하거나 sampling을 검토한다.
 
 ### 7. 테스트/시드 로그 격리
 

--- a/onboarding/log/README.md
+++ b/onboarding/log/README.md
@@ -1,0 +1,60 @@
+# Logging Onboarding
+
+이 문서는 `feature/logging-hardening` 기준으로 운영 코드의 로그 사용 현황과 추가 개선 계획을 정리한다.
+
+## 읽는 순서
+
+1. [domains.md](./domains.md): 도메인별 현재 로그 인벤토리
+2. 아래 정책: 로그로 남길 정보와 audit/metric으로 분리할 정보의 기준
+3. 아래 개선 계획: 이후 작업을 나눌 수 있는 단위
+
+## 현재 기준
+
+- 일반 애플리케이션 로그는 장애 원인 분석, 배치/스케줄러 실행 상태, 외부 연동 실패 원인, 운영 흐름 추적에 사용한다.
+- 재식별 가능한 OAuth provider id, subject, email, response body, 수신자 주소 원문은 로그에 남기지 않는다.
+- 외부 API 호출 결과와 지연 시간은 `ExternalApiCallLogger`의 `external_api_called` 구조화 이벤트로 남긴다.
+- 생성/수정/삭제처럼 추적 책임이 필요한 사용자/관리자 작업은 일반 로그만으로 끝내지 않고 audit log 대상인지 검토한다.
+- 반복적으로 집계해야 하는 성공률, 실패율, 지연 시간, 처리량은 로그보다 metric 후보로 본다.
+
+## 추가 로깅 계획
+
+### 1. 인증과 인가 audit 보강
+
+- 대상: 로그인 성공/실패, OAuth 계정 연결/해제, 비밀번호 재설정 요청, 접근 거부.
+- 방식: 개인 식별 원문은 제외하고 `actorMemberId`, `provider`, `clientType`, `result`, `reasonCode` 중심으로 audit event 또는 security event를 남긴다.
+- 주의: 사용자 존재 여부를 노출하지 않는 enumeration 방어 흐름은 결과 문구와 필드를 더 엄격히 제한한다.
+
+### 2. 외부 연동 metric 분리
+
+- 대상: OAuth provider, Figma, Discord, Slack, Telegram, SES, S3/CloudFront, LLM provider.
+- 현재: 일부는 `ExternalApiCallLogger`로 `provider`, `operation`, `result`, `durationMs`, `errorClass`를 남긴다.
+- 추가: Micrometer `Timer`/`Counter`로 `provider`, `operation`, `result` 태그를 남겨 대시보드와 알람에 사용한다.
+
+### 3. 스토리지 audit와 metric 보강
+
+- 대상: 업로드 URL 발급, 업로드 완료 확인, 파일 삭제, 다운로드 URL 발급 실패.
+- audit 후보: 파일 생성/삭제는 actor와 fileId를 남긴다.
+- metric 후보: presigned URL 발급 실패율, S3/CloudFront 호출 지연 시간, 삭제 실패 건수.
+- 보안 기준: signed URL, signature, private key, storage object URL 원문은 로그 금지.
+
+### 4. 알림 발송 관측성 개선
+
+- 대상: FCM audience 발송, invalid token 비활성화, webhook flush, SES 발송.
+- 추가: 성공/실패 건수를 metric으로 분리하고, 로그에는 batch size와 실패 reason class만 남긴다.
+- 주의: 알림 title/content는 사용자 입력 또는 운영 메시지를 포함할 수 있으므로 장기적으로 원문 로그를 줄인다.
+
+### 5. 배치와 스케줄러 표준화
+
+- 대상: email verification retention, figma dispatch retention, workbook auto release, matching round deadline.
+- 표준 필드: `jobName`, `trigger`, `threshold`, `processed`, `deleted`, `durationMs`, `result`, `errorClass`.
+- 추가: batch job 공통 helper를 두면 시작/종료/실패 로그와 metric을 일관되게 남길 수 있다.
+
+### 6. 과도한 INFO 정리
+
+- 후보: `AuthorizationService`의 권한 평가 시작/subject attribute, JWT 검증 실패 INFO, Firebase 초기화 세부 로그, FCM topic deprecated warning.
+- 방향: 요청마다 반복되는 진단 로그는 DEBUG로 내리고, 운영자가 즉시 알아야 하는 상태 변화만 INFO/WARN으로 유지한다.
+
+### 7. 테스트/시드 로그 격리
+
+- `test` 도메인의 seed 로그는 운영 관측성과 성격이 다르다.
+- 장기적으로 별도 profile/logger name 또는 admin seed 전용 structured event로 분리한다.

--- a/onboarding/log/domains.md
+++ b/onboarding/log/domains.md
@@ -5,27 +5,26 @@
 - 대상: `src/main/java/com/umc/product/**`
 - 패턴: `log.trace/debug/info/warn/error`, `LoggerFactory.getLogger`
 - 기준 브랜치: `feature/logging-hardening`
-- 참고: `feature/remove-gcs-storage`가 병합되면 `storage/adapter/out/gcs` 항목은 제거된다.
 
 ## 요약
 
 | 도메인 | 현재 로그 호출 | 주요 목적 |
 | --- | ---: | --- |
-| authentication | 71 | OAuth/ID/PW 인증 흐름, provider 호출 실패, 토큰 revoke, email verification retention |
+| authentication | 72 | OAuth/ID/PW 인증 흐름, provider 호출 실패, 토큰 revoke, email verification retention |
 | authorization | 6 | 권한 evaluator 등록, 권한 평가, 접근 거부 |
 | audit | 6 | audit event 발행/저장 실패, details 직렬화 실패 |
 | blog | 3 | 지원하지 않는 permission type |
-| challenger | 4 active, 2 commented | ChallengerRecord 생성/대량생성/검증 실패, deprecated API |
+| challenger | 6 | ChallengerRecord 생성/대량생성/검증 실패, deprecated API |
 | community | 2 | 지원하지 않는 permission type |
 | curriculum | 3 | Workbook 자동 배포 스케줄 |
-| figma | 34 | Figma sync/digest/classification, Discord batch 전송, 외부 API 실패 |
-| global | 42 | request logging, exception handling, JWT/Firebase/security/bootstrap |
+| figma | 35 | Figma sync/digest/classification, Discord batch 전송, 외부 API 실패 |
+| global | 36 | request logging, exception handling, JWT/Firebase/security/bootstrap |
 | llm | 16 | LLM provider 선택, 호출 시작/완료/실패, circuit/rate limit |
 | maintenance | 1 | maintenance snapshot refresh 실패 |
 | notice | 2 | 공지 조회 조건, viewer 지부 정보 fallback |
 | notification | 39 | FCM, webhook, SES, server lifecycle |
 | project | 3 | matching round deadline 실패, project response assembly fallback |
-| storage | 29 | file lifecycle, S3/CloudFront, GCS legacy adapter |
+| storage | 12 | file lifecycle, S3/CloudFront |
 | test | 42 | seed/test endpoint diagnostics |
 
 직접 로그 호출이 없는 도메인: `member`, `organization`, `schedule`, `survey`, `term`.
@@ -60,23 +59,24 @@
 
 추가 계획:
 
-- 로그인 성공/실패/계정 연결/해제는 audit 또는 security event로 별도 정리한다.
-- token verification/revoke 성공률과 provider latency는 metric으로 분리한다.
+- 이메일 로그인 성공, OAuth 로그인 성공/회원가입 필요, OAuth 계정 연결/해제는 audit 대상으로 선언했다.
+- 로그인 실패와 비밀번호 재설정 실패는 사용자 열거 방어를 유지하기 위해 security metric으로 집계한다.
+- token verification/revoke 성공률과 provider latency는 `ExternalApiCallLogger`를 통해 metric으로도 기록한다.
 
 ## authorization
 
 | 위치 | 레벨 | 무엇을 남기는가 | 판단 |
 | --- | --- | --- | --- |
 | `AuthorizationService` | INFO | 등록된 evaluator key set | bootstrap 시 1회라 유지 가능 |
-| `AuthorizationService` | INFO | 권한 평가 시작, subject attribute | 요청마다 발생할 수 있어 DEBUG 후보. subject 전체 `toString`은 필드 통제가 어려움 |
+| `AuthorizationService` | DEBUG | 권한 평가 시작, subject memberId/roleCount/challengerCount | 요청마다 발생할 수 있어 DEBUG 유지. subject 전체 `toString`은 제거 완료 |
 | `AuthorizationService` | DEBUG | permission check 상세. `memberId`, roles, resource, permission, result | 디버깅용으로 적절 |
 | `AuthorizationService` | WARN | permission denied | 보안 이벤트. audit/security event 또는 metric 후보 |
 | `AccessControlAspect` | WARN | annotation 기반 접근 거부. `memberId`, resource, permission | 보안 이벤트. audit/security event 후보 |
 
 추가 계획:
 
-- 접근 거부는 `actorMemberId`, `resourceType`, `permission`, `reason`을 표준화해 audit/security event로 남긴다.
-- 정상 권한 평가 시작 로그는 DEBUG로 낮추거나 제거한다.
+- 접근 거부는 WARN 로그와 `OperationalMetrics.recordSecurityEvent`로 집계한다.
+- 정상 권한 평가 시작 로그는 DEBUG로 낮췄다.
 
 ## audit
 
@@ -121,7 +121,7 @@
 추가 계획:
 
 - deprecated API 호출 횟수는 metric으로 분리하면 제거 판단에 유용하다.
-- ChallengerRecord 생성/삭제 audit는 이미 추가됐고, consumeCode 성공/실패 audit도 검토한다.
+- ChallengerRecord 생성/삭제/consumeCode는 audit 대상으로 선언했다. consumeCode audit target은 일회용 코드 원문이 아니라 target member id를 사용한다.
 
 ## community
 
@@ -144,7 +144,7 @@
 
 추가 계획:
 
-- `jobName`, `durationMs`, `result`, `releasedCount` 형태로 표준화하고 metric counter를 추가한다.
+- `jobName`, `durationMs`, `result`, `processed` 형태로 표준화했고 batch metric을 추가했다.
 
 ## figma
 
@@ -171,7 +171,8 @@
 
 추가 계획:
 
-- Figma digest 결과는 metric으로 분리한다. `total`, `unmatched`, `skippedDispatched`, `sent`, `failed`를 태그/카운터로 관리한다.
+- Figma dispatch retention scheduler는 batch metric과 표준 로그를 사용한다.
+- Figma digest 결과는 후속으로 metric 분리를 검토한다. `total`, `unmatched`, `skippedDispatched`, `sent`, `failed`를 태그/카운터로 관리한다.
 - Figma integration 등록은 audit 대상인지 검토한다.
 - LLM classification 실패/후보 외 응답은 metric으로 집계해 품질 추이를 본다.
 
@@ -179,21 +180,21 @@
 
 | 위치 | 레벨 | 무엇을 남기는가 | 판단 |
 | --- | --- | --- | --- |
-| `ExternalApiCallLogger` | INFO/WARN | `external_api_called` structured event. provider, operation, result, durationMs, errorClass | 적절. metric 연계 후보 |
+| `ExternalApiCallLogger` | INFO/WARN | `external_api_called` structured event. provider, operation, result, durationMs, errorClass | structured log schema 유지. `OperationalMetrics` 연계 완료 |
 | `LoggingInterceptor` | INFO/ERROR | request start/end summary, latency, status, 예외 요약 | 운영 요청 추적용. actuator/static 제외 정책 확인 필요 |
 | `GlobalExceptionHandler` | WARN/ERROR | validation, JSON parse, missing parameter, type mismatch, business exception, unhandled exception | 4xx WARN 과다 가능. unhandled ERROR는 적절 |
 | `CustomErrorController` | WARN | error controller fallback, business exception | fallback 진단용 |
-| `JwtTokenProvider` | WARN/INFO | clientType claim 파싱 실패, JWT invalid/expired/unsupported/malformed | 반복 실패는 DEBUG 또는 security metric 후보 |
+| `JwtTokenProvider` | WARN/DEBUG | clientType claim 파싱 실패, JWT invalid/expired/unsupported/malformed | 반복 JWT 실패는 DEBUG로 낮춤. security metric 후보 |
 | `JwtAuthenticationFilter` | DEBUG | JWT 인증 성공 memberId | 디버깅용 |
 | `ApiAuthenticationEntryPoint` | WARN/ERROR | 인증 실패 URI/errorCode/message, unknown JWT error | 보안 이벤트 후보 |
 | `QueryStatsJdbcEventListener` | DEBUG | slow query/query stats 요약 | SQL value 노출 정책 유지 필요 |
 | `AsyncConfig` | ERROR | async method 예외 | 적절 |
 | `SecurityConfig` | INFO | CORS allowed origins | bootstrap 설정 확인용 |
-| `FcmConfig` | INFO/DEBUG/TRACE | Firebase 초기화, service account email, key algorithm/format, credentials length/prefix | credentials 계열은 제거 또는 local profile 제한 필요 |
+| `FcmConfig` | INFO/DEBUG | Firebase 초기화, 기존 FirebaseApp 확인 | credential/email/private key 세부 로그 제거 완료 |
 
 추가 계획:
 
-- `FcmConfig` credential trace/debug 로그를 제거한다.
+- `FcmConfig` credential trace/debug 로그는 제거했다.
 - 4xx validation/business exception은 WARN이 아니라 DEBUG/INFO 또는 request summary와 통합하는 방안을 검토한다.
 - JWT 실패는 security metric으로 집계하고 로그는 샘플링/레벨 조정한다.
 
@@ -242,13 +243,13 @@
 | `ServerLifecycleAlarmListener` | INFO | 서버 시작/종료 알림 전송 완료 시간 | 운영 이벤트 |
 | `FcmOutboxEventListener`, `FcmOutboxScheduler` | DEBUG | outbox 즉시/스케줄 처리 시작 | 디버깅용 |
 | `FcmOutboxService` | WARN | deprecated topic outbox 잔여 이벤트 실패 처리 | migration 상태 추적 |
-| `FcmTopicService` | WARN | deprecated topic API 호출/비활성화 | 제거 전 호출 추적 |
-| `FcmAudienceService` | INFO/WARN/ERROR | FCM 비활성화 skip, 대상 없음, active token 없음, 발송 완료, batch 실패, 성공/실패 수 | metric 후보. title 원문 로그는 축소 후보 |
+| `FcmTopicService` | DEBUG | deprecated topic API 호출/비활성화 | 제거 전 디버깅용. 반복 WARN 제거 완료 |
+| `FcmAudienceService` | INFO/WARN/ERROR | FCM 비활성화 skip, 대상 없음, active token 없음, 발송 완료, batch 실패, 성공/실패 수 | title 원문 제거 완료. notification metric 추가 |
 | `FcmTokenDeactivator` | INFO | invalid token 비활성화 tokenId/memberId | 운영 추적용. metric 후보 |
 | `WebhookAlarmAspect` | DEBUG/ERROR | webhook annotation 감지, 처리 오류 | AOP 진단 |
 | `WebhookAlarmScheduler` | DEBUG | buffer flush 스케줄 실행 | 디버깅용 |
-| `WebhookAlarmService` | DEBUG/INFO/WARN/ERROR | buffer add, flush start, missing adapter, platform send success/failure | 운영 추적용 |
-| `DiscordWebhookAdapter`, `SlackWebhookAdapter`, `TelegramWebhookAdapter` | DEBUG | webhook 전송 완료 title/parts | title 원문 축소 후보 |
+| `WebhookAlarmService` | DEBUG/INFO/WARN/ERROR | buffer add, flush start, missing adapter, platform send success/failure | title/content 원문 제거 완료. notification metric 추가 |
+| `DiscordWebhookAdapter`, `SlackWebhookAdapter`, `TelegramWebhookAdapter` | DEBUG | webhook 전송 완료 parts | title 원문 제거 완료 |
 | `SesEmailAdapter` | INFO/ERROR | SES 성공 messageId, 실패 awsErrorCode, recipientPresent | 원문 수신자 제거 완료. external_api event 적용 |
 | `SendEmailService` | ERROR | template rendering 실패 recipientPresent | 적절 |
 
@@ -261,8 +262,8 @@
 
 추가 계획:
 
-- FCM/웹훅/SES 발송 성공률과 실패율은 metric으로 분리한다.
-- title/content 원문은 사용자 입력 가능성이 있으므로 로그 필드에서 제거하거나 길이/타입으로 대체한다.
+- FCM/웹훅 발송 성공률과 실패율은 metric으로 분리했다.
+- title/content 원문은 로그 필드에서 제거했다.
 
 ## project
 
@@ -273,24 +274,23 @@
 
 추가 계획:
 
-- matching round auto decision은 job result metric과 audit 후보를 검토한다.
+- matching round auto decision은 batch metric과 `FINALIZE` audit 대상으로 선언했다.
 
 ## storage
 
 | 위치 | 레벨 | 무엇을 남기는가 | 판단 |
 | --- | --- | --- | --- |
-| `FileCommandService` | INFO | upload URL 생성 완료, upload confirm, file delete 완료 | 파일 lifecycle 추적. audit 후보 |
+| `FileCommandService` | INFO | upload URL 생성 완료, upload confirm, file delete 완료 | 파일 lifecycle 추적. audit 추가 완료 |
 | `FileCommandService` | WARN | 파일 삭제/confirm 등에서 기대 상태와 다른 경우 | 운영 진단용 |
 | `S3StorageProperties` | WARN | CloudFront 활성화 상태에서 signed URL key 누락 | 설정 오류 |
-| `S3StorageAdapter` | DEBUG | S3 upload URL 생성, CloudFront signed URL 생성 완료 | signed URL 원문은 남기지 않아야 함. 현재 `resourceUrl`은 원문 URL인지 검토 필요 |
-| `S3StorageAdapter` | INFO/WARN/ERROR | S3 삭제 완료, S3/CloudFront/S3 metadata 조회 실패 | 외부 스토리지 장애 추적 |
-| `GcsStorageAdapter` | DEBUG/INFO/WARN/ERROR | GCS upload/download/delete, CDN signed URL 생성 세부 값 | GCS 제거 PR 병합 시 삭제 예정. 현재 signed URL/signature 로그는 부적절 |
+| `S3StorageAdapter` | DEBUG | S3 upload URL 생성, CloudFront signed URL 생성 완료 | signed URL 원문 제거 완료. storage external metric 추가 |
+| `S3StorageAdapter` | INFO/WARN/ERROR | S3 삭제 완료, S3/CloudFront/S3 metadata 조회 실패 | 외부 스토리지 장애 추적. 성공/실패 metric 추가 |
 
 추가 계획:
 
-- 파일 생성/삭제는 audit 대상에 추가한다.
-- S3/CloudFront 호출은 `ExternalApiCallLogger` 또는 metric으로 지연 시간/실패율을 남긴다.
-- signed URL, signature, object URL 원문은 로그 금지 정책 테스트에 포함한다.
+- 파일 생성/확인/삭제는 audit 대상에 추가했다.
+- S3/CloudFront 호출은 metric으로 지연 시간/실패율을 남긴다.
+- signed URL, signature, object URL 원문은 로그 금지 정책 테스트에 포함했다.
 
 ## test
 

--- a/onboarding/log/domains.md
+++ b/onboarding/log/domains.md
@@ -1,0 +1,312 @@
+# Domain Log Inventory
+
+수집 기준:
+
+- 대상: `src/main/java/com/umc/product/**`
+- 패턴: `log.trace/debug/info/warn/error`, `LoggerFactory.getLogger`
+- 기준 브랜치: `feature/logging-hardening`
+- 참고: `feature/remove-gcs-storage`가 병합되면 `storage/adapter/out/gcs` 항목은 제거된다.
+
+## 요약
+
+| 도메인 | 현재 로그 호출 | 주요 목적 |
+| --- | ---: | --- |
+| authentication | 71 | OAuth/ID/PW 인증 흐름, provider 호출 실패, 토큰 revoke, email verification retention |
+| authorization | 6 | 권한 evaluator 등록, 권한 평가, 접근 거부 |
+| audit | 6 | audit event 발행/저장 실패, details 직렬화 실패 |
+| blog | 3 | 지원하지 않는 permission type |
+| challenger | 4 active, 2 commented | ChallengerRecord 생성/대량생성/검증 실패, deprecated API |
+| community | 2 | 지원하지 않는 permission type |
+| curriculum | 3 | Workbook 자동 배포 스케줄 |
+| figma | 34 | Figma sync/digest/classification, Discord batch 전송, 외부 API 실패 |
+| global | 42 | request logging, exception handling, JWT/Firebase/security/bootstrap |
+| llm | 16 | LLM provider 선택, 호출 시작/완료/실패, circuit/rate limit |
+| maintenance | 1 | maintenance snapshot refresh 실패 |
+| notice | 2 | 공지 조회 조건, viewer 지부 정보 fallback |
+| notification | 39 | FCM, webhook, SES, server lifecycle |
+| project | 3 | matching round deadline 실패, project response assembly fallback |
+| storage | 29 | file lifecycle, S3/CloudFront, GCS legacy adapter |
+| test | 42 | seed/test endpoint diagnostics |
+
+직접 로그 호출이 없는 도메인: `member`, `organization`, `schedule`, `survey`, `term`.
+`schedule`은 직접 로그 대신 `@Audited`로 create/update/delete/forceDelete를 audit 대상으로 남긴다.
+
+## authentication
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `OAuthAuthenticationService` | INFO | OAuth login start, existing/new member 분기, token/code 검증 성공. `provider`, `memberId`, `hasEmail` 사용 | provider id/email 원문 제거 완료. 로그인 성공/실패는 audit/security event 후보 |
+| `OAuthAuthenticationService` | WARN | OAuth unlink 시 refresh/access token 누락, access token 소유자 불일치 | 계정 연결 해제 실패 원인 파악에 필요. actor audit 보강 필요 |
+| `OAuthTokenVerificationAdapter` | INFO/WARN | provider별 verify/code exchange/revoke 시작, 미지원 provider | adapter routing 흐름 확인용. 반복 호출 INFO는 DEBUG 후보 |
+| `AppleTokenVerifier` | DEBUG | ID token 검증 시작/성공, private key length | 성공 로그는 DEBUG 적절. private key length/credential 진단 로그는 제거 또는 local profile 제한 후보 |
+| `AppleTokenVerifier` | INFO | authorization code exchange 성공, token revoke 시작/성공 | 외부 API structured event가 있으므로 시작/성공 INFO 축소 후보 |
+| `AppleTokenVerifier` | ERROR | token endpoint/revoke/JWKS/RSA/client secret 실패. `status`, `errorCode`, `bodyLength`, `kid` | body 원문 미기록은 적절. `kid` 노출 필요성은 검토 가능 |
+| `GoogleTokenVerifier` | DEBUG | ID/access token 검증 시작/성공, `hasEmail` | 적절 |
+| `GoogleTokenVerifier` | INFO | token revoke 시작/성공 | external_api metric으로 대체 가능 |
+| `GoogleTokenVerifier` | ERROR | tokeninfo/revoke 실패, audience 불일치, 검증 중 예외 | `expected` client id list는 설정값 노출 가능성이 있어 축약 후보 |
+| `KakaoTokenVerifier` | DEBUG | authorization code/access token 검증 시작/성공 | 적절 |
+| `KakaoTokenVerifier` | INFO | token exchange 성공, unlink 시작/성공, admin unlink targetProvided | external_api event와 중복. 성공 INFO 축소 후보 |
+| `KakaoTokenVerifier` | WARN | 허용되지 않은 redirect URI, admin key 미설정 skip | 보안/설정 이슈라 유지 가능. redirect URI 원문은 allowlist mismatch 분석에 필요하지만 마스킹 검토 |
+| `KakaoTokenVerifier` | ERROR | token exchange/userinfo/unlink 실패, 예외 | status 중심이라 적절 |
+| `CredentialRehashService` | INFO/WARN | 비밀번호 해시 정책 갱신 완료/실패, `memberId` | 보안 상태 변화라 유지. audit/security event 후보 |
+| `AuthenticationService` | INFO | 비밀번호 재설정 요청에서 가입/자격증명 미존재 시 발송 skip | enumeration 방어 흐름 설명용. metric으로 누적하면 좋음 |
+| `EmailVerificationRetentionScheduler` | INFO/DEBUG | email verification retention 삭제 완료/없음, `threshold`, `deleted` | 스케줄러 표준 필드 `jobName`, `durationMs`, `result` 추가 후보 |
+
+구조화 외부 API 이벤트:
+
+- `APPLE`: `EXCHANGE_AUTHORIZATION_CODE`, `REVOKE_TOKEN`, `FETCH_JWKS`
+- `GOOGLE`: `VERIFY_ID_TOKEN`, `VERIFY_ACCESS_TOKEN`, `REVOKE_TOKEN`
+- `KAKAO`: `EXCHANGE_AUTHORIZATION_CODE`, `GET_USER_INFO`, `UNLINK_USER`, `ADMIN_UNLINK_USER`
+
+추가 계획:
+
+- 로그인 성공/실패/계정 연결/해제는 audit 또는 security event로 별도 정리한다.
+- token verification/revoke 성공률과 provider latency는 metric으로 분리한다.
+
+## authorization
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `AuthorizationService` | INFO | 등록된 evaluator key set | bootstrap 시 1회라 유지 가능 |
+| `AuthorizationService` | INFO | 권한 평가 시작, subject attribute | 요청마다 발생할 수 있어 DEBUG 후보. subject 전체 `toString`은 필드 통제가 어려움 |
+| `AuthorizationService` | DEBUG | permission check 상세. `memberId`, roles, resource, permission, result | 디버깅용으로 적절 |
+| `AuthorizationService` | WARN | permission denied | 보안 이벤트. audit/security event 또는 metric 후보 |
+| `AccessControlAspect` | WARN | annotation 기반 접근 거부. `memberId`, resource, permission | 보안 이벤트. audit/security event 후보 |
+
+추가 계획:
+
+- 접근 거부는 `actorMemberId`, `resourceType`, `permission`, `reason`을 표준화해 audit/security event로 남긴다.
+- 정상 권한 평가 시작 로그는 DEBUG로 낮추거나 제거한다.
+
+## audit
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `AuditLogCommandService` | DEBUG | audit 저장 요청의 domain/action/target/actor | 적절 |
+| `AuditLogCommandService` | WARN | details JSON 직렬화 실패 | audit detail 누락 가능성이라 유지 |
+| `AuditLogEventListener` | ERROR | audit log 저장 실패 | 중요. 알람 후보 |
+| `AuditAspect` | ERROR | audit event 발행 오류 | 중요. 알람 후보 |
+| `AuditAspect` | DEBUG | SecurityContext memberId/IP 추출 실패 | fallback 진단용 |
+
+추가 계획:
+
+- audit 저장 실패는 metric counter와 alert를 붙인다.
+- details 직렬화 실패는 event id 또는 target을 포함해 추적성을 높인다.
+
+## blog
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `BlogSeriesPermissionEvaluator` | WARN | 지원하지 않는 permission type | 개발/설정 오류 진단용 |
+| `BlogContentPermissionEvaluator` | WARN | 지원하지 않는 permission type | 개발/설정 오류 진단용 |
+| `BlogCommentPermissionEvaluator` | WARN | 지원하지 않는 permission type | 개발/설정 오류 진단용 |
+
+추가 계획:
+
+- permission evaluator 공통 helper로 메시지와 필드를 표준화한다.
+
+## challenger
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `ChallengerSearchController` | WARN | deprecated global search API 호출 | 제거 일정 관리용 |
+| `ChallengerRecordCommandService` | INFO | ChallengerRecord 생성 완료. `recordId`, `gisuId`, `schoolId`, `chapterId`, `adminRecord` | 관리성 상태 변화라 유지. audit 추가 완료 |
+| `ChallengerRecordCommandService` | INFO | ChallengerRecord 대량 생성 완료. `count` | audit 추가 완료 |
+| `ChallengerRecordCommandService` | DEBUG | school/chapter mismatch 검증 실패 상세 | 요청 검증 디버깅용 |
+
+비활성 로그:
+
+- `ChallengerQueryController`에 deprecated API 로그 2건이 주석 처리되어 있다.
+
+추가 계획:
+
+- deprecated API 호출 횟수는 metric으로 분리하면 제거 판단에 유용하다.
+- ChallengerRecord 생성/삭제 audit는 이미 추가됐고, consumeCode 성공/실패 audit도 검토한다.
+
+## community
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `CommunityPostPermissionEvaluator` | WARN | 지원하지 않는 permission type | 개발/설정 오류 진단용 |
+| `CommunityCommentPermissionEvaluator` | WARN | 지원하지 않는 permission type | 개발/설정 오류 진단용 |
+
+추가 계획:
+
+- blog와 같은 permission evaluator 공통 로그 포맷으로 맞춘다.
+
+## curriculum
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `WorkbookAutoReleaseScheduler` | INFO | 자동 배포 스케줄 시작 | batch 시작 추적 |
+| `WorkbookAutoReleaseScheduler` | INFO | 자동 배포 완료, 배포 건수 | batch 결과 추적 |
+| `WorkbookAutoReleaseScheduler` | ERROR | 자동 배포 중 오류 | 장애 원인 분석 |
+
+추가 계획:
+
+- `jobName`, `durationMs`, `result`, `releasedCount` 형태로 표준화하고 metric counter를 추가한다.
+
+## figma
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `FigmaCommentDispatchRetentionScheduler` | INFO/DEBUG | dispatch retention 삭제 완료/없음. `threshold`, `deleted` | 스케줄러 로그로 적절 |
+| `FigmaCommentSyncScheduler` | DEBUG | sync polling window `from`, `to` | 디버깅용 |
+| `FigmaCommentDigestService` | INFO | digest 완료. 기간, total, unmatched, skipped, domains | 운영 요약으로 유용. metric 후보 |
+| `FigmaIntegrationCommandService` | INFO | Figma 통합 등록 완료. owner/integration id | audit 후보 |
+| `FigmaCommentSummaryService` | WARN | access token 확보 실패, comment fetch 실패, routing fallback 없음, Discord batch 실패, page name 해석 실패 | 실패/부분 실패 추적에 필요 |
+| `FigmaCommentDomainClassifier` | DEBUG | L1/L2 cache hit, classification 성공 | 진단용 |
+| `FigmaCommentDomainClassifier` | WARN | 후보 외 LLM 응답, 호출 실패, batch 실패, cache 저장 실패, 빈 응답, hallucination 의심, JSON 파싱 실패 | LLM 품질/연동 장애 추적 |
+| `FigmaCommentClient` | WARN | 댓글 페이지 상한 도달, 댓글 조회 실패. `fileKey`, `cursor`, `status`, `bodyLength` | 적절. 원문 body 미기록 |
+| `FigmaFileMetadataClient` | WARN | 파일 메타데이터 조회 실패. `fileKey`, `status`, `bodyLength` | 적절 |
+| `FigmaOAuthClient` | ERROR | OAuth code/refresh 실패. `status`, `bodyLength` | 적절 |
+| `DiscordMentionWebhookAdapter` | WARN/ERROR/DEBUG | embed size 한도, message size 한도, batch 전송 성공/실패/부분 실패 | Discord payload 제약 진단에 필요 |
+| `FigmaCommentClassificationPersistenceAdapter` | DEBUG | classification 동시 저장 race 무시 | race 처리 확인용 |
+| `FigmaCommentDispatchPersistenceAdapter` | DEBUG | dispatch saveAll race 무시 | race 처리 확인용 |
+
+구조화 외부 API 이벤트:
+
+- `FIGMA`: `LIST_COMMENTS`, `RESOLVE_FILE_NODES`, `EXCHANGE_OAUTH_CODE`, `REFRESH_OAUTH_TOKEN`
+- `DISCORD`: `SEND_FIGMA_DOMAIN_BATCH`
+
+추가 계획:
+
+- Figma digest 결과는 metric으로 분리한다. `total`, `unmatched`, `skippedDispatched`, `sent`, `failed`를 태그/카운터로 관리한다.
+- Figma integration 등록은 audit 대상인지 검토한다.
+- LLM classification 실패/후보 외 응답은 metric으로 집계해 품질 추이를 본다.
+
+## global
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `ExternalApiCallLogger` | INFO/WARN | `external_api_called` structured event. provider, operation, result, durationMs, errorClass | 적절. metric 연계 후보 |
+| `LoggingInterceptor` | INFO/ERROR | request start/end summary, latency, status, 예외 요약 | 운영 요청 추적용. actuator/static 제외 정책 확인 필요 |
+| `GlobalExceptionHandler` | WARN/ERROR | validation, JSON parse, missing parameter, type mismatch, business exception, unhandled exception | 4xx WARN 과다 가능. unhandled ERROR는 적절 |
+| `CustomErrorController` | WARN | error controller fallback, business exception | fallback 진단용 |
+| `JwtTokenProvider` | WARN/INFO | clientType claim 파싱 실패, JWT invalid/expired/unsupported/malformed | 반복 실패는 DEBUG 또는 security metric 후보 |
+| `JwtAuthenticationFilter` | DEBUG | JWT 인증 성공 memberId | 디버깅용 |
+| `ApiAuthenticationEntryPoint` | WARN/ERROR | 인증 실패 URI/errorCode/message, unknown JWT error | 보안 이벤트 후보 |
+| `QueryStatsJdbcEventListener` | DEBUG | slow query/query stats 요약 | SQL value 노출 정책 유지 필요 |
+| `AsyncConfig` | ERROR | async method 예외 | 적절 |
+| `SecurityConfig` | INFO | CORS allowed origins | bootstrap 설정 확인용 |
+| `FcmConfig` | INFO/DEBUG/TRACE | Firebase 초기화, service account email, key algorithm/format, credentials length/prefix | credentials 계열은 제거 또는 local profile 제한 필요 |
+
+추가 계획:
+
+- `FcmConfig` credential trace/debug 로그를 제거한다.
+- 4xx validation/business exception은 WARN이 아니라 DEBUG/INFO 또는 request summary와 통합하는 방안을 검토한다.
+- JWT 실패는 security metric으로 집계하고 로그는 샘플링/레벨 조정한다.
+
+## llm
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `ChatCompletionService` | INFO | 활성 provider, 호출 시작, 호출 완료. prompt/response length, latency, token count | 원문 prompt 미기록이라 적절. metric 후보 |
+| `ChatCompletionService` | WARN | guard 차단, domain exception, unexpected exception | 장애 추적용 |
+| `LlmCallGuard` | WARN | circuit open, consecutive failures, skipUntil | 운영 알림 후보 |
+| `LlmRateLimiter` | DEBUG | token 부족 대기 시간 | 디버깅용 |
+| `LlmFallbackConfig` | WARN | fallback provider 설정 | bootstrap 설정 이슈 |
+| `SpringAi*ChatCompletionAdapter` | DEBUG/WARN | provider별 성공 length/token, 실패 model/error | provider adapter 진단용 |
+| `MockChatCompletionAdapter` | DEBUG | mock echo length | local/test용 |
+
+추가 계획:
+
+- LLM 호출 latency/tokens/failure는 metric으로 분리한다.
+- `ExternalApiCallLogger`를 LLM adapter에도 적용할지 결정한다. 현재 `ChatCompletionService`가 유사 정보를 직접 남긴다.
+
+## maintenance
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `MaintenanceStateHolder` | WARN | snapshot refresh 실패, 기존 상태 유지 | 운영 상태 전환에 중요 |
+
+추가 계획:
+
+- maintenance mode 변경/조회 실패를 audit 또는 metric으로 보강한다.
+
+## notice
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `NoticeQueryRepository` | DEBUG | 공지 조회 조건. gisu/chapter/school/part/memberParts/viewerRole | 쿼리 디버깅용 |
+| `NoticeViewerInfoAssembler` | DEBUG | 지부 정보 조회 실패 fallback | 조합 실패 진단용 |
+
+추가 계획:
+
+- 공지 생성/수정/삭제/읽음 처리의 audit 대상 여부를 검토한다.
+
+## notification
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `ServerLifecycleAlarmListener` | INFO | 서버 시작/종료 알림 전송 완료 시간 | 운영 이벤트 |
+| `FcmOutboxEventListener`, `FcmOutboxScheduler` | DEBUG | outbox 즉시/스케줄 처리 시작 | 디버깅용 |
+| `FcmOutboxService` | WARN | deprecated topic outbox 잔여 이벤트 실패 처리 | migration 상태 추적 |
+| `FcmTopicService` | WARN | deprecated topic API 호출/비활성화 | 제거 전 호출 추적 |
+| `FcmAudienceService` | INFO/WARN/ERROR | FCM 비활성화 skip, 대상 없음, active token 없음, 발송 완료, batch 실패, 성공/실패 수 | metric 후보. title 원문 로그는 축소 후보 |
+| `FcmTokenDeactivator` | INFO | invalid token 비활성화 tokenId/memberId | 운영 추적용. metric 후보 |
+| `WebhookAlarmAspect` | DEBUG/ERROR | webhook annotation 감지, 처리 오류 | AOP 진단 |
+| `WebhookAlarmScheduler` | DEBUG | buffer flush 스케줄 실행 | 디버깅용 |
+| `WebhookAlarmService` | DEBUG/INFO/WARN/ERROR | buffer add, flush start, missing adapter, platform send success/failure | 운영 추적용 |
+| `DiscordWebhookAdapter`, `SlackWebhookAdapter`, `TelegramWebhookAdapter` | DEBUG | webhook 전송 완료 title/parts | title 원문 축소 후보 |
+| `SesEmailAdapter` | INFO/ERROR | SES 성공 messageId, 실패 awsErrorCode, recipientPresent | 원문 수신자 제거 완료. external_api event 적용 |
+| `SendEmailService` | ERROR | template rendering 실패 recipientPresent | 적절 |
+
+구조화 외부 API 이벤트:
+
+- `AWS_SES`: `SEND_EMAIL`
+- `DISCORD`: `SEND_WEBHOOK`
+- `SLACK`: `SEND_WEBHOOK`
+- `TELEGRAM`: `SEND_WEBHOOK`
+
+추가 계획:
+
+- FCM/웹훅/SES 발송 성공률과 실패율은 metric으로 분리한다.
+- title/content 원문은 사용자 입력 가능성이 있으므로 로그 필드에서 제거하거나 길이/타입으로 대체한다.
+
+## project
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `MatchingRoundDeadlineHandler` | ERROR | matching round 자동 결정 실패, matchingRoundId | 스케줄러 장애 추적 |
+| `ProjectResponseAssembler` | WARN | 팀원 일괄 조회 중 접근 권한 없음, 프로젝트 조회 실패 | response assembly fallback 진단 |
+
+추가 계획:
+
+- matching round auto decision은 job result metric과 audit 후보를 검토한다.
+
+## storage
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `FileCommandService` | INFO | upload URL 생성 완료, upload confirm, file delete 완료 | 파일 lifecycle 추적. audit 후보 |
+| `FileCommandService` | WARN | 파일 삭제/confirm 등에서 기대 상태와 다른 경우 | 운영 진단용 |
+| `S3StorageProperties` | WARN | CloudFront 활성화 상태에서 signed URL key 누락 | 설정 오류 |
+| `S3StorageAdapter` | DEBUG | S3 upload URL 생성, CloudFront signed URL 생성 완료 | signed URL 원문은 남기지 않아야 함. 현재 `resourceUrl`은 원문 URL인지 검토 필요 |
+| `S3StorageAdapter` | INFO/WARN/ERROR | S3 삭제 완료, S3/CloudFront/S3 metadata 조회 실패 | 외부 스토리지 장애 추적 |
+| `GcsStorageAdapter` | DEBUG/INFO/WARN/ERROR | GCS upload/download/delete, CDN signed URL 생성 세부 값 | GCS 제거 PR 병합 시 삭제 예정. 현재 signed URL/signature 로그는 부적절 |
+
+추가 계획:
+
+- 파일 생성/삭제는 audit 대상에 추가한다.
+- S3/CloudFront 호출은 `ExternalApiCallLogger` 또는 metric으로 지연 시간/실패율을 남긴다.
+- signed URL, signature, object URL 원문은 로그 금지 정책 테스트에 포함한다.
+
+## test
+
+| 위치 | 레벨 | 무엇을 남기는가 | 판단 |
+| --- | --- | --- | --- |
+| `TestController` | TRACE/DEBUG/INFO/WARN/ERROR | 로그 레벨 테스트, webhook AOP 테스트 | test/admin 목적. 운영 노출 여부 확인 필요 |
+| `MemberSeedService` | INFO/ERROR | seed skip/start/complete/fail | seed 작업 추적 |
+| `ChallengerSeedService` | INFO/ERROR | challenger seed start/result/fail | seed 작업 추적 |
+| `CurriculumSeedService` | INFO/ERROR | curriculum/week/workbook/mission seed result/fail | seed 작업 추적 |
+| `NoticeSeedService` | INFO/ERROR | notice seed result/fail | seed 작업 추적 |
+| `ProjectSeedService` | INFO/ERROR | project seed start/result/fail | seed 작업 추적 |
+| `ProjectApplicationSeedService` | INFO/WARN/ERROR | application seed skip/result/fail | seed 작업 추적 |
+| `ProjectScenarioSeedService` | INFO/ERROR | scenario seed progress/fail | seed 작업 추적 |
+| `ProjectSeedDataCleanupService` | WARN | seed project data cleanup start/result | destructive cleanup 강조 목적 |
+
+추가 계획:
+
+- seed 로그는 운영 관측성과 분리하기 위해 `seed` logger name 또는 admin operation audit로 분리한다.
+- 실패 로그의 `e.toString()`은 errorClass/reasonCode로 표준화하고 stacktrace 필요 여부를 정한다.

--- a/src/main/java/com/umc/product/audit/domain/AuditAction.java
+++ b/src/main/java/com/umc/product/audit/domain/AuditAction.java
@@ -9,5 +9,14 @@ public enum AuditAction {
     CHECK,
     SUBMIT,
     REGISTER,
-    WITHDRAW
+    WITHDRAW,
+    LOGIN,
+    LINK,
+    UNLINK,
+    ACCESS_DENIED,
+    PUBLISH,
+    CANCEL,
+    REMIND,
+    REORDER,
+    FINALIZE
 }

--- a/src/main/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionScheduler.java
+++ b/src/main/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionScheduler.java
@@ -1,13 +1,17 @@
 package com.umc.product.authentication.adapter.in.scheduler;
 
-import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
 import java.time.Duration;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
+import com.umc.product.global.logging.OperationalMetrics;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * email_verification 의 만료된 세션을 주기적으로 정리하는 회수 잡.
@@ -21,18 +25,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmailVerificationRetentionScheduler {
 
     private static final Duration RETENTION = Duration.ofDays(7);
+    private static final String JOB_NAME = "email_verification_retention";
 
     private final DeleteEmailVerificationPort deleteEmailVerificationPort;
+    private final OperationalMetrics operationalMetrics;
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     @Transactional
     public void purge() {
+        Instant startedAt = Instant.now();
         Instant threshold = Instant.now().minus(RETENTION);
-        int deleted = deleteEmailVerificationPort.deleteExpiredBefore(threshold);
-        if (deleted > 0) {
-            log.info("email_verification 회수 완료: threshold={}, deleted={}", threshold, deleted);
-        } else {
-            log.debug("email_verification 회수: 보존 기간 초과 행 없음. threshold={}", threshold);
+        try {
+            int deleted = deleteEmailVerificationPort.deleteExpiredBefore(threshold);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "success", duration, deleted);
+            if (deleted > 0) {
+                log.info("batch job completed: jobName={}, threshold={}, processed={}, durationMs={}, result={}",
+                    JOB_NAME, threshold, deleted, duration.toMillis(), "success");
+            } else {
+                log.debug("batch job completed: jobName={}, threshold={}, processed={}, durationMs={}, result={}",
+                    JOB_NAME, threshold, deleted, duration.toMillis(), "success");
+            }
+        } catch (RuntimeException e) {
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "failure", duration, 0);
+            log.error("batch job failed: jobName={}, threshold={}, durationMs={}, result={}, errorClass={}",
+                JOB_NAME, threshold, duration.toMillis(), "failure", e.getClass().getSimpleName(), e);
+            throw e;
         }
     }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -9,6 +9,7 @@ import com.umc.product.authentication.application.port.out.AppleAuthorizationCod
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.ClientType;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
@@ -135,22 +136,24 @@ public class AppleTokenVerifier {
             formData.add("code", authorizationCode);
             formData.add("grant_type", "authorization_code");
 
-            AppleTokenResponse response = restClient.post()
-                .uri(APPLE_TOKEN_URL)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(formData)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    // ADR-016 §민감 필드 정책: 성공 응답 body 에는 access_token / id_token / refresh_token
-                    // 이 포함되어 있어 통째로 로깅하면 토큰이 stdout / Loki 에 남는다. 에러 응답이라도
-                    // 잘못된 분기로 성공 body 가 흘러올 수 있으므로 status / errorCode 만 남긴다.
-                    String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
-                    String errorCode = extractAppleErrorCode(body);
-                    log.error("Apple token endpoint 호출 실패: status={}, errorCode={}, bodyLength={}",
-                        res.getStatusCode(), errorCode, body.length());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
-                })
-                .body(AppleTokenResponse.class);
+            AppleTokenResponse response = ExternalApiCallLogger.measure("APPLE", "EXCHANGE_AUTHORIZATION_CODE", () ->
+                restClient.post()
+                    .uri(APPLE_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        // ADR-016 §민감 필드 정책: 성공 응답 body 에는 access_token / id_token / refresh_token
+                        // 이 포함되어 있어 통째로 로깅하면 토큰이 stdout / Loki 에 남는다. 에러 응답이라도
+                        // 잘못된 분기로 성공 body 가 흘러올 수 있으므로 status / errorCode 만 남긴다.
+                        String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
+                        String errorCode = extractAppleErrorCode(body);
+                        log.error("Apple token endpoint 호출 실패: status={}, errorCode={}, bodyLength={}",
+                            res.getStatusCode(), errorCode, body.length());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
+                    })
+                    .body(AppleTokenResponse.class)
+            );
 
             if (response == null || response.idToken() == null) {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
@@ -188,20 +191,22 @@ public class AppleTokenVerifier {
             formData.add("token", refreshToken);
             formData.add("token_type_hint", "refresh_token");
 
-            restClient.post()
-                .uri(APPLE_REVOKE_URL)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(formData)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    // ADR-016 §민감 필드 정책: revoke 응답 본문 통째로 로깅하지 않는다.
-                    String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
-                    String errorCode = extractAppleErrorCode(body);
-                    log.error("Apple token revoke 실패: status={}, errorCode={}, bodyLength={}",
-                        res.getStatusCode(), errorCode, body.length());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
-                })
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("APPLE", "REVOKE_TOKEN", () ->
+                restClient.post()
+                    .uri(APPLE_REVOKE_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        // ADR-016 §민감 필드 정책: revoke 응답 본문 통째로 로깅하지 않는다.
+                        String body = StreamUtils.copyToString(res.getBody(), StandardCharsets.UTF_8);
+                        String errorCode = extractAppleErrorCode(body);
+                        log.error("Apple token revoke 실패: status={}, errorCode={}, bodyLength={}",
+                            res.getStatusCode(), errorCode, body.length());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .toBodilessEntity()
+            );
 
             log.info("Apple token revoke 성공");
 
@@ -293,14 +298,16 @@ public class AppleTokenVerifier {
      * Apple's public key</a>
      */
     private PublicKey fetchApplePublicKey(String kid) {
-        AppleJwksResponse jwks = restClient.get()
-            .uri(APPLE_JWKS_URL)
-            .retrieve()
-            .onStatus(HttpStatusCode::isError, (req, res) -> {
-                log.error("Apple JWKS 조회 실패: status={}", res.getStatusCode());
-                throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
-            })
-            .body(AppleJwksResponse.class);
+        AppleJwksResponse jwks = ExternalApiCallLogger.measure("APPLE", "FETCH_JWKS", () ->
+            restClient.get()
+                .uri(APPLE_JWKS_URL)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("Apple JWKS 조회 실패: status={}", res.getStatusCode());
+                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                })
+                .body(AppleJwksResponse.class)
+        );
 
         if (jwks == null || jwks.keys() == null) {
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -1,18 +1,5 @@
 package com.umc.product.authentication.adapter.out.external;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.product.authentication.domain.OAuthAttributes;
-import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
-import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
-import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
-import com.umc.product.common.domain.enums.ClientType;
-import com.umc.product.global.logging.ExternalApiCallLogger;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.Jwts.SIG;
 import java.io.StringReader;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -26,8 +13,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -38,6 +24,23 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.authentication.application.port.out.AppleAuthorizationCodeResult;
+import com.umc.product.authentication.domain.OAuthAttributes;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.common.domain.enums.ClientType;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Apple Sign-In 토큰 검증 Adapter

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -93,7 +93,7 @@ public class AppleTokenVerifier {
             String sub = claims.getSubject();
             String email = claims.get("email", String.class);
 
-            log.info("Apple ID Token 검증 성공: sub={}, email={}", sub, email);
+            log.debug("Apple ID Token 검증 성공: hasEmail={}", hasEmail(email));
 
             Map<String, Object> attributes = new HashMap<>();
             attributes.put("sub", sub);
@@ -357,6 +357,10 @@ public class AppleTokenVerifier {
 
             return cachedPrivateKey;
         }
+    }
+
+    private boolean hasEmail(String email) {
+        return email != null && !email.isBlank();
     }
 
     // ===== Response DTOs =====

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java
@@ -97,7 +97,7 @@ public class AppleTokenVerifier {
             String sub = claims.getSubject();
             String email = claims.get("email", String.class);
 
-            log.debug("Apple ID Token 검증 성공: hasEmail={}", hasEmail(email));
+            log.debug("Apple ID Token을 검증했습니다: hasEmail={}", hasEmail(email));
 
             Map<String, Object> attributes = new HashMap<>();
             attributes.put("sub", sub);
@@ -108,7 +108,7 @@ public class AppleTokenVerifier {
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Apple ID Token 검증 중 오류 발생", e);
+            log.error("Apple ID Token 검증 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -162,7 +162,7 @@ public class AppleTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
             }
 
-            log.info("Apple Authorization Code 교환 성공, ID Token 검증 진행");
+            log.info("Apple Authorization Code를 교환했습니다. ID Token을 검증합니다");
 
             // 3. 받은 id_token을 검증
             OAuthAttributes attrs = verifyIdToken(response.idToken(), clientId);
@@ -171,7 +171,7 @@ public class AppleTokenVerifier {
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Apple Authorization Code 교환 중 오류 발생", e);
+            log.error("Apple Authorization Code 교환 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -211,12 +211,12 @@ public class AppleTokenVerifier {
                     .toBodilessEntity()
             );
 
-            log.info("Apple token revoke 성공");
+            log.info("Apple token revoke를 완료했습니다");
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Apple token revoke 중 오류 발생", e);
+            log.error("Apple token revoke 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
@@ -3,6 +3,7 @@ package com.umc.product.authentication.adapter.out.external;
 import com.umc.product.authentication.domain.OAuthAttributes;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,14 +48,16 @@ public class GoogleTokenVerifier {
 
         try {
             // Google tokeninfo endpoint 호출
-            GoogleTokenInfoResponse response = restClient.get()
-                .uri(GOOGLE_TOKEN_INFO_URL + "?id_token=" + idToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Google tokeninfo 호출 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
-                })
-                .body(GoogleTokenInfoResponse.class);
+            GoogleTokenInfoResponse response = ExternalApiCallLogger.measure("GOOGLE", "VERIFY_ID_TOKEN", () ->
+                restClient.get()
+                    .uri(GOOGLE_TOKEN_INFO_URL + "?id_token=" + idToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Google tokeninfo 호출 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
+                    })
+                    .body(GoogleTokenInfoResponse.class)
+            );
 
             if (response == null) {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
@@ -90,14 +93,16 @@ public class GoogleTokenVerifier {
 
         try {
             // Google tokeninfo endpoint 호출
-            GoogleAccessTokenInfoResponse response = restClient.get()
-                .uri(GOOGLE_TOKEN_INFO_URL + "?access_token=" + accessToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Google tokeninfo 호출 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
-                })
-                .body(GoogleAccessTokenInfoResponse.class);
+            GoogleAccessTokenInfoResponse response = ExternalApiCallLogger.measure("GOOGLE", "VERIFY_ACCESS_TOKEN", () ->
+                restClient.get()
+                    .uri(GOOGLE_TOKEN_INFO_URL + "?access_token=" + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Google tokeninfo 호출 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_INVALID_ACCESS_TOKEN);
+                    })
+                    .body(GoogleAccessTokenInfoResponse.class)
+            );
 
             if (response == null) {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
@@ -140,16 +145,18 @@ public class GoogleTokenVerifier {
             MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
             formData.add("token", token);
 
-            restClient.post()
-                .uri(GOOGLE_REVOKE_URL)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(formData)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Google token revoke 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
-                })
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("GOOGLE", "REVOKE_TOKEN", () ->
+                restClient.post()
+                    .uri(GOOGLE_REVOKE_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Google token revoke 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .toBodilessEntity()
+            );
 
             log.info("Google token revoke 성공");
 

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
@@ -66,7 +66,7 @@ public class GoogleTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
-            log.info("Google ID 토큰 검증 성공: sub={}, email={}", response.sub(), response.email());
+            log.debug("Google ID 토큰 검증 성공: hasEmail={}", hasEmail(response.email()));
 
             // OAuthAttributes 형식에 맞게 Map 생성
             Map<String, Object> attributes = new HashMap<>();
@@ -109,7 +109,7 @@ public class GoogleTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
-            log.info("Google Access Token 검증 성공: sub={}, email={}", response.sub(), response.email());
+            log.debug("Google Access Token 검증 성공: hasEmail={}", hasEmail(response.email()));
 
             // OAuthAttributes 형식에 맞게 Map 생성
             Map<String, Object> attributes = new HashMap<>();
@@ -185,5 +185,9 @@ public class GoogleTokenVerifier {
         String email,
         String aud         // audience (client ID)
     ) {
+    }
+
+    private boolean hasEmail(String email) {
+        return email != null && !email.isBlank();
     }
 }

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
@@ -72,7 +72,7 @@ public class GoogleTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
-            log.debug("Google ID 토큰 검증 성공: hasEmail={}", hasEmail(response.email()));
+            log.debug("Google ID Token을 검증했습니다: hasEmail={}", hasEmail(response.email()));
 
             // OAuthAttributes 형식에 맞게 Map 생성
             Map<String, Object> attributes = new HashMap<>();
@@ -86,7 +86,7 @@ public class GoogleTokenVerifier {
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Google ID 토큰 검증 중 오류 발생", e);
+            log.error("Google ID Token 검증 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -117,7 +117,7 @@ public class GoogleTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
             }
 
-            log.debug("Google Access Token 검증 성공: hasEmail={}", hasEmail(response.email()));
+            log.debug("Google Access Token을 검증했습니다: hasEmail={}", hasEmail(response.email()));
 
             // OAuthAttributes 형식에 맞게 Map 생성
             Map<String, Object> attributes = new HashMap<>();
@@ -129,7 +129,7 @@ public class GoogleTokenVerifier {
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Google Access Token 검증 중 오류 발생", e);
+            log.error("Google Access Token 검증 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -161,12 +161,12 @@ public class GoogleTokenVerifier {
                     .toBodilessEntity()
             );
 
-            log.info("Google token revoke 성공");
+            log.info("Google token revoke를 완료했습니다");
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Google token revoke 중 오류 발생", e);
+            log.error("Google token revoke 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java
@@ -1,14 +1,9 @@
 package com.umc.product.authentication.adapter.out.external;
 
-import com.umc.product.authentication.domain.OAuthAttributes;
-import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
-import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -16,6 +11,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+
+import com.umc.product.authentication.domain.OAuthAttributes;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Google ID 토큰 검증 Adapter

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.umc.product.authentication.domain.OAuthAttributes;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -79,16 +80,18 @@ public class KakaoTokenVerifier {
         }
 
         try {
-            KakaoTokenResponse response = restClient.post()
-                .uri(KAKAO_TOKEN_URL)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(formData)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Kakao 토큰 교환 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
-                })
-                .body(KakaoTokenResponse.class);
+            KakaoTokenResponse response = ExternalApiCallLogger.measure("KAKAO", "EXCHANGE_AUTHORIZATION_CODE", () ->
+                restClient.post()
+                    .uri(KAKAO_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 토큰 교환 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
+                    })
+                    .body(KakaoTokenResponse.class)
+            );
 
             if (response == null || response.accessToken() == null) {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
@@ -119,15 +122,17 @@ public class KakaoTokenVerifier {
 
         try {
             // Kakao 사용자 정보 조회 API 호출
-            KakaoUserResponse response = restClient.get()
-                .uri(KAKAO_USER_INFO_URL)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Kakao 사용자 정보 조회 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
-                })
-                .body(KakaoUserResponse.class);
+            KakaoUserResponse response = ExternalApiCallLogger.measure("KAKAO", "GET_USER_INFO", () ->
+                restClient.get()
+                    .uri(KAKAO_USER_INFO_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 사용자 정보 조회 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_OAUTH_TOKEN);
+                    })
+                    .body(KakaoUserResponse.class)
+            );
 
             // 응답을 검증합니다.
             if (response == null || response.id() == null) {
@@ -184,15 +189,17 @@ public class KakaoTokenVerifier {
         log.info("Kakao 사용자 연결 끊기 시작");
 
         try {
-            restClient.post()
-                .uri(KAKAO_UNLINK_URL)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Kakao 연결 끊기 실패: status={}", res.getStatusCode());
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
-                })
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("KAKAO", "UNLINK_USER", () ->
+                restClient.post()
+                    .uri(KAKAO_UNLINK_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 연결 끊기 실패: status={}", res.getStatusCode());
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .toBodilessEntity()
+            );
 
             log.info("Kakao 연결 끊기 성공");
 
@@ -223,17 +230,20 @@ public class KakaoTokenVerifier {
             formData.add("target_id_type", "user_id");
             formData.add("target_id", kakaoUserId);
 
-            restClient.post()
-                .uri(KAKAO_UNLINK_URL)
-                .header("Authorization", "KakaoAK " + kakaoAdminKey)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(formData)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Kakao 연결 끊기 실패: status={}, targetProvided={}", res.getStatusCode(), hasText(kakaoUserId));
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
-                })
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("KAKAO", "ADMIN_UNLINK_USER", () ->
+                restClient.post()
+                    .uri(KAKAO_UNLINK_URL)
+                    .header("Authorization", "KakaoAK " + kakaoAdminKey)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        log.error("Kakao 연결 끊기 실패: status={}, targetProvided={}",
+                            res.getStatusCode(), hasText(kakaoUserId));
+                        throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
+                    })
+                    .toBodilessEntity()
+            );
 
             log.info("Kakao 연결 끊기 성공: targetProvided={}", hasText(kakaoUserId));
 

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
@@ -134,10 +134,7 @@ public class KakaoTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
             }
 
-            log.info("Kakao Access Token 검증 성공: id={}, email={}",
-                response.id(),
-                response.kakaoAccount() != null ? response.kakaoAccount().email() : "N/A"
-            );
+            log.debug("Kakao Access Token 검증 성공: hasEmail={}", hasEmail(response));
 
             // OAuthAttributes.of("kakao", ...) 형식에 맞게 Map 생성
             Map<String, Object> attributes = buildAttributesMap(response);
@@ -214,10 +211,10 @@ public class KakaoTokenVerifier {
      * @see <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink">Kakao 연결 끊기</a>
      */
     public void unlinkUserByAdmin(String kakaoUserId) {
-        log.info("Kakao 사용자 연결 끊기 시작: kakaoUserId={}", kakaoUserId);
+        log.info("Kakao 사용자 연결 끊기 시작: targetProvided={}", hasText(kakaoUserId));
 
         if (kakaoAdminKey == null || kakaoAdminKey.isBlank()) {
-            log.warn("Kakao Admin Key가 설정되지 않아 연결 끊기를 skip합니다: kakaoUserId={}", kakaoUserId);
+            log.warn("Kakao Admin Key가 설정되지 않아 연결 끊기를 skip합니다: targetProvided={}", hasText(kakaoUserId));
             return;
         }
 
@@ -233,19 +230,27 @@ public class KakaoTokenVerifier {
                 .body(formData)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, (req, res) -> {
-                    log.error("Kakao 연결 끊기 실패: status={}, kakaoUserId={}", res.getStatusCode(), kakaoUserId);
+                    log.error("Kakao 연결 끊기 실패: status={}, targetProvided={}", res.getStatusCode(), hasText(kakaoUserId));
                     throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
                 })
                 .toBodilessEntity();
 
-            log.info("Kakao 연결 끊기 성공: kakaoUserId={}", kakaoUserId);
+            log.info("Kakao 연결 끊기 성공: targetProvided={}", hasText(kakaoUserId));
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Kakao 연결 끊기 중 오류 발생: kakaoUserId={}", kakaoUserId, e);
+            log.error("Kakao 연결 끊기 중 오류 발생: targetProvided={}", hasText(kakaoUserId), e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
+    }
+
+    private boolean hasEmail(KakaoUserResponse response) {
+        return response.kakaoAccount() != null && hasText(response.kakaoAccount().email());
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     // ===== Response DTOs =====

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
@@ -1,14 +1,8 @@
 package com.umc.product.authentication.adapter.out.external;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.umc.product.authentication.domain.OAuthAttributes;
-import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
-import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -16,6 +10,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.umc.product.authentication.domain.OAuthAttributes;
+import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
+import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Kakao Access Token 검증 Adapter

--- a/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
+++ b/src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java
@@ -100,13 +100,13 @@ public class KakaoTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
             }
 
-            log.info("Kakao 토큰 교환 성공");
+            log.info("Kakao 토큰을 교환했습니다");
             return response.accessToken();
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Kakao 토큰 교환 중 오류 발생", e);
+            log.error("Kakao 토큰 교환 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -142,7 +142,7 @@ public class KakaoTokenVerifier {
                 throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
             }
 
-            log.debug("Kakao Access Token 검증 성공: hasEmail={}", hasEmail(response));
+            log.debug("Kakao Access Token을 검증했습니다: hasEmail={}", hasEmail(response));
 
             // OAuthAttributes.of("kakao", ...) 형식에 맞게 Map 생성
             Map<String, Object> attributes = buildAttributesMap(response);
@@ -152,7 +152,7 @@ public class KakaoTokenVerifier {
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Kakao Access Token 검증 중 오류 발생", e);
+            log.error("Kakao Access Token 검증 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -204,12 +204,12 @@ public class KakaoTokenVerifier {
                     .toBodilessEntity()
             );
 
-            log.info("Kakao 연결 끊기 성공");
+            log.info("Kakao 연결을 끊었습니다");
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Kakao 연결 끊기 중 오류 발생", e);
+            log.error("Kakao 연결 끊기 실패", e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }
@@ -224,7 +224,7 @@ public class KakaoTokenVerifier {
         log.info("Kakao 사용자 연결 끊기 시작: targetProvided={}", hasText(kakaoUserId));
 
         if (kakaoAdminKey == null || kakaoAdminKey.isBlank()) {
-            log.warn("Kakao Admin Key가 설정되지 않아 연결 끊기를 skip합니다: targetProvided={}", hasText(kakaoUserId));
+            log.warn("Kakao Admin Key가 없어 연결 끊기를 건너뜁니다: targetProvided={}", hasText(kakaoUserId));
             return;
         }
 
@@ -248,12 +248,12 @@ public class KakaoTokenVerifier {
                     .toBodilessEntity()
             );
 
-            log.info("Kakao 연결 끊기 성공: targetProvided={}", hasText(kakaoUserId));
+            log.info("Kakao 연결을 끊었습니다: targetProvided={}", hasText(kakaoUserId));
 
         } catch (AuthenticationDomainException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Kakao 연결 끊기 중 오류 발생: targetProvided={}", hasText(kakaoUserId), e);
+            log.error("Kakao 연결 끊기 실패: targetProvided={}", hasText(kakaoUserId), e);
             throw new AuthenticationDomainException(AuthenticationErrorCode.OAUTH_TOKEN_VERIFICATION_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
@@ -6,6 +6,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authentication.application.port.in.command.CredentialAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.ChangePasswordCommand;
 import com.umc.product.authentication.application.port.in.command.dto.LocalLoginResult;
@@ -15,6 +17,8 @@ import com.umc.product.authentication.application.port.in.command.dto.RegisterCr
 import com.umc.product.authentication.application.port.in.command.dto.ResetPasswordByEmailCommand;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.global.exception.constant.Domain;
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
 import com.umc.product.member.application.port.in.command.dto.RegisterMemberCredentialByEmailCommand;
@@ -41,6 +45,7 @@ public class CredentialAuthenticationService implements CredentialAuthentication
     private final GetMemberCredentialUseCase getMemberCredentialUseCase;
     private final ManageMemberCredentialUseCase manageMemberCredentialUseCase;
     private final CredentialRehashService rehashService;
+    private final OperationalMetrics operationalMetrics;
 
     @Override
     public void registerCredentialByEmail(RegisterCredentialByEmailCommand command) {
@@ -74,53 +79,72 @@ public class CredentialAuthenticationService implements CredentialAuthentication
 
     @Override
     public void resetPasswordByEmail(ResetPasswordByEmailCommand command) {
-        // 이메일은 emailVerificationToken 으로 사전 검증되어 들어오므로 해당 이메일 소유자가 호출했다고 간주한다.
-        // 다만 시스템에 가입되지 않은 이메일이거나 자격증명이 등록되지 않은 회원(OAuth 전용 등) 인 경우는
-        // 사용자 열거 방지를 위해 단일 메시지로 응답한다.
-        MemberCredentialInfo credential = getMemberCredentialUseCase
-            .findCredentialByEmail(command.email())
-            .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL));
+        try {
+            // 이메일은 emailVerificationToken 으로 사전 검증되어 들어오므로 해당 이메일 소유자가 호출했다고 간주한다.
+            // 다만 시스템에 가입되지 않은 이메일이거나 자격증명이 등록되지 않은 회원(OAuth 전용 등) 인 경우는
+            // 사용자 열거 방지를 위해 단일 메시지로 응답한다.
+            MemberCredentialInfo credential = getMemberCredentialUseCase
+                .findCredentialByEmail(command.email())
+                .orElseThrow(() -> new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL));
 
-        String newEncodedPassword = passwordEncoder.encode(command.newRawPassword());
+            String newEncodedPassword = passwordEncoder.encode(command.newRawPassword());
 
-        manageMemberCredentialUseCase.changePassword(
-            ChangeMemberPasswordCommand.of(credential.memberId(), newEncodedPassword)
-        );
+            manageMemberCredentialUseCase.changePassword(
+                ChangeMemberPasswordCommand.of(credential.memberId(), newEncodedPassword)
+            );
+            operationalMetrics.recordSecurityEvent("AUTHENTICATION", "PASSWORD_RESET", "success");
+        } catch (RuntimeException e) {
+            operationalMetrics.recordSecurityEvent("AUTHENTICATION", "PASSWORD_RESET", "failure");
+            throw e;
+        }
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LOGIN,
+        targetType = "MemberCredential",
+        targetId = "#result.memberId()",
+        description = "'이메일 로그인에 성공했습니다.'"
+    )
     @Override
     @Transactional
     public LocalLoginResult loginByEmail(LoginByEmailCommand command) {
-        // 1) 자격증명 조회: 부재 / 실패 모두 동일 메시지로 처리하여 사용자 열거 공격을 방지한다.
-        Optional<MemberCredentialInfo> credentialOpt =
-            getMemberCredentialUseCase.findCredentialByEmail(command.email());
+        try {
+            // 1) 자격증명 조회: 부재 / 실패 모두 동일 메시지로 처리하여 사용자 열거 공격을 방지한다.
+            Optional<MemberCredentialInfo> credentialOpt =
+                getMemberCredentialUseCase.findCredentialByEmail(command.email());
 
-        if (credentialOpt.isEmpty()) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL);
+            if (credentialOpt.isEmpty()) {
+                throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL);
+            }
+
+            MemberCredentialInfo credential = credentialOpt.get();
+
+            // 2) 비밀번호 검증
+            if (!passwordEncoder.matches(command.rawPassword(), credential.passwordHash())) {
+                throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL);
+            }
+
+            // 3) 점진적 rehash: 해시 정책이 갱신되었으면 최신 정책으로 재저장한다.
+            // 별도 트랜잭션(REQUIRES_NEW)에서 수행하여 실패가 로그인에 영향을 주지 않도록 한다.
+            rehashService.rehashIfNeeded(credential, command.rawPassword());
+
+            // 4) 토큰 발급
+            Long memberId = credential.memberId();
+            NewTokens newTokens = authenticationTokenIssuer.issue(
+                memberId,
+                command.clientType()
+            );
+
+            operationalMetrics.recordSecurityEvent("AUTHENTICATION", "EMAIL_LOGIN", "success");
+            return LocalLoginResult.builder()
+                .memberId(memberId)
+                .accessToken(newTokens.accessToken())
+                .refreshToken(newTokens.refreshToken())
+                .build();
+        } catch (RuntimeException e) {
+            operationalMetrics.recordSecurityEvent("AUTHENTICATION", "EMAIL_LOGIN", "failure");
+            throw e;
         }
-
-        MemberCredentialInfo credential = credentialOpt.get();
-
-        // 2) 비밀번호 검증
-        if (!passwordEncoder.matches(command.rawPassword(), credential.passwordHash())) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_LOGIN_CREDENTIAL);
-        }
-
-        // 3) 점진적 rehash: 해시 정책이 갱신되었으면 최신 정책으로 재저장한다.
-        // 별도 트랜잭션(REQUIRES_NEW)에서 수행하여 실패가 로그인에 영향을 주지 않도록 한다.
-        rehashService.rehashIfNeeded(credential, command.rawPassword());
-
-        // 4) 토큰 발급
-        Long memberId = credential.memberId();
-        NewTokens newTokens = authenticationTokenIssuer.issue(
-            memberId,
-            command.clientType()
-        );
-
-        return LocalLoginResult.builder()
-            .memberId(memberId)
-            .accessToken(newTokens.accessToken())
-            .refreshToken(newTokens.refreshToken())
-            .build();
     }
 }

--- a/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/CredentialAuthenticationService.java
@@ -104,7 +104,7 @@ public class CredentialAuthenticationService implements CredentialAuthentication
         action = AuditAction.LOGIN,
         targetType = "MemberCredential",
         targetId = "#result.memberId()",
-        description = "'이메일 로그인에 성공했습니다.'"
+        description = "'이메일 로그인을 완료했습니다.'"
     )
     @Override
     @Transactional

--- a/src/main/java/com/umc/product/authentication/application/service/CredentialRehashService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/CredentialRehashService.java
@@ -1,14 +1,16 @@
 package com.umc.product.authentication.application.service;
 
-import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
-import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
-import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
+import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
+import com.umc.product.member.application.port.in.query.dto.MemberCredentialInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 비밀번호 해시 정책 변경 시 점진적으로 재해싱(Rehash)을 수행하는 서비스.
@@ -36,7 +38,7 @@ public class CredentialRehashService {
                 manageMemberCredentialUseCase.changePassword(
                     ChangeMemberPasswordCommand.of(credential.memberId(), upgraded)
                 );
-                log.info("[ID/PW 로그인] 비밀번호 해시 정책 갱신 완료: memberId={}", credential.memberId());
+                log.info("[ID/PW 로그인] 비밀번호 해시 정책을 갱신했습니다: memberId={}", credential.memberId());
             } catch (Exception e) {
                 // rehash 실패는 로그인 자체에는 영향을 주지 않으므로 로그만 남기고 삼킨다.
                 log.warn("[ID/PW 로그인] 비밀번호 해시 정책 갱신 실패: memberId={}", credential.memberId(), e);

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -54,7 +54,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         action = AuditAction.LOGIN,
         targetType = "OAuthAuthentication",
         targetId = "#result.memberId()",
-        description = "'OAuth 로그인 처리가 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+        description = "'OAuth 로그인을 처리했습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
     )
     @Override
     @Transactional(readOnly = true)
@@ -70,7 +70,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             )
             // 기존 회원이 존재하는지 확인
             .map(memberOAuth -> {
-                log.info("기존 회원 로그인 성공: memberId={}", memberOAuth.getMemberId());
+                log.info("기존 회원이 로그인했습니다: memberId={}", memberOAuth.getMemberId());
                 operationalMetrics.recordSecurityEvent("AUTHENTICATION", "OAUTH_LOGIN", "success");
                 return OAuthTokenLoginResult.existingMember(
                     memberOAuth.getMemberId(),
@@ -81,7 +81,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             })
             // 존재하지 않는 회원인 경우에 대한 처리
             .orElseGet(() -> {
-                log.info("신규 회원 - 회원가입 필요: provider={}, hasEmail={}",
+                log.info("회원가입이 필요합니다: provider={}, hasEmail={}",
                     oAuthAttributes.provider(), hasEmail(oAuthAttributes.email()));
                 operationalMetrics.recordSecurityEvent("AUTHENTICATION", "OAUTH_LOGIN", "register_required");
                 return OAuthTokenLoginResult.newMember(
@@ -97,7 +97,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         action = AuditAction.LOGIN,
         targetType = "OAuthAuthentication",
         targetId = "#result.memberId()",
-        description = "'OAuth access token 로그인이 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+        description = "'OAuth access token 로그인을 완료했습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
     )
     @Override
     public OAuthTokenLoginResult accessTokenLogin(AccessTokenLoginCommand command) {
@@ -109,7 +109,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             command.token()
         );
 
-        log.info("OAuth 토큰 검증 성공: provider={}, hasEmail={}",
+        log.info("OAuth 토큰을 검증했습니다: provider={}, hasEmail={}",
             oauthAttrs.provider(),
             hasEmail(oauthAttrs.email())
         );
@@ -123,7 +123,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         action = AuditAction.LOGIN,
         targetType = "OAuthAuthentication",
         targetId = "#result.memberId()",
-        description = "'OAuth authorization code 로그인이 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+        description = "'OAuth authorization code 로그인을 완료했습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
     )
     @Override
     public OAuthTokenLoginResult authorizationCodeLogin(AuthorizationCodeLoginCommand command) {
@@ -136,7 +136,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             command.redirectUri()
         );
 
-        log.info("OAuth Authorization Code 교환 성공: provider={}, hasEmail={}",
+        log.info("OAuth Authorization Code를 교환했습니다: provider={}, hasEmail={}",
             oauthAttrs.provider(),
             hasEmail(oauthAttrs.email())
         );
@@ -150,7 +150,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         action = AuditAction.LINK,
         targetType = "MemberOAuth",
         targetId = "#result",
-        description = "'OAuth 계정이 연결되었습니다. provider=' + #command.provider()"
+        description = "'OAuth 계정을 연결했습니다. provider=' + #command.provider()"
     )
     @Override
     public Long linkOAuth(LinkOAuthCommand command) {
@@ -176,7 +176,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         domain = Domain.AUTHENTICATION,
         action = AuditAction.LINK,
         targetType = "MemberOAuth",
-        description = "'OAuth 계정이 대량 연결되었습니다. count=' + #result.size()"
+        description = "'OAuth 계정을 대량 연결했습니다. count=' + #result.size()"
     )
     @Override
     public List<Long> linkOAuthBulk(List<LinkOAuthCommand> commands) {
@@ -225,7 +225,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         action = AuditAction.UNLINK,
         targetType = "MemberOAuth",
         targetId = "#command.memberOAuthId()",
-        description = "'OAuth 계정 연결이 해제되었습니다.'"
+        description = "'OAuth 계정 연결을 해제했습니다.'"
     )
     @Override
     public void unlinkOAuth(UnlinkOAuthCommand command) {
@@ -267,7 +267,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
                             memberOAuth.getAppleClientId()
                     );
                 } else {
-                    log.warn("[Apple 계정 연동 해제] refresh token 또는 client_id가 없어 revoke를 skip합니다: "
+                    log.warn("[Apple 계정 연동 해제] refresh token 또는 client_id가 없어 revoke를 건너뜁니다: "
                                     + "memberId={} memberOAuthId={} hasRefreshToken={} hasClientId={}",
                             memberOAuth.getMemberId(), memberOAuth.getId(),
                             memberOAuth.getAppleRefreshToken() != null,
@@ -279,7 +279,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
                     validateAccessTokenOwner(memberOAuth, command.kakaoAccessToken());
                     revokeOAuthTokenPort.revokeKakaoToken(command.kakaoAccessToken());
                 } else {
-                    log.warn("[Kakao 계정 연동 해제] access token이 전달되지 않아 revoke를 skip합니다: memberId={} memberOAuthId={}",
+                    log.warn("[Kakao 계정 연동 해제] access token이 없어 revoke를 건너뜁니다: memberId={} memberOAuthId={}",
                         memberOAuth.getMemberId(), memberOAuth.getId());
                 }
             }
@@ -288,7 +288,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
                     validateAccessTokenOwner(memberOAuth, command.googleAccessToken());
                     revokeOAuthTokenPort.revokeGoogleToken(command.googleAccessToken());
                 } else {
-                    log.warn("[Google 계정 연동 해제] access token이 전달되지 않아 revoke를 skip합니다: memberId={} memberOAuthId={}",
+                    log.warn("[Google 계정 연동 해제] access token이 없어 revoke를 건너뜁니다: memberId={} memberOAuthId={}",
                         memberOAuth.getMemberId(), memberOAuth.getId());
                 }
             }

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authentication.application.port.in.command.OAuthAuthenticationUseCase;
 import com.umc.product.authentication.application.port.in.command.dto.AccessTokenLoginCommand;
 import com.umc.product.authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand;
@@ -23,6 +25,8 @@ import com.umc.product.authentication.domain.OAuthAttributes;
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.OAuthProvider;
+import com.umc.product.global.exception.constant.Domain;
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.member.application.port.in.command.LockMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.dto.MemberCredentialStatusInfo;
 
@@ -43,7 +47,15 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
     private final SaveMemberOAuthPort saveMemberOAuthPort;
     private final RevokeOAuthTokenPort revokeOAuthTokenPort;
     private final LockMemberCredentialUseCase lockMemberCredentialUseCase;
+    private final OperationalMetrics operationalMetrics;
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LOGIN,
+        targetType = "OAuthAuthentication",
+        targetId = "#result.memberId()",
+        description = "'OAuth 로그인 처리가 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+    )
     @Override
     @Transactional(readOnly = true)
     public OAuthTokenLoginResult loginWithOAuthAttributes(OAuthAttributes oAuthAttributes) {
@@ -59,6 +71,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             // 기존 회원이 존재하는지 확인
             .map(memberOAuth -> {
                 log.info("기존 회원 로그인 성공: memberId={}", memberOAuth.getMemberId());
+                operationalMetrics.recordSecurityEvent("AUTHENTICATION", "OAUTH_LOGIN", "success");
                 return OAuthTokenLoginResult.existingMember(
                     memberOAuth.getMemberId(),
                     oAuthAttributes.provider(),
@@ -70,6 +83,7 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             .orElseGet(() -> {
                 log.info("신규 회원 - 회원가입 필요: provider={}, hasEmail={}",
                     oAuthAttributes.provider(), hasEmail(oAuthAttributes.email()));
+                operationalMetrics.recordSecurityEvent("AUTHENTICATION", "OAUTH_LOGIN", "register_required");
                 return OAuthTokenLoginResult.newMember(
                     oAuthAttributes.provider(),
                     oAuthAttributes.providerId(),
@@ -78,6 +92,13 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             });
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LOGIN,
+        targetType = "OAuthAuthentication",
+        targetId = "#result.memberId()",
+        description = "'OAuth access token 로그인이 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+    )
     @Override
     public OAuthTokenLoginResult accessTokenLogin(AccessTokenLoginCommand command) {
         log.info("ID 토큰 기반 OAuth 로그인 시도: provider={}", command.provider());
@@ -97,6 +118,13 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         return loginWithOAuthAttributes(oauthAttrs);
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LOGIN,
+        targetType = "OAuthAuthentication",
+        targetId = "#result.memberId()",
+        description = "'OAuth authorization code 로그인이 완료되었습니다. provider=' + #result.provider() + ', existingMember=' + #result.isExistingMember()"
+    )
     @Override
     public OAuthTokenLoginResult authorizationCodeLogin(AuthorizationCodeLoginCommand command) {
         log.info("Authorization Code 기반 OAuth 로그인 시도: provider={}", command.provider());
@@ -117,6 +145,13 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         return loginWithOAuthAttributes(oauthAttrs);
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LINK,
+        targetType = "MemberOAuth",
+        targetId = "#result",
+        description = "'OAuth 계정이 연결되었습니다. provider=' + #command.provider()"
+    )
     @Override
     public Long linkOAuth(LinkOAuthCommand command) {
         // 1. 동일한 OAuth 계정이 이미 연동되어 있는지 확인
@@ -137,6 +172,12 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
         return created.getId();
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.LINK,
+        targetType = "MemberOAuth",
+        description = "'OAuth 계정이 대량 연결되었습니다. count=' + #result.size()"
+    )
     @Override
     public List<Long> linkOAuthBulk(List<LinkOAuthCommand> commands) {
         // provider별로 그룹핑하여 벌크 검증
@@ -179,6 +220,13 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             .toList();
     }
 
+    @Audited(
+        domain = Domain.AUTHENTICATION,
+        action = AuditAction.UNLINK,
+        targetType = "MemberOAuth",
+        targetId = "#command.memberOAuthId()",
+        description = "'OAuth 계정 연결이 해제되었습니다.'"
+    )
     @Override
     public void unlinkOAuth(UnlinkOAuthCommand command) {
         MemberOAuth memberOAuth = loadMemberOAuthPort.findByMemberOAuthId(command.memberOAuthId())

--- a/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/OAuthAuthenticationService.java
@@ -47,8 +47,8 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
     @Override
     @Transactional(readOnly = true)
     public OAuthTokenLoginResult loginWithOAuthAttributes(OAuthAttributes oAuthAttributes) {
-        log.info("OAuthAttributes 기반 로그인 시도: provider={}, providerId={}",
-            oAuthAttributes.provider(), oAuthAttributes.providerId());
+        log.info("OAuthAttributes 기반 로그인 시도: provider={}, hasEmail={}",
+            oAuthAttributes.provider(), hasEmail(oAuthAttributes.email()));
 
         return loadMemberOAuthPort
             // OAuth 정보로 기존 회원이 존재하는지 확인
@@ -68,8 +68,8 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             })
             // 존재하지 않는 회원인 경우에 대한 처리
             .orElseGet(() -> {
-                log.info("신규 회원 - 회원가입 필요: provider={}, providerId={}",
-                    oAuthAttributes.provider(), oAuthAttributes.providerId());
+                log.info("신규 회원 - 회원가입 필요: provider={}, hasEmail={}",
+                    oAuthAttributes.provider(), hasEmail(oAuthAttributes.email()));
                 return OAuthTokenLoginResult.newMember(
                     oAuthAttributes.provider(),
                     oAuthAttributes.providerId(),
@@ -88,10 +88,9 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             command.token()
         );
 
-        log.info("OAuth 토큰 검증 성공: provider={}, providerId={}, email={}",
+        log.info("OAuth 토큰 검증 성공: provider={}, hasEmail={}",
             oauthAttrs.provider(),
-            oauthAttrs.providerId(),
-            oauthAttrs.email()
+            hasEmail(oauthAttrs.email())
         );
 
         // 2. 공통 비즈니스 로직 재사용
@@ -109,10 +108,9 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
             command.redirectUri()
         );
 
-        log.info("OAuth Authorization Code 교환 성공: provider={}, providerId={}, email={}",
+        log.info("OAuth Authorization Code 교환 성공: provider={}, hasEmail={}",
             oauthAttrs.provider(),
-            oauthAttrs.providerId(),
-            oauthAttrs.email()
+            hasEmail(oauthAttrs.email())
         );
 
         // 2. 공통 비즈니스 로직 재사용
@@ -269,5 +267,9 @@ public class OAuthAuthenticationService implements OAuthAuthenticationUseCase {
 
         memberOAuth.updateAppleCredentials(refreshToken, clientId);
         saveMemberOAuthPort.save(memberOAuth);
+    }
+
+    private boolean hasEmail(String email) {
+        return email != null && !email.isBlank();
     }
 }

--- a/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
@@ -1,5 +1,13 @@
 package com.umc.product.authorization.application.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
 import com.umc.product.authorization.application.port.out.LoadChallengerRolePort;
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
@@ -12,16 +20,12 @@ import com.umc.product.authorization.domain.exception.AuthorizationDomainExcepti
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,6 +38,7 @@ public class AuthorizationService implements CheckPermissionUseCase {
     private final GetMemberUseCase getMemberUseCase;
     private final GetChapterUseCase getChapterUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
+    private final OperationalMetrics operationalMetrics;
 
     /**
      * ResourcePermissionEvaluator에 대한 생성자 주입
@@ -42,11 +47,13 @@ public class AuthorizationService implements CheckPermissionUseCase {
      */
     public AuthorizationService(LoadChallengerRolePort loadChallengerRolePort,
                                 List<ResourcePermissionEvaluator> evaluatorList, GetMemberUseCase getMemberUseCase,
-                                GetChapterUseCase getChapterUseCase, GetChallengerUseCase getChallengerUseCase) {
+                                GetChapterUseCase getChapterUseCase, GetChallengerUseCase getChallengerUseCase,
+                                OperationalMetrics operationalMetrics) {
         this.loadChallengerRolePort = loadChallengerRolePort;
         this.getMemberUseCase = getMemberUseCase;
         this.getChapterUseCase = getChapterUseCase;
         this.getChallengerUseCase = getChallengerUseCase;
+        this.operationalMetrics = operationalMetrics;
         this.evaluators = evaluatorList.stream()
             .collect(Collectors.toMap(
                 ResourcePermissionEvaluator::supportedResourceType,
@@ -64,7 +71,7 @@ public class AuthorizationService implements CheckPermissionUseCase {
 
     @Override
     public SubjectAttributes loadSubject(Long memberId) {
-        log.info("권한 평가 시작");
+        log.debug("권한 평가 시작: memberId={}", memberId);
 
         // 사용자가 활동한 모든 기수를 확인
         // 해당 기수마다 chapterId, challengerRoleId를 가져옴
@@ -95,7 +102,9 @@ public class AuthorizationService implements CheckPermissionUseCase {
             .roleAttributes(roles)
             .build();
 
-        log.info("Subject Attribute {}가 평가를 요청했습니다.", subjectAttributes.toString());
+        log.debug("권한 평가 subject 로드 완료: memberId={}, roleCount={}, challengerCount={}",
+            subjectAttributes.memberId(), subjectAttributes.roleAttributes().size(),
+            subjectAttributes.gisuChallengerInfos().size());
 
         return subjectAttributes;
     }
@@ -125,6 +134,7 @@ public class AuthorizationService implements CheckPermissionUseCase {
         if (!check(memberId, permission)) {
             log.warn("Permission denied - memberId: {}, resource: {}:{}, permission: {}",
                 memberId, permission.resourceType(), permission.resourceId(), permission.permission());
+            operationalMetrics.recordSecurityEvent("AUTHORIZATION", "ACCESS_DENIED", "denied");
 
             throw new AuthorizationDomainException(AuthorizationErrorCode.RESOURCE_ACCESS_DENIED);
         }

--- a/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
@@ -102,7 +102,7 @@ public class AuthorizationService implements CheckPermissionUseCase {
             .roleAttributes(roles)
             .build();
 
-        log.debug("권한 평가 subject 로드 완료: memberId={}, roleCount={}, challengerCount={}",
+        log.debug("권한 평가 subject를 로드했습니다: memberId={}, roleCount={}, challengerCount={}",
             subjectAttributes.memberId(), subjectAttributes.roleAttributes().size(),
             subjectAttributes.gisuChallengerInfos().size());
 

--- a/src/main/java/com/umc/product/authorization/application/service/command/ChallengerRoleCommandService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/command/ChallengerRoleCommandService.java
@@ -31,7 +31,7 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
         action = AuditAction.CREATE,
         targetType = "ChallengerRole",
         targetId = "#result",
-        description = "'ChallengerRole이 생성되었습니다.'"
+        description = "'ChallengerRole을 생성했습니다.'"
     )
     @Override
     public Long createChallengerRole(CreateChallengerRoleCommand command) {
@@ -55,7 +55,7 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
         action = AuditAction.UPDATE,
         targetType = "ChallengerRole",
         targetId = "#command.challengerRoleId()",
-        description = "'ChallengerRole이 수정되었습니다.'"
+        description = "'ChallengerRole을 수정했습니다.'"
     )
     @Override
     public void updateChallengerRole(UpdateChallengerRoleCommand command) {
@@ -69,7 +69,7 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
         action = AuditAction.DELETE,
         targetType = "ChallengerRole",
         targetId = "#command.challengerRoleId()",
-        description = "'ChallengerRole이 삭제되었습니다.'"
+        description = "'ChallengerRole을 삭제했습니다.'"
     )
     @Override
     public void deleteChallengerRole(DeleteChallengerRoleCommand command) {

--- a/src/main/java/com/umc/product/authorization/application/service/command/ChallengerRoleCommandService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/command/ChallengerRoleCommandService.java
@@ -1,5 +1,12 @@
 package com.umc.product.authorization.application.service.command;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
 import com.umc.product.authorization.application.port.in.command.dto.DeleteChallengerRoleCommand;
@@ -7,10 +14,9 @@ import com.umc.product.authorization.application.port.in.command.dto.UpdateChall
 import com.umc.product.authorization.application.port.out.LoadChallengerRolePort;
 import com.umc.product.authorization.application.port.out.SaveChallengerRolePort;
 import com.umc.product.authorization.domain.ChallengerRole;
-import java.util.List;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +26,13 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
     private final LoadChallengerRolePort loadChallengerRolePort;
     private final SaveChallengerRolePort saveChallengerRolePort;
 
+    @Audited(
+        domain = Domain.AUTHORIZATION,
+        action = AuditAction.CREATE,
+        targetType = "ChallengerRole",
+        targetId = "#result",
+        description = "'ChallengerRole이 생성되었습니다.'"
+    )
     @Override
     public Long createChallengerRole(CreateChallengerRoleCommand command) {
         ChallengerRole challengerRole = command.toEntity();
@@ -37,6 +50,13 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
             .toList();
     }
 
+    @Audited(
+        domain = Domain.AUTHORIZATION,
+        action = AuditAction.UPDATE,
+        targetType = "ChallengerRole",
+        targetId = "#command.challengerRoleId()",
+        description = "'ChallengerRole이 수정되었습니다.'"
+    )
     @Override
     public void updateChallengerRole(UpdateChallengerRoleCommand command) {
         ChallengerRole challengerRole = loadChallengerRolePort.getById(command.challengerRoleId());
@@ -44,6 +64,13 @@ public class ChallengerRoleCommandService implements ManageChallengerRoleUseCase
         saveChallengerRolePort.save(challengerRole);
     }
 
+    @Audited(
+        domain = Domain.AUTHORIZATION,
+        action = AuditAction.DELETE,
+        targetType = "ChallengerRole",
+        targetId = "#command.challengerRoleId()",
+        description = "'ChallengerRole이 삭제되었습니다.'"
+    )
     @Override
     public void deleteChallengerRole(DeleteChallengerRoleCommand command) {
         ChallengerRole challengerRole = loadChallengerRolePort.getById(command.challengerRoleId());

--- a/src/main/java/com/umc/product/blog/application/service/BlogCommentCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogCommentCommandService.java
@@ -51,7 +51,7 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
         action = AuditAction.CREATE,
         targetType = "BlogComment",
         targetId = "#result.id()",
-        description = "'블로그 댓글이 생성되었습니다.'"
+        description = "'블로그 댓글을 생성했습니다.'"
     )
     @Override
     public BlogCommentInfo create(CreateBlogCommentCommand command) {
@@ -82,7 +82,7 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
         action = AuditAction.UPDATE,
         targetType = "BlogComment",
         targetId = "#command.commentId()",
-        description = "'블로그 댓글이 수정되었습니다.'"
+        description = "'블로그 댓글을 수정했습니다.'"
     )
     @Override
     public BlogCommentInfo update(UpdateBlogCommentCommand command) {
@@ -99,7 +99,7 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
         action = AuditAction.DELETE,
         targetType = "BlogComment",
         targetId = "#command.commentId()",
-        description = "'블로그 댓글이 삭제되었습니다.'"
+        description = "'블로그 댓글을 삭제했습니다.'"
     )
     @Override
     public void delete(DeleteBlogCommentCommand command) {

--- a/src/main/java/com/umc/product/blog/application/service/BlogCommentCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogCommentCommandService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.blog.application.port.in.command.CreateBlogCommentUseCase;
 import com.umc.product.blog.application.port.in.command.DeleteBlogCommentUseCase;
@@ -26,6 +28,7 @@ import com.umc.product.blog.domain.BlogContent;
 import com.umc.product.blog.domain.BlogContentType;
 import com.umc.product.blog.domain.BlogDomainException;
 import com.umc.product.blog.domain.BlogErrorCode;
+import com.umc.product.global.exception.constant.Domain;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +46,13 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
     private final BlogCommentInfoAssembler commentInfoAssembler;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.CREATE,
+        targetType = "BlogComment",
+        targetId = "#result.id()",
+        description = "'블로그 댓글이 생성되었습니다.'"
+    )
     @Override
     public BlogCommentInfo create(CreateBlogCommentCommand command) {
         BlogContent content = getPublishedContent(command.type(), command.slug());
@@ -67,6 +77,13 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
         );
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.UPDATE,
+        targetType = "BlogComment",
+        targetId = "#command.commentId()",
+        description = "'블로그 댓글이 수정되었습니다.'"
+    )
     @Override
     public BlogCommentInfo update(UpdateBlogCommentCommand command) {
         BlogContent content = getPublishedContent(command.type(), command.slug());
@@ -77,6 +94,13 @@ public class BlogCommentCommandService implements CreateBlogCommentUseCase, Upda
         return assembleSingle(updated, command.memberId());
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.DELETE,
+        targetType = "BlogComment",
+        targetId = "#command.commentId()",
+        description = "'블로그 댓글이 삭제되었습니다.'"
+    )
     @Override
     public void delete(DeleteBlogCommentCommand command) {
         BlogContent content = getPublishedContent(command.type(), command.slug());

--- a/src/main/java/com/umc/product/blog/application/service/BlogContentCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogContentCommandService.java
@@ -51,7 +51,7 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
         action = AuditAction.CREATE,
         targetType = "BlogContent",
         targetId = "#result.id()",
-        description = "'블로그 콘텐츠가 생성되었습니다.'"
+        description = "'블로그 콘텐츠를 생성했습니다.'"
     )
     @Override
     public BlogContentInfo create(CreateBlogContentCommand command) {
@@ -83,7 +83,7 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
         action = AuditAction.UPDATE,
         targetType = "BlogContent",
         targetId = "#command.contentId()",
-        description = "'블로그 콘텐츠가 수정되었습니다.'"
+        description = "'블로그 콘텐츠를 수정했습니다.'"
     )
     @Override
     public BlogContentInfo update(UpdateBlogContentCommand command) {
@@ -113,7 +113,7 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
         action = AuditAction.DELETE,
         targetType = "BlogContent",
         targetId = "#command.contentId()",
-        description = "'블로그 콘텐츠가 삭제되었습니다.'"
+        description = "'블로그 콘텐츠를 삭제했습니다.'"
     )
     @Override
     public void delete(DeleteBlogContentCommand command) {

--- a/src/main/java/com/umc/product/blog/application/service/BlogContentCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogContentCommandService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.blog.application.port.in.command.CreateBlogContentUseCase;
 import com.umc.product.blog.application.port.in.command.DeleteBlogContentUseCase;
 import com.umc.product.blog.application.port.in.command.UpdateBlogContentUseCase;
@@ -26,6 +28,7 @@ import com.umc.product.blog.domain.BlogContentType;
 import com.umc.product.blog.domain.BlogDomainException;
 import com.umc.product.blog.domain.BlogErrorCode;
 import com.umc.product.blog.domain.BlogHashtag;
+import com.umc.product.global.exception.constant.Domain;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +46,13 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
     private final SaveBlogHashtagPort saveBlogHashtagPort;
     private final BlogContentInfoAssembler contentInfoAssembler;
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.CREATE,
+        targetType = "BlogContent",
+        targetId = "#result.id()",
+        description = "'블로그 콘텐츠가 생성되었습니다.'"
+    )
     @Override
     public BlogContentInfo create(CreateBlogContentCommand command) {
         BlogContentType type = BlogContentType.fromPath(command.type());
@@ -68,6 +78,13 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
         return contentInfoAssembler.assemble(saved, command.authorMemberId(), true);
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.UPDATE,
+        targetType = "BlogContent",
+        targetId = "#command.contentId()",
+        description = "'블로그 콘텐츠가 수정되었습니다.'"
+    )
     @Override
     public BlogContentInfo update(UpdateBlogContentCommand command) {
         BlogContent content = loadBlogContentPort.findContentById(command.contentId())
@@ -91,6 +108,13 @@ public class BlogContentCommandService implements CreateBlogContentUseCase, Upda
         return contentInfoAssembler.assemble(saved, content.getAuthorMemberId(), false);
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.DELETE,
+        targetType = "BlogContent",
+        targetId = "#command.contentId()",
+        description = "'블로그 콘텐츠가 삭제되었습니다.'"
+    )
     @Override
     public void delete(DeleteBlogContentCommand command) {
         BlogContent content = loadBlogContentPort.findContentById(command.contentId())

--- a/src/main/java/com/umc/product/blog/application/service/BlogSeriesCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogSeriesCommandService.java
@@ -49,7 +49,7 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         action = AuditAction.CREATE,
         targetType = "BlogSeries",
         targetId = "#result.id()",
-        description = "'블로그 시리즈가 생성되었습니다.'"
+        description = "'블로그 시리즈를 생성했습니다.'"
     )
     @Override
     public BlogSeriesInfo create(CreateBlogSeriesCommand command) {
@@ -77,7 +77,7 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         action = AuditAction.UPDATE,
         targetType = "BlogSeries",
         targetId = "#command.seriesId()",
-        description = "'블로그 시리즈가 수정되었습니다.'"
+        description = "'블로그 시리즈를 수정했습니다.'"
     )
     @Override
     public BlogSeriesInfo update(UpdateBlogSeriesCommand command) {
@@ -102,7 +102,7 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         action = AuditAction.DELETE,
         targetType = "BlogSeries",
         targetId = "#command.seriesId()",
-        description = "'블로그 시리즈가 삭제되었습니다.'"
+        description = "'블로그 시리즈를 삭제했습니다.'"
     )
     @Override
     public void delete(DeleteBlogSeriesCommand command) {
@@ -116,7 +116,7 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         action = AuditAction.REORDER,
         targetType = "BlogSeries",
         targetId = "#command.seriesId()",
-        description = "'블로그 시리즈 콘텐츠 순서가 변경되었습니다.'"
+        description = "'블로그 시리즈 콘텐츠 순서를 변경했습니다.'"
     )
     @Override
     public BlogSeriesInfo replaceContents(ReplaceBlogSeriesContentsCommand command) {

--- a/src/main/java/com/umc/product/blog/application/service/BlogSeriesCommandService.java
+++ b/src/main/java/com/umc/product/blog/application/service/BlogSeriesCommandService.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.blog.application.port.in.command.CreateBlogSeriesUseCase;
 import com.umc.product.blog.application.port.in.command.DeleteBlogSeriesUseCase;
 import com.umc.product.blog.application.port.in.command.ReplaceBlogSeriesContentsUseCase;
@@ -26,6 +28,7 @@ import com.umc.product.blog.domain.BlogDomainException;
 import com.umc.product.blog.domain.BlogErrorCode;
 import com.umc.product.blog.domain.BlogSeries;
 import com.umc.product.blog.domain.BlogSeriesContent;
+import com.umc.product.global.exception.constant.Domain;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,6 +44,13 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
     private final SaveBlogSeriesContentPort saveBlogSeriesContentPort;
     private final BlogSeriesInfoAssembler seriesInfoAssembler;
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.CREATE,
+        targetType = "BlogSeries",
+        targetId = "#result.id()",
+        description = "'블로그 시리즈가 생성되었습니다.'"
+    )
     @Override
     public BlogSeriesInfo create(CreateBlogSeriesCommand command) {
         BlogContentType type = BlogContentType.fromPath(command.type());
@@ -62,6 +72,13 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         return seriesInfoAssembler.assemble(saved, command.authorMemberId(), true);
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.UPDATE,
+        targetType = "BlogSeries",
+        targetId = "#command.seriesId()",
+        description = "'블로그 시리즈가 수정되었습니다.'"
+    )
     @Override
     public BlogSeriesInfo update(UpdateBlogSeriesCommand command) {
         BlogSeries series = getSeries(command.seriesId());
@@ -80,6 +97,13 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         return seriesInfoAssembler.assemble(saveBlogSeriesPort.save(series), series.getAuthorMemberId(), false);
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.DELETE,
+        targetType = "BlogSeries",
+        targetId = "#command.seriesId()",
+        description = "'블로그 시리즈가 삭제되었습니다.'"
+    )
     @Override
     public void delete(DeleteBlogSeriesCommand command) {
         BlogSeries series = getSeries(command.seriesId());
@@ -87,6 +111,13 @@ public class BlogSeriesCommandService implements CreateBlogSeriesUseCase, Update
         saveBlogSeriesPort.save(series);
     }
 
+    @Audited(
+        domain = Domain.BLOG,
+        action = AuditAction.REORDER,
+        targetType = "BlogSeries",
+        targetId = "#command.seriesId()",
+        description = "'블로그 시리즈 콘텐츠 순서가 변경되었습니다.'"
+    )
     @Override
     public BlogSeriesInfo replaceContents(ReplaceBlogSeriesContentsCommand command) {
         BlogSeries series = getSeries(command.seriesId());

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
@@ -12,9 +12,7 @@ import com.umc.product.organization.application.port.in.query.dto.chapter.Chapte
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import java.util.List;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Builder
 public record ChallengerInfoResponse(
     Long challengerId,

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
@@ -1,5 +1,7 @@
 package com.umc.product.challenger.adapter.in.web.dto.response;
 
+import java.util.List;
+
 import com.umc.product.authorization.adapter.in.web.dto.response.ChallengerRoleResponse;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
@@ -10,7 +12,7 @@ import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
-import java.util.List;
+
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerInfo.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerInfo.java
@@ -1,9 +1,11 @@
 package com.umc.product.challenger.application.port.in.query.dto;
 
+import java.util.List;
+
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
-import java.util.List;
+
 import lombok.Builder;
 
 

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerInfo.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerInfo.java
@@ -5,7 +5,6 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerStatus;
 import java.util.List;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -14,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
  * 각 챌린저의 상벌점 현황을 포함하여 번환하며, 성능 상 해당 정보를 제외하고자 하는 경우 별도의 DTO를 생성해서 사용해주세요.
  */
 @Builder
-@Slf4j
 public record ChallengerInfo(
     Long challengerId,
     Long memberId,
@@ -28,8 +26,6 @@ public record ChallengerInfo(
     // 아직 만들지 않았어요.
     @Deprecated(since = "v1.5.0", forRemoval = true)
     public static ChallengerInfo from(Challenger challenger) {
-        log.error("챌린저 상벌점을 포함하지 않는 생성자를 사용하고 있습니다.");
-
         return ChallengerInfo.builder()
             .challengerId(challenger.getId())
             .memberId(challenger.getMemberId())

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -46,24 +46,24 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
 
     @Override
     public Long create(CreateChallengerRecordCommand command) {
-        log.info("ChallengerRecord를 생성합니다. command={}", command.toString());
-
         validateRecord(command.gisuId(), command.schoolId(), command.chapterId());
 
-        return saveChallengerRecordPort.save(command.toEntity()).getId();
+        ChallengerRecord savedRecord = saveChallengerRecordPort.save(command.toEntity());
+        log.info("ChallengerRecord 생성 완료: recordId={}, gisuId={}, schoolId={}, chapterId={}, adminRecord={}",
+            savedRecord.getId(), command.gisuId(), command.schoolId(), command.chapterId(),
+            command.challengerRoleType() != null);
+        return savedRecord.getId();
     }
 
     @Override
     public List<Long> createBulk(List<CreateChallengerRecordCommand> commands) {
-        log.info("ChallengerRecord를 대량으로 생성합니다. commands={}",
-            commands.stream().map(CreateChallengerRecordCommand::toString).toList());
-
         List<ChallengerRecord> records = commands.stream()
             .map(CreateChallengerRecordCommand::toEntity)
             .toList();
 
-        return saveChallengerRecordPort.saveAll(records)
-            .stream().map(ChallengerRecord::getId).toList();
+        List<ChallengerRecord> savedRecords = saveChallengerRecordPort.saveAll(records);
+        log.info("ChallengerRecord 대량 생성 완료: count={}", savedRecords.size());
+        return savedRecords.stream().map(ChallengerRecord::getId).toList();
     }
 
     @Override

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -97,6 +97,13 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         saveChallengerRecordPort.delete(loadChallengerRecordPort.getById(id));
     }
 
+    @Audited(
+        domain = Domain.CHALLENGER,
+        action = AuditAction.CHECK,
+        targetType = "ChallengerRecord",
+        targetId = "#command.targetMemberId()",
+        description = "'ChallengerRecord 코드가 사용되었습니다.'"
+    )
     @Override
     public void consumeCode(ConsumeChallengerRecordCommand command) {
         String code = command.code();

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -1,5 +1,9 @@
 package com.umc.product.challenger.application.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
@@ -23,11 +27,10 @@ import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmComm
 import com.umc.product.notification.domain.WebhookPlatform;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+
 import jakarta.transaction.Transactional;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -55,14 +55,14 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         action = AuditAction.CREATE,
         targetType = "ChallengerRecord",
         targetId = "#result",
-        description = "'ChallengerRecord가 생성되었습니다.'"
+        description = "'ChallengerRecord를 생성했습니다.'"
     )
     @Override
     public Long create(CreateChallengerRecordCommand command) {
         validateRecord(command.gisuId(), command.schoolId(), command.chapterId());
 
         ChallengerRecord savedRecord = saveChallengerRecordPort.save(command.toEntity());
-        log.info("ChallengerRecord 생성 완료: recordId={}, gisuId={}, schoolId={}, chapterId={}, adminRecord={}",
+        log.info("ChallengerRecord를 생성했습니다: recordId={}, gisuId={}, schoolId={}, chapterId={}, adminRecord={}",
             savedRecord.getId(), command.gisuId(), command.schoolId(), command.chapterId(),
             command.challengerRoleType() != null);
         return savedRecord.getId();
@@ -72,7 +72,7 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         domain = Domain.CHALLENGER,
         action = AuditAction.CREATE,
         targetType = "ChallengerRecord",
-        description = "'ChallengerRecord가 대량 생성되었습니다. count=' + #result.size()"
+        description = "'ChallengerRecord를 대량 생성했습니다. count=' + #result.size()"
     )
     @Override
     public List<Long> createBulk(List<CreateChallengerRecordCommand> commands) {
@@ -81,7 +81,7 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
             .toList();
 
         List<ChallengerRecord> savedRecords = saveChallengerRecordPort.saveAll(records);
-        log.info("ChallengerRecord 대량 생성 완료: count={}", savedRecords.size());
+        log.info("ChallengerRecord를 대량 생성했습니다: count={}", savedRecords.size());
         return savedRecords.stream().map(ChallengerRecord::getId).toList();
     }
 
@@ -90,7 +90,7 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         action = AuditAction.DELETE,
         targetType = "ChallengerRecord",
         targetId = "#id",
-        description = "'ChallengerRecord가 삭제되었습니다.'"
+        description = "'ChallengerRecord를 삭제했습니다.'"
     )
     @Override
     public void delete(Long id) {
@@ -102,7 +102,7 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         action = AuditAction.CHECK,
         targetType = "ChallengerRecord",
         targetId = "#command.targetMemberId()",
-        description = "'ChallengerRecord 코드가 사용되었습니다.'"
+        description = "'ChallengerRecord 코드를 사용했습니다.'"
     )
     @Override
     public void consumeCode(ConsumeChallengerRecordCommand command) {

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -1,5 +1,7 @@
 package com.umc.product.challenger.application.service;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
 import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
@@ -13,6 +15,7 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.ChallengerRecord;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
@@ -44,6 +47,13 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
 
     private final SendWebhookAlarmUseCase sendWebhookAlarmUseCase;
 
+    @Audited(
+        domain = Domain.CHALLENGER,
+        action = AuditAction.CREATE,
+        targetType = "ChallengerRecord",
+        targetId = "#result",
+        description = "'ChallengerRecord가 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateChallengerRecordCommand command) {
         validateRecord(command.gisuId(), command.schoolId(), command.chapterId());
@@ -55,6 +65,12 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         return savedRecord.getId();
     }
 
+    @Audited(
+        domain = Domain.CHALLENGER,
+        action = AuditAction.CREATE,
+        targetType = "ChallengerRecord",
+        description = "'ChallengerRecord가 대량 생성되었습니다. count=' + #result.size()"
+    )
     @Override
     public List<Long> createBulk(List<CreateChallengerRecordCommand> commands) {
         List<ChallengerRecord> records = commands.stream()
@@ -66,6 +82,13 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
         return savedRecords.stream().map(ChallengerRecord::getId).toList();
     }
 
+    @Audited(
+        domain = Domain.CHALLENGER,
+        action = AuditAction.DELETE,
+        targetType = "ChallengerRecord",
+        targetId = "#id",
+        description = "'ChallengerRecord가 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long id) {
         saveChallengerRecordPort.delete(loadChallengerRecordPort.getById(id));

--- a/src/main/java/com/umc/product/community/application/service/command/PostCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/command/PostCommandService.java
@@ -1,5 +1,12 @@
 package com.umc.product.community.application.service.command;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.community.application.port.in.command.post.CreatePostUseCase;
 import com.umc.product.community.application.port.in.command.post.DeletePostUseCase;
 import com.umc.product.community.application.port.in.command.post.TogglePostLikeUseCase;
@@ -18,10 +25,9 @@ import com.umc.product.community.domain.Post;
 import com.umc.product.community.domain.Post.LightningInfo;
 import com.umc.product.community.domain.exception.CommunityDomainException;
 import com.umc.product.community.domain.exception.CommunityErrorCode;
-import java.time.Instant;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +39,13 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
     private final SavePostPort savePostPort;
     private final AuthorInfoProvider authorInfoProvider;
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.CREATE,
+        targetType = "Post",
+        targetId = "#result.postId()",
+        description = "'커뮤니티 게시글이 생성되었습니다.'"
+    )
     @Override
     public PostInfo createPost(CreatePostCommand command) {
         Post post = Post.createPost(
@@ -47,6 +60,13 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         return PostInfo.from(savedPost, command.authorChallengerId(), authorName);
     }
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.CREATE,
+        targetType = "Post",
+        targetId = "#result.postId()",
+        description = "'커뮤니티 번개 게시글이 생성되었습니다.'"
+    )
     @Override
     public PostInfo createLightningPost(CreateLightningCommand command) {
         LightningInfo lightningInfo = new LightningInfo(
@@ -71,6 +91,13 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         return PostInfo.from(savedPost, command.authorChallengerId(), authorName);
     }
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.UPDATE,
+        targetType = "Post",
+        targetId = "#command.postId()",
+        description = "'커뮤니티 게시글이 수정되었습니다.'"
+    )
     @Override
     public PostInfo updatePost(UpdatePostCommand command) {
         PostWithAuthor postWithAuthor = loadPostPort.findByIdWithAuthor(command.postId())
@@ -88,6 +115,13 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         return PostInfo.from(savedPost, postWithAuthor.authorChallengerId(), authorName);
     }
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.UPDATE,
+        targetType = "Post",
+        targetId = "#command.postId()",
+        description = "'커뮤니티 번개 게시글이 수정되었습니다.'"
+    )
     @Override
     public PostInfo updateLightning(UpdateLightningCommand command) {
         PostWithAuthor postWithAuthor = loadPostPort.findByIdWithAuthor(command.postId())
@@ -116,6 +150,13 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         return PostInfo.from(savedPost, postWithAuthor.authorChallengerId(), authorName);
     }
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.DELETE,
+        targetType = "Post",
+        targetId = "#postId",
+        description = "'커뮤니티 게시글이 삭제되었습니다.'"
+    )
     @Override
     public void deletePost(Long postId) {
         loadPostPort.findById(postId)

--- a/src/main/java/com/umc/product/community/application/service/command/PostCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/command/PostCommandService.java
@@ -44,7 +44,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         action = AuditAction.CREATE,
         targetType = "Post",
         targetId = "#result.postId()",
-        description = "'커뮤니티 게시글이 생성되었습니다.'"
+        description = "'커뮤니티 게시글을 생성했습니다.'"
     )
     @Override
     public PostInfo createPost(CreatePostCommand command) {
@@ -65,7 +65,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         action = AuditAction.CREATE,
         targetType = "Post",
         targetId = "#result.postId()",
-        description = "'커뮤니티 번개 게시글이 생성되었습니다.'"
+        description = "'커뮤니티 번개 게시글을 생성했습니다.'"
     )
     @Override
     public PostInfo createLightningPost(CreateLightningCommand command) {
@@ -96,7 +96,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         action = AuditAction.UPDATE,
         targetType = "Post",
         targetId = "#command.postId()",
-        description = "'커뮤니티 게시글이 수정되었습니다.'"
+        description = "'커뮤니티 게시글을 수정했습니다.'"
     )
     @Override
     public PostInfo updatePost(UpdatePostCommand command) {
@@ -120,7 +120,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         action = AuditAction.UPDATE,
         targetType = "Post",
         targetId = "#command.postId()",
-        description = "'커뮤니티 번개 게시글이 수정되었습니다.'"
+        description = "'커뮤니티 번개 게시글을 수정했습니다.'"
     )
     @Override
     public PostInfo updateLightning(UpdateLightningCommand command) {
@@ -155,7 +155,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         action = AuditAction.DELETE,
         targetType = "Post",
         targetId = "#postId",
-        description = "'커뮤니티 게시글이 삭제되었습니다.'"
+        description = "'커뮤니티 게시글을 삭제했습니다.'"
     )
     @Override
     public void deletePost(Long postId) {

--- a/src/main/java/com/umc/product/community/application/service/command/ReportCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/command/ReportCommandService.java
@@ -1,5 +1,10 @@
 package com.umc.product.community.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.community.application.port.in.command.report.ReportCommentUseCase;
 import com.umc.product.community.application.port.in.command.report.ReportPostUseCase;
 import com.umc.product.community.application.port.in.command.report.dto.ReportCommentCommand;
@@ -13,9 +18,9 @@ import com.umc.product.community.domain.enums.ReportTargetType;
 import com.umc.product.community.domain.exception.CommunityDomainException;
 import com.umc.product.community.domain.exception.CommunityErrorCode;
 import com.umc.product.global.exception.BusinessException;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,13 @@ public class ReportCommandService implements ReportPostUseCase, ReportCommentUse
     private final LoadReportPort loadReportPort;
     private final SaveReportPort saveReportPort;
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.SUBMIT,
+        targetType = "PostReport",
+        targetId = "#command.postId()",
+        description = "'커뮤니티 게시글 신고가 제출되었습니다.'"
+    )
     @Override
     public void report(ReportPostCommand command) {
         // 게시글 존재 확인
@@ -37,6 +49,13 @@ public class ReportCommandService implements ReportPostUseCase, ReportCommentUse
         checkDuplicateAndSaveReport(command.reporterId(), ReportTargetType.POST, command.postId());
     }
 
+    @Audited(
+        domain = Domain.COMMUNITY,
+        action = AuditAction.SUBMIT,
+        targetType = "CommentReport",
+        targetId = "#command.commentId()",
+        description = "'커뮤니티 댓글 신고가 제출되었습니다.'"
+    )
     @Override
     public void report(ReportCommentCommand command) {
         // 댓글 존재 확인

--- a/src/main/java/com/umc/product/community/application/service/command/ReportCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/command/ReportCommandService.java
@@ -37,7 +37,7 @@ public class ReportCommandService implements ReportPostUseCase, ReportCommentUse
         action = AuditAction.SUBMIT,
         targetType = "PostReport",
         targetId = "#command.postId()",
-        description = "'커뮤니티 게시글 신고가 제출되었습니다.'"
+        description = "'커뮤니티 게시글 신고를 제출했습니다.'"
     )
     @Override
     public void report(ReportPostCommand command) {
@@ -54,7 +54,7 @@ public class ReportCommandService implements ReportPostUseCase, ReportCommentUse
         action = AuditAction.SUBMIT,
         targetType = "CommentReport",
         targetId = "#command.commentId()",
-        description = "'커뮤니티 댓글 신고가 제출되었습니다.'"
+        description = "'커뮤니티 댓글 신고를 제출했습니다.'"
     )
     @Override
     public void report(ReportCommentCommand command) {

--- a/src/main/java/com/umc/product/curriculum/adapter/in/scheduler/WorkbookAutoReleaseScheduler.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/scheduler/WorkbookAutoReleaseScheduler.java
@@ -1,10 +1,16 @@
 package com.umc.product.curriculum.adapter.in.scheduler;
 
-import com.umc.product.curriculum.application.port.in.command.AutoReleaseWorkbookUseCase;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
+import java.time.Instant;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.curriculum.application.port.in.command.AutoReleaseWorkbookUseCase;
+import com.umc.product.global.logging.OperationalMetrics;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 워크북 자동 배포 스케줄러
@@ -23,7 +29,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WorkbookAutoReleaseScheduler {
 
+    private static final String JOB_NAME = "workbook_auto_release";
+
     private final AutoReleaseWorkbookUseCase autoReleaseWorkbookUseCase;
+    private final OperationalMetrics operationalMetrics;
 
     /**
      * 매일 자정(KST)에 실행
@@ -32,13 +41,20 @@ public class WorkbookAutoReleaseScheduler {
      */
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void releaseDueWorkbooks() {
-        log.info("[WorkbookAutoRelease] 자동 배포 스케줄 시작");
+        Instant startedAt = Instant.now();
+        log.info("batch job started: jobName={}", JOB_NAME);
 
         try {
             int releasedCount = autoReleaseWorkbookUseCase.releaseAllDue();
-            log.info("[WorkbookAutoRelease] 자동 배포 스케줄 완료: {}건 배포", releasedCount);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "success", duration, releasedCount);
+            log.info("batch job completed: jobName={}, processed={}, durationMs={}, result={}",
+                JOB_NAME, releasedCount, duration.toMillis(), "success");
         } catch (Exception e) {
-            log.error("[WorkbookAutoRelease] 자동 배포 중 오류 발생", e);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "failure", duration, 0);
+            log.error("batch job failed: jobName={}, durationMs={}, result={}, errorClass={}",
+                JOB_NAME, duration.toMillis(), "failure", e.getClass().getSimpleName(), e);
         }
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/command/CurriculumCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/CurriculumCommandService.java
@@ -1,5 +1,10 @@
 package com.umc.product.curriculum.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.curriculum.application.port.in.command.ManageCurriculumUseCase;
 import com.umc.product.curriculum.application.port.in.command.dto.curriculum.CreateCurriculumCommand;
 import com.umc.product.curriculum.application.port.in.command.dto.curriculum.EditCurriculumCommand;
@@ -9,9 +14,9 @@ import com.umc.product.curriculum.application.port.out.SaveCurriculumPort;
 import com.umc.product.curriculum.domain.Curriculum;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,13 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
 
     // TODO: 기수(Gisu) 유효성 검사 필요 - organization 도메인의 GetGisuUseCase.getById() 호출로 존재 여부 확인
     //  현재 gisuId가 실제 존재하는 기수인지 검증하지 않음
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.CREATE,
+        targetType = "Curriculum",
+        targetId = "#result",
+        description = "'커리큘럼이 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateCurriculumCommand command) {
         if (loadCurriculumPort.existsByGisuIdAndPart(command.gisuId(), command.part())) {
@@ -33,6 +45,13 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
         return saveCurriculumPort.save(curriculum).getId();
     }
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.UPDATE,
+        targetType = "Curriculum",
+        targetId = "#command.curriculumId()",
+        description = "'커리큘럼이 수정되었습니다.'"
+    )
     @Override
     public void edit(EditCurriculumCommand command) {
         Curriculum curriculum = loadCurriculumPort.findById(command.curriculumId())
@@ -41,6 +60,13 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
         saveCurriculumPort.save(curriculum);
     }
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.DELETE,
+        targetType = "Curriculum",
+        targetId = "#curriculumId",
+        description = "'커리큘럼이 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long curriculumId) {
         Curriculum curriculum = loadCurriculumPort.findById(curriculumId)

--- a/src/main/java/com/umc/product/curriculum/application/service/command/CurriculumCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/CurriculumCommandService.java
@@ -34,7 +34,7 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
         action = AuditAction.CREATE,
         targetType = "Curriculum",
         targetId = "#result",
-        description = "'커리큘럼이 생성되었습니다.'"
+        description = "'커리큘럼을 생성했습니다.'"
     )
     @Override
     public Long create(CreateCurriculumCommand command) {
@@ -50,7 +50,7 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
         action = AuditAction.UPDATE,
         targetType = "Curriculum",
         targetId = "#command.curriculumId()",
-        description = "'커리큘럼이 수정되었습니다.'"
+        description = "'커리큘럼을 수정했습니다.'"
     )
     @Override
     public void edit(EditCurriculumCommand command) {
@@ -65,7 +65,7 @@ public class CurriculumCommandService implements ManageCurriculumUseCase {
         action = AuditAction.DELETE,
         targetType = "Curriculum",
         targetId = "#curriculumId",
-        description = "'커리큘럼이 삭제되었습니다.'"
+        description = "'커리큘럼을 삭제했습니다.'"
     )
     @Override
     public void delete(Long curriculumId) {

--- a/src/main/java/com/umc/product/curriculum/application/service/command/MissionSubmissionCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/MissionSubmissionCommandService.java
@@ -24,7 +24,7 @@ public class MissionSubmissionCommandService implements ManageMissionSubmissionU
         action = AuditAction.SUBMIT,
         targetType = "MissionSubmission",
         targetId = "#result",
-        description = "'미션 제출물이 생성되었습니다.'"
+        description = "'미션 제출물을 생성했습니다.'"
     )
     @Override
     public Long create(CreateMissionSubmissionCommand command) {

--- a/src/main/java/com/umc/product/curriculum/application/service/command/MissionSubmissionCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/MissionSubmissionCommandService.java
@@ -1,19 +1,31 @@
 package com.umc.product.curriculum.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.curriculum.application.port.in.command.ManageMissionSubmissionUseCase;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.mission.CreateMissionSubmissionCommand;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.mission.DeleteMissionSubmissionCommand;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.mission.EditMissionSubmissionCommand;
 import com.umc.product.global.exception.NotImplementedException;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MissionSubmissionCommandService implements ManageMissionSubmissionUseCase {
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.SUBMIT,
+        targetType = "MissionSubmission",
+        targetId = "#result",
+        description = "'미션 제출물이 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateMissionSubmissionCommand command) {
         throw new NotImplementedException();

--- a/src/main/java/com/umc/product/curriculum/application/service/command/OriginalWorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/OriginalWorkbookCommandService.java
@@ -57,7 +57,7 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         action = AuditAction.CREATE,
         targetType = "OriginalWorkbook",
         targetId = "#result",
-        description = "'원본 워크북이 생성되었습니다.'"
+        description = "'원본 워크북을 생성했습니다.'"
     )
     @Override
     public Long create(CreateOriginalWorkbookCommand command) {
@@ -83,7 +83,7 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         action = AuditAction.UPDATE,
         targetType = "OriginalWorkbook",
         targetId = "#command.originalWorkbookId()",
-        description = "'원본 워크북이 수정되었습니다.'"
+        description = "'원본 워크북을 수정했습니다.'"
     )
     @Override
     public void edit(EditOriginalWorkbookCommand command) {
@@ -97,7 +97,7 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         action = AuditAction.DELETE,
         targetType = "OriginalWorkbook",
         targetId = "#originalWorkbookId",
-        description = "'원본 워크북이 삭제되었습니다.'"
+        description = "'원본 워크북을 삭제했습니다.'"
     )
     @Override
     public void delete(Long originalWorkbookId) {
@@ -131,7 +131,7 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         domain = Domain.CURRICULUM,
         action = AuditAction.PUBLISH,
         targetType = "OriginalWorkbook",
-        description = "'배포 예정 워크북 자동 배포가 실행되었습니다.'"
+        description = "'배포 예정 워크북 자동 배포를 실행했습니다.'"
     )
     @Override
     public int releaseAllDue() {

--- a/src/main/java/com/umc/product/curriculum/application/service/command/OriginalWorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/OriginalWorkbookCommandService.java
@@ -1,5 +1,15 @@
 package com.umc.product.curriculum.application.service.command;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.curriculum.application.port.in.command.AutoReleaseWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.command.ManageOriginalWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.ChangeOriginalWorkbookStatusCommand;
@@ -11,18 +21,13 @@ import com.umc.product.curriculum.application.port.out.LoadWeeklyCurriculumPort;
 import com.umc.product.curriculum.application.port.out.SaveOriginalWorkbookPort;
 import com.umc.product.curriculum.domain.OriginalWorkbook;
 import com.umc.product.curriculum.domain.WeeklyCurriculum;
-import com.umc.product.curriculum.domain.enums.OriginalWorkbookStatus;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
 import com.umc.product.global.exception.NotImplementedException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -47,6 +52,13 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         return ids;
     }
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.CREATE,
+        targetType = "OriginalWorkbook",
+        targetId = "#result",
+        description = "'원본 워크북이 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateOriginalWorkbookCommand command) {
         WeeklyCurriculum weeklyCurriculum = loadWeeklyCurriculumPort.getById(command.weeklyCurriculumId());
@@ -66,6 +78,13 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         return saveOriginalWorkbookPort.save(workbook).getId();
     }
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.UPDATE,
+        targetType = "OriginalWorkbook",
+        targetId = "#command.originalWorkbookId()",
+        description = "'원본 워크북이 수정되었습니다.'"
+    )
     @Override
     public void edit(EditOriginalWorkbookCommand command) {
         OriginalWorkbook workbook = loadOriginalWorkbookPort.getById(command.originalWorkbookId());
@@ -73,6 +92,13 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
         saveOriginalWorkbookPort.save(workbook);
     }
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.DELETE,
+        targetType = "OriginalWorkbook",
+        targetId = "#originalWorkbookId",
+        description = "'원본 워크북이 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long originalWorkbookId) {
         OriginalWorkbook workbook = loadOriginalWorkbookPort.getById(originalWorkbookId);
@@ -101,6 +127,12 @@ public class OriginalWorkbookCommandService implements ManageOriginalWorkbookUse
 
     // ===== AutoReleaseWorkbookUseCase =====
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.PUBLISH,
+        targetType = "OriginalWorkbook",
+        description = "'배포 예정 워크북 자동 배포가 실행되었습니다.'"
+    )
     @Override
     public int releaseAllDue() {
         throw new NotImplementedException();

--- a/src/main/java/com/umc/product/curriculum/application/service/command/WeeklyBestWorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/WeeklyBestWorkbookCommandService.java
@@ -22,7 +22,7 @@ public class WeeklyBestWorkbookCommandService implements ManageWeeklyBestWorkboo
         domain = Domain.CURRICULUM,
         action = AuditAction.APPROVE,
         targetType = "WeeklyBestWorkbook",
-        description = "'주간 베스트 워크북이 선정되었습니다.'"
+        description = "'주간 베스트 워크북을 선정했습니다.'"
     )
     @Override
     public void selectBest(CreateWeeklyBestWorkbookCommand command) {

--- a/src/main/java/com/umc/product/curriculum/application/service/command/WeeklyBestWorkbookCommandService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/command/WeeklyBestWorkbookCommandService.java
@@ -1,18 +1,29 @@
 package com.umc.product.curriculum.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.curriculum.application.port.in.command.ManageWeeklyBestWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.CreateWeeklyBestWorkbookCommand;
 import com.umc.product.curriculum.application.port.in.command.dto.workbook.EditWeeklyBestWorkbookCommand;
 import com.umc.product.global.exception.NotImplementedException;
+import com.umc.product.global.exception.constant.Domain;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class WeeklyBestWorkbookCommandService implements ManageWeeklyBestWorkbookUseCase {
 
+    @Audited(
+        domain = Domain.CURRICULUM,
+        action = AuditAction.APPROVE,
+        targetType = "WeeklyBestWorkbook",
+        description = "'주간 베스트 워크북이 선정되었습니다.'"
+    )
     @Override
     public void selectBest(CreateWeeklyBestWorkbookCommand command) {
         throw new NotImplementedException();

--- a/src/main/java/com/umc/product/feedback/application/service/command/UserFeedbackResponseCommandService.java
+++ b/src/main/java/com/umc/product/feedback/application/service/command/UserFeedbackResponseCommandService.java
@@ -3,10 +3,13 @@ package com.umc.product.feedback.application.service.command;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.feedback.application.port.in.command.SubmitUserFeedbackResponseUseCase;
 import com.umc.product.feedback.application.port.in.command.dto.SubmitUserFeedbackResponseCommand;
 import com.umc.product.feedback.application.port.out.LoadUserFeedbackTemplatePort;
 import com.umc.product.feedback.domain.UserFeedbackTemplate;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.SubmitFormResponseCommand;
 
@@ -20,6 +23,13 @@ public class UserFeedbackResponseCommandService implements SubmitUserFeedbackRes
     private final LoadUserFeedbackTemplatePort loadUserFeedbackTemplatePort;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
 
+    @Audited(
+        domain = Domain.FEEDBACK,
+        action = AuditAction.SUBMIT,
+        targetType = "UserFeedbackResponse",
+        targetId = "#result",
+        description = "'사용자 피드백 응답이 제출되었습니다.'"
+    )
     @Override
     public Long submit(SubmitUserFeedbackResponseCommand command) {
         UserFeedbackTemplate template = loadUserFeedbackTemplatePort.getById(command.templateId());

--- a/src/main/java/com/umc/product/feedback/application/service/command/UserFeedbackResponseCommandService.java
+++ b/src/main/java/com/umc/product/feedback/application/service/command/UserFeedbackResponseCommandService.java
@@ -28,7 +28,7 @@ public class UserFeedbackResponseCommandService implements SubmitUserFeedbackRes
         action = AuditAction.SUBMIT,
         targetType = "UserFeedbackResponse",
         targetId = "#result",
-        description = "'사용자 피드백 응답이 제출되었습니다.'"
+        description = "'사용자 피드백 응답을 제출했습니다.'"
     )
     @Override
     public Long submit(SubmitUserFeedbackResponseCommand command) {

--- a/src/main/java/com/umc/product/figma/adapter/in/scheduler/FigmaCommentDispatchRetentionScheduler.java
+++ b/src/main/java/com/umc/product/figma/adapter/in/scheduler/FigmaCommentDispatchRetentionScheduler.java
@@ -1,13 +1,18 @@
 package com.umc.product.figma.adapter.in.scheduler;
 
-import com.umc.product.figma.adapter.out.external.FigmaSummaryProperties;
-import com.umc.product.figma.config.FigmaSyncProperties;
-import com.umc.product.figma.application.port.out.SaveFigmaCommentDispatchPort;
+import java.time.Duration;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.figma.adapter.out.external.FigmaSummaryProperties;
+import com.umc.product.figma.application.port.out.SaveFigmaCommentDispatchPort;
+import com.umc.product.figma.config.FigmaSyncProperties;
+import com.umc.product.global.logging.OperationalMetrics;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * figma_comment_dispatch 의 보존 기간 초과 행을 정리하는 회수 잡 (ADR-004 §Implementation Plan §7).
@@ -24,21 +29,37 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FigmaCommentDispatchRetentionScheduler {
 
+    private static final String JOB_NAME = "figma_comment_dispatch_retention";
+
     private final SaveFigmaCommentDispatchPort saveFigmaCommentDispatchPort;
     private final FigmaSyncProperties figmaSyncProperties;
     private final FigmaSummaryProperties figmaSummaryProperties;
+    private final OperationalMetrics operationalMetrics;
 
     @Scheduled(fixedDelayString = "${app.figma.summary.retention-poll-interval}")
     public void purge() {
         if (!figmaSyncProperties.enabled()) {
             return;
         }
+        Instant startedAt = Instant.now();
         Instant threshold = Instant.now().minus(figmaSummaryProperties.dispatchRetention());
-        int deleted = saveFigmaCommentDispatchPort.deleteOlderThan(threshold);
-        if (deleted > 0) {
-            log.info("figma_comment_dispatch 회수 완료: threshold={}, deleted={}", threshold, deleted);
-        } else {
-            log.debug("figma_comment_dispatch 회수: 보존 기간 초과 행 없음. threshold={}", threshold);
+        try {
+            int deleted = saveFigmaCommentDispatchPort.deleteOlderThan(threshold);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "success", duration, deleted);
+            if (deleted > 0) {
+                log.info("batch job completed: jobName={}, threshold={}, processed={}, durationMs={}, result={}",
+                    JOB_NAME, threshold, deleted, duration.toMillis(), "success");
+            } else {
+                log.debug("batch job completed: jobName={}, threshold={}, processed={}, durationMs={}, result={}",
+                    JOB_NAME, threshold, deleted, duration.toMillis(), "success");
+            }
+        } catch (RuntimeException e) {
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "failure", duration, 0);
+            log.error("batch job failed: jobName={}, threshold={}, durationMs={}, result={}, errorClass={}",
+                JOB_NAME, threshold, duration.toMillis(), "failure", e.getClass().getSimpleName(), e);
+            throw e;
         }
     }
 }

--- a/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
@@ -5,6 +5,7 @@ import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage;
 import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage.CommentEntry;
 import com.umc.product.figma.domain.exception.FigmaDomainException;
 import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -493,12 +494,14 @@ public class DiscordMentionWebhookAdapter implements SendDiscordMentionPort {
             payload.put("allowed_mentions", Map.of("parse", List.of("roles", "users")));
 
             try {
-                restClient.post()
-                    .uri(message.webhookUrl())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(payload)
-                    .retrieve()
-                    .toBodilessEntity();
+                ExternalApiCallLogger.measure("DISCORD", "SEND_FIGMA_DOMAIN_BATCH", () ->
+                    restClient.post()
+                        .uri(message.webhookUrl())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(payload)
+                        .retrieve()
+                        .toBodilessEntity()
+                );
                 sent.addAll(commentIdsByPage.get(i));
                 log.debug("Discord domain batch 전송 완료: domainKey={}, page={}/{}, comments={}",
                     message.domainKey(), i + 1, pages.size(), message.comments().size());

--- a/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
@@ -503,9 +503,9 @@ public class DiscordMentionWebhookAdapter implements SendDiscordMentionPort {
                 log.debug("Discord domain batch 전송 완료: domainKey={}, page={}/{}, comments={}",
                     message.domainKey(), i + 1, pages.size(), message.comments().size());
             } catch (RestClientResponseException e) {
-                log.error("Discord domain batch 전송 실패: domainKey={}, page={}/{}, status={}, body={}",
+                log.error("Discord domain batch 전송 실패: domainKey={}, page={}/{}, status={}, bodyLength={}",
                     message.domainKey(), i + 1, pages.size(),
-                    e.getStatusCode(), e.getResponseBodyAsString());
+                    e.getStatusCode(), e.getResponseBodyAsByteArray().length);
                 if (sent.isEmpty()) {
                     throw new FigmaDomainException(FigmaErrorCode.DISCORD_MENTION_SEND_FAILED);
                 }

--- a/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
@@ -1,11 +1,5 @@
 package com.umc.product.figma.adapter.out.external;
 
-import com.umc.product.figma.application.port.out.SendDiscordMentionPort;
-import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage;
-import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage.CommentEntry;
-import com.umc.product.figma.domain.exception.FigmaDomainException;
-import com.umc.product.figma.domain.exception.FigmaErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -17,12 +11,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+
+import com.umc.product.figma.application.port.out.SendDiscordMentionPort;
+import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage;
+import com.umc.product.figma.application.port.out.dto.DiscordDomainBatchMessage.CommentEntry;
+import com.umc.product.figma.domain.exception.FigmaDomainException;
+import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 도메인 단위로 묶인 댓글 batch 를 Discord 로 발송하는 webhook 어댑터.

--- a/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java
@@ -506,7 +506,7 @@ public class DiscordMentionWebhookAdapter implements SendDiscordMentionPort {
                         .toBodilessEntity()
                 );
                 sent.addAll(commentIdsByPage.get(i));
-                log.debug("Discord domain batch 전송 완료: domainKey={}, page={}/{}, comments={}",
+                log.debug("Discord domain batch를 전송했습니다: domainKey={}, page={}/{}, comments={}",
                     message.domainKey(), i + 1, pages.size(), message.comments().size());
             } catch (RestClientResponseException e) {
                 log.error("Discord domain batch 전송 실패: domainKey={}, page={}/{}, status={}, bodyLength={}",

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
@@ -62,8 +62,8 @@ public class FigmaCommentClient implements FetchFigmaCommentPort {
                 .body(Map.class);
             return body != null ? body : Map.of();
         } catch (RestClientResponseException e) {
-            log.warn("Figma 댓글 조회 실패: fileKey={}, cursor={}, status={}, body={}",
-                fileKey, cursor, e.getStatusCode(), e.getResponseBodyAsString());
+            log.warn("Figma 댓글 조회 실패: fileKey={}, cursor={}, status={}, bodyLength={}",
+                fileKey, cursor, e.getStatusCode(), e.getResponseBodyAsByteArray().length);
             throw new FigmaDomainException(FigmaErrorCode.COMMENT_FETCH_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
@@ -4,6 +4,7 @@ import com.umc.product.figma.application.port.out.FetchFigmaCommentPort;
 import com.umc.product.figma.application.port.out.dto.FigmaCommentInfo;
 import com.umc.product.figma.domain.exception.FigmaDomainException;
 import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -55,11 +56,13 @@ public class FigmaCommentClient implements FetchFigmaCommentPort {
             ? String.format(COMMENTS_URI_TEMPLATE, fileKey)
             : String.format(COMMENTS_CURSOR_URI_TEMPLATE, fileKey, cursor);
         try {
-            Map<String, Object> body = restClient.get()
-                .uri(uri)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
-                .body(Map.class);
+            Map<String, Object> body = ExternalApiCallLogger.measure("FIGMA", "LIST_COMMENTS", () ->
+                restClient.get()
+                    .uri(uri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(Map.class)
+            );
             return body != null ? body : Map.of();
         } catch (RestClientResponseException e) {
             log.warn("Figma 댓글 조회 실패: fileKey={}, cursor={}, status={}, bodyLength={}",

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java
@@ -1,22 +1,25 @@
 package com.umc.product.figma.adapter.out.external;
 
-import com.umc.product.figma.application.port.out.FetchFigmaCommentPort;
-import com.umc.product.figma.application.port.out.dto.FigmaCommentInfo;
-import com.umc.product.figma.domain.exception.FigmaDomainException;
-import com.umc.product.figma.domain.exception.FigmaErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+
+import com.umc.product.figma.application.port.out.FetchFigmaCommentPort;
+import com.umc.product.figma.application.port.out.dto.FigmaCommentInfo;
+import com.umc.product.figma.domain.exception.FigmaDomainException;
+import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
@@ -1,19 +1,22 @@
 package com.umc.product.figma.adapter.out.external;
 
-import com.umc.product.figma.application.port.out.FetchFigmaFileMetadataPort;
-import com.umc.product.figma.domain.exception.FigmaDomainException;
-import com.umc.product.figma.domain.exception.FigmaErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+
+import com.umc.product.figma.application.port.out.FetchFigmaFileMetadataPort;
+import com.umc.product.figma.domain.exception.FigmaDomainException;
+import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
@@ -41,8 +41,8 @@ public class FigmaFileMetadataClient implements FetchFigmaFileMetadataPort {
 
             return parsePageNames(body, nodeIds);
         } catch (RestClientResponseException e) {
-            log.warn("Figma 파일 메타데이터 조회 실패: fileKey={}, status={}, body={}",
-                fileKey, e.getStatusCode(), e.getResponseBodyAsString());
+            log.warn("Figma 파일 메타데이터 조회 실패: fileKey={}, status={}, bodyLength={}",
+                fileKey, e.getStatusCode(), e.getResponseBodyAsByteArray().length);
             throw new FigmaDomainException(FigmaErrorCode.FILE_METADATA_FETCH_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java
@@ -3,6 +3,7 @@ package com.umc.product.figma.adapter.out.external;
 import com.umc.product.figma.application.port.out.FetchFigmaFileMetadataPort;
 import com.umc.product.figma.domain.exception.FigmaDomainException;
 import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,11 +34,13 @@ public class FigmaFileMetadataClient implements FetchFigmaFileMetadataPort {
         String idsParam = String.join(",", nodeIds);
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> body = restClient.get()
-                .uri(String.format(FILE_NODES_URI_TEMPLATE, fileKey, idsParam))
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
-                .body(Map.class);
+            Map<String, Object> body = ExternalApiCallLogger.measure("FIGMA", "RESOLVE_FILE_NODES", () ->
+                restClient.get()
+                    .uri(String.format(FILE_NODES_URI_TEMPLATE, fileKey, idsParam))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(Map.class)
+            );
 
             return parsePageNames(body, nodeIds);
         } catch (RestClientResponseException e) {

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
@@ -47,7 +47,8 @@ public class FigmaOAuthClient implements FigmaOAuthPort {
                 .body(Map.class);
             return toTokenInfo(response, /* fallbackRefreshToken */ null);
         } catch (RestClientResponseException e) {
-            log.error("Figma OAuth code 교환 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            log.error("Figma OAuth code 교환 실패: status={}, bodyLength={}",
+                e.getStatusCode(), e.getResponseBodyAsByteArray().length);
             throw new FigmaDomainException(FigmaErrorCode.OAUTH_TOKEN_EXCHANGE_FAILED);
         }
     }
@@ -69,7 +70,8 @@ public class FigmaOAuthClient implements FigmaOAuthPort {
                 .body(Map.class);
             return toTokenInfo(response, refreshToken);
         } catch (RestClientResponseException e) {
-            log.error("Figma OAuth refresh 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            log.error("Figma OAuth refresh 실패: status={}, bodyLength={}",
+                e.getStatusCode(), e.getResponseBodyAsByteArray().length);
             throw new FigmaDomainException(FigmaErrorCode.OAUTH_TOKEN_REFRESH_FAILED);
         }
     }

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
@@ -4,6 +4,7 @@ import com.umc.product.figma.application.port.out.FigmaOAuthPort;
 import com.umc.product.figma.application.port.out.dto.FigmaTokenInfo;
 import com.umc.product.figma.domain.exception.FigmaDomainException;
 import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -39,12 +40,14 @@ public class FigmaOAuthClient implements FigmaOAuthPort {
 
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> response = restClient.post()
-                .uri(properties.tokenUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(form)
-                .retrieve()
-                .body(Map.class);
+            Map<String, Object> response = ExternalApiCallLogger.measure("FIGMA", "EXCHANGE_OAUTH_CODE", () ->
+                restClient.post()
+                    .uri(properties.tokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(Map.class)
+            );
             return toTokenInfo(response, /* fallbackRefreshToken */ null);
         } catch (RestClientResponseException e) {
             log.error("Figma OAuth code 교환 실패: status={}, bodyLength={}",
@@ -62,12 +65,14 @@ public class FigmaOAuthClient implements FigmaOAuthPort {
 
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> response = restClient.post()
-                .uri(properties.refreshUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(form)
-                .retrieve()
-                .body(Map.class);
+            Map<String, Object> response = ExternalApiCallLogger.measure("FIGMA", "REFRESH_OAUTH_TOKEN", () ->
+                restClient.post()
+                    .uri(properties.refreshUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(form)
+                    .retrieve()
+                    .body(Map.class)
+            );
             return toTokenInfo(response, refreshToken);
         } catch (RestClientResponseException e) {
             log.error("Figma OAuth refresh 실패: status={}, bodyLength={}",

--- a/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
+++ b/src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java
@@ -1,21 +1,24 @@
 package com.umc.product.figma.adapter.out.external;
 
-import com.umc.product.figma.application.port.out.FigmaOAuthPort;
-import com.umc.product.figma.application.port.out.dto.FigmaTokenInfo;
-import com.umc.product.figma.domain.exception.FigmaDomainException;
-import com.umc.product.figma.domain.exception.FigmaErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
+
+import com.umc.product.figma.application.port.out.FigmaOAuthPort;
+import com.umc.product.figma.application.port.out.dto.FigmaTokenInfo;
+import com.umc.product.figma.domain.exception.FigmaDomainException;
+import com.umc.product.figma.domain.exception.FigmaErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/figma/application/service/FigmaCommentDigestService.java
+++ b/src/main/java/com/umc/product/figma/application/service/FigmaCommentDigestService.java
@@ -45,7 +45,7 @@ public class FigmaCommentDigestService implements DigestFigmaCommentsUseCase {
             .map(d -> new FigmaDigestSummary.DomainResult(d.domainKey(), d.comments().size(), d.sent()))
             .toList();
 
-        log.info("Figma digest 완료: from={}, to={}, total={}, unmatched={}, skippedDispatched={}, domains={}",
+        log.info("Figma digest를 생성했습니다: from={}, to={}, total={}, unmatched={}, skippedDispatched={}, domains={}",
             result.from(), result.to(), result.totalComments(), result.unmatchedCount(),
             result.skippedAlreadyDispatchedCount(), domainResults.size());
 

--- a/src/main/java/com/umc/product/figma/application/service/FigmaCommentDomainClassifier.java
+++ b/src/main/java/com/umc/product/figma/application/service/FigmaCommentDomainClassifier.java
@@ -1,5 +1,16 @@
 package com.umc.product.figma.application.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.product.figma.application.port.out.FigmaClassificationCachePort;
@@ -10,16 +21,8 @@ import com.umc.product.llm.application.port.in.ChatCompleteUseCase;
 import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
 import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
 import com.umc.product.llm.domain.exception.LlmDomainException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 /**
  * Figma 댓글 본문을 LLM 으로 분석해 등록된 라우팅 도메인 키 중 하나로 분류한다. 후보 도메인 리스트는 운영진이 figma_routing_domain 에 등록한 도메인 키들에서 가져오며, LLM 응답이
@@ -207,7 +210,7 @@ public class FigmaCommentDomainClassifier {
                 // 호출은 성공했으나 응답이 후보에 매칭되지 않음 → callSucceeded=true 로 negative 캐싱 허용.
                 return new SingleClassifyOutcome(null, true);
             }
-            log.debug("LLM 분류 성공: commentId={}, picked={}, provider={}",
+            log.debug("LLM 분류를 완료했습니다: commentId={}, picked={}, provider={}",
                 comment.commentId(), picked, result.provider());
             persistIfEligible(comment.commentId(), picked, result.provider());
             return new SingleClassifyOutcome(picked, true);

--- a/src/main/java/com/umc/product/figma/application/service/FigmaIntegrationCommandService.java
+++ b/src/main/java/com/umc/product/figma/application/service/FigmaIntegrationCommandService.java
@@ -1,5 +1,11 @@
 package com.umc.product.figma.application.service;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.figma.application.port.in.RegisterFigmaIntegrationUseCase;
 import com.umc.product.figma.application.port.in.dto.RegisterFigmaIntegrationCommand;
 import com.umc.product.figma.application.port.out.FigmaOAuthPort;
@@ -9,12 +15,9 @@ import com.umc.product.figma.application.port.out.dto.FigmaTokenInfo;
 import com.umc.product.figma.domain.FigmaIntegration;
 import com.umc.product.figma.domain.exception.FigmaDomainException;
 import com.umc.product.figma.domain.exception.FigmaErrorCode;
-import java.time.Instant;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Figma OAuth 위임 통합의 Command 서비스. - authorization code → token 교환 후 영속화 - access token 만료 시 refresh - state 발급/검증은
@@ -56,7 +59,7 @@ public class FigmaIntegrationCommandService implements RegisterFigmaIntegrationU
             ));
 
         FigmaIntegration saved = saveFigmaIntegrationPort.save(integration);
-        log.info("Figma 통합 등록 완료: ownerMemberId={}, integrationId={}",
+        log.info("Figma 통합을 등록했습니다: ownerMemberId={}, integrationId={}",
             command.ownerMemberId(), saved.getId());
         return saved.getId();
     }

--- a/src/main/java/com/umc/product/global/config/FcmConfig.java
+++ b/src/main/java/com/umc/product/global/config/FcmConfig.java
@@ -31,7 +31,7 @@ public class FcmConfig {
             new ByteArrayInputStream(firebaseCredentials.getBytes(StandardCharsets.UTF_8))
         );
 
-        log.debug("Firebase credentials 로드 완료");
+        log.debug("Firebase credentials를 로드했습니다");
 
         FirebaseApp firebaseApp = null;
         List<FirebaseApp> apps = FirebaseApp.getApps();
@@ -54,10 +54,10 @@ public class FcmConfig {
                     .build();
 
             firebaseApp = FirebaseApp.initializeApp(options);
-            log.info("FirebaseApp 초기화 완료: {}", firebaseApp.getName());
+            log.info("FirebaseApp을 초기화했습니다: name={}", firebaseApp.getName());
         }
 
-        log.info("FirebaseMessaging 인스턴스 생성 완료");
+        log.info("FirebaseMessaging 인스턴스를 생성했습니다");
         return FirebaseMessaging.getInstance(firebaseApp);
     }
 }

--- a/src/main/java/com/umc/product/global/config/FcmConfig.java
+++ b/src/main/java/com/umc/product/global/config/FcmConfig.java
@@ -1,17 +1,20 @@
 package com.umc.product.global.config;
 
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
-import com.google.firebase.messaging.FirebaseMessaging;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
@@ -28,29 +31,18 @@ public class FcmConfig {
             new ByteArrayInputStream(firebaseCredentials.getBytes(StandardCharsets.UTF_8))
         );
 
-        // private_key가 제대로 파싱됐는지 확인
-        if (credentials instanceof com.google.auth.oauth2.ServiceAccountCredentials saCreds) {
-            log.debug("service account email: {}", saCreds.getClientEmail());
-            log.debug("private key algorithm: {}", saCreds.getPrivateKey().getAlgorithm());
-            log.debug("private key format: {}", saCreds.getPrivateKey().getFormat());
-        }
-
         log.debug("Firebase credentials 로드 완료");
-
-        log.trace("Firebase credentials 길이: {}", firebaseCredentials.length());
-        log.trace("Firebase credentials 시작: {}",
-            firebaseCredentials.substring(0, Math.min(30, firebaseCredentials.length())));
 
         FirebaseApp firebaseApp = null;
         List<FirebaseApp> apps = FirebaseApp.getApps();
 
         if (apps != null && !apps.isEmpty()) {
-            log.info("기존 FirebaseApp 검색 중... (총 {}개)", apps.size());
+            log.debug("기존 FirebaseApp 검색 중: count={}", apps.size());
 
             for (FirebaseApp app : apps) {
                 if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
                     firebaseApp = app;
-                    log.info("기존 FirebaseApp 발견: {}", app.getName());
+                    log.debug("기존 FirebaseApp 발견: name={}", app.getName());
                 }
             }
         } else {

--- a/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
+++ b/src/main/java/com/umc/product/global/logging/ExternalApiCallLogger.java
@@ -2,7 +2,9 @@ package com.umc.product.global.logging;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
+import java.time.Duration;
 import java.util.function.Supplier;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +44,14 @@ public final class ExternalApiCallLogger {
     private static final Logger log = LoggerFactory.getLogger("external_api");
 
     private static final String EVENT = "external_api_called";
+    private static volatile OperationalMetrics operationalMetrics;
 
     private ExternalApiCallLogger() {
         // util
+    }
+
+    static void setOperationalMetrics(OperationalMetrics metrics) {
+        operationalMetrics = metrics;
     }
 
     /**
@@ -64,24 +71,35 @@ public final class ExternalApiCallLogger {
         long startNanos = System.nanoTime();
         try {
             T result = call.get();
+            long elapsedNanos = System.nanoTime() - startNanos;
+            recordMetric(provider, operation, "success", elapsedNanos);
             log.info(
                 EVENT,
                 kv("provider", provider),
                 kv("operation", operation),
                 kv("result", "SUCCESS"),
-                kv("durationMs", (System.nanoTime() - startNanos) / 1_000_000L)
+                kv("durationMs", elapsedNanos / 1_000_000L)
             );
             return result;
         } catch (RuntimeException e) {
+            long elapsedNanos = System.nanoTime() - startNanos;
+            recordMetric(provider, operation, "failure", elapsedNanos);
             log.warn(
                 EVENT,
                 kv("provider", provider),
                 kv("operation", operation),
                 kv("result", "FAILURE"),
-                kv("durationMs", (System.nanoTime() - startNanos) / 1_000_000L),
+                kv("durationMs", elapsedNanos / 1_000_000L),
                 kv("errorClass", e.getClass().getSimpleName())
             );
             throw e;
+        }
+    }
+
+    private static void recordMetric(String provider, String operation, String result, long elapsedNanos) {
+        OperationalMetrics metrics = operationalMetrics;
+        if (metrics != null) {
+            metrics.recordExternalCall(provider, operation, result, Duration.ofNanos(elapsedNanos));
         }
     }
 

--- a/src/main/java/com/umc/product/global/logging/ExternalApiCallMetricsBinder.java
+++ b/src/main/java/com/umc/product/global/logging/ExternalApiCallMetricsBinder.java
@@ -1,0 +1,18 @@
+package com.umc.product.global.logging;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PreDestroy;
+
+@Component
+class ExternalApiCallMetricsBinder {
+
+    ExternalApiCallMetricsBinder(OperationalMetrics operationalMetrics) {
+        ExternalApiCallLogger.setOperationalMetrics(operationalMetrics);
+    }
+
+    @PreDestroy
+    void clear() {
+        ExternalApiCallLogger.setOperationalMetrics(null);
+    }
+}

--- a/src/main/java/com/umc/product/global/logging/OperationalMetrics.java
+++ b/src/main/java/com/umc/product/global/logging/OperationalMetrics.java
@@ -1,0 +1,111 @@
+package com.umc.product.global.logging;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * 운영 관측용 metric recorder.
+ *
+ * <p>cardinality 폭증을 막기 위해 memberId, fileId, requestId 같은 개별 식별자는 tag 로 받지 않는다.
+ */
+@Component
+public class OperationalMetrics {
+
+    private static final String METRIC_EXTERNAL_LATENCY = "operational.external.call.seconds";
+    private static final String METRIC_EXTERNAL_TOTAL = "operational.external.call.total";
+    private static final String METRIC_BATCH_LATENCY = "operational.batch.job.seconds";
+    private static final String METRIC_BATCH_TOTAL = "operational.batch.job.total";
+    private static final String METRIC_BATCH_PROCESSED = "operational.batch.job.processed.total";
+    private static final String METRIC_NOTIFICATION_TOTAL = "operational.notification.send.total";
+    private static final String METRIC_SECURITY_TOTAL = "operational.security.event.total";
+    private static final int MAX_TAG_VALUE_LENGTH = 64;
+    private static final Pattern HIGH_CARDINALITY_VALUE = Pattern.compile(
+        ".*([/?=&@]|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\\d{6,}).*"
+    );
+
+    private final MeterRegistry registry;
+
+    public OperationalMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordExternalCall(String provider, String operation, String result, Duration latency) {
+        Timer.builder(METRIC_EXTERNAL_LATENCY)
+            .tag("provider", normalize(provider))
+            .tag("operation", normalize(operation))
+            .tag("result", normalize(result))
+            .register(registry)
+            .record(nonNegative(latency));
+        Counter.builder(METRIC_EXTERNAL_TOTAL)
+            .tag("provider", normalize(provider))
+            .tag("operation", normalize(operation))
+            .tag("result", normalize(result))
+            .register(registry)
+            .increment();
+    }
+
+    public void recordBatchJob(String jobName, String result, Duration duration, long processed) {
+        Timer.builder(METRIC_BATCH_LATENCY)
+            .tag("jobName", normalize(jobName))
+            .tag("result", normalize(result))
+            .register(registry)
+            .record(nonNegative(duration));
+        Counter.builder(METRIC_BATCH_TOTAL)
+            .tag("jobName", normalize(jobName))
+            .tag("result", normalize(result))
+            .register(registry)
+            .increment();
+        if (processed > 0) {
+            Counter.builder(METRIC_BATCH_PROCESSED)
+                .tag("jobName", normalize(jobName))
+                .tag("result", normalize(result))
+                .register(registry)
+                .increment(processed);
+        }
+    }
+
+    public void recordNotification(String provider, String operation, String result, long count) {
+        if (count <= 0) {
+            return;
+        }
+        Counter.builder(METRIC_NOTIFICATION_TOTAL)
+            .tag("provider", normalize(provider))
+            .tag("operation", normalize(operation))
+            .tag("result", normalize(result))
+            .register(registry)
+            .increment(count);
+    }
+
+    public void recordSecurityEvent(String domain, String operation, String result) {
+        Counter.builder(METRIC_SECURITY_TOTAL)
+            .tag("domain", normalize(domain))
+            .tag("operation", normalize(operation))
+            .tag("result", normalize(result))
+            .register(registry)
+            .increment();
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        String normalized = value.trim();
+        if (normalized.length() > MAX_TAG_VALUE_LENGTH || HIGH_CARDINALITY_VALUE.matcher(normalized).matches()) {
+            return "other";
+        }
+        return normalized;
+    }
+
+    private static Duration nonNegative(Duration duration) {
+        if (duration == null || duration.isNegative()) {
+            return Duration.ZERO;
+        }
+        return duration;
+    }
+}

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -211,7 +211,7 @@ public class JwtTokenProvider {
             log.debug("지원되지 않는 JWT 토큰입니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
-            log.debug("JWT 토큰이 잘못되었습니다.");
+            log.debug("JWT token 형식이 올바르지 않습니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_JWT);
         }
 //        return false;

--- a/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/umc/product/global/security/JwtTokenProvider.java
@@ -202,16 +202,16 @@ public class JwtTokenProvider {
             parseClaims(token, secretKey);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
+            log.debug("잘못된 JWT 서명입니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.WRONG_JWT_SIGNATURE);
         } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
+            log.debug("만료된 JWT 토큰입니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
+            log.debug("지원되지 않는 JWT 토큰입니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
+            log.debug("JWT 토큰이 잘못되었습니다.");
             throw new AuthenticationDomainException(AuthenticationErrorCode.INVALID_JWT);
         }
 //        return false;

--- a/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiGeminiChatCompletionAdapter.java
+++ b/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiGeminiChatCompletionAdapter.java
@@ -1,17 +1,19 @@
 package com.umc.product.llm.adapter.out.external;
 
-import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
-import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
-import com.umc.product.llm.application.port.out.ChatCompletionPort;
-import com.umc.product.llm.domain.exception.LlmDomainException;
-import com.umc.product.llm.domain.exception.LlmErrorCode;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
+import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
+import com.umc.product.llm.application.port.out.ChatCompletionPort;
+import com.umc.product.llm.domain.exception.LlmDomainException;
+import com.umc.product.llm.domain.exception.LlmErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Spring AI ChatClient 위에 얹은 Vertex AI Gemini 어댑터.
@@ -64,7 +66,7 @@ public class SpringAiGeminiChatCompletionAdapter implements ChatCompletionPort {
             String normalized = ChatPromptHelper.normalizeResponse(content);
             Long promptTokens = ChatPromptHelper.extractPromptTokens(response);
             Long completionTokens = ChatPromptHelper.extractCompletionTokens(response);
-            log.debug("Gemini 호출 성공: model={}, length={}, promptTokens={}, completionTokens={}",
+            log.debug("Gemini 호출을 완료했습니다: model={}, length={}, promptTokens={}, completionTokens={}",
                 properties.model(), normalized.length(), promptTokens, completionTokens);
             return ChatCompletionResult.of(normalized, PROVIDER_NAME, promptTokens, completionTokens);
         } catch (Exception e) {

--- a/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiGoogleGenAiChatCompletionAdapter.java
+++ b/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiGoogleGenAiChatCompletionAdapter.java
@@ -1,17 +1,19 @@
 package com.umc.product.llm.adapter.out.external;
 
-import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
-import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
-import com.umc.product.llm.application.port.out.ChatCompletionPort;
-import com.umc.product.llm.domain.exception.LlmDomainException;
-import com.umc.product.llm.domain.exception.LlmErrorCode;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
+import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
+import com.umc.product.llm.application.port.out.ChatCompletionPort;
+import com.umc.product.llm.domain.exception.LlmDomainException;
+import com.umc.product.llm.domain.exception.LlmErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Spring AI ChatClient 위에 얹은 Google GenAI (Gemini Developer API) 어댑터.
@@ -68,7 +70,7 @@ public class SpringAiGoogleGenAiChatCompletionAdapter implements ChatCompletionP
             Long promptTokens = ChatPromptHelper.extractPromptTokens(response);
             Long completionTokens = ChatPromptHelper.extractCompletionTokens(response);
             log.debug(
-                "Google GenAI 호출 성공: model={}, length={}, promptTokens={}, completionTokens={}",
+                "Google GenAI 호출을 완료했습니다: model={}, length={}, promptTokens={}, completionTokens={}",
                 properties.model(), normalized.length(), promptTokens, completionTokens);
             return ChatCompletionResult.of(normalized, PROVIDER_NAME, promptTokens, completionTokens);
         } catch (Exception e) {

--- a/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiOpenAiChatCompletionAdapter.java
+++ b/src/main/java/com/umc/product/llm/adapter/out/external/SpringAiOpenAiChatCompletionAdapter.java
@@ -1,17 +1,19 @@
 package com.umc.product.llm.adapter.out.external;
 
-import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
-import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
-import com.umc.product.llm.application.port.out.ChatCompletionPort;
-import com.umc.product.llm.domain.exception.LlmDomainException;
-import com.umc.product.llm.domain.exception.LlmErrorCode;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.llm.application.port.in.dto.ChatCompleteCommand;
+import com.umc.product.llm.application.port.in.dto.ChatCompletionResult;
+import com.umc.product.llm.application.port.out.ChatCompletionPort;
+import com.umc.product.llm.domain.exception.LlmDomainException;
+import com.umc.product.llm.domain.exception.LlmErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Spring AI ChatClient 위에 얹은 OpenAI 어댑터.
@@ -63,7 +65,7 @@ public class SpringAiOpenAiChatCompletionAdapter implements ChatCompletionPort {
             String normalized = ChatPromptHelper.normalizeResponse(content);
             Long promptTokens = ChatPromptHelper.extractPromptTokens(response);
             Long completionTokens = ChatPromptHelper.extractCompletionTokens(response);
-            log.debug("OpenAI 호출 성공: model={}, length={}, promptTokens={}, completionTokens={}",
+            log.debug("OpenAI 호출을 완료했습니다: model={}, length={}, promptTokens={}, completionTokens={}",
                 properties.model(), normalized.length(), promptTokens, completionTokens);
             return ChatCompletionResult.of(normalized, PROVIDER_NAME, promptTokens, completionTokens);
         } catch (Exception e) {

--- a/src/main/java/com/umc/product/llm/application/service/ChatCompletionService.java
+++ b/src/main/java/com/umc/product/llm/application/service/ChatCompletionService.java
@@ -89,7 +89,7 @@ public class ChatCompletionService implements ChatCompleteUseCase {
         }
         String provider = chatCompletionPort.providerName();
         if (!callGuard.allow()) {
-            log.debug("LLM 호출 가드가 차단 상태입니다. 즉시 실패 응답 반환.");
+            log.debug("LLM 호출 가드가 요청을 차단했습니다. 실패 응답을 반환합니다.");
             metrics.recordCall(provider, LlmMetrics.STATUS_CIRCUIT_OPEN, Duration.ZERO);
             throw new LlmDomainException(LlmErrorCode.CHAT_COMPLETION_FAILED, "AI 응답 생성이 잠시 제한됐어요. 잠시 후 다시 시도해주세요.");
         }
@@ -107,7 +107,7 @@ public class ChatCompletionService implements ChatCompleteUseCase {
             metrics.recordCall(result.provider(), LlmMetrics.STATUS_SUCCESS, latency);
             metrics.recordTokens(result.provider(), result.promptTokens(), result.completionTokens());
             callGuard.recordSuccess();
-            log.info("LLM 호출 완료: provider={}, latencyMs={}, promptTokens={}, completionTokens={}, responseLen={}",
+            log.info("LLM 호출을 완료했습니다: provider={}, latencyMs={}, promptTokens={}, completionTokens={}, responseLen={}",
                 result.provider(),
                 latency.toMillis(),
                 result.promptTokens(),

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
@@ -1,11 +1,13 @@
 package com.umc.product.member.adapter.in.web.dto.response;
 
+import java.util.List;
+
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
 import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
-import java.util.List;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java
@@ -7,7 +7,6 @@ import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.application.port.in.query.dto.MemberProfileInfo;
 import java.util.List;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 사용자 정보를 응답하는 DTO 입니다.
@@ -17,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
  * 추후 Public/Private 정보를 구분해서 사용해야 할 경우 분리가 필요합니다.
  */
 @Builder
-@Slf4j
 public record MemberInfoResponse(
     Long id,
     String name,

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberInfo.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberInfo.java
@@ -1,11 +1,13 @@
 package com.umc.product.member.application.port.in.query.dto;
 
+import java.util.List;
+
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.member.domain.Member;
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
-import java.util.List;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberInfo.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberInfo.java
@@ -7,12 +7,10 @@ import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
 import java.util.List;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 회원에 대한 모든 정보를 담고 있는 DTO
  */
-@Slf4j
 @Builder
 public record MemberInfo(
     Long id,
@@ -28,8 +26,6 @@ public record MemberInfo(
 ) {
     @Deprecated
     public static MemberInfo from(Member member) {
-        log.error("학교명과 프로필 이미지 링크를 포함하지 않는 생성자를 사용 중에 있습니다.");
-
         return new MemberInfo(
             member.getId(),
             member.getName(),
@@ -46,8 +42,6 @@ public record MemberInfo(
 
     @Deprecated
     public static MemberInfo from(Member member, String schoolName, String profileImageLink) {
-        log.error("챌린저 역할 정보를 포함하지 않는 생성자를 이용하고 있습니다.");
-
         return new MemberInfo(
             member.getId(),
             member.getName(),

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberProfileInfo.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberProfileInfo.java
@@ -1,6 +1,7 @@
 package com.umc.product.member.application.port.in.query.dto;
 
 import com.umc.product.member.domain.MemberProfile;
+
 import lombok.Builder;
 
 /**

--- a/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberProfileInfo.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/dto/MemberProfileInfo.java
@@ -2,14 +2,12 @@ package com.umc.product.member.application.port.in.query.dto;
 
 import com.umc.product.member.domain.MemberProfile;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 회원의 프로필 정보를 나타내는 DTO
  * <p>
  * 회원 자체의 ID나 프로필 이미지 등은 {@link MemberInfo}에 있습니다. 여기는 프로필 링크나 부가적인, 조회할 일이 적은 정보들을 포함합니다.
  */
-@Slf4j
 @Builder
 public record MemberProfileInfo(
     Long id,
@@ -22,7 +20,6 @@ public record MemberProfileInfo(
     // TODO: 도메인 로직으로 분리하는 것이 나은가? or Member를 제공받아서 getProfile() 등을 쓰는게 좋은가? 고민이 필요한 부분
     public static MemberProfileInfo from(MemberProfile memberProfile) {
         if (memberProfile == null) {
-            log.warn("MemberProfile이 null인 사용자를 호출하였습니다.");
             return MemberProfileInfo.builder().build();
         }
 

--- a/src/main/java/com/umc/product/member/application/service/MemberCredentialCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberCredentialCommandService.java
@@ -3,6 +3,9 @@ package com.umc.product.member.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.command.LockMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
@@ -22,6 +25,13 @@ public class MemberCredentialCommandService implements ManageMemberCredentialUse
 
     private final LoadMemberPort loadMemberPort;
 
+    @Audited(
+        domain = Domain.MEMBER,
+        action = AuditAction.CREATE,
+        targetType = "MemberCredential",
+        targetId = "#command.memberId()",
+        description = "'회원 자격증명이 등록되었습니다.'"
+    )
     @Override
     public void registerCredentialByEmail(RegisterMemberCredentialByEmailCommand command) {
         Member member = loadMemberPort.findById(command.memberId())
@@ -32,6 +42,13 @@ public class MemberCredentialCommandService implements ManageMemberCredentialUse
         member.registerCredential(command.encodedPassword());
     }
 
+    @Audited(
+        domain = Domain.MEMBER,
+        action = AuditAction.UPDATE,
+        targetType = "MemberCredential",
+        targetId = "#command.memberId()",
+        description = "'회원 비밀번호가 변경되었습니다.'"
+    )
     @Override
     public void changePassword(ChangeMemberPasswordCommand command) {
         Member member = loadMemberPort.findById(command.memberId())

--- a/src/main/java/com/umc/product/member/application/service/MemberCredentialCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberCredentialCommandService.java
@@ -30,7 +30,7 @@ public class MemberCredentialCommandService implements ManageMemberCredentialUse
         action = AuditAction.CREATE,
         targetType = "MemberCredential",
         targetId = "#command.memberId()",
-        description = "'회원 자격증명이 등록되었습니다.'"
+        description = "'회원 자격증명을 등록했습니다.'"
     )
     @Override
     public void registerCredentialByEmail(RegisterMemberCredentialByEmailCommand command) {
@@ -47,7 +47,7 @@ public class MemberCredentialCommandService implements ManageMemberCredentialUse
         action = AuditAction.UPDATE,
         targetType = "MemberCredential",
         targetId = "#command.memberId()",
-        description = "'회원 비밀번호가 변경되었습니다.'"
+        description = "'회원 비밀번호를 변경했습니다.'"
     )
     @Override
     public void changePassword(ChangeMemberPasswordCommand command) {

--- a/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
@@ -3,6 +3,9 @@ package com.umc.product.member.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.command.ChangeMemberEmailUseCase;
 import com.umc.product.member.application.port.in.command.dto.ChangeMemberEmailCommand;
 import com.umc.product.member.application.port.out.LoadMemberPort;
@@ -19,6 +22,13 @@ public class MemberEmailCommandService implements ChangeMemberEmailUseCase {
 
     private final LoadMemberPort loadMemberPort;
 
+    @Audited(
+        domain = Domain.MEMBER,
+        action = AuditAction.UPDATE,
+        targetType = "MemberEmail",
+        targetId = "#command.memberId()",
+        description = "'회원 이메일이 변경되었습니다.'"
+    )
     @Override
     public void changeEmail(ChangeMemberEmailCommand command) {
         Member member = loadMemberPort.findByIdForUpdate(command.memberId())

--- a/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberEmailCommandService.java
@@ -27,7 +27,7 @@ public class MemberEmailCommandService implements ChangeMemberEmailUseCase {
         action = AuditAction.UPDATE,
         targetType = "MemberEmail",
         targetId = "#command.memberId()",
-        description = "'회원 이메일이 변경되었습니다.'"
+        description = "'회원 이메일을 변경했습니다.'"
     )
     @Override
     public void changeEmail(ChangeMemberEmailCommand command) {

--- a/src/main/java/com/umc/product/member/application/service/MemberProfileCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberProfileCommandService.java
@@ -32,7 +32,7 @@ public class MemberProfileCommandService implements ManageMemberProfileUseCase {
         action = AuditAction.UPDATE,
         targetType = "MemberProfile",
         targetId = "#command.memberId()",
-        description = "'회원 프로필이 저장되었습니다.'"
+        description = "'회원 프로필을 저장했습니다.'"
     )
     @Override
     public void upsert(UpsertMemberProfileCommand command) {
@@ -56,7 +56,7 @@ public class MemberProfileCommandService implements ManageMemberProfileUseCase {
         action = AuditAction.DELETE,
         targetType = "MemberProfile",
         targetId = "#memberId",
-        description = "'회원 프로필이 삭제되었습니다.'"
+        description = "'회원 프로필을 삭제했습니다.'"
     )
     @Override
     public void delete(Long memberId) {

--- a/src/main/java/com/umc/product/member/application/service/MemberProfileCommandService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberProfileCommandService.java
@@ -1,5 +1,11 @@
 package com.umc.product.member.application.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.command.ManageMemberProfileUseCase;
 import com.umc.product.member.application.port.in.command.dto.UpsertMemberProfileCommand;
 import com.umc.product.member.application.port.out.LoadMemberPort;
@@ -9,9 +15,8 @@ import com.umc.product.member.domain.Member;
 import com.umc.product.member.domain.MemberProfile;
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,13 @@ public class MemberProfileCommandService implements ManageMemberProfileUseCase {
     private final SaveMemberPort saveMemberPort;
     private final SaveMemberProfilePort saveMemberProfilePort;
 
+    @Audited(
+        domain = Domain.MEMBER,
+        action = AuditAction.UPDATE,
+        targetType = "MemberProfile",
+        targetId = "#command.memberId()",
+        description = "'회원 프로필이 저장되었습니다.'"
+    )
     @Override
     public void upsert(UpsertMemberProfileCommand command) {
         Member member = loadMemberPort.findByIdForUpdate(command.memberId())
@@ -39,6 +51,13 @@ public class MemberProfileCommandService implements ManageMemberProfileUseCase {
         }
     }
 
+    @Audited(
+        domain = Domain.MEMBER,
+        action = AuditAction.DELETE,
+        targetType = "MemberProfile",
+        targetId = "#memberId",
+        description = "'회원 프로필이 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long memberId) {
         Member member = loadMemberPort.findByIdForUpdate(memberId)

--- a/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
+++ b/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
@@ -10,8 +10,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.notice.application.port.in.command.ManageNoticeContentUseCase;
 import com.umc.product.notice.application.port.in.command.ManageNoticeUseCase;
 import com.umc.product.notice.application.port.in.command.dto.CreateNoticeCommand;
@@ -74,6 +77,13 @@ public class NoticeService implements ManageNoticeUseCase {
         return ids;
     }
 
+    @Audited(
+        domain = Domain.NOTICE,
+        action = AuditAction.CREATE,
+        targetType = "Notice",
+        targetId = "#result",
+        description = "'공지사항이 생성되었습니다.'"
+    )
     @Override
     public Long createNotice(CreateNoticeCommand command) {
         if (!validateNoticeWritePermission(command.targetInfo(), command.memberId())) {
@@ -118,6 +128,13 @@ public class NoticeService implements ManageNoticeUseCase {
         return savedNotice.getId();
     }
 
+    @Audited(
+        domain = Domain.NOTICE,
+        action = AuditAction.UPDATE,
+        targetType = "Notice",
+        targetId = "#command.noticeId()",
+        description = "'공지사항이 수정되었습니다.'"
+    )
     @Override
     public void updateNoticeTitleOrContent(UpdateNoticeCommand command) {
         Notice notice = findNoticeById(command.noticeId());
@@ -127,6 +144,13 @@ public class NoticeService implements ManageNoticeUseCase {
 
     }
 
+    @Audited(
+        domain = Domain.NOTICE,
+        action = AuditAction.DELETE,
+        targetType = "Notice",
+        targetId = "#command.noticeId()",
+        description = "'공지사항이 삭제되었습니다.'"
+    )
     @Override
     public void deleteNotice(DeleteNoticeCommand command) {
         Notice notice = findNoticeById(command.noticeId());
@@ -142,6 +166,13 @@ public class NoticeService implements ManageNoticeUseCase {
         saveNoticePort.delete(notice);
     }
 
+    @Audited(
+        domain = Domain.NOTICE,
+        action = AuditAction.REMIND,
+        targetType = "Notice",
+        targetId = "#command.noticeId()",
+        description = "'공지사항 리마인드가 발송되었습니다.'"
+    )
     @Override
     public void remindNotice(SendNoticeReminderCommand command) {
         Notice notice = findNoticeById(command.noticeId());

--- a/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
+++ b/src/main/java/com/umc/product/notice/application/service/command/NoticeService.java
@@ -82,7 +82,7 @@ public class NoticeService implements ManageNoticeUseCase {
         action = AuditAction.CREATE,
         targetType = "Notice",
         targetId = "#result",
-        description = "'공지사항이 생성되었습니다.'"
+        description = "'공지사항을 생성했습니다.'"
     )
     @Override
     public Long createNotice(CreateNoticeCommand command) {
@@ -133,7 +133,7 @@ public class NoticeService implements ManageNoticeUseCase {
         action = AuditAction.UPDATE,
         targetType = "Notice",
         targetId = "#command.noticeId()",
-        description = "'공지사항이 수정되었습니다.'"
+        description = "'공지사항을 수정했습니다.'"
     )
     @Override
     public void updateNoticeTitleOrContent(UpdateNoticeCommand command) {
@@ -149,7 +149,7 @@ public class NoticeService implements ManageNoticeUseCase {
         action = AuditAction.DELETE,
         targetType = "Notice",
         targetId = "#command.noticeId()",
-        description = "'공지사항이 삭제되었습니다.'"
+        description = "'공지사항을 삭제했습니다.'"
     )
     @Override
     public void deleteNotice(DeleteNoticeCommand command) {
@@ -171,7 +171,7 @@ public class NoticeService implements ManageNoticeUseCase {
         action = AuditAction.REMIND,
         targetType = "Notice",
         targetId = "#command.noticeId()",
-        description = "'공지사항 리마인드가 발송되었습니다.'"
+        description = "'공지사항 리마인드를 발송했습니다.'"
     )
     @Override
     public void remindNotice(SendNoticeReminderCommand command) {

--- a/src/main/java/com/umc/product/notice/application/service/command/NoticeVoteResponseCommandService.java
+++ b/src/main/java/com/umc/product/notice/application/service/command/NoticeVoteResponseCommandService.java
@@ -40,7 +40,7 @@ public class NoticeVoteResponseCommandService implements ManageNoticeVoteRespons
         action = AuditAction.SUBMIT,
         targetType = "NoticeVoteResponse",
         targetId = "#result",
-        description = "'공지 투표 응답이 제출되었습니다.'"
+        description = "'공지 투표 응답을 제출했습니다.'"
     )
     @Override
     public Long submit(SubmitNoticeVoteResponseCommand command) {

--- a/src/main/java/com/umc/product/notice/application/service/command/NoticeVoteResponseCommandService.java
+++ b/src/main/java/com/umc/product/notice/application/service/command/NoticeVoteResponseCommandService.java
@@ -1,5 +1,14 @@
 package com.umc.product.notice.application.service.command;
 
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.notice.application.port.in.command.ManageNoticeVoteResponseUseCase;
 import com.umc.product.notice.application.port.in.command.dto.SubmitNoticeVoteResponseCommand;
 import com.umc.product.notice.application.port.in.command.dto.UpdateNoticeVoteResponseCommand;
@@ -14,12 +23,8 @@ import com.umc.product.survey.application.port.in.command.dto.DeleteFormResponse
 import com.umc.product.survey.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.survey.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.survey.application.port.in.query.GetVoteUseCase;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
@@ -30,6 +35,13 @@ public class NoticeVoteResponseCommandService implements ManageNoticeVoteRespons
     private final GetVoteUseCase getVoteUseCase;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
 
+    @Audited(
+        domain = Domain.NOTICE,
+        action = AuditAction.SUBMIT,
+        targetType = "NoticeVoteResponse",
+        targetId = "#result",
+        description = "'공지 투표 응답이 제출되었습니다.'"
+    )
     @Override
     public Long submit(SubmitNoticeVoteResponseCommand command) {
         NoticeVote noticeVote = loadOpenNoticeVote(command.noticeId());

--- a/src/main/java/com/umc/product/notice/domain/enums/NoticeTargetPattern.java
+++ b/src/main/java/com/umc/product/notice/domain/enums/NoticeTargetPattern.java
@@ -5,9 +5,6 @@ import com.umc.product.notice.domain.NoticeTargetInfo;
 import com.umc.product.notice.domain.exception.NoticeDomainException;
 import com.umc.product.notice.domain.exception.NoticeErrorCode;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public enum NoticeTargetPattern {
 
     // =============================
@@ -169,22 +166,16 @@ public enum NoticeTargetPattern {
             }
             // 교내운영진 공지 (schoolId 지정): part 유무와 무관하게 동일 패턴
             if (hasSchool) {
-                log.info("매칭된 NoticeTargetPattern: STAFF_SPECIFIC_GISU_SPECIFIC_SCHOOL");
                 return STAFF_SPECIFIC_GISU_SPECIFIC_SCHOOL;
             }
             if (hasPart) {
-                log.info("매칭된 NoticeTargetPattern: STAFF_SPECIFIC_GISU_SPECIFIC_PART");
                 return STAFF_SPECIFIC_GISU_SPECIFIC_PART;
             }
-            log.info("매칭된 NoticeTargetPattern: STAFF_SPECIFIC_GISU");
             return STAFF_SPECIFIC_GISU;
         }
 
         for (NoticeTargetPattern pattern : values()) {
             if (pattern.matches(hasGisu, hasChapter, hasSchool, hasPart, false)) {
-                log.info(
-                    "매칭된 NoticeTargetPattern: {}, hasGisu: {}, hasChapter: {}, hasSchool: {}, hasPart: {}",
-                    pattern.name(), hasGisu, hasChapter, hasSchool, hasPart);
                 return pattern;
             }
         }

--- a/src/main/java/com/umc/product/notification/adapter/in/event/ServerLifecycleAlarmListener.java
+++ b/src/main/java/com/umc/product/notification/adapter/in/event/ServerLifecycleAlarmListener.java
@@ -1,17 +1,20 @@
 package com.umc.product.notification.adapter.in.event;
 
-import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
-import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmCommand;
-import com.umc.product.notification.domain.WebhookPlatform;
-import jakarta.annotation.PreDestroy;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
+import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmCommand;
+import com.umc.product.notification.domain.WebhookPlatform;
+
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -35,7 +38,7 @@ public class ServerLifecycleAlarmListener {
             .build();
 
         sendWebhookAlarmUseCase.send(command);
-        log.info("서버 시작 알림 전송 완료 [time={}]", time);
+        log.info("서버 시작 알림을 전송했습니다: time={}", time);
     }
 
     @PreDestroy
@@ -49,6 +52,6 @@ public class ServerLifecycleAlarmListener {
             .build();
 
         sendWebhookAlarmUseCase.send(command);
-        log.info("서버 종료 알림 전송 완료 [time={}]", time);
+        log.info("서버 종료 알림을 전송했습니다: time={}", time);
     }
 }

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
@@ -4,6 +4,7 @@ import com.umc.product.notification.application.port.out.SendEmailPort;
 import com.umc.product.notification.application.port.out.dto.EmailMessage;
 import com.umc.product.notification.domain.exception.EmailDomainException;
 import com.umc.product.notification.domain.exception.EmailErrorCode;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -38,7 +39,9 @@ public class SesEmailAdapter implements SendEmailPort {
     public void send(EmailMessage message) {
         SendEmailRequest request = buildRequest(message);
         try {
-            SendEmailResponse response = sesV2Client.sendEmail(request);
+            SendEmailResponse response = ExternalApiCallLogger.measure("AWS_SES", "SEND_EMAIL", () ->
+                sesV2Client.sendEmail(request)
+            );
             log.info("SES 이메일 발송 성공: recipientPresent={}, messageId={}",
                 hasRecipient(message.to()), response.messageId());
         } catch (SesV2Exception e) {

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
@@ -44,7 +44,7 @@ public class SesEmailAdapter implements SendEmailPort {
             SendEmailResponse response = ExternalApiCallLogger.measure("AWS_SES", "SEND_EMAIL", () ->
                 sesV2Client.sendEmail(request)
             );
-            log.info("SES 이메일 발송 성공: recipientPresent={}, messageId={}",
+            log.info("SES 이메일을 발송했습니다: recipientPresent={}, messageId={}",
                 hasRecipient(message.to()), response.messageId());
         } catch (SesV2Exception e) {
             // 예외 삼킴 방지: AWS error code 까지 컨텍스트에 남기고 cause 를 포함해 도메인 예외로 변환한다.

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
@@ -1,13 +1,15 @@
 package com.umc.product.notification.adapter.out.external.ses;
 
+import org.springframework.stereotype.Component;
+
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import com.umc.product.notification.application.port.out.SendEmailPort;
 import com.umc.product.notification.application.port.out.dto.EmailMessage;
 import com.umc.product.notification.domain.exception.EmailDomainException;
 import com.umc.product.notification.domain.exception.EmailErrorCode;
-import com.umc.product.global.logging.ExternalApiCallLogger;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.Body;
 import software.amazon.awssdk.services.sesv2.model.Content;

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
@@ -39,14 +39,16 @@ public class SesEmailAdapter implements SendEmailPort {
         SendEmailRequest request = buildRequest(message);
         try {
             SendEmailResponse response = sesV2Client.sendEmail(request);
-            log.info("SES 이메일 발송 성공: to={}, messageId={}", message.to(), response.messageId());
+            log.info("SES 이메일 발송 성공: recipientPresent={}, messageId={}",
+                hasRecipient(message.to()), response.messageId());
         } catch (SesV2Exception e) {
             // 예외 삼킴 방지: AWS error code 까지 컨텍스트에 남기고 cause 를 포함해 도메인 예외로 변환한다.
             String awsErrorCode = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null;
-            log.error("SES 발송 실패: to={}, awsErrorCode={}", message.to(), awsErrorCode, e);
+            log.error("SES 발송 실패: recipientPresent={}, awsErrorCode={}",
+                hasRecipient(message.to()), awsErrorCode, e);
             throw new EmailDomainException(EmailErrorCode.EMAIL_SEND_FAILED, e);
         } catch (RuntimeException e) {
-            log.error("SES 발송 중 예기치 못한 예외: to={}", message.to(), e);
+            log.error("SES 발송 중 예기치 못한 예외: recipientPresent={}", hasRecipient(message.to()), e);
             throw new EmailDomainException(EmailErrorCode.EMAIL_SEND_FAILED, e);
         }
     }
@@ -83,5 +85,9 @@ public class SesEmailAdapter implements SendEmailPort {
             .replace("\\", "\\\\")
             .replace("\"", "\\\"");
         return String.format("\"%s\" <%s>", escapedDisplayName, fromAddress);
+    }
+
+    private boolean hasRecipient(String recipient) {
+        return recipient != null && !recipient.isBlank();
     }
 }

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
@@ -59,7 +59,7 @@ public class DiscordWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Discord 웹훅 전송 완료: parts={}", totalParts);
+        log.debug("Discord 웹훅을 전송했습니다: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
 import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,12 +46,14 @@ public class DiscordWebhookAdapter implements SendWebhookPort {
                 "description", chunks.get(i)
             );
 
-            restClient.post()
-                .uri(webhookUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of("embeds", List.of(embed)))
-                .retrieve()
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("DISCORD", "SEND_WEBHOOK", () ->
+                restClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("embeds", List.of(embed)))
+                    .retrieve()
+                    .toBodilessEntity()
+            );
         }
 
         log.debug("Discord 웹훅 전송 완료: title={}, parts={}", title, totalParts);

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
@@ -59,7 +59,7 @@ public class DiscordWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Discord 웹훅 전송 완료: title={}, parts={}", title, totalParts);
+        log.debug("Discord 웹훅 전송 완료: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java
@@ -1,17 +1,20 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
-import com.umc.product.notification.application.port.out.SendWebhookPort;
-import com.umc.product.global.logging.ExternalApiCallLogger;
-import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import com.umc.product.global.logging.ExternalApiCallLogger;
+import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.notification.domain.WebhookPlatform;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
 import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,12 +42,14 @@ public class SlackWebhookAdapter implements SendWebhookPort {
                 : "*" + title + " (" + (i + 1) + "/" + totalParts + ")*";
             String text = partTitle + "\n" + chunks.get(i);
 
-            restClient.post()
-                .uri(webhookUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of("text", text))
-                .retrieve()
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("SLACK", "SEND_WEBHOOK", () ->
+                restClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("text", text))
+                    .retrieve()
+                    .toBodilessEntity()
+            );
         }
 
         log.debug("Slack 웹훅 전송 완료: title={}, parts={}", title, totalParts);

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
@@ -55,7 +55,7 @@ public class SlackWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Slack 웹훅 전송 완료: parts={}", totalParts);
+        log.debug("Slack 웹훅을 전송했습니다: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
@@ -55,7 +55,7 @@ public class SlackWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Slack 웹훅 전송 완료: title={}, parts={}", title, totalParts);
+        log.debug("Slack 웹훅 전송 완료: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java
@@ -1,17 +1,20 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
-import com.umc.product.notification.application.port.out.SendWebhookPort;
-import com.umc.product.global.logging.ExternalApiCallLogger;
-import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import com.umc.product.global.logging.ExternalApiCallLogger;
+import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.notification.domain.WebhookPlatform;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
@@ -66,7 +66,7 @@ public class TelegramWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Telegram 웹훅 전송 완료: parts={}", totalParts);
+        log.debug("Telegram 웹훅을 전송했습니다: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
@@ -66,7 +66,7 @@ public class TelegramWebhookAdapter implements SendWebhookPort {
             );
         }
 
-        log.debug("Telegram 웹훅 전송 완료: title={}, parts={}", title, totalParts);
+        log.debug("Telegram 웹훅 전송 완료: parts={}", totalParts);
     }
 
     @Override

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
 import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.global.logging.ExternalApiCallLogger;
 import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,16 +49,18 @@ public class TelegramWebhookAdapter implements SendWebhookPort {
                 : "*" + escapedTitle + " \\(" + (i + 1) + "/" + totalParts + "\\)*";
             String text = partTitle + "\n" + chunks.get(i);
 
-            restClient.post()
-                .uri(TELEGRAM_API_URL, botToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of(
-                    "chat_id", chatId,
-                    "text", text,
-                    "parse_mode", "MarkdownV2"
-                ))
-                .retrieve()
-                .toBodilessEntity();
+            ExternalApiCallLogger.measure("TELEGRAM", "SEND_WEBHOOK", () ->
+                restClient.post()
+                    .uri(TELEGRAM_API_URL, botToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of(
+                        "chat_id", chatId,
+                        "text", text,
+                        "parse_mode", "MarkdownV2"
+                    ))
+                    .retrieve()
+                    .toBodilessEntity()
+            );
         }
 
         log.debug("Telegram 웹훅 전송 완료: title={}, parts={}", title, totalParts);

--- a/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java
@@ -1,17 +1,20 @@
 package com.umc.product.notification.adapter.out.external.webhook;
 
-import com.umc.product.notification.application.port.out.SendWebhookPort;
-import com.umc.product.global.logging.ExternalApiCallLogger;
-import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import com.umc.product.global.logging.ExternalApiCallLogger;
+import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.notification.domain.WebhookPlatform;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umc/product/notification/application/service/FcmAudienceService.java
+++ b/src/main/java/com/umc/product/notification/application/service/FcmAudienceService.java
@@ -51,7 +51,7 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
     public void sendToAudience(AudienceNotificationCommand command) {
 
         if (!fcmProperties.enabled()) {
-            log.info("[FCM 비활성화] sendToAudience 스킵");
+            log.info("[FCM 비활성화] sendToAudience를 건너뜁니다");
             return;
         }
 
@@ -69,14 +69,14 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
 
         SendBatchResult result = sendBatch(tokens, command.title(), command.body());
         recordFcmMetric("SEND_TO_AUDIENCE", result);
-        log.info("대상자 알림 발송 완료: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
+        log.info("대상자 알림을 발송했습니다: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
     }
 
     @Override
     public void sendToMember(NotificationCommand command) {
 
         if (!fcmProperties.enabled()) {
-            log.info("[FCM 비활성화] sendToMember 스킵 memberId={}", command.memberId());
+            log.info("[FCM 비활성화] sendToMember를 건너뜁니다: memberId={}", command.memberId());
             return;
         }
 
@@ -94,7 +94,7 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
     public void sendToMembers(List<Long> memberIds, String title, String body) {
 
         if (!fcmProperties.enabled()) {
-            log.info("[FCM 비활성화] sendToMembers 스킵 count={}", memberIds == null ? 0 : memberIds.size());
+            log.info("[FCM 비활성화] sendToMembers를 건너뜁니다: count={}", memberIds == null ? 0 : memberIds.size());
             return;
         }
 
@@ -110,7 +110,7 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
 
         SendBatchResult result = sendBatch(tokens, title, body);
         recordFcmMetric("SEND_TO_MEMBERS", result);
-        log.info("bulk 알림 발송 완료: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
+        log.info("bulk 알림을 발송했습니다: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
     }
 
     // =========== PRIVATE ===========
@@ -143,7 +143,7 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
             }
         }
 
-        log.info("FCM 발송 완료 성공={}, 실패={}", totalSuccess, totalFail);
+        log.info("FCM 발송 결과: success={}, failure={}", totalSuccess, totalFail);
         return new SendBatchResult(totalSuccess, totalFail);
     }
 

--- a/src/main/java/com/umc/product/notification/application/service/FcmAudienceService.java
+++ b/src/main/java/com/umc/product/notification/application/service/FcmAudienceService.java
@@ -1,5 +1,14 @@
 package com.umc.product.notification.application.service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -8,6 +17,7 @@ import com.google.firebase.messaging.Notification;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.global.config.FcmProperties;
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.notice.domain.NoticeTargetInfo;
 import com.umc.product.notification.application.port.in.SendNotificationToAudienceUseCase;
@@ -17,15 +27,9 @@ import com.umc.product.notification.application.port.out.LoadFcmPort;
 import com.umc.product.notification.domain.FcmToken;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -41,6 +45,7 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetMemberUseCase getMemberUseCase;
     private final GetChapterUseCase getChapterUseCase;
+    private final OperationalMetrics operationalMetrics;
 
     @Override
     public void sendToAudience(AudienceNotificationCommand command) {
@@ -62,8 +67,9 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
             return;
         }
 
-        sendBatch(tokens, command.title(), command.body());
-        log.info("대상자 알림 발송 완료 title={}", command.title());
+        SendBatchResult result = sendBatch(tokens, command.title(), command.body());
+        recordFcmMetric("SEND_TO_AUDIENCE", result);
+        log.info("대상자 알림 발송 완료: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
     }
 
     @Override
@@ -80,7 +86,8 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
             return;
         }
 
-        sendBatch(tokens, command.title(), command.body());
+        SendBatchResult result = sendBatch(tokens, command.title(), command.body());
+        recordFcmMetric("SEND_TO_MEMBER", result);
     }
 
     @Override
@@ -101,13 +108,14 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
             return;
         }
 
-        sendBatch(tokens, title, body);
-        log.info("bulk 알림 발송 완료 title={}, 대상 멤버 수={}", title, memberIds.size());
+        SendBatchResult result = sendBatch(tokens, title, body);
+        recordFcmMetric("SEND_TO_MEMBERS", result);
+        log.info("bulk 알림 발송 완료: memberCount={}, tokenCount={}", memberIds.size(), tokens.size());
     }
 
     // =========== PRIVATE ===========
 
-    private void sendBatch(List<FcmToken> tokens, String title, String body) {
+    private SendBatchResult sendBatch(List<FcmToken> tokens, String title, String body) {
         Notification notification = Notification.builder()
             .setTitle(title)
             .setBody(body)
@@ -136,6 +144,12 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
         }
 
         log.info("FCM 발송 완료 성공={}, 실패={}", totalSuccess, totalFail);
+        return new SendBatchResult(totalSuccess, totalFail);
+    }
+
+    private void recordFcmMetric(String operation, SendBatchResult result) {
+        operationalMetrics.recordNotification("FCM", operation, "success", result.successCount());
+        operationalMetrics.recordNotification("FCM", operation, "failure", result.failureCount());
     }
 
     private List<Long> resolveTargetMemberIds(NoticeTargetInfo targetInfo) {
@@ -194,5 +208,8 @@ public class FcmAudienceService implements SendNotificationToAudienceUseCase {
         }
 
         return result;
+    }
+
+    private record SendBatchResult(int successCount, int failureCount) {
     }
 }

--- a/src/main/java/com/umc/product/notification/application/service/FcmOutboxService.java
+++ b/src/main/java/com/umc/product/notification/application/service/FcmOutboxService.java
@@ -1,13 +1,16 @@
 package com.umc.product.notification.application.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.umc.product.notification.application.port.in.ProcessFcmOutboxUseCase;
 import com.umc.product.notification.application.port.out.LoadFcmOutboxPort;
 import com.umc.product.notification.application.port.out.SaveFcmOutboxPort;
 import com.umc.product.notification.domain.FcmOutbox;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -26,7 +29,7 @@ public class FcmOutboxService implements ProcessFcmOutboxUseCase {
             return;
         }
 
-        log.warn("[DEPRECATED] FCM Outbox 토픽 이벤트 {} 건이 남아있어 FAILED 처리합니다. 토큰 기반 알림으로 전환되었습니다.",
+        log.warn("[DEPRECATED] FCM Outbox 토픽 이벤트 {}건을 FAILED로 처리합니다. 토큰 기반 알림을 사용하세요.",
             pendingEvents.size());
 
         for (FcmOutbox event : pendingEvents) {

--- a/src/main/java/com/umc/product/notification/application/service/FcmTopicService.java
+++ b/src/main/java/com/umc/product/notification/application/service/FcmTopicService.java
@@ -1,10 +1,13 @@
 package com.umc.product.notification.application.service;
 
-import com.umc.product.notification.application.port.in.ManageFcmTopicUseCase;
 import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.umc.product.notification.application.port.in.ManageFcmTopicUseCase;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -15,42 +18,42 @@ public class FcmTopicService implements ManageFcmTopicUseCase {
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void subscribeAllTopicsByMemberId(Long memberId) {
-        log.warn("[DEPRECATED] 토픽 기반 구독은 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 구독은 비활성화되었습니다. memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeAllTopicsByMemberId(Long memberId) {
-        log.warn("[DEPRECATED] 토픽 기반 구독 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 구독 해제는 비활성화되었습니다. memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeTokenFromTopics(String fcmToken, Long memberId) {
-        log.warn("[DEPRECATED] 토픽 기반 토큰 구독 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 토큰 구독 해제는 비활성화되었습니다. memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeLegacyTopics(Long memberId) {
-        log.warn("[DEPRECATED] 레거시 토픽 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 레거시 토픽 해제는 비활성화되었습니다. memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void subscribeToTopic(List<String> fcmTokens, String topic) {
-        log.warn("[DEPRECATED] 토픽 구독은 비활성화되었습니다. topic={}", topic);
+        log.debug("[DEPRECATED] 토픽 구독은 비활성화되었습니다. topic={}", topic);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeFromTopic(List<String> fcmTokens, String topic) {
-        log.warn("[DEPRECATED] 토픽 구독 해제는 비활성화되었습니다. topic={}", topic);
+        log.debug("[DEPRECATED] 토픽 구독 해제는 비활성화되었습니다. topic={}", topic);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void resubscribeAllLegacyTopics() {
-        log.warn("[DEPRECATED] 전체 레거시 토픽 재구독은 비활성화되었습니다.");
+        log.debug("[DEPRECATED] 전체 레거시 토픽 재구독은 비활성화되었습니다.");
     }
 }

--- a/src/main/java/com/umc/product/notification/application/service/FcmTopicService.java
+++ b/src/main/java/com/umc/product/notification/application/service/FcmTopicService.java
@@ -18,42 +18,42 @@ public class FcmTopicService implements ManageFcmTopicUseCase {
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void subscribeAllTopicsByMemberId(Long memberId) {
-        log.debug("[DEPRECATED] 토픽 기반 구독은 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 구독을 사용하지 않습니다: memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeAllTopicsByMemberId(Long memberId) {
-        log.debug("[DEPRECATED] 토픽 기반 구독 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 구독 해제를 사용하지 않습니다: memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeTokenFromTopics(String fcmToken, Long memberId) {
-        log.debug("[DEPRECATED] 토픽 기반 토큰 구독 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 토픽 기반 토큰 구독 해제를 사용하지 않습니다: memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeLegacyTopics(Long memberId) {
-        log.debug("[DEPRECATED] 레거시 토픽 해제는 비활성화되었습니다. memberId={}", memberId);
+        log.debug("[DEPRECATED] 레거시 토픽 해제를 사용하지 않습니다: memberId={}", memberId);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void subscribeToTopic(List<String> fcmTokens, String topic) {
-        log.debug("[DEPRECATED] 토픽 구독은 비활성화되었습니다. topic={}", topic);
+        log.debug("[DEPRECATED] 토픽 구독을 사용하지 않습니다: topic={}", topic);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void unsubscribeFromTopic(List<String> fcmTokens, String topic) {
-        log.debug("[DEPRECATED] 토픽 구독 해제는 비활성화되었습니다. topic={}", topic);
+        log.debug("[DEPRECATED] 토픽 구독 해제를 사용하지 않습니다: topic={}", topic);
     }
 
     @Override
     @Deprecated(since = "token-based migration", forRemoval = true)
     public void resubscribeAllLegacyTopics() {
-        log.debug("[DEPRECATED] 전체 레거시 토픽 재구독은 비활성화되었습니다.");
+        log.debug("[DEPRECATED] 전체 레거시 토픽 재구독을 사용하지 않습니다.");
     }
 }

--- a/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
+++ b/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
@@ -1,17 +1,19 @@
 package com.umc.product.notification.application.service;
 
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
 import com.umc.product.notification.application.port.in.SendEmailUseCase;
 import com.umc.product.notification.application.port.in.dto.SendVerificationEmailCommand;
 import com.umc.product.notification.application.port.out.SendEmailPort;
 import com.umc.product.notification.application.port.out.dto.EmailMessage;
 import com.umc.product.notification.domain.exception.EmailDomainException;
 import com.umc.product.notification.domain.exception.EmailErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 @Slf4j
 @Service

--- a/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
+++ b/src/main/java/com/umc/product/notification/application/service/SendEmailService.java
@@ -37,7 +37,7 @@ public class SendEmailService implements SendEmailUseCase {
             SUBJECT_PREFIX + command.verificationCode(),
             htmlContent
         );
-        // 발송 실패 시 SesEmailAdapter 가 to/awsErrorCode 컨텍스트와 cause 를 포함해 도메인 예외로 변환한다.
+        // 발송 실패 시 SesEmailAdapter 가 AWS error code 와 cause 를 포함해 도메인 예외로 변환한다.
         // 비동기 호출이므로 예외는 AsyncUncaughtExceptionHandler 에서 처리된다.
         sendEmailPort.send(message);
     }
@@ -49,8 +49,12 @@ public class SendEmailService implements SendEmailUseCase {
             return templateEngine.process(VERIFICATION_TEMPLATE, context);
         } catch (RuntimeException e) {
             // 예외 삼킴 방지: 비동기 컨텍스트에서도 원인 추적이 가능하도록 stacktrace 와 컨텍스트를 로그에 남긴다.
-            log.error("이메일 템플릿 렌더링 실패: to={}", command.to(), e);
+            log.error("이메일 템플릿 렌더링 실패: recipientPresent={}", hasRecipient(command.to()), e);
             throw new EmailDomainException(EmailErrorCode.EMAIL_TEMPLATE_RENDER_FAILED, e);
         }
+    }
+
+    private boolean hasRecipient(String recipient) {
+        return recipient != null && !recipient.isBlank();
     }
 }

--- a/src/main/java/com/umc/product/notification/application/service/WebhookAlarmService.java
+++ b/src/main/java/com/umc/product/notification/application/service/WebhookAlarmService.java
@@ -1,10 +1,5 @@
 package com.umc.product.notification.application.service;
 
-import com.umc.product.notification.application.port.in.FlushWebhookBufferUseCase;
-import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
-import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmCommand;
-import com.umc.product.notification.application.port.out.SendWebhookPort;
-import com.umc.product.notification.domain.WebhookPlatform;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -12,9 +7,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+
+import com.umc.product.global.logging.OperationalMetrics;
+import com.umc.product.notification.application.port.in.FlushWebhookBufferUseCase;
+import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
+import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmCommand;
+import com.umc.product.notification.application.port.out.SendWebhookPort;
+import com.umc.product.notification.domain.WebhookPlatform;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -23,13 +27,15 @@ public class WebhookAlarmService implements SendWebhookAlarmUseCase, FlushWebhoo
     private final Map<WebhookPlatform, SendWebhookPort> adapterMap;
     private final WebhookAlarmBuffer webhookAlarmBuffer;
     private final String profilePrefix;
+    private final OperationalMetrics operationalMetrics;
 
     public WebhookAlarmService(List<SendWebhookPort> adapters, WebhookAlarmBuffer webhookAlarmBuffer,
-                               Environment environment) {
+                               Environment environment, OperationalMetrics operationalMetrics) {
         this.adapterMap = adapters.stream()
             .collect(Collectors.toMap(SendWebhookPort::platform, Function.identity()));
         this.webhookAlarmBuffer = webhookAlarmBuffer;
         this.profilePrefix = buildProfilePrefix(environment);
+        this.operationalMetrics = operationalMetrics;
     }
 
     @Override
@@ -43,7 +49,8 @@ public class WebhookAlarmService implements SendWebhookAlarmUseCase, FlushWebhoo
     @Override
     public void sendBuffered(SendWebhookAlarmCommand command) {
         webhookAlarmBuffer.add(command);
-        log.debug("웹훅 알람 버퍼에 추가: title={}, platforms={}", command.title(), command.platforms());
+        log.debug("웹훅 알람 버퍼에 추가: platforms={}, contentLength={}",
+            command.platforms(), command.content() == null ? 0 : command.content().length());
     }
 
     @Override
@@ -71,13 +78,16 @@ public class WebhookAlarmService implements SendWebhookAlarmUseCase, FlushWebhoo
         SendWebhookPort adapter = adapterMap.get(platform);
         if (adapter == null) {
             log.warn("웹훅 어댑터가 등록되지 않았습니다: platform={}", platform);
+            operationalMetrics.recordNotification(platform.name(), "SEND_WEBHOOK", "missing_adapter", 1);
             return;
         }
 
         try {
             adapter.send(title, content);
+            operationalMetrics.recordNotification(platform.name(), "SEND_WEBHOOK", "success", 1);
             log.info("웹훅 알람 전송 성공: platform={}", platform);
         } catch (Exception e) {
+            operationalMetrics.recordNotification(platform.name(), "SEND_WEBHOOK", "failure", 1);
             log.error("웹훅 알람 전송 실패: platform={}, error={}", platform, e.getMessage(), e);
         }
     }

--- a/src/main/java/com/umc/product/notification/application/service/WebhookAlarmService.java
+++ b/src/main/java/com/umc/product/notification/application/service/WebhookAlarmService.java
@@ -85,7 +85,7 @@ public class WebhookAlarmService implements SendWebhookAlarmUseCase, FlushWebhoo
         try {
             adapter.send(title, content);
             operationalMetrics.recordNotification(platform.name(), "SEND_WEBHOOK", "success", 1);
-            log.info("웹훅 알람 전송 성공: platform={}", platform);
+            log.info("웹훅 알람을 전송했습니다: platform={}", platform);
         } catch (Exception e) {
             operationalMetrics.recordNotification(platform.name(), "SEND_WEBHOOK", "failure", 1);
             log.error("웹훅 알람 전송 실패: platform={}, error={}", platform, e.getMessage(), e);

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductGenerationCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductGenerationCommandService.java
@@ -31,7 +31,7 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
         action = AuditAction.CREATE,
         targetType = "UmcProductGeneration",
         targetId = "#result",
-        description = "'UMC Product 기수가 생성되었습니다.'"
+        description = "'UMC Product 기수를 생성했습니다.'"
     )
     @Override
     public Long create(CreateUmcProductGenerationCommand command) {
@@ -56,7 +56,7 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
         action = AuditAction.UPDATE,
         targetType = "UmcProductGeneration",
         targetId = "#command.umcProductGenerationId()",
-        description = "'UMC Product 기수가 수정되었습니다.'"
+        description = "'UMC Product 기수를 수정했습니다.'"
     )
     @Override
     public void update(UpdateUmcProductGenerationCommand command) {
@@ -79,7 +79,7 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
         action = AuditAction.DELETE,
         targetType = "UmcProductGeneration",
         targetId = "#umcProductGenerationId",
-        description = "'UMC Product 기수가 삭제되었습니다.'"
+        description = "'UMC Product 기수를 삭제했습니다.'"
     )
     @Override
     public void delete(Long umcProductGenerationId, Long requesterMemberId) {

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductGenerationCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductGenerationCommandService.java
@@ -3,6 +3,9 @@ package com.umc.product.organization.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductGenerationUseCase;
 import com.umc.product.organization.application.port.in.command.dto.CreateUmcProductGenerationCommand;
 import com.umc.product.organization.application.port.in.command.dto.UpdateUmcProductGenerationCommand;
@@ -23,6 +26,13 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
     private final SaveUmcProductGenerationPort saveUmcProductGenerationPort;
     private final UmcProductAccessPolicy umcProductAccessPolicy;
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.CREATE,
+        targetType = "UmcProductGeneration",
+        targetId = "#result",
+        description = "'UMC Product 기수가 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateUmcProductGenerationCommand command) {
         if (!umcProductAccessPolicy.canCreateGeneration(command.requesterMemberId())) {
@@ -41,6 +51,13 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
         return saveUmcProductGenerationPort.save(generation).getId();
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.UPDATE,
+        targetType = "UmcProductGeneration",
+        targetId = "#command.umcProductGenerationId()",
+        description = "'UMC Product 기수가 수정되었습니다.'"
+    )
     @Override
     public void update(UpdateUmcProductGenerationCommand command) {
         if (!umcProductAccessPolicy.canManageGeneration(command.requesterMemberId(), command.umcProductGenerationId())) {
@@ -57,6 +74,13 @@ public class UmcProductGenerationCommandService implements ManageUmcProductGener
         saveUmcProductGenerationPort.save(generation);
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.DELETE,
+        targetType = "UmcProductGeneration",
+        targetId = "#umcProductGenerationId",
+        description = "'UMC Product 기수가 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long umcProductGenerationId, Long requesterMemberId) {
         if (!umcProductAccessPolicy.canManageGeneration(requesterMemberId, umcProductGenerationId)) {

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductMemberCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductMemberCommandService.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductMemberUseCase;
 import com.umc.product.organization.application.port.in.command.dto.CreateUmcProductMemberCommand;
@@ -55,6 +58,13 @@ public class UmcProductMemberCommandService implements ManageUmcProductMemberUse
     private final GetFileUseCase getFileUseCase;
     private final UmcProductAccessPolicy umcProductAccessPolicy;
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.CREATE,
+        targetType = "UmcProductMember",
+        targetId = "#result",
+        description = "'UMC Product 멤버가 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateUmcProductMemberCommand command) {
         validateCanManage(command.requesterMemberId());
@@ -79,6 +89,13 @@ public class UmcProductMemberCommandService implements ManageUmcProductMemberUse
         return savedMember.getId();
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.UPDATE,
+        targetType = "UmcProductMember",
+        targetId = "#command.umcProductMemberId()",
+        description = "'UMC Product 멤버 프로필이 수정되었습니다.'"
+    )
     @Override
     public void updateProfile(UpdateUmcProductMemberProfileCommand command) {
         UmcProductMember member = loadUmcProductMemberPort.getById(command.umcProductMemberId());

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductMemberCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductMemberCommandService.java
@@ -63,7 +63,7 @@ public class UmcProductMemberCommandService implements ManageUmcProductMemberUse
         action = AuditAction.CREATE,
         targetType = "UmcProductMember",
         targetId = "#result",
-        description = "'UMC Product 멤버가 생성되었습니다.'"
+        description = "'UMC Product 멤버를 생성했습니다.'"
     )
     @Override
     public Long create(CreateUmcProductMemberCommand command) {
@@ -94,7 +94,7 @@ public class UmcProductMemberCommandService implements ManageUmcProductMemberUse
         action = AuditAction.UPDATE,
         targetType = "UmcProductMember",
         targetId = "#command.umcProductMemberId()",
-        description = "'UMC Product 멤버 프로필이 수정되었습니다.'"
+        description = "'UMC Product 멤버 프로필을 수정했습니다.'"
     )
     @Override
     public void updateProfile(UpdateUmcProductMemberProfileCommand command) {

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductSquadCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductSquadCommandService.java
@@ -11,6 +11,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.organization.application.port.in.command.ManageUmcProductSquadUseCase;
 import com.umc.product.organization.application.port.in.command.dto.CreateUmcProductSquadCommand;
 import com.umc.product.organization.application.port.in.command.dto.ReplaceUmcProductSquadParticipantsCommand;
@@ -39,6 +42,13 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
     private final SaveUmcProductSquadParticipantPort saveUmcProductSquadParticipantPort;
     private final UmcProductAccessPolicy umcProductAccessPolicy;
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.CREATE,
+        targetType = "UmcProductSquad",
+        targetId = "#result",
+        description = "'UMC Product 스쿼드가 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateUmcProductSquadCommand command) {
         validateCanManage(command.requesterMemberId());
@@ -54,6 +64,13 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         return saveUmcProductSquadPort.save(squad).getId();
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.UPDATE,
+        targetType = "UmcProductSquad",
+        targetId = "#command.squadId()",
+        description = "'UMC Product 스쿼드가 수정되었습니다.'"
+    )
     @Override
     public void update(UpdateUmcProductSquadCommand command) {
         validateCanManage(command.requesterMemberId());
@@ -70,6 +87,13 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         saveUmcProductSquadPort.save(squad);
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.DELETE,
+        targetType = "UmcProductSquad",
+        targetId = "#squadId",
+        description = "'UMC Product 스쿼드가 삭제되었습니다.'"
+    )
     @Override
     public void delete(Long squadId, Long requesterMemberId) {
         validateCanManage(requesterMemberId);
@@ -78,6 +102,13 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         saveUmcProductSquadPort.delete(squad);
     }
 
+    @Audited(
+        domain = Domain.ORGANIZATION,
+        action = AuditAction.UPDATE,
+        targetType = "UmcProductSquad",
+        targetId = "#command.squadId()",
+        description = "'UMC Product 스쿼드 참여자가 교체되었습니다.'"
+    )
     @Override
     public void replaceParticipants(ReplaceUmcProductSquadParticipantsCommand command) {
         validateCanManage(command.requesterMemberId());

--- a/src/main/java/com/umc/product/organization/application/service/UmcProductSquadCommandService.java
+++ b/src/main/java/com/umc/product/organization/application/service/UmcProductSquadCommandService.java
@@ -47,7 +47,7 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         action = AuditAction.CREATE,
         targetType = "UmcProductSquad",
         targetId = "#result",
-        description = "'UMC Product 스쿼드가 생성되었습니다.'"
+        description = "'UMC Product 스쿼드를 생성했습니다.'"
     )
     @Override
     public Long create(CreateUmcProductSquadCommand command) {
@@ -69,7 +69,7 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         action = AuditAction.UPDATE,
         targetType = "UmcProductSquad",
         targetId = "#command.squadId()",
-        description = "'UMC Product 스쿼드가 수정되었습니다.'"
+        description = "'UMC Product 스쿼드를 수정했습니다.'"
     )
     @Override
     public void update(UpdateUmcProductSquadCommand command) {
@@ -92,7 +92,7 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         action = AuditAction.DELETE,
         targetType = "UmcProductSquad",
         targetId = "#squadId",
-        description = "'UMC Product 스쿼드가 삭제되었습니다.'"
+        description = "'UMC Product 스쿼드를 삭제했습니다.'"
     )
     @Override
     public void delete(Long squadId, Long requesterMemberId) {
@@ -107,7 +107,7 @@ public class UmcProductSquadCommandService implements ManageUmcProductSquadUseCa
         action = AuditAction.UPDATE,
         targetType = "UmcProductSquad",
         targetId = "#command.squadId()",
-        description = "'UMC Product 스쿼드 참여자가 교체되었습니다.'"
+        description = "'UMC Product 스쿼드 참여자를 교체했습니다.'"
     )
     @Override
     public void replaceParticipants(ReplaceUmcProductSquadParticipantsCommand command) {

--- a/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandler.java
@@ -1,9 +1,15 @@
 package com.umc.product.project.adapter.in.scheduler;
 
+import java.time.Duration;
+import java.time.Instant;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 /**
  * 매칭 차수 결정 마감 시점에 트리거되어 자동 선발 UseCase 를 호출하는 driving adapter.
@@ -16,16 +22,25 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class MatchingRoundDeadlineHandler {
 
+    private static final String JOB_NAME = "matching_round_deadline";
+
     private final AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+    private final OperationalMetrics operationalMetrics;
 
     /**
      * deadline 시점에 1회 호출되어 자동 선발을 실행한다. 예외는 swallow 하여 다음 task 진행을 막지 않는다.
      */
     public void handle(Long matchingRoundId) {
+        Instant startedAt = Instant.now();
         try {
             autoDecideUseCase.autoDecide(matchingRoundId, null);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "success", duration, 1);
         } catch (Exception e) {
-            log.error("Failed to auto-decide matching round {}", matchingRoundId, e);
+            Duration duration = Duration.between(startedAt, Instant.now());
+            operationalMetrics.recordBatchJob(JOB_NAME, "failure", duration, 0);
+            log.error("batch job failed: jobName={}, matchingRoundId={}, durationMs={}, result={}, errorClass={}",
+                JOB_NAME, matchingRoundId, duration.toMillis(), "failure", e.getClass().getSimpleName(), e);
         }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -12,9 +12,12 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.project.application.port.in.command.CancelProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectApplicationUseCase;
 import com.umc.product.project.application.port.in.command.DecideApplicationUseCase;
@@ -75,6 +78,13 @@ public class ProjectApplicationCommandService implements
     private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
     private final GetFormUseCase getFormUseCase;
 
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.CREATE,
+        targetType = "ProjectApplication",
+        targetId = "#result.applicationId()",
+        description = "'프로젝트 지원서 초안이 생성되었습니다.'"
+    )
     @Override
     public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
         ProjectApplicationForm form = loadProjectApplicationFormPort.findByProjectId(command.projectId())
@@ -168,6 +178,13 @@ public class ProjectApplicationCommandService implements
         return ProjectApplicationInfo.of(application.getId(), application.getStatus());
     }
 
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.SUBMIT,
+        targetType = "ProjectApplication",
+        targetId = "#result.applicationId()",
+        description = "'프로젝트 지원서가 제출되었습니다.'"
+    )
     @Override
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {
         ProjectApplication application = loadDraftApplication(

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -83,7 +83,7 @@ public class ProjectApplicationCommandService implements
         action = AuditAction.CREATE,
         targetType = "ProjectApplication",
         targetId = "#result.applicationId()",
-        description = "'프로젝트 지원서 초안이 생성되었습니다.'"
+        description = "'프로젝트 지원서 초안을 생성했습니다.'"
     )
     @Override
     public ProjectApplicationInfo create(CreateDraftProjectApplicationCommand command) {
@@ -183,7 +183,7 @@ public class ProjectApplicationCommandService implements
         action = AuditAction.SUBMIT,
         targetType = "ProjectApplication",
         targetId = "#result.applicationId()",
-        description = "'프로젝트 지원서가 제출되었습니다.'"
+        description = "'프로젝트 지원서를 제출했습니다.'"
     )
     @Override
     public ProjectApplicationInfo submit(SubmitProjectApplicationCommand command) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -6,12 +6,15 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
@@ -86,6 +89,13 @@ public class ProjectCommandService implements
     private final GetChapterUseCase getChapterUseCase;
     private final ManageFormUseCase manageFormUseCase;
 
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.CREATE,
+        targetType = "Project",
+        targetId = "#result",
+        description = "'프로젝트 초안이 생성되었습니다.'"
+    )
     @Override
     public Long create(CreateDraftProjectCommand command) {
         getGisuUseCase.getById(command.gisuId());
@@ -218,6 +228,13 @@ public class ProjectCommandService implements
      *   <li>같은 트랜잭션에서 Form 도 PUBLISHED 로 전이</li>
      * </ul>
      */
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.PUBLISH,
+        targetType = "Project",
+        targetId = "#command.projectId()",
+        description = "'프로젝트가 게시되었습니다.'"
+    )
     @Override
     public ProjectStatus publish(PublishProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
@@ -252,6 +269,13 @@ public class ProjectCommandService implements
      * 권한 검증은 Controller 단의 {@code @CheckAccess(DELETE)} + {@link com.umc.product.project.application.service.evaluator.ProjectPermissionEvaluator}
      * 가 담당. 본 Service 는 도메인 상태 invariant 만 책임진다.
      */
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.DELETE,
+        targetType = "Project",
+        targetId = "#command.projectId()",
+        description = "'프로젝트가 삭제되었습니다.'"
+    )
     @Override
     public void delete(DeleteProjectCommand command) {
         Project project = loadProjectPort.getById(command.projectId());

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -94,7 +94,7 @@ public class ProjectCommandService implements
         action = AuditAction.CREATE,
         targetType = "Project",
         targetId = "#result",
-        description = "'프로젝트 초안이 생성되었습니다.'"
+        description = "'프로젝트 초안을 생성했습니다.'"
     )
     @Override
     public Long create(CreateDraftProjectCommand command) {
@@ -233,7 +233,7 @@ public class ProjectCommandService implements
         action = AuditAction.PUBLISH,
         targetType = "Project",
         targetId = "#command.projectId()",
-        description = "'프로젝트가 게시되었습니다.'"
+        description = "'프로젝트를 게시했습니다.'"
     )
     @Override
     public ProjectStatus publish(PublishProjectCommand command) {
@@ -274,7 +274,7 @@ public class ProjectCommandService implements
         action = AuditAction.DELETE,
         targetType = "Project",
         targetId = "#command.projectId()",
-        description = "'프로젝트가 삭제되었습니다.'"
+        description = "'프로젝트를 삭제했습니다.'"
     )
     @Override
     public void delete(DeleteProjectCommand command) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -27,6 +29,7 @@ import com.umc.product.challenger.application.port.in.query.dto.SearchChallenger
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
@@ -88,6 +91,13 @@ public class ProjectMatchingRoundFinalizationCommandService implements
     private final GetChallengerUseCase getChallengerUseCase;
     private final SearchChallengerUseCase searchChallengerUseCase;
 
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.FINALIZE,
+        targetType = "ProjectMatchingRound",
+        targetId = "#matchingRoundId",
+        description = "'프로젝트 매칭 라운드가 자동 확정되었습니다.'"
+    )
     @Override
     public void autoDecide(Long matchingRoundId, Long executedByMemberId) {
         ProjectMatchingRound round = loadProjectMatchingRoundPort.getById(matchingRoundId);

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMatchingRoundFinalizationCommandService.java
@@ -96,7 +96,7 @@ public class ProjectMatchingRoundFinalizationCommandService implements
         action = AuditAction.FINALIZE,
         targetType = "ProjectMatchingRound",
         targetId = "#matchingRoundId",
-        description = "'프로젝트 매칭 라운드가 자동 확정되었습니다.'"
+        description = "'프로젝트 매칭 라운드를 자동 확정했습니다.'"
     )
     @Override
     public void autoDecide(Long matchingRoundId, Long executedByMemberId) {

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandService.java
@@ -1,6 +1,19 @@
 package com.umc.product.project.application.service.command;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
 import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand;
 import com.umc.product.project.application.port.in.command.dto.UpdatePartQuotasCommand.Entry;
@@ -11,15 +24,8 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectPartQuota;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +39,13 @@ public class ProjectPartQuotaCommandService implements UpdatePartQuotasUseCase {
     /**
      * PUT 시멘틱 — 본문에 있는 파트만 유지/갱신, 본문에 없는 기존 파트는 삭제.
      */
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.UPDATE,
+        targetType = "ProjectPartQuota",
+        targetId = "#command.projectId()",
+        description = "'프로젝트 파트 정원이 수정되었습니다.'"
+    )
     @Override
     public void update(UpdatePartQuotasCommand command) {
         Project project = loadProjectPort.getById(command.projectId());

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectPartQuotaCommandService.java
@@ -44,7 +44,7 @@ public class ProjectPartQuotaCommandService implements UpdatePartQuotasUseCase {
         action = AuditAction.UPDATE,
         targetType = "ProjectPartQuota",
         targetId = "#command.projectId()",
-        description = "'프로젝트 파트 정원이 수정되었습니다.'"
+        description = "'프로젝트 파트 정원을 수정했습니다.'"
     )
     @Override
     public void update(UpdatePartQuotasCommand command) {

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleCommandService.java
@@ -1,5 +1,15 @@
 package com.umc.product.schedule.application.service.command;
 
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
@@ -27,16 +37,9 @@ import com.umc.product.schedule.domain.Schedule;
 import com.umc.product.schedule.domain.ScheduleParticipant;
 import com.umc.product.schedule.domain.exception.ScheduleDomainException;
 import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.Point;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -67,7 +70,7 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
         action = AuditAction.CREATE,
         targetType = "Schedule",
         targetId = "#result",
-        description = "'일정이 생성되었습니다.'"
+        description = "'일정을 생성했습니다.'"
     )
     @Override
     public Long create(CreateScheduleCommand command) {
@@ -132,7 +135,7 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
         action = AuditAction.UPDATE,
         targetType = "Schedule",
         targetId = "#command.scheduleId()",
-        description = "'일정이 수정되었습니다.'"
+        description = "'일정을 수정했습니다.'"
     )
     @Override
     public Long update(EditScheduleCommand command) {
@@ -218,7 +221,7 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
         action = AuditAction.DELETE,
         targetType = "Schedule",
         targetId = "#scheduleId",
-        description = "'일정이 삭제되었습니다.'"
+        description = "'일정을 삭제했습니다.'"
     )
     @Override
     public void delete(Long scheduleId) {
@@ -239,7 +242,7 @@ public class ScheduleCommandService implements CreateScheduleUseCase, UpdateSche
         action = AuditAction.DELETE,
         targetType = "Schedule",
         targetId = "#scheduleId",
-        description = "'일정이 강제 삭제되었습니다.'"
+        description = "'일정을 강제로 삭제했습니다.'"
     )
     @Override
     public void forceDelete(Long scheduleId) {

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleParticipantCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleParticipantCommandService.java
@@ -1,5 +1,14 @@
 package com.umc.product.schedule.application.service.command;
 
+import java.util.List;
+
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.global.util.GeometryUtils;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
@@ -17,11 +26,8 @@ import com.umc.product.schedule.domain.ScheduleParticipant;
 import com.umc.product.schedule.domain.ScheduleParticipantAttendance;
 import com.umc.product.schedule.domain.exception.ScheduleDomainException;
 import com.umc.product.schedule.domain.exception.ScheduleErrorCode;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -135,6 +141,12 @@ public class ScheduleParticipantCommandService implements
     }
 
     // 출석 요청 승인/거절
+    @Audited(
+        domain = Domain.SCHEDULE,
+        action = AuditAction.CHECK,
+        targetType = "ScheduleAttendance",
+        description = "'일정 출석 요청이 처리되었습니다. count=' + #commands.size()"
+    )
     @Override
     public List<ScheduleParticipantAttendanceResult> decideAttendances(List<DecideAttendanceCommand> commands) {
         return commands.stream()

--- a/src/main/java/com/umc/product/schedule/application/service/command/ScheduleParticipantCommandService.java
+++ b/src/main/java/com/umc/product/schedule/application/service/command/ScheduleParticipantCommandService.java
@@ -145,7 +145,7 @@ public class ScheduleParticipantCommandService implements
         domain = Domain.SCHEDULE,
         action = AuditAction.CHECK,
         targetType = "ScheduleAttendance",
-        description = "'일정 출석 요청이 처리되었습니다. count=' + #commands.size()"
+        description = "'일정 출석 요청을 처리했습니다. count=' + #commands.size()"
     )
     @Override
     public List<ScheduleParticipantAttendanceResult> decideAttendances(List<DecideAttendanceCommand> commands) {

--- a/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
+++ b/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
@@ -21,6 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
 
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.out.StoragePort;
 import com.umc.product.storage.application.port.out.dto.StorageObjectInfo;
@@ -58,6 +59,7 @@ public class S3StorageAdapter implements StoragePort {
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
     private final S3StorageProperties properties;
+    private final OperationalMetrics operationalMetrics;
 
     @Value("${spring.profiles.active:default}")
     private String springProfile;
@@ -87,6 +89,7 @@ public class S3StorageAdapter implements StoragePort {
         Long fileSize,
         long durationMinutes
     ) {
+        long startNanos = System.nanoTime();
         try {
             PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
                 .bucket(properties.bucketName())
@@ -113,6 +116,7 @@ public class S3StorageAdapter implements StoragePort {
             LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(durationMinutes);
 
             log.debug("S3 업로드 URL 생성: storageKey={}", storageKey);
+            recordStorageMetric("CREATE_UPLOAD_URL", "success", startNanos);
 
             return new FileUploadInfo(
                 null,  // fileId는 Service에서 설정
@@ -122,6 +126,7 @@ public class S3StorageAdapter implements StoragePort {
                 expiresAt
             );
         } catch (Exception e) {
+            recordStorageMetric("CREATE_UPLOAD_URL", "failure", startNanos);
             log.error("S3 업로드 URL 생성 실패: storageKey={}", storageKey, e);
             throw new StorageException(StorageErrorCode.STORAGE_URL_GENERATION_FAILED);
         }
@@ -141,23 +146,28 @@ public class S3StorageAdapter implements StoragePort {
 
     @Override
     public Optional<StorageObjectInfo> findObjectInfoByStorageKey(String storageKey) {
+        long startNanos = System.nanoTime();
         try {
             HeadObjectRequest headRequest = HeadObjectRequest.builder()
                 .bucket(properties.bucketName())
                 .key(storageKey)
                 .build();
             HeadObjectResponse response = s3Client.headObject(headRequest);
+            recordStorageMetric("GET_OBJECT_METADATA", "success", startNanos);
             return Optional.of(StorageObjectInfo.of(
                 storageKey,
                 response.contentLength(),
                 response.contentType()
             ));
         } catch (NoSuchKeyException e) {
+            recordStorageMetric("GET_OBJECT_METADATA", "not_found", startNanos);
             return Optional.empty();
         } catch (S3Exception e) {
             if (e.statusCode() == 404) {
+                recordStorageMetric("GET_OBJECT_METADATA", "not_found", startNanos);
                 return Optional.empty();
             }
+            recordStorageMetric("GET_OBJECT_METADATA", "failure", startNanos);
             log.error("S3 객체 정보 조회 실패: storageKey={}", storageKey, e);
             throw new StorageException(StorageErrorCode.STORAGE_METADATA_READ_FAILED, e);
         }
@@ -165,6 +175,7 @@ public class S3StorageAdapter implements StoragePort {
 
     @Override
     public void delete(String storageKey) {
+        long startNanos = System.nanoTime();
         try {
             DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                 .bucket(properties.bucketName())
@@ -173,7 +184,9 @@ public class S3StorageAdapter implements StoragePort {
 
             s3Client.deleteObject(deleteRequest);
             log.info("S3 파일 삭제 완료: storageKey={}", storageKey);
+            recordStorageMetric("DELETE_OBJECT", "success", startNanos);
         } catch (Exception e) {
+            recordStorageMetric("DELETE_OBJECT", "failure", startNanos);
             log.error("S3 파일 삭제 실패: storageKey={}", storageKey, e);
             throw new StorageException(StorageErrorCode.STORAGE_DELETE_FAILED);
         }
@@ -202,6 +215,7 @@ public class S3StorageAdapter implements StoragePort {
      * Signed URLs</a>
      */
     private String generateCloudFrontSignedUrl(String storageKey, long durationMinutes) {
+        long startNanos = System.nanoTime();
         try {
             S3StorageProperties.CloudFront cloudfront = properties.cloudfront();
 
@@ -232,13 +246,24 @@ public class S3StorageAdapter implements StoragePort {
 
             SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(signerRequest);
 
-            log.debug("CloudFront Signed URL 생성 완료: storageKey={}, url={}", storageKey, resourceUrl);
+            log.debug("CloudFront Signed URL 생성 완료: storageKey={}", storageKey);
+            recordStorageMetric("CREATE_DOWNLOAD_URL", "success", startNanos);
 
             return signedUrl.url();
         } catch (Exception e) {
+            recordStorageMetric("CREATE_DOWNLOAD_URL", "failure", startNanos);
             log.error("CloudFront Signed URL 생성 실패: storageKey={}", storageKey, e);
             throw new StorageException(StorageErrorCode.CDN_SIGNING_FAILED);
         }
+    }
+
+    private void recordStorageMetric(String operation, String result, long startNanos) {
+        operationalMetrics.recordExternalCall(
+            "STORAGE",
+            operation,
+            result,
+            Duration.ofNanos(System.nanoTime() - startNanos)
+        );
     }
 
     /**

--- a/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
+++ b/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
@@ -183,7 +183,7 @@ public class S3StorageAdapter implements StoragePort {
                 .build();
 
             s3Client.deleteObject(deleteRequest);
-            log.info("S3 파일 삭제 완료: storageKey={}", storageKey);
+            log.info("S3 파일을 삭제했습니다: storageKey={}", storageKey);
             recordStorageMetric("DELETE_OBJECT", "success", startNanos);
         } catch (Exception e) {
             recordStorageMetric("DELETE_OBJECT", "failure", startNanos);
@@ -246,7 +246,7 @@ public class S3StorageAdapter implements StoragePort {
 
             SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(signerRequest);
 
-            log.debug("CloudFront Signed URL 생성 완료: storageKey={}", storageKey);
+            log.debug("CloudFront Signed URL을 생성했습니다: storageKey={}", storageKey);
             recordStorageMetric("CREATE_DOWNLOAD_URL", "success", startNanos);
 
             return signedUrl.url();

--- a/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
+++ b/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
@@ -45,7 +45,7 @@ public class FileCommandService implements ManageFileUseCase {
         action = AuditAction.CREATE,
         targetType = "FileMetadata",
         targetId = "#result.fileId()",
-        description = "'파일 업로드 URL이 생성되었습니다.'"
+        description = "'파일 업로드 URL을 생성했습니다.'"
     )
     @Override
     @Transactional
@@ -88,7 +88,7 @@ public class FileCommandService implements ManageFileUseCase {
             UPLOAD_URL_DURATION_MINUTES
         );
 
-        log.info("파일 업로드 URL 생성 완료: fileId={}, category={}", fileId, command.category());
+        log.info("파일 업로드 URL을 생성했습니다: fileId={}, category={}", fileId, command.category());
 
         return new FileUploadInfo(
             fileId,
@@ -104,7 +104,7 @@ public class FileCommandService implements ManageFileUseCase {
         action = AuditAction.CHECK,
         targetType = "FileMetadata",
         targetId = "#fileId",
-        description = "'파일 업로드가 확인되었습니다.'"
+        description = "'파일 업로드를 확인했습니다.'"
     )
     @Override
     @Transactional
@@ -122,7 +122,7 @@ public class FileCommandService implements ManageFileUseCase {
         confirmUploaded(metadata, objectInfo);
         saveFileMetadataPort.save(metadata);
 
-        log.info("파일 업로드 완료 확인: fileId={}", fileId);
+        log.info("파일 업로드를 확인했습니다: fileId={}", fileId);
     }
 
     @Audited(
@@ -130,7 +130,7 @@ public class FileCommandService implements ManageFileUseCase {
         action = AuditAction.DELETE,
         targetType = "FileMetadata",
         targetId = "#command.fileId()",
-        description = "'파일이 삭제되었습니다.'"
+        description = "'파일을 삭제했습니다.'"
     )
     @Override
     public void deleteFile(DeleteFileCommand command) {
@@ -145,7 +145,7 @@ public class FileCommandService implements ManageFileUseCase {
         // 메타데이터 삭제
         saveFileMetadataPort.deleteByFileId(command.fileId());
 
-        log.info("파일 삭제 완료: fileId={}", command.fileId());
+        log.info("파일을 삭제했습니다: fileId={}", command.fileId());
     }
 
     private void validateDeletePermission(FileMetadata metadata, Long requesterMemberId) {

--- a/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
+++ b/src/main/java/com/umc/product/storage/application/service/FileCommandService.java
@@ -6,8 +6,11 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.storage.application.port.in.command.ManageFileUseCase;
 import com.umc.product.storage.application.port.in.command.dto.DeleteFileCommand;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
@@ -37,6 +40,13 @@ public class FileCommandService implements ManageFileUseCase {
     private final SaveFileMetadataPort saveFileMetadataPort;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
 
+    @Audited(
+        domain = Domain.STORAGE,
+        action = AuditAction.CREATE,
+        targetType = "FileMetadata",
+        targetId = "#result.fileId()",
+        description = "'파일 업로드 URL이 생성되었습니다.'"
+    )
     @Override
     @Transactional
     public FileUploadInfo getFileUploadUrl(PrepareFileUploadCommand command) {
@@ -89,6 +99,13 @@ public class FileCommandService implements ManageFileUseCase {
         );
     }
 
+    @Audited(
+        domain = Domain.STORAGE,
+        action = AuditAction.CHECK,
+        targetType = "FileMetadata",
+        targetId = "#fileId",
+        description = "'파일 업로드가 확인되었습니다.'"
+    )
     @Override
     @Transactional
     public void confirmUpload(String fileId) {
@@ -108,6 +125,13 @@ public class FileCommandService implements ManageFileUseCase {
         log.info("파일 업로드 완료 확인: fileId={}", fileId);
     }
 
+    @Audited(
+        domain = Domain.STORAGE,
+        action = AuditAction.DELETE,
+        targetType = "FileMetadata",
+        targetId = "#command.fileId()",
+        description = "'파일이 삭제되었습니다.'"
+    )
     @Override
     public void deleteFile(DeleteFileCommand command) {
         FileMetadata metadata = loadFileMetadataPort.findByFileId(command.fileId())

--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -44,7 +44,7 @@ public class VoteService implements ManageVoteUseCase {
         action = AuditAction.CREATE,
         targetType = "Vote",
         targetId = "#result",
-        description = "'투표가 생성되었습니다.'"
+        description = "'투표를 생성했습니다.'"
     )
     @Override
     public Long createVote(CreateVoteCommand command) {

--- a/src/main/java/com/umc/product/survey/application/service/VoteService.java
+++ b/src/main/java/com/umc/product/survey/application/service/VoteService.java
@@ -1,23 +1,31 @@
 package com.umc.product.survey.application.service;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
 import com.umc.product.survey.application.port.in.command.ManageVoteUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateVoteCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
-import com.umc.product.survey.application.port.out.*;
+import com.umc.product.survey.application.port.out.SaveFormPort;
+import com.umc.product.survey.application.port.out.SaveFormSectionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.survey.application.port.out.SaveQuestionPort;
 import com.umc.product.survey.domain.Form;
 import com.umc.product.survey.domain.FormSection;
 import com.umc.product.survey.domain.Question;
 import com.umc.product.survey.domain.QuestionOption;
 import com.umc.product.survey.domain.enums.QuestionType;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,6 +39,13 @@ public class VoteService implements ManageVoteUseCase {
     private final SaveQuestionOptionPort saveQuestionOptionPort;
     private final ManageFormUseCase manageFormUseCase;
 
+    @Audited(
+        domain = Domain.SURVEY,
+        action = AuditAction.CREATE,
+        targetType = "Vote",
+        targetId = "#result",
+        description = "'투표가 생성되었습니다.'"
+    )
     @Override
     public Long createVote(CreateVoteCommand command) {
         QuestionType qType = command.allowMultipleChoice()

--- a/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
@@ -3,6 +3,9 @@ package com.umc.product.survey.application.service.command;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.survey.application.port.in.command.ManageFormUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateDraftFormCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteFormCommand;
@@ -34,6 +37,13 @@ public class FormCommandService implements ManageFormUseCase {
     private final SaveFormResponsePort saveFormResponsePort;
     private final SaveAnswerPort saveAnswerPort;
 
+    @Audited(
+        domain = Domain.SURVEY,
+        action = AuditAction.CREATE,
+        targetType = "Form",
+        targetId = "#result",
+        description = "'설문 폼 초안이 생성되었습니다.'"
+    )
     @Override
     public Long createDraft(CreateDraftFormCommand command) {
         Form form = Form.createDraft(
@@ -61,6 +71,13 @@ public class FormCommandService implements ManageFormUseCase {
         saveFormPort.save(form);
     }
 
+    @Audited(
+        domain = Domain.SURVEY,
+        action = AuditAction.PUBLISH,
+        targetType = "Form",
+        targetId = "#command.formId()",
+        description = "'설문 폼이 게시되었습니다.'"
+    )
     @Override
     public void publishForm(PublishFormCommand command) {
         Form form = loadFormPort.findById(command.formId())

--- a/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormCommandService.java
@@ -42,7 +42,7 @@ public class FormCommandService implements ManageFormUseCase {
         action = AuditAction.CREATE,
         targetType = "Form",
         targetId = "#result",
-        description = "'설문 폼 초안이 생성되었습니다.'"
+        description = "'설문 폼 초안을 생성했습니다.'"
     )
     @Override
     public Long createDraft(CreateDraftFormCommand command) {
@@ -76,7 +76,7 @@ public class FormCommandService implements ManageFormUseCase {
         action = AuditAction.PUBLISH,
         targetType = "Form",
         targetId = "#command.formId()",
-        description = "'설문 폼이 게시되었습니다.'"
+        description = "'설문 폼을 게시했습니다.'"
     )
     @Override
     public void publishForm(PublishFormCommand command) {

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -10,6 +10,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 import com.umc.product.survey.application.port.in.command.ManageFormResponseUseCase;
 import com.umc.product.survey.application.port.in.command.dto.AnswerCommand;
@@ -54,6 +57,13 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     private final SaveAnswerPort saveAnswerPort;
     private final GetFileUseCase getFileUseCase;
 
+    @Audited(
+        domain = Domain.SURVEY,
+        action = AuditAction.SUBMIT,
+        targetType = "FormResponse",
+        targetId = "#result",
+        description = "'설문 응답이 제출되었습니다.'"
+    )
     @Override
     public Long submitImmediately(SubmitFormResponseCommand command) {
         Form form = loadPublishedForm(command.formId());

--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -62,7 +62,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         action = AuditAction.SUBMIT,
         targetType = "FormResponse",
         targetId = "#result",
-        description = "'설문 응답이 제출되었습니다.'"
+        description = "'설문 응답을 제출했습니다.'"
     )
     @Override
     public Long submitImmediately(SubmitFormResponseCommand command) {

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -10,6 +10,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.survey.application.port.in.command.ManageQuestionUseCase;
 import com.umc.product.survey.application.port.in.command.dto.CreateQuestionCommand;
 import com.umc.product.survey.application.port.in.command.dto.DeleteQuestionCommand;
@@ -93,6 +96,13 @@ public class QuestionCommandService implements ManageQuestionUseCase {
         saveQuestionPort.deleteById(questionId);
     }
 
+    @Audited(
+        domain = Domain.SURVEY,
+        action = AuditAction.REORDER,
+        targetType = "Question",
+        targetId = "#command.sectionId()",
+        description = "'설문 질문 순서가 변경되었습니다.'"
+    )
     @Override
     public void reorderQuestions(ReorderQuestionsCommand command) {
         List<Question> questions = loadQuestionPort.listBySectionId(command.sectionId());

--- a/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/QuestionCommandService.java
@@ -101,7 +101,7 @@ public class QuestionCommandService implements ManageQuestionUseCase {
         action = AuditAction.REORDER,
         targetType = "Question",
         targetId = "#command.sectionId()",
-        description = "'설문 질문 순서가 변경되었습니다.'"
+        description = "'설문 질문 순서를 변경했습니다.'"
     )
     @Override
     public void reorderQuestions(ReorderQuestionsCommand command) {

--- a/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
@@ -5,6 +5,9 @@ import java.time.Instant;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.term.application.port.in.command.ManageTermAgreementUseCase;
 import com.umc.product.term.application.port.in.command.dto.CreateTermConsentCommand;
 import com.umc.product.term.application.port.out.LoadTermConsentPort;
@@ -31,6 +34,13 @@ public class TermAgreementCommandService implements ManageTermAgreementUseCase {
     private final SaveTermConsentPort saveTermConsentPort;
     private final SaveTermConsentLogPort saveTermConsentLogPort;
 
+    @Audited(
+        domain = Domain.TERMS,
+        action = AuditAction.SUBMIT,
+        targetType = "TermConsent",
+        targetId = "#command.termId()",
+        description = "'약관 동의가 제출되었습니다.'"
+    )
     @Override
     public void createTermConsent(CreateTermConsentCommand command) {
         // 약관 존재 확인

--- a/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermAgreementCommandService.java
@@ -39,7 +39,7 @@ public class TermAgreementCommandService implements ManageTermAgreementUseCase {
         action = AuditAction.SUBMIT,
         targetType = "TermConsent",
         targetId = "#command.termId()",
-        description = "'약관 동의가 제출되었습니다.'"
+        description = "'약관 동의를 제출했습니다.'"
     )
     @Override
     public void createTermConsent(CreateTermConsentCommand command) {

--- a/src/main/java/com/umc/product/term/application/service/command/TermCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermCommandService.java
@@ -1,13 +1,18 @@
 package com.umc.product.term.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.global.exception.constant.Domain;
 import com.umc.product.term.application.port.in.command.ManageTermUseCase;
 import com.umc.product.term.application.port.in.command.dto.CreateTermCommand;
 import com.umc.product.term.application.port.out.LoadTermPort;
 import com.umc.product.term.application.port.out.SaveTermPort;
 import com.umc.product.term.domain.Term;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,13 @@ public class TermCommandService implements ManageTermUseCase {
     private final SaveTermPort saveTermPort;
     private final LoadTermPort loadTermPort;
 
+    @Audited(
+        domain = Domain.TERMS,
+        action = AuditAction.CREATE,
+        targetType = "Term",
+        targetId = "#result",
+        description = "'약관이 생성되었습니다.'"
+    )
     @Override
     public Long createTerms(CreateTermCommand command) {
         // 새로 생성하려는 약관과 동일한 타입의 기존 활성 약관을 찾아 비활성화 처리

--- a/src/main/java/com/umc/product/term/application/service/command/TermCommandService.java
+++ b/src/main/java/com/umc/product/term/application/service/command/TermCommandService.java
@@ -27,7 +27,7 @@ public class TermCommandService implements ManageTermUseCase {
         action = AuditAction.CREATE,
         targetType = "Term",
         targetId = "#result",
-        description = "'약관이 생성되었습니다.'"
+        description = "'약관을 생성했습니다.'"
     )
     @Override
     public Long createTerms(CreateTermCommand command) {

--- a/src/main/java/com/umc/product/test/adapter/in/web/TestController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/TestController.java
@@ -109,7 +109,7 @@ public class TestController {
         @RequestParam String title,
         @RequestParam String content
     ) {
-        log.debug("웹훅 알람 AOP 테스트가 호출되었습니다~!");
+        log.debug("웹훅 알람 AOP 테스트를 호출했습니다.");
 
         return TestAopAlarmResponse.builder()
             .content(content)

--- a/src/test/java/com/umc/product/audit/application/service/AuditCoveragePolicyTest.java
+++ b/src/test/java/com/umc/product/audit/application/service/AuditCoveragePolicyTest.java
@@ -1,0 +1,173 @@
+package com.umc.product.audit.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+
+class AuditCoveragePolicyTest {
+
+    @Test
+    @DisplayName("감사 로그 액션 enum은 전 도메인 상태 변경에 필요한 값을 제공한다")
+    void required_audit_actions_exist() {
+        assertThat(Stream.of("LOGIN", "LINK", "UNLINK", "ACCESS_DENIED", "PUBLISH", "CANCEL", "REMIND", "REORDER", "FINALIZE")
+            .map(this::auditAction)
+            .toList()).hasSize(9);
+    }
+
+    @Test
+    @DisplayName("주요 CommandService 상태 변경 메서드는 감사 로그 대상으로 선언한다")
+    void command_services_are_audited() {
+        List<String> violations = auditedSpecs().stream()
+            .filter(spec -> !matchesAuditPolicy(spec))
+            .map(AuditSpec::describe)
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    private boolean matchesAuditPolicy(AuditSpec spec) {
+        Audited audited = getMethod(spec).getAnnotation(Audited.class);
+        return audited != null
+            && audited.domain().name().equals(spec.domain())
+            && audited.action().name().equals(spec.action())
+            && audited.targetType().equals(spec.targetType());
+    }
+
+    private Method getMethod(AuditSpec spec) {
+        try {
+            return type(spec.serviceClassName()).getMethod(spec.methodName(), spec.parameterTypes());
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("감사 로그 정책 테스트 메서드 조회 실패: " + spec.describe(), e);
+        }
+    }
+
+    private Object auditAction(String name) {
+        try {
+            Class<?> auditActionClass = type("audit.domain.AuditAction");
+            return Enum.valueOf((Class<Enum>) auditActionClass.asSubclass(Enum.class), name);
+        } catch (IllegalArgumentException e) {
+            throw new AssertionError("필수 AuditAction 누락: " + name, e);
+        }
+    }
+
+    private static Class<?> type(String shortName) {
+        try {
+            return Class.forName("com.umc.product." + shortName);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("감사 로그 정책 테스트 타입 조회 실패: " + shortName, e);
+        }
+    }
+
+    private static AuditSpec spec(
+        String serviceClassName,
+        String methodName,
+        String domain,
+        String action,
+        String targetType,
+        Class<?>... parameterTypes
+    ) {
+        return new AuditSpec(serviceClassName, methodName, domain, action, targetType, parameterTypes);
+    }
+
+    private static List<AuditSpec> auditedSpecs() {
+        Class<?> longType = Long.class;
+        Class<?> listType = List.class;
+        return List.of(
+            spec("authentication.application.service.CredentialAuthenticationService", "loginByEmail", "AUTHENTICATION", "LOGIN", "MemberCredential", type("authentication.application.port.in.command.dto.LoginByEmailCommand")),
+            spec("authentication.application.service.OAuthAuthenticationService", "loginWithOAuthAttributes", "AUTHENTICATION", "LOGIN", "OAuthAuthentication", type("authentication.domain.OAuthAttributes")),
+            spec("authentication.application.service.OAuthAuthenticationService", "accessTokenLogin", "AUTHENTICATION", "LOGIN", "OAuthAuthentication", type("authentication.application.port.in.command.dto.AccessTokenLoginCommand")),
+            spec("authentication.application.service.OAuthAuthenticationService", "authorizationCodeLogin", "AUTHENTICATION", "LOGIN", "OAuthAuthentication", type("authentication.application.port.in.command.dto.AuthorizationCodeLoginCommand")),
+            spec("authentication.application.service.OAuthAuthenticationService", "linkOAuth", "AUTHENTICATION", "LINK", "MemberOAuth", type("authentication.application.port.in.command.dto.LinkOAuthCommand")),
+            spec("authentication.application.service.OAuthAuthenticationService", "linkOAuthBulk", "AUTHENTICATION", "LINK", "MemberOAuth", listType),
+            spec("authentication.application.service.OAuthAuthenticationService", "unlinkOAuth", "AUTHENTICATION", "UNLINK", "MemberOAuth", type("authentication.application.port.in.command.dto.UnlinkOAuthCommand")),
+
+            spec("authorization.application.service.command.ChallengerRoleCommandService", "createChallengerRole", "AUTHORIZATION", "CREATE", "ChallengerRole", type("authorization.application.port.in.command.dto.CreateChallengerRoleCommand")),
+            spec("authorization.application.service.command.ChallengerRoleCommandService", "updateChallengerRole", "AUTHORIZATION", "UPDATE", "ChallengerRole", type("authorization.application.port.in.command.dto.UpdateChallengerRoleCommand")),
+            spec("authorization.application.service.command.ChallengerRoleCommandService", "deleteChallengerRole", "AUTHORIZATION", "DELETE", "ChallengerRole", type("authorization.application.port.in.command.dto.DeleteChallengerRoleCommand")),
+
+            spec("member.application.service.MemberEmailCommandService", "changeEmail", "MEMBER", "UPDATE", "MemberEmail", type("member.application.port.in.command.dto.ChangeMemberEmailCommand")),
+            spec("member.application.service.MemberCredentialCommandService", "registerCredentialByEmail", "MEMBER", "CREATE", "MemberCredential", type("member.application.port.in.command.dto.RegisterMemberCredentialByEmailCommand")),
+            spec("member.application.service.MemberCredentialCommandService", "changePassword", "MEMBER", "UPDATE", "MemberCredential", type("member.application.port.in.command.dto.ChangeMemberPasswordCommand")),
+            spec("member.application.service.MemberProfileCommandService", "upsert", "MEMBER", "UPDATE", "MemberProfile", type("member.application.port.in.command.dto.UpsertMemberProfileCommand")),
+            spec("member.application.service.MemberProfileCommandService", "delete", "MEMBER", "DELETE", "MemberProfile", longType),
+
+            spec("term.application.service.command.TermCommandService", "createTerms", "TERMS", "CREATE", "Term", type("term.application.port.in.command.dto.CreateTermCommand")),
+            spec("term.application.service.command.TermAgreementCommandService", "createTermConsent", "TERMS", "SUBMIT", "TermConsent", type("term.application.port.in.command.dto.CreateTermConsentCommand")),
+
+            spec("organization.application.service.UmcProductGenerationCommandService", "create", "ORGANIZATION", "CREATE", "UmcProductGeneration", type("organization.application.port.in.command.dto.CreateUmcProductGenerationCommand")),
+            spec("organization.application.service.UmcProductGenerationCommandService", "update", "ORGANIZATION", "UPDATE", "UmcProductGeneration", type("organization.application.port.in.command.dto.UpdateUmcProductGenerationCommand")),
+            spec("organization.application.service.UmcProductGenerationCommandService", "delete", "ORGANIZATION", "DELETE", "UmcProductGeneration", longType, longType),
+            spec("organization.application.service.UmcProductMemberCommandService", "create", "ORGANIZATION", "CREATE", "UmcProductMember", type("organization.application.port.in.command.dto.CreateUmcProductMemberCommand")),
+            spec("organization.application.service.UmcProductMemberCommandService", "updateProfile", "ORGANIZATION", "UPDATE", "UmcProductMember", type("organization.application.port.in.command.dto.UpdateUmcProductMemberProfileCommand")),
+            spec("organization.application.service.UmcProductSquadCommandService", "replaceParticipants", "ORGANIZATION", "UPDATE", "UmcProductSquad", type("organization.application.port.in.command.dto.ReplaceUmcProductSquadParticipantsCommand")),
+
+            spec("challenger.application.service.ChallengerRecordCommandService", "consumeCode", "CHALLENGER", "CHECK", "ChallengerRecord", type("challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand")),
+
+            spec("curriculum.application.service.command.CurriculumCommandService", "create", "CURRICULUM", "CREATE", "Curriculum", type("curriculum.application.port.in.command.dto.curriculum.CreateCurriculumCommand")),
+            spec("curriculum.application.service.command.CurriculumCommandService", "edit", "CURRICULUM", "UPDATE", "Curriculum", type("curriculum.application.port.in.command.dto.curriculum.EditCurriculumCommand")),
+            spec("curriculum.application.service.command.CurriculumCommandService", "delete", "CURRICULUM", "DELETE", "Curriculum", longType),
+            spec("curriculum.application.service.command.OriginalWorkbookCommandService", "releaseAllDue", "CURRICULUM", "PUBLISH", "OriginalWorkbook"),
+            spec("curriculum.application.service.command.MissionSubmissionCommandService", "create", "CURRICULUM", "SUBMIT", "MissionSubmission", type("curriculum.application.port.in.command.dto.workbook.mission.CreateMissionSubmissionCommand")),
+            spec("curriculum.application.service.command.WeeklyBestWorkbookCommandService", "selectBest", "CURRICULUM", "APPROVE", "WeeklyBestWorkbook", type("curriculum.application.port.in.command.dto.workbook.CreateWeeklyBestWorkbookCommand")),
+
+            spec("schedule.application.service.command.ScheduleParticipantCommandService", "decideAttendances", "SCHEDULE", "CHECK", "ScheduleAttendance", listType),
+
+            spec("community.application.service.command.PostCommandService", "createPost", "COMMUNITY", "CREATE", "Post", type("community.application.port.in.command.post.dto.CreatePostCommand")),
+            spec("community.application.service.command.PostCommandService", "updatePost", "COMMUNITY", "UPDATE", "Post", type("community.application.port.in.command.post.dto.UpdatePostCommand")),
+            spec("community.application.service.command.PostCommandService", "deletePost", "COMMUNITY", "DELETE", "Post", longType),
+            spec("community.application.service.command.ReportCommandService", "report", "COMMUNITY", "SUBMIT", "PostReport", type("community.application.port.in.command.report.dto.ReportPostCommand")),
+
+            spec("blog.application.service.BlogContentCommandService", "create", "BLOG", "CREATE", "BlogContent", type("blog.application.port.in.command.dto.CreateBlogContentCommand")),
+            spec("blog.application.service.BlogContentCommandService", "update", "BLOG", "UPDATE", "BlogContent", type("blog.application.port.in.command.dto.UpdateBlogContentCommand")),
+            spec("blog.application.service.BlogContentCommandService", "delete", "BLOG", "DELETE", "BlogContent", type("blog.application.port.in.command.dto.DeleteBlogContentCommand")),
+            spec("blog.application.service.BlogSeriesCommandService", "replaceContents", "BLOG", "REORDER", "BlogSeries", type("blog.application.port.in.command.dto.ReplaceBlogSeriesContentsCommand")),
+
+            spec("notice.application.service.command.NoticeService", "createNotice", "NOTICE", "CREATE", "Notice", type("notice.application.port.in.command.dto.CreateNoticeCommand")),
+            spec("notice.application.service.command.NoticeService", "updateNoticeTitleOrContent", "NOTICE", "UPDATE", "Notice", type("notice.application.port.in.command.dto.UpdateNoticeCommand")),
+            spec("notice.application.service.command.NoticeService", "deleteNotice", "NOTICE", "DELETE", "Notice", type("notice.application.port.in.command.dto.DeleteNoticeCommand")),
+            spec("notice.application.service.command.NoticeService", "remindNotice", "NOTICE", "REMIND", "Notice", type("notice.application.port.in.command.dto.SendNoticeReminderCommand")),
+            spec("notice.application.service.command.NoticeVoteResponseCommandService", "submit", "NOTICE", "SUBMIT", "NoticeVoteResponse", type("notice.application.port.in.command.dto.SubmitNoticeVoteResponseCommand")),
+
+            spec("survey.application.service.command.FormCommandService", "createDraft", "SURVEY", "CREATE", "Form", type("survey.application.port.in.command.dto.CreateDraftFormCommand")),
+            spec("survey.application.service.command.FormCommandService", "publishForm", "SURVEY", "PUBLISH", "Form", type("survey.application.port.in.command.dto.PublishFormCommand")),
+            spec("survey.application.service.command.QuestionCommandService", "reorderQuestions", "SURVEY", "REORDER", "Question", type("survey.application.port.in.command.dto.ReorderQuestionsCommand")),
+            spec("survey.application.service.command.FormResponseCommandService", "submitImmediately", "SURVEY", "SUBMIT", "FormResponse", type("survey.application.port.in.command.dto.SubmitFormResponseCommand")),
+            spec("survey.application.service.VoteService", "createVote", "SURVEY", "CREATE", "Vote", type("survey.application.port.in.command.dto.CreateVoteCommand")),
+
+            spec("feedback.application.service.command.UserFeedbackResponseCommandService", "submit", "FEEDBACK", "SUBMIT", "UserFeedbackResponse", type("feedback.application.port.in.command.dto.SubmitUserFeedbackResponseCommand")),
+
+            spec("project.application.service.command.ProjectCommandService", "create", "PROJECT", "CREATE", "Project", type("project.application.port.in.command.dto.CreateDraftProjectCommand")),
+            spec("project.application.service.command.ProjectCommandService", "publish", "PROJECT", "PUBLISH", "Project", type("project.application.port.in.command.dto.PublishProjectCommand")),
+            spec("project.application.service.command.ProjectCommandService", "delete", "PROJECT", "DELETE", "Project", type("project.application.port.in.command.dto.DeleteProjectCommand")),
+            spec("project.application.service.command.ProjectApplicationCommandService", "submit", "PROJECT", "SUBMIT", "ProjectApplication", type("project.application.port.in.command.dto.SubmitProjectApplicationCommand")),
+            spec("project.application.service.command.ProjectMatchingRoundFinalizationCommandService", "autoDecide", "PROJECT", "FINALIZE", "ProjectMatchingRound", longType, longType),
+            spec("project.application.service.command.ProjectPartQuotaCommandService", "update", "PROJECT", "UPDATE", "ProjectPartQuota", type("project.application.port.in.command.dto.UpdatePartQuotasCommand")),
+
+            spec("storage.application.service.FileCommandService", "getFileUploadUrl", "STORAGE", "CREATE", "FileMetadata", type("storage.application.port.in.command.dto.PrepareFileUploadCommand")),
+            spec("storage.application.service.FileCommandService", "confirmUpload", "STORAGE", "CHECK", "FileMetadata", String.class),
+            spec("storage.application.service.FileCommandService", "deleteFile", "STORAGE", "DELETE", "FileMetadata", type("storage.application.port.in.command.dto.DeleteFileCommand"))
+        );
+    }
+
+    private record AuditSpec(
+        String serviceClassName,
+        String methodName,
+        String domain,
+        String action,
+        String targetType,
+        Class<?>[] parameterTypes
+    ) {
+
+        private String describe() {
+            return "%s#%s expected domain=%s action=%s targetType=%s"
+                .formatted(serviceClassName, methodName, domain, action, targetType);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionSchedulerTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/in/scheduler/EmailVerificationRetentionSchedulerTest.java
@@ -5,9 +5,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
 import java.time.Duration;
 import java.time.Instant;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +15,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.authentication.application.port.out.DeleteEmailVerificationPort;
+import com.umc.product.global.logging.OperationalMetrics;
 
 /**
  * EmailVerificationRetentionScheduler 단위 테스트.
@@ -27,6 +30,9 @@ class EmailVerificationRetentionSchedulerTest {
 
     @Mock
     DeleteEmailVerificationPort deleteEmailVerificationPort;
+
+    @Mock
+    OperationalMetrics operationalMetrics;
 
     @InjectMocks
     EmailVerificationRetentionScheduler scheduler;

--- a/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/CredentialAuthenticationServiceTest.java
@@ -30,6 +30,7 @@ import com.umc.product.authentication.application.port.in.command.dto.ResetPassw
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
 import com.umc.product.common.domain.enums.ClientType;
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.member.application.port.in.command.ManageMemberCredentialUseCase;
 import com.umc.product.member.application.port.in.command.dto.ChangeMemberPasswordCommand;
 import com.umc.product.member.application.port.in.command.dto.RegisterMemberCredentialByEmailCommand;
@@ -59,6 +60,8 @@ class CredentialAuthenticationServiceTest {
     ManageMemberCredentialUseCase manageMemberCredentialUseCase;
     @Mock
     CredentialRehashService rehashService;
+    @Mock
+    OperationalMetrics operationalMetrics;
     @InjectMocks
     CredentialAuthenticationService service;
 

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordAuditPolicyTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordAuditPolicyTest.java
@@ -1,0 +1,56 @@
+package com.umc.product.challenger.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
+import com.umc.product.global.exception.constant.Domain;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChallengerRecordAuditPolicyTest {
+
+    @Test
+    @DisplayName("챌린저 기록 생성은 감사 로그 대상으로 선언한다")
+    void create_is_audited() throws NoSuchMethodException {
+        Audited audited = audited("create", CreateChallengerRecordCommand.class);
+
+        assertThat(audited).isNotNull();
+        assertThat(audited.domain()).isEqualTo(Domain.CHALLENGER);
+        assertThat(audited.action()).isEqualTo(AuditAction.CREATE);
+        assertThat(audited.targetType()).isEqualTo("ChallengerRecord");
+        assertThat(audited.targetId()).isEqualTo("#result");
+    }
+
+    @Test
+    @DisplayName("챌린저 기록 대량 생성은 감사 로그 대상으로 선언한다")
+    void create_bulk_is_audited() throws NoSuchMethodException {
+        Audited audited = audited("createBulk", List.class);
+
+        assertThat(audited).isNotNull();
+        assertThat(audited.domain()).isEqualTo(Domain.CHALLENGER);
+        assertThat(audited.action()).isEqualTo(AuditAction.CREATE);
+        assertThat(audited.targetType()).isEqualTo("ChallengerRecord");
+        assertThat(audited.targetId()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("챌린저 기록 삭제는 감사 로그 대상으로 선언한다")
+    void delete_is_audited() throws NoSuchMethodException {
+        Audited audited = audited("delete", Long.class);
+
+        assertThat(audited).isNotNull();
+        assertThat(audited.domain()).isEqualTo(Domain.CHALLENGER);
+        assertThat(audited.action()).isEqualTo(AuditAction.DELETE);
+        assertThat(audited.targetType()).isEqualTo("ChallengerRecord");
+        assertThat(audited.targetId()).isEqualTo("#id");
+    }
+
+    private Audited audited(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        Method method = ChallengerRecordCommandService.class.getMethod(methodName, parameterTypes);
+        return method.getAnnotation(Audited.class);
+    }
+}

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordAuditPolicyTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordAuditPolicyTest.java
@@ -2,14 +2,16 @@ package com.umc.product.challenger.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
 import com.umc.product.global.exception.constant.Domain;
-import java.lang.reflect.Method;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 class ChallengerRecordAuditPolicyTest {
 

--- a/src/test/java/com/umc/product/global/logging/ExternalApiCallUsagePolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/ExternalApiCallUsagePolicyTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/umc/product/global/logging/ExternalApiCallUsagePolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/ExternalApiCallUsagePolicyTest.java
@@ -1,0 +1,46 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExternalApiCallUsagePolicyTest {
+
+    private static final List<Path> EXTERNAL_CALL_ADAPTERS = List.of(
+        Path.of("src/main/java/com/umc/product/authentication/adapter/out/external/AppleTokenVerifier.java"),
+        Path.of("src/main/java/com/umc/product/authentication/adapter/out/external/GoogleTokenVerifier.java"),
+        Path.of("src/main/java/com/umc/product/authentication/adapter/out/external/KakaoTokenVerifier.java"),
+        Path.of("src/main/java/com/umc/product/figma/adapter/out/external/FigmaOAuthClient.java"),
+        Path.of("src/main/java/com/umc/product/figma/adapter/out/external/FigmaCommentClient.java"),
+        Path.of("src/main/java/com/umc/product/figma/adapter/out/external/FigmaFileMetadataClient.java"),
+        Path.of("src/main/java/com/umc/product/figma/adapter/out/external/DiscordMentionWebhookAdapter.java"),
+        Path.of("src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java"),
+        Path.of("src/main/java/com/umc/product/notification/adapter/out/external/webhook/DiscordWebhookAdapter.java"),
+        Path.of("src/main/java/com/umc/product/notification/adapter/out/external/webhook/SlackWebhookAdapter.java"),
+        Path.of("src/main/java/com/umc/product/notification/adapter/out/external/webhook/TelegramWebhookAdapter.java")
+    );
+
+    @Test
+    @DisplayName("주요 외부 호출 어댑터는 구조화된 외부 API 호출 로그를 남긴다")
+    void external_call_adapters_use_external_api_call_logger() throws IOException {
+        List<String> violations = EXTERNAL_CALL_ADAPTERS.stream()
+            .filter(path -> !usesExternalApiCallLogger(path))
+            .map(Path::toString)
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    private boolean usesExternalApiCallLogger(Path path) {
+        try {
+            return Files.readString(path).contains("ExternalApiCallLogger.measure(");
+        } catch (IOException e) {
+            throw new IllegalStateException("외부 API 호출 정책 테스트 파일 읽기 실패: " + path, e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/logging/LoggingPlacementPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/LoggingPlacementPolicyTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/umc/product/global/logging/LoggingPlacementPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/LoggingPlacementPolicyTest.java
@@ -1,0 +1,76 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoggingPlacementPolicyTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
+    private static final List<String> LOG_METHODS = List.of(
+        "log.trace(", "log.debug(", "log.info(", "log.warn(", "log.error("
+    );
+
+    @Test
+    @DisplayName("DTO와 도메인 enum은 운영 로그를 직접 남기지 않는다")
+    void dto_and_domain_enum_do_not_log_directly() throws IOException {
+        List<String> violations = findJavaFiles()
+            .filter(LoggingPlacementPolicyTest::isDtoOrDomainEnum)
+            .flatMap(this::findLoggerUsage)
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("운영 로그는 command 객체 전체를 직접 남기지 않는다")
+    void logs_do_not_write_full_command_objects() throws IOException {
+        List<String> violations = findJavaFiles()
+            .flatMap(this::findFullCommandLogUsage)
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    private Stream<Path> findJavaFiles() throws IOException {
+        return Files.walk(MAIN_SOURCE_ROOT)
+            .filter(path -> path.toString().endsWith(".java"));
+    }
+
+    private static boolean isDtoOrDomainEnum(Path path) {
+        String normalizedPath = path.toString();
+        return normalizedPath.contains("/dto/") || normalizedPath.contains("/domain/enums/");
+    }
+
+    private Stream<String> findLoggerUsage(Path path) {
+        return findLineViolations(path, line -> line.contains("@Slf4j") || usesLogger(line));
+    }
+
+    private Stream<String> findFullCommandLogUsage(Path path) {
+        return findLineViolations(path, line ->
+            usesLogger(line) && (line.contains("command={}") || line.contains("commands={}"))
+        );
+    }
+
+    private static boolean usesLogger(String line) {
+        return LOG_METHODS.stream().anyMatch(line::contains);
+    }
+
+    private Stream<String> findLineViolations(Path path, java.util.function.Predicate<String> predicate) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            return IntStream.range(0, lines.size())
+                .filter(index -> predicate.test(lines.get(index)))
+                .mapToObj(index -> "%s:%d %s".formatted(path, index + 1, lines.get(index).trim()));
+        } catch (IOException e) {
+            throw new IllegalStateException("로그 위치 정책 테스트 파일 읽기 실패: " + path, e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/logging/LoggingUxWritingPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/LoggingUxWritingPolicyTest.java
@@ -1,0 +1,81 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoggingUxWritingPolicyTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
+    private static final List<String> PASSIVE_AUDIT_PATTERNS = List.of(
+        "되었습니다",
+        "처리되었습니다",
+        "완료되었습니다"
+    );
+    private static final List<String> ROUGH_LOG_PATTERNS = List.of(
+        "오류 발생",
+        "skip합니다",
+        "스킵",
+        "호출되었습니다",
+        "완료:",
+        "생성 완료",
+        "전송 완료",
+        "처리 완료",
+        "성공:"
+    );
+
+    @Test
+    @DisplayName("감사 로그 설명은 피동형 상태 보고 대신 행동 중심 문장으로 쓴다")
+    void audit_descriptions_use_action_oriented_copy() throws IOException {
+        List<String> violations = findJavaFiles()
+            .flatMap(path -> findLineViolations(path, this::isPassiveAuditDescription))
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("운영 로그 문구는 거친 축약어와 상태 보고 표현을 피한다")
+    void application_logs_follow_ux_writing_guidelines() throws IOException {
+        List<String> violations = findJavaFiles()
+            .flatMap(path -> findLineViolations(path, this::isRoughLogLine))
+            .toList();
+
+        assertThat(violations).isEmpty();
+    }
+
+    private Stream<Path> findJavaFiles() throws IOException {
+        return Files.walk(MAIN_SOURCE_ROOT)
+            .filter(path -> path.toString().endsWith(".java"));
+    }
+
+    private boolean isPassiveAuditDescription(String line) {
+        return line.contains("description = \"'")
+            && PASSIVE_AUDIT_PATTERNS.stream().anyMatch(line::contains);
+    }
+
+    private boolean isRoughLogLine(String line) {
+        return line.contains("log.")
+            && ROUGH_LOG_PATTERNS.stream().anyMatch(line::contains);
+    }
+
+    private Stream<String> findLineViolations(Path path, Predicate<String> predicate) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            return IntStream.range(0, lines.size())
+                .filter(index -> predicate.test(lines.get(index)))
+                .mapToObj(index -> "%s:%d %s".formatted(path, index + 1, lines.get(index).trim()));
+        } catch (IOException e) {
+            throw new IllegalStateException("로그 UX 라이팅 정책 테스트 파일 읽기 실패: " + path, e);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/logging/OperationalMetricsTest.java
+++ b/src/test/java/com/umc/product/global/logging/OperationalMetricsTest.java
@@ -1,0 +1,92 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class OperationalMetricsTest {
+
+    @Test
+    @DisplayName("외부 호출 메트릭은 provider operation result 낮은 cardinality 태그로 기록한다")
+    void record_external_call_metrics() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OperationalMetrics metrics = new OperationalMetrics(registry);
+
+        metrics.recordExternalCall("KAKAO", "VERIFY_ID_TOKEN", "success", Duration.ofMillis(25));
+
+        assertThat(registry.get("operational.external.call.total")
+            .tag("provider", "KAKAO")
+            .tag("operation", "VERIFY_ID_TOKEN")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(1);
+        assertThat(registry.get("operational.external.call.seconds")
+            .tag("provider", "KAKAO")
+            .tag("operation", "VERIFY_ID_TOKEN")
+            .tag("result", "success")
+            .timer()
+            .count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("배치와 알림과 보안 이벤트 메트릭은 집계 가능한 값만 기록한다")
+    void record_operational_metrics() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OperationalMetrics metrics = new OperationalMetrics(registry);
+
+        metrics.recordBatchJob("email_verification_retention", "success", Duration.ofMillis(10), 7);
+        metrics.recordNotification("FCM", "SEND_TO_MEMBERS", "success", 3);
+        metrics.recordSecurityEvent("AUTHORIZATION", "ACCESS_DENIED", "denied");
+
+        assertThat(registry.get("operational.batch.job.total")
+            .tag("jobName", "email_verification_retention")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(1);
+        assertThat(registry.get("operational.batch.job.processed.total")
+            .tag("jobName", "email_verification_retention")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(7);
+        assertThat(registry.get("operational.notification.send.total")
+            .tag("provider", "FCM")
+            .tag("operation", "SEND_TO_MEMBERS")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(3);
+        assertThat(registry.get("operational.security.event.total")
+            .tag("domain", "AUTHORIZATION")
+            .tag("operation", "ACCESS_DENIED")
+            .tag("result", "denied")
+            .counter()
+            .count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("메트릭 태그 값에 높은 cardinality 값이 들어오면 other로 축약한다")
+    void collapse_high_cardinality_tag_values() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OperationalMetrics metrics = new OperationalMetrics(registry);
+
+        metrics.recordNotification("FCM", "member-123456789", "success", 1);
+        metrics.recordExternalCall("https://example.com/callback?id=123", "CALL", "success", Duration.ZERO);
+
+        assertThat(registry.get("operational.notification.send.total")
+            .tag("provider", "FCM")
+            .tag("operation", "other")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(1);
+        assertThat(registry.get("operational.external.call.total")
+            .tag("provider", "other")
+            .tag("operation", "CALL")
+            .tag("result", "success")
+            .counter()
+            .count()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
@@ -1,0 +1,55 @@
+package com.umc.product.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SensitiveLoggingPolicyTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
+    private static final List<String> SENSITIVE_RAW_FIELD_NAMES = List.of("body={}", "email={}", "providerId={}", "sub={}");
+    private static final String NOTIFICATION_PACKAGE_PATH = "com/umc/product/notification";
+
+    @Test
+    @DisplayName("운영 로그는 민감한 OAuth 식별자와 외부 API 응답 본문을 직접 남기지 않는다")
+    void logs_do_not_write_sensitive_raw_fields() throws IOException {
+        List<String> violations = findLogViolations();
+
+        assertThat(violations).isEmpty();
+    }
+
+    private List<String> findLogViolations() throws IOException {
+        try (var paths = Files.walk(MAIN_SOURCE_ROOT)) {
+            return paths
+                .filter(path -> path.toString().endsWith(".java"))
+                .flatMap(this::findLogViolationsInFile)
+                .toList();
+        }
+    }
+
+    private java.util.stream.Stream<String> findLogViolationsInFile(Path path) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            return java.util.stream.IntStream.range(0, lines.size())
+                .filter(index -> isSensitiveLogLine(path, lines.get(index)))
+                .mapToObj(index -> "%s:%d %s".formatted(path, index + 1, lines.get(index).trim()));
+        } catch (IOException e) {
+            throw new IllegalStateException("로그 정책 테스트 파일 읽기 실패: " + path, e);
+        }
+    }
+
+    private boolean isSensitiveLogLine(Path path, String line) {
+        if (!line.contains("log.")) {
+            return false;
+        }
+        if (SENSITIVE_RAW_FIELD_NAMES.stream().anyMatch(line::contains)) {
+            return true;
+        }
+        return path.toString().contains(NOTIFICATION_PACKAGE_PATH) && line.contains("to={}");
+    }
+}

--- a/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
+++ b/src/test/java/com/umc/product/global/logging/SensitiveLoggingPolicyTest.java
@@ -13,8 +13,19 @@ import org.junit.jupiter.api.Test;
 class SensitiveLoggingPolicyTest {
 
     private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
-    private static final List<String> SENSITIVE_RAW_FIELD_NAMES = List.of("body={}", "email={}", "providerId={}", "sub={}");
+    private static final List<String> SENSITIVE_RAW_FIELD_NAMES = List.of(
+        "body={}",
+        "email={}",
+        "providerId={}",
+        "sub={}",
+        "signedUrl={}",
+        "signature={}",
+        "Signature: {}",
+        "Full URL: {}",
+        "Final URL: {}"
+    );
     private static final String NOTIFICATION_PACKAGE_PATH = "com/umc/product/notification";
+    private static final String STORAGE_PACKAGE_PATH = "com/umc/product/storage";
 
     @Test
     @DisplayName("운영 로그는 민감한 OAuth 식별자와 외부 API 응답 본문을 직접 남기지 않는다")
@@ -51,6 +62,10 @@ class SensitiveLoggingPolicyTest {
         if (SENSITIVE_RAW_FIELD_NAMES.stream().anyMatch(line::contains)) {
             return true;
         }
-        return path.toString().contains(NOTIFICATION_PACKAGE_PATH) && line.contains("to={}");
+        if (path.toString().contains(NOTIFICATION_PACKAGE_PATH)
+            && (line.contains("to={}") || line.contains("title={}") || line.contains("content={}"))) {
+            return true;
+        }
+        return path.toString().contains(STORAGE_PACKAGE_PATH) && line.contains("url={}");
     }
 }

--- a/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandlerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/scheduler/MatchingRoundDeadlineHandlerTest.java
@@ -3,18 +3,23 @@ package com.umc.product.project.adapter.in.scheduler;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 
-import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.umc.product.global.logging.OperationalMetrics;
+import com.umc.product.project.application.port.in.command.AutoDecideProjectMatchingRoundUseCase;
+
 @ExtendWith(MockitoExtension.class)
 class MatchingRoundDeadlineHandlerTest {
 
     @Mock
     AutoDecideProjectMatchingRoundUseCase autoDecideUseCase;
+
+    @Mock
+    OperationalMetrics operationalMetrics;
 
     @InjectMocks
     MatchingRoundDeadlineHandler sut;

--- a/src/test/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapterTest.java
+++ b/src/test/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapterTest.java
@@ -15,11 +15,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.storage.application.port.in.command.dto.FileUploadInfo;
 import com.umc.product.storage.application.port.out.dto.StorageObjectInfo;
 import com.umc.product.storage.domain.exception.StorageErrorCode;
 import com.umc.product.storage.domain.exception.StorageException;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -45,7 +47,7 @@ class S3StorageAdapterTest {
     @DisplayName("Presigned PUT 생성 시 요청 파일 크기를 Content-Length로 서명한다")
     void Presigned_PUT_생성_시_요청_파일_크기를_Content_Length로_서명한다() throws Exception {
         // given
-        S3StorageAdapter sut = new S3StorageAdapter(s3Client, s3Presigner, properties());
+        S3StorageAdapter sut = adapter();
         ArgumentCaptor<PutObjectPresignRequest> captor = ArgumentCaptor.forClass(PutObjectPresignRequest.class);
         given(presignedPutObjectRequest.url()).willReturn(URI.create("https://storage.example.com/upload").toURL());
         given(s3Presigner.presignPutObject(captor.capture())).willReturn(presignedPutObjectRequest);
@@ -67,7 +69,7 @@ class S3StorageAdapterTest {
     @DisplayName("HeadObject 결과를 S3 객체 정보로 반환한다")
     void HeadObject_결과를_S3_객체_정보로_반환한다() {
         // given
-        S3StorageAdapter sut = new S3StorageAdapter(s3Client, s3Presigner, properties());
+        S3StorageAdapter sut = adapter();
         given(s3Client.headObject(org.mockito.ArgumentMatchers.any(HeadObjectRequest.class)))
             .willReturn(HeadObjectResponse.builder()
                 .contentLength(1024L)
@@ -85,7 +87,7 @@ class S3StorageAdapterTest {
     @DisplayName("S3 객체가 없으면 빈 객체 정보를 반환하고 exists는 false를 반환한다")
     void S3_객체가_없으면_빈_객체_정보를_반환하고_exists는_false를_반환한다() {
         // given
-        S3StorageAdapter sut = new S3StorageAdapter(s3Client, s3Presigner, properties());
+        S3StorageAdapter sut = adapter();
         given(s3Client.headObject(org.mockito.ArgumentMatchers.any(HeadObjectRequest.class)))
             .willThrow(NoSuchKeyException.builder().build());
 
@@ -98,7 +100,7 @@ class S3StorageAdapterTest {
     @DisplayName("HeadObject 조회 중 404가 아닌 S3Exception은 StorageException으로 변환한다")
     void HeadObject_조회_중_404가_아닌_S3Exception은_StorageException으로_변환한다() {
         // given
-        S3StorageAdapter sut = new S3StorageAdapter(s3Client, s3Presigner, properties());
+        S3StorageAdapter sut = adapter();
         given(s3Client.headObject(org.mockito.ArgumentMatchers.any(HeadObjectRequest.class)))
             .willThrow(S3Exception.builder().statusCode(500).build());
 
@@ -108,6 +110,15 @@ class S3StorageAdapterTest {
             .hasCauseInstanceOf(S3Exception.class)
             .extracting("baseCode")
             .isEqualTo(StorageErrorCode.STORAGE_METADATA_READ_FAILED);
+    }
+
+    private S3StorageAdapter adapter() {
+        return new S3StorageAdapter(
+            s3Client,
+            s3Presigner,
+            properties(),
+            new OperationalMetrics(new SimpleMeterRegistry())
+        );
     }
 
     private S3StorageProperties properties() {


### PR DESCRIPTION
## 요약
- OAuth/외부 API/이메일 로그에서 providerId, sub, email, response body, 수신자 주소 원문을 제거했습니다.
- DTO/domain enum 내부 로거와 command 객체 전체 로그를 제거하고, 필요한 서비스 로그는 결과 중심 요약으로 조정했습니다.
- ChallengerRecord 생성/대량생성/삭제를 audit log 대상으로 선언했습니다.
- 주요 OAuth/Figma/webhook/SES 외부 호출을 ExternalApiCallLogger로 감싸 result/durationMs/errorClass 구조화 이벤트를 남기도록 했습니다.

## 테스트
- ./gradlew test

## 비고
- GCS 제거는 별도 PR #1028로 분리했습니다.