### PR TITLE
[Refactor] 커리큘럼 내부 아키텍쳐 개선

### DIFF
--- a/docs/onboarding/domain/curriculum.md
+++ b/docs/onboarding/domain/curriculum.md
@@ -15,6 +15,48 @@
 
 챌린저, 기수, 스터디 그룹, 파일은 다른 도메인의 소유다. 커리큘럼 도메인은 ID로 연결하고 필요한 검증은 공개 UseCase를 통해 수행한다.
 
+## 핵심 모델 관계
+
+`curriculum` 도메인은 원본 콘텐츠와 챌린저별 제출 상태를 분리해서 관리한다. 교육국이 관리하는 템플릿은 `OriginalWorkbook`과 `OriginalWorkbookMission`이고, 챌린저에게 배포된 개별 작업 단위는 `ChallengerWorkbook`과 `MissionSubmission`이다.
+
+```mermaid
+erDiagram
+  Curriculum ||--o{ WeeklyCurriculum : "has weeks"
+  WeeklyCurriculum ||--o{ OriginalWorkbook : "has template workbooks"
+  OriginalWorkbook ||--o{ OriginalWorkbookMission : "has template missions"
+  OriginalWorkbook ||--o{ ChallengerWorkbook : "is deployed as"
+  ChallengerWorkbook ||--o{ MissionSubmission : "has submissions"
+  OriginalWorkbookMission ||--o{ MissionSubmission : "is submitted for"
+  MissionSubmission ||--o{ MissionFeedback : "has feedback"
+  WeeklyCurriculum ||--o{ WeeklyBestWorkbook : "selects best"
+```
+
+### 엔티티별 의미
+
+- `Curriculum`: 특정 기수와 파트에 대한 상위 커리큘럼이다. 다른 도메인의 기수는 `gisuId`로만 참조한다.
+- `WeeklyCurriculum`: 커리큘럼 안의 주차 단위다. 정규 주차와 부록 주차를 `weekNo`, `isExtra` 조합으로 구분한다.
+- `OriginalWorkbook`: 주차별 커리큘럼에 속한 원본 워크북이다. 교육국이 작성하고 `DRAFT`, `READY`, `RELEASED` 상태로 관리한다.
+- `OriginalWorkbookMission`: 원본 워크북에 포함된 원본 미션이다. 제출 방식과 필수 여부를 정의한다.
+- `ChallengerWorkbook`: 원본 워크북이 특정 챌린저에게 배포된 개별 워크북이다. `memberId`, `studyGroupId`는 다른 도메인 Aggregate를 직접 참조하지 않고 ID로 저장한다.
+- `MissionSubmission`: 챌린저가 특정 원본 미션에 대해 제출한 결과다. 하나의 제출은 `ChallengerWorkbook`과 `OriginalWorkbookMission`을 함께 참조한다.
+- `MissionFeedback`: 제출물에 대한 운영진 피드백이다. 리뷰어는 `reviewerMemberId`로만 참조한다.
+- `WeeklyBestWorkbook`: 주차별 베스트 워크북 선정 결과다. 현재는 `ChallengerWorkbook` FK가 아니라 `WeeklyCurriculum`, `memberId`, `studyGroupId` 조합으로 표현한다.
+
+### 흐름
+
+1. 운영진이 `Curriculum`을 만들고 그 아래에 `WeeklyCurriculum`을 생성한다.
+2. 교육국이 주차별로 `OriginalWorkbook`을 작성하고, 필요한 `OriginalWorkbookMission`을 붙인다.
+3. 원본 워크북이 배포 가능한 상태가 되면 챌린저별 `ChallengerWorkbook`이 생성된다.
+4. 챌린저는 원본 미션마다 `MissionSubmission`을 생성한다.
+5. 운영진은 제출물에 `MissionFeedback`을 남기고, 주차별 조건을 만족한 챌린저를 `WeeklyBestWorkbook`으로 선정한다.
+
+### 구현상 주의점
+
+- 도메인 내부 JPA 관계는 자식이 부모를 `@ManyToOne(fetch = FetchType.LAZY)`로 참조하는 방향을 기본으로 한다.
+- 컬렉션 `@OneToMany`는 두지 않는다. 목록 조회는 포트와 리포지토리에서 ID 기반 조회나 IN query로 처리한다.
+- 챌린저, 멤버, 기수, 스터디 그룹, 파일 정보가 필요하면 해당 도메인의 공개 Query UseCase를 호출한다.
+- 원본 워크북과 원본 미션은 템플릿이고, 챌린저 워크북과 미션 제출은 사용자별 진행 상태다. 두 개념을 섞으면 배포 이후 수정 제한, 제출 여부, 피드백 조회 정책이 꼬일 수 있다.
+
 ## UX Writing Notes
 
 운영자 작업이 많으므로 삭제 불가, 배포 후 수정 제한, 권한 제한을 명확히 쓴다. `삭제할 수 없어요` 뒤에는 `제출 내역을 먼저 확인해주세요`, `원본 워크북을 먼저 정리해주세요`처럼 다음 행동을 붙인다.

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/OriginalWorkbookMissionCommandV2Controller.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/OriginalWorkbookMissionCommandV2Controller.java
@@ -13,6 +13,7 @@ import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.curriculum.adapter.in.web.v2.dto.request.CreateOriginalWorkbookMissionRequest;
 import com.umc.product.curriculum.adapter.in.web.v2.dto.request.EditOriginalWorkbookMissionRequest;
