### PR TITLE
[Fix] 로그 탐색 대시보드 내 필터가 동작하지 않는 문제 수정

### DIFF
--- a/infra/monitoring/grafana/config/grafana/dashboards/server-logs.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-logs.json
@@ -50,7 +50,7 @@
                       "spec": {
                         "direction": "backward",
                         "editorMode": "code",
-                        "expr": "{service_name=~\"$service\"} | detected_level=~\"$log_level\" |~ \"(?i)$traceId\" |~ \"(?i)$memberId\" |~ \"(?i)$clientType\" |~ \"(?i)$log_search\"",
+                        "expr": "{service_name=~\"$service\"} | detected_level=~\"$log_level\" | traceId =~ \"(?i).*$traceId.*\" | memberId =~ \"(?i).*$memberId.*\" | clientType =~ \"^$clientType$\" |~ \"(?i)$log_search\"",
                         "queryType": "range"
                       },
                       "version": "v0"


### PR DESCRIPTION
## 🚀 작업 내용
서버팀 로그 탐색 대시보드에서 Client Type, Trace ID, Member ID 필터 적용 시 로그가 0건 조회되는 문제를 수정했습니다.

traceId, memberId, clientType 필드는 Loki structured metadata로 저장되는데, 기존 쿼리는 라인 필터를 사용해 로그 본문 텍스트만 검색했기 때문에 해당 필드를 찾지 못하는 문제가 있었습니다.
각 필드를 명시하는 structured metadata 필터로 변경하여 정상 동작하도록 수정했습니다.

## 💬 리뷰 중점사항
