### PR TITLE
[Feat] AWS RDS CPU 및 CPU Credit 모니터링 추가

### DIFF
--- a/infra/monitoring/grafana/.env.example
+++ b/infra/monitoring/grafana/.env.example
@@ -25,13 +25,13 @@ GRAFANA_ADMIN_PASSWORD=change-me
 GRAFANA_SERVER_ROOT_URL=https://your-grafana-url.com
 
 # ===== AWS CloudWatch datasource =====
-# 홈서버의 .env에만 읽기 전용 IAM User 또는 임시 자격 증명을 입력한다.
 # 실제 Access Key / Secret은 저장소에 커밋하지 않는다.
 AWS_REGION=ap-northeast-2
+# 현재 IAM User Access Key 방식에서는 아래 두 값을 입력해 설정한다.
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-# 임시 자격 증명(STS)을 사용할 때만 설정한다.
-AWS_SESSION_TOKEN=
+# 현재 방식에서는 필요하지 않으며, 추후 STS 기반 임시 자격 증명을 환경변수로 주입할 때 사용한다.
+# AWS_SESSION_TOKEN=
 
 # ===== Backends (호스트 측 디버그용 포트. 운영 시에는 외부 노출 불필요) =====
 # 앱의 actuator 9090, 일반 개발 서버 3000 과 충돌하지 않도록 backend UI 기본값은 1xxxx 대역을 사용한다.

--- a/infra/monitoring/grafana/.env.example
+++ b/infra/monitoring/grafana/.env.example
@@ -24,6 +24,15 @@ GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-me
 GRAFANA_SERVER_ROOT_URL=https://your-grafana-url.com
 
+# ===== AWS CloudWatch datasource =====
+# 홈서버의 .env에만 읽기 전용 IAM User 또는 임시 자격 증명을 입력한다.
+# 실제 Access Key / Secret은 저장소에 커밋하지 않는다.
+AWS_REGION=ap-northeast-2
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# 임시 자격 증명(STS)을 사용할 때만 설정한다.
+AWS_SESSION_TOKEN=
+
 # ===== Backends (호스트 측 디버그용 포트. 운영 시에는 외부 노출 불필요) =====
 # 앱의 actuator 9090, 일반 개발 서버 3000 과 충돌하지 않도록 backend UI 기본값은 1xxxx 대역을 사용한다.
 PROMETHEUS_PORT=9090

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2970,6 +2970,295 @@
             "version": "13.0.1"
           }
         }
+      },
+      "panel-90": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "cpu_utilization",
+                        "label": "CPUUtilization",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "CPUUtilization",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS CPUUtilization 지표입니다. 선택한 RDS 인스턴스의 CPU 사용률을 백분율로 표시합니다.",
+          "id": 90,
+          "links": [],
+          "title": "RDS CPU Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "none"
+                    }
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 70
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-91": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "cpu_credit_balance",
+                        "label": "CPUCreditBalance",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "CPUCreditBalance",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "300",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "db.t2, db.t3, db.t4g 계열에서만 제공되는 AWS/RDS CPUCreditBalance 지표입니다. T 계열이 아닌 인스턴스는 데이터가 표시되지 않는 것이 정상입니다.",
+          "id": 91,
+          "links": [],
+          "title": "RDS CPU Credit Balance",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-92": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "cpu_credit_usage",
+                        "label": "CPUCreditUsage",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "CPUCreditUsage",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "300",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Sum"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "db.t2, db.t3, db.t4g 계열에서만 제공되는 AWS/RDS CPUCreditUsage 지표입니다. 5분 동안 소비한 CPU Credit 합계를 표시합니다.",
+          "id": 92,
+          "links": [],
+          "title": "RDS CPU Credit Usage",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "stacking": {
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
       }
     },
     "layout": {
@@ -3423,6 +3712,59 @@
               },
               "title": "📝 Logs, Tomcat & Security"
             }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-90"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-91"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 8,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-92"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 16,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "☁️ AWS RDS PostgreSQL — CloudWatch"
+            }
           }
         ]
       }
@@ -3450,7 +3792,10 @@
       "performance",
       "prometheus",
       "loki",
