### PR TITLE
[Feat] API별 DB 쿼리 통계 표 추가

### DIFF
--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2824,7 +2824,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "max_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]) by (uriTemplate)",
+                        "expr": "max by (uriTemplate) (max_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2844,7 +2844,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "avg_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]) by (uriTemplate)",
+                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range])) / sum by (uriTemplate) (count_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2804,6 +2804,237 @@
             "version": "13.0.1"
           }
         }
+      },
+      "panel-79": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]) by (uriTemplate)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]) by (uriTemplate)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap durationMs | __error__=\"\" [$__range])) * 100",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range]))",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Time": true
+                      },
+                      "indexByName": {
+                        "uriTemplate": 0,
+                        "Value #A": 1,
+                        "Value #B": 2,
+                        "Value #C": 3,
+                        "Value #D": 4,
+                        "Value #E": 5
+                      },
+                      "renameByName": {
+                        "Value #A": "max queryCount",
+                        "Value #B": "avg queryCount",
+                        "Value #C": "쿼리당 시간(ms)",
+                        "Value #D": "DB 비중(%)",
+                        "Value #E": "total queryTimeMs"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "api_request_completed 로그 기반 API별 DB 쿼리 통계(원본값=정확). 쿼리당시간=느린쿼리, DB비중=DB가 병목인지, total=DB부하 순위. 동기 쿼리만(@Async 제외). 진단은 Tempo.",
+          "id": 79,
+          "links": [],
+          "title": "DB queries by API (Loki 로그 기반)",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "쿼리당 시간(ms)"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ms"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "total queryTimeMs"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ms"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "DB 비중(%)"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "displayName": "max queryCount",
+                    "desc": true
+                  }
+                ]
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
       }
     },
     "layout": {
@@ -3091,6 +3322,19 @@
                         "width": 8,
                         "x": 16,
                         "y": 26
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-79"
+                        },
+                        "height": 12,
+                        "width": 24,
+                        "x": 0,
+                        "y": 34
                       }
                     }
                   ]

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2824,7 +2824,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "max by (uriTemplate) (max_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
+                        "expr": "max by (uriTemplate, method) (max_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2844,7 +2844,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range])) / sum by (uriTemplate) (count_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" [$__range]))",
+                        "expr": "sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range])) / sum by (uriTemplate, method) (count_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2864,7 +2864,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
+                        "expr": "sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryCount | __error__=\"\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2884,7 +2884,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap durationMs | __error__=\"\" [$__range])) * 100",
+                        "expr": "sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range])) / sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap durationMs | __error__=\"\" [$__range])) * 100",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2904,7 +2904,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (uriTemplate) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range]))",
+                        "expr": "sum by (uriTemplate, method) (sum_over_time({service_name=~\"$service\"} | event=\"api_request_completed\" | unwrap queryTimeMs | __error__=\"\" [$__range]))",
                         "queryType": "instant"
                       },
                       "version": "v0"
@@ -2931,12 +2931,13 @@
                         "Time": true
                       },
                       "indexByName": {
-                        "uriTemplate": 0,
-                        "Value #A": 1,
-                        "Value #B": 2,
-                        "Value #C": 3,
-                        "Value #D": 4,
-                        "Value #E": 5
+                        "method": 0,
+                        "uriTemplate": 1,
+                        "Value #A": 2,
+                        "Value #B": 3,
+                        "Value #C": 4,
+                        "Value #D": 5,
+                        "Value #E": 6
                       },
                       "renameByName": {
                         "Value #A": "max queryCount",


### PR DESCRIPTION
## 🚀 작업 내용 

  `server-default` 대시보드의 **API Performance 행**에 **API(uriTemplate)별 DB 쿼리 통계 표**를 추가했습니다.

  - **왜**: 기존엔 요청 수·응답시간·커넥션 풀(HikariCP)은 있었지만, "각 API가 **DB 쿼리를 몇 번 / 얼마나 오래** 날리나"가 없어 N+1·DB 병목을 데이터로 판단할 수 없었습니다.
  - **어떻게**: 이미 `api_request_completed` 로그에 있는 `queryCount`/`queryTimeMs`/`durationMs`를 Loki에서 집계 (**앱 코드 변경 0**, 대시보드 JSON만).
  - **컬럼**:
    - `max queryCount` — N+1 스파이크 (max ≫ avg 면 의심)
    - `avg queryCount` — 평소 쿼리 부하
    - `쿼리당 시간(ms)` — 느린 쿼리 vs 많은 쿼리 구분
    - `DB 비중(%)` — 느린 이유가 DB인지 (latency 패널과 짝)
    - `total queryTimeMs` — DB 부하 순위 (최적화 우선순위)
  - 표 = triage(용의자 추리기), 실제 SQL 진단은 Tempo 트레이스가 담당.

<img width="1099" height="439" alt="image" src="https://github.com/user-attachments/assets/036dd8a6-f21e-4599-b895-ca21f49deb12" />

resolves #1087 

  ## 💬 리뷰 중점사항


  - `DB 비중`은 **SQL 실행시간 기준** (커넥션 대기·ORM 매핑 제외) → "DB 관련 부담"을 약간 과소평가하나 추세·분류엔 충분.
  - LogQL: `sum_over_time`은 `by` 직접 불가라 `sum by (uriTemplate)(sum_over_time(...))`로 감쌌습니다.
  - 동기 요청 스레드 쿼리만 집계 (`@Async` 제외 — 비동기 DB는 Tempo 참조).