### PR TITLE
[Feat] 최고관리자의 지원서 상태 변경 bypass 적용

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectApplicationController.java
@@ -126,8 +126,9 @@ public class ProjectApplicationController {
         operationId = "APPLY-103",
         summary = "지원서 합격 여부 결정",
         description = """
-            PM 이 지원서의 status 를 토글합니다.
-            - 매칭 차수 진행 중에만 가능 (decisionDeadline 까지)
+            PM 또는 SUPER_ADMIN 이 지원서의 status 를 토글합니다.
+            - PM: 매칭 차수 진행 중에만 가능 (decisionDeadline 까지)
+            - SUPER_ADMIN: 매칭 차수 시간과 관계없이 가능
             - APPROVED ↔ REJECTED 재토글 허용
             - REJECTED 처리 후 매칭 규칙의 최소선발 수를 만족하지 못하면 거절
             """

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectApplicationCommandService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -75,6 +76,7 @@ public class ProjectApplicationCommandService implements
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
     private final ManageFormResponseUseCase manageFormResponseUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final List<MatchingDecisionPolicy> matchingDecisionPolicies;
     private final GetFormUseCase getFormUseCase;
 
@@ -259,13 +261,37 @@ public class ProjectApplicationCommandService implements
             validateMinimumSelectionAfterRejection(application);
         }
 
-        switch (targetStatus) {
-            case APPROVED -> application.approve(decidedByMemberId, reason);
-            case REJECTED -> application.reject(decidedByMemberId, reason);
-        }
+        applyDecision(application, targetStatus, reason, decidedByMemberId);
 
         saveProjectApplicationPort.save(application);
         return ProjectApplicationInfo.of(application.getId(), application.getStatus());
