### PR TITLE
[Chore] Recent Loki Logs 패널 쿼리 개선 및 레벨/텍스트 검색 변수 추가

### DIFF
--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -1946,7 +1946,7 @@
                       "spec": {
                         "direction": "backward",
                         "editorMode": "code",
-                        "expr": "{service_name=~\"$service\"} | event=\"api_request_completed\"",
+                        "expr": "{service_name=~\"$service\"} | detected_level=~\"$log_level\" |~ \"$log_search\"",
                         "queryType": "range"
                       },
                       "version": "v0"
@@ -1959,7 +1959,7 @@
               "transformations": []
             }
           },
-          "description": "최근 애플리케이션 로그. Loki OTLP 기본 라벨 service_name 을 기준으로 필터링한다.",
+          "description": "최근 애플리케이션 로그. 기본값은 error/warn 레벨만 표시하며, 상단 Log Level 드롭다운으로 레벨을 변경하고 Log Search 로 텍스트 필터링할 수 있다.",
           "id": 7,
           "links": [],
           "title": "Recent Loki Logs",
@@ -3691,6 +3691,43 @@
           "regexApplyTo": "value",
           "skipUrlSync": false,
           "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "allowCustomValue": false,
+          "current": {
+            "text": "error|warn",
+            "value": "error|warn"
+          },
+          "hide": "dontHide",
+          "label": "Log Level",
+          "multi": false,
+          "name": "log_level",
+          "options": [
+            {"selected": true, "text": "error|warn", "value": "error|warn"},
+            {"selected": false, "text": "error", "value": "error"},
+            {"selected": false, "text": "warn", "value": "warn"},
+            {"selected": false, "text": "info", "value": "info"},
+            {"selected": false, "text": "전체", "value": ".*"}
+          ],
+          "query": "error|warn,error,warn,info,.*",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "hide": "dontHide",
+          "label": "Log Search",
+          "name": "log_search",
+          "query": "",
+          "skipUrlSync": false
         }
       },
       {

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -1946,7 +1946,7 @@
                       "spec": {
                         "direction": "backward",
                         "editorMode": "code",
-                        "expr": "{service_name=~\"$service\"} | detected_level=~\"$log_level\" |~ \"$log_search\"",
+                        "expr": "{service_name=~\"$service\"} | detected_level=~\"$log_level\" |~ \"(?i)$log_search\"",
                         "queryType": "range"
                       },
                       "version": "v0"


### PR DESCRIPTION
## 🚀 작업 내용
대시보드 최상단 Recent Loki Logs 패널의 LogQL 쿼리를 `api_request_completed` 고정 필터에서 로그 레벨 기반으로 변경하고, 레벨 드롭다운과 텍스트 검색 변수를 추가했습니다.

- 패널 쿼리: `event="api_request_completed"` -> `detected_level=~"$log_level" |~ "$log_search"`
- 변수 추가: Log Level 드롭다운 (기본값: error|warn), Log Search 텍스트 입력
- 패널 description 업데이트
- resolves #1044 

## 💬 리뷰 중점사항
