### PR TITLE
[Feat] 비동기 작업 및 동적 스케줄러에 traceId 전파

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.19") // Fixture 생성에 도움을 주는 친구
+    testImplementation("io.micrometer:micrometer-tracing-test") // SimpleTracer 기반 trace 전파 검증
     testRuntimeOnly("jakarta.mail:jakarta.mail-api") // JavaMailSender MockitoBean 초기화에 필요
 
     testCompileOnly("org.projectlombok:lombok")

--- a/src/main/java/com/umc/product/global/config/AsyncConfig.java
+++ b/src/main/java/com/umc/product/global/config/AsyncConfig.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Executor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -23,6 +24,9 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(700);
         executor.setThreadNamePrefix("email-");
+        // 비동기 스레드로 넘어가도 trace/Observation/MDC 컨텍스트가 유지되도록 데코레이터 장착.
+        // 원 요청과 같은 traceId 아래 자식 span 으로 이메일 발송이 잡힌다.
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
         executor.initialize();
         return executor;
     }
@@ -34,6 +38,8 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(200);
         executor.setThreadNamePrefix("audit-");
+        // 감사 로그도 동일하게 원 요청 trace 컨텍스트를 이어받아 자식 span 으로 연결한다.
+        executor.setTaskDecorator(new ContextPropagatingTaskDecorator());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/umc/product/global/observability/ScheduledTaskTracer.java
+++ b/src/main/java/com/umc/product/global/observability/ScheduledTaskTracer.java
@@ -1,0 +1,59 @@
+package com.umc.product.global.observability;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+
+/**
+ * {@code @Scheduled} 어노테이션을 거치지 않는 동적(프로그래밍 방식) 스케줄 task 를 새 root span 으로 감싼다.
+ *
+ * <p>Spring Boot 는 {@code @Scheduled} 메서드만 {@code tasks.scheduled.execution} 관측으로 감싸 준다.
+ * 반면 {@link org.springframework.scheduling.TaskScheduler#schedule} 로 직접 등록되는 task 는 trace
+ * 컨텍스트 없이 실행돼, 그 안의 usecase/adapter 호출이 {@link TraceFlowAspect} 의 {@code nextSpan()} 마다
+ * 제각각 새 trace 로 흩어진다. 등록 직전 Runnable 을 이 클래스로 감싸면 실행 시 새 root span 이 열려
+ * 한 번의 실행 전체가 하나의 traceId 로 묶인다.
+ */
+@Component
+public class ScheduledTaskTracer {
+
+    private final Tracer tracer;
+
+    @Autowired
+    public ScheduledTaskTracer(ObjectProvider<Tracer> tracerProvider) {
+        this(tracerProvider.getIfAvailable(() -> Tracer.NOOP));
+    }
+
+    public ScheduledTaskTracer(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    /**
+     * 주어진 Runnable 을 새 root span 으로 감싼 Runnable 을 돌려준다.
+     *
+     * <p>동적 스케줄러 스레드에는 현재 span 이 없으므로 {@code nextSpan()} 은 부모 없는 새 root span
+     * (= 새 trace)이 된다.
+     *
+     * @param taskName span 이름·태그에 쓰일 task 식별자 (집계를 위해 저-cardinality 값 권장)
+     * @param task     실제 실행할 작업
+     */
+    public Runnable trace(String taskName, Runnable task) {
+        return () -> {
+            Span span = tracer.nextSpan()
+                .name("scheduled." + taskName)
+                .tag("app.layer", "scheduler")
+                .tag("scheduled.task", taskName);
+            span.start();
+            try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+                task.run();
+            } catch (RuntimeException e) {
+                span.error(e);
+                throw e;
+            } finally {
+                span.end();
+            }
+        };
+    }
+}

--- a/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
+++ b/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
@@ -48,6 +48,6 @@ public class SpanContextPropagationConfig {
         }
         ContextRegistry.getInstance()
             .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(observationRegistry, tracer));