+    }
+
+    private void applyDecision(
+        ProjectApplication application,
+        ApplicationDecisionStatus targetStatus,
+        String reason,
+        Long decidedByMemberId
+    ) {
+        boolean superAdmin = decidedByMemberId != null
+            && getChallengerRoleUseCase.isSuperAdmin(decidedByMemberId);
+
+        switch (targetStatus) {
+            case APPROVED -> {
+                if (superAdmin) {
+                    application.forceApprove(decidedByMemberId, reason);
+                } else {
+                    application.approve(decidedByMemberId, reason);
+                }
+            }
+            case REJECTED -> {
+                if (superAdmin) {
+                    application.forceReject(decidedByMemberId, reason);
+                } else {
+                    application.reject(decidedByMemberId, reason);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluator.java
@@ -125,6 +125,7 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
 
     /**
      * 합불 결정. 부모 프로젝트의 PO 가 SUBMITTED / APPROVED / REJECTED 상태에서 자유롭게 토글한다.
+     * SUPER_ADMIN 은 기수/프로젝트 소유 여부와 관계없이 토글할 수 있다.
      * 차수 진행 중 잠금 해제는 도메인 메서드({@code ProjectMatchingRound.validateIsMutableAt}) 가 책임진다.
      * (자동 매칭 스케줄러는 권한 모델 외)
      */
@@ -134,7 +135,7 @@ public class ProjectApplicationPermissionEvaluator implements ResourcePermission
             return false;
         }
         Project project = application.getApplicationForm().getProject();
-        return isOwner(subject, project);
+        return isOwner(subject, project) || isSuperAdmin(subject);
     }
 
     private boolean isDecidableStatus(ProjectApplicationStatus status) {

--- a/src/main/java/com/umc/product/project/domain/ProjectApplication.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectApplication.java
@@ -107,13 +107,7 @@ public class ProjectApplication extends BaseEntity {
      * @param reason            결정 사유 (필수 아님)
      */
     public void approve(Long decidedByMemberId, String reason) {
-        validateCanBeDecided();
-        appliedMatchingRound.validateIsMutableAt(Instant.now());
-
-        this.status = ProjectApplicationStatus.APPROVED;
-        this.statusChangedMemberId = decidedByMemberId;
-        this.statusChangeReason = reason;
-        this.statusChangedAt = Instant.now();
+        applyDecision(ProjectApplicationStatus.APPROVED, decidedByMemberId, reason, true);
     }
 
     /**
@@ -127,10 +121,42 @@ public class ProjectApplication extends BaseEntity {
      * @param reason            결정 사유 (필수 아님)
      */
     public void reject(Long decidedByMemberId, String reason) {
-        validateCanBeDecided();
-        appliedMatchingRound.validateIsMutableAt(Instant.now());
+        applyDecision(ProjectApplicationStatus.REJECTED, decidedByMemberId, reason, true);
+    }
 
-        this.status = ProjectApplicationStatus.REJECTED;
+    /**
+     * 지원서를 시간 제한과 관계없이 합격 처리합니다.
+     * <p>
+     * 상태 전이 규칙(SUBMITTED / APPROVED / REJECTED 만 가능)은 유지하고, 매칭 차수의 결정 가능 시간 검증만 건너뜁니다.
+     *
+     * @param decidedByMemberId 결정한 슈퍼어드민 ID
+     * @param reason            결정 사유 (필수 아님)
+     */
+    public void forceApprove(Long decidedByMemberId, String reason) {
+        applyDecision(ProjectApplicationStatus.APPROVED, decidedByMemberId, reason, false);
+    }
+
+    /**
+     * 지원서를 시간 제한과 관계없이 불합격 처리합니다.
+     * <p>
+     * 상태 전이 규칙(SUBMITTED / APPROVED / REJECTED 만 가능)은 유지하고, 매칭 차수의 결정 가능 시간 검증만 건너뜁니다.
+     *
+     * @param decidedByMemberId 결정한 슈퍼어드민 ID
+     * @param reason            결정 사유 (필수 아님)
+     */
+    public void forceReject(Long decidedByMemberId, String reason) {
+        applyDecision(ProjectApplicationStatus.REJECTED, decidedByMemberId, reason, false);
+    }
+
+    private void applyDecision(
+        ProjectApplicationStatus targetStatus, Long decidedByMemberId, String reason, boolean validateDecisionPeriod
+    ) {
+        validateCanBeDecided();
+        if (validateDecisionPeriod) {
+            appliedMatchingRound.validateIsMutableAt(Instant.now());
+        }
+
+        this.status = targetStatus;
         this.statusChangedMemberId = decidedByMemberId;
         this.statusChangeReason = reason;
         this.statusChangedAt = Instant.now();

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectApplicationCommandServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -112,6 +113,8 @@ class ProjectApplicationCommandServiceTest {
     @Mock
     GetChallengerUseCase getChallengerUseCase;
     @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+    @Mock
     GetFormUseCase getFormUseCase;
 
     ProjectApplicationCommandService sut;
@@ -128,6 +131,7 @@ class ProjectApplicationCommandServiceTest {
             loadProjectMatchingRoundPort,
             manageFormResponseUseCase,
             getChallengerUseCase,
+            getChallengerRoleUseCase,
             List.of(new DeveloperMatchingPolicy(), new DesignerMatchingPolicy()),
             getFormUseCase
         );
@@ -468,6 +472,30 @@ class ProjectApplicationCommandServiceTest {
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_MATCHING_ROUND_LOCKED);
             then(saveProjectApplicationPort).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("SUPER_ADMIN은 결정 가능 시간과 관계없이 지원서 상태를 변경할 수 있다")
+        void SUPER_ADMIN은_결정_가능_시간과_관계없이_지원서_상태를_변경할_수_있다() {
+            ProjectMatchingRound expiredRound = openRound();
+            ReflectionTestUtils.setField(expiredRound, "decisionDeadline", NOW.minusSeconds(60));
+            ProjectApplication application = ProjectApplication.create(
+                applicationForm(), 999L, APPLICANT_MEMBER_ID, expiredRound
+            );
+            ReflectionTestUtils.setField(application, "id", APPLICATION_ID);
+            ReflectionTestUtils.setField(application, "status", ProjectApplicationStatus.SUBMITTED);
+            given(loadProjectApplicationPort.findById(APPLICATION_ID)).willReturn(Optional.of(application));
+            given(getChallengerRoleUseCase.isSuperAdmin(DECIDER_MEMBER_ID)).willReturn(true);
+
+            ProjectApplicationInfo result = sut.decide(
+                APPLICATION_ID, ApplicationDecisionStatus.APPROVED, "슈퍼어드민 수정", DECIDER_MEMBER_ID
+            );
+
+            assertThat(result.status()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("슈퍼어드민 수정");
+            then(saveProjectApplicationPort).should(times(1)).save(application);
         }
 
         @Test

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectApplicationPermissionEvaluatorTest.java
@@ -415,6 +415,15 @@ class ProjectApplicationPermissionEvaluatorTest {
         assertThat(sut.evaluate(subject, approvePermission())).isFalse();
     }
 
+    @Test
+    void APPROVE는_SUPER_ADMIN_허용_기수_무관() {
+        givenApplication(ProjectApplicationStatus.SUBMITTED);
+        SubjectAttributes subject = subjectWith(30L, List.of(),
+            List.of(superAdminRoleInGisu(99L)));
+
+        assertThat(sut.evaluate(subject, approvePermission())).isTrue();
+    }
+
     // --- helpers ---
 
     private void givenProject(ProjectStatus status) {

--- a/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectApplicationTest.java
@@ -156,6 +156,42 @@ class ProjectApplicationTest {
     }
 
     @Nested
+    class forceDecision {
+
+        @Test
+        void forceApprove는_결정_마감_후에도_APPROVED로_전이한다() {
+            setRoundDeadline(round, NOW.minusSeconds(60));
+
+            application.forceApprove(DECIDER_MEMBER_ID, "슈퍼어드민 수정");
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.APPROVED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("슈퍼어드민 수정");
+        }
+
+        @Test
+        void forceReject는_지원_진행_중에도_REJECTED로_전이한다() {
+            setRoundEndsAt(round, NOW.plusSeconds(43_200));
+
+            application.forceReject(DECIDER_MEMBER_ID, "슈퍼어드민 수정");
+
+            assertThat(application.getStatus()).isEqualTo(ProjectApplicationStatus.REJECTED);
+            assertThat(application.getStatusChangedMemberId()).isEqualTo(DECIDER_MEMBER_ID);
+            assertThat(application.getStatusChangeReason()).isEqualTo("슈퍼어드민 수정");
+        }
+
+        @Test
+        void forceApprove도_DRAFT_상태에서는_PROJECT_APPLICATION_DECISION_INVALID_TRANSITION() {
+            setStatus(application, ProjectApplicationStatus.DRAFT);
+
+            assertThatThrownBy(() -> application.forceApprove(DECIDER_MEMBER_ID, null))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_APPLICATION_DECISION_INVALID_TRANSITION);
+        }
+    }
+
+    @Nested
     class applyAutoDecision {
 
         @Test


### PR DESCRIPTION
## 🚀 작업 내용

Super Admin이 지원서 상태를 매칭 차수 시간 제한과 관계없이 변경할 수 있도록 프로젝트 지원서 결정 경로를 수정했어요.

- `[APPLY-103] PATCH /api/v1/projects/{projectId}/applications/{applicationId}/decision` 설명에 PM과 Super Admin의 시간 제한 정책 차이를 반영했어요.
- `ProjectApplication`에 시간 제한만 우회하는 `forceApprove`, `forceReject` 도메인 메서드를 추가했어요.
- `ProjectApplicationCommandService`에서 `GetChallengerRoleUseCase.isSuperAdmin()`으로 결정자를 판별하고, Super Admin이면 강제 결정 메서드를 호출하도록 분기했어요.
- `ProjectApplicationPermissionEvaluator`에서 Super Admin이 지원서 APPROVE 권한을 통과하도록 허용했어요.
- 도메인, 서비스, 권한 evaluator 테스트에 Super Admin 예외와 기존 상태 전이 검증 유지 케이스를 추가했어요.

## 테스트

- `./gradlew test --tests 'com.umc.product.project.domain.ProjectApplicationTest' --tests 'com.umc.product.project.application.service.command.ProjectApplicationCommandServiceTest' --tests 'com.umc.product.project.application.service.evaluator.ProjectApplicationPermissionEvaluatorTest'`를 통과했어요.
- `git diff --check HEAD~1..HEAD`를 통과했어요.
- 참고로 전체 `./gradlew test`는 `AuthenticationServiceTest.renewAccessToken` 2건이 고정 만료 시각 `2026-06-20T00:00:00Z` 때문에 별도로 실패했어요.

## 💬 리뷰 중점사항

- Super Admin 예외가 매칭 차수 시간 제한만 우회하고, 지원서 상태 전이 규칙은 유지하는지 확인해주세요.
- APPROVE 권한을 Super Admin에게 확장한 범위가 운영 정책과 맞는지 확인해주세요.
- DB 마이그레이션과 환경 설정 변경은 없어요.