### PR TITLE
[Feat] 프로젝트 지원자 batch 조회 추가

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -5,12 +5,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.validation.annotation.Validated;
 
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
@@ -113,9 +113,7 @@ public class ProjectApplicationQueryController {
     public Map<Long, List<ProjectApplicantResponse>> getProjectApplicantsBatch(
         @CurrentMember MemberPrincipal memberPrincipal,
         @RequestParam
-        @NotEmpty(message = "projectIds는 비어 있을 수 없습니다.")
-        @Size(max = 100, message = "projectIds는 최대 100개까지 조회할 수 있습니다.")
-        List<@NotNull Long> projectIds,
+        @NotEmpty(message = "projectIds는 비어 있을 수 없습니다.") @Size(max = 100, message = "projectIds는 최대 100개까지 조회할 수 있습니다.") List<@NotNull Long> projectIds,
         @RequestParam(required = false) Long matchingRoundId,
         @RequestParam(required = false) ChallengerPart part,
         @Parameter(description = """

--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryController.java
@@ -1,12 +1,16 @@
 package com.umc.product.project.adapter.in.web;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
 
 import com.umc.product.authorization.adapter.in.aspect.CheckAccess;
 import com.umc.product.authorization.domain.PermissionType;
@@ -20,14 +24,19 @@ import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicantRespo
 import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicationDetailResponse;
 import com.umc.product.project.application.port.in.query.dto.GetMyProjectApplicationsQuery;
 import com.umc.product.project.application.port.in.query.dto.GetProjectApplicationDetailQuery;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/projects")
 @RequiredArgsConstructor
@@ -81,6 +90,50 @@ public class ProjectApplicationQueryController {
             .build();
 
         return assembler.myApplicationsFor(query);
+    }
+
+    @GetMapping("/applications")
+    @Operation(
+        operationId = "APPLY-101-BATCH",
+        summary = "PM/운영진 복수 프로젝트 지원자 목록 조회",
+        description = """
+            복수 프로젝트의 제출된 지원자 목록을 프로젝트별로 조회합니다. 임시저장(DRAFT) 지원서는 포함하지 않습니다.
+            권한이 없거나 존재하지 않는 프로젝트는 해당 projectId 의 값을 빈 목록으로 반환합니다.
+            <p>
+            필터:
+            <ul>
+              <li>projectIds: 프로젝트 ID 목록. 최대 100개까지 조회할 수 있습니다.</li>
+              <li>matchingRoundId: 매칭 차수 ID</li>
+              <li>part: 지원자(챌린저) 파트</li>
+              <li>status: 지원 상태. SUBMITTED, APPROVED, REJECTED 만 사용할 수 있습니다.
+                  DRAFT 를 보내면 APPLICATION_DRAFT_FILTER_NOT_ALLOWED 오류를 반환합니다.</li>
+            </ul>
+            """
+    )
+    public Map<Long, List<ProjectApplicantResponse>> getProjectApplicantsBatch(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @RequestParam
+        @NotEmpty(message = "projectIds는 비어 있을 수 없습니다.")
+        @Size(max = 100, message = "projectIds는 최대 100개까지 조회할 수 있습니다.")
+        List<@NotNull Long> projectIds,
+        @RequestParam(required = false) Long matchingRoundId,
+        @RequestParam(required = false) ChallengerPart part,
+        @Parameter(description = """
+            지원 상태 필터입니다. DRAFT 는 지원자 목록에서 사용할 수 없습니다.
+            허용 값: SUBMITTED / APPROVED / REJECTED.
+            """)
+        @RequestParam(required = false) ProjectApplicationStatus status
+    ) {
+        List<Long> deduplicatedProjectIds = new ArrayList<>(new LinkedHashSet<>(projectIds));
+        SearchProjectApplicationsBatchQuery query = SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(memberPrincipal.getMemberId())
+            .projectIds(deduplicatedProjectIds)
+            .matchingRoundId(matchingRoundId)
+            .part(part)
+            .status(status)
+            .build();
+
+        return assembler.applicantsForBatch(query);
     }
 
     @GetMapping("/{projectId}/applications")

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
@@ -182,6 +182,7 @@ public class ProjectApplicationResponseAssembler {
             return Map.of();
         }
 
+        // Service 가 보존한 요청 projectId key 를 Web 응답에서도 그대로 유지한다.
         Map<Long, List<ProjectApplicantResponse>> result = new LinkedHashMap<>();
         applicationsByProject.keySet().forEach(projectId -> result.put(projectId, List.of()));
 
@@ -210,6 +211,7 @@ public class ProjectApplicationResponseAssembler {
         Map<Long, MemberInfo> memberMap = getMemberUseCase.findAllByIds(applicantMemberIds);
 
         for (Map.Entry<Long, List<ProjectApplicationSummaryInfo>> entry : applicationsByProject.entrySet()) {
+            // 전체 부가 정보는 batch 로 한 번에 가져오고, 마지막 단계에서 프로젝트별 필터/정렬만 적용한다.
             List<ProjectApplicantResponse> responses = entry.getValue().stream()
                 .filter(application -> {
                     ChallengerPart applicantPart = applicantPartOf(application, projects, partsByMemberAndGisu);
@@ -275,6 +277,7 @@ public class ProjectApplicationResponseAssembler {
                 .add(application.applicantMemberId());
         }
 
+        // Challenger part 는 같은 memberId 여도 기수별로 다를 수 있어 gisuId 를 key 에 함께 넣는다.
         Map<MemberGisuKey, ChallengerPart> result = new HashMap<>();
         memberIdsByGisu.forEach((gisuId, memberIds) ->
             getChallengerUseCase.batchGetByMemberIdsAndGisuId(memberIds, gisuId)

--- a/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssembler.java
@@ -2,7 +2,9 @@ package com.umc.product.project.adapter.in.web.assembler;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +35,7 @@ import com.umc.product.project.application.port.in.query.dto.ProjectApplicationS
 import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMemberInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 
 import lombok.RequiredArgsConstructor;
@@ -167,6 +170,66 @@ public class ProjectApplicationResponseAssembler {
     }
 
     /**
+     * 복수 프로젝트의 지원자 목록 카드 조립 (APPLY-101 batch).
+     * <p>
+     * Service 는 요청 projectId 별 ProjectApplication 자원 Map 을 돌려준다. 여기서는 프로젝트/차수/회원/챌린저 정보를 batch 로 조회한 뒤 프로젝트별로 기존
+     * 지원자 카드 응답을 조립한다.
+     */
+    public Map<Long, List<ProjectApplicantResponse>> applicantsForBatch(SearchProjectApplicationsBatchQuery query) {
+        Map<Long, List<ProjectApplicationSummaryInfo>> applicationsByProject =
+            searchProjectApplicationsUseCase.searchByProjects(query);
+        if (applicationsByProject.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, List<ProjectApplicantResponse>> result = new LinkedHashMap<>();
+        applicationsByProject.keySet().forEach(projectId -> result.put(projectId, List.of()));
+
+        List<ProjectApplicationSummaryInfo> applications = applicationsByProject.values().stream()
+            .flatMap(List::stream)
+            .toList();
+        if (applications.isEmpty()) {
+            return result;
+        }
+
+        Set<Long> projectIds = applications.stream()
+            .map(ProjectApplicationSummaryInfo::projectId)
+            .collect(Collectors.toSet());
+        Set<Long> applicantMemberIds = applications.stream()
+            .map(ProjectApplicationSummaryInfo::applicantMemberId)
+            .collect(Collectors.toSet());
+        Set<Long> roundIds = applications.stream()
+            .map(ProjectApplicationSummaryInfo::matchingRoundId)
+            .collect(Collectors.toSet());
+
+        Map<Long, ProjectInfo> projects = getProjectUseCase.findAllByIds(projectIds);
+        Map<MemberGisuKey, ChallengerPart> partsByMemberAndGisu =
+            resolveApplicantParts(applications, projects);
+        Map<Long, ProjectMatchingRoundInfo> rounds =
+            getProjectMatchingRoundUseCase.findAllByIds(roundIds);
+        Map<Long, MemberInfo> memberMap = getMemberUseCase.findAllByIds(applicantMemberIds);
+
+        for (Map.Entry<Long, List<ProjectApplicationSummaryInfo>> entry : applicationsByProject.entrySet()) {
+            List<ProjectApplicantResponse> responses = entry.getValue().stream()
+                .filter(application -> {
+                    ChallengerPart applicantPart = applicantPartOf(application, projects, partsByMemberAndGisu);
+                    return query.part() == null || query.part() == applicantPart;
+                })
+                .sorted(applicantSortOrder(rounds, projects, partsByMemberAndGisu))
+                .map(application -> {
+                    ChallengerPart applicantPart = applicantPartOf(application, projects, partsByMemberAndGisu);
+                    ProjectMatchingRoundInfo round = rounds.get(application.matchingRoundId());
+                    MemberBrief brief = toBrief(memberMap.get(application.applicantMemberId()));
+                    return ProjectApplicantResponse.from(application, applicantPart, round, brief);
+                })
+                .toList();
+            result.put(entry.getKey(), responses);
+        }
+
+        return result;
+    }
+
+    /**
      * APPLY-101 지원자 카드 정렬자: 매칭 차수(phase) ASC -> 파트(part) ASC -> 제출 시각(submittedAt) ASC.
      */
     private Comparator<ProjectApplicationSummaryInfo> applicantSortOrder(
@@ -179,6 +242,57 @@ public class ProjectApplicationResponseAssembler {
             .thenComparingInt(application ->
                 partsByMember.get(application.applicantMemberId()).getSortOrder())
             .thenComparing(ProjectApplicationSummaryInfo::submittedAt);
+    }
+
+    /**
+     * APPLY-101 batch 지원자 카드 정렬자: 매칭 차수(phase) ASC -> 파트(part) ASC -> 제출 시각(submittedAt) ASC.
+     */
+    private Comparator<ProjectApplicationSummaryInfo> applicantSortOrder(
+        Map<Long, ProjectMatchingRoundInfo> rounds,
+        Map<Long, ProjectInfo> projects,
+        Map<MemberGisuKey, ChallengerPart> partsByMemberAndGisu
+    ) {
+        return Comparator
+            .comparingInt((ProjectApplicationSummaryInfo application) ->
+                rounds.get(application.matchingRoundId()).phase().ordinal())
+            .thenComparingInt(application ->
+                applicantPartOf(application, projects, partsByMemberAndGisu).getSortOrder())
+            .thenComparing(ProjectApplicationSummaryInfo::submittedAt);
+    }
+
+    private Map<MemberGisuKey, ChallengerPart> resolveApplicantParts(
+        List<ProjectApplicationSummaryInfo> applications,
+        Map<Long, ProjectInfo> projects
+    ) {
+        Map<Long, Set<Long>> memberIdsByGisu = new HashMap<>();
+        for (ProjectApplicationSummaryInfo application : applications) {
+            ProjectInfo project = projects.get(application.projectId());
+            if (project == null) {
+                continue;
+            }
+            memberIdsByGisu
+                .computeIfAbsent(project.gisuId(), ignored -> new HashSet<>())
+                .add(application.applicantMemberId());
+        }
+
+        Map<MemberGisuKey, ChallengerPart> result = new HashMap<>();
+        memberIdsByGisu.forEach((gisuId, memberIds) ->
+            getChallengerUseCase.batchGetByMemberIdsAndGisuId(memberIds, gisuId)
+                .forEach((memberId, challenger) ->
+                    result.put(new MemberGisuKey(memberId, gisuId), challenger.part())));
+        return result;
+    }
+
+    private ChallengerPart applicantPartOf(
+        ProjectApplicationSummaryInfo application,
+        Map<Long, ProjectInfo> projects,
+        Map<MemberGisuKey, ChallengerPart> partsByMemberAndGisu
+    ) {
+        ProjectInfo project = projects.get(application.projectId());
+        if (project == null) {
+            return null;
+        }
+        return partsByMemberAndGisu.get(new MemberGisuKey(application.applicantMemberId(), project.gisuId()));
     }
 
     /**
@@ -205,5 +319,8 @@ public class ProjectApplicationResponseAssembler {
 
     private MemberBrief toBrief(MemberInfo info) {
         return info == null ? null : MemberBrief.from(info);
+    }
+
+    private record MemberGisuKey(Long memberId, Long gisuId) {
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationPersistenceAdapter.java
@@ -139,6 +139,23 @@ public class ProjectApplicationPersistenceAdapter implements LoadProjectApplicat
     }
 
     @Override
+    public List<ProjectApplication> searchProjectApplicationsByProjectIds(
+        Collection<Long> projectIds,
+        Collection<Long> includeOngoingProjectIds,
+        Long matchingRoundId,
+        ProjectApplicationStatus status,
+        Instant now
+    ) {
+        return projectApplicationQueryRepository.searchProjectApplicationsByProjectIds(
+            projectIds,
+            includeOngoingProjectIds,
+            matchingRoundId,
+            status,
+            now
+        );
+    }
+
+    @Override
     public List<ProjectMemberMatchedRoundInfo> listLatestApprovedMatchedRoundsByProjectIdsAndMemberIds(
         Collection<Long> projectIds,
         Collection<Long> memberIds

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepository.java
@@ -151,11 +151,53 @@ public class ProjectApplicationQueryRepository {
             .fetch();
     }
 
+    /**
+     * PM/운영진용 복수 프로젝트의 지원자 목록을 조회한다.
+     * <p>
+     * 단건 조회와 동일하게 DRAFT 를 제외하고, {@code includeOngoingProjectIds} 에 포함된 프로젝트만 진행 중 차수의 지원서를 함께 노출한다.
+     */
+    public List<ProjectApplication> searchProjectApplicationsByProjectIds(
+        Collection<Long> projectIds,
+        Collection<Long> includeOngoingProjectIds,
+        Long matchingRoundId,
+        ProjectApplicationStatus status,
+        Instant now
+    ) {
+        if (projectIds == null || projectIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+            .selectFrom(projectApplication)
+            .innerJoin(projectApplication.applicationForm, projectApplicationForm).fetchJoin()
+            .innerJoin(projectApplicationForm.project, project).fetchJoin()
+            .innerJoin(projectApplication.appliedMatchingRound, projectMatchingRound).fetchJoin()
+            .where(
+                project.id.in(projectIds),
+                matchingRoundIdEq(matchingRoundId),
+                managedStatusCond(status),
+                matchingRoundViewableByProjectCond(includeOngoingProjectIds, now)
+            )
+            .orderBy(project.id.asc(), projectMatchingRound.phase.asc(), projectApplication.submittedAt.asc())
+            .fetch();
+    }
+
     private BooleanExpression matchingRoundViewableCond(Instant now, boolean includeOngoingMatchingRounds) {
         if (includeOngoingMatchingRounds) {
             return null;
         }
         return projectMatchingRound.endsAt.before(now);
+    }
+
+    private BooleanExpression matchingRoundViewableByProjectCond(
+        Collection<Long> includeOngoingProjectIds,
+        Instant now
+    ) {
+        if (includeOngoingProjectIds == null || includeOngoingProjectIds.isEmpty()) {
+            return projectMatchingRound.endsAt.before(now);
+        }
+        return project.id.in(includeOngoingProjectIds)
+            .or(projectMatchingRound.endsAt.before(now));
     }
 
     /**

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -106,6 +106,11 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     }
 
     @Override
+    public List<Long> listProjectIdsByActivePlanMember(Collection<Long> projectIds, Long memberId) {
+        return queryRepository.listProjectIdsByActivePlanMember(projectIds, memberId);
+    }
+
+    @Override
     public Optional<ProjectMember> findActiveWithoutApplicationByMemberIdAndGisuIdAndMatchingType(
         Long memberId, Long gisuId, MatchingType matchingType
     ) {

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepository.java
@@ -110,6 +110,27 @@ public class ProjectMemberQueryRepository {
     }
 
     /**
+     * 여러 프로젝트 중 특정 멤버가 ACTIVE PLAN 멤버인 프로젝트 ID 를 조회한다.
+     */
+    public List<Long> listProjectIdsByActivePlanMember(Collection<Long> projectIds, Long memberId) {
+        if (projectIds == null || projectIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+            .select(projectMember.project.id)
+            .distinct()
+            .from(projectMember)
+            .where(
+                projectMember.project.id.in(projectIds),
+                projectMember.memberId.eq(memberId),
+                projectMember.part.eq(ChallengerPart.PLAN),
+                projectMember.status.eq(ProjectMemberStatus.ACTIVE)
+            )
+            .fetch();
+    }
+
+    /**
      * 여러 프로젝트의 (projectId, part) 별 ACTIVE 멤버 수를 한 번에 집계한다.
      *
      * @return projectId -> (part -> 인원수) 맵. 인원이 0 인 (project, part) 조합은 엔트리 없음.

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -1,5 +1,8 @@
 package com.umc.product.project.application.access;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -89,6 +92,82 @@ public class ProjectApplicationAccessScopeResolver {
         return new None();
     }
 
+    /**
+     * 복수 프로젝트 지원자 목록(APPLY-101 batch) 화면의 프로젝트별 scope 를 한 번에 결정한다.
+     * <p>
+     * 단건 판정의 우선순위(PO/Sub-PM -> SUPER_ADMIN -> Central Core -> 지부장 -> 학교 회장단)를 유지하되, 역할/보조 PM/학교-지부 매핑 조회를 batch 로
+     * 수행한다.
+     */
+    public Map<Long, ProjectApplicationAccessScope> resolveForProjectApplicantLists(
+        Long memberId,
+        Collection<Project> projects
+    ) {
+        if (projects == null || projects.isEmpty()) {
+            return Map.of();
+        }
+
+        Set<Long> projectIds = projects.stream()
+            .map(Project::getId)
+            .collect(Collectors.toSet());
+        Set<Long> activePlanProjectIds = new HashSet<>(
+            loadProjectMemberPort.listProjectIdsByActivePlanMember(projectIds, memberId));
+
+        List<ChallengerRoleInfo> roles = getChallengerRoleUseCase.findAllByMemberId(memberId);
+        boolean superAdmin = roles.stream().anyMatch(r -> r.roleType().isSuperAdmin());
+
+        Set<Long> gisuIds = projects.stream()
+            .map(Project::getGisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        Set<Long> schoolIds = roles.stream()
+            .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                || r.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = schoolIds.isEmpty()
+            ? Map.of()
+            : getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(gisuIds, schoolIds);
+
+        Map<Long, ProjectApplicationAccessScope> result = new LinkedHashMap<>();
+        for (Project project : projects) {
+            Long projectId = project.getId();
+            if (Objects.equals(project.getProductOwnerMemberId(), memberId)
+                || activePlanProjectIds.contains(projectId)) {
+                result.put(projectId, new ProjectScoped(projectId));
+                continue;
+            }
+
+            if (superAdmin) {
+                result.put(projectId, new ProjectScoped(projectId, true));
+                continue;
+            }
+
+            List<ChallengerRoleInfo> rolesInGisu = roles.stream()
+                .filter(r -> Objects.equals(r.gisuId(), project.getGisuId()))
+                .toList();
+
+            if (rolesInGisu.stream().anyMatch(r -> r.roleType().isAtLeastCentralCore())) {
+                result.put(projectId, new ProjectScoped(projectId, true));
+                continue;
+            }
+
+            if (rolesInGisu.stream().anyMatch(r -> r.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT
+                && Objects.equals(r.organizationId(), project.getChapterId()))) {
+                result.put(projectId, new ProjectScoped(projectId));
+                continue;
+            }
+
+            if (isSchoolCoreInProjectChapter(rolesInGisu, project, chapterByGisuAndSchool)) {
+                result.put(projectId, new ProjectScoped(projectId));
+                continue;
+            }
+
+            result.put(projectId, new None());
+        }
+        return result;
+    }
+
     private boolean isSchoolCoreInProjectChapter(List<ChallengerRoleInfo> rolesInGisu, Project project) {
         Set<Long> schoolIds = rolesInGisu.stream()
             .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
@@ -107,6 +186,31 @@ public class ProjectApplicationAccessScopeResolver {
             chapterByGisuAndSchool.getOrDefault(project.getGisuId(), Map.of());
 
         return chapterBySchool.values().stream()
+            .filter(Objects::nonNull)
+            .anyMatch(chapter -> Objects.equals(chapter.id(), project.getChapterId()));
+    }
+
+    private boolean isSchoolCoreInProjectChapter(
+        List<ChallengerRoleInfo> rolesInGisu,
+        Project project,
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool
+    ) {
+        Set<Long> schoolIds = rolesInGisu.stream()
+            .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
+                || r.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
+            .map(ChallengerRoleInfo::organizationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        if (schoolIds.isEmpty()) {
+            return false;
+        }
+
+        Map<Long, ChapterInfo> chapterBySchool =
+            chapterByGisuAndSchool.getOrDefault(project.getGisuId(), Map.of());
+
+        return schoolIds.stream()
+            .map(chapterBySchool::get)
             .filter(Objects::nonNull)
             .anyMatch(chapter -> Objects.equals(chapter.id(), project.getChapterId()));
     }

--- a/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolver.java
@@ -125,7 +125,7 @@ public class ProjectApplicationAccessScopeResolver {
             .map(ChallengerRoleInfo::organizationId)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
-        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = schoolIds.isEmpty()
+        Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool = schoolIds.isEmpty() || gisuIds.isEmpty()
             ? Map.of()
             : getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(gisuIds, schoolIds);
 
@@ -169,6 +169,10 @@ public class ProjectApplicationAccessScopeResolver {
     }
 
     private boolean isSchoolCoreInProjectChapter(List<ChallengerRoleInfo> rolesInGisu, Project project) {
+        if (project.getGisuId() == null) {
+            return false;
+        }
+
         Set<Long> schoolIds = rolesInGisu.stream()
             .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
                 || r.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)
@@ -195,6 +199,10 @@ public class ProjectApplicationAccessScopeResolver {
         Project project,
         Map<Long, Map<Long, ChapterInfo>> chapterByGisuAndSchool
     ) {
+        if (project.getGisuId() == null) {
+            return false;
+        }
+
         Set<Long> schoolIds = rolesInGisu.stream()
             .filter(r -> r.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
                 || r.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT)

--- a/src/main/java/com/umc/product/project/application/port/in/query/SearchProjectApplicationsUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/SearchProjectApplicationsUseCase.java
@@ -1,8 +1,10 @@
 package com.umc.product.project.application.port.in.query;
 
 import java.util.List;
+import java.util.Map;
 
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationSummaryInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 
 /**
@@ -18,4 +20,11 @@ import com.umc.product.project.application.port.in.query.dto.SearchProjectApplic
 public interface SearchProjectApplicationsUseCase {
 
     List<ProjectApplicationSummaryInfo> searchByProject(SearchProjectApplicationsQuery query);
+
+    /**
+     * PM/운영진용 복수 프로젝트 지원자 목록을 조회한다.
+     * <p>
+     * 요청한 projectId 는 권한 없음/미존재 여부와 무관하게 결과 Map 의 key 로 유지하며, 노출할 지원서가 없으면 빈 리스트를 반환한다.
+     */
+    Map<Long, List<ProjectApplicationSummaryInfo>> searchByProjects(SearchProjectApplicationsBatchQuery query);
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectApplicationsBatchQuery.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/SearchProjectApplicationsBatchQuery.java
@@ -1,0 +1,48 @@
+package com.umc.product.project.application.port.in.query.dto;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
+
+import lombok.Builder;
+
+/**
+ * PM/운영진용 복수 프로젝트 지원자 목록 조회 Query.
+ * <p>
+ * 단건 조회와 동일하게 DRAFT 지원서는 응답과 상태 필터에서 제외한다.
+ *
+ * @param requesterMemberId 요청자 Member ID. 권한 scope 결정(L1)에 사용된다.
+ * @param projectIds        대상 프로젝트 ID 목록. 입력 순서 기준으로 중복을 제거한다.
+ * @param matchingRoundId   매칭 차수 필터 (선택). null 이면 전체 차수.
+ * @param part              지원 파트 필터 (선택). null 이면 전체 파트.
+ * @param status            지원 상태 필터 (선택). null 이면 SUBMITTED/APPROVED/REJECTED 전체.
+ */
+@Builder
+public record SearchProjectApplicationsBatchQuery(
+    Long requesterMemberId,
+    List<Long> projectIds,
+    Long matchingRoundId,
+    ChallengerPart part,
+    ProjectApplicationStatus status
+) {
+    public SearchProjectApplicationsBatchQuery {
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+        Objects.requireNonNull(projectIds, "projectIds must not be null");
+        if (projectIds.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("projectIds must not contain null");
+        }
+        projectIds = List.copyOf(new LinkedHashSet<>(projectIds));
+        if (projectIds.isEmpty()) {
+            throw new IllegalArgumentException("projectIds must not be empty");
+        }
+        if (status == ProjectApplicationStatus.DRAFT) {
+            throw new ProjectDomainException(
+                ProjectErrorCode.APPLICATION_DRAFT_FILTER_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectApplicationPort.java
@@ -126,6 +126,26 @@ public interface LoadProjectApplicationPort {
     );
 
     /**
+     * PM/운영진용 복수 프로젝트의 지원자 목록을 조회한다.
+     * <p>
+     * 임시저장(DRAFT)은 결과에서 제외된다. {@code includeOngoingProjectIds} 에 포함된 프로젝트는 진행 중인 차수의 지원서도 반환하고, 그 외 프로젝트는
+     * 지원(모집)이 끝난 차수({@code endsAt < now})의 지원서만 반환한다.
+     *
+     * @param projectIds                대상 프로젝트 ID 목록
+     * @param includeOngoingProjectIds  진행 중인 매칭 차수까지 노출할 프로젝트 ID 목록
+     * @param matchingRoundId           매칭 차수 필터 (선택). null 이면 전체.
+     * @param status                    상태 필터 (선택). null 이면 DRAFT 제외 전체.
+     * @param now                       조회 기준 시각
+     */
+    List<ProjectApplication> searchProjectApplicationsByProjectIds(
+        Collection<Long> projectIds,
+        Collection<Long> includeOngoingProjectIds,
+        Long matchingRoundId,
+        ProjectApplicationStatus status,
+        Instant now
+    );
+
+    /**
      * 프로젝트/멤버 쌍별 APPROVED 지원서 중 가장 최신 매칭 차수를 조회합니다.
      * <p>
      * 최신 기준: matchingRound.startsAt DESC, 동률이면 application.id DESC.

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -69,6 +69,12 @@ public interface LoadProjectMemberPort {
     boolean isActivePlanMember(Long projectId, Long memberId);
 
     /**
+     * 여러 프로젝트 중 요청자가 ACTIVE PLAN 멤버인 프로젝트 ID 를 조회합니다. PM/운영진 지원자 목록 batch 권한 판정에서 Sub-PM 여부를 IN 쿼리로 확인할 때
+     * 사용합니다.
+     */
+    List<Long> listProjectIdsByActivePlanMember(Collection<Long> projectIds, Long memberId);
+
+    /**
      * 본인이 ACTIVE 멤버이면서 application 이 null 인 (즉, 지원서 경로가 아닌 랜덤 매칭/운영진 강제 배정으로 합류한) 멤버를 단건 조회한다. APPLY-004(본인 지원 내역 목록
      * 조회) 의 랜덤 매칭 카드 합성에 사용된다.
      * <p>

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -211,6 +211,7 @@ public class ProjectApplicationQueryService
     public Map<Long, List<ProjectApplicationSummaryInfo>> searchByProjects(
         SearchProjectApplicationsBatchQuery query
     ) {
+        // 요청한 projectId key 는 응답에서 그대로 보존한다. 권한 없음/미존재 프로젝트도 빈 리스트로 채운다.
         Map<Long, List<ProjectApplicationSummaryInfo>> result = new LinkedHashMap<>();
         for (Long projectId : query.projectIds()) {
             result.put(projectId, new ArrayList<>());
@@ -232,12 +233,14 @@ public class ProjectApplicationQueryService
             return freeze(result);
         }
 
+        // 중앙총괄/SUPER_ADMIN scope 프로젝트만 진행 중 차수 지원서를 함께 조회한다.
         Set<Long> includeOngoingProjectIds = scopes.entrySet().stream()
             .filter(entry -> entry.getValue() instanceof ProjectApplicationAccessScope.ProjectScoped projectScoped
                 && projectScoped.includeOngoingMatchingRounds())
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
 
+        // 권한이 확인된 프로젝트만 DB 조회 대상에 넣어 권한 없는 프로젝트의 존재 여부가 결과로 새지 않게 한다.
         List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplicationsByProjectIds(
             accessibleProjectIds,
             includeOngoingProjectIds,

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectApplicationQueryService.java
@@ -3,6 +3,7 @@ package com.umc.product.project.application.service.query;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,6 +26,7 @@ import com.umc.product.project.application.port.in.query.dto.GetMyProjectApplica
 import com.umc.product.project.application.port.in.query.dto.GetProjectApplicationDetailQuery;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationDetailInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationSummaryInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
@@ -200,6 +202,61 @@ public class ProjectApplicationQueryService
             .toList();
     }
 
+    /**
+     * PM/운영진용 복수 프로젝트 지원자 목록 조회.
+     * <p>
+     * 요청한 projectId 는 결과 Map 의 key 로 보존한다. 존재하지 않거나 권한이 없는 프로젝트는 빈 리스트를 반환하여 단건 조회의 권한 없음 위장 정책과 맞춘다.
+     */
+    @Override
+    public Map<Long, List<ProjectApplicationSummaryInfo>> searchByProjects(
+        SearchProjectApplicationsBatchQuery query
+    ) {
+        Map<Long, List<ProjectApplicationSummaryInfo>> result = new LinkedHashMap<>();
+        for (Long projectId : query.projectIds()) {
+            result.put(projectId, new ArrayList<>());
+        }
+
+        List<Project> projects = loadProjectPort.listByIds(query.projectIds());
+        if (projects.isEmpty()) {
+            return freeze(result);
+        }
+
+        Map<Long, ProjectApplicationAccessScope> scopes =
+            accessScopeResolver.resolveForProjectApplicantLists(query.requesterMemberId(), projects);
+
+        Set<Long> accessibleProjectIds = scopes.entrySet().stream()
+            .filter(entry -> entry.getValue() instanceof ProjectApplicationAccessScope.ProjectScoped)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+        if (accessibleProjectIds.isEmpty()) {
+            return freeze(result);
+        }
+
+        Set<Long> includeOngoingProjectIds = scopes.entrySet().stream()
+            .filter(entry -> entry.getValue() instanceof ProjectApplicationAccessScope.ProjectScoped projectScoped
+                && projectScoped.includeOngoingMatchingRounds())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+
+        List<ProjectApplication> applications = loadProjectApplicationPort.searchProjectApplicationsByProjectIds(
+            accessibleProjectIds,
+            includeOngoingProjectIds,
+            query.matchingRoundId(),
+            query.status(),
+            Instant.now()
+        );
+
+        for (ProjectApplication application : applications) {
+            ProjectApplicationSummaryInfo info = ProjectApplicationSummaryInfo.from(application);
+            List<ProjectApplicationSummaryInfo> projectApplications = result.get(info.projectId());
+            if (projectApplications != null) {
+                projectApplications.add(info);
+            }
+        }
+
+        return freeze(result);
+    }
+
     // ==============================================================
     //                      Helper Method
     // ==============================================================
@@ -234,6 +291,14 @@ public class ProjectApplicationQueryService
             return true;
         }
         return application.getAppliedMatchingRound().isDecisionDeadlinePassed(Instant.now());
+    }
+
+    private Map<Long, List<ProjectApplicationSummaryInfo>> freeze(
+        Map<Long, List<ProjectApplicationSummaryInfo>> source
+    ) {
+        Map<Long, List<ProjectApplicationSummaryInfo>> frozen = new LinkedHashMap<>();
+        source.forEach((projectId, applications) -> frozen.put(projectId, List.copyOf(applications)));
+        return frozen;
     }
 
     /**

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectApplicationQueryControllerTest.java
@@ -1,0 +1,144 @@
+package com.umc.product.project.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.assembler.ProjectApplicationResponseAssembler;
+import com.umc.product.project.adapter.in.web.dto.response.ProjectApplicantResponse;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
+import com.umc.product.project.domain.enums.ProjectApplicationStatus;
+
+@WebMvcTest(controllers = ProjectApplicationQueryController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProjectApplicationQueryControllerTest {
+
+    private static final Long TEST_MEMBER_ID = 99L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    ProjectApplicationResponseAssembler assembler;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        MemberPrincipal principal = MemberPrincipal.builder()
+            .memberId(TEST_MEMBER_ID)
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    @DisplayName("batch_지원자_목록_조회는_projectIds_중복을_제거하고_필터를_query에_전달한다")
+    void batch_지원자_목록_조회_query_전달() throws Exception {
+        // given
+        Map<Long, List<ProjectApplicantResponse>> response = new LinkedHashMap<>();
+        response.put(1L, List.of());
+        response.put(2L, List.of());
+        given(assembler.applicantsForBatch(any())).willReturn(response);
+
+        // when
+        mockMvc.perform(get("/api/v1/projects/applications")
+                .param("projectIds", "1", "2", "1")
+                .param("matchingRoundId", "7")
+                .param("part", "WEB")
+                .param("status", "APPROVED"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result['1']").isArray())
+            .andExpect(jsonPath("$.result['2']").isArray());
+
+        // then
+        ArgumentCaptor<SearchProjectApplicationsBatchQuery> captor =
+            ArgumentCaptor.forClass(SearchProjectApplicationsBatchQuery.class);
+        then(assembler).should().applicantsForBatch(captor.capture());
+        SearchProjectApplicationsBatchQuery query = captor.getValue();
+        assertThat(query.requesterMemberId()).isEqualTo(TEST_MEMBER_ID);
+        assertThat(query.projectIds()).containsExactly(1L, 2L);
+        assertThat(query.matchingRoundId()).isEqualTo(7L);
+        assertThat(query.part()).isEqualTo(ChallengerPart.WEB);
+        assertThat(query.status()).isEqualTo(ProjectApplicationStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("batch_지원자_목록_조회는_projectIds가_없으면_400")
+    void batch_지원자_목록_projectIds_누락_400() throws Exception {
+        mockMvc.perform(get("/api/v1/projects/applications"))
+            .andExpect(status().isBadRequest());
+
+        then(assembler).should(never()).applicantsForBatch(any());
+    }
+
+    @Test
+    @DisplayName("batch_지원자_목록_조회는_projectIds가_100개를_초과하면_400")
+    void batch_지원자_목록_projectIds_100개_초과_400() throws Exception {
+        var request = get("/api/v1/projects/applications");
+        for (int i = 1; i <= 101; i++) {
+            request.param("projectIds", String.valueOf(i));
+        }
+
+        mockMvc.perform(request)
+            .andExpect(status().isBadRequest());
+
+        then(assembler).should(never()).applicantsForBatch(any());
+    }
+
+    @Test
+    @DisplayName("기존_단일_프로젝트_지원자_목록_경로는_유지된다")
+    void 단일_프로젝트_지원자_목록_경로_유지() throws Exception {
+        // given
+        given(assembler.applicantsFor(any())).willReturn(List.of());
+
+        // when
+        mockMvc.perform(get("/api/v1/projects/{projectId}/applications", 42L)
+                .param("matchingRoundId", "7")
+                .param("part", "WEB")
+                .param("status", "SUBMITTED"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result").isArray());
+
+        // then
+        ArgumentCaptor<SearchProjectApplicationsQuery> captor =
+            ArgumentCaptor.forClass(SearchProjectApplicationsQuery.class);
+        then(assembler).should().applicantsFor(captor.capture());
+        SearchProjectApplicationsQuery query = captor.getValue();
+        assertThat(query.requesterMemberId()).isEqualTo(TEST_MEMBER_ID);
+        assertThat(query.projectId()).isEqualTo(42L);
+        assertThat(query.matchingRoundId()).isEqualTo(7L);
+        assertThat(query.part()).isEqualTo(ChallengerPart.WEB);
+        assertThat(query.status()).isEqualTo(ProjectApplicationStatus.SUBMITTED);
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/assembler/ProjectApplicationResponseAssemblerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,6 +49,7 @@ import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMatchingRoundInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectMemberInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectPartQuotaInfo;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
@@ -458,6 +460,111 @@ class ProjectApplicationResponseAssemblerTest {
         //   THIRD  / IOS(4)      / 06:00  -> g (107)   // 시간이 가장 빨라도 차수가 가장 늦으면 마지막
         assertThat(result).extracting(ProjectApplicantResponse::applicationId)
             .containsExactly(103L, 106L, 102L, 104L, 108L, 101L, 105L, 107L);
+    }
+
+    @Test
+    @DisplayName("applicantsForBatch_프로젝트별로_응답을_묶고_part_필터를_적용한다")
+    void applicantsForBatch_프로젝트별_그룹핑_및_part_필터() {
+        // given
+        SearchProjectApplicationsBatchQuery query = SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(100L)
+            .projectIds(List.of(1L, 2L, 3L))
+            .part(ChallengerPart.WEB)
+            .build();
+        ProjectApplicationSummaryInfo webApp = applicationSummaryOf(55L, 1L, 7L, 200L);
+        ProjectApplicationSummaryInfo androidApp = applicationSummaryOf(56L, 1L, 7L, 201L);
+        ProjectApplicationSummaryInfo secondProjectApp = applicationSummaryOf(57L, 2L, 8L, 202L);
+
+        Map<Long, List<ProjectApplicationSummaryInfo>> applicationsByProject = new LinkedHashMap<>();
+        applicationsByProject.put(1L, List.of(androidApp, webApp));
+        applicationsByProject.put(2L, List.of(secondProjectApp));
+        applicationsByProject.put(3L, List.of());
+
+        given(searchProjectApplicationsUseCase.searchByProjects(query))
+            .willReturn(applicationsByProject);
+        given(getProjectUseCase.findAllByIds(eq(Set.of(1L, 2L))))
+            .willReturn(Map.of(
+                1L, projectInfoOf(1L, "프로젝트A", 99L),
+                2L, projectInfoOf(2L, "프로젝트B", 88L)
+            ));
+        given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(eq(Set.of(200L, 201L, 202L)), eq(GISU_ID)))
+            .willReturn(Map.of(
+                200L, challengerInfoOf(200L, ChallengerPart.WEB),
+                201L, challengerInfoOf(201L, ChallengerPart.ANDROID),
+                202L, challengerInfoOf(202L, ChallengerPart.WEB)
+            ));
+        given(getProjectMatchingRoundUseCase.findAllByIds(eq(Set.of(7L, 8L))))
+            .willReturn(Map.of(
+                7L, roundInfoOf(7L, MatchingPhase.FIRST),
+                8L, roundInfoOf(8L, MatchingPhase.SECOND)
+            ));
+        given(getMemberUseCase.findAllByIds(eq(Set.of(200L, 201L, 202L))))
+            .willReturn(Map.of(
+                200L, memberOf(200L, "웹지원자", "김웹", "중앙대"),
+                202L, memberOf(202L, "웹지원자2", "이웹", "숭실대")
+            ));
+
+        // when
+        Map<Long, List<ProjectApplicantResponse>> result = sut.applicantsForBatch(query);
+
+        // then
+        assertThat(result.keySet()).containsExactly(1L, 2L, 3L);
+        assertThat(result.get(1L)).extracting(ProjectApplicantResponse::applicationId)
+            .containsExactly(55L);
+        assertThat(result.get(1L).get(0).applicant().part()).isEqualTo(ChallengerPart.WEB);
+        assertThat(result.get(1L).get(0).applicant().nickname()).isEqualTo("웹지원자");
+        assertThat(result.get(2L)).extracting(ProjectApplicantResponse::applicationId)
+            .containsExactly(57L);
+        assertThat(result.get(3L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("applicantsForBatch_프로젝트별_차수_파트_시간_순으로_정렬되어_반환된다")
+    void applicantsForBatch_정렬_순서() {
+        // given
+        Long roundFirstId = 11L;
+        Long roundSecondId = 22L;
+        ProjectApplicationSummaryInfo secondDesignLate = applicationSummaryOf(
+            101L, 1L, roundSecondId, 300L, Instant.parse("2026-04-22T10:00:00Z"));
+        ProjectApplicationSummaryInfo firstWebLate = applicationSummaryOf(
+            102L, 1L, roundFirstId, 301L, Instant.parse("2026-04-22T09:00:00Z"));
+        ProjectApplicationSummaryInfo firstDesign = applicationSummaryOf(
+            103L, 1L, roundFirstId, 302L, Instant.parse("2026-04-22T11:00:00Z"));
+        ProjectApplicationSummaryInfo firstWebEarly = applicationSummaryOf(
+            104L, 1L, roundFirstId, 303L, Instant.parse("2026-04-22T07:00:00Z"));
+
+        SearchProjectApplicationsBatchQuery query = SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(100L)
+            .projectIds(List.of(1L))
+            .build();
+        Map<Long, List<ProjectApplicationSummaryInfo>> applicationsByProject = new LinkedHashMap<>();
+        applicationsByProject.put(1L, List.of(secondDesignLate, firstWebLate, firstDesign, firstWebEarly));
+
+        given(searchProjectApplicationsUseCase.searchByProjects(query))
+            .willReturn(applicationsByProject);
+        given(getProjectUseCase.findAllByIds(eq(Set.of(1L))))
+            .willReturn(Map.of(1L, projectInfoOf(1L, "프로젝트A", 99L)));
+        given(getChallengerUseCase.batchGetByMemberIdsAndGisuId(eq(Set.of(300L, 301L, 302L, 303L)), eq(GISU_ID)))
+            .willReturn(Map.of(
+                300L, challengerInfoOf(300L, ChallengerPart.DESIGN),
+                301L, challengerInfoOf(301L, ChallengerPart.WEB),
+                302L, challengerInfoOf(302L, ChallengerPart.DESIGN),
+                303L, challengerInfoOf(303L, ChallengerPart.WEB)
+            ));
+        given(getProjectMatchingRoundUseCase.findAllByIds(eq(Set.of(roundFirstId, roundSecondId))))
+            .willReturn(Map.of(
+                roundFirstId, roundInfoOf(roundFirstId, MatchingPhase.FIRST),
+                roundSecondId, roundInfoOf(roundSecondId, MatchingPhase.SECOND)
+            ));
+        given(getMemberUseCase.findAllByIds(eq(Set.of(300L, 301L, 302L, 303L))))
+            .willReturn(Map.of());
+
+        // when
+        Map<Long, List<ProjectApplicantResponse>> result = sut.applicantsForBatch(query);
+
+        // then
+        assertThat(result.get(1L)).extracting(ProjectApplicantResponse::applicationId)
+            .containsExactly(103L, 104L, 102L, 101L);
     }
 
     // ============================================================

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectApplicationQueryRepositoryTest.java
@@ -175,6 +175,85 @@ class ProjectApplicationQueryRepositoryTest {
             .containsExactly(ongoingApp.getId());
     }
 
+    @Test
+    @DisplayName("searchProjectApplicationsByProjectIds_includeOngoingProjectIds에_포함된_프로젝트만_진행중_차수_지원서를_반환한다")
+    void searchProjectApplicationsByProjectIdsIncludesOngoingOnlyForAllowedProjects() {
+        // given
+        Instant now = Instant.parse("2026-05-10T00:00:00Z");
+        Project projectB = persistProject("프로젝트 베타", 20L);
+        ProjectApplicationForm formB = ProjectApplicationForm.create(projectB, 600L);
+        em.persist(formB);
+
+        ProjectMatchingRound endedRound = persistRound(
+            "종료 차수", MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST,
+            now.minusSeconds(7_200));
+        ProjectMatchingRound ongoingRound = persistRound(
+            "진행 차수", MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND,
+            now.minusSeconds(1_800));
+
+        ProjectApplication projectAEnded = persistApplication(200L, endedRound, ProjectApplicationStatus.SUBMITTED);
+        persistApplication(201L, ongoingRound, ProjectApplicationStatus.SUBMITTED);
+        persistApplication(202L, endedRound, ProjectApplicationStatus.DRAFT);
+        ProjectApplication projectBEnded = persistApplication(
+            formB, 300L, endedRound, ProjectApplicationStatus.APPROVED);
+        ProjectApplication projectBOngoing = persistApplication(
+            formB, 301L, ongoingRound, ProjectApplicationStatus.SUBMITTED);
+        em.flush();
+        em.clear();
+
+        // when
+        List<ProjectApplication> result = sut.searchProjectApplicationsByProjectIds(
+            Set.of(project.getId(), projectB.getId()),
+            Set.of(projectB.getId()),
+            null,
+            null,
+            now
+        );
+
+        // then
+        assertThat(result)
+            .extracting(ProjectApplication::getId)
+            .containsExactly(projectAEnded.getId(), projectBEnded.getId(), projectBOngoing.getId());
+    }
+
+    @Test
+    @DisplayName("searchProjectApplicationsByProjectIds_matchingRoundId_status_필터를_적용한다")
+    void searchProjectApplicationsByProjectIdsAppliesMatchingRoundAndStatusFilters() {
+        // given
+        Instant now = Instant.parse("2026-05-10T00:00:00Z");
+        Project projectB = persistProject("프로젝트 베타", 20L);
+        ProjectApplicationForm formB = ProjectApplicationForm.create(projectB, 600L);
+        em.persist(formB);
+
+        ProjectMatchingRound firstRound = persistRound(
+            "1차", MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST,
+            now.minusSeconds(7_200));
+        ProjectMatchingRound secondRound = persistRound(
+            "2차", MatchingType.PLAN_DEVELOPER, MatchingPhase.SECOND,
+            now.minusSeconds(7_200));
+
+        persistApplication(200L, firstRound, ProjectApplicationStatus.SUBMITTED);
+        ProjectApplication approved = persistApplication(201L, firstRound, ProjectApplicationStatus.APPROVED);
+        persistApplication(formB, 300L, firstRound, ProjectApplicationStatus.REJECTED);
+        persistApplication(formB, 301L, secondRound, ProjectApplicationStatus.APPROVED);
+        em.flush();
+        em.clear();
+
+        // when
+        List<ProjectApplication> result = sut.searchProjectApplicationsByProjectIds(
+            Set.of(project.getId(), projectB.getId()),
+            Set.of(),
+            firstRound.getId(),
+            ProjectApplicationStatus.APPROVED,
+            now
+        );
+
+        // then
+        assertThat(result)
+            .extracting(ProjectApplication::getId)
+            .containsExactly(approved.getId());
+    }
+
     private Project persistProject(String name, Long ownerId) {
         Project project;
         try {
@@ -220,8 +299,17 @@ class ProjectApplicationQueryRepositoryTest {
         ProjectMatchingRound round,
         ProjectApplicationStatus status
     ) {
+        return persistApplication(form, applicantMemberId, round, status);
+    }
+
+    private ProjectApplication persistApplication(
+        ProjectApplicationForm applicationForm,
+        Long applicantMemberId,
+        ProjectMatchingRound round,
+        ProjectApplicationStatus status
+    ) {
         ProjectApplication application = ProjectApplication.create(
-            form, applicantMemberId * 10, applicantMemberId, round);
+            applicationForm, applicantMemberId * 10, applicantMemberId, round);
         ReflectionTestUtils.setField(application, "status", status);
         em.persist(application);
         return application;

--- a/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/persistence/ProjectMemberQueryRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.umc.product.project.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@Import({ProjectMemberQueryRepository.class})
+class ProjectMemberQueryRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ProjectMemberQueryRepository sut;
+
+    @Test
+    @DisplayName("listProjectIdsByActivePlanMember_ACTIVE_PLAN_멤버인_프로젝트_ID만_반환")
+    void listProjectIdsByActivePlanMemberReturnsOnlyActivePlanProjects() {
+        // given
+        Long memberId = 10L;
+        Project planProject = persistProject("플랜 프로젝트", 100L);
+        Project webProject = persistProject("웹 프로젝트", 101L);
+        Project dismissedProject = persistProject("종료 프로젝트", 102L);
+        Project otherMemberProject = persistProject("타인 프로젝트", 103L);
+
+        em.persist(ProjectMember.create(planProject, memberId, ChallengerPart.PLAN, 999L));
+        em.persist(ProjectMember.create(webProject, memberId, ChallengerPart.WEB, 999L));
+        ProjectMember dismissed = ProjectMember.create(dismissedProject, memberId, ChallengerPart.PLAN, 999L);
+        dismissed.dismiss("권한 제거", 999L);
+        em.persist(dismissed);
+        em.persist(ProjectMember.create(otherMemberProject, 11L, ChallengerPart.PLAN, 999L));
+        em.flush();
+        em.clear();
+
+        // when
+        List<Long> result = sut.listProjectIdsByActivePlanMember(
+            Set.of(planProject.getId(), webProject.getId(), dismissedProject.getId(), otherMemberProject.getId()),
+            memberId
+        );
+
+        // then
+        assertThat(result).containsExactly(planProject.getId());
+    }
+
+    private Project persistProject(String name, Long ownerId) {
+        Project project;
+        try {
+            var constructor = Project.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            project = constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(project, "gisuId", 1L);
+        ReflectionTestUtils.setField(project, "chapterId", 1L);
+        ReflectionTestUtils.setField(project, "status", ProjectStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(project, "name", name);
+        ReflectionTestUtils.setField(project, "productOwnerMemberId", ownerId);
+        ReflectionTestUtils.setField(project, "productOwnerSchoolId", 1L);
+        ReflectionTestUtils.setField(project, "creatorMemberId", ownerId);
+        em.persist(project);
+        return project;
+    }
+}

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -52,8 +52,12 @@ class ProjectApplicationAccessScopeResolverTest {
     // --- PO / Sub-PM (프로젝트 단위 권한) ---
 
     private static Project project(Long ownerMemberId, Long gisuId, Long chapterId, Long schoolId) {
+        return project(PROJECT_ID, ownerMemberId, gisuId, chapterId, schoolId);
+    }
+
+    private static Project project(Long projectId, Long ownerMemberId, Long gisuId, Long chapterId, Long schoolId) {
         Project p = newInstance(Project.class);
-        ReflectionTestUtils.setField(p, "id", PROJECT_ID);
+        ReflectionTestUtils.setField(p, "id", projectId);
         ReflectionTestUtils.setField(p, "productOwnerMemberId", ownerMemberId);
         ReflectionTestUtils.setField(p, "gisuId", gisuId);
         ReflectionTestUtils.setField(p, "chapterId", chapterId);
@@ -342,5 +346,34 @@ class ProjectApplicationAccessScopeResolverTest {
             sut.resolveForProjectApplicantList(MEMBER_ID, project);
 
         assertThat(scope).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantLists_batch는_PO_SubPM_중앙총괄_scope를_프로젝트별로_반환")
+    void projectApplicantLists_batch_scope_판정() {
+        // given
+        Project ownerProject = project(100L, MEMBER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
+        Project subPmProject = project(101L, OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
+        Project centralProject = project(102L, OWNER_ID, GISU_ID, OTHER_CHAPTER_ID, SCHOOL_ID);
+        Project deniedProject = project(103L, OWNER_ID, OTHER_GISU_ID, OTHER_CHAPTER_ID, SCHOOL_ID);
+        List<Project> projects = List.of(ownerProject, subPmProject, centralProject, deniedProject);
+
+        given(loadProjectMemberPort.listProjectIdsByActivePlanMember(
+            Set.of(100L, 101L, 102L, 103L), MEMBER_ID))
+            .willReturn(List.of(101L));
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null, GISU_ID)
+        ));
+
+        // when
+        Map<Long, ProjectApplicationAccessScope> result =
+            sut.resolveForProjectApplicantLists(MEMBER_ID, projects);
+
+        // then
+        assertThat(result.keySet()).containsExactly(100L, 101L, 102L, 103L);
+        assertThat(result.get(100L)).isEqualTo(new ProjectScoped(100L));
+        assertThat(result.get(101L)).isEqualTo(new ProjectScoped(101L));
+        assertThat(result.get(102L)).isEqualTo(new ProjectScoped(102L, true));
+        assertThat(result.get(103L)).isInstanceOf(None.class);
     }
 }

--- a/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/project/application/access/ProjectApplicationAccessScopeResolverTest.java
@@ -2,6 +2,7 @@ package com.umc.product.project.application.access;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 import java.util.Map;
@@ -336,6 +337,22 @@ class ProjectApplicationAccessScopeResolverTest {
     }
 
     @Test
+    @DisplayName("projectApplicantList_프로젝트_기수가_null이면_학교_회장단_scope는_None")
+    void projectApplicantList_프로젝트_기수_null_학교회장_거부() {
+        Project project = project(OWNER_ID, null, CHAPTER_ID, SCHOOL_ID);
+        given(loadProjectMemberPort.isActivePlanMember(PROJECT_ID, MEMBER_ID)).willReturn(false);
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, null)
+        ));
+
+        ProjectApplicationAccessScope scope =
+            sut.resolveForProjectApplicantList(MEMBER_ID, project);
+
+        assertThat(scope).isInstanceOf(None.class);
+        verifyNoInteractions(getChapterUseCase);
+    }
+
+    @Test
     @DisplayName("projectApplicantList_역할이_없는_일반_챌린저면_None")
     void projectApplicantList_일반_챌린저_거부() {
         Project project = project(OWNER_ID, GISU_ID, CHAPTER_ID, SCHOOL_ID);
@@ -375,5 +392,25 @@ class ProjectApplicationAccessScopeResolverTest {
         assertThat(result.get(101L)).isEqualTo(new ProjectScoped(101L));
         assertThat(result.get(102L)).isEqualTo(new ProjectScoped(102L, true));
         assertThat(result.get(103L)).isInstanceOf(None.class);
+    }
+
+    @Test
+    @DisplayName("projectApplicantLists_batch에서_프로젝트_기수가_null이면_학교_회장단_scope는_None")
+    void projectApplicantLists_batch_프로젝트_기수_null_학교회장_거부() {
+        // given
+        Project project = project(PROJECT_ID, OWNER_ID, null, CHAPTER_ID, SCHOOL_ID);
+        given(loadProjectMemberPort.listProjectIdsByActivePlanMember(Set.of(PROJECT_ID), MEMBER_ID))
+            .willReturn(List.of());
+        given(getChallengerRoleUseCase.findAllByMemberId(MEMBER_ID)).willReturn(List.of(
+            roleInfo(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, SCHOOL_ID, null)
+        ));
+
+        // when
+        Map<Long, ProjectApplicationAccessScope> result =
+            sut.resolveForProjectApplicantLists(MEMBER_ID, List.of(project));
+
+        // then
+        assertThat(result).containsEntry(PROJECT_ID, new None());
+        verifyNoInteractions(getChapterUseCase);
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectApplicationQueryServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import com.umc.product.project.application.port.in.query.dto.GetProjectApplicati
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationDetailInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationSummaryInfo;
 import com.umc.product.project.application.port.in.query.dto.ProjectApplicationViewStatus;
+import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsBatchQuery;
 import com.umc.product.project.application.port.in.query.dto.SearchProjectApplicationsQuery;
 import com.umc.product.project.application.port.out.LoadProjectApplicationFormPolicyPort;
 import com.umc.product.project.application.port.out.LoadProjectApplicationPort;
@@ -509,6 +511,96 @@ class ProjectApplicationQueryServiceTest {
         // then
         verify(loadProjectApplicationPort).searchProjectApplications(
             eq(1L), eq(7L), eq(ProjectApplicationStatus.APPROVED), any(), eq(false));
+    }
+
+    @Test
+    @DisplayName("searchByProjects_요청한_projectId_key를_보존하고_권한_없는_프로젝트와_없는_프로젝트는_빈_리스트")
+    void searchByProjects_키_보존_및_빈_리스트() {
+        // given
+        Project projectA = createProject(1L, "프로젝트A", null, 99L);
+        Project projectB = createProject(2L, "프로젝트B", null, 88L);
+        ProjectMatchingRound round = createMatchingRound(
+            7L, MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST);
+        ProjectApplication application = createSubmittedApplication(
+            55L, projectA, round, 200L, ProjectApplicationStatus.SUBMITTED);
+        SearchProjectApplicationsBatchQuery query = SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
+            .projectIds(List.of(1L, 2L, 3L))
+            .build();
+
+        given(loadProjectPort.listByIds(List.of(1L, 2L, 3L)))
+            .willReturn(List.of(projectA, projectB));
+        given(accessScopeResolver.resolveForProjectApplicantLists(REQUESTER_ID, List.of(projectA, projectB)))
+            .willReturn(Map.of(
+                1L, new ProjectApplicationAccessScope.ProjectScoped(1L),
+                2L, new ProjectApplicationAccessScope.None()
+            ));
+        given(loadProjectApplicationPort.searchProjectApplicationsByProjectIds(
+            eq(Set.of(1L)), eq(Set.of()), isNull(), isNull(), any()))
+            .willReturn(List.of(application));
+
+        // when
+        Map<Long, List<ProjectApplicationSummaryInfo>> result = sut.searchByProjects(query);
+
+        // then
+        assertThat(result.keySet()).containsExactly(1L, 2L, 3L);
+        assertThat(result.get(1L)).extracting(ProjectApplicationSummaryInfo::id).containsExactly(55L);
+        assertThat(result.get(2L)).isEmpty();
+        assertThat(result.get(3L)).isEmpty();
+        verify(loadProjectApplicationPort).searchProjectApplicationsByProjectIds(
+            eq(Set.of(1L)), eq(Set.of()), isNull(), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("searchByProjects_ProjectScoped_includeOngoing_true인_프로젝트만_진행중_차수_포함_목록으로_전달")
+    void searchByProjects_includeOngoing_프로젝트만_전달() {
+        // given
+        Project projectA = createProject(1L, "프로젝트A", null, 99L);
+        Project projectB = createProject(2L, "프로젝트B", null, 88L);
+        SearchProjectApplicationsBatchQuery query = SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
+            .projectIds(List.of(1L, 2L))
+            .matchingRoundId(7L)
+            .status(ProjectApplicationStatus.APPROVED)
+            .build();
+
+        given(loadProjectPort.listByIds(List.of(1L, 2L)))
+            .willReturn(List.of(projectA, projectB));
+        given(accessScopeResolver.resolveForProjectApplicantLists(REQUESTER_ID, List.of(projectA, projectB)))
+            .willReturn(Map.of(
+                1L, new ProjectApplicationAccessScope.ProjectScoped(1L),
+                2L, new ProjectApplicationAccessScope.ProjectScoped(2L, true)
+            ));
+        given(loadProjectApplicationPort.searchProjectApplicationsByProjectIds(
+            eq(Set.of(1L, 2L)),
+            eq(Set.of(2L)),
+            eq(7L),
+            eq(ProjectApplicationStatus.APPROVED),
+            any()
+        )).willReturn(List.of());
+
+        // when
+        sut.searchByProjects(query);
+
+        // then
+        verify(loadProjectApplicationPort).searchProjectApplicationsByProjectIds(
+            eq(Set.of(1L, 2L)),
+            eq(Set.of(2L)),
+            eq(7L),
+            eq(ProjectApplicationStatus.APPROVED),
+            any()
+        );
+    }
+
+    @Test
+    @DisplayName("searchByProjects_DRAFT_상태_필터를_사용하면_도메인_예외")
+    void searchByProjects_DRAFT_필터_금지() {
+        assertThatThrownBy(() -> SearchProjectApplicationsBatchQuery.builder()
+            .requesterMemberId(REQUESTER_ID)
+            .projectIds(List.of(1L))
+            .status(ProjectApplicationStatus.DRAFT)
+            .build())
+            .isInstanceOf(ProjectDomainException.class);
     }
 
     // ============================================================


### PR DESCRIPTION
## 🚀 작업 내용

### 변경 범위 요약

- 프로젝트 지원서 조회의 adapter/in, application service/port, access scope resolver, adapter/out QueryDSL 계층을 함께 수정했어요.
- `[APPLY-101-BATCH] GET /api/v1/projects/applications?projectIds=...` API를 추가했고, DB 마이그레이션이나 환경 설정 변경은 없어요.

### 작업 단위별 상세

1. **무엇을**: 복수 프로젝트 지원자 목록을 한 번에 조회하는 batch API를 추가했어요.
   - **어떻게**: 기존 `GET /api/v1/projects/{projectId}/applications`는 유지하고, `projectIds`, `matchingRoundId`, `part`, `status` query parameter를 받는 `GET /api/v1/projects/applications`를 별도로 추가했어요. 응답은 `projectId -> 지원자 목록` Map 형태로 내려요.
   - **왜**: 클라이언트가 여러 프로젝트의 지원자 목록을 화면에서 사용할 때 단건 API를 반복 호출하지 않아도 되게 하기 위해서예요.

2. **무엇을**: batch 조회용 UseCase, Query DTO, Port 계약을 추가했어요.
   - **어떻게**: `SearchProjectApplicationsBatchQuery`와 `searchByProjects` 진입점을 추가하고, 요청한 projectId 순서를 유지하면서 중복을 제거하도록 했어요. 권한이 없거나 존재하지 않는 프로젝트도 결과 key는 유지하고 빈 목록으로 반환해요.
   - **왜**: 단건 API의 권한 없음 위장 정책을 batch에서도 유지하면서 클라이언트가 요청한 projectId와 응답을 안정적으로 매핑할 수 있어야 해서예요.

3. **무엇을**: 지원자 목록과 Sub-PM 권한 판정을 batch 쿼리로 처리하도록 개선했어요.
   - **어떻게**: ProjectApplication QueryDSL에 projectId IN 조회를 추가하고, `includeOngoingProjectIds`에 포함된 프로젝트만 진행 중 차수 지원서를 포함하도록 조건을 분리했어요. ProjectMember QueryDSL에는 ACTIVE PLAN 멤버 프로젝트 ID 조회를 추가했어요.
   - **왜**: 프로젝트별 지원서 조회와 Sub-PM 여부 확인에서 N번 반복 조회가 발생하지 않도록 하기 위해서예요.

4. **무엇을**: 프로젝트별 권한 scope 판정을 batch로 확장했어요.
   - **어떻게**: 기존 단건 판정 순서인 PO, Sub-PM, SUPER_ADMIN, Central Core, 지부장, 학교 회장단 흐름은 유지하고, 사용자 role 조회와 학교-지부 매핑 조회는 한 번에 처리하도록 했어요.
   - **왜**: 권한 정책은 단건 API와 동일해야 하지만, 복수 프로젝트 조회에서는 같은 사용자 정보와 조직 정보를 반복 조회하지 않아야 해서예요.

5. **무엇을**: batch 응답 조립과 테스트를 보강했어요.
   - **어떻게**: assembler에서 프로젝트, 매칭 차수, 회원, 챌린저 파트를 batch로 조회해 프로젝트별 응답을 조립하고, `part` 필터와 정렬 규칙을 단건 API와 동일하게 적용했어요. 컨트롤러, 서비스, 권한 resolver, QueryDSL 어댑터 테스트를 추가했어요.
   - **왜**: batch API가 기존 단건 응답 규칙과 동일하게 동작하고, 권한 없음/미존재 프로젝트 처리와 진행 중 차수 포함 조건이 회귀 없이 유지되는지 검증하기 위해서예요.

### 테스트

- `./gradlew test --tests 'com.umc.product.project.application.service.query.ProjectApplicationQueryServiceTest' --tests 'com.umc.product.project.adapter.in.web.assembler.ProjectApplicationResponseAssemblerTest' --tests 'com.umc.product.project.adapter.in.web.ProjectApplicationQueryControllerTest' --tests 'com.umc.product.project.application.access.ProjectApplicationAccessScopeResolverTest' --tests 'com.umc.product.project.adapter.out.persistence.ProjectApplicationQueryRepositoryTest' --tests 'com.umc.product.project.adapter.out.persistence.ProjectMemberQueryRepositoryTest'`
- `./gradlew test`

## 💬 리뷰 중점사항

- `GET /api/v1/projects/applications?projectIds=...`가 기존 단건 경로와 충돌하지 않고, 요청한 projectId key를 권한 없음/미존재 상황에서도 유지하는 정책이 클라이언트 요구와 맞는지 확인 부탁드려요.
- ProjectApplication QueryDSL의 `includeOngoingProjectIds` 조건이 중앙총괄/SUPER_ADMIN scope 프로젝트에만 진행 중 차수 지원서를 포함하는지 확인 부탁드려요.
- batch 권한 판정에서 기존 단건 권한 우선순위가 유지되는지 확인 부탁드려요.
- DB 마이그레이션, 환경 설정, CI 설정 변경은 없어요.
