### PR TITLE
[Fix] 지원서 상세 조회 시 미답변 선택 질문이 폼 수정 이후 누락되는 오류 수정

### DIFF
--- a/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/survey/application/service/command/FormResponseCommandService.java
@@ -162,6 +162,8 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             validateAllRequiredAnswered(draft.getForm().getId(), answeredQuestionIds);
         }
 
+        saveEmptyAnswersForUnanswered(draft, command.allowedQuestionIds(), answeredQuestionIds);
+
         draft.submit(Instant.now(), command.submittedIp());
         saveFormResponsePort.save(draft);
     }
@@ -371,6 +373,35 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             result.add(new AnswerWithOptions(answer, selectedOptions));
         }
         return result;
+    }
+
+    /**
+     * allowedQuestionIds 중 아직 답변되지 않은 질문에 대해 빈 Answer를 저장한다.
+     * 제출 이후 해당 질문이 fork되더라도 Answer.questionId 역추적으로 질문을 복원하기 위함이다.
+     */
+    private void saveEmptyAnswersForUnanswered(
+        FormResponse formResponse,
+        Set<Long> allowedQuestionIds,
+        Set<Long> answeredQuestionIds
+    ) {
+        if (allowedQuestionIds == null) {
+            return;
+        }
+
+        Set<Long> unansweredIds = allowedQuestionIds.stream()
+            .filter(id -> !answeredQuestionIds.contains(id))
+            .collect(Collectors.toSet());
+
+        if (unansweredIds.isEmpty()) {
+            return;
+        }
+
+        List<Question> unansweredQuestions = loadQuestionPort.listByIdIn(unansweredIds);
+        List<Answer> emptyAnswers = unansweredQuestions.stream()
+            .map(q -> Answer.createEmpty(formResponse, q))
+            .toList();
+
+        saveAnswerPort.saveAll(emptyAnswers);
     }
 
     private void saveAnswers(List<AnswerWithOptions> data) {

--- a/src/main/java/com/umc/product/survey/domain/Answer.java
+++ b/src/main/java/com/umc/product/survey/domain/Answer.java
@@ -1,16 +1,28 @@
 package com.umc.product.survey.domain;
 
-import com.umc.product.common.BaseEntity;
-import com.umc.product.survey.domain.enums.QuestionType;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.Instant;
+import java.util.Set;
+
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.time.Instant;
-import java.util.Set;
+import com.umc.product.common.BaseEntity;
+import com.umc.product.survey.domain.enums.QuestionType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 한 사용자가 한 질문에 대해 작성한 답변의 루트 엔티티.

--- a/src/main/java/com/umc/product/survey/domain/Answer.java
+++ b/src/main/java/com/umc/product/survey/domain/Answer.java
@@ -85,6 +85,19 @@ public class Answer extends BaseEntity {
     }
 
     /**
+     * 미답변 선택 질문을 위한 빈 답변 생성.
+     * 제출 시점의 질문 구조 스냅샷 역할로, 값 필드는 모두 null이다.
+     */
+    public static Answer createEmpty(FormResponse formResponse, Question question) {
+        Answer answer = new Answer();
+        answer.formResponse = formResponse;
+        answer.question = question;
+        answer.answeredAsType = question.getType();
+
+        return answer;
+    }
+
+    /**
      * 답변 내용 (textValue / fileIds) 부분 갱신 (PATCH 시맨틱 — 다른 도메인 update 메서드와 일관).
      * <ul>
      *   <li>null -> 기존 값 유지</li>

--- a/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
@@ -277,6 +277,29 @@ class FormResponseCommandServiceTest {
     }
 
     @Test
+    @DisplayName("submitDraft_allowedQuestionIds_밖의_질문에는_null_answer가_생성되지_않는다")
+    void submitDraft_allowedQuestionIds_밖_질문에_null_answer_미생성() {
+        // given — allowedQuestionIds = {Q10} (파트 필터링 결과), Q20은 범위 밖
+        FormResponse draft = draftResponse();
+        Question q10 = question(10L, true);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, q10)));
+
+        // when
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of(10L))
+            .allowedQuestionIds(Set.of(10L))
+            .build());
+
+        // then — Q20은 allowedQuestionIds 밖이므로 listByIdIn 호출 안 됨
+        then(loadQuestionPort).should(never()).listByIdIn(any());
+    }
+
+    @Test
     @DisplayName("submitDraft_allowedQuestionIds가_모두_답변됐으면_null_answer를_저장하지_않는다")
     void submitDraft_전체_답변_완료시_null_answer_미저장() {
         // given — Q10, Q20 모두 답변됨

--- a/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/survey/application/service/command/FormResponseCommandServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -242,6 +243,83 @@ class FormResponseCommandServiceTest {
             .isEqualTo(SurveyErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
 
         then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft_allowedQuestionIds_중_미답변_질문에_null_answer가_저장된다")
+    void submitDraft_미답변_선택_질문에_null_answer_저장() {
+        // given — Q10(필수, 답변됨) + Q20(선택, 미답변)
+        FormResponse draft = draftResponse();
+        Question requiredAnswered = question(10L, QuestionType.SHORT_TEXT, true);
+        Question optionalUnanswered = question(20L, QuestionType.LONG_TEXT, false);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, requiredAnswered)));
+        given(loadQuestionPort.listByIdIn(Set.of(20L)))
+            .willReturn(List.of(optionalUnanswered));
+
+        // when
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of(10L))
+            .allowedQuestionIds(Set.of(10L, 20L))
+            .build());
+
+        // then — Q20에 대한 null answer가 saveAll로 저장됨
+        then(loadQuestionPort).should().listByIdIn(Set.of(20L));
+        then(saveAnswerPort).should().saveAll(argThat(answers ->
+            answers.size() == 1 &&
+            answers.get(0).getQuestion().getId().equals(20L) &&
+            answers.get(0).getTextValue() == null
+        ));
+    }
+
+    @Test
+    @DisplayName("submitDraft_allowedQuestionIds가_모두_답변됐으면_null_answer를_저장하지_않는다")
+    void submitDraft_전체_답변_완료시_null_answer_미저장() {
+        // given — Q10, Q20 모두 답변됨
+        FormResponse draft = draftResponse();
+        Question q10 = question(10L, true);
+        Question q20 = question(20L, false);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, q10), answer(draft, q20)));
+
+        // when
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of(10L))
+            .allowedQuestionIds(Set.of(10L, 20L))
+            .build());
+
+        // then — 미답변 질문 없으므로 listByIdIn 호출 안 함
+        then(loadQuestionPort).should(never()).listByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft_allowedQuestionIds가_null이면_null_answer를_저장하지_않는다")
+    void submitDraft_allowedQuestionIds_null이면_null_answer_미저장() {
+        // given — 비프로젝트 경로: allowedQuestionIds 없음
+        FormResponse draft = draftResponse();
+        Question q = question(10L, true);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(answer(draft, q)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q));
+
+        // when
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .build());
+
+        // then — allowedQuestionIds null → early return
+        then(loadQuestionPort).should(never()).listByIdIn(any());
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용
지원서 제출 시점에 존재했던 선택 질문에 답변하지 않은 경우, 이후 해당 질문이 수정(fork)되면 지원서 상세 조회에서 해당 질문이 누락되는 버그를 수정했습니다.

- 원인: 지원서 상세 조회는 `Answer.questionId` 집합 기준으로 폼 구조를 역추적하는 방식인데, 미답변 질문은 `Answer`가 없어 역추적 대상에 포함되지 않았습니다. 질문 수정(fork) 이후에는 활성 질문 조회로도 복구되지 않았습니다.
- 수정: 지원서 제출(`submitDraft`) 시점에 `allowedQuestionIds` 중 답변되지 않은 질문을 값 필드가 `null`인 빈
`Answer`로 저장하도록 수정했습니다. 이후 fork가 발생해도 `Answer.questionId` 역추적으로 질문 복원이 가능해졌습니다.
- 빈 `Answer`는 백엔드 제출 시점에만 생성되며, 프론트에서 null 값을 직접 저장하는 경로는 기존 validation에서 차단됩니다. 따라서 null 답변 검증 우회 문제도 발생하지 않습니다.

- resolves #1046

## 💬 리뷰 중점사항
- `Answer.createEmpty()` 도메인 메서드를 신규 생성했습니다. 값 필드 전부 null인 Answer row만 생성합니다. (AnswerChoice 별도 생성 로직은 넣지 않았습니다)