-      "otel"
+      "otel",
+      "aws",
+      "rds",
+      "cloudwatch"
     ],
     "timeSettings": {
       "autoRefresh": "30s",
@@ -3553,6 +3898,89 @@
             "spec": {
               "query": "label_values(jvm_memory_used_bytes{application=~\"$service\"}, instance)",
               "refId": "StandardVariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": false,
+          "current": {
+            "text": "ap-northeast-2",
+            "value": "ap-northeast-2"
+          },
+          "definition": "regions()",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "AWS Region",
+          "multi": false,
+          "name": "aws_region",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "cloudwatch"
+            },
+            "group": "cloudwatch",
+            "kind": "DataQuery",
+            "spec": {
+              "attributeName": "",
+              "dimensionKey": "",
+              "instanceID": "",
+              "metricName": "",
+              "namespace": "",
+              "queryType": "regions",
+              "refId": "CloudWatchRegionsVariableQuery",
+              "region": "default",
+              "resourceType": ""
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": false,
+          "current": {
+            "text": "server-rds-prod",
+            "value": "server-rds-prod"
+          },
+          "definition": "dimension_values($aws_region, AWS/RDS, CPUUtilization, DBInstanceIdentifier)",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "RDS Instance",
+          "multi": false,
+          "name": "rds_instance",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "cloudwatch"
+            },
+            "group": "cloudwatch",
+            "kind": "DataQuery",
+            "spec": {
+              "attributeName": "",
+              "dimensionFilters": {},
+              "dimensionKey": "DBInstanceIdentifier",
+              "instanceID": "",
+              "metricName": "CPUUtilization",
+              "namespace": "AWS/RDS",
+              "queryType": "dimensionValues",
+              "refId": "CloudWatchRdsInstanceVariableQuery",
+              "region": "$aws_region",
+              "resourceType": ""
             },
             "version": "v0"
           },

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -3259,6 +3259,475 @@
             "version": "13.0.1"
           }
         }
+      },
+      "panel-93": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "database_connections",
+                        "label": "DatabaseConnections",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "DatabaseConnections",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS DatabaseConnections 지표입니다. 선택한 RDS 인스턴스에 연결된 클라이언트 네트워크 연결 수를 표시합니다.",
+          "id": 93,
+          "links": [],
+          "title": "RDS Database Connections",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-94": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "freeable_memory",
+                        "label": "FreeableMemory",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "FreeableMemory",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS FreeableMemory 지표입니다. PostgreSQL 인스턴스에서 사용 가능한 메모리를 표시합니다.",
+          "id": 94,
+          "links": [],
+          "title": "RDS Freeable Memory",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-95": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "free_storage_space",
+                        "label": "FreeStorageSpace",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "FreeStorageSpace",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS FreeStorageSpace 지표입니다. 선택한 RDS 인스턴스의 사용 가능한 스토리지 공간을 표시합니다.",
+          "id": 95,
+          "links": [],
+          "title": "RDS Free Storage Space",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-96": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "disk_queue_depth",
+                        "label": "DiskQueueDepth",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "DiskQueueDepth",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS DiskQueueDepth 지표입니다. 디스크 I/O 처리를 기다리는 읽기·쓰기 요청 수를 표시합니다.",
+          "id": 96,
+          "links": [],
+          "title": "RDS Disk Queue Depth",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-97": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "read_latency",
+                        "label": "ReadLatency",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "ReadLatency",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "write_latency",
+                        "label": "WriteLatency",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "WriteLatency",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS ReadLatency와 WriteLatency 지표입니다. 디스크 읽기·쓰기 I/O 작업당 평균 지연 시간을 초 단위로 표시합니다.",
+          "id": 97,
+          "links": [],
+          "title": "RDS Read / Write Latency",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
+      },
+      "panel-98": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "cloudwatch"
+                      },
+                      "group": "cloudwatch",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "dimensions": {
+                          "DBInstanceIdentifier": "$rds_instance"
+                        },
+                        "id": "swap_usage",
+                        "label": "SwapUsage",
+                        "matchExact": true,
+                        "metricEditorMode": 0,
+                        "metricName": "SwapUsage",
+                        "metricQueryType": 0,
+                        "namespace": "AWS/RDS",
+                        "period": "auto",
+                        "queryMode": "Metrics",
+                        "region": "$aws_region",
+                        "statistic": "Average"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "AWS/RDS SwapUsage 지표입니다. PostgreSQL 인스턴스에서 사용 중인 swap 공간을 표시합니다.",
+          "id": 98,
+          "links": [],
+          "title": "RDS Swap Usage",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.0.1"
+          }
+        }
       }
     },
     "layout": {
@@ -3758,6 +4227,84 @@
                         "width": 8,
                         "x": 16,
                         "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-93"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 0,
+                        "y": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-94"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 8,
+                        "y": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-95"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 16,
+                        "y": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-96"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 0,
+                        "y": 18
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-97"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 8,
+                        "y": 18
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-98"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 16,
+                        "y": 18
                       }
                     }
                   ]