-        log.info("Span ThreadLocalAccessor 등록 완료: 비동기 경계에서 수동 생성 Span 컨텍스트가 전파됩니다.");
+        log.info("Span ThreadLocalAccessor를 등록해 비동기 경계에서 수동 생성 Span 컨텍스트를 전파합니다.");
     }
 }

--- a/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
+++ b/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
@@ -8,7 +8,6 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,7 +30,6 @@ public class SpanContextPropagationConfig {
 
     private final ObservationRegistry observationRegistry;
     private final ObjectProvider<Tracer> tracerProvider;
-    private boolean registered;
 
     public SpanContextPropagationConfig(
         ObservationRegistry observationRegistry,
@@ -50,14 +48,6 @@ public class SpanContextPropagationConfig {
         }
         ContextRegistry.getInstance()
             .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(observationRegistry, tracer));
-        this.registered = true;
         log.info("Span ThreadLocalAccessor 등록 완료: 비동기 경계에서 수동 생성 Span 컨텍스트가 전파됩니다.");
-    }
-
-    @PreDestroy
-    void removeSpanThreadLocalAccessor() {
-        if (registered) {
-            ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareSpanThreadLocalAccessor.KEY);
-        }
     }
 }

--- a/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
+++ b/src/main/java/com/umc/product/global/observability/SpanContextPropagationConfig.java
@@ -1,0 +1,63 @@
+package com.umc.product.global.observability;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 비동기 경계에서 직접 생성한 Span 컨텍스트가 전파되도록 {@link ObservationAwareSpanThreadLocalAccessor}
+ * 를 전역 {@link ContextRegistry} 에 등록한다.
+ *
+ * <p>{@code micrometer-observation} 은 {@code ObservationThreadLocalAccessor} 만 ServiceLoader 로 자동
+ * 등록하고, Spring Boot 트레이싱 오토컨피그는 Span 전용 accessor 를 등록하지 않는다. 이 accessor 가 없으면
+ * {@link org.springframework.core.task.support.ContextPropagatingTaskDecorator} 가 Observation 컨텍스트만
+ * 전파해, {@link TraceFlowAspect} 가 {@code tracer.withSpan()} 으로 직접 만든 Span 의 부모 연결이
+ * 비동기 스레드에서 누락된다.
+ *
+ * <p>Observation accessor({@code micrometer.observation}) 와 Span accessor({@code micrometer.tracing}) 는
+ * KEY 가 달라 공존하며, "Observation aware" accessor 는 이미 Observation 이 관리 중인 Span 은 중복 복원하지
+ * 않는다. 트레이싱이 비활성(=Tracer 빈 부재)인 환경에서는 등록을 건너뛴다.
+ */
+@Slf4j
+@Configuration
+public class SpanContextPropagationConfig {
+
+    private final ObservationRegistry observationRegistry;
+    private final ObjectProvider<Tracer> tracerProvider;
+    private boolean registered;
+
+    public SpanContextPropagationConfig(
+        ObservationRegistry observationRegistry,
+        ObjectProvider<Tracer> tracerProvider
+    ) {
+        this.observationRegistry = observationRegistry;
+        this.tracerProvider = tracerProvider;
+    }
+
+    @PostConstruct
+    void registerSpanThreadLocalAccessor() {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        if (tracer == null) {
+            log.info("Tracer 빈이 없어 Span ThreadLocalAccessor 등록을 건너뜁니다 (트레이싱 비활성).");
+            return;
+        }
+        ContextRegistry.getInstance()
+            .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(observationRegistry, tracer));
+        this.registered = true;
+        log.info("Span ThreadLocalAccessor 등록 완료: 비동기 경계에서 수동 생성 Span 컨텍스트가 전파됩니다.");
+    }
+
+    @PreDestroy
+    void removeSpanThreadLocalAccessor() {
+        if (registered) {
+            ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareSpanThreadLocalAccessor.KEY);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineScheduler.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
+import com.umc.product.global.observability.ScheduledTaskTracer;
 import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
@@ -52,6 +53,7 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
     private final TaskScheduler taskScheduler;
     private final MatchingRoundDeadlineHandler handler;
     private final LoadProjectMatchingRoundPort loadProjectMatchingRoundPort;
+    private final ScheduledTaskTracer scheduledTaskTracer;
 
     private final Map<Long, ScheduledFuture<?>> pendingTasks = new ConcurrentHashMap<>();
 
@@ -59,12 +61,14 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
         @Qualifier("matchingDeadlineTaskScheduler") TaskScheduler taskScheduler,
         MatchingRoundDeadlineHandler handler,
         LoadProjectMatchingRoundPort loadProjectMatchingRoundPort,
-        MatchingRoundDeadlineSchedulerProperties properties
+        MatchingRoundDeadlineSchedulerProperties properties,
+        ScheduledTaskTracer scheduledTaskTracer
     ) {
         this.taskScheduler = taskScheduler;
         this.handler = handler;
         this.loadProjectMatchingRoundPort = loadProjectMatchingRoundPort;
         this.deadlineBuffer = properties.deadlineBuffer();
+        this.scheduledTaskTracer = scheduledTaskTracer;
     }
 
     @PostConstruct
