### PR TITLE
[Fix] 프로젝트 지원 현황 요약 집계 기준 수정

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryController.java
@@ -60,29 +60,31 @@ public class ProjectStatisticsQueryController {
     @GetMapping("/statistics")
     @Operation(
         operationId = "PROJECT-STAT-002",
-        summary = "프로젝트 지원/매칭 현황 통합 조회",
+        summary = "프로젝트 지원 현황 조회",
         description = """
+            프로젝트 지원 현황 조회 API입니다.
             projectIds 또는 chapterId 중 정확히 하나만 query parameter로 제공해야 합니다.
 
-            - projectIds 제공: 프로젝트 지원/매칭 현황을 `projects` 배열로 반환합니다. 단건은 1개 값으로 요청하고, 다건은 같은 지부 프로젝트만 요청할 수 있습니다.
-            - chapterId 제공: 지부 전체 프로젝트 지원/매칭 현황을 반환합니다.
+            - projectIds 제공: 요청한 프로젝트의 지원 현황을 `projects` 배열로 반환합니다. 단건은 1개 값으로 요청하고, 다건은 같은 지부 프로젝트만 요청할 수 있습니다.
+            - chapterId 제공: 지부 전체 프로젝트 지원 현황을 반환합니다.
 
-            chapterId에 속한 전체 프로젝트를 대상으로 ACTIVE ProjectMember 목록과
-            각 멤버가 해당 프로젝트에 작성한 지원 이력을 프로젝트별로 반환합니다.
-            summary에는 차수별 지원 완료 인원/지원 가능 총원, 학교 순위, 학교별 매칭 인원,
-            프로젝트별 차수 인원 수를 함께 반환합니다.
-
-            지부 내 회장단 이상의 운영진이 매칭 통계를 조회할 때 활용합니다.
-
-            지부 내 모든 프로젝트 목록 및 각 프로젝트에 대한 프로젝트 멤버를 포함하고 있으며,
+            지부 내 모든 프로젝트 목록 및 각 프로젝트에 대한 프로젝트 멤버를 포함하며,
             이는 `/api/v1/projects/{projectId}/statistics` 에서 제공하는 것과 동일한 형태입니다.
+            추가로 BFF 패턴을 적용하여 FE단 데이터 가공 책임을 줄이기 위해 `summary` 필드를 제공합니다.
 
-            추가로 BFF 패턴을 적용하여 FE단 데이터 가공 책임을 줄이기 위해 `summary` 필드를 제공하고 있습니다.
+            응답 필드 설명:
+            - projects: 프로젝트별 지원 현황 목록입니다.
+            - projects[].projectMembers: 해당 프로젝트에 최종 합류한 ACTIVE ProjectMember 목록입니다.
+            - projects[].projectMembers[].applications: 해당 멤버가 해당 프로젝트에 작성한 지원 이력입니다. 강제 배정처럼 지원서 없이 합류한 경우 빈 배열입니다.
+            - projects[].roundApplicationStatistics: 프로젝트 단위의 매칭 차수별 지원서 수와 지원 가능 인원 수입니다.
+            - projects[].schoolApplicationStatistics: 프로젝트 단위의 매칭 차수별 학교 지원자 수입니다. 같은 차수 안에서는 memberId 기준으로 중복 제거합니다.
+            - summary.roundApplicationStatistics: 조회 범위 전체의 매칭 차수별 지원서 수와 지원 가능 인원 수입니다. `appliedMemberCount`는 지원서 수 합계이고, `availableMemberCount`는 지원 가능 챌린저 총원에서 이전 차수까지 이미 ProjectMember로 합류한 인원을 제외한 값입니다.
+            - summary.roundSchoolRankings: 조회 범위 전체의 매칭 차수별 학교 지원자 수입니다. 같은 차수 안에서는 memberId 기준으로 중복 제거합니다.
+            - summary.schoolMatchingStatistics: 학교별 지원 가능 총원, 매칭 완료 인원, 한 번이라도 지원한 인원 수입니다. `totalMemberCount`는 지원 가능한 ACTIVE 챌린저 수, `matchedMemberCount`는 ACTIVE ProjectMember 수, `appliedMemberCount`는 조회 범위에서 한 번이라도 지원한 memberId 기준 unique 인원 수입니다.
+            - summary.projectRoundStatistics: 프로젝트별 매칭 차수 지원 현황입니다. `appliedMemberCount`는 프로젝트와 차수 안에서 memberId 기준으로 중복 제거한 지원자 수이고, `matchedMemberCount`는 해당 프로젝트와 차수에서 매칭 완료된 인원 수입니다.
 
-            - roundApplicationStatistics: N차 매칭 지원 현황 카드에 활용합니다. 각 매칭 차수별 정보 (매칭 종류 및 차수) 와 각 차수별 지원자 수 & 지원 가능했던 인원
-            - roundSchoolRankings: N차 매칭 지원 Top N에 활용합니다. 각 차수별로, 각 학교별 지원자 수
-            - schoolMatchingStatistics: 총원 N명 카드에 활용합니다. 차수와 무관하게, 각 학교별 총 매칭 완료 인원 & 지원 가능 총원
-            - projectRoundStatistics: 프로젝트별 지원 현황 필드에 활용합니다. 각 프로젝트별로, 각 매칭 차수별 정보 (매칭 종류 & 차수) 와 지원자 수
+            프로젝트별 지원자 목록은 `/api/v1/projects/{projectId}/applications`를 호출해서 조회해야 합니다.
+            공개 매칭 요약은 `/api/v1/projects/statistics/matchings`를 호출해서 조회해야 합니다.
 
             권한: projectIds 조회는 각 프로젝트의 PO/Sub-PM(본인 프로젝트), 총괄단, 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다.
             chapterId 조회는 총괄단(모든 지부), 해당 지부장, 해당 지부 소속 학교 회장/부회장만 조회할 수 있습니다. 그 외에는 403.

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/response/statistics/ChapterProjectStatisticsResponse.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/response/statistics/ChapterProjectStatisticsResponse.java
@@ -10,7 +10,7 @@ import com.umc.product.project.application.port.in.query.dto.statistics.ChapterP
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectMatchingRoundStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectRoundMemberCountInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.ProjectRoundMemberStatisticsInfo;
-import com.umc.product.project.application.port.in.query.dto.statistics.SchoolMatchingStatisticsInfo;
+import com.umc.product.project.application.port.in.query.dto.statistics.SchoolApplicationMatchingStatisticsInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -39,7 +39,7 @@ public record ChapterProjectStatisticsResponse(
         List<RoundApplicationStatisticsResponse> roundApplicationStatistics,
         @Schema(description = "매칭 차수별 지원자 학교 순위")
         List<RoundSchoolApplicationStatisticsResponse> roundSchoolRankings,
-        @Schema(description = "학교별 총 매칭 인원 수와 총원")
+        @Schema(description = "학교별 지원 가능 총원, 지원 완료 인원 수, 매칭 완료 인원 수")
         List<SchoolMatchingStatisticsResponse> schoolMatchingStatistics,
         @Schema(description = "프로젝트별 매칭 차수 인원 수")
         List<ProjectRoundMemberStatisticsResponse> projectRoundStatistics
@@ -62,20 +62,23 @@ public record ChapterProjectStatisticsResponse(
         }
     }
 
-    @Schema(description = "학교별 총 매칭 인원 수와 총원")
+    @Schema(description = "학교별 지원 가능 총원, 지원 완료 인원 수, 매칭 완료 인원 수")
     public record SchoolMatchingStatisticsResponse(
         @Schema(description = "학교 ID")
         Long schoolId,
         @Schema(description = "매칭 완료 인원 수")
         long matchedMemberCount,
         @Schema(description = "학교별 지원 가능 총원")
-        long totalMemberCount
+        long totalMemberCount,
+        @Schema(description = "매칭 차수 중 한 번이라도 지원한 인원 수")
+        long appliedMemberCount
     ) {
-        private static SchoolMatchingStatisticsResponse from(SchoolMatchingStatisticsInfo info) {
+        private static SchoolMatchingStatisticsResponse from(SchoolApplicationMatchingStatisticsInfo info) {
             return new SchoolMatchingStatisticsResponse(
                 info.schoolId(),
                 info.matchedMemberCount(),
-                info.totalMemberCount()
+                info.totalMemberCount(),
+                info.appliedMemberCount()
             );
         }
     }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/statistics/ChapterProjectStatisticsSummaryInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/statistics/ChapterProjectStatisticsSummaryInfo.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record ChapterProjectStatisticsSummaryInfo(
     List<RoundApplicationStatisticsInfo> roundApplicationStatistics,
     List<RoundSchoolApplicationStatisticsInfo> roundSchoolRankings,
-    List<SchoolMatchingStatisticsInfo> schoolMatchingStatistics,
+    List<SchoolApplicationMatchingStatisticsInfo> schoolMatchingStatistics,
     List<ProjectRoundMemberStatisticsInfo> projectRoundStatistics
 ) {
 }

--- a/src/main/java/com/umc/product/project/application/port/in/query/dto/statistics/SchoolApplicationMatchingStatisticsInfo.java
+++ b/src/main/java/com/umc/product/project/application/port/in/query/dto/statistics/SchoolApplicationMatchingStatisticsInfo.java
@@ -1,0 +1,12 @@
+package com.umc.product.project.application.port.in.query.dto.statistics;
+
+/**
+ * 학교별 지원 가능 총원, 지원 완료 인원 수, 매칭 완료 인원 수.
+ */
+public record SchoolApplicationMatchingStatisticsInfo(
+    Long schoolId,
+    long matchedMemberCount,
+    long totalMemberCount,
+    long appliedMemberCount
+) {
+}

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -344,6 +344,9 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
     ) {
         Map<Long, Map<Long, Set<Long>>> roundSchoolApplicants = new HashMap<>();
         for (ProjectStatisticsApplicationRow application : context.applications()) {
+            if (application.applicantMemberId() == null) {
+                continue;
+            }
             Long schoolId = context.population().schoolIdByMemberId().get(application.applicantMemberId());
             if (schoolId == null) {
                 continue;
@@ -382,6 +385,9 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         Map<Long, Set<Long>> matchedMemberIdsBySchool = new HashMap<>();
         for (ProjectStatisticsMemberRow member : context.members()) {
+            if (member.memberId() == null) {
+                continue;
+            }
             Long schoolId = context.population().schoolIdByMemberId().get(member.memberId());
             if (schoolId == null) {
                 continue;
@@ -393,6 +399,9 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
         Map<Long, Set<Long>> appliedMemberIdsBySchool = new HashMap<>();
         for (ProjectStatisticsApplicationRow application : context.applications()) {
+            if (application.applicantMemberId() == null) {
+                continue;
+            }
             Long schoolId = context.population().schoolIdByMemberId().get(application.applicantMemberId());
             if (schoolId == null) {
                 continue;
@@ -521,6 +530,9 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
 
         Map<Long, Set<Long>> matchedMemberIdsBySchool = new HashMap<>();
         for (ProjectStatisticsMemberRow member : context.allMembers()) {
+            if (member.memberId() == null) {
+                continue;
+            }
             Long schoolId = context.population().schoolIdByMemberId().get(member.memberId());
             if (schoolId == null) {
                 continue;

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryService.java
@@ -36,6 +36,7 @@ import com.umc.product.project.application.port.in.query.dto.statistics.ProjectS
 import com.umc.product.project.application.port.in.query.dto.statistics.RoundApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.RoundMatchingStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.RoundSchoolApplicationStatisticsInfo;
+import com.umc.product.project.application.port.in.query.dto.statistics.SchoolApplicationMatchingStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolApplicationStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.SchoolMatchingStatisticsInfo;
 import com.umc.product.project.application.port.in.query.dto.statistics.UnclassifiedMatchingStatisticsInfo;
@@ -314,11 +315,11 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             .filter(application -> activeMemberKeys.contains(ProjectMemberKey.from(application)))
             .toList();
 
-        return new StatisticsContext(rounds, eligibleApplications, matchedApplications, population);
+        return new StatisticsContext(rounds, eligibleApplications, matchedApplications, members, population);
     }
 
     private List<RoundApplicationStatisticsInfo> buildRoundApplicationStatistics(StatisticsContext context) {
-        Map<Long, Set<Long>> applicantsByRound = groupMemberIdsByRound(context.applications());
+        Map<Long, Long> applicationCountByRound = countApplicationsByRound(context.applications());
         Map<Long, Set<Long>> matchedByRound = groupMemberIdsByRound(context.matchedApplications());
 
         List<RoundApplicationStatisticsInfo> statistics = new ArrayList<>();
@@ -330,7 +331,7 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             );
             statistics.add(new RoundApplicationStatisticsInfo(
                 toMatchingRoundInfo(round),
-                applicantsByRound.getOrDefault(round.matchingRoundId(), Set.of()).size(),
+                applicationCountByRound.getOrDefault(round.matchingRoundId(), 0L),
                 availableMemberCount
             ));
             cumulativeMatchedMemberIds.addAll(matchedByRound.getOrDefault(round.matchingRoundId(), Set.of()));
@@ -374,29 +375,41 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             .toList();
     }
 
-    private List<SchoolMatchingStatisticsInfo> buildSchoolMatchingStatistics(StatisticsContext context) {
+    private List<SchoolApplicationMatchingStatisticsInfo> buildSchoolMatchingStatistics(StatisticsContext context) {
         Map<Long, Long> totalMemberCountBySchool = context.population().eligibleMemberIds().stream()
             .map(context.population().schoolIdByMemberId()::get)
             .filter(Objects::nonNull)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         Map<Long, Set<Long>> matchedMemberIdsBySchool = new HashMap<>();
-        for (ProjectStatisticsApplicationRow application : context.matchedApplications()) {
-            Long schoolId = context.population().schoolIdByMemberId().get(application.applicantMemberId());
+        for (ProjectStatisticsMemberRow member : context.members()) {
+            Long schoolId = context.population().schoolIdByMemberId().get(member.memberId());
             if (schoolId == null) {
                 continue;
             }
             matchedMemberIdsBySchool
                 .computeIfAbsent(schoolId, ignored -> new HashSet<>())
+                .add(member.memberId());
+        }
+
+        Map<Long, Set<Long>> appliedMemberIdsBySchool = new HashMap<>();
+        for (ProjectStatisticsApplicationRow application : context.applications()) {
+            Long schoolId = context.population().schoolIdByMemberId().get(application.applicantMemberId());
+            if (schoolId == null) {
+                continue;
+            }
+            appliedMemberIdsBySchool
+                .computeIfAbsent(schoolId, ignored -> new HashSet<>())
                 .add(application.applicantMemberId());
         }
 
         return totalMemberCountBySchool.entrySet().stream()
-            .map(entry -> new SchoolMatchingStatisticsInfo(
+            .map(entry -> new SchoolApplicationMatchingStatisticsInfo(
                 entry.getKey(),
                 matchedMemberIdsBySchool.getOrDefault(entry.getKey(), Set.of()).size(),
-                entry.getValue()
+                entry.getValue(),
+                appliedMemberIdsBySchool.getOrDefault(entry.getKey(), Set.of()).size()
             ))
-            .sorted(Comparator.comparing(SchoolMatchingStatisticsInfo::schoolId))
+            .sorted(Comparator.comparing(SchoolApplicationMatchingStatisticsInfo::schoolId))
             .toList();
     }
 
@@ -582,6 +595,14 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
             .count();
     }
 
+    private Map<Long, Long> countApplicationsByRound(Collection<ProjectStatisticsApplicationRow> applications) {
+        return applications.stream()
+            .collect(Collectors.groupingBy(
+                ProjectStatisticsApplicationRow::matchingRoundId,
+                Collectors.counting()
+            ));
+    }
+
     private Map<Long, Set<Long>> groupMemberIdsByRound(Collection<ProjectStatisticsApplicationRow> applications) {
         Map<Long, Set<Long>> memberIdsByRound = new HashMap<>();
         for (ProjectStatisticsApplicationRow application : applications) {
@@ -697,6 +718,7 @@ public class ProjectStatisticsQueryService implements GetProjectStatisticsUseCas
         List<ProjectStatisticsMatchingRoundRow> rounds,
         List<ProjectStatisticsApplicationRow> applications,
         List<ProjectStatisticsApplicationRow> matchedApplications,
+        List<ProjectStatisticsMemberRow> members,
         StatisticsPopulation population
     ) {
     }

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
@@ -148,6 +148,7 @@ class ProjectStatisticsQueryControllerTest {
             .andExpect(jsonPath("$.result.projects[1].projectId").value(11L))
             .andExpect(jsonPath("$.result.summary.roundApplicationStatistics[0].appliedMemberCount").value(2))
             .andExpect(jsonPath("$.result.summary.schoolMatchingStatistics[0].matchedMemberCount").value(1))
+            .andExpect(jsonPath("$.result.summary.schoolMatchingStatistics[0].appliedMemberCount").value(1))
             .andExpect(jsonPath("$.result.summary.projectRoundStatistics[0].matchingRounds[0].appliedMemberCount")
                 .value(2))
             .andExpect(jsonPath("$.result.summary.projectRoundStatistics[0].matchingRounds[0].matchedMemberCount")
@@ -252,7 +253,7 @@ class ProjectStatisticsQueryControllerTest {
                     round,
                     List.of(new SchoolApplicationStatisticsResponse(501L, 2L))
                 )),
-                List.of(new SchoolMatchingStatisticsResponse(501L, 1L, 2L)),
+                List.of(new SchoolMatchingStatisticsResponse(501L, 1L, 2L, 1L)),
                 List.of(new ProjectRoundMemberStatisticsResponse(
                     projects.get(0).projectId(),
                     List.of(new ProjectRoundMemberCountResponse(round, 2L, 1L))

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectStatisticsQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.umc.product.project.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -45,6 +46,8 @@ import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectApplicationStatus;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
 
+import io.swagger.v3.oas.annotations.Operation;
+
 @WebMvcTest(controllers = ProjectStatisticsQueryController.class)
 @Import(JacksonConfig.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -69,6 +72,42 @@ class ProjectStatisticsQueryControllerTest {
         SecurityContextHolder.getContext().setAuthentication(
             new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
         );
+    }
+
+    @Test
+    @DisplayName("GET_statistics_Operation_문서는_지원_현황_조회와_필드별_의미를_설명한다")
+    void 통합_통계_조회_Operation_문서() throws Exception {
+        // given
+        var method = ProjectStatisticsQueryController.class.getDeclaredMethod(
+            "getStatistics",
+            MemberPrincipal.class,
+            List.class,
+            Long.class
+        );
+
+        // when
+        Operation operation = method.getAnnotation(Operation.class);
+
+        // then
+        assertThat(operation.summary()).isEqualTo("프로젝트 지원 현황 조회");
+        assertThat(operation.description())
+            .contains(
+                "프로젝트 지원 현황 조회 API입니다.",
+                "projects",
+                "projectMembers",
+                "summary.roundApplicationStatistics",
+                "summary.roundSchoolRankings",
+                "summary.schoolMatchingStatistics",
+                "summary.projectRoundStatistics",
+                "appliedMemberCount",
+                "availableMemberCount",
+                "matchedMemberCount",
+                "totalMemberCount"
+            )
+            .doesNotContain(
+                "지원/매칭 현황",
+                "매칭 통계를 조회"
+            );
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -364,6 +364,33 @@ class ProjectStatisticsQueryServiceTest {
     }
 
     @Test
+    @DisplayName("getByChapterId_null_memberId는_학교별_summary_집계에서_무시한다")
+    void 지부_통계_null_memberId_학교별_summary_집계_무시() {
+        // given
+        Long chapterId = 3L;
+        Long gisuId = 1L;
+        Long requesterMemberId = 7000L;
+        given(loadProjectStatisticsPort.listProjectsByChapterId(chapterId))
+            .willReturn(List.of(projectRow(10L, gisuId, chapterId)));
+        given(loadProjectStatisticsPort.listMatchingRoundsByChapterId(chapterId))
+            .willReturn(List.of(roundRow(1L, MatchingType.PLAN_DEVELOPER, MatchingPhase.FIRST)));
+        given(loadProjectStatisticsPort.listActiveMembersByChapterId(chapterId))
+            .willReturn(List.of(memberRow(10L, 101L, null, ChallengerPart.WEB)));
+        given(loadProjectStatisticsPort.listCountedApplicationsByProjectIds(Set.of(10L)))
+            .willReturn(List.of());
+        given(getChallengerUseCase.listByChapterId(chapterId))
+            .willReturn(List.of());
+        given(projectStatisticsAccessPolicy.canReadChapterStatistics(requesterMemberId, chapterId))
+            .willReturn(true);
+
+        // when
+        ChapterProjectStatisticsInfo result = sut.getByChapterId(chapterId, requesterMemberId);
+
+        // then
+        assertThat(result.summary().schoolMatchingStatistics()).isEmpty();
+    }
+
+    @Test
     @DisplayName("getPublicMatchingStatisticsByChapterId_ProjectMember_기준_공개_매칭_요약을_반환한다")
     void 공개_프로젝트_매칭_요약_반환() {
         // given

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectStatisticsQueryServiceTest.java
@@ -248,7 +248,7 @@ class ProjectStatisticsQueryServiceTest {
                 s -> s.availableMemberCount()
             )
             .containsExactly(
-                tuple(1L, 2L, 4L),
+                tuple(1L, 3L, 4L),
                 tuple(2L, 1L, 3L)
             );
         assertThat(result.summary().roundSchoolRankings().get(0).schools())
@@ -258,10 +258,10 @@ class ProjectStatisticsQueryServiceTest {
                 tuple(502L, 1L)
             );
         assertThat(result.summary().schoolMatchingStatistics())
-            .extracting("schoolId", "matchedMemberCount", "totalMemberCount")
+            .extracting("schoolId", "matchedMemberCount", "totalMemberCount", "appliedMemberCount")
             .containsExactly(
-                tuple(501L, 2L, 2L),
-                tuple(502L, 0L, 2L)
+                tuple(501L, 2L, 2L, 2L),
+                tuple(502L, 1L, 2L, 1L)
             );
         assertThat(result.summary().projectRoundStatistics())
             .extracting("projectId")


### PR DESCRIPTION
## 🚀 작업 내용

### 변경 범위 요약

- 프로젝트 지원 현황 통합 API인 [PROJECT-STAT-002] GET /api/v1/projects/statistics의 summary 집계 기준을 정리했어요.
- project application summary 조립 로직, summary 응답 DTO, OpenAPI Operation 설명, 서비스/WebMvc 테스트를 수정했어요.
- DB 마이그레이션이나 환경 설정 변경은 없어요.

### 변경 전후 비교

| 항목 | 기존 | 변경 후 |
|---|---|---|
| summary.roundApplicationStatistics[].appliedMemberCount | 차수별 memberId unique 지원자 수였어요. | 차수별 지원서 수 합계로 계산해요. |
| summary.roundApplicationStatistics[].availableMemberCount | 지원 가능 챌린저 총원에서 이전 차수까지 매칭 완료된 인원을 누적 제외했어요. | 동일한 기준을 유지해요. |
| summary.projectRoundStatistics[].matchingRounds[].appliedMemberCount | 프로젝트별, 차수별 memberId unique 지원자 수였어요. | 동일한 기준을 유지해요. |
| summary.schoolMatchingStatistics[].matchedMemberCount | APPROVED 지원서와 ACTIVE ProjectMember가 연결된 인원만 계산했어요. | 학교별 ACTIVE ProjectMember 인원으로 계산해요. |
| summary.schoolMatchingStatistics[].totalMemberCount | 학교별 지원 가능 챌린저 총원이었어요. | 동일한 기준을 유지해요. |
| summary.schoolMatchingStatistics[].appliedMemberCount | 응답 필드가 없었어요. | 매칭 차수 중 한 번이라도 지원한 학교별 unique memberId 수를 내려줘요. |
| [PROJECT-STAT-002] Operation 문서 | 지원/매칭 현황 통합 조회로 설명했어요. | 지원 현황 조회 API로 명시하고 필드별 계산 기준을 설명해요. |

### 작업 단위별 상세

1. **무엇을**: roundApplicationStatistics의 appliedMemberCount를 지원자 수가 아니라 지원서 수 합계로 바꿨어요.
   - **어떻게**: ProjectStatisticsApplicationRow를 matchingRoundId 기준으로 grouping하고 row count를 집계하도록 변경했어요.
   - **왜**: 이 API는 매칭 현황이 아니라 지원 현황 조회가 주 목적이라서, 차수별 지원 합계는 지원서 수를 기준으로 보여줘야 하기 때문이에요.

2. **무엇을**: schoolMatchingStatistics에 학교별 지원 인원 수를 별도 필드로 추가했어요.
   - **어떻게**: SchoolApplicationMatchingStatisticsInfo를 추가하고, 응답 DTO에 appliedMemberCount를 포함하도록 확장했어요.
   - **왜**: matchedMemberCount를 지원 인원처럼 파싱하던 Web 화면에서 지원 인원과 매칭 인원을 명확히 구분할 수 있게 하기 위해서예요.

3. **무엇을**: schoolMatchingStatistics의 matchedMemberCount 계산 기준을 ProjectMember 기준으로 정리했어요.
   - **어떻게**: 기존 APPROVED 지원서 기반 matchedApplications 대신 ACTIVE ProjectMember 목록을 학교별로 집계하도록 변경했어요.
   - **왜**: 매칭된 인원은 지원서 상태가 아니라 실제 프로젝트 멤버 합류 여부를 기준으로 보여주는 값이기 때문이에요.

4. **무엇을**: [PROJECT-STAT-002] Operation summary와 description을 지원 현황 조회 중심으로 정리했어요.
   - **어떻게**: summary에서 지원/매칭 현황 표현을 제거하고, description에 projects, projectMembers, summary.roundApplicationStatistics, summary.roundSchoolRankings, summary.schoolMatchingStatistics, summary.projectRoundStatistics의 의미와 주요 count 필드 계산 기준을 적었어요.
   - **왜**: Web에서 이 API를 지원 현황 조회 API로 이해하고, 매칭 관련 부가 필드를 올바른 의미로 파싱할 수 있게 하기 위해서예요.

5. **무엇을**: summary 집계 기준과 Operation 문구 변경을 테스트로 고정했어요.
   - **어떻게**: ProjectStatisticsQueryServiceTest에서 roundApplicationStatistics, schoolMatchingStatistics의 기대값을 변경된 의미에 맞게 보정했어요. ProjectStatisticsQueryControllerTest에는 새 appliedMemberCount 응답 필드와 Operation annotation 문구 검증을 추가했어요.
   - **왜**: FE가 파싱해야 하는 응답 의미가 다시 섞이지 않도록 회귀 테스트로 잡기 위해서예요.

### 테스트

- ./gradlew test --tests 'com.umc.product.project.application.service.query.ProjectStatisticsQueryServiceTest' 를 통과했어요.
- ./gradlew test --tests 'com.umc.product.project.adapter.in.web.ProjectStatisticsQueryControllerTest' 를 통과했어요.
- ./gradlew test 를 통과했어요.

## 💬 리뷰 중점사항

- schoolMatchingStatistics[].appliedMemberCount가 새로 추가되므로 Web에서 지원 인원은 이 필드를 읽도록 맞춰야 해요.
- schoolMatchingStatistics[].matchedMemberCount는 이제 지원서 기준이 아니라 ACTIVE ProjectMember 기준이라는 점을 확인해 주세요.
- roundApplicationStatistics[].appliedMemberCount는 memberId unique가 아니라 지원서 수 합계로 바뀌었으니 화면 문구와 기대값이 맞는지 확인해 주세요.
- [PROJECT-STAT-002] Operation 문서가 지원 현황 조회 API로 충분히 명확한지 확인해 주세요.
