### PR TITLE
[Fix] 지원서 상세 조회 시 변경된 질문에 대한 응답이 누락되는 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -104,7 +105,6 @@ public class ProjectApplicationQueryService
             .map(ChallengerInfo::part)
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
 
-        FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
         List<ProjectApplicationFormPolicy> formPolicies =
             loadProjectApplicationFormPolicyPort.listByApplicationFormId(applicationForm.getId());
         // dangling formResponseId 는 invariant 위반이지만, 클라이언트에는 PROJECT_APPLICATION_NOT_FOUND 로 통일한다.
@@ -112,6 +112,13 @@ public class ProjectApplicationQueryService
         FormResponseWithAnswersInfo formResponseWithAnswers =
             getFormResponseUseCase.findResponseWithAnswers(application.getFormResponseId())
                 .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND));
+        // 답변이 존재하는 questionId 기준으로 폼 구조를 조립한다.
+        // fork로 비활성화된 구 버전 질문도 Answer.questionId 역추적으로 포함하기 위함이다.
+        Set<Long> answeredQuestionIds = formResponseWithAnswers.answers().stream()
+            .map(AnswerInfo::questionId)
+            .collect(Collectors.toSet());
+        FormWithStructureInfo formStructure = getFormUseCase.getFormWithStructureByQuestionIds(
+            applicationForm.getFormId(), answeredQuestionIds);
         Map<String, FileInfo> filesByFileId = resolveFiles(formResponseWithAnswers.answers());
 
         return ProjectApplicationDetailInfo.of(

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionPersistenceAdapter.java
@@ -80,6 +80,11 @@ public class QuestionPersistenceAdapter implements SaveQuestionPort, LoadQuestio
     }
 
     @Override
+    public List<Question> listByIdIn(Set<Long> questionIds) {
+        return questionQueryRepository.findAllByIdIn(questionIds);
+    }
+
+    @Override
     public Question save(Question question) {
         return questionJpaRepository.save(question);
     }

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
@@ -1,13 +1,15 @@
 package com.umc.product.survey.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.survey.domain.QQuestion;
 import com.umc.product.survey.domain.Question;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Set;
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
+++ b/src/main/java/com/umc/product/survey/adapter/out/persistence/QuestionQueryRepository.java
@@ -43,4 +43,19 @@ public class QuestionQueryRepository {
             .orderBy(q.orderNo.asc())
             .fetch();
     }
+
+    /**
+     * questionId 목록으로 질문을 조회한다 (isActive 무관). orderNo 오름차순 정렬.
+     */
+    public List<Question> findAllByIdIn(Set<Long> questionIds) {
+        if (questionIds.isEmpty()) {
+            return List.of();
+        }
+        QQuestion q = QQuestion.question;
+        return queryFactory
+            .selectFrom(q)
+            .where(q.id.in(questionIds))
+            .orderBy(q.orderNo.asc())
+            .fetch();
+    }
 }

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormUseCase.java
@@ -1,10 +1,10 @@
 package com.umc.product.survey.application.port.in.query;
 
-import com.umc.product.survey.application.port.in.query.dto.FormInfo;
-import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
-
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.survey.application.port.in.query.dto.FormInfo;
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 
 /**
  * Form 조회 UseCase.

--- a/src/main/java/com/umc/product/survey/application/port/in/query/GetFormUseCase.java
+++ b/src/main/java/com/umc/product/survey/application/port/in/query/GetFormUseCase.java
@@ -4,6 +4,7 @@ import com.umc.product.survey.application.port.in.query.dto.FormInfo;
 import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
 
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Form 조회 UseCase.
@@ -29,4 +30,12 @@ public interface GetFormUseCase {
      * 편집기 초기 로딩이나 응답자 UI 렌더링 시 N+1 왕복을 피하기 위한 facade.
      */
     FormWithStructureInfo getFormWithStructure(Long formId);