@@ -78,14 +82,16 @@ public class MatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDead
         cancel(roundId);
 
         Instant runAt = round.getDecisionDeadline().plus(deadlineBuffer);
+        // 동적 등록 task 는 @Scheduled 가 아니라 Spring 의 관측 span 이 붙지 않는다.
+        // 실행 시 새 root span 을 열어 마감 자동 선발 처리를 하나의 traceId 로 묶는다.
         ScheduledFuture<?> future = taskScheduler.schedule(
-            () -> {
+            scheduledTaskTracer.trace("matchingRoundDeadline", () -> {
                 try {
                     handler.handle(roundId);
                 } finally {
                     pendingTasks.remove(roundId);
                 }
-            },
+            }),
             runAt
         );
         pendingTasks.put(roundId, future);

--- a/src/test/java/com/umc/product/global/observability/ScheduledTaskTracerTest.java
+++ b/src/test/java/com/umc/product/global/observability/ScheduledTaskTracerTest.java
@@ -1,0 +1,72 @@
+package com.umc.product.global.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+
+class ScheduledTaskTracerTest {
+
+    private Tracer tracer;
+    private Span span;
+    private Tracer.SpanInScope spanInScope;
+    private ScheduledTaskTracer sut;
+
+    @BeforeEach
+    void setUp() {
+        tracer = mock(Tracer.class);
+        span = mock(Span.class);
+        spanInScope = mock(Tracer.SpanInScope.class);
+
+        given(tracer.nextSpan()).willReturn(span);
+        given(tracer.withSpan(span)).willReturn(spanInScope);
+        given(span.name(anyString())).willReturn(span);
+        given(span.tag(anyString(), anyString())).willReturn(span);
+        given(span.start()).willReturn(span);
+
+        sut = new ScheduledTaskTracer(tracer);
+    }
+
+    @Test
+    @DisplayName("동적 task를 새 root span으로 감싸 실행한다")
+    void 동적_task_root_span으로_감싸_실행() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        Runnable traced = sut.trace("matchingRoundDeadline", () -> executed.set(true));
+        traced.run();
+
+        assertThat(executed).isTrue();
+        then(tracer).should().nextSpan();
+        then(span).should().name("scheduled.matchingRoundDeadline");
+        then(span).should().tag("app.layer", "scheduler");
+        then(span).should().tag("scheduled.task", "matchingRoundDeadline");
+        then(span).should().start();
+        then(span).should().end();
+        then(spanInScope).should().close();
+    }
+
+    @Test
+    @DisplayName("task에서 예외가 발생하면 span에 에러를 기록하고 그대로 전파한다")
+    void 동적_task_예외_시_span_에러_기록() {
+        RuntimeException failure = new IllegalStateException("boom");
+
+        Runnable traced = sut.trace("matchingRoundDeadline", () -> {
+            throw failure;
+        });
+
+        assertThatThrownBy(traced::run).isSameAs(failure);
+        then(span).should().error(failure);
+        then(span).should().end();
+    }
+}