+import com.umc.product.curriculum.adapter.in.web.v2.dto.response.CreateOriginalWorkbookMissionResponse;
 import com.umc.product.curriculum.application.port.in.command.ManageOriginalWorkbookMissionUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,10 +45,12 @@ public class OriginalWorkbookMissionCommandV2Controller {
         message = "원본 워크북 미션 추가는 중앙파트장 이상 권한이 필요합니다."
     )
     @PostMapping
-    public Long createOriginalWorkbookMission(
+    public CreateOriginalWorkbookMissionResponse createOriginalWorkbookMission(
         @Valid @RequestBody CreateOriginalWorkbookMissionRequest request
     ) {
-        return manageOriginalWorkbookMissionUseCase.create(request.toCommand());
+        return CreateOriginalWorkbookMissionResponse.from(
+            manageOriginalWorkbookMissionUseCase.create(request.toCommand())
+        );
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/CreateOriginalWorkbookMissionResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/CreateOriginalWorkbookMissionResponse.java
@@ -1,0 +1,10 @@
+package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
+
+public record CreateOriginalWorkbookMissionResponse(
+    Long originalWorkbookMissionId
+) {
+
+    public static CreateOriginalWorkbookMissionResponse from(Long originalWorkbookMissionId) {
+        return new CreateOriginalWorkbookMissionResponse(originalWorkbookMissionId);
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/domain/Curriculum.java
+++ b/src/main/java/com/umc/product/curriculum/domain/Curriculum.java
@@ -2,6 +2,7 @@ package com.umc.product.curriculum.domain;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.common.domain.enums.ChallengerPart;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,7 +14,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 /**
  * Curriculum과 WeeklyCurriculum는 하나의 Aggregate Curriculum이 WeeklyCurriculum을 관리하는 형태로 설계 예정
@@ -56,7 +56,7 @@ public class Curriculum extends BaseEntity {
     }
 
     public void updateTitle(String title) {
-        if (StringUtils.hasText(title)) {
+        if (title != null && !title.isBlank()) {
             this.title = title;
         }
     }

--- a/src/main/java/com/umc/product/curriculum/domain/OriginalWorkbook.java
+++ b/src/main/java/com/umc/product/curriculum/domain/OriginalWorkbook.java
@@ -1,10 +1,13 @@
 package com.umc.product.curriculum.domain;
 
+import java.time.Instant;
+
 import com.umc.product.common.BaseEntity;
 import com.umc.product.curriculum.domain.enums.OriginalWorkbookStatus;
 import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,12 +19,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 @Entity
 @Table(name = "original_workbook")
@@ -124,7 +125,7 @@ public class OriginalWorkbook extends BaseEntity {
         String url,
         String content
     ) {
-        if (StringUtils.hasText(title)) {
+        if (title != null && !title.isBlank()) {
             this.title = title;
         }
         if (description != null) {

--- a/src/main/java/com/umc/product/curriculum/domain/WeeklyCurriculum.java
+++ b/src/main/java/com/umc/product/curriculum/domain/WeeklyCurriculum.java
@@ -1,8 +1,11 @@
 package com.umc.product.curriculum.domain;
 
+import java.time.Instant;
+
 import com.umc.product.common.BaseEntity;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,12 +16,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.StringUtils;
 
 @Entity
 @Table(
@@ -97,7 +98,7 @@ public class WeeklyCurriculum extends BaseEntity {
     }
 
     public void updateTitle(String title) {
-        if (StringUtils.hasText(title)) {
+        if (title != null && !title.isBlank()) {
             this.title = title;
         }
     }


### PR DESCRIPTION
## 🚀 작업 내용

1. **무엇을**: PR #937 리뷰 후속으로 원본 워크북 미션 생성 API 응답을 DTO로 감쌌어요.
   - **어떻게**: `CreateOriginalWorkbookMissionResponse`를 추가하고, controller가 `Long` 원시값 대신 응답 DTO를 반환하도록 바꿨어요.
   - **왜**: API 응답 확장성과 adapter 계층 DTO 컨벤션을 맞추기 위해서예요.

2. **무엇을**: curriculum 도메인 엔티티의 Spring `StringUtils` 의존성을 제거했어요.
   - **어떻게**: 제목 변경 조건을 표준 Java의 `title != null && !title.isBlank()`로 대체했어요.
   - **왜**: 도메인 계층이 Spring 유틸에 직접 의존하지 않도록 하기 위해서예요.

3. **무엇을**: onboarding 문서에 curriculum 도메인 관계를 정리했어요.
   - **어떻게**: `Curriculum`, `WeeklyCurriculum`, `OriginalWorkbook`, `OriginalWorkbookMission`, `ChallengerWorkbook`, `MissionSubmission`, `MissionFeedback`, `WeeklyBestWorkbook` 관계와 흐름을 Mermaid 다이어그램과 설명으로 추가했어요.
   - **왜**: 워크북, 원본 워크북, 커리큘럼, 미션 사이의 관계를 신규 작업자가 빠르게 이해할 수 있게 하기 위해서예요.

## 💬 리뷰 중점사항

- 원본 미션 생성 API 응답 필드명이 `originalWorkbookMissionId`로 충분한지 확인 부탁드려요.
- onboarding 문서의 관계 설명이 현재 v2 모델 의도와 맞는지 확인 부탁드려요.
- Java 변경은 `./gradlew check`로 검증했어요. 문서 커밋 이후에는 코드 변경이 없어요.