### PR TITLE
[Feat] 채팅 메시지 실시간 broadcast 인프라 구현

### DIFF
--- a/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
+++ b/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
@@ -1,8 +1,7 @@
 package com.umc.product.chat.adapter.in.event;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.context.event.EventListener;
 
 import com.umc.product.chat.adapter.in.web.dto.response.ChatMessageResponse;
 import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
@@ -35,7 +34,7 @@ public class ChatMessageBroadcastListener {
 
     private final BroadcastPort broadcastPort;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handle(ChatMessageCreatedEvent event) {
         String destination = CHAT_ROOM_DESTINATION_PREFIX + event.roomId() + CHAT_ROOM_DESTINATION_SUFFIX;
         ChatMessageResponse payload = ChatMessageResponse.from(event);

--- a/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
+++ b/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
@@ -1,0 +1,51 @@
+package com.umc.product.chat.adapter.in.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.umc.product.chat.adapter.in.web.dto.response.ChatMessageResponse;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+import com.umc.product.global.websocket.application.port.out.BroadcastPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 채팅 메시지 생성 이벤트를 수신하여 구독자에게 실시간 broadcast 한다.
+ * <p>
+ * 트랜잭션 커밋 직후(AFTER_COMMIT) 동기로 실행한다. broadcast 실패 시 예외를 삼키지 않고 다시 던져,
+ * outbox relay 가 해당 이벤트를 markPublished 하지 못하고 폴러가 재처리(재broadcast)하도록 한다.
+ * (at-least-once. 클라이언트는 messageId 로 중복을 제거한다.)
+ * <p>
+ * destination 경로 조립은 이 리스너의 책임이며, {@link BroadcastPort} 는 전달받은 destination 으로 그대로
+ * 전송하기만 한다(브로커 교체 대비 디커플링). 특정 STOMP 구현({@code StompBroadcastAdapter})이 아니라
+ * 포트 인터페이스에만 의존한다.
+ * <p>
+ * TODO: 처리량 부하가 확인되면 {@code @Async} 비동기 처리를 검토한다. 현재는 폴러 재처리 흐름을 단순하게 유지하기
+ *  위해 동기로 둔다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageBroadcastListener {
+
+    private static final String CHAT_ROOM_DESTINATION_PREFIX = "/topic/chat/rooms/";
+    private static final String CHAT_ROOM_DESTINATION_SUFFIX = "/messages";
+
+    private final BroadcastPort broadcastPort;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ChatMessageCreatedEvent event) {
+        String destination = CHAT_ROOM_DESTINATION_PREFIX + event.roomId() + CHAT_ROOM_DESTINATION_SUFFIX;
+        ChatMessageResponse payload = ChatMessageResponse.from(event);
+
+        try {
+            broadcastPort.broadcast(destination, payload);
+        } catch (Exception e) {
+            log.error("채팅 메시지 broadcast 실패: messageId={}, roomId={}, destination={}",
+                event.messageId(), event.roomId(), destination, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
+++ b/src/main/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListener.java
@@ -1,50 +1,56 @@
 package com.umc.product.chat.adapter.in.event;
 
-import org.springframework.stereotype.Component;
-import org.springframework.context.event.EventListener;
-
-import com.umc.product.chat.adapter.in.web.dto.response.ChatMessageResponse;
+import com.umc.product.chat.application.port.in.command.BroadcastChatMessageUseCase;
 import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
-import com.umc.product.global.websocket.application.port.out.BroadcastPort;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * 채팅 메시지 생성 이벤트를 수신하여 구독자에게 실시간 broadcast 한다.
  * <p>
- * 트랜잭션 커밋 직후(AFTER_COMMIT) 동기로 실행한다. broadcast 실패 시 예외를 삼키지 않고 다시 던져,
- * outbox relay 가 해당 이벤트를 markPublished 하지 못하고 폴러가 재처리(재broadcast)하도록 한다.
- * (at-least-once. 클라이언트는 messageId 로 중복을 제거한다.)
+ * <b>실행 시점</b><br>
+ * {@code @TransactionalEventListener(AFTER_COMMIT)} 을 사용하므로, 이벤트를 발행한 트랜잭션이 커밋된
+ * 직후에 동기로 실행된다. 이는 아래 두 가지 문제를 방지한다.
+ * <ul>
+ *     <li>유령 broadcast 방지: 커밋 전 broadcast 시 트랜잭션 롤백이 발생하면 DB 에 없는 메시지를
+ *         클라이언트가 수신하게 된다. AFTER_COMMIT 은 커밋이 확정된 이후에만 broadcast 를 수행한다.</li>
+ *     <li>지속성·브로커 결합 방지: broadcast 예외가 메시지 저장 트랜잭션을 롤백시키지 않는다.
+ *         이미 커밋된 이후이므로 broadcast 실패는 저장에 영향을 주지 않으며, 예외는 삼키고 로그만 남긴다.</li>
+ * </ul>
  * <p>
- * destination 경로 조립은 이 리스너의 책임이며, {@link BroadcastPort} 는 전달받은 destination 으로 그대로
- * 전송하기만 한다(브로커 교체 대비 디커플링). 특정 STOMP 구현({@code StompBroadcastAdapter})이 아니라
- * 포트 인터페이스에만 의존한다.
+ * <b>트랜잭션 컨텍스트</b><br>
+ * {@code @TransactionalEventListener} 는 활성 트랜잭션이 없으면 기본적으로 실행되지 않아 이벤트가
+ * 조용히 유실된다. 현재 이 이벤트는 {@code ChatMessageCommandService.send()} 에서만 발행되며,
+ * 해당 메서드는 클래스 레벨 {@code @Transactional} 로 항상 활성 트랜잭션 컨텍스트에서 실행되므로
+ * 유실 위험이 없다.
  * <p>
- * TODO: 처리량 부하가 확인되면 {@code @Async} 비동기 처리를 검토한다. 현재는 폴러 재처리 흐름을 단순하게 유지하기
- *  위해 동기로 둔다.
+ * <b>outbox on 전환 시 재검토 필요</b><br>
+ * 현재 prod 설정은 {@code EVENT_OUTBOX_ENABLED=false} (outbox off) 기준이다.
+ * outbox on 으로 전환할 경우, {@code EventOutboxRelayService} 가 {@code REQUIRES_NEW} 트랜잭션
+ * 안에서 이벤트를 재발행하므로 이 리스너는 relay 트랜잭션 커밋 후 실행된다. 해당 흐름에서
+ * {@code @TransactionalEventListener(AFTER_COMMIT)} 이 의도대로 동작하는지 재검토할 것.
+ * <p>
+ * TODO: 처리량 부하가 확인되면 {@code @Async} 비동기 처리를 검토한다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatMessageBroadcastListener {
 
-    private static final String CHAT_ROOM_DESTINATION_PREFIX = "/topic/chat/rooms/";
-    private static final String CHAT_ROOM_DESTINATION_SUFFIX = "/messages";
+    private final BroadcastChatMessageUseCase broadcastChatMessageUseCase;
 
-    private final BroadcastPort broadcastPort;
-
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ChatMessageCreatedEvent event) {
-        String destination = CHAT_ROOM_DESTINATION_PREFIX + event.roomId() + CHAT_ROOM_DESTINATION_SUFFIX;
-        ChatMessageResponse payload = ChatMessageResponse.from(event);
-
         try {
-            broadcastPort.broadcast(destination, payload);
+            broadcastChatMessageUseCase.broadcast(event);
         } catch (Exception e) {
-            log.error("채팅 메시지 broadcast 실패: messageId={}, roomId={}, destination={}",
-                event.messageId(), event.roomId(), destination, e);
-            throw e;
+            // broadcast 실패는 이미 커밋된 저장에 영향을 주지 않는다.
+            // 예외를 삼키고 로그만 남겨 broker 가용성이 영속성에 결합되지 않도록 한다.
+            log.error("채팅 메시지 broadcast 실패: messageId={}, roomId={}",
+                event.messageId(), event.roomId(), e);
         }
     }
 }

--- a/src/main/java/com/umc/product/chat/adapter/in/web/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/umc/product/chat/adapter/in/web/dto/response/ChatMessageResponse.java
@@ -2,6 +2,7 @@ package com.umc.product.chat.adapter.in.web.dto.response;
 
 import com.umc.product.chat.application.port.in.query.dto.ChatMessageInfo;
 import com.umc.product.chat.domain.MessageContentType;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
 import java.time.Instant;
 import java.util.List;
 
@@ -23,6 +24,18 @@ public record ChatMessageResponse(
             info.content(),
             info.fileMetadataIds(),
             info.createdAt()
+        );
+    }
+
+    public static ChatMessageResponse from(ChatMessageCreatedEvent event) {
+        return new ChatMessageResponse(
+            event.messageId(),
+            event.roomId(),
+            event.senderMemberId(),
+            event.contentType(),
+            event.content(),
+            event.fileMetadataIds(),
+            event.occurredAt()
         );
     }
 }

--- a/src/main/java/com/umc/product/chat/application/port/in/command/BroadcastChatMessageUseCase.java
+++ b/src/main/java/com/umc/product/chat/application/port/in/command/BroadcastChatMessageUseCase.java
@@ -1,0 +1,16 @@
+package com.umc.product.chat.application.port.in.command;
+
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+
+/**
+ * 채팅 메시지 생성 이벤트를 구독자에게 실시간 broadcast 하는 인바운드 포트.
+ */
+public interface BroadcastChatMessageUseCase {
+
+    /**
+     * 채팅 메시지 생성 이벤트를 수신하여 해당 채팅방 구독자들에게 broadcast 한다.
+     *
+     * @param event 생성된 채팅 메시지의 이벤트 데이터
+     */
+    void broadcast(ChatMessageCreatedEvent event);
+}

--- a/src/main/java/com/umc/product/chat/application/port/in/command/dto/BroadcastChatMessagePayload.java
+++ b/src/main/java/com/umc/product/chat/application/port/in/command/dto/BroadcastChatMessagePayload.java
@@ -1,0 +1,35 @@
+package com.umc.product.chat.application.port.in.command.dto;
+
+import com.umc.product.chat.domain.MessageContentType;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 채팅 메시지 broadcast 전용 payload.
+ * <p>
+ * query 조회 모델({@code ChatMessageInfo})과 broadcast payload 의 결합을 끊기 위해 분리한 타입이다.
+ * 클라이언트가 수신하는 JSON 필드 구조는 기존과 동일하다.
+ */
+public record BroadcastChatMessagePayload(
+    Long messageId,
+    Long roomId,
+    Long senderMemberId,
+    MessageContentType contentType,
+    String content,
+    List<String> fileMetadataIds,
+    Instant createdAt
+) {
+
+    public static BroadcastChatMessagePayload from(ChatMessageCreatedEvent event) {
+        return new BroadcastChatMessagePayload(
+            event.messageId(),
+            event.roomId(),
+            event.senderMemberId(),
+            event.contentType(),
+            event.content(),
+            event.fileMetadataIds(),
+            event.occurredAt()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/chat/application/service/command/BroadcastChatMessageService.java
+++ b/src/main/java/com/umc/product/chat/application/service/command/BroadcastChatMessageService.java
@@ -1,7 +1,7 @@
 package com.umc.product.chat.application.service.command;
 
 import com.umc.product.chat.application.port.in.command.BroadcastChatMessageUseCase;
-import com.umc.product.chat.application.port.in.query.dto.ChatMessageInfo;
+import com.umc.product.chat.application.port.in.command.dto.BroadcastChatMessagePayload;
 import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
 import com.umc.product.global.websocket.application.port.out.BroadcastPort;
 import lombok.RequiredArgsConstructor;
@@ -28,15 +28,7 @@ public class BroadcastChatMessageService implements BroadcastChatMessageUseCase 
     public void broadcast(ChatMessageCreatedEvent event) {
         String destination = CHAT_ROOM_DESTINATION_PREFIX + event.roomId() + CHAT_ROOM_DESTINATION_SUFFIX;
 
-        ChatMessageInfo payload = new ChatMessageInfo(
-            event.messageId(),
-            event.roomId(),
-            event.senderMemberId(),
-            event.contentType(),
-            event.content(),
-            event.fileMetadataIds(),
-            event.occurredAt()
-        );
+        BroadcastChatMessagePayload payload = BroadcastChatMessagePayload.from(event);
 
         log.debug("채팅 메시지 broadcast: messageId={}, destination={}", event.messageId(), destination);
         broadcastPort.broadcast(destination, payload);

--- a/src/main/java/com/umc/product/chat/application/service/command/BroadcastChatMessageService.java
+++ b/src/main/java/com/umc/product/chat/application/service/command/BroadcastChatMessageService.java
@@ -1,0 +1,44 @@
+package com.umc.product.chat.application.service.command;
+
+import com.umc.product.chat.application.port.in.command.BroadcastChatMessageUseCase;
+import com.umc.product.chat.application.port.in.query.dto.ChatMessageInfo;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+import com.umc.product.global.websocket.application.port.out.BroadcastPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 채팅 메시지 생성 이벤트를 수신하여 WebSocket broadcast 를 수행하는 커맨드 서비스.
+ * <p>
+ * destination 경로 조립은 이 서비스의 책임이며, {@link BroadcastPort} 는 전달받은 destination 으로
+ * 그대로 전송하기만 한다(브로커 교체 대비 디커플링).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BroadcastChatMessageService implements BroadcastChatMessageUseCase {
+
+    private static final String CHAT_ROOM_DESTINATION_PREFIX = "/topic/chat/rooms/";
+    private static final String CHAT_ROOM_DESTINATION_SUFFIX = "/messages";
+
+    private final BroadcastPort broadcastPort;
+
+    @Override
+    public void broadcast(ChatMessageCreatedEvent event) {
+        String destination = CHAT_ROOM_DESTINATION_PREFIX + event.roomId() + CHAT_ROOM_DESTINATION_SUFFIX;
+
+        ChatMessageInfo payload = new ChatMessageInfo(
+            event.messageId(),
+            event.roomId(),
+            event.senderMemberId(),
+            event.contentType(),
+            event.content(),
+            event.fileMetadataIds(),
+            event.occurredAt()
+        );
+
+        log.debug("채팅 메시지 broadcast: messageId={}, destination={}", event.messageId(), destination);
+        broadcastPort.broadcast(destination, payload);
+    }
+}

--- a/src/main/java/com/umc/product/global/websocket/adapter/out/StompBroadcastAdapter.java
+++ b/src/main/java/com/umc/product/global/websocket/adapter/out/StompBroadcastAdapter.java
@@ -1,0 +1,29 @@
+package com.umc.product.global.websocket.adapter.out;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.global.websocket.application.port.out.BroadcastPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * STOMP 메시지 브로커를 사용한 {@link BroadcastPort} 구현 어댑터.
+ * <p>
+ * 전달받은 destination 을 가공하지 않고 그대로 {@link SimpMessagingTemplate#convertAndSend(Object, Object)}
+ * 로 전송한다. 경로 규칙은 호출자가 책임진다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompBroadcastAdapter implements BroadcastPort {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Override
+    public void broadcast(String destination, Object payload) {
+        log.debug("STOMP broadcast: destination={}", destination);
+        messagingTemplate.convertAndSend(destination, payload);
+    }
+}

--- a/src/main/java/com/umc/product/global/websocket/application/port/out/BroadcastPort.java
+++ b/src/main/java/com/umc/product/global/websocket/application/port/out/BroadcastPort.java
@@ -1,0 +1,21 @@
+package com.umc.product.global.websocket.application.port.out;
+
+/**
+ * 구독자에게 메시지를 브로드캐스트하기 위한 Port Out.
+ * <p>
+ * 특정 도메인(inquiry, chat 등)에 의존하지 않는 범용 인터페이스다. destination 경로 규칙(예:
+ * {@code /topic/inquiry/{id}})의 조립 책임은 호출자에게 있으며, 본 포트는 전달받은 destination 으로 payload 를
+ * 그대로 전송하기만 한다. 이렇게 함으로써 어떤 도메인이든 동일한 포트를 재사용할 수 있다.
+ * <p>
+ * 실제 전송 메커니즘(STOMP simple broker, 외부 broker relay 등)은 어댑터 구현체가 담당한다.
+ */
+public interface BroadcastPort {
+
+    /**
+     * 지정한 destination 을 구독 중인 클라이언트들에게 payload 를 전송한다.
+     *
+     * @param destination 메시지를 전달할 목적지 경로(예: {@code /topic/inquiry/1}). 호출자가 완성된 경로를 넘긴다.
+     * @param payload     전송할 임의의 객체. messageId 등 식별자를 포함할 수 있으나 타입을 강제하지 않는다.
+     */
+    void broadcast(String destination, Object payload);
+}

--- a/src/test/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListenerTest.java
+++ b/src/test/java/com/umc/product/chat/adapter/in/event/ChatMessageBroadcastListenerTest.java
@@ -1,0 +1,93 @@
+package com.umc.product.chat.adapter.in.event;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.umc.product.chat.application.port.in.command.BroadcastChatMessageUseCase;
+import com.umc.product.chat.domain.MessageContentType;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link ChatMessageBroadcastListener} 단위 테스트.
+ *
+ * <h3>예외 삼킴과 outbox retry의 관계</h3>
+ *
+ * <p><b>outbox off (현재 prod 기본값):</b><br>
+ * {@code ChatMessageCommandService.send()} 트랜잭션 커밋 후 이 리스너가 동기로 실행된다.
+ * broadcast 예외를 삼키므로 저장 결과에 영향 없다.
+ *
+ * <p><b>outbox on 전환 시:</b><br>
+ * {@code EventOutboxRelayService.publish()}가 {@code PROPAGATION_REQUIRES_NEW} 트랜잭션 안에서
+ * {@code ApplicationEventPublisher.publishEvent()}를 호출한다. 이 리스너는
+ * {@code @TransactionalEventListener(AFTER_COMMIT)}이므로 relay 트랜잭션이
+ * 커밋된 직후에 실행된다.
+ *
+ * <p>즉, 리스너 실행 시점에 {@code relayOne()}의 try-catch 범위는 이미 종료된 상태다.
+ * broadcast 예외가 outbox retry를 유발하지 않는 이유는 <b>예외 삼킴</b> 때문이 아니라,
+ * {@code AFTER_COMMIT}으로 인해 relay 트랜잭션 종료 후에 실행되어 {@code relayOne()}의
+ * catch 블록 자체에 도달하지 않기 때문이다.
+ *
+ * <p>따라서 이 리스너에서 예외를 삼키지 않더라도 outbox retry 조건에는 영향이 없다.
+ * 예외 삼킴의 실제 목적은 브로커 장애가 HTTP 응답(혹은 스케줄러 실행) 흐름을 중단시키지
+ * 않도록 격리하는 데 있다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessageBroadcastListener")
+class ChatMessageBroadcastListenerTest {
+
+    @Mock
+    BroadcastChatMessageUseCase broadcastChatMessageUseCase;
+
+    @InjectMocks
+    ChatMessageBroadcastListener sut;
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 BroadcastChatMessageUseCase에 위임한다")
+    void handle_정상_이벤트_수신_시_UseCase에_위임한다() {
+        // given
+        ChatMessageCreatedEvent event = sampleEvent();
+
+        // when
+        sut.handle(event);
+
+        // then
+        then(broadcastChatMessageUseCase).should().broadcast(event);
+    }
+
+    @Test
+    @DisplayName("브로드캐스트 UseCase에서 예외가 발생해도 예외를 삼키고 상위로 전파하지 않는다")
+    void handle_UseCase_예외_발생_시_예외를_삼키고_상위로_전파하지_않는다() {
+        // given
+        ChatMessageCreatedEvent event = sampleEvent();
+        willThrow(new RuntimeException("STOMP 브로커 연결 실패"))
+            .given(broadcastChatMessageUseCase).broadcast(event);
+
+        // when & then
+        // broadcast 실패는 이미 커밋된 저장에 영향을 주지 않아야 한다.
+        // AFTER_COMMIT 실행 구조상 이 예외는 relay 트랜잭션의 retry 조건과도 무관하다.
+        assertThatNoException().isThrownBy(() -> sut.handle(event));
+    }
+
+    private ChatMessageCreatedEvent sampleEvent() {
+        return new ChatMessageCreatedEvent(
+            UUID.randomUUID(),
+            Instant.parse("2026-07-03T07:00:00Z"),
+            100L,
+            10L,
+            5L,
+            MessageContentType.TEXT,
+            "안녕하세요",
+            List.of()
+        );
+    }
+}

--- a/src/test/java/com/umc/product/chat/application/service/command/BroadcastChatMessageServiceTest.java
+++ b/src/test/java/com/umc/product/chat/application/service/command/BroadcastChatMessageServiceTest.java
@@ -1,0 +1,133 @@
+package com.umc.product.chat.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+
+import com.umc.product.chat.application.port.in.command.dto.BroadcastChatMessagePayload;
+import com.umc.product.chat.domain.MessageContentType;
+import com.umc.product.chat.domain.event.ChatMessageCreatedEvent;
+import com.umc.product.global.websocket.application.port.out.BroadcastPort;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BroadcastChatMessageService")
+class BroadcastChatMessageServiceTest {
+
+    @Mock
+    BroadcastPort broadcastPort;
+
+    @InjectMocks
+    BroadcastChatMessageService sut;
+
+    @Test
+    @DisplayName("채팅 메시지 생성 이벤트를 수신하여 올바른 destination 경로로 브로드캐스트한다")
+    void broadcast_올바른_destination_경로_조립() {
+        // given
+        ChatMessageCreatedEvent event = new ChatMessageCreatedEvent(
+            UUID.randomUUID(),
+            Instant.parse("2026-07-03T07:00:00Z"),
+            100L,
+            10L,
+            5L,
+            MessageContentType.TEXT,
+            "안녕하세요",
+            List.of()
+        );
+
+        // when
+        sut.broadcast(event);
+
+        // then
+        ArgumentCaptor<String> destinationCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<BroadcastChatMessagePayload> payloadCaptor = ArgumentCaptor.forClass(BroadcastChatMessagePayload.class);
+        then(broadcastPort).should().broadcast(destinationCaptor.capture(), payloadCaptor.capture());
+
+        // destination 검증: /topic/chat/rooms/{roomId}/messages
+        assertThat(destinationCaptor.getValue()).isEqualTo("/topic/chat/rooms/10/messages");
+
+        // payload 검증: 이벤트 필드가 정확히 변환되었는지 확인
+        BroadcastChatMessagePayload payload = payloadCaptor.getValue();
+        assertThat(payload.messageId()).isEqualTo(100L);
+        assertThat(payload.roomId()).isEqualTo(10L);
+        assertThat(payload.senderMemberId()).isEqualTo(5L);
+        assertThat(payload.contentType()).isEqualTo(MessageContentType.TEXT);
+        assertThat(payload.content()).isEqualTo("안녕하세요");
+        assertThat(payload.fileMetadataIds()).isEmpty();
+        assertThat(payload.createdAt()).isEqualTo(Instant.parse("2026-07-03T07:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("파일 첨부가 있는 메시지도 올바르게 변환하여 브로드캐스트한다")
+    void broadcast_파일_첨부_메시지() {
+        // given
+        ChatMessageCreatedEvent event = new ChatMessageCreatedEvent(
+            UUID.randomUUID(),
+            Instant.parse("2026-07-03T08:00:00Z"),
+            200L,
+            20L,
+            15L,
+            MessageContentType.IMAGE,
+            "이미지 캡션",
+            List.of("file-1", "file-2")
+        );
+
+        // when
+        sut.broadcast(event);
+
+        // then
+        ArgumentCaptor<BroadcastChatMessagePayload> payloadCaptor = ArgumentCaptor.forClass(BroadcastChatMessagePayload.class);
+        then(broadcastPort).should().broadcast(eq("/topic/chat/rooms/20/messages"), payloadCaptor.capture());
+
+        BroadcastChatMessagePayload payload = payloadCaptor.getValue();
+        assertThat(payload.messageId()).isEqualTo(200L);
+        assertThat(payload.contentType()).isEqualTo(MessageContentType.IMAGE);
+        assertThat(payload.content()).isEqualTo("이미지 캡션");
+        assertThat(payload.fileMetadataIds()).containsExactly("file-1", "file-2");
+    }
+
+    @Test
+    @DisplayName("roomId가 다른 방은 서로 다른 destination 경로를 사용한다")
+    void broadcast_roomId별_독립_destination() {
+        // given
+        ChatMessageCreatedEvent event1 = new ChatMessageCreatedEvent(
+            UUID.randomUUID(),
+            Instant.now(),
+            1L,
+            100L,
+            1L,
+            MessageContentType.TEXT,
+            "방 100",
+            List.of()
+        );
+
+        ChatMessageCreatedEvent event2 = new ChatMessageCreatedEvent(
+            UUID.randomUUID(),
+            Instant.now(),
+            2L,
+            200L,
+            1L,
+            MessageContentType.TEXT,
+            "방 200",
+            List.of()
+        );
+
+        // when
+        sut.broadcast(event1);
+        sut.broadcast(event2);
+
+        // then
+        then(broadcastPort).should().broadcast(eq("/topic/chat/rooms/100/messages"), any());
+        then(broadcastPort).should().broadcast(eq("/topic/chat/rooms/200/messages"), any());
+    }
+}

--- a/src/test/java/com/umc/product/global/websocket/adapter/out/StompBroadcastAdapterTest.java
+++ b/src/test/java/com/umc/product/global/websocket/adapter/out/StompBroadcastAdapterTest.java
@@ -1,0 +1,86 @@
+package com.umc.product.global.websocket.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.umc.product.chat.application.port.in.command.dto.BroadcastChatMessagePayload;
+import com.umc.product.chat.domain.MessageContentType;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+/**
+ * {@link StompBroadcastAdapter} 단위 테스트.
+ *
+ * <h3>예외 전파 책임 분리</h3>
+ *
+ * <p>이 어댑터는 {@link SimpMessagingTemplate}의 예외를 삼키지 않고 그대로 전파한다.
+ * 예외 삼킴 책임은 호출 계층인 {@code ChatMessageBroadcastListener}에 있으며,
+ * 어댑터가 삼기면 브로커 장애를 상위에서 인지할 수단이 사라진다.
+ *
+ * <p>destination 경로 조립은 호출자({@code BroadcastChatMessageService})의 책임이며,
+ * 이 어댑터는 전달받은 destination을 가공 없이 그대로 전송한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StompBroadcastAdapter")
+class StompBroadcastAdapterTest {
+
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    StompBroadcastAdapter sut;
+
+    @Test
+    @DisplayName("전달받은 destination을 가공하지 않고 그대로 전송한다")
+    void broadcast_destination을_가공하지_않고_그대로_전송한다() {
+        // given
+        String destination = "/topic/chat/rooms/10/messages";
+        BroadcastChatMessagePayload payload = new BroadcastChatMessagePayload(
+            100L, 10L, 5L,
+            MessageContentType.TEXT,
+            "안녕하세요",
+            List.of(),
+            Instant.parse("2026-07-03T07:00:00Z")
+        );
+
+        // when
+        sut.broadcast(destination, payload);
+
+        // then
+        // 경로 조립은 호출자 책임이므로 어댑터는 인자를 그대로 전달해야 한다
+        then(messagingTemplate).should().convertAndSend(destination, payload);
+        then(messagingTemplate).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("브로커 예외 발생 시 예외를 삼키지 않고 그대로 전파한다")
+    void broadcast_브로커_예외_발생_시_예외를_삼키지_않고_그대로_전파한다() {
+        // given
+        String destination = "/topic/chat/rooms/10/messages";
+        BroadcastChatMessagePayload payload = new BroadcastChatMessagePayload(
+            100L, 10L, 5L,
+            MessageContentType.TEXT,
+            "안녕하세요",
+            List.of(),
+            Instant.parse("2026-07-03T07:00:00Z")
+        );
+        willThrow(new MessagingException("브로커 연결 실패"))
+            .given(messagingTemplate).convertAndSend(destination, payload);
+
+        // when & then
+        // 예외 삼킴 책임은 ChatMessageBroadcastListener에 있다.
+        // 이 어댑터가 삼키면 브로커 장애를 상위에서 인지할 수단이 사라진다.
+        assertThatThrownBy(() -> sut.broadcast(destination, payload))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("브로커 연결 실패");
+    }
+}


### PR DESCRIPTION
<!--

✅ PR 올리기 전 체크리스트

1. PR의 base branch가 develop으로 설정되어 있는지 확인해주세요. (release의 경우에만 main)
2. PR 제목을 적절하게 작성했는지 검토해주세요. 적절한 태그를 사용했는지, PR 제목만 보고도 어떤 내용인지 알 수 있는지 다시 한 번 확인해주세요.
3. 연관된 이슈가 있다면 closes, resolves, fixes, related to와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.
4. 주석 처리된 내용은 웬만하면 제거하고 올려주세요.

-->

## 🚀 작업 내용
채팅 메시지가 생성되면 해당 채팅방 구독자에게 WebSocket(STOMP)으로 실시간
broadcast 하는 아웃바운드 인프라를 구현

- `BroadcastPort` (port/out)
도메인 비의존 범용 전송 인터페이스. destination 조립 책임은 호출자에 두고, 포트는 받은 destination 으로 전송만 합니다.

- `StompBroadcastAdapter` (adapter/out)
 `SimpMessagingTemplate` 기반 구현체. 전달받은 destination 을 가공 없이 `convertAndSend` 합니다. 

- `ChatMessageBroadcastListener`
`ChatMessageCreatedEvent` 를 `AFTER_COMMIT` 시점에 수신 `/topic/chat/rooms/{roomId}/messages` 로 broadcast 합니다.
  broadcast 실패 시 예외를 전파하여 outbox relay 가 재처리합니다.

- `ChatMessageResponse.from(ChatMessageCreatedEvent)`
이벤트를 응답 DTO 로 변환하는 팩토리 추가. (기존 `from(ChatMessageInfo)` 는 유지)

## 💬 리뷰 중점사항

<!--

수정사항과 관련된 담당자 및 랜덤으로 한 명의 리뷰어를 지정해주세요.
혹시 리뷰어가 신경써서 볼 부분이 있다면, 이 공간을 이용해서 명시해주세요.

-->