--- a/src/test/java/com/umc/product/global/observability/SpanContextPropagationTest.java
+++ b/src/test/java/com/umc/product/global/observability/SpanContextPropagationTest.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
@@ -26,6 +26,10 @@ import io.micrometer.tracing.test.simple.SimpleTracer;
  * <p>{@link SpanContextPropagationConfig} 가 등록하는 {@link ObservationAwareSpanThreadLocalAccessor} 와
  * {@link ContextPropagatingTaskDecorator} 의 조합으로, 직접 생성한 Span 의 traceId 가 작업 스레드로
  * 전파됨을 {@link SimpleTracer} 로 확인한다.
+ *
+ * <p>전역 정적 {@link ContextRegistry} 를 오염시키지 않도록, 테스트는 <b>로컬 ContextRegistry</b> 에만
+ * accessor 를 등록한 {@link ContextSnapshotFactory} 로 데코레이터를 만든다. (전역에 등록·제거하면 이후 실행되는
+ * {@code @SpringBootTest} 의 캐시된 컨텍스트가 잃어버린 accessor 때문에 비동기 전파에 실패할 수 있다.)
  */
 class SpanContextPropagationTest {
 
@@ -34,21 +38,13 @@ class SpanContextPropagationTest {
     @BeforeEach
     void setUp() {
         tracer = new SimpleTracer();
-        // SpanContextPropagationConfig 와 동일하게 Span 전용 accessor 를 전역 ContextRegistry 에 등록한다.
-        ContextRegistry.getInstance()
-            .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(ObservationRegistry.NOOP, tracer));
-    }
-
-    @AfterEach
-    void tearDown() {
-        ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareSpanThreadLocalAccessor.KEY);
     }
 
     @Test
     @DisplayName("TaskDecorator 가 장착된 Executor 는 비동기 스레드로 넘어가도 같은 traceId 를 전파한다")
     void TaskDecorator_장착_시_traceId_전파() throws InterruptedException {
-        // given: 데코레이터가 장착된 Executor 와, 현재 스레드에 시작된 Span
-        ThreadPoolTaskExecutor executor = newExecutor(new ContextPropagatingTaskDecorator());
+        // given: 로컬 레지스트리 기반 데코레이터가 장착된 Executor 와, 현재 스레드에 시작된 Span
+        ThreadPoolTaskExecutor executor = newExecutor(spanPropagatingDecorator());
         Span span = tracer.nextSpan().name("root").start();
         AtomicReference<String> propagatedTraceId = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -102,6 +98,17 @@ class SpanContextPropagationTest {
 
         // then: 작업 스레드에는 현재 Span 이 없어 traceId 가 단절된다 (데코레이터의 효과 대조)
         assertThat(propagatedTraceId.get()).isNull();
+    }
+
+    /**
+     * Span 전용 accessor 를 <b>로컬</b> ContextRegistry 에만 등록한 데코레이터를 만든다.
+     * 전역 {@link ContextRegistry#getInstance()} 를 건드리지 않으므로 다른 테스트와 격리된다.
+     */
+    private ContextPropagatingTaskDecorator spanPropagatingDecorator() {
+        ContextRegistry registry = new ContextRegistry()
+            .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(ObservationRegistry.NOOP, tracer));
+        ContextSnapshotFactory factory = ContextSnapshotFactory.builder().contextRegistry(registry).build();
+        return new ContextPropagatingTaskDecorator(factory);
     }
 
     private ThreadPoolTaskExecutor newExecutor(ContextPropagatingTaskDecorator taskDecorator) {

--- a/src/test/java/com/umc/product/global/observability/SpanContextPropagationTest.java
+++ b/src/test/java/com/umc/product/global/observability/SpanContextPropagationTest.java
@@ -1,0 +1,119 @@
+package com.umc.product.global.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.contextpropagation.ObservationAwareSpanThreadLocalAccessor;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+
+/**
+ * 비동기 경계(@Async 스레드풀)에서 trace 컨텍스트가 끊기지 않는지 검증한다.
+ *
+ * <p>{@link SpanContextPropagationConfig} 가 등록하는 {@link ObservationAwareSpanThreadLocalAccessor} 와
+ * {@link ContextPropagatingTaskDecorator} 의 조합으로, 직접 생성한 Span 의 traceId 가 작업 스레드로
+ * 전파됨을 {@link SimpleTracer} 로 확인한다.
+ */
+class SpanContextPropagationTest {
+
+    private SimpleTracer tracer;
+
+    @BeforeEach
+    void setUp() {
+        tracer = new SimpleTracer();
+        // SpanContextPropagationConfig 와 동일하게 Span 전용 accessor 를 전역 ContextRegistry 에 등록한다.
+        ContextRegistry.getInstance()
+            .registerThreadLocalAccessor(new ObservationAwareSpanThreadLocalAccessor(ObservationRegistry.NOOP, tracer));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ContextRegistry.getInstance().removeThreadLocalAccessor(ObservationAwareSpanThreadLocalAccessor.KEY);
+    }
+
+    @Test
+    @DisplayName("TaskDecorator 가 장착된 Executor 는 비동기 스레드로 넘어가도 같은 traceId 를 전파한다")
+    void TaskDecorator_장착_시_traceId_전파() throws InterruptedException {
+        // given: 데코레이터가 장착된 Executor 와, 현재 스레드에 시작된 Span
+        ThreadPoolTaskExecutor executor = newExecutor(new ContextPropagatingTaskDecorator());
+        Span span = tracer.nextSpan().name("root").start();
+        AtomicReference<String> propagatedTraceId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // when: Span 이 scope 에 있는 동안 작업을 제출하고, 작업 스레드에서 현재 traceId 를 읽는다
+        String expectedTraceId;
+        try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+            expectedTraceId = tracer.currentSpan().context().traceId();
+            executor.execute(() -> {
+                Span current = tracer.currentSpan();
+                if (current != null) {
+                    propagatedTraceId.set(current.context().traceId());
+                }
+                latch.countDown();
+            });
+            latch.await(2, TimeUnit.SECONDS);
+        } finally {
+            span.end();
+            executor.shutdown();
+        }
+
+        // then: 작업 스레드가 원 요청과 동일한 traceId 를 본다
+        assertThat(propagatedTraceId.get())
+            .isNotNull()
+            .isEqualTo(expectedTraceId);
+    }
+
+    @Test
+    @DisplayName("TaskDecorator 가 없는 Executor 는 비동기 스레드로 trace 컨텍스트가 전파되지 않는다")
+    void TaskDecorator_미장착_시_traceId_단절() throws InterruptedException {
+        // given: 데코레이터가 없는 Executor 와, 현재 스레드에 시작된 Span
+        ThreadPoolTaskExecutor executor = newExecutor(null);
+        Span span = tracer.nextSpan().name("root").start();
+        AtomicReference<String> propagatedTraceId = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // when: Span 이 scope 에 있는 동안 작업을 제출한다
+        try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+            executor.execute(() -> {
+                Span current = tracer.currentSpan();
+                if (current != null) {
+                    propagatedTraceId.set(current.context().traceId());
+                }
+                latch.countDown();
+            });
+            latch.await(2, TimeUnit.SECONDS);
+        } finally {
+            span.end();
+            executor.shutdown();
+        }
+
+        // then: 작업 스레드에는 현재 Span 이 없어 traceId 가 단절된다 (데코레이터의 효과 대조)
+        assertThat(propagatedTraceId.get()).isNull();
+    }
+
+    private ThreadPoolTaskExecutor newExecutor(ContextPropagatingTaskDecorator taskDecorator) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(1);
+        executor.setThreadNamePrefix("test-async-");
+        if (taskDecorator != null) {
+            executor.setTaskDecorator(taskDecorator);
+        }
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/MatchingRoundDeadlineSchedulerTest.java
@@ -24,11 +24,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.global.observability.ScheduledTaskTracer;
 import com.umc.product.project.adapter.in.scheduler.MatchingRoundDeadlineHandler;
 import com.umc.product.project.application.port.out.LoadProjectMatchingRoundPort;
 import com.umc.product.project.domain.ProjectMatchingRound;
 import com.umc.product.project.domain.enums.MatchingPhase;
 import com.umc.product.project.domain.enums.MatchingType;