+
+    /**
+     * 제출된 응답의 questionId 집합을 기준으로 폼 구조를 조립한다 (isActive 무관).
+     * <p>
+     * 질문 fork 이후에도 답변 당시의 질문이 표시되도록 Answer.questionId 역추적 방식으로 구조를 구성한다.
+     * 편집기, 모집문항 보기, 신규 지원 경로에서는 {@link #getFormWithStructure}를 사용할 것.
+     */
+    FormWithStructureInfo getFormWithStructureByQuestionIds(Long formId, Set<Long> questionIds);
 }

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
@@ -1,10 +1,11 @@
 package com.umc.product.survey.application.port.out;
 
-import com.umc.product.survey.domain.Question;
-import com.umc.product.survey.domain.enums.QuestionType;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.enums.QuestionType;
 
 public interface LoadQuestionPort {
     List<Question> findAllByFormSectionIdIn(Set<Long> formSectionIds);

--- a/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
+++ b/src/main/java/com/umc/product/survey/application/port/out/LoadQuestionPort.java
@@ -31,4 +31,10 @@ public interface LoadQuestionPort {
      * 폼 전체 구조 조회 등 N+1 회피 용도.
      */
     List<Question> listBySectionIdIn(Set<Long> sectionIds);
+
+    /**
+     * questionId 목록으로 질문을 조회한다 (isActive 무관). orderNo 오름차순 정렬.
+     * 지원서 상세 조회처럼 fork로 비활성화된 구 버전 질문도 포함해야 하는 경로 전용.
+     */
+    List<Question> listByIdIn(Set<Long> questionIds);
 }

--- a/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
+++ b/src/main/java/com/umc/product/survey/application/service/query/FormQueryService.java
@@ -53,32 +53,64 @@ public class FormQueryService implements GetFormUseCase {
 
     @Override
     public FormWithStructureInfo getFormWithStructure(Long formId) {
-        // 1. 폼 메타 로드
         Form form = loadFormPort.findById(formId)
             .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
 
-        // 2. 섹션 로드 (orderNo asc)
         List<FormSection> sections = loadFormSectionPort.listByFormId(formId);
         Set<Long> sectionIds = sections.stream()
             .map(FormSection::getId)
             .collect(Collectors.toSet());
 
-        // 3. 모든 섹션의 질문을 벌크 로드 (N+1 회피)
         List<Question> questions = loadQuestionPort.listBySectionIdIn(sectionIds);
         Set<Long> questionIds = questions.stream()
             .map(Question::getId)
             .collect(Collectors.toSet());
 
-        // 4. 모든 질문의 선택지를 벌크 로드
         List<QuestionOption> options = loadQuestionOptionPort.listByQuestionIdIn(questionIds);
 
-        // 5. 메모리 grouping — sectionId -> 질문 / questionId -> 옵션
+        return buildFormInfo(form, sections, questions, options);
+    }
+
+    @Override
+    public FormWithStructureInfo getFormWithStructureByQuestionIds(Long formId, Set<Long> questionIds) {
+        Form form = loadFormPort.findById(formId)
+            .orElseThrow(() -> new SurveyDomainException(SurveyErrorCode.SURVEY_NOT_FOUND));
+
+        if (questionIds.isEmpty()) {
+            List<FormSection> sections = loadFormSectionPort.listByFormId(formId);
+            return buildFormInfo(form, sections, List.of(), List.of());
+        }
+
+        // Answer.questionId 기반으로 직접 조회 (isActive 무관 — fork된 구 버전 포함)
+        List<Question> questions = loadQuestionPort.listByIdIn(questionIds);
+        Set<Long> resolvedQuestionIds = questions.stream()
+            .map(Question::getId)
+            .collect(Collectors.toSet());
+
+        List<QuestionOption> options = loadQuestionOptionPort.listByQuestionIdIn(resolvedQuestionIds);
+
+        // 질문이 속한 섹션만 추려서 조회
+        Set<Long> sectionIds = questions.stream()
+            .map(q -> q.getFormSection().getId())
+            .collect(Collectors.toSet());
+        List<FormSection> sections = loadFormSectionPort.listByFormId(formId).stream()
+            .filter(s -> sectionIds.contains(s.getId()))
+            .toList();
+
+        return buildFormInfo(form, sections, questions, options);
+    }
+
+    private FormWithStructureInfo buildFormInfo(
+        Form form,
+        List<FormSection> sections,
+        List<Question> questions,
+        List<QuestionOption> options
+    ) {
         Map<Long, List<Question>> questionsBySection = questions.stream()
             .collect(Collectors.groupingBy(q -> q.getFormSection().getId()));
         Map<Long, List<QuestionOption>> optionsByQuestion = options.stream()
             .collect(Collectors.groupingBy(o -> o.getQuestion().getId()));
 
-        // 6. 중첩 DTO 조립
         List<SectionWithQuestions> sectionDtos = sections.stream()
             .map(section -> SectionWithQuestions.builder()
                 .sectionId(section.getId())

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -590,8 +591,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(new ProjectApplicationAccessScope.ProjectScoped(1L, true));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
@@ -600,6 +599,8 @@ class ProjectApplicationQueryServiceTest {
                 .status(FormResponseStatus.SUBMITTED)
                 .answers(List.of())
                 .build()));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet())).willReturn(
+            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
 
         // when
         ProjectApplicationDetailInfo result = sut.getDetail(query);
@@ -628,7 +629,7 @@ class ProjectApplicationQueryServiceTest {
         assertThatThrownBy(() -> sut.getDetail(query))
             .isInstanceOf(ProjectDomainException.class)
             .hasFieldOrPropertyWithValue("baseCode", ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
-        verify(getFormUseCase, never()).getFormWithStructure(any());
+        verify(getFormUseCase, never()).getFormWithStructureByQuestionIds(any(), any());
     }
 
     @Test
@@ -653,7 +654,6 @@ class ProjectApplicationQueryServiceTest {
             .description(null)
             .sections(List.of())
             .build();
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(formStructure);
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
 
@@ -691,6 +691,8 @@ class ProjectApplicationQueryServiceTest {
             .build();
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
             .willReturn(Optional.of(formResponseWithAnswers));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet()))
+            .willReturn(formStructure);
 
         FileInfo fileInfo = new FileInfo(
             "f-abc", "포트폴리오.pdf", FileCategory.PORTFOLIO,
@@ -735,8 +737,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(Optional.of(application));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
@@ -745,6 +745,8 @@ class ProjectApplicationQueryServiceTest {
                 .status(FormResponseStatus.DRAFT)
                 .answers(List.of())
                 .build()));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet()))
+            .willReturn(FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
 
         // when
         ProjectApplicationDetailInfo result = sut.getDetail(query);
@@ -770,8 +772,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(Optional.of(application));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
@@ -780,6 +780,8 @@ class ProjectApplicationQueryServiceTest {
                 .status(FormResponseStatus.SUBMITTED)
                 .answers(List.of())
                 .build()));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet()))
