### PR TITLE
[Feat] 프로젝트 멤버 삭제 API를 hard delete와 soft delete로 구분

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -17,6 +17,7 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.AddProjectMemberRequest;
+import com.umc.product.project.adapter.in.web.dto.request.ChangeProjectMemberStatusRequest;
 import com.umc.product.project.adapter.in.web.dto.request.CreateDraftProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.TransferProjectOwnershipRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdatePartQuotasRequest;
@@ -24,6 +25,7 @@ import com.umc.product.project.adapter.in.web.dto.request.UpdateProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.response.ProjectStatusResponse;
 import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
 import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.ChangeProjectMemberStatusUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
@@ -55,6 +57,7 @@ public class ProjectCommandController {
     private final TransferProjectOwnershipUseCase transferProjectOwnershipUseCase;
     private final AddProjectMemberUseCase addProjectMemberUseCase;
     private final RemoveProjectMemberUseCase removeProjectMemberUseCase;
+    private final ChangeProjectMemberStatusUseCase changeProjectMemberStatusUseCase;
     private final UpdatePartQuotasUseCase updatePartQuotasUseCase;
     private final PublishProjectUseCase publishProjectUseCase;
     private final DeleteProjectUseCase deleteProjectUseCase;
@@ -254,8 +257,14 @@ public class ProjectCommandController {
     @DeleteMapping("/{projectId}/members/{memberId}")
     @Operation(
         operationId = "PROJECT-005",
-        summary = "프로젝트 팀원 제거",
-        description = "프로젝트에서 멤버를 제거합니다. DRAFT/PENDING_REVIEW 단계는 hard delete (실수 정정), IN_PROGRESS 단계는 soft delete (히스토리 보존). 메인 PM 은 양도 API 로 변경해야 합니다."
+        summary = "프로젝트 팀원 제거 (hard delete)",
+        description = """
+            프로젝트에서 멤버 행을 완전히 삭제합니다. 동일 멤버를 같은 프로젝트에 재등록할 수 있습니다.
+            DRAFT/PENDING_REVIEW/IN_PROGRESS 프로젝트 단계에서만 가능하며, 종료(COMPLETED/ABORTED) 프로젝트는 이력 보존을 위해 거부됩니다.
+            상태 변경 히스토리를 남겨야 하면 [PROJECT-006] API 를 사용하세요.
+            메인 PM 은 양도 API 로 변경해야 합니다.
+            reason 은 DB 에는 남지 않고 감사 로그로만 기록됩니다.
+            """
     )
     @CheckAccess(
         resourceType = ResourceType.PROJECT,
@@ -275,5 +284,31 @@ public class ProjectCommandController {
             .reason(reason)
             .requesterMemberId(memberPrincipal.getMemberId())
             .build());
+    }
+
+    @PatchMapping("/{projectId}/members/{memberId}/status")
+    @Operation(
+        operationId = "PROJECT-006",
+        summary = "프로젝트 팀원 상태 변경 (soft delete)",
+        description = """
+            멤버 행을 보존한 채 status 를 변경합니다(COMPLETED/WITHDRAWN/DISMISSED 등).
+            변경 사유(reason)는 필수입니다.
+            종료(COMPLETED/ABORTED) 프로젝트와 메인 PM 은 거부됩니다. 동일 멤버 재등록이 필요하면 hard delete(DELETE) 를 사용하세요.
+            """
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        resourceId = "#projectId",
+        permission = PermissionType.EDIT,
+        message = "프로젝트 팀원 상태를 변경할 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
+    )
+    public void changeMemberStatus(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable Long projectId,
+        @PathVariable Long memberId,
+        @Valid @RequestBody ChangeProjectMemberStatusRequest request
+    ) {
+        changeProjectMemberStatusUseCase.changeStatus(
+            request.toCommand(projectId, memberId, memberPrincipal.getMemberId()));
     }
 }

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/ChangeProjectMemberStatusRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/ChangeProjectMemberStatusRequest.java
@@ -1,0 +1,30 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import com.umc.product.project.application.port.in.command.dto.ChangeProjectMemberStatusCommand;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * PROJECT-006 요청 (멤버 상태 변경, soft delete).
+ * <p>
+ * 변경할 {@code status} 와 사유를 함께 전달한다. {@code reason} 은 행의
+ * {@code status_change_reason} 컬럼에 영속화되는 정식 변경 이력이므로 필수.
+ */
+public record ChangeProjectMemberStatusRequest(
+    @NotNull(message = "status 는 필수입니다") ProjectMemberStatus status,
+
+    @NotBlank(message = "reason 은 필수입니다") @Size(max = 255) String reason
+) {
+    public ChangeProjectMemberStatusCommand toCommand(Long projectId, Long memberId, Long requesterMemberId) {
+        return ChangeProjectMemberStatusCommand.builder()
+            .projectId(projectId)
+            .memberId(memberId)
+            .status(status)
+            .reason(reason)
+            .requesterMemberId(requesterMemberId)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/project/adapter/out/persistence/ProjectMemberPersistenceAdapter.java
@@ -15,6 +15,8 @@ import com.umc.product.project.application.port.out.SaveProjectMemberPort;
 import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.enums.MatchingType;
 import com.umc.product.project.domain.enums.ProjectMemberStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -91,6 +93,12 @@ public class ProjectMemberPersistenceAdapter implements LoadProjectMemberPort, S
     @Override
     public Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId) {
         return repository.findByProjectIdAndMemberId(projectId, memberId);
+    }
+
+    @Override
+    public ProjectMember getByProjectIdAndMemberId(Long projectId, Long memberId) {
+        return repository.findByProjectIdAndMemberId(projectId, memberId)
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/umc/product/project/application/port/in/command/ChangeProjectMemberStatusUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/ChangeProjectMemberStatusUseCase.java
@@ -1,0 +1,14 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.ChangeProjectMemberStatusCommand;
+
+/**
+ * 프로젝트 멤버 상태 변경 UseCase (PROJECT-006, soft delete).
+ * <p>
+ * 멤버 행을 보존한 채 {@code status} 만 변경(COMPLETED/WITHDRAWN/DISMISSED 등)하고 사유·주체를 기록한다.
+ * 행 자체를 지워 재등록을 허용해야 하면 {@link RemoveProjectMemberUseCase}(PROJECT-005, hard delete) 를 사용한다.
+ */
+public interface ChangeProjectMemberStatusUseCase {
+
+    void changeStatus(ChangeProjectMemberStatusCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/RemoveProjectMemberUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/RemoveProjectMemberUseCase.java
@@ -3,7 +3,10 @@ package com.umc.product.project.application.port.in.command;
 import com.umc.product.project.application.port.in.command.dto.RemoveProjectMemberCommand;
 
 /**
- * 프로젝트 멤버 제거 UseCase (PROJECT-005).
+ * 프로젝트 멤버 hard delete UseCase (PROJECT-005).
+ * <p>
+ * 멤버 행을 물리적으로 삭제해 동일 멤버의 재등록을 가능하게 한다. 상태 이력 보존이 필요하면
+ * {@link ChangeProjectMemberStatusUseCase}(PROJECT-006) 를 사용한다.
  */
 public interface RemoveProjectMemberUseCase {
 

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/ChangeProjectMemberStatusCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/ChangeProjectMemberStatusCommand.java
@@ -30,6 +30,9 @@ public record ChangeProjectMemberStatusCommand(
         Objects.requireNonNull(projectId, "projectId must not be null");
         Objects.requireNonNull(memberId, "memberId must not be null");
         Objects.requireNonNull(status, "status must not be null");
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason must not be null or blank");
+        }
         Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
     }
 }

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/ChangeProjectMemberStatusCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/ChangeProjectMemberStatusCommand.java
@@ -1,0 +1,35 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.Objects;
+
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
+
+import lombok.Builder;
+
+/**
+ * 프로젝트 멤버 상태 변경 Command (PROJECT-006, soft delete).
+ * <p>
+ * 행을 보존한 채 {@code status} 로 변경하고 {@code reason} 을 감사 이력으로 기록한다.
+ * 동일 멤버 재등록이 필요하면 hard delete API({@code PROJECT-005}) 를 사용한다.
+ * <p>
+ * 정책:
+ * <ul>
+ *   <li>메인 PM 상태 변경 거부 — 소유권 양도 API({@code PROJECT-104}) 로 유도</li>
+ *   <li>COMPLETED/ABORTED 프로젝트: 거부 — 종료된 프로젝트의 이력 고정</li>
+ * </ul>
+ */
+@Builder
+public record ChangeProjectMemberStatusCommand(
+    Long projectId,
+    Long memberId,
+    ProjectMemberStatus status,
+    String reason,
+    Long requesterMemberId
+) {
+    public ChangeProjectMemberStatusCommand {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(memberId, "memberId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/RemoveProjectMemberCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/RemoveProjectMemberCommand.java
@@ -1,18 +1,22 @@
 package com.umc.product.project.application.port.in.command.dto;
 
 import java.util.Objects;
+
 import lombok.Builder;
 
 /**
- * 프로젝트 멤버 제거 Command (PROJECT-005).
+ * 프로젝트 멤버 hard delete Command (PROJECT-005).
+ * <p>
+ * 행을 DB 에서 완전히 삭제하여 동일 멤버의 재등록을 가능하게 합니다. 히스토리 보존이 필요한 경우
+ * 상태 변경(soft delete) API({@code PROJECT-006}) 를 사용합니다.
  * <p>
  * 정책:
  * <ul>
  *   <li>메인 PM 제거 거부 — 소유권 양도 API({@code PROJECT-104}) 로 유도</li>
- *   <li>DRAFT/PENDING_REVIEW: hard delete (실수 정정)</li>
- *   <li>IN_PROGRESS: soft delete (status = DISMISSED, 매칭/출석 등 외부 도메인 무결성)</li>
- *   <li>COMPLETED/ABORTED: 거부 (도메인 가드)</li>
+ *   <li>DRAFT/PENDING_REVIEW/IN_PROGRESS: hard delete</li>
+ *   <li>COMPLETED/ABORTED: 거부 — 종료된 프로젝트의 참여 이력 보존</li>
  * </ul>
+ * {@code reason} 은 행과 함께 삭제되므로 DB 에는 남지 않으며, 삭제 직전 감사 로그로만 기록됩니다.
  */
 @Builder
 public record RemoveProjectMemberCommand(

--- a/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
+++ b/src/main/java/com/umc/product/project/application/port/out/LoadProjectMemberPort.java
@@ -59,6 +59,11 @@ public interface LoadProjectMemberPort {
     Optional<ProjectMember> findByProjectIdAndMemberId(Long projectId, Long memberId);
 
     /**
+     * 특정 프로젝트의 특정 멤버를 status 무관 단건 조회합니다. 존재하지 않으면 도메인 예외를 던집니다.
+     */
+    ProjectMember getByProjectIdAndMemberId(Long projectId, Long memberId);
+
+    /**
      * 해당 기수에서 이미 ACTIVE 팀원인지 확인합니다. (중복 지원 방지용)
      */
     boolean existsByGisuAndMember(Long gisuId, Long memberId);

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMemberCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMemberCommandService.java
@@ -1,7 +1,5 @@
 package com.umc.product.project.application.service.command;
 
-import java.util.Objects;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,7 +59,7 @@ public class ProjectMemberCommandService
     public void remove(RemoveProjectMemberCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
 
-        if (Objects.equals(project.getProductOwnerMemberId(), command.memberId())) {
+        if (project.isOwner(command.memberId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER);
         }
 
@@ -69,8 +67,7 @@ public class ProjectMemberCommandService
         project.validateMutable();
 
         ProjectMember member = loadProjectMemberPort
-            .findByProjectIdAndMemberId(command.projectId(), command.memberId())
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
+            .getByProjectIdAndMemberId(command.projectId(), command.memberId());
 
         log.info(
             "[ProjectMember hardDelete] projectId={}, memberId={}, projectMemberId={}, requesterMemberId={}, reason={}",
@@ -91,15 +88,14 @@ public class ProjectMemberCommandService
     public void changeStatus(ChangeProjectMemberStatusCommand command) {
         Project project = loadProjectPort.getById(command.projectId());
 
-        if (Objects.equals(project.getProductOwnerMemberId(), command.memberId())) {
+        if (project.isOwner(command.memberId())) {
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER);
         }
 
         project.validateMutable();
 
         ProjectMember member = loadProjectMemberPort
-            .findByProjectIdAndMemberId(command.projectId(), command.memberId())
-            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
+            .getByProjectIdAndMemberId(command.projectId(), command.memberId());
 
         member.changeStatus(command.status(), command.requesterMemberId(), command.reason());
         saveProjectMemberPort.save(member);

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectMemberCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectMemberCommandService.java
@@ -1,8 +1,15 @@
 package com.umc.product.project.application.service.command;
 
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.ChangeProjectMemberStatusUseCase;
 import com.umc.product.project.application.port.in.command.RemoveProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.dto.AddProjectMemberCommand;
+import com.umc.product.project.application.port.in.command.dto.ChangeProjectMemberStatusCommand;
 import com.umc.product.project.application.port.in.command.dto.RemoveProjectMemberCommand;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
@@ -11,15 +18,16 @@ import com.umc.product.project.domain.Project;
 import com.umc.product.project.domain.ProjectMember;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.Objects;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ProjectMemberCommandService implements AddProjectMemberUseCase, RemoveProjectMemberUseCase {
+public class ProjectMemberCommandService
+    implements AddProjectMemberUseCase, RemoveProjectMemberUseCase, ChangeProjectMemberStatusUseCase {
 
     private final LoadProjectPort loadProjectPort;
     private final LoadProjectMemberPort loadProjectMemberPort;
@@ -41,13 +49,13 @@ public class ProjectMemberCommandService implements AddProjectMemberUseCase, Rem
     }
 
     /**
-     * 멤버 제거. status 에 따라 hard / soft delete 가 갈린다.
+     * 멤버 hard delete. 행을 물리적으로 삭제해 동일 멤버의 재등록을 허용한다.
      * <ul>
-     *   <li>DRAFT / PENDING_REVIEW: hard delete (실수 정정)</li>
-     *   <li>IN_PROGRESS: soft delete (status = DISMISSED, 매칭/출석 등 외부 도메인 무결성)</li>
-     *   <li>COMPLETED / ABORTED: 거부</li>
+     *   <li>DRAFT / PENDING_REVIEW / IN_PROGRESS: hard delete</li>
+     *   <li>COMPLETED / ABORTED: 거부 — 종료된 프로젝트의 참여 이력 보존</li>
      * </ul>
      * 메인 PM 은 양도 API 로 변경해야 하므로 본 메서드에서 거부한다.
+     * 행과 함께 사라지는 {@code reason} 은 삭제 직전 감사 로그로만 남긴다.
      */
     @Override
     public void remove(RemoveProjectMemberCommand command) {
@@ -57,18 +65,43 @@ public class ProjectMemberCommandService implements AddProjectMemberUseCase, Rem
             throw new ProjectDomainException(ProjectErrorCode.PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER);
         }
 
+        // COMPLETED / ABORTED 거부. 추후 ABORTED 만 허용하려면 이 가드를 COMPLETED 단독 검사로 교체한다.
+        project.validateMutable();
+
         ProjectMember member = loadProjectMemberPort
             .findByProjectIdAndMemberId(command.projectId(), command.memberId())
             .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
 
-        switch (project.getStatus()) {
-            case DRAFT, PENDING_REVIEW -> saveProjectMemberPort.hardDelete(member.getId());
-            case IN_PROGRESS -> {
-                member.dismiss(command.reason(), command.requesterMemberId());
-                saveProjectMemberPort.save(member);
-            }
-            case COMPLETED, ABORTED ->
-                throw new ProjectDomainException(ProjectErrorCode.PROJECT_INVALID_STATE);
+        log.info(
+            "[ProjectMember hardDelete] projectId={}, memberId={}, projectMemberId={}, requesterMemberId={}, reason={}",
+            command.projectId(), command.memberId(), member.getId(), command.requesterMemberId(), command.reason());
+
+        saveProjectMemberPort.hardDelete(member.getId());
+    }
+
+    /**
+     * 멤버 상태 변경 (soft delete). 행을 보존한 채 {@code status} 만 바꾸고 사유·주체를 기록한다.
+     * <ul>
+     *   <li>메인 PM: 거부 — 양도 API 로 유도</li>
+     *   <li>COMPLETED / ABORTED 프로젝트: 거부 — 종료된 프로젝트의 이력 고정</li>
+     * </ul>
+     * 재등록이 필요하면 hard delete API({@code PROJECT-005}) 를 사용한다.
+     */
+    @Override
+    public void changeStatus(ChangeProjectMemberStatusCommand command) {
+        Project project = loadProjectPort.getById(command.projectId());
+
+        if (Objects.equals(project.getProductOwnerMemberId(), command.memberId())) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER);
         }
+
+        project.validateMutable();
+
+        ProjectMember member = loadProjectMemberPort
+            .findByProjectIdAndMemberId(command.projectId(), command.memberId())
+            .orElseThrow(() -> new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
+
+        member.changeStatus(command.status(), command.requesterMemberId(), command.reason());
+        saveProjectMemberPort.save(member);
     }
 }

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -1,5 +1,7 @@
 package com.umc.product.project.domain;
 
+import java.util.Objects;
+
 import com.umc.product.common.BaseEntity;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
@@ -186,6 +188,13 @@ public class Project extends BaseEntity {
         this.productOwnerMemberId = newOwnerMemberId;
         this.productOwnerSchoolId = newOwnerSchoolId;
         this.chapterId = newChapterId;
+    }
+
+    /**
+     * 전달된 멤버가 프로젝트의 메인 PM인지 확인합니다.
+     */
+    public boolean isOwner(Long memberId) {
+        return Objects.equals(this.productOwnerMemberId, memberId);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -6,6 +6,7 @@ import com.umc.product.common.BaseEntity;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -121,14 +121,24 @@ public class ProjectMember extends BaseEntity {
     }
 
     /**
+     * 멤버의 상태를 변경합니다 (soft delete 포함).
+     * <p>
+     * status 를 {@code newStatus} 로 바꾸고 변경 사유·주체·시각 메타데이터를 함께 기록합니다.
+     * 행을 물리적으로 삭제하지 않으므로 히스토리가 보존됩니다.
+     */
+    public void changeStatus(ProjectMemberStatus newStatus, Long changedByMemberId, String reason) {
+        this.status = newStatus;
+        this.statusUpdatedAt = Instant.now();
+        this.statusChangeReason = reason;
+        this.statusChangedMemberId = changedByMemberId;
+    }
+
+    /**
      * 멤버를 강제 퇴출 처리합니다 (soft delete).
      * status 를 {@link ProjectMemberStatus#DISMISSED} 로 바꾸고 변경 메타데이터를 기록합니다.
      */
     public void dismiss(String reason, Long removedByMemberId) {
-        this.status = ProjectMemberStatus.DISMISSED;
-        this.statusUpdatedAt = Instant.now();
-        this.statusChangeReason = reason;
-        this.statusChangedMemberId = removedByMemberId;
+        changeStatus(ProjectMemberStatus.DISMISSED, removedByMemberId, reason);
     }
 
     /**
@@ -138,9 +148,6 @@ public class ProjectMember extends BaseEntity {
      * 프로젝트 중단(abort) 시 일괄 처리에도 동일 메서드를 사용하며, 사유에 명시합니다.
      */
     public void withdraw(String reason, Long decidedByMemberId) {
-        this.status = ProjectMemberStatus.WITHDRAWN;
-        this.statusUpdatedAt = Instant.now();
-        this.statusChangeReason = reason;
-        this.statusChangedMemberId = decidedByMemberId;
+        changeStatus(ProjectMemberStatus.WITHDRAWN, decidedByMemberId, reason);
     }
 }

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
@@ -4,24 +4,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
-import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
-import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
-import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
-import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
-import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
-import com.umc.product.project.application.port.in.command.RemoveProjectMemberUseCase;
-import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
-import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
-import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
-import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +19,25 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
+import com.umc.product.project.adapter.in.web.dto.request.ChangeProjectMemberStatusRequest;
+import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
+import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.ChangeProjectMemberStatusUseCase;
+import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
+import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
+import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
+import com.umc.product.project.application.port.in.command.RemoveProjectMemberUseCase;
+import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
+import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
+import com.umc.product.project.application.port.in.command.UpdatePartQuotasUseCase;
+import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
 
 @WebMvcTest(controllers = ProjectCommandController.class)
 @Import(JacksonConfig.class)
@@ -63,6 +68,8 @@ class ProjectCommandControllerTest {
     AddProjectMemberUseCase addProjectMemberUseCase;
     @MockitoBean
     RemoveProjectMemberUseCase removeProjectMemberUseCase;
+    @MockitoBean
+    ChangeProjectMemberStatusUseCase changeProjectMemberStatusUseCase;
     @MockitoBean
     UpdatePartQuotasUseCase updatePartQuotasUseCase;
     @MockitoBean
@@ -121,5 +128,52 @@ class ProjectCommandControllerTest {
             .andExpect(status().isBadRequest());
 
         then(abortProjectUseCase).should(never()).abort(any());
+    }
+
+    @Test
+    void DELETE_프로젝트_팀원_제거_hard_delete_200() throws Exception {
+        mockMvc.perform(delete("/api/v1/projects/" + PROJECT_ID + "/members/200"))
+            .andExpect(status().isOk());
+
+        then(removeProjectMemberUseCase).should().remove(any());
+    }
+
+    @Test
+    void PATCH_프로젝트_팀원_상태변경_soft_delete_200() throws Exception {
+        ChangeProjectMemberStatusRequest request =
+            new ChangeProjectMemberStatusRequest(ProjectMemberStatus.DISMISSED, "팀 적합도 부족");
+
+        mockMvc.perform(patch("/api/v1/projects/" + PROJECT_ID + "/members/200/status")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        then(changeProjectMemberStatusUseCase).should().changeStatus(any());
+    }
+
+    @Test
+    void PATCH_프로젝트_팀원_상태변경_reason_누락이면_400() throws Exception {
+        ChangeProjectMemberStatusRequest request =
+            new ChangeProjectMemberStatusRequest(ProjectMemberStatus.DISMISSED, "  ");
+
+        mockMvc.perform(patch("/api/v1/projects/" + PROJECT_ID + "/members/200/status")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(changeProjectMemberStatusUseCase).should(never()).changeStatus(any());
+    }
+
+    @Test
+    void PATCH_프로젝트_팀원_상태변경_status_누락이면_400() throws Exception {
+        ChangeProjectMemberStatusRequest request =
+            new ChangeProjectMemberStatusRequest(null, "사유");
+
+        mockMvc.perform(patch("/api/v1/projects/" + PROJECT_ID + "/members/200/status")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(changeProjectMemberStatusUseCase).should(never()).changeStatus(any());
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,6 +45,7 @@ class ProjectMemberCommandServiceTest {
     ProjectMemberCommandService sut;
 
     @Test
+    @DisplayName("프로젝트 멤버를 정상 추가하면 저장된 ID를 반환한다")
     void add_정상_추가_시_저장된_id_반환() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.DRAFT);
@@ -65,6 +67,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("이미 존재하는 프로젝트 멤버를 추가하면 예외가 발생한다")
     void add_이미_존재하는_멤버면_예외() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.DRAFT);
@@ -83,6 +86,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("COMPLETED 프로젝트에는 멤버를 추가할 수 없다")
     void add_COMPLETED_프로젝트에는_추가_불가() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.COMPLETED);
@@ -97,6 +101,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("ABORTED 프로젝트에는 멤버를 추가할 수 없다")
     void add_ABORTED_프로젝트에는_추가_불가() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.ABORTED);
@@ -112,6 +117,7 @@ class ProjectMemberCommandServiceTest {
     // --- remove ---
 
     @Test
+    @DisplayName("DRAFT 단계 프로젝트 멤버 제거는 hard delete를 호출한다")
     void remove_DRAFT_단계는_hardDelete_호출() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.DRAFT);
@@ -119,8 +125,8 @@ class ProjectMemberCommandServiceTest {
 
         ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
         ReflectionTestUtils.setField(member, "id", 555L);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.of(member));
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(member);
 
         sut.remove(RemoveProjectMemberCommand.builder()
             .projectId(projectId).memberId(200L).reason("실수 추가").requesterMemberId(99L).build());
@@ -130,6 +136,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("PENDING_REVIEW 단계 프로젝트 멤버 제거도 hard delete를 호출한다")
     void remove_PENDING_REVIEW_단계도_hardDelete() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.PENDING_REVIEW);
@@ -137,8 +144,8 @@ class ProjectMemberCommandServiceTest {
 
         ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
         ReflectionTestUtils.setField(member, "id", 555L);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.of(member));
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(member);
 
         sut.remove(RemoveProjectMemberCommand.builder()
             .projectId(projectId).memberId(200L).reason(null).requesterMemberId(99L).build());
@@ -147,6 +154,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("IN_PROGRESS 단계 프로젝트 멤버 제거도 hard delete를 호출한다")
     void remove_IN_PROGRESS_단계도_hardDelete() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.IN_PROGRESS);
@@ -154,8 +162,8 @@ class ProjectMemberCommandServiceTest {
 
         ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
         ReflectionTestUtils.setField(member, "id", 555L);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.of(member));
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(member);
 
         sut.remove(RemoveProjectMemberCommand.builder()
             .projectId(projectId).memberId(200L).reason("팀 적합도 부족").requesterMemberId(99L).build());
@@ -165,6 +173,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("메인 PM 제거 시 소유권 양도 API 안내 예외가 발생한다")
     void remove_메인_PM은_양도_API_안내_예외() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.DRAFT);
@@ -178,12 +187,13 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("프로젝트에 없는 멤버를 제거하면 NOT_FOUND 예외가 발생한다")
     void remove_없는_멤버면_예외() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.DRAFT);
         given(loadProjectPort.getById(projectId)).willReturn(project);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.empty());
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willThrow(new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
 
         assertThatThrownBy(() -> sut.remove(RemoveProjectMemberCommand.builder()
                 .projectId(projectId).memberId(200L).requesterMemberId(99L).build()))
@@ -192,6 +202,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("COMPLETED 프로젝트의 멤버 제거는 거부된다")
     void remove_COMPLETED_프로젝트는_거부() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.COMPLETED);
@@ -205,6 +216,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("ABORTED 프로젝트의 멤버 제거는 거부된다")
     void remove_ABORTED_프로젝트는_거부() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.ABORTED);
@@ -220,6 +232,7 @@ class ProjectMemberCommandServiceTest {
     // --- changeStatus (soft delete) ---
 
     @Test
+    @DisplayName("정상적으로 멤버 상태를 변경할 때 저장 및 메타데이터가 기록된다")
     void changeStatus_정상_상태변경_시_save_및_메타데이터_기록() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.IN_PROGRESS);
@@ -227,8 +240,8 @@ class ProjectMemberCommandServiceTest {
 
         ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
         ReflectionTestUtils.setField(member, "id", 555L);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.of(member));
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(member);
 
         sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
             .projectId(projectId).memberId(200L).status(ProjectMemberStatus.DISMISSED)
@@ -242,6 +255,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("메인 PM 상태 변경 시 소유권 양도 API 안내 예외가 발생한다")
     void changeStatus_메인_PM은_양도_API_안내_예외() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.IN_PROGRESS);
@@ -256,6 +270,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("COMPLETED 프로젝트의 멤버 상태 변경은 거부된다")
     void changeStatus_COMPLETED_프로젝트는_거부() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.COMPLETED);
@@ -270,18 +285,39 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("프로젝트에 없는 멤버의 상태를 변경하면 NOT_FOUND 예외가 발생한다")
     void changeStatus_프로젝트에_없는_멤버면_NOT_FOUND_예외() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.IN_PROGRESS);
         given(loadProjectPort.getById(projectId)).willReturn(project);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.empty());
+        given(loadProjectMemberPort.getByProjectIdAndMemberId(projectId, 200L))
+            .willThrow(new ProjectDomainException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
 
         assertThatThrownBy(() -> sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
                 .projectId(projectId).memberId(200L).status(ProjectMemberStatus.DISMISSED)
                 .reason("사유").requesterMemberId(99L).build()))
             .isInstanceOf(ProjectDomainException.class)
             .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("멤버 상태 변경 사유가 null이면 예외가 발생한다")
+    void changeStatusCommand_reason이_null이면_예외() {
+        assertThatThrownBy(() -> ChangeProjectMemberStatusCommand.builder()
+                .projectId(42L).memberId(200L).status(ProjectMemberStatus.DISMISSED)
+                .reason(null).requesterMemberId(99L).build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("reason must not be null or blank");
+    }
+
+    @Test
+    @DisplayName("멤버 상태 변경 사유가 blank이면 예외가 발생한다")
+    void changeStatusCommand_reason이_blank이면_예외() {
+        assertThatThrownBy(() -> ChangeProjectMemberStatusCommand.builder()
+                .projectId(42L).memberId(200L).status(ProjectMemberStatus.DISMISSED)
+                .reason(" ").requesterMemberId(99L).build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("reason must not be null or blank");
     }
 
     // --- helpers ---

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectMemberCommandServiceTest.java
@@ -4,12 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.project.application.port.in.command.dto.AddProjectMemberCommand;
+import com.umc.product.project.application.port.in.command.dto.ChangeProjectMemberStatusCommand;
 import com.umc.product.project.application.port.in.command.dto.RemoveProjectMemberCommand;
 import com.umc.product.project.application.port.out.LoadProjectMemberPort;
 import com.umc.product.project.application.port.out.LoadProjectPort;
@@ -20,13 +29,6 @@ import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectMemberCommandServiceTest {
@@ -145,7 +147,7 @@ class ProjectMemberCommandServiceTest {
     }
 
     @Test
-    void remove_IN_PROGRESS_단계는_soft_delete_DISMISSED() {
+    void remove_IN_PROGRESS_단계도_hardDelete() {
         Long projectId = 42L;
         Project project = project(projectId, ProjectStatus.IN_PROGRESS);
         given(loadProjectPort.getById(projectId)).willReturn(project);
@@ -158,11 +160,8 @@ class ProjectMemberCommandServiceTest {
         sut.remove(RemoveProjectMemberCommand.builder()
             .projectId(projectId).memberId(200L).reason("팀 적합도 부족").requesterMemberId(99L).build());
 
-        verify(saveProjectMemberPort).save(member);
-        verify(saveProjectMemberPort, never()).hardDelete(any());
-        assertThat(member.getStatus()).isEqualTo(ProjectMemberStatus.DISMISSED);
-        assertThat(member.getStatusChangeReason()).isEqualTo("팀 적합도 부족");
-        assertThat(member.getStatusChangedMemberId()).isEqualTo(99L);
+        verify(saveProjectMemberPort).hardDelete(555L);
+        verify(saveProjectMemberPort, never()).save(any());
     }
 
     @Test
@@ -198,14 +197,91 @@ class ProjectMemberCommandServiceTest {
         Project project = project(projectId, ProjectStatus.COMPLETED);
         given(loadProjectPort.getById(projectId)).willReturn(project);
 
-        ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
-        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
-            .willReturn(Optional.of(member));
+        assertThatThrownBy(() -> sut.remove(RemoveProjectMemberCommand.builder()
+                .projectId(projectId).memberId(200L).requesterMemberId(99L).build()))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        verify(saveProjectMemberPort, never()).hardDelete(any());
+    }
+
+    @Test
+    void remove_ABORTED_프로젝트는_거부() {
+        Long projectId = 42L;
+        Project project = project(projectId, ProjectStatus.ABORTED);
+        given(loadProjectPort.getById(projectId)).willReturn(project);
 
         assertThatThrownBy(() -> sut.remove(RemoveProjectMemberCommand.builder()
                 .projectId(projectId).memberId(200L).requesterMemberId(99L).build()))
             .isInstanceOf(ProjectDomainException.class)
             .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        verify(saveProjectMemberPort, never()).hardDelete(any());
+    }
+
+    // --- changeStatus (soft delete) ---
+
+    @Test
+    void changeStatus_정상_상태변경_시_save_및_메타데이터_기록() {
+        Long projectId = 42L;
+        Project project = project(projectId, ProjectStatus.IN_PROGRESS);
+        given(loadProjectPort.getById(projectId)).willReturn(project);
+
+        ProjectMember member = projectMember(200L, ChallengerPart.PLAN);
+        ReflectionTestUtils.setField(member, "id", 555L);
+        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(Optional.of(member));
+
+        sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
+            .projectId(projectId).memberId(200L).status(ProjectMemberStatus.DISMISSED)
+            .reason("팀 적합도 부족").requesterMemberId(99L).build());
+
+        verify(saveProjectMemberPort).save(member);
+        verify(saveProjectMemberPort, never()).hardDelete(any());
+        assertThat(member.getStatus()).isEqualTo(ProjectMemberStatus.DISMISSED);
+        assertThat(member.getStatusChangeReason()).isEqualTo("팀 적합도 부족");
+        assertThat(member.getStatusChangedMemberId()).isEqualTo(99L);
+    }
+
+    @Test
+    void changeStatus_메인_PM은_양도_API_안내_예외() {
+        Long projectId = 42L;
+        Project project = project(projectId, ProjectStatus.IN_PROGRESS);
+        given(loadProjectPort.getById(projectId)).willReturn(project);
+
+        // 메인 PM 의 memberId = 99L (project() helper 에서 설정)
+        assertThatThrownBy(() -> sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
+                .projectId(projectId).memberId(99L).status(ProjectMemberStatus.WITHDRAWN)
+                .reason("사유").requesterMemberId(99L).build()))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_MAIN_PM_REMOVAL_REQUIRES_TRANSFER);
+    }
+
+    @Test
+    void changeStatus_COMPLETED_프로젝트는_거부() {
+        Long projectId = 42L;
+        Project project = project(projectId, ProjectStatus.COMPLETED);
+        given(loadProjectPort.getById(projectId)).willReturn(project);
+
+        assertThatThrownBy(() -> sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
+                .projectId(projectId).memberId(200L).status(ProjectMemberStatus.DISMISSED)
+                .reason("사유").requesterMemberId(99L).build()))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        verify(saveProjectMemberPort, never()).save(any());
+    }
+
+    @Test
+    void changeStatus_프로젝트에_없는_멤버면_NOT_FOUND_예외() {
+        Long projectId = 42L;
+        Project project = project(projectId, ProjectStatus.IN_PROGRESS);
+        given(loadProjectPort.getById(projectId)).willReturn(project);
+        given(loadProjectMemberPort.findByProjectIdAndMemberId(projectId, 200L))
+            .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.changeStatus(ChangeProjectMemberStatusCommand.builder()
+                .projectId(projectId).memberId(200L).status(ProjectMemberStatus.DISMISSED)
+                .reason("사유").requesterMemberId(99L).build()))
+            .isInstanceOf(ProjectDomainException.class)
+            .extracting("baseCode").isEqualTo(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
     }
 
     // --- helpers ---


### PR DESCRIPTION
resolves #1094 

## 🚀 작업 내용

## 🎯 What - 무엇을
프로젝트 멤버 제거를 **hard delete**와 **soft delete(상태 변경)** 두 API로 분리했습니다. 
- 기존 DELETE는 hard delete로 단일화하였습니다. `DELETE [PROJECT-005] /api/v1/projects/{projectId}/members/{memberId}`
- 상태 변경 전용 `PATCH [PROJECT-006] /api/v1/projects/{projectId}/members/{memberId}/status` 를 신설했습니다.

## ❓ Why - 왜
`IN_PROGRESS` 단계에서 멤버를 강제 해제하면 `DISMISSED`로 soft delete 되는데, `DISMISSED`는 enum 정의상 "강제 퇴출"입니다. 문제는 멤버 행이 남아있어 `(project_id, member_id)` unique 제약 때문에 동일 멤버를 같은 프로젝트에 재등록할 수 없었습니다. "퇴출 이력 보존"과 "잘못 배정한 멤버를 지우고 재등록"은 서로 다른 요구라, 하나의 DELETE에 status별로 분기하던 구조로는 둘 다 만족시킬 수 없어 API를 분리했습니다.

## 🛠 How - 어떻게
- **hard delete [PROJECT-005]** : `status` 분기 제거하고 행을 물리 삭제로 단일화 -> 재등록 가능. `validateMutable()`로 종료.(`COMPLETED/ABORTED`) 프로젝트는 거부, 메인 PM은 양도 유도로 거부. reason은 행과 함께 사라지므로 삭제 직전 [log.info](http://log.info/) 감사 로그로만 기록.
- **soft delete [PROJECT-006]** : 행을 보존한 채 임의의 `ProjectMemberStatus`로 전이. `reason`(필수)/변경 주체/시각, `status_change_reason` 등 컬럼에 영속화. 종료 프로젝트/메인 PM 거부.
- **도메인 정리** : 상태 변경 로직을 `ProjectMember.changeStatus(status, changedBy, reason)` 단일 메서드로 일원화하고 기존 `dismiss/withdraw`가 이를 위임.
- **권한** : 두 API 모두 `PermissionType.EDIT`. `DELETE` 권한은 `IN_PROGRESS`를 차단하므로 재등록 시나리오에 부적합 -> 일부러 EDIT 사용.
- **엔드포인트 설계** : 상태 전이는 사유/가드/감사가 얽힌 별개 행위라, 레포의 기존 액션형 엔드포인트 컨벤션(/submit·/abort·/part-quotas)에 맞춰 /status 하위 경로로 분리.

## 📍 Where - 어디를
- project/adapter/in/web/`ProjectCommandController` (DELETE 갱신 + PATCH 신설)
- project/adapter/in/web/dto/request/`ChangeProjectMemberStatusRequest` (신규)
- project/application/port/in/command/`ChangeProjectMemberStatusUseCase` (신규), .../dto/`ChangeProjectMemberStatusCommand` (신규)
- project/application/port/in/command/`RemoveProjectMemberUseCase`, .../dto/`RemoveProjectMemberCommand`
- project/application/service/command/`ProjectMemberCommandService`
- project/domain/`ProjectMember`

## ⏱ When - 언제 발동
- 운영진/PM이 팀원을 완전 제거(재등록 목적) 할 때 `DELETE [PROJECT-005]` 호출
- 팀원을 퇴출·하차·완료 등 상태로 기록 보존할 때 `PATCH [PROJECT-006]` 호출.

## 👤 Who - 영향 범위
- DB 마이그레이션 없음
- 기존 `DELETE`의 `IN_PROGRESS` 동작이 soft -> hard로 변경되는 breaking change. `IN_PROGRESS` 멤버 제거를 호출하던 클라이언트는 이제 행이 삭제되며, 퇴출 이력을 남기려면 신설 `PATCH` 로 전환 필요.
- `dismiss/withdraw` 외부 동작은 동일

## ✅ 검증
- 단위/웹 레이어 테스트 통과
   - `ProjectMemberCommandServiceTest` :프로젝트 `DRAFT/PENDING_REVIEW/IN_PROGRESS `모두 hardDelete 호출, 종료 프로젝트/메인 PM/플젝에 속하지 않는 멤버 거부, `changeStatus` 정상/가드 케이스 검증.
   - `ProjectCommandControllerTest` : DELETE 200, PATCH 200, reason/status 누락 시 400.


## 💬 리뷰 중점사항

- 종료 프로젝트 hard delete는 `COMPLETED/ABORTED` 둘 다 차단으로 두었습니다. 추후 `ABORTED`만 허용하고 싶으면 가드를 `COMPLETED` 단독 검사로 한 줄 교체하면 됩니다
- `changeStatus`는 현재 임의 `status` 전이를 허용합니다(e.g. : `ACTIVE` 복구 포함). 운영 유연성을 위해 의도적으로 열어뒀는데, 특정 전이만 허용(전이 검증)할지 의견 주세요.
