### PR TITLE
[Feat] 워크북 조회 API 제작

### DIFF
--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2Controller.java
@@ -4,18 +4,23 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.curriculum.adapter.in.web.v2.dto.request.GetBestWorkbooksRequest;
 import com.umc.product.curriculum.adapter.in.web.v2.dto.response.BestWorkbookResponse;
 import com.umc.product.curriculum.adapter.in.web.v2.dto.response.ChallengerWorkbookResponse;
 import com.umc.product.curriculum.adapter.in.web.v2.dto.response.OriginalWorkbookResponse;
-import com.umc.product.global.exception.NotImplementedException;
-import com.umc.product.global.response.PageResponse;
+import com.umc.product.curriculum.application.port.in.query.GetChallengerWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.GetOriginalWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.GetWeeklyBestWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookPageInfo;
+import com.umc.product.global.response.CursorResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -23,6 +28,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Tag(name = "Curriculum V2 | 워크북 Query", description = "원본 워크북, 챌린저 워크북, 베스트 워크북을 조회합니다.")
 public class WorkbookQueryV2Controller {
+
+    private final GetOriginalWorkbookUseCase getOriginalWorkbookUseCase;
+    private final GetChallengerWorkbookUseCase getChallengerWorkbookUseCase;
+    private final GetWeeklyBestWorkbookUseCase getWeeklyBestWorkbookUseCase;
 
     @Operation(
         operationId = "WORKBOOK-101",
@@ -35,7 +44,8 @@ public class WorkbookQueryV2Controller {
     public OriginalWorkbookResponse getOriginalWorkbook(
         @PathVariable Long originalWorkbookId
     ) {
-        throw new NotImplementedException();
+        OriginalWorkbookInfo info = getOriginalWorkbookUseCase.getById(originalWorkbookId);
+        return OriginalWorkbookResponse.from(info);
     }
 
     @Operation(
@@ -52,7 +62,8 @@ public class WorkbookQueryV2Controller {
     public ChallengerWorkbookResponse getChallengerWorkbook(
         @PathVariable Long challengerWorkbookId
     ) {
-        throw new NotImplementedException();
+        ChallengerWorkbookInfo info = getChallengerWorkbookUseCase.getById(challengerWorkbookId);
+        return ChallengerWorkbookResponse.from(info);
     }
 
     @Operation(
@@ -72,13 +83,17 @@ public class WorkbookQueryV2Controller {
             """
     )
     @GetMapping("/weekly-best-workbooks")
-    public PageResponse<BestWorkbookResponse> getBestWorkbooks(
+    public CursorResponse<BestWorkbookResponse> getBestWorkbooks(
         @ParameterObject
-        @RequestParam(required = false)
-        GetBestWorkbooksRequest request
+        @Valid GetBestWorkbooksRequest request
     ) {
-        // TODO: 경운 - 이거 IN Query로 안짜면 죽어도 Approve 안해줄거임,,,,,,
-
-        throw new NotImplementedException();
+        WeeklyBestWorkbookPageInfo page = getWeeklyBestWorkbookUseCase.searchBestWorkbooks(request.toQuery());
+        return CursorResponse.of(
+            page.content().stream()
+                .map(BestWorkbookResponse::from)
+                .toList(),
+            page.nextCursor(),
+            page.hasNext()
+        );
     }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetBestWorkbooksRequest.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetBestWorkbooksRequest.java
@@ -1,14 +1,25 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.request;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
 import java.util.List;
 import java.util.Set;
 
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record GetBestWorkbooksRequest(
-    Long gisuId,
-    Set<Long> schoolIds,
+    @NotNull Long gisuId,
+    Set<@Positive Long> schoolIds,
     Set<ChallengerPart> parts,
-    List<Long> weekNos,
-    List<Long> studyGroupIds
+    List<@Positive Long> weekNos,
+    List<@Positive Long> studyGroupIds,
+    @Positive Long cursor,
+    @Positive Integer size
 ) {
+
+    public GetBestWorkbooksQuery toQuery() {
+        return GetBestWorkbooksQuery.of(gisuId, schoolIds, parts, weekNos, studyGroupIds, cursor, size);
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/BestWorkbookResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/BestWorkbookResponse.java
@@ -1,7 +1,10 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
-import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
 import java.util.List;
+
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookInfo;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+
 import lombok.Builder;
 
 /**
@@ -23,4 +26,17 @@ public record BestWorkbookResponse(
     String reason,
     List<ChallengerWorkbookResponse> challengerWorkbooks
 ) {
+
+    public static BestWorkbookResponse from(WeeklyBestWorkbookInfo info) {
+        return BestWorkbookResponse.builder()
+            .weeklyBestWorkbookEntityId(info.weeklyBestWorkbookEntityId())
+            .memberId(info.challengerId())
+            .studyGroupId(info.studyGroupId())
+            .decidedMemberId(info.decidedMemberId())
+            .reason(info.reason())
+            .challengerWorkbooks(info.challengerWorkbooks().stream()
+                .map(ChallengerWorkbookResponse::from)
+                .toList())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/ChallengerWorkbookResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/ChallengerWorkbookResponse.java
@@ -1,5 +1,10 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
+import java.util.List;
+
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.domain.enums.SubmissionStatus;
+
 import lombok.Builder;
 
 @Builder
@@ -14,7 +19,7 @@ public record ChallengerWorkbookResponse(
     boolean isBestWorkbook,
     ChallengerWorkbookStatusResponse status,
     boolean hasSubmission,
-    MissionSubmissionResponse submission
+    List<MissionSubmissionResponse> submissions
 ) {
     // 고민거리:
     // 현재 DTO는 내 커리큘럼 조회 시에도 사용됨.
@@ -27,4 +32,46 @@ public record ChallengerWorkbookResponse(
 
     // status는 OriginalWorkbookStatus와 분리된 것이며, 기존에 존재하던 WorkbookStatus와도 다름.
     // 작성에 주의할 것
+
+    public static ChallengerWorkbookResponse from(ChallengerWorkbookInfo info) {
+        List<MissionSubmissionResponse> submissions = info.submissions().stream()
+            .map(MissionSubmissionResponse::from)
+            .toList();
+
+        return ChallengerWorkbookResponse.builder()
+            .challengerWorkbookId(info.challengerWorkbookId())
+            .originalWorkbookId(info.originalWorkbookId())
+            .receivedStudyGroupId(info.receivedStudyGroupId())
+            .memberId(info.challengerId())
+            .isExcused(info.isExcused())
+            .excusedReason(info.excusedReason())
+            .content(info.content())
+            .isBestWorkbook(info.isBestWorkbook())
+            .status(resolveStatus(info, submissions))
+            .hasSubmission(!submissions.isEmpty())
+            .submissions(submissions)
+            .build();
+    }
+
+    private static ChallengerWorkbookStatusResponse resolveStatus(
+        ChallengerWorkbookInfo info,
+        List<MissionSubmissionResponse> submissions
+    ) {
+        if (info.isExcused()) {
+            return ChallengerWorkbookStatusResponse.PASS;
+        }
+        if (submissions.isEmpty()) {
+            return ChallengerWorkbookStatusResponse.IN_PROGRESS;
+        }
+        boolean hasFail = submissions.stream()
+            .map(MissionSubmissionResponse::status)
+            .anyMatch(status -> status == SubmissionStatus.FAIL);
+        if (hasFail) {
+            return ChallengerWorkbookStatusResponse.FAIL;
+        }
+        boolean allPass = submissions.stream()
+            .map(MissionSubmissionResponse::status)
+            .allMatch(status -> status == SubmissionStatus.PASS);
+        return allPass ? ChallengerWorkbookStatusResponse.PASS : ChallengerWorkbookStatusResponse.IN_PROGRESS;
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionFeedbackResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionFeedbackResponse.java
@@ -2,6 +2,7 @@ package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
 import com.umc.product.curriculum.application.port.in.query.dto.MyCurriculumInfo.MissionFeedbackInfo;
 import com.umc.product.curriculum.domain.enums.FeedbackResult;
+
 import lombok.Builder;
 
 @Builder
@@ -13,6 +14,17 @@ public record MissionFeedbackResponse(
 ) {
 
     static MissionFeedbackResponse from(MissionFeedbackInfo info) {
+        return MissionFeedbackResponse.builder()
+            .missionFeedbackId(info.missionFeedbackId())
+            .reviewerMemberId(info.reviewerMemberId())
+            .content(info.content())
+            .feedbackResult(info.feedbackResult())
+            .build();
+    }
+
+    public static MissionFeedbackResponse from(
+        com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionFeedbackInfo info
+    ) {
         return MissionFeedbackResponse.builder()
             .missionFeedbackId(info.missionFeedbackId())
             .reviewerMemberId(info.reviewerMemberId())

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionFeedbackResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionFeedbackResponse.java
@@ -1,5 +1,6 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
 import com.umc.product.curriculum.application.port.in.query.dto.MyCurriculumInfo.MissionFeedbackInfo;
 import com.umc.product.curriculum.domain.enums.FeedbackResult;
 
@@ -23,7 +24,7 @@ public record MissionFeedbackResponse(
     }
 
     public static MissionFeedbackResponse from(
-        com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionFeedbackInfo info
+        ChallengerWorkbookInfo.MissionFeedbackInfo info
     ) {
         return MissionFeedbackResponse.builder()
             .missionFeedbackId(info.missionFeedbackId())

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionSubmissionResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionSubmissionResponse.java
@@ -1,10 +1,12 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
+import java.time.Instant;
+import java.util.List;
+
 import com.umc.product.curriculum.application.port.in.query.dto.MyCurriculumInfo.MissionSubmissionInfo;
 import com.umc.product.curriculum.domain.enums.MissionType;
 import com.umc.product.curriculum.domain.enums.SubmissionStatus;
-import java.time.Instant;
-import java.util.List;
+
 import lombok.Builder;
 
 @Builder
@@ -34,5 +36,36 @@ public record MissionSubmissionResponse(
                 .map(MissionFeedbackResponse::from)
                 .toList())
             .build();
+    }
+
+    public static MissionSubmissionResponse from(
+        com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionSubmissionInfo info
+    ) {
+        List<MissionFeedbackResponse> feedbacks = info.feedbacks().stream()
+            .map(MissionFeedbackResponse::from)
+            .toList();
+
+        return MissionSubmissionResponse.builder()
+            .missionSubmissionId(info.missionSubmissionId())
+            .originalWorkbookMissionId(info.originalWorkbookMissionId())
+            .submittedAsType(info.submittedAsType())
+            .submittedContent(info.submittedContent())
+            .submittedAt(info.submittedAt())
+            .lastEditedAt(info.lastEditedAt())
+            .status(resolveStatus(feedbacks))
+            .hasFeedback(info.hasFeedback())
+            .feedbacks(feedbacks)
+            .build();
+    }
+
+    private static SubmissionStatus resolveStatus(List<MissionFeedbackResponse> feedbacks) {
+        if (feedbacks.isEmpty()) {
+            return SubmissionStatus.PENDING;
+        }
+        return feedbacks.stream()
+            .map(MissionFeedbackResponse::feedbackResult)
+            .anyMatch(result -> result == com.umc.product.curriculum.domain.enums.FeedbackResult.PASS)
+            ? SubmissionStatus.PASS
+            : SubmissionStatus.FAIL;
     }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionSubmissionResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/MissionSubmissionResponse.java
@@ -3,7 +3,9 @@ package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 import java.time.Instant;
 import java.util.List;
 
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
 import com.umc.product.curriculum.application.port.in.query.dto.MyCurriculumInfo.MissionSubmissionInfo;
+import com.umc.product.curriculum.domain.enums.FeedbackResult;
 import com.umc.product.curriculum.domain.enums.MissionType;
 import com.umc.product.curriculum.domain.enums.SubmissionStatus;
 
@@ -39,7 +41,7 @@ public record MissionSubmissionResponse(
     }
 
     public static MissionSubmissionResponse from(
-        com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionSubmissionInfo info
+        ChallengerWorkbookInfo.MissionSubmissionInfo info
     ) {
         List<MissionFeedbackResponse> feedbacks = info.feedbacks().stream()
             .map(MissionFeedbackResponse::from)
@@ -64,7 +66,7 @@ public record MissionSubmissionResponse(
         }
         return feedbacks.stream()
             .map(MissionFeedbackResponse::feedbackResult)
-            .anyMatch(result -> result == com.umc.product.curriculum.domain.enums.FeedbackResult.PASS)
+            .anyMatch(result -> result == FeedbackResult.PASS)
             ? SubmissionStatus.PASS
             : SubmissionStatus.FAIL;
     }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/OriginalWorkbookMissionResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/OriginalWorkbookMissionResponse.java
@@ -1,5 +1,6 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
 import com.umc.product.curriculum.domain.enums.MissionType;
 
 public record OriginalWorkbookMissionResponse(
@@ -10,4 +11,18 @@ public record OriginalWorkbookMissionResponse(
     MissionType missionType,
     boolean isNecessary
 ) {
+
+    public static OriginalWorkbookMissionResponse from(
+        Long originalWorkbookId,
+        OriginalWorkbookInfo.OriginalWorkbookMissionInfo info
+    ) {
+        return new OriginalWorkbookMissionResponse(
+            originalWorkbookId,
+            info.originalWorkbookMissionId(),
+            info.title(),
+            info.description(),
+            info.missionType(),
+            info.isNecessary()
+        );
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/OriginalWorkbookResponse.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/response/OriginalWorkbookResponse.java
@@ -1,8 +1,11 @@
 package com.umc.product.curriculum.adapter.in.web.v2.dto.response;
 
+import java.time.Instant;
+import java.util.List;
+
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
 import com.umc.product.curriculum.domain.enums.OriginalWorkbookStatus;
 import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
-import java.time.Instant;
 
 /**
  * OriginalWorkbook에 대한 정보를 조회합니다.
@@ -25,6 +28,23 @@ public record OriginalWorkbookResponse(
     OriginalWorkbookStatus status,
     Instant releasedAt,
     Long releasedMemberId,
-    OriginalWorkbookMissionResponse missions
+    List<OriginalWorkbookMissionResponse> missions
 ) {
+
+    public static OriginalWorkbookResponse from(OriginalWorkbookInfo info) {
+        return new OriginalWorkbookResponse(
+            info.originalWorkbookId(),
+            info.title(),
+            info.description(),
+            info.url(),
+            info.content(),
+            info.type(),
+            info.status(),
+            info.releasedAt(),
+            info.releasedMemberId(),
+            info.missions().stream()
+                .map(mission -> OriginalWorkbookMissionResponse.from(info.originalWorkbookId(), mission))
+                .toList()
+        );
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/ChallengerWorkbookJpaRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/ChallengerWorkbookJpaRepository.java
@@ -1,15 +1,29 @@
 package com.umc.product.curriculum.adapter.out.persistence;
 
-import com.umc.product.curriculum.domain.ChallengerWorkbook;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+
 public interface ChallengerWorkbookJpaRepository extends JpaRepository<ChallengerWorkbook, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"originalWorkbook", "originalWorkbook.weeklyCurriculum"})
+    Optional<ChallengerWorkbook> findById(Long id);
 
     Optional<ChallengerWorkbook> findByMemberIdAndOriginalWorkbookId(Long memberId, Long originalWorkbookId);
 
     boolean existsByOriginalWorkbookId(Long originalWorkbookId);
 
+    @EntityGraph(attributePaths = {"originalWorkbook", "originalWorkbook.weeklyCurriculum"})
     List<ChallengerWorkbook> findByMemberIdAndOriginalWorkbookIdIn(Long memberId, List<Long> originalWorkbookIds);
+
+    @EntityGraph(attributePaths = {"originalWorkbook", "originalWorkbook.weeklyCurriculum"})
+    List<ChallengerWorkbook> findByMemberIdInAndOriginalWorkbook_WeeklyCurriculum_IdIn(
+        List<Long> memberIds,
+        List<Long> weeklyCurriculumIds
+    );
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/ChallengerWorkbookPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/ChallengerWorkbookPersistenceAdapter.java
@@ -1,14 +1,17 @@
 package com.umc.product.curriculum.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
 import com.umc.product.curriculum.application.port.out.SaveChallengerWorkbookPort;
 import com.umc.product.curriculum.domain.ChallengerWorkbook;
 import com.umc.product.curriculum.domain.exception.CurriculumDomainException;
 import com.umc.product.curriculum.domain.exception.CurriculumErrorCode;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -33,11 +36,28 @@ public class ChallengerWorkbookPersistenceAdapter implements LoadChallengerWorkb
     }
 
     @Override
-    public List<ChallengerWorkbook> findByMemberIdAndOriginalWorkbookIdIn(Long memberId, List<Long> originalWorkbookIds) {
+    public List<ChallengerWorkbook> findByMemberIdAndOriginalWorkbookIdIn(
+        Long memberId,
+        List<Long> originalWorkbookIds
+    ) {
         if (originalWorkbookIds.isEmpty()) {
             return List.of();
         }
         return challengerWorkbookJpaRepository.findByMemberIdAndOriginalWorkbookIdIn(memberId, originalWorkbookIds);
+    }
+
+    @Override
+    public List<ChallengerWorkbook> findByMemberIdInAndWeeklyCurriculumIdIn(
+        List<Long> memberIds,
+        List<Long> weeklyCurriculumIds
+    ) {
+        if (memberIds.isEmpty() || weeklyCurriculumIds.isEmpty()) {
+            return List.of();
+        }
+        return challengerWorkbookJpaRepository.findByMemberIdInAndOriginalWorkbook_WeeklyCurriculum_IdIn(
+            memberIds,
+            weeklyCurriculumIds
+        );
     }
 
     @Override

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/MissionFeedbackJpaRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/MissionFeedbackJpaRepository.java
@@ -1,10 +1,14 @@
 package com.umc.product.curriculum.adapter.out.persistence;
 
-import com.umc.product.curriculum.domain.MissionFeedback;
 import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.umc.product.curriculum.domain.MissionFeedback;
 
 public interface MissionFeedbackJpaRepository extends JpaRepository<MissionFeedback, Long> {
 
+    @EntityGraph(attributePaths = {"missionSubmission"})
     List<MissionFeedback> findByMissionSubmission_IdIn(List<Long> submissionIds);
 }

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/MissionSubmissionJpaRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/MissionSubmissionJpaRepository.java
@@ -2,14 +2,17 @@ package com.umc.product.curriculum.adapter.out.persistence;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.umc.product.curriculum.domain.MissionSubmission;
 
 public interface MissionSubmissionJpaRepository extends JpaRepository<MissionSubmission, Long> {
 
+    @EntityGraph(attributePaths = {"originalWorkbookMission", "challengerWorkbook"})
     List<MissionSubmission> findByChallengerWorkbook_Id(Long challengerWorkbookId);
 
+    @EntityGraph(attributePaths = {"originalWorkbookMission", "challengerWorkbook"})
     List<MissionSubmission> findByChallengerWorkbook_IdIn(List<Long> challengerWorkbookIds);
 
     boolean existsByOriginalWorkbookMission_Id(Long originalWorkbookMissionId);

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookPersistenceAdapter.java
@@ -1,0 +1,23 @@
+package com.umc.product.curriculum.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.application.port.out.SearchWeeklyBestWorkbookPort;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyBestWorkbookPersistenceAdapter implements SearchWeeklyBestWorkbookPort {
+
+    private final WeeklyBestWorkbookQueryRepository weeklyBestWorkbookQueryRepository;
+
+    @Override
+    public List<WeeklyBestWorkbook> searchBestWorkbooks(GetBestWorkbooksQuery query) {
+        return weeklyBestWorkbookQueryRepository.searchBestWorkbooks(query);
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookQueryRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookQueryRepository.java
@@ -1,0 +1,74 @@
+package com.umc.product.curriculum.adapter.out.persistence;
+
+import static com.umc.product.curriculum.domain.QCurriculum.curriculum;
+import static com.umc.product.curriculum.domain.QWeeklyBestWorkbook.weeklyBestWorkbook;
+import static com.umc.product.curriculum.domain.QWeeklyCurriculum.weeklyCurriculum;
+import static com.umc.product.member.domain.QMember.member;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class WeeklyBestWorkbookQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<WeeklyBestWorkbook> searchBestWorkbooks(GetBestWorkbooksQuery query) {
+        return queryFactory
+            .selectFrom(weeklyBestWorkbook)
+            .join(weeklyBestWorkbook.weeklyCurriculum, weeklyCurriculum).fetchJoin()
+            .join(weeklyCurriculum.curriculum, curriculum).fetchJoin()
+            .leftJoin(member).on(member.id.eq(weeklyBestWorkbook.memberId))
+            .where(
+                gisuIdEq(query.gisuId()),
+                schoolIdIn(query.schoolIds()),
+                partIn(query.parts()),
+                weekNoIn(query.weekNos()),
+                studyGroupIdIn(query.studyGroupIds()),
+                cursorLt(query.cursor())
+            )
+            .orderBy(weeklyBestWorkbook.id.desc())
+            .limit(query.size())
+            .fetch();
+    }
+
+    private BooleanExpression gisuIdEq(Long gisuId) {
+        return gisuId != null ? curriculum.gisuId.eq(gisuId) : null;
+    }
+
+    private BooleanExpression schoolIdIn(Set<Long> schoolIds) {
+        return hasValues(schoolIds) ? member.schoolId.in(schoolIds) : null;
+    }
+
+    private BooleanExpression partIn(Set<ChallengerPart> parts) {
+        return hasValues(parts) ? curriculum.part.in(parts) : null;
+    }
+
+    private BooleanExpression weekNoIn(List<Long> weekNos) {
+        return hasValues(weekNos) ? weeklyCurriculum.weekNo.in(weekNos) : null;
+    }
+
+    private BooleanExpression studyGroupIdIn(List<Long> studyGroupIds) {
+        return hasValues(studyGroupIds) ? weeklyBestWorkbook.studyGroupId.in(studyGroupIds) : null;
+    }
+
+    private BooleanExpression cursorLt(Long cursor) {
+        return cursor != null ? weeklyBestWorkbook.id.lt(cursor) : null;
+    }
+
+    private boolean hasValues(Collection<?> values) {
+        return values != null && !values.isEmpty();
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookQueryRepository.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/out/persistence/WeeklyBestWorkbookQueryRepository.java
@@ -3,7 +3,6 @@ package com.umc.product.curriculum.adapter.out.persistence;
 import static com.umc.product.curriculum.domain.QCurriculum.curriculum;
 import static com.umc.product.curriculum.domain.QWeeklyBestWorkbook.weeklyBestWorkbook;
 import static com.umc.product.curriculum.domain.QWeeklyCurriculum.weeklyCurriculum;
-import static com.umc.product.member.domain.QMember.member;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,10 +29,9 @@ public class WeeklyBestWorkbookQueryRepository {
             .selectFrom(weeklyBestWorkbook)
             .join(weeklyBestWorkbook.weeklyCurriculum, weeklyCurriculum).fetchJoin()
             .join(weeklyCurriculum.curriculum, curriculum).fetchJoin()
-            .leftJoin(member).on(member.id.eq(weeklyBestWorkbook.memberId))
             .where(
                 gisuIdEq(query.gisuId()),
-                schoolIdIn(query.schoolIds()),
+                memberIdIn(query.memberIds()),
                 partIn(query.parts()),
                 weekNoIn(query.weekNos()),
                 studyGroupIdIn(query.studyGroupIds()),
@@ -48,8 +46,8 @@ public class WeeklyBestWorkbookQueryRepository {
         return gisuId != null ? curriculum.gisuId.eq(gisuId) : null;
     }
 
-    private BooleanExpression schoolIdIn(Set<Long> schoolIds) {
-        return hasValues(schoolIds) ? member.schoolId.in(schoolIds) : null;
+    private BooleanExpression memberIdIn(Set<Long> memberIds) {
+        return hasValues(memberIds) ? weeklyBestWorkbook.memberId.in(memberIds) : null;
     }
 
     private BooleanExpression partIn(Set<ChallengerPart> parts) {

--- a/src/main/java/com/umc/product/curriculum/application/port/in/query/GetWeeklyBestWorkbookUseCase.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/query/GetWeeklyBestWorkbookUseCase.java
@@ -1,8 +1,7 @@
 package com.umc.product.curriculum.application.port.in.query;
 
 import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
-import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookInfo;
-import java.util.List;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookPageInfo;
 
 /**
  * 베스트 워크북 조회 UseCase
@@ -15,7 +14,7 @@ public interface GetWeeklyBestWorkbookUseCase {
      * 기수 / 학교 / 파트 / 주차 / 스터디 그룹 등 다중 필터를 지원합니다.
      *
      * @param query 필터 및 페이지네이션 정보
-     * @return 베스트 워크북 목록
+     * @return 베스트 워크북 커서 페이지
      */
-    List<WeeklyBestWorkbookInfo> searchBestWorkbooks(GetBestWorkbooksQuery query);
+    WeeklyBestWorkbookPageInfo searchBestWorkbooks(GetBestWorkbooksQuery query);
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/GetBestWorkbooksQuery.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/GetBestWorkbooksQuery.java
@@ -1,8 +1,9 @@
 package com.umc.product.curriculum.application.port.in.query.dto;
 
-import com.umc.product.common.domain.enums.ChallengerPart;
 import java.util.List;
 import java.util.Set;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
 
 /**
  * 베스트 워크북 목록 조회 쿼리
@@ -26,7 +27,35 @@ public record GetBestWorkbooksQuery(
     Long cursor,
     int size
 ) {
+    private static final int DEFAULT_SIZE = 20;
+
     public GetBestWorkbooksQuery {
-        if (size <= 0) size = 20;
+        if (size <= 0) {
+            size = DEFAULT_SIZE;
+        }
+    }
+
+    public static GetBestWorkbooksQuery of(
+        Long gisuId,
+        Set<Long> schoolIds,
+        Set<ChallengerPart> parts,
+        List<Long> weekNos,
+        List<Long> studyGroupIds,
+        Long cursor,
+        Integer size
+    ) {
+        return new GetBestWorkbooksQuery(
+            gisuId,
+            schoolIds,
+            parts,
+            weekNos,
+            studyGroupIds,
+            cursor,
+            size == null ? DEFAULT_SIZE : size
+        );
+    }
+
+    public GetBestWorkbooksQuery withSize(int size) {
+        return new GetBestWorkbooksQuery(gisuId, schoolIds, parts, weekNos, studyGroupIds, cursor, size);
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/GetBestWorkbooksQuery.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/GetBestWorkbooksQuery.java
@@ -21,6 +21,7 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 public record GetBestWorkbooksQuery(
     Long gisuId,
     Set<Long> schoolIds,
+    Set<Long> memberIds,
     Set<ChallengerPart> parts,
     List<Long> weekNos,
     List<Long> studyGroupIds,
@@ -47,6 +48,7 @@ public record GetBestWorkbooksQuery(
         return new GetBestWorkbooksQuery(
             gisuId,
             schoolIds,
+            null,
             parts,
             weekNos,
             studyGroupIds,
@@ -55,7 +57,11 @@ public record GetBestWorkbooksQuery(
         );
     }
 
+    public GetBestWorkbooksQuery withMemberIds(Set<Long> memberIds) {
+        return new GetBestWorkbooksQuery(gisuId, schoolIds, memberIds, parts, weekNos, studyGroupIds, cursor, size);
+    }
+
     public GetBestWorkbooksQuery withSize(int size) {
-        return new GetBestWorkbooksQuery(gisuId, schoolIds, parts, weekNos, studyGroupIds, cursor, size);
+        return new GetBestWorkbooksQuery(gisuId, schoolIds, memberIds, parts, weekNos, studyGroupIds, cursor, size);
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/WeeklyBestWorkbookPageInfo.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/in/query/dto/WeeklyBestWorkbookPageInfo.java
@@ -1,0 +1,25 @@
+package com.umc.product.curriculum.application.port.in.query.dto;
+
+import java.util.List;
+
+public record WeeklyBestWorkbookPageInfo(
+    List<WeeklyBestWorkbookInfo> content,
+    Long nextCursor,
+    boolean hasNext
+) {
+
+    public static WeeklyBestWorkbookPageInfo of(List<WeeklyBestWorkbookInfo> fetchedContent, int requestedSize) {
+        boolean hasNext = fetchedContent.size() > requestedSize;
+        List<WeeklyBestWorkbookInfo> content = hasNext
+            ? fetchedContent.subList(0, requestedSize)
+            : fetchedContent;
+        Long nextCursor = hasNext && !content.isEmpty()
+            ? content.get(content.size() - 1).weeklyBestWorkbookEntityId()
+            : null;
+        return new WeeklyBestWorkbookPageInfo(content, nextCursor, hasNext);
+    }
+
+    public static WeeklyBestWorkbookPageInfo empty() {
+        return new WeeklyBestWorkbookPageInfo(List.of(), null, false);
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/application/port/out/LoadChallengerWorkbookPort.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/out/LoadChallengerWorkbookPort.java
@@ -1,8 +1,9 @@
 package com.umc.product.curriculum.application.port.out;
 
-import com.umc.product.curriculum.domain.ChallengerWorkbook;
 import java.util.List;
 import java.util.Optional;
+
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
 
 public interface LoadChallengerWorkbookPort {
 
@@ -21,4 +22,12 @@ public interface LoadChallengerWorkbookPort {
      * memberId + 여러 originalWorkbookId에 해당하는 ChallengerWorkbook 목록 일괄 조회 (N+1 방지)
      */
     List<ChallengerWorkbook> findByMemberIdAndOriginalWorkbookIdIn(Long memberId, List<Long> originalWorkbookIds);
+
+    /**
+     * 여러 멤버와 여러 주차 커리큘럼에 해당하는 ChallengerWorkbook 목록 일괄 조회 (N+1 방지)
+     */
+    List<ChallengerWorkbook> findByMemberIdInAndWeeklyCurriculumIdIn(
+        List<Long> memberIds,
+        List<Long> weeklyCurriculumIds
+    );
 }

--- a/src/main/java/com/umc/product/curriculum/application/port/out/SearchWeeklyBestWorkbookPort.java
+++ b/src/main/java/com/umc/product/curriculum/application/port/out/SearchWeeklyBestWorkbookPort.java
@@ -1,0 +1,11 @@
+package com.umc.product.curriculum.application.port.out;
+
+import java.util.List;
+
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+
+public interface SearchWeeklyBestWorkbookPort {
+
+    List<WeeklyBestWorkbook> searchBestWorkbooks(GetBestWorkbooksQuery query);
+}

--- a/src/main/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookInfoAssembler.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookInfoAssembler.java
@@ -1,0 +1,68 @@
+package com.umc.product.curriculum.application.service.query;
+
+import java.util.List;
+import java.util.Map;
+
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionFeedbackInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo.MissionSubmissionInfo;
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+import com.umc.product.curriculum.domain.MissionFeedback;
+import com.umc.product.curriculum.domain.MissionSubmission;
+
+final class ChallengerWorkbookInfoAssembler {
+
+    private ChallengerWorkbookInfoAssembler() {
+    }
+
+    static ChallengerWorkbookInfo toInfo(
+        ChallengerWorkbook workbook,
+        List<MissionSubmission> submissions,
+        Map<Long, List<MissionFeedback>> feedbacksBySubmissionId,
+        boolean isBestWorkbook
+    ) {
+        return ChallengerWorkbookInfo.builder()
+            .challengerWorkbookId(workbook.getId())
+            .originalWorkbookId(workbook.getOriginalWorkbook().getId())
+            .receivedStudyGroupId(workbook.getStudyGroupId())
+            .challengerId(workbook.getMemberId())
+            .isExcused(workbook.isExcused())
+            .excusedReason(workbook.getExcusedReason())
+            .content(workbook.getContent())
+            .isBestWorkbook(isBestWorkbook)
+            .submissions(submissions.stream()
+                .map(submission -> toSubmissionInfo(
+                    submission,
+                    feedbacksBySubmissionId.getOrDefault(submission.getId(), List.of())
+                ))
+                .toList())
+            .build();
+    }
+
+    private static MissionSubmissionInfo toSubmissionInfo(
+        MissionSubmission submission,
+        List<MissionFeedback> feedbacks
+    ) {
+        return MissionSubmissionInfo.builder()
+            .missionSubmissionId(submission.getId())
+            .originalWorkbookMissionId(submission.getOriginalWorkbookMission().getId())
+            .submittedAsType(submission.getSubmittedAsType())
+            .submittedContent(submission.getContent())
+            .submittedAt(submission.getCreatedAt())
+            .lastEditedAt(submission.getUpdatedAt())
+            .hasFeedback(!feedbacks.isEmpty())
+            .feedbacks(feedbacks.stream()
+                .map(ChallengerWorkbookInfoAssembler::toFeedbackInfo)
+                .toList())
+            .build();
+    }
+
+    private static MissionFeedbackInfo toFeedbackInfo(MissionFeedback feedback) {
+        return MissionFeedbackInfo.builder()
+            .missionFeedbackId(feedback.getId())
+            .reviewerMemberId(feedback.getReviewerMemberId())
+            .content(feedback.getContent())
+            .feedbackResult(feedback.getFeedbackResult())
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryService.java
@@ -1,29 +1,45 @@
 package com.umc.product.curriculum.application.service.query;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.curriculum.application.port.in.query.GetChallengerWorkbookUseCase;
 import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
 import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
-import com.umc.product.curriculum.application.port.out.LoadWorkbookSubmissionPort;
-import com.umc.product.global.exception.NotImplementedException;
-import com.umc.product.organization.application.port.in.query.GetStudyGroupUseCase;
-import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.curriculum.application.port.out.LoadMissionFeedbackPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionSubmissionPort;
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+import com.umc.product.curriculum.domain.MissionFeedback;
+import com.umc.product.curriculum.domain.MissionSubmission;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ChallengerWorkbookQueryService implements GetChallengerWorkbookUseCase {
 
-    private final LoadWorkbookSubmissionPort loadWorkbookSubmissionPort;
     private final LoadChallengerWorkbookPort loadChallengerWorkbookPort;
-    private final GetStudyGroupUseCase getStudyGroupUseCase;
-    private final GetFileUseCase getFileUseCase;
+    private final LoadMissionSubmissionPort loadMissionSubmissionPort;
+    private final LoadMissionFeedbackPort loadMissionFeedbackPort;
 
     @Override
     public ChallengerWorkbookInfo getById(Long challengerWorkbookId) {
-        throw new NotImplementedException();
-    }
+        ChallengerWorkbook workbook = loadChallengerWorkbookPort.findById(challengerWorkbookId);
+        List<MissionSubmission> submissions =
+            loadMissionSubmissionPort.findByChallengerWorkbookId(challengerWorkbookId);
+        List<Long> submissionIds = submissions.stream()
+            .map(MissionSubmission::getId)
+            .toList();
+        Map<Long, List<MissionFeedback>> feedbacksBySubmissionId = submissionIds.isEmpty()
+            ? Map.of()
+            : loadMissionFeedbackPort.findByMissionSubmissionIdIn(submissionIds).stream()
+                .collect(Collectors.groupingBy(feedback -> feedback.getMissionSubmission().getId()));
 
+        return ChallengerWorkbookInfoAssembler.toInfo(workbook, submissions, feedbacksBySubmissionId, false);
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/query/OriginalWorkbookQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/OriginalWorkbookQueryService.java
@@ -1,12 +1,19 @@
 package com.umc.product.curriculum.application.service.query;
 
-import com.umc.product.curriculum.application.port.in.query.GetOriginalWorkbookUseCase;
-import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
-import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookPort;
-import com.umc.product.global.exception.NotImplementedException;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.curriculum.application.port.in.query.GetOriginalWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo.OriginalWorkbookMissionInfo;
+import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookMissionPort;
+import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookPort;
+import com.umc.product.curriculum.domain.OriginalWorkbook;
+import com.umc.product.curriculum.domain.OriginalWorkbookMission;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +21,37 @@ import org.springframework.transaction.annotation.Transactional;
 public class OriginalWorkbookQueryService implements GetOriginalWorkbookUseCase {
 
     private final LoadOriginalWorkbookPort loadOriginalWorkbookPort;
+    private final LoadOriginalWorkbookMissionPort loadOriginalWorkbookMissionPort;
 
     @Override
     public OriginalWorkbookInfo getById(Long originalWorkbookId) {
-        throw new NotImplementedException();
+        OriginalWorkbook workbook = loadOriginalWorkbookPort.getById(originalWorkbookId);
+        List<OriginalWorkbookMission> missions =
+            loadOriginalWorkbookMissionPort.findByOriginalWorkbookId(originalWorkbookId);
+
+        return OriginalWorkbookInfo.builder()
+            .originalWorkbookId(workbook.getId())
+            .title(workbook.getTitle())
+            .description(workbook.getDescription())
+            .url(workbook.getUrl())
+            .content(workbook.getContent())
+            .type(workbook.getType())
+            .status(workbook.getOriginalWorkbookStatus())
+            .releasedAt(workbook.getReleasedAt())
+            .releasedMemberId(workbook.getReleasedMemberId())
+            .missions(missions.stream()
+                .map(this::toMissionInfo)
+                .toList())
+            .build();
     }
 
+    private OriginalWorkbookMissionInfo toMissionInfo(OriginalWorkbookMission mission) {
+        return OriginalWorkbookMissionInfo.builder()
+            .originalWorkbookMissionId(mission.getId())
+            .title(mission.getTitle())
+            .description(mission.getDescription())
+            .missionType(mission.getMissionType())
+            .isNecessary(mission.isNecessary())
+            .build();
+    }
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryService.java
@@ -1,21 +1,149 @@
 package com.umc.product.curriculum.application.service.query;
 
-import com.umc.product.curriculum.application.port.in.query.GetWeeklyBestWorkbookUseCase;
-import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
-import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookInfo;
-import com.umc.product.global.exception.NotImplementedException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.curriculum.application.port.in.query.GetWeeklyBestWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookPageInfo;
+import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionFeedbackPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionSubmissionPort;
+import com.umc.product.curriculum.application.port.out.SearchWeeklyBestWorkbookPort;
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+import com.umc.product.curriculum.domain.MissionFeedback;
+import com.umc.product.curriculum.domain.MissionSubmission;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+import com.umc.product.curriculum.domain.WeeklyCurriculum;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WeeklyBestWorkbookQueryService implements GetWeeklyBestWorkbookUseCase {
 
+    private final SearchWeeklyBestWorkbookPort searchWeeklyBestWorkbookPort;
+    private final LoadChallengerWorkbookPort loadChallengerWorkbookPort;
+    private final LoadMissionSubmissionPort loadMissionSubmissionPort;
+    private final LoadMissionFeedbackPort loadMissionFeedbackPort;
+
     @Override
-    public List<WeeklyBestWorkbookInfo> searchBestWorkbooks(GetBestWorkbooksQuery query) {
-        throw new NotImplementedException();
+    public WeeklyBestWorkbookPageInfo searchBestWorkbooks(GetBestWorkbooksQuery query) {
+        List<WeeklyBestWorkbook> fetched =
+            searchWeeklyBestWorkbookPort.searchBestWorkbooks(query.withSize(query.size() + 1));
+        boolean hasNext = fetched.size() > query.size();
+        List<WeeklyBestWorkbook> pageItems = hasNext ? fetched.subList(0, query.size()) : fetched;
+        if (pageItems.isEmpty()) {
+            return WeeklyBestWorkbookPageInfo.empty();
+        }
+
+        List<Long> memberIds = pageItems.stream()
+            .map(WeeklyBestWorkbook::getMemberId)
+            .distinct()
+            .toList();
+        List<Long> weeklyCurriculumIds = pageItems.stream()
+            .map(bestWorkbook -> bestWorkbook.getWeeklyCurriculum().getId())
+            .distinct()
+            .toList();
+
+        List<ChallengerWorkbook> challengerWorkbooks =
+            loadChallengerWorkbookPort.findByMemberIdInAndWeeklyCurriculumIdIn(memberIds, weeklyCurriculumIds);
+        Map<BestWorkbookKey, List<ChallengerWorkbook>> challengerWorkbooksByKey = challengerWorkbooks.stream()
+            .collect(Collectors.groupingBy(workbook -> BestWorkbookKey.from(
+                workbook.getMemberId(),
+                workbook.getOriginalWorkbook().getWeeklyCurriculum().getId()
+            )));
+
+        Map<Long, List<MissionSubmission>> submissionsByChallengerWorkbookId =
+            findSubmissionsByChallengerWorkbookId(challengerWorkbooks);
+        Map<Long, List<MissionFeedback>> feedbacksBySubmissionId =
+            findFeedbacksBySubmissionId(submissionsByChallengerWorkbookId);
+
+        List<WeeklyBestWorkbookInfo> content = pageItems.stream()
+            .map(bestWorkbook -> toInfo(
+                bestWorkbook,
+                challengerWorkbooksByKey,
+                submissionsByChallengerWorkbookId,
+                feedbacksBySubmissionId
+            ))
+            .toList();
+
+        Long nextCursor = hasNext ? content.get(content.size() - 1).weeklyBestWorkbookEntityId() : null;
+        return new WeeklyBestWorkbookPageInfo(content, nextCursor, hasNext);
+    }
+
+    private Map<Long, List<MissionSubmission>> findSubmissionsByChallengerWorkbookId(
+        List<ChallengerWorkbook> challengerWorkbooks
+    ) {
+        List<Long> challengerWorkbookIds = challengerWorkbooks.stream()
+            .map(ChallengerWorkbook::getId)
+            .toList();
+        if (challengerWorkbookIds.isEmpty()) {
+            return Map.of();
+        }
+        return loadMissionSubmissionPort.findByChallengerWorkbookIdIn(challengerWorkbookIds).stream()
+            .collect(Collectors.groupingBy(submission -> submission.getChallengerWorkbook().getId()));
+    }
+
+    private Map<Long, List<MissionFeedback>> findFeedbacksBySubmissionId(
+        Map<Long, List<MissionSubmission>> submissionsByChallengerWorkbookId
+    ) {
+        List<Long> submissionIds = submissionsByChallengerWorkbookId.values().stream()
+            .flatMap(List::stream)
+            .map(MissionSubmission::getId)
+            .toList();
+        if (submissionIds.isEmpty()) {
+            return Map.of();
+        }
+        return loadMissionFeedbackPort.findByMissionSubmissionIdIn(submissionIds).stream()
+            .collect(Collectors.groupingBy(feedback -> feedback.getMissionSubmission().getId()));
+    }
+
+    private WeeklyBestWorkbookInfo toInfo(
+        WeeklyBestWorkbook bestWorkbook,
+        Map<BestWorkbookKey, List<ChallengerWorkbook>> challengerWorkbooksByKey,
+        Map<Long, List<MissionSubmission>> submissionsByChallengerWorkbookId,
+        Map<Long, List<MissionFeedback>> feedbacksBySubmissionId
+    ) {
+        WeeklyCurriculum weeklyCurriculum = bestWorkbook.getWeeklyCurriculum();
+        List<ChallengerWorkbookInfo> challengerWorkbookInfos = challengerWorkbooksByKey
+            .getOrDefault(BestWorkbookKey.from(bestWorkbook.getMemberId(), weeklyCurriculum.getId()), List.of())
+            .stream()
+            .map(workbook -> ChallengerWorkbookInfoAssembler.toInfo(
+                workbook,
+                submissionsByChallengerWorkbookId.getOrDefault(workbook.getId(), List.of()),
+                feedbacksBySubmissionId,
+                true
+            ))
+            .toList();
+
+        return WeeklyBestWorkbookInfo.builder()
+            .weeklyBestWorkbookEntityId(bestWorkbook.getId())
+            .challengerId(bestWorkbook.getMemberId())
+            .gisuId(weeklyCurriculum.getCurriculum().getGisuId())
+            .part(weeklyCurriculum.getCurriculum().getPart())
+            .studyGroupId(bestWorkbook.getStudyGroupId())
+            .decidedMemberId(bestWorkbook.getDecidedMemberId())
+            .reason(bestWorkbook.getReason())
+            .challengerWorkbooks(challengerWorkbookInfos)
+            .build();
+    }
+
+    private record BestWorkbookKey(Long memberId, Long weeklyCurriculumId) {
+
+        private static BestWorkbookKey from(Long memberId, Long weeklyCurriculumId) {
+            return new BestWorkbookKey(
+                Objects.requireNonNull(memberId),
+                Objects.requireNonNull(weeklyCurriculumId)
+            );
+        }
     }
 }

--- a/src/main/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryService.java
+++ b/src/main/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryService.java
@@ -3,6 +3,7 @@ package com.umc.product.curriculum.application.service.query;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ import com.umc.product.curriculum.domain.MissionFeedback;
 import com.umc.product.curriculum.domain.MissionSubmission;
 import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
 import com.umc.product.curriculum.domain.WeeklyCurriculum;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,11 +36,18 @@ public class WeeklyBestWorkbookQueryService implements GetWeeklyBestWorkbookUseC
     private final LoadChallengerWorkbookPort loadChallengerWorkbookPort;
     private final LoadMissionSubmissionPort loadMissionSubmissionPort;
     private final LoadMissionFeedbackPort loadMissionFeedbackPort;
+    private final GetMemberUseCase getMemberUseCase;
 
     @Override
     public WeeklyBestWorkbookPageInfo searchBestWorkbooks(GetBestWorkbooksQuery query) {
+        Set<Long> filteredMemberIds = resolveMemberIds(query.schoolIds());
+        if (query.schoolIds() != null && !query.schoolIds().isEmpty() && filteredMemberIds.isEmpty()) {
+            return WeeklyBestWorkbookPageInfo.empty();
+        }
+
+        GetBestWorkbooksQuery searchQuery = query.withMemberIds(filteredMemberIds).withSize(query.size() + 1);
         List<WeeklyBestWorkbook> fetched =
-            searchWeeklyBestWorkbookPort.searchBestWorkbooks(query.withSize(query.size() + 1));
+            searchWeeklyBestWorkbookPort.searchBestWorkbooks(searchQuery);
         boolean hasNext = fetched.size() > query.size();
         List<WeeklyBestWorkbook> pageItems = hasNext ? fetched.subList(0, query.size()) : fetched;
         if (pageItems.isEmpty()) {
@@ -78,6 +87,15 @@ public class WeeklyBestWorkbookQueryService implements GetWeeklyBestWorkbookUseC
 
         Long nextCursor = hasNext ? content.get(content.size() - 1).weeklyBestWorkbookEntityId() : null;
         return new WeeklyBestWorkbookPageInfo(content, nextCursor, hasNext);
+    }
+
+    private Set<Long> resolveMemberIds(Set<Long> schoolIds) {
+        if (schoolIds == null || schoolIds.isEmpty()) {
+            return null;
+        }
+        return getMemberUseCase.listIdsBySchoolIds(schoolIds).values().stream()
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
     }
 
     private Map<Long, List<MissionSubmission>> findSubmissionsByChallengerWorkbookId(

--- a/src/test/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2ControllerTest.java
+++ b/src/test/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2ControllerTest.java
@@ -1,0 +1,149 @@
+package com.umc.product.curriculum.adapter.in.web.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.curriculum.application.port.in.query.GetChallengerWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.GetOriginalWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.GetWeeklyBestWorkbookUseCase;
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookInfo;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookPageInfo;
+import com.umc.product.curriculum.domain.enums.MissionType;
+import com.umc.product.curriculum.domain.enums.OriginalWorkbookStatus;
+import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+
+@WebMvcTest(controllers = WorkbookQueryV2Controller.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+class WorkbookQueryV2ControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetOriginalWorkbookUseCase getOriginalWorkbookUseCase;
+
+    @MockitoBean
+    GetChallengerWorkbookUseCase getChallengerWorkbookUseCase;
+
+    @MockitoBean
+    GetWeeklyBestWorkbookUseCase getWeeklyBestWorkbookUseCase;
+
+    @Test
+    @DisplayName("원본 워크북 상세 조회 API는 UseCase 결과를 응답으로 변환한다")
+    void getOriginalWorkbookSuccess() throws Exception {
+        // given
+        OriginalWorkbookInfo info = OriginalWorkbookInfo.builder()
+            .originalWorkbookId(200L)
+            .title("1주차 워크북")
+            .description("설명")
+            .url("https://workbook.example.com")
+            .content("본문")
+            .type(OriginalWorkbookType.MAIN)
+            .status(OriginalWorkbookStatus.RELEASED)
+            .missions(List.of(OriginalWorkbookInfo.OriginalWorkbookMissionInfo.builder()
+                .originalWorkbookMissionId(300L)
+                .title("미션 1")
+                .description("미션 설명")
+                .missionType(MissionType.LINK)
+                .isNecessary(true)
+                .build()))
+            .build();
+        given(getOriginalWorkbookUseCase.getById(200L)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/curriculums/original-workbooks/{originalWorkbookId}", 200L))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.originalWorkbookId").value(200L))
+            .andExpect(jsonPath("$.result.missions[0].originalWorkbookMissionId").value(300L));
+    }
+
+    @Test
+    @DisplayName("챌린저 워크북 상세 조회 API는 UseCase 결과를 응답으로 변환한다")
+    void getChallengerWorkbookSuccess() throws Exception {
+        // given
+        ChallengerWorkbookInfo info = ChallengerWorkbookInfo.builder()
+            .challengerWorkbookId(10L)
+            .originalWorkbookId(200L)
+            .receivedStudyGroupId(30L)
+            .challengerId(40L)
+            .isExcused(false)
+            .content("본문")
+            .isBestWorkbook(false)
+            .submissions(List.of())
+            .build();
+        given(getChallengerWorkbookUseCase.getById(10L)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/curriculums/challenger-workbooks/{challengerWorkbookId}", 10L))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.challengerWorkbookId").value(10L))
+            .andExpect(jsonPath("$.result.hasSubmission").value(false));
+    }
+
+    @Test
+    @DisplayName("베스트 워크북 조회 API는 필터를 Query로 변환하고 커서 응답을 반환한다")
+    void getBestWorkbooksSuccess() throws Exception {
+        // given
+        WeeklyBestWorkbookInfo info = WeeklyBestWorkbookInfo.builder()
+            .weeklyBestWorkbookEntityId(100L)
+            .challengerId(40L)
+            .gisuId(9L)
+            .part(ChallengerPart.SPRINGBOOT)
+            .studyGroupId(30L)
+            .decidedMemberId(99L)
+            .reason("잘 작성했습니다")
+            .challengerWorkbooks(List.of())
+            .build();
+        given(getWeeklyBestWorkbookUseCase.searchBestWorkbooks(any(GetBestWorkbooksQuery.class)))
+            .willReturn(WeeklyBestWorkbookPageInfo.of(List.of(info), 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v2/curriculums/weekly-best-workbooks")
+                .param("gisuId", "9")
+                .param("schoolIds", "1", "2")
+                .param("parts", "SPRINGBOOT")
+                .param("weekNos", "1")
+                .param("studyGroupIds", "30")
+                .param("size", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.content[0].weeklyBestWorkbookEntityId").value(100L))
+            .andExpect(jsonPath("$.result.content[0].memberId").value(40L))
+            .andExpect(jsonPath("$.result.hasNext").value(false));
+
+        ArgumentCaptor<GetBestWorkbooksQuery> captor = ArgumentCaptor.forClass(GetBestWorkbooksQuery.class);
+        then(getWeeklyBestWorkbookUseCase).should().searchBestWorkbooks(captor.capture());
+        GetBestWorkbooksQuery query = captor.getValue();
+        org.assertj.core.api.Assertions.assertThat(query.gisuId()).isEqualTo(9L);
+        org.assertj.core.api.Assertions.assertThat(query.schoolIds()).containsExactlyInAnyOrder(1L, 2L);
+        org.assertj.core.api.Assertions.assertThat(query.parts()).containsExactly(ChallengerPart.SPRINGBOOT);
+        org.assertj.core.api.Assertions.assertThat(query.weekNos()).containsExactly(1L);
+        org.assertj.core.api.Assertions.assertThat(query.studyGroupIds()).containsExactly(30L);
+        org.assertj.core.api.Assertions.assertThat(query.size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryServiceTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryServiceTest.java
@@ -1,0 +1,110 @@
+package com.umc.product.curriculum.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbookInfo;
+import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionFeedbackPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionSubmissionPort;
+import com.umc.product.curriculum.application.port.out.LoadWorkbookSubmissionPort;
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+import com.umc.product.curriculum.domain.MissionFeedback;
+import com.umc.product.curriculum.domain.MissionSubmission;
+import com.umc.product.curriculum.domain.OriginalWorkbook;
+import com.umc.product.curriculum.domain.OriginalWorkbookMission;
+import com.umc.product.curriculum.domain.enums.FeedbackResult;
+import com.umc.product.curriculum.domain.enums.MissionType;
+import com.umc.product.organization.application.port.in.query.GetStudyGroupUseCase;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengerWorkbookQueryServiceTest {
+
+    @Mock
+    LoadWorkbookSubmissionPort loadWorkbookSubmissionPort;
+
+    @Mock
+    LoadChallengerWorkbookPort loadChallengerWorkbookPort;
+
+    @Mock
+    LoadMissionSubmissionPort loadMissionSubmissionPort;
+
+    @Mock
+    LoadMissionFeedbackPort loadMissionFeedbackPort;
+
+    @Mock
+    GetStudyGroupUseCase getStudyGroupUseCase;
+
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @InjectMocks
+    ChallengerWorkbookQueryService sut;
+
+    @Test
+    @DisplayName("챌린저 워크북 상세 조회 시 제출물과 피드백을 조립한다")
+    void getChallengerWorkbookSuccess() {
+        // given
+        OriginalWorkbook originalWorkbook = Mockito.mock(OriginalWorkbook.class);
+        given(originalWorkbook.getId()).willReturn(200L);
+
+        ChallengerWorkbook challengerWorkbook = Mockito.mock(ChallengerWorkbook.class);
+        given(challengerWorkbook.getId()).willReturn(10L);
+        given(challengerWorkbook.getOriginalWorkbook()).willReturn(originalWorkbook);
+        given(challengerWorkbook.getStudyGroupId()).willReturn(30L);
+        given(challengerWorkbook.getMemberId()).willReturn(40L);
+        given(challengerWorkbook.isExcused()).willReturn(false);
+        given(challengerWorkbook.getExcusedReason()).willReturn(null);
+        given(challengerWorkbook.getContent()).willReturn("챌린저 워크북 본문");
+
+        OriginalWorkbookMission mission = Mockito.mock(OriginalWorkbookMission.class);
+        given(mission.getId()).willReturn(300L);
+
+        MissionSubmission submission = Mockito.mock(MissionSubmission.class);
+        given(submission.getId()).willReturn(400L);
+        given(submission.getOriginalWorkbookMission()).willReturn(mission);
+        given(submission.getSubmittedAsType()).willReturn(MissionType.LINK);
+        given(submission.getContent()).willReturn("https://github.com/umc/product");
+        given(submission.getCreatedAt()).willReturn(Instant.parse("2026-06-02T00:00:00Z"));
+        given(submission.getUpdatedAt()).willReturn(Instant.parse("2026-06-03T00:00:00Z"));
+
+        MissionFeedback feedback = Mockito.mock(MissionFeedback.class);
+        given(feedback.getId()).willReturn(500L);
+        given(feedback.getMissionSubmission()).willReturn(submission);
+        given(feedback.getReviewerMemberId()).willReturn(60L);
+        given(feedback.getContent()).willReturn("좋습니다");
+        given(feedback.getFeedbackResult()).willReturn(FeedbackResult.PASS);
+
+        given(loadChallengerWorkbookPort.findById(10L)).willReturn(challengerWorkbook);
+        given(loadMissionSubmissionPort.findByChallengerWorkbookId(10L)).willReturn(List.of(submission));
+        given(loadMissionFeedbackPort.findByMissionSubmissionIdIn(List.of(400L))).willReturn(List.of(feedback));
+
+        // when
+        ChallengerWorkbookInfo result = sut.getById(10L);
+
+        // then
+        assertThat(result.challengerWorkbookId()).isEqualTo(10L);
+        assertThat(result.originalWorkbookId()).isEqualTo(200L);
+        assertThat(result.receivedStudyGroupId()).isEqualTo(30L);
+        assertThat(result.challengerId()).isEqualTo(40L);
+        assertThat(result.content()).isEqualTo("챌린저 워크북 본문");
+        assertThat(result.isBestWorkbook()).isFalse();
+        assertThat(result.submissions()).hasSize(1);
+        assertThat(result.submissions().get(0).missionSubmissionId()).isEqualTo(400L);
+        assertThat(result.submissions().get(0).hasFeedback()).isTrue();
+        assertThat(result.submissions().get(0).feedbacks()).hasSize(1);
+        assertThat(result.submissions().get(0).feedbacks().get(0).feedbackResult()).isEqualTo(FeedbackResult.PASS);
+    }
+}

--- a/src/test/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryServiceTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/service/query/ChallengerWorkbookQueryServiceTest.java
@@ -18,7 +18,6 @@ import com.umc.product.curriculum.application.port.in.query.dto.ChallengerWorkbo
 import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
 import com.umc.product.curriculum.application.port.out.LoadMissionFeedbackPort;
 import com.umc.product.curriculum.application.port.out.LoadMissionSubmissionPort;
-import com.umc.product.curriculum.application.port.out.LoadWorkbookSubmissionPort;
 import com.umc.product.curriculum.domain.ChallengerWorkbook;
 import com.umc.product.curriculum.domain.MissionFeedback;
 import com.umc.product.curriculum.domain.MissionSubmission;
@@ -26,14 +25,9 @@ import com.umc.product.curriculum.domain.OriginalWorkbook;
 import com.umc.product.curriculum.domain.OriginalWorkbookMission;
 import com.umc.product.curriculum.domain.enums.FeedbackResult;
 import com.umc.product.curriculum.domain.enums.MissionType;
-import com.umc.product.organization.application.port.in.query.GetStudyGroupUseCase;
-import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengerWorkbookQueryServiceTest {
-
-    @Mock
-    LoadWorkbookSubmissionPort loadWorkbookSubmissionPort;
 
     @Mock
     LoadChallengerWorkbookPort loadChallengerWorkbookPort;
@@ -43,12 +37,6 @@ class ChallengerWorkbookQueryServiceTest {
 
     @Mock
     LoadMissionFeedbackPort loadMissionFeedbackPort;
-
-    @Mock
-    GetStudyGroupUseCase getStudyGroupUseCase;
-
-    @Mock
-    GetFileUseCase getFileUseCase;
 
     @InjectMocks
     ChallengerWorkbookQueryService sut;

--- a/src/test/java/com/umc/product/curriculum/application/service/query/OriginalWorkbookQueryServiceTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/service/query/OriginalWorkbookQueryServiceTest.java
@@ -1,0 +1,96 @@
+package com.umc.product.curriculum.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.curriculum.application.port.in.query.dto.OriginalWorkbookInfo;
+import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookMissionPort;
+import com.umc.product.curriculum.application.port.out.LoadOriginalWorkbookPort;
+import com.umc.product.curriculum.domain.Curriculum;
+import com.umc.product.curriculum.domain.OriginalWorkbook;
+import com.umc.product.curriculum.domain.OriginalWorkbookMission;
+import com.umc.product.curriculum.domain.WeeklyCurriculum;
+import com.umc.product.curriculum.domain.enums.MissionType;
+import com.umc.product.curriculum.domain.enums.OriginalWorkbookStatus;
+import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
+
+@ExtendWith(MockitoExtension.class)
+class OriginalWorkbookQueryServiceTest {
+
+    @Mock
+    LoadOriginalWorkbookPort loadOriginalWorkbookPort;
+
+    @Mock
+    LoadOriginalWorkbookMissionPort loadOriginalWorkbookMissionPort;
+
+    @InjectMocks
+    OriginalWorkbookQueryService sut;
+
+    @Test
+    @DisplayName("원본 워크북 상세 조회 시 워크북과 미션 목록을 조립한다")
+    void getOriginalWorkbookSuccess() {
+        // given
+        OriginalWorkbook workbook = originalWorkbook();
+        OriginalWorkbookMission mission = OriginalWorkbookMission.create(
+            workbook, "미션 1", "링크 제출", MissionType.LINK, true
+        );
+        ReflectionTestUtils.setField(mission, "id", 300L);
+
+        given(loadOriginalWorkbookPort.getById(200L)).willReturn(workbook);
+        given(loadOriginalWorkbookMissionPort.findByOriginalWorkbookId(200L)).willReturn(List.of(mission));
+
+        // when
+        OriginalWorkbookInfo result = sut.getById(200L);
+
+        // then
+        assertThat(result.originalWorkbookId()).isEqualTo(200L);
+        assertThat(result.title()).isEqualTo("1주차 워크북");
+        assertThat(result.description()).isEqualTo("상세 설명");
+        assertThat(result.url()).isEqualTo("https://workbook.example.com");
+        assertThat(result.content()).isEqualTo("워크북 본문");
+        assertThat(result.type()).isEqualTo(OriginalWorkbookType.MAIN);
+        assertThat(result.status()).isEqualTo(OriginalWorkbookStatus.RELEASED);
+        assertThat(result.releasedAt()).isEqualTo(Instant.parse("2026-06-01T00:00:00Z"));
+        assertThat(result.releasedMemberId()).isEqualTo(10L);
+        assertThat(result.missions()).hasSize(1);
+        assertThat(result.missions().get(0).originalWorkbookMissionId()).isEqualTo(300L);
+        assertThat(result.missions().get(0).missionType()).isEqualTo(MissionType.LINK);
+        assertThat(result.missions().get(0).isNecessary()).isTrue();
+    }
+
+    private OriginalWorkbook originalWorkbook() {
+        Curriculum curriculum = Curriculum.create(9L, ChallengerPart.SPRINGBOOT, "9기 스프링부트");
+        WeeklyCurriculum weeklyCurriculum = WeeklyCurriculum.create(
+            curriculum,
+            1L,
+            false,
+            "1주차",
+            Instant.parse("2026-06-01T00:00:00Z"),
+            Instant.parse("2026-06-07T00:00:00Z")
+        );
+        OriginalWorkbook workbook = OriginalWorkbook.createAsReady(
+            weeklyCurriculum,
+            "1주차 워크북",
+            "상세 설명",
+            "https://workbook.example.com",
+            "워크북 본문",
+            OriginalWorkbookType.MAIN
+        );
+        workbook.changeStatus(OriginalWorkbookStatus.RELEASED, 10L);
+        ReflectionTestUtils.setField(workbook, "id", 200L);
+        ReflectionTestUtils.setField(workbook, "releasedAt", Instant.parse("2026-06-01T00:00:00Z"));
+        return workbook;
+    }
+}

--- a/src/test/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryServiceTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryServiceTest.java
@@ -1,0 +1,126 @@
+package com.umc.product.curriculum.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.curriculum.application.port.in.query.dto.GetBestWorkbooksQuery;
+import com.umc.product.curriculum.application.port.in.query.dto.WeeklyBestWorkbookPageInfo;
+import com.umc.product.curriculum.application.port.out.LoadChallengerWorkbookPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionFeedbackPort;
+import com.umc.product.curriculum.application.port.out.LoadMissionSubmissionPort;
+import com.umc.product.curriculum.application.port.out.SearchWeeklyBestWorkbookPort;
+import com.umc.product.curriculum.domain.ChallengerWorkbook;
+import com.umc.product.curriculum.domain.Curriculum;
+import com.umc.product.curriculum.domain.OriginalWorkbook;
+import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
+import com.umc.product.curriculum.domain.WeeklyCurriculum;
+import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyBestWorkbookQueryServiceTest {
+
+    @Mock
+    SearchWeeklyBestWorkbookPort searchWeeklyBestWorkbookPort;
+
+    @Mock
+    LoadChallengerWorkbookPort loadChallengerWorkbookPort;
+
+    @Mock
+    LoadMissionSubmissionPort loadMissionSubmissionPort;
+
+    @Mock
+    LoadMissionFeedbackPort loadMissionFeedbackPort;
+
+    @InjectMocks
+    WeeklyBestWorkbookQueryService sut;
+
+    @Test
+    @DisplayName("베스트 워크북 조회 시 size+1로 조회하고 다음 커서를 계산한다")
+    void searchBestWorkbooksSuccess() {
+        // given
+        GetBestWorkbooksQuery query = GetBestWorkbooksQuery.of(
+            9L,
+            Set.of(1L),
+            Set.of(ChallengerPart.SPRINGBOOT),
+            List.of(1L),
+            List.of(30L),
+            null,
+            1
+        );
+
+        WeeklyBestWorkbook first = weeklyBestWorkbook(100L, 40L, 30L);
+        WeeklyBestWorkbook second = Mockito.mock(WeeklyBestWorkbook.class);
+        ChallengerWorkbook challengerWorkbook = Mockito.mock(ChallengerWorkbook.class);
+        OriginalWorkbook originalWorkbook = OriginalWorkbook.createAsReady(
+            first.getWeeklyCurriculum(),
+            "1주차 워크북",
+            null,
+            null,
+            "본문",
+            OriginalWorkbookType.MAIN
+        );
+        ReflectionTestUtils.setField(originalWorkbook, "id", 200L);
+        given(challengerWorkbook.getId()).willReturn(500L);
+        given(challengerWorkbook.getOriginalWorkbook()).willReturn(originalWorkbook);
+        given(challengerWorkbook.getMemberId()).willReturn(40L);
+        given(challengerWorkbook.getStudyGroupId()).willReturn(30L);
+        given(challengerWorkbook.isExcused()).willReturn(false);
+        given(challengerWorkbook.getContent()).willReturn("챌린저 본문");
+
+        given(searchWeeklyBestWorkbookPort.searchBestWorkbooks(query.withSize(2)))
+            .willReturn(List.of(first, second));
+        given(loadChallengerWorkbookPort.findByMemberIdInAndWeeklyCurriculumIdIn(List.of(40L), List.of(10L)))
+            .willReturn(List.of(challengerWorkbook));
+        given(loadMissionSubmissionPort.findByChallengerWorkbookIdIn(List.of(500L))).willReturn(List.of());
+
+        // when
+        WeeklyBestWorkbookPageInfo result = sut.searchBestWorkbooks(query);
+
+        // then
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).weeklyBestWorkbookEntityId()).isEqualTo(100L);
+        assertThat(result.content().get(0).challengerId()).isEqualTo(40L);
+        assertThat(result.content().get(0).gisuId()).isEqualTo(9L);
+        assertThat(result.content().get(0).part()).isEqualTo(ChallengerPart.SPRINGBOOT);
+        assertThat(result.content().get(0).challengerWorkbooks()).hasSize(1);
+        assertThat(result.nextCursor()).isEqualTo(100L);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    private WeeklyBestWorkbook weeklyBestWorkbook(Long id, Long memberId, Long studyGroupId) {
+        Curriculum curriculum = Curriculum.create(9L, ChallengerPart.SPRINGBOOT, "9기 스프링부트");
+        ReflectionTestUtils.setField(curriculum, "id", 1L);
+        WeeklyCurriculum weeklyCurriculum = WeeklyCurriculum.create(
+            curriculum,
+            1L,
+            false,
+            "1주차",
+            Instant.parse("2026-06-01T00:00:00Z"),
+            Instant.parse("2026-06-07T00:00:00Z")
+        );
+        ReflectionTestUtils.setField(weeklyCurriculum, "id", 10L);
+
+        WeeklyBestWorkbook bestWorkbook = Mockito.mock(WeeklyBestWorkbook.class);
+        given(bestWorkbook.getId()).willReturn(id);
+        given(bestWorkbook.getMemberId()).willReturn(memberId);
+        given(bestWorkbook.getStudyGroupId()).willReturn(studyGroupId);
+        given(bestWorkbook.getWeeklyCurriculum()).willReturn(weeklyCurriculum);
+        given(bestWorkbook.getReason()).willReturn("잘 작성했습니다");
+        given(bestWorkbook.getDecidedMemberId()).willReturn(99L);
+        return bestWorkbook;
+    }
+}

--- a/src/test/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryServiceTest.java
+++ b/src/test/java/com/umc/product/curriculum/application/service/query/WeeklyBestWorkbookQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,7 @@ import com.umc.product.curriculum.domain.OriginalWorkbook;
 import com.umc.product.curriculum.domain.WeeklyBestWorkbook;
 import com.umc.product.curriculum.domain.WeeklyCurriculum;
 import com.umc.product.curriculum.domain.enums.OriginalWorkbookType;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 
 @ExtendWith(MockitoExtension.class)
 class WeeklyBestWorkbookQueryServiceTest {
@@ -44,6 +46,9 @@ class WeeklyBestWorkbookQueryServiceTest {
 
     @Mock
     LoadMissionFeedbackPort loadMissionFeedbackPort;
+
+    @Mock
+    GetMemberUseCase getMemberUseCase;
 
     @InjectMocks
     WeeklyBestWorkbookQueryService sut;
@@ -81,7 +86,8 @@ class WeeklyBestWorkbookQueryServiceTest {
         given(challengerWorkbook.isExcused()).willReturn(false);
         given(challengerWorkbook.getContent()).willReturn("챌린저 본문");
 
-        given(searchWeeklyBestWorkbookPort.searchBestWorkbooks(query.withSize(2)))
+        given(getMemberUseCase.listIdsBySchoolIds(Set.of(1L))).willReturn(Map.of(1L, Set.of(40L)));
+        given(searchWeeklyBestWorkbookPort.searchBestWorkbooks(query.withMemberIds(Set.of(40L)).withSize(2)))
             .willReturn(List.of(first, second));
         given(loadChallengerWorkbookPort.findByMemberIdInAndWeeklyCurriculumIdIn(List.of(40L), List.of(10L)))
             .willReturn(List.of(challengerWorkbook));


### PR DESCRIPTION
## 🚀 작업 내용

1. **무엇을**: curriculum v2 워크북 조회 API 3종을 구현했어요.
   - **어떻게**: `WorkbookQueryV2Controller`가 원본 워크북 상세, 챌린저 워크북 상세, 베스트 워크북 조회 UseCase를 호출하고 adapter response DTO로 변환하도록 연결했어요.
   - **왜**: 기존 v2 조회 API가 `NotImplementedException` 상태라 클라이언트에서 워크북 상세와 베스트 워크북 목록을 사용할 수 없었기 때문이에요.

2. **무엇을**: 조회 서비스와 QueryDSL 기반 베스트 워크북 조회를 추가했어요.
   - **어떻게**: 원본 워크북/챌린저 워크북 상세는 포트 기반으로 조립하고, 베스트 워크북은 커서 페이지 정보를 `WeeklyBestWorkbookPageInfo`로 반환하도록 구성했어요.
   - **왜**: controller가 persistence에 직접 의존하지 않고 application query 계층을 통해 응답을 조립해야 하기 때문이에요.

3. **무엇을**: controller/service 단위 테스트를 추가했어요.
   - **어떻게**: v2 query controller와 원본/챌린저/베스트 워크북 query service의 성공 경로를 검증했어요.
   - **왜**: 조회 DTO 조립과 커서 페이지 계산이 API 응답에 직접 영향을 주기 때문이에요.

## 💬 리뷰 중점사항

- 베스트 워크북 조회 필터와 커서 응답 shape가 FE 요구사항과 맞는지 확인 부탁드려요.
- 상세 조회 응답에 포함한 mission/submission/feedback 필드 범위가 과하거나 부족하지 않은지 확인 부탁드려요.
- `./gradlew check`로 검증했어요.