### PR TITLE
[Fix] Prometheus API 성능 대시보드 집계 오류 수정

### DIFF
--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2825,7 +2825,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\", method!=\"OPTIONS\"}[$__range])))",
+                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\", method!=\"OPTIONS\"}[$__range])) > 0)",
                         "format": "table",
                         "instant": true,
                         "range": false

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2825,7 +2825,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\", method!=\"OPTIONS\"}[$__range])) > 0)",
+                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\", method!=\"OPTIONS\", uri!=\"UNKNOWN\"}[$__range])) > 0)",
                         "format": "table",
                         "instant": true,
                         "range": false
@@ -2964,7 +2964,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "topk(10, histogram_quantile(0.95, sum by (le, method, uri) (rate(http_server_requests_milliseconds_bucket{application=~\"$service\", instance=~\"$instance\"}[$__rate_interval]))) > 0)",
+                        "expr": "topk(10, histogram_quantile(0.95, sum by (le, method, uri) (rate(http_server_requests_milliseconds_bucket{application=~\"$service\", instance=~\"$instance\", uri!=\"UNKNOWN\"}[$__rate_interval]))) > 0)",
                         "format": "table",
                         "instant": true,
                         "range": false

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2964,7 +2964,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "topk(10, histogram_quantile(0.95, sum by (le, method, uri) (rate(http_server_requests_milliseconds_bucket{application=~\"$service\", instance=~\"$instance\"}[$__rate_interval]))))",
+                        "expr": "topk(10, histogram_quantile(0.95, sum by (le, method, uri) (rate(http_server_requests_milliseconds_bucket{application=~\"$service\", instance=~\"$instance\"}[$__rate_interval]))) > 0)",
                         "format": "table",
                         "instant": true,
                         "range": false

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2825,7 +2825,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\"}[$__range])))",
+                        "expr": "topk(10, sum by (method, uri) (increase(http_server_requests_milliseconds_count{application=~\"$service\", instance=~\"$instance\", method!=\"OPTIONS\"}[$__range])))",
                         "format": "table",
                         "instant": true,
                         "range": false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,6 +227,11 @@ management:
       loki.resource.labels: service.name, environment
 
   metrics:
+    distribution:
+      # Prometheus에서 URI별 P95/P99를 집계할 수 있도록 HTTP 요청 duration histogram을 발행한다.
+      percentiles-histogram:
+        http.server.requests: true
+
     tags:
       application: ${spring.application.name}
       instance: ${HOSTNAME:${LOCAL_DEVELOPER_ID:${USER:${USERNAME:unknown}}}}


### PR DESCRIPTION
## 🚀 작업 내용
- HTTP 요청 duration histogram을 활성화해 URI별 P95 latency를 계산할 수 있도록 수정했습니다.
- `Top 10 request count`에서 CORS preflight 요청인 `OPTIONS`를 제외했습니다.
- `Top 10 slow latency`에서 최근 표본이 없어 P95를 계산할 수 없는 URI의 `NaN` 행을 제외했습니다.
- closes #1059 

## 💬 리뷰 중점사항

- P95 패널은 최근 활성 요청의 지연을 보기 위해 기존 `rate(...[$__rate_interval])` 집계 방식을 유지했습니다.
- 요청 표본이 없는 URI는 P95가 정의되지 않으므로, `> 0` 조건으로 `NaN` 대신 표에서 제외되도록 했습니다.
- OPTIONS는 전체 트래픽 집계에는 유지하고, Top 10 요청 수 순위에서만 제외했습니다.