+
+import io.micrometer.tracing.Tracer;
 
 @ExtendWith(MockitoExtension.class)
 class MatchingRoundDeadlineSchedulerTest {
@@ -54,7 +57,9 @@ class MatchingRoundDeadlineSchedulerTest {
             taskScheduler,
             handler,
             loadProjectMatchingRoundPort,
-            new MatchingRoundDeadlineSchedulerProperties(TEST_DEADLINE_BUFFER.toMinutes())
+            new MatchingRoundDeadlineSchedulerProperties(TEST_DEADLINE_BUFFER.toMinutes()),
+            // NOOP Tracer 기반 — trace() 래퍼는 task 를 그대로 실행하므로 스케줄러 동작 검증에 영향이 없다.
+            new ScheduledTaskTracer(Tracer.NOOP)
         );
     }
 


### PR DESCRIPTION
## 🚀 작업 내용
resolves #1062, #1063 

## 🎯 What — 무엇을
  @Async(이메일/감사로그) 경계와 동적 스케줄러(매칭 마감 자동선발) 실행을 **원 요청/실행과 동일한 traceId로 묶이게** 했습니다.

## ❓  Why - 왜
  스레드가 넘어가면 trace 컨텍스트(ThreadLocal)가 끊겨, 이메일/감사로그·마감 자동선발의 usecase/adapter 호출이 원 흐름과 분리된 채 **제각각 새 traceId로 흩어져** 추적이 불가능했습니다.