+            .willReturn(FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
 
         // when
         ProjectApplicationDetailInfo result = sut.getDetail(query);
@@ -803,8 +805,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(Optional.of(application));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
@@ -813,6 +813,8 @@ class ProjectApplicationQueryServiceTest {
                 .status(FormResponseStatus.SUBMITTED)
                 .answers(List.of())
                 .build()));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet()))
+            .willReturn(FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
 
         // when
         ProjectApplicationDetailInfo result = sut.getDetail(query);
@@ -839,8 +841,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(Optional.of(application));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(123L))
@@ -849,6 +849,8 @@ class ProjectApplicationQueryServiceTest {
                 .status(FormResponseStatus.SUBMITTED)
                 .answers(List.of())
                 .build()));
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), anySet()))
+            .willReturn(FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
 
         // when
         ProjectApplicationDetailInfo result = sut.getDetail(query);
@@ -874,8 +876,6 @@ class ProjectApplicationQueryServiceTest {
             .willReturn(Optional.of(application));
         given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
             .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
-        given(getFormUseCase.getFormWithStructure(7L)).willReturn(
-            FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
         given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
             .willReturn(List.of());
         given(getFormResponseUseCase.findResponseWithAnswers(999L))
@@ -885,6 +885,54 @@ class ProjectApplicationQueryServiceTest {
         assertThatThrownBy(() -> sut.getDetail(query))
             .isInstanceOf(ProjectDomainException.class)
             .hasFieldOrPropertyWithValue("baseCode", ProjectErrorCode.PROJECT_APPLICATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getDetail_질문_fork_후에도_구_질문의_답변이_answersByQuestionId에_포함됨")
+    void getDetail_fork된_구_질문_답변_노출() {
+        // given
+        // 질문 A(id=10)가 fork되어 비활성화됨. 지원자는 questionId=10에 답변을 제출한 상태.
+        Project project = createProject(1L, "프로젝트A", null, 99L);
+        ProjectMatchingRound round = createMatchingRound(
+            7L, MatchingType.PLAN_DESIGN, MatchingPhase.FIRST);
+        ProjectApplication application = createApplicationWithFormResponse(
+            55L, project, round, 200L, ProjectApplicationStatus.SUBMITTED, 123L);
+
+        GetProjectApplicationDetailQuery query = detailQuery(1L, 55L);
+        given(loadProjectApplicationPort.findByIdWithDetails(55L))
+            .willReturn(Optional.of(application));
+        given(getChallengerUseCase.findByMemberIdAndGisuId(200L, GISU_ID))
+            .willReturn(Optional.of(challengerInfoOf(200L, ChallengerPart.DESIGN)));
+        given(loadProjectApplicationFormPolicyPort.listByApplicationFormId(any()))
+            .willReturn(List.of());
+
+        AnswerInfo forkedQuestionAnswer = AnswerInfo.builder()
+            .id(501L)
+            .formResponseId(123L)
+            .questionId(10L)  // fork로 비활성화된 구 질문 ID
+            .answeredAsType(QuestionType.SHORT_TEXT)
+            .textValue("답변 내용")
+            .selectedOptions(List.of())
+            .fileIds(null)
+            .times(null)
+            .build();
+        given(getFormResponseUseCase.findResponseWithAnswers(123L))
+            .willReturn(Optional.of(FormResponseWithAnswersInfo.builder()
+                .id(123L).formId(7L).respondentMemberId(200L)
+                .status(FormResponseStatus.SUBMITTED)
+                .answers(List.of(forkedQuestionAnswer))
+                .build()));
+        // answeredQuestionIds = {10L} 로 getFormWithStructureByQuestionIds 가 호출되어야 함
+        given(getFormUseCase.getFormWithStructureByQuestionIds(eq(7L), eq(java.util.Set.of(10L))))
+            .willReturn(FormWithStructureInfo.builder().formId(7L).sections(List.of()).build());
+
+        // when
+        ProjectApplicationDetailInfo result = sut.getDetail(query);
+
+        // then
+        assertThat(result.answersByQuestionId()).containsOnlyKeys(10L);
+        assertThat(result.answersByQuestionId().get(10L).textValue()).isEqualTo("답변 내용");
+        verify(getFormUseCase).getFormWithStructureByQuestionIds(eq(7L), eq(java.util.Set.of(10L)));
     }
 
     // ============================================================

--- a/src/test/java/com/umc/product/survey/application/service/query/FormQueryServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/query/FormQueryServiceTest.java
@@ -1,0 +1,205 @@
+package com.umc.product.survey.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.survey.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.survey.application.port.out.LoadFormPort;
+import com.umc.product.survey.application.port.out.LoadFormSectionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.survey.application.port.out.LoadQuestionPort;
+import com.umc.product.survey.domain.Form;
+import com.umc.product.survey.domain.FormSection;
+import com.umc.product.survey.domain.Question;
+import com.umc.product.survey.domain.enums.QuestionType;
+
+@ExtendWith(MockitoExtension.class)
+class FormQueryServiceTest {
+
+    @Mock
+    LoadFormPort loadFormPort;
+    @Mock
+    LoadFormSectionPort loadFormSectionPort;
+    @Mock
+    LoadQuestionPort loadQuestionPort;
+    @Mock
+    LoadQuestionOptionPort loadQuestionOptionPort;
+
+    @InjectMocks
+    FormQueryService sut;
+
+    // ============================================================
+    //          getFormWithStructureByQuestionIds 테스트
+    // ============================================================
+
+    @Test
+    @DisplayName("getFormWithStructureByQuestionIds_answeredQuestionIds에_해당하는_질문이_포함됨")
+    void getFormWithStructureByQuestionIds_답변된_질문_포함() {
+        // given
+        Form form = createForm(7L);
+        FormSection section = createSection(1L, 7L, 1L);
+        Question question = createQuestion(10L, section, 1L);
+
+        given(loadFormPort.findById(7L)).willReturn(java.util.Optional.of(form));
+        given(loadQuestionPort.listByIdIn(Set.of(10L))).willReturn(List.of(question));
+        given(loadFormSectionPort.listByFormId(7L)).willReturn(List.of(section));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(10L))).willReturn(List.of());
+
+        // when
+        FormWithStructureInfo result = sut.getFormWithStructureByQuestionIds(7L, Set.of(10L));
+
+        // then
+        assertThat(result.sections()).hasSize(1);
+        assertThat(result.sections().get(0).questions()).hasSize(1);
+        assertThat(result.sections().get(0).questions().get(0).questionId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("getFormWithStructureByQuestionIds_answeredQuestionIds에_없는_질문은_포함되지_않음")
+    void getFormWithStructureByQuestionIds_답변_없는_질문_제외() {
+        // given — questionId=10만 answeredQuestionIds에 포함, questionId=20은 미포함
+        Form form = createForm(7L);
+        FormSection section = createSection(1L, 7L, 1L);
+        Question question10 = createQuestion(10L, section, 1L);
+
+        given(loadFormPort.findById(7L)).willReturn(java.util.Optional.of(form));
+        // listByIdIn은 Set.of(10L)만 받아 question10만 반환
+        given(loadQuestionPort.listByIdIn(Set.of(10L))).willReturn(List.of(question10));
+        given(loadFormSectionPort.listByFormId(7L)).willReturn(List.of(section));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(10L))).willReturn(List.of());
+
+        // when
+        FormWithStructureInfo result = sut.getFormWithStructureByQuestionIds(7L, Set.of(10L));
+
+        // then — questionId=20은 조회 요청 자체가 없었으므로 결과에도 없음
+        assertThat(result.sections().get(0).questions())
+            .extracting(FormWithStructureInfo.QuestionWithOptions::questionId)
+            .containsExactly(10L);
+    }
+
+    @Test
+    @DisplayName("getFormWithStructureByQuestionIds_answeredQuestionIds가_비어있으면_질문_없는_섹션_구조_반환")
+    void getFormWithStructureByQuestionIds_빈_questionIds() {
+        // given
+        Form form = createForm(7L);
+        FormSection section = createSection(1L, 7L, 1L);
+
+        given(loadFormPort.findById(7L)).willReturn(java.util.Optional.of(form));
+        given(loadFormSectionPort.listByFormId(7L)).willReturn(List.of(section));
+
+        // when
+        FormWithStructureInfo result = sut.getFormWithStructureByQuestionIds(7L, Set.of());
+
+        // then — 섹션은 있지만 질문은 없음
+        assertThat(result.sections()).hasSize(1);
+        assertThat(result.sections().get(0).questions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getFormWithStructureByQuestionIds_fork된_비활성_질문도_questionIds에_있으면_포함됨")
+    void getFormWithStructureByQuestionIds_비활성_질문_포함() {
+        // given — isActive=false인 구 질문(fork된 원본)
+        Form form = createForm(7L);
+        FormSection section = createSection(1L, 7L, 1L);
+        Question inactiveQuestion = createQuestion(10L, section, 1L);
+        ReflectionTestUtils.setField(inactiveQuestion, "isActive", false);
+
+        given(loadFormPort.findById(7L)).willReturn(java.util.Optional.of(form));
+        given(loadQuestionPort.listByIdIn(Set.of(10L))).willReturn(List.of(inactiveQuestion));
+        given(loadFormSectionPort.listByFormId(7L)).willReturn(List.of(section));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(10L))).willReturn(List.of());
+
+        // when
+        FormWithStructureInfo result = sut.getFormWithStructureByQuestionIds(7L, Set.of(10L));
+
+        // then — isActive=false여도 questionIds에 포함되어 있으면 구조에 포함됨
+        assertThat(result.sections().get(0).questions())
+            .extracting(FormWithStructureInfo.QuestionWithOptions::questionId)
+            .containsExactly(10L);
+    }
+
+    // ============================================================
+    //          getFormWithStructure 회귀 방지 테스트
+    // ============================================================
+
+    @Test
+    @DisplayName("getFormWithStructure_isActive_true인_질문만_반환됨")
+    void getFormWithStructure_활성_질문만_반환() {
+        // given
+        Form form = createForm(7L);
+        FormSection section = createSection(1L, 7L, 1L);
+        // listBySectionIdIn은 isActive=true 필터를 어댑터 레벨에서 적용 — 여기서는 활성 질문만 반환되는 상황 모킹
+        Question activeQuestion = createQuestion(20L, section, 1L);
+
+        given(loadFormPort.findById(7L)).willReturn(java.util.Optional.of(form));
+        given(loadFormSectionPort.listByFormId(7L)).willReturn(List.of(section));
+        given(loadQuestionPort.listBySectionIdIn(Set.of(1L))).willReturn(List.of(activeQuestion));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(20L))).willReturn(List.of());
+
+        // when
+        FormWithStructureInfo result = sut.getFormWithStructure(7L);
+
+        // then — 활성 질문만 포함됨 (어댑터가 isActive 필터 책임)
+        assertThat(result.sections().get(0).questions())
+            .extracting(FormWithStructureInfo.QuestionWithOptions::questionId)
+            .containsExactly(20L);
+    }
+
+    // ============================================================
+    //                      Helper Methods
+    // ============================================================
+
+    private static <T> T newInstance(Class<T> clazz) {
+        try {
+            var constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Form createForm(Long id) {
+        Form form = newInstance(Form.class);
+        ReflectionTestUtils.setField(form, "id", id);
+        ReflectionTestUtils.setField(form, "title", "테스트 폼");
+        ReflectionTestUtils.setField(form, "isAnonymous", false);
+        ReflectionTestUtils.setField(form, "allowDuplicateResponses", false);
+        return form;
+    }
+
+    private FormSection createSection(Long id, Long formId, Long orderNo) {
+        Form form = newInstance(Form.class);
+        ReflectionTestUtils.setField(form, "id", formId);
+
+        FormSection section = newInstance(FormSection.class);
+        ReflectionTestUtils.setField(section, "id", id);
+        ReflectionTestUtils.setField(section, "form", form);
+        ReflectionTestUtils.setField(section, "title", "섹션 " + id);
+        ReflectionTestUtils.setField(section, "orderNo", orderNo);
+        return section;
+    }
+
+    private Question createQuestion(Long id, FormSection section, Long orderNo) {
+        Question question = newInstance(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "formSection", section);
+        ReflectionTestUtils.setField(question, "title", "질문 " + id);
+        ReflectionTestUtils.setField(question, "type", QuestionType.SHORT_TEXT);
+        ReflectionTestUtils.setField(question, "isRequired", true);
+        ReflectionTestUtils.setField(question, "orderNo", orderNo);
+        ReflectionTestUtils.setField(question, "isActive", true);
+        return question;
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
질문 수정(fork) 이후 지원서 상세 조회(APPLY-102) 시, fork로 비활성화된 구 버전 질문에 대한 답변이 응답에서 누락되는 버그를 수정했습니다.

- 원인: 기존 `getFormWithStructure`는 `isActive=true` 질문만 조회하여, fork된 원본 질문(`isActive=false`)에 연결된 답변이 폼 구조에 포함되지 않는 문제가 있었습니다.
- 수정: `Answer.questionId` 집합을 기준으로 폼 구조를 역추적하는 `getFormWithStructureByQuestionIds`를 신규 도입. 지원서 상세 조회 경로에서만 이 메서드를 사용하며, 편집기/신규 지원 경로(`getFormWithStructure`)는 변경 없습니다.

closes #1042 

## 💬 리뷰 중점사항
`getFormWithStructureByQuestionIds` - `isActive` 무관 조회이므로, 이 메서드가 지원서 상세 조회 외 다른 경로에서 호출되지 않도록 주의해 주시면 감사하겠습니다!