### PR TITLE
[Hotfix] 테스트 실패 수정

### DIFF
--- a/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/umc/product/authentication/application/service/AuthenticationServiceTest.java
@@ -62,7 +62,7 @@ class AuthenticationServiceTest {
     private static final String ISSUED_TOKEN = "issued.jwt.token";
     private static final String REFRESH_TOKEN = "refresh.jwt.token";
     private static final UUID REFRESH_JTI = UUID.fromString("33333333-3333-3333-3333-333333333333");
-    private static final Instant REFRESH_EXPIRES_AT = Instant.parse("2026-06-20T00:00:00Z");
+    private static final Instant REFRESH_EXPIRES_AT = Instant.now().plusSeconds(86_400);
 
     @Mock
     LoadEmailVerificationPort loadEmailVerificationPort;


### PR DESCRIPTION
## 대상 브랜치
- develop

## 이슈
- 없음

## 작업 내용
- `AuthenticationServiceTest`의 RefreshToken 재발급 테스트 fixture에서 만료시각을 실행 시점 기준 미래값으로 변경했습니다.
- 기존 fixture는 `2026-06-20T00:00:00Z`로 고정되어 있어 2026-06-20 이후 실행 시 활성 토큰 시나리오가 먼저 `EXPIRED_JWT_TOKEN`으로 실패했습니다.

## 리뷰 중점사항
- 테스트 의도인 활성 RefreshToken 검증 경로가 유지되는지 확인 부탁드립니다.

## 검증
- `./gradlew test --tests 'com.umc.product.authentication.application.service.AuthenticationServiceTest$RenewAccessToken'`
- `./gradlew test`