--- a/infra/monitoring/grafana/config/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/monitoring/grafana/config/grafana/provisioning/datasources/datasources.yaml
@@ -15,6 +15,16 @@ datasources:
     jsonData:
       timeInterval: 30s
 
+  # 홈서버에 주입된 AWS SDK 기본 자격 증명 체인으로 CloudWatch를 조회한다.
+  # Access Key, Secret, Role ARN 등 민감한 인증 정보는 provisioning 파일에 두지 않는다.
+  - name: CloudWatch
+    type: cloudwatch
+    uid: cloudwatch
+    access: proxy
+    jsonData:
+      authType: default
+      defaultRegion: ap-northeast-2
+
   - name: Alertmanager
     type: alertmanager
     uid: alertmanager

--- a/infra/monitoring/grafana/config/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/monitoring/grafana/config/grafana/provisioning/datasources/datasources.yaml
@@ -17,7 +17,7 @@ datasources:
 
   # 홈서버에 주입된 AWS SDK 기본 자격 증명 체인으로 CloudWatch를 조회한다.
   # Access Key, Secret, Role ARN 등 민감한 인증 정보는 provisioning 파일에 두지 않는다.
-  - name: CloudWatch
+  - name: cloudwatch
     type: cloudwatch
     uid: cloudwatch
     access: proxy

--- a/infra/monitoring/grafana/docker-compose.yml
+++ b/infra/monitoring/grafana/docker-compose.yml
@@ -103,11 +103,11 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_ROOT_URL=${GRAFANA_SERVER_ROOT_URL:-}
       # CloudWatch datasource는 AWS SDK 기본 인증 체인을 사용한다.
-      # 실제 자격 증명은 홈서버의 .env에서만 주입하며 저장소에는 포함하지 않는다.
+      # 자격 증명 변수가 없으면 컨테이너에 전달하지 않아 기본 인증 체인의 다음 단계를 사용할 수 있다.
       - AWS_REGION=${AWS_REGION:-ap-northeast-2}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
     ports:
       - "${MONITORING_BIND_ADDRESS:-127.0.0.1}:${GRAFANA_PORT:-13000}:3000"
     depends_on:

--- a/infra/monitoring/grafana/docker-compose.yml
+++ b/infra/monitoring/grafana/docker-compose.yml
@@ -102,6 +102,12 @@ services:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_ROOT_URL=${GRAFANA_SERVER_ROOT_URL:-}
+      # CloudWatch datasource는 AWS SDK 기본 인증 체인을 사용한다.
+      # 실제 자격 증명은 홈서버의 .env에서만 주입하며 저장소에는 포함하지 않는다.
+      - AWS_REGION=${AWS_REGION:-ap-northeast-2}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
     ports:
       - "${MONITORING_BIND_ADDRESS:-127.0.0.1}:${GRAFANA_PORT:-13000}:3000"
     depends_on:


### PR DESCRIPTION
## 🚀 작업 내용
Grafana 공용 기본 대시보드에서 AWS RDS PostgreSQL의 CPU 상태를 확인할 수 있도록 CloudWatch 기반 패널을 추가했습니다.

- CloudWatch datasource를 Grafana provisioning으로 추가
- `ap-northeast-2`, `server-rds-prod`를 기본값으로 하는 리전·RDS 인스턴스 선택 변수 추가
- `CPUUtilization`, `CPUCreditBalance`, `CPUCreditUsage` 패널 추가
- `db.t4g.small` 인스턴스의 CPU Credit 지표를 고려해 5분 주기로 조회

closes #1085

## 💬 리뷰 중점사항
- 현재 Grafana CloudWatch datasource는 AWS SDK 기본 인증 방식을 사용하도록 구현했습니다.  홈서버의 `.env`에 설정된`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`를 Grafana 컨테이너에 전달해 CloudWatch를 조회하는 구조입니다.
- 이를 위해 운영 홈서버의 그라파나에 CloudWatch 조회 권한이 있는 AWS 인증 정보가 설정되어 있는지 확인이 필요합니다.
- 현재는 홈서버의 환경변수로 AWS 인증 정보를 전달하도록 구성했습니다. 보안과 자격 증명 관리 측면에서, 추후 IAM Roles Anywhere 등 임시 자격 증명 방식으로의 전환을 고려해봐도 좋을 것 같습니다.