## 🛠 How - 어떻게
  - **#1062 비동기 경계** : `ObservationAwareSpanThreadLocalAccessor`를 전역 ContextRegistry에 등록
    (`SpanContextPropagationConfig`) + `emailTaskExecutor`/`auditTaskExecutor`에 `ContextPropagatingTaskDecorator` 장착. (Spring Boot 트레이싱 오토컨피그가 Span 전용 accessor를 등록하지 않아, 직접 생성한 span 전파를 위해 명시 등록)
  - **#1063 동적 스케줄러**: `taskScheduler.schedule(Runnable, …)`로 등록되는 task를 `tasks.scheduled.execution`으로 자동 계측하므로 **별도 처리하지 않음**.
    
## 📍 Where - 어디를
  `global/observability/{SpanContextPropagationConfig, ScheduledTaskTracer}`,
  `global/config/AsyncConfig`, `project/.../MatchingRoundDeadlineScheduler`
  
## ⏱ When - 언제 발동
  @Async 메서드 호출 시 / 매칭 마감 시점에 동적 task 실행 시.
  
## 👤 Who - 영향 범위
  **관측(Tempo/Loki)에만** 영향. 비즈니스 런타임 동작 변화 없음.
  
## ✅  검증
  - 로컬 Tempo E2E :
    - 이메일 `@Async` span이 원 요청과 **같은 traceId의 자식**으로 잡힘
    - <img width="3068" height="1962" alt="image" src="https://github.com/user-attachments/assets/2c3b2c40-3d73-46a6-8fc3-06c6241f181b" />
    - <img width="3068" height="1962" alt="image" src="https://github.com/user-attachments/assets/38d9dad4-5984-46e8-998b-d085a382a8d2" />

    - 매칭 마감 자동선발(`autoDecide` + adapter/db)이 `scheduled.matchingRoundDeadline` **단일 trace**로 묶임
    - <img width="3420" height="1964" alt="image" src="https://github.com/user-attachments/assets/d8598c51-e42d-48c7-a69a-9fe0666f9012" />
  - 단위 테스트 추가(`SimpleTracer`로 전파 증명 + mock으로 동작 검증)

## 💬 리뷰 중점사항
단일 `TaskScheduler` 빈(`matchingDeadlineTaskScheduler`)이 컨텍스트의 유일한 `TaskScheduler`라, 모든 `@Scheduled`가 이 pool size 2 풀을 공유 중입니다. 의도된 동작인지 궁금합니다.