### PR TITLE
[Chore] 부하 테스트 Terraform 모듈 스캐폴드

### DIFF
--- a/infra/terraform/load-test/.gitignore
+++ b/infra/terraform/load-test/.gitignore
@@ -1,0 +1,7 @@
+# Terraform state / 시크릿 — 커밋 금지
+*.tfstate
+*.tfstate.*
+.terraform/
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/infra/terraform/load-test/.terraform.lock.hcl
+++ b/infra/terraform/load-test/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/load-test/alb.tf
+++ b/infra/terraform/load-test/alb.tf
@@ -1,0 +1,52 @@
+# 운영 HTTP 진입점이 ALB 이므로 부하 테스트도 generator -> ALB -> SUT 경로를 사용한다.
+# 단일 SUT 한 대만 target 으로 붙여 "단일 앱 + RDS" 스펙 자체는 유지한다.
+resource "aws_lb" "sut" {
+  name               = "${local.name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.primary.id, aws_subnet.public_secondary.id]
+
+  tags = merge(local.tags, { Name = "${local.name}-alb" })
+}
+
+resource "aws_lb_target_group" "sut" {
+  name        = "${local.name}-sut"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "instance"
+  vpc_id      = aws_vpc.this.id
+
+  # 실제 요청은 8080 으로 보내되, health 는 actuator management port 로 본다.
+  # 앱 컨텍스트/루트 경로가 바뀌어도 ALB health check 가 안정적으로 동작하게 하려는 선택이다.
+  health_check {
+    enabled             = true
+    protocol            = "HTTP"
+    port                = "9090"
+    path                = "/actuator/health"
+    matcher             = "200-399"
+    interval            = 15
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-sut-tg" })
+}
+
+resource "aws_lb_target_group_attachment" "sut" {
+  target_group_arn = aws_lb_target_group.sut.arn
+  target_id        = aws_instance.sut.id
+  port             = 8080
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.sut.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.sut.arn
+  }
+}

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -1,23 +1,30 @@
 # 관측 EC2 — 먼저 떠야 SUT 가 OTLP 를 보낼 수 있음 (otel-collector 토큰 공유)
+# 앱이 collector 로 보내는 OTLP 요청의 Bearer token. monitoring 과 SUT user-data 에 같은 값이 들어간다.
 resource "random_password" "otel_token" {
   length  = 32
   special = false
 }
 
+# Grafana 초기 admin password. output 은 sensitive 로만 노출한다.
 resource "random_password" "grafana_admin" {
   length  = 20
   special = false
 }
 
 resource "aws_instance" "monitoring" {
-  ami                         = data.aws_ssm_parameter.ami.value
-  instance_type               = var.monitoring_instance_type
-  subnet_id                   = aws_subnet.primary.id
-  private_ip                  = local.monitoring_private_ip
-  vpc_security_group_ids      = [aws_security_group.monitoring.id]
-  key_name                    = var.key_name
+  ami                    = data.aws_ssm_parameter.ami.value
+  instance_type          = var.monitoring_instance_type
+  subnet_id              = aws_subnet.primary.id
+  private_ip             = local.monitoring_private_ip
+  vpc_security_group_ids = [aws_security_group.monitoring.id]
+  key_name               = var.key_name
+
+  # user-data 를 바꾸면 기존 인스턴스 안에서 스크립트가 재실행되지 않는다.
+  # 변경 내용을 확실히 반영하려고 인스턴스를 교체한다.
   user_data_replace_on_change = true
 
+  # monitoring 은 기존 repo 의 infra/monitoring/grafana compose 를 clone 한 뒤,
+  # 부하 테스트용 Prometheus scrape/remote-write/postgres_exporter 설정을 덮어쓴다.
   user_data = templatefile("${path.module}/user-data/monitoring.sh.tftpl", {
     git_repo_url           = var.git_repo_url
     otel_token             = random_password.otel_token.result
@@ -32,11 +39,13 @@ resource "aws_instance" "monitoring" {
   })
 
   dynamic "credit_specification" {
+    # T 계열 EC2 는 CPU credit 고갈이 측정값을 오염시키지 않도록 unlimited 로 둔다.
     for_each = startswith(var.monitoring_instance_type, "t") ? [1] : []
     content { cpu_credits = "unlimited" }
   }
 
   root_block_device {
+    # Loki/Tempo/Prometheus chunk 가 기본 8GB 디스크를 빠르게 채울 수 있어 여유를 둔다.
     volume_size = 60 # tempo/loki chunk 여유
     volume_type = "gp3"
   }
@@ -45,6 +54,7 @@ resource "aws_instance" "monitoring" {
 }
 
 # SUT — 앱(dev) + valkey, DB 는 RDS
+# SUT 는 측정 대상이므로 여기의 instance_type, Hikari pool, RDS 스펙이 실험 조건이다.
 resource "aws_instance" "sut" {
   ami                         = data.aws_ssm_parameter.ami.value
   instance_type               = var.sut_instance_type
@@ -54,6 +64,8 @@ resource "aws_instance" "sut" {
   key_name                    = var.key_name
   user_data_replace_on_change = true
 
+  # app_env 에는 외부 연동 secret 만 넣고, DB/OTLP/Hikari/dev profile 값은 여기서 강제로 덮어쓴다.
+  # 이렇게 해야 매 테스트가 같은 DB/관측/풀 크기 조건에서 시작한다.
   user_data = templatefile("${path.module}/user-data/sut.sh.tftpl", {
     app_image         = var.app_image
     registry_server   = var.registry_server
@@ -71,16 +83,19 @@ resource "aws_instance" "sut" {
   })
 
   dynamic "credit_specification" {
+    # T 계열 앱 인스턴스는 credit exhausted 상태가 임계점처럼 보일 수 있어 unlimited 로 둔다.
     for_each = startswith(var.sut_instance_type, "t") ? [1] : []
     content { cpu_credits = "unlimited" }
   }
 
   tags = merge(local.tags, { Name = "${local.name}-sut" })
 
+  # DB 와 collector endpoint 가 준비된 뒤 앱을 올린다. 앱 기동 시 Flyway/OTLP 연결이 바로 필요하다.
   depends_on = [aws_db_instance.this, aws_instance.monitoring]
 }
 
 # 생성기 — k6 설치 (실행은 수동)
+# generator 는 측정 대상이 아니므로 SUT 보다 넉넉하게 잡아 k6 CPU 가 먼저 병목나지 않게 한다.
 resource "aws_instance" "generator" {
   ami                         = data.aws_ssm_parameter.ami.value
   instance_type               = var.generator_instance_type
@@ -90,6 +105,8 @@ resource "aws_instance" "generator" {
   key_name                    = var.key_name
   user_data_replace_on_change = true
 
+  # k6 스크립트는 repo 의 docs/guides/load-test/k6 에서 가져오고,
+  # 실행 결과는 monitoring Prometheus remote-write endpoint 로 바로 보낸다.
   user_data = templatefile("${path.module}/user-data/generator.sh.tftpl", {
     git_repo_url = var.git_repo_url
     sut_host     = local.sut_private_ip
@@ -97,11 +114,13 @@ resource "aws_instance" "generator" {
   })
 
   dynamic "credit_specification" {
+    # generator 가 T 계열이면 k6 자체가 credit 에 막힐 수 있어 unlimited 로 둔다.
     for_each = startswith(var.generator_instance_type, "t") ? [1] : []
     content { cpu_credits = "unlimited" }
   }
 
   tags = merge(local.tags, { Name = "${local.name}-generator" })
 
+  # RUN.md 와 run-umc-k6 가 SUT/Prometheus private endpoint 를 내장하므로 두 인스턴스 이후 생성한다.
   depends_on = [aws_instance.sut, aws_instance.monitoring]
 }

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -62,24 +62,26 @@ resource "aws_instance" "sut" {
   private_ip                  = local.sut_private_ip
   vpc_security_group_ids      = [aws_security_group.sut.id]
   key_name                    = var.key_name
+  iam_instance_profile        = try(aws_iam_instance_profile.sut[0].name, null)
   user_data_replace_on_change = true
 
-  # app_env 에는 외부 연동 secret 만 넣고, DB/OTLP/Hikari/dev profile 값은 여기서 강제로 덮어쓴다.
+  # 앱 env/registry credential 은 Secrets Manager ARN 만 전달하고 EC2 role 로 런타임 조회한다.
+  # DB/OTLP/Hikari/dev profile 값은 여기서 강제로 덮어써 매 테스트 조건을 고정한다.
   # 이렇게 해야 매 테스트가 같은 DB/관측/풀 크기 조건에서 시작한다.
   user_data = templatefile("${path.module}/user-data/sut.sh.tftpl", {
-    app_image         = var.app_image
-    registry_server   = var.registry_server
-    registry_username = var.registry_username
-    registry_password = var.registry_password
-    db_host           = aws_db_instance.this.address
-    db_port           = aws_db_instance.this.port
-    db_name           = var.db_name
-    db_username       = var.db_username
-    db_password       = random_password.db.result
-    otel_host         = local.monitoring_private_ip
-    otel_token        = random_password.otel_token.result
-    app_env           = var.app_env
-    hikari_pool       = 4
+    app_image                       = var.app_image
+    registry_server                 = var.registry_server
+    registry_credentials_secret_arn = var.registry_credentials_secret_arn
+    app_env_secret_arn              = var.app_env_secret_arn
+    region                          = var.region
+    db_host                         = aws_db_instance.this.address
+    db_port                         = aws_db_instance.this.port
+    db_name                         = var.db_name
+    db_username                     = var.db_username
+    db_password                     = random_password.db.result
+    otel_host                       = local.monitoring_private_ip
+    otel_token                      = random_password.otel_token.result
+    hikari_pool                     = 4
   })
 
   dynamic "credit_specification" {

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -1,0 +1,107 @@
+# 관측 EC2 — 먼저 떠야 SUT 가 OTLP 를 보낼 수 있음 (otel-collector 토큰 공유)
+resource "random_password" "otel_token" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "grafana_admin" {
+  length  = 20
+  special = false
+}
+
+resource "aws_instance" "monitoring" {
+  ami                         = data.aws_ssm_parameter.ami.value
+  instance_type               = var.monitoring_instance_type
+  subnet_id                   = aws_subnet.primary.id
+  private_ip                  = local.monitoring_private_ip
+  vpc_security_group_ids      = [aws_security_group.monitoring.id]
+  key_name                    = var.key_name
+  user_data_replace_on_change = true
+
+  user_data = templatefile("${path.module}/user-data/monitoring.sh.tftpl", {
+    git_repo_url           = var.git_repo_url
+    otel_token             = random_password.otel_token.result
+    grafana_admin_password = random_password.grafana_admin.result
+    db_host                = aws_db_instance.this.address
+    db_port                = aws_db_instance.this.port
+    db_name                = var.db_name
+    db_username            = var.db_username
+    db_password            = random_password.db.result
+    sut_private_ip         = local.sut_private_ip
+    generator_private_ip   = local.generator_private_ip
+  })
+
+  dynamic "credit_specification" {
+    for_each = startswith(var.monitoring_instance_type, "t") ? [1] : []
+    content { cpu_credits = "unlimited" }
+  }
+
+  root_block_device {
+    volume_size = 60 # tempo/loki chunk 여유
+    volume_type = "gp3"
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-monitoring" })
+}
+
+# SUT — 앱(dev) + valkey, DB 는 RDS
+resource "aws_instance" "sut" {
+  ami                         = data.aws_ssm_parameter.ami.value
+  instance_type               = var.sut_instance_type
+  subnet_id                   = aws_subnet.primary.id
+  private_ip                  = local.sut_private_ip
+  vpc_security_group_ids      = [aws_security_group.sut.id]
+  key_name                    = var.key_name
+  user_data_replace_on_change = true
+
+  user_data = templatefile("${path.module}/user-data/sut.sh.tftpl", {
+    app_image         = var.app_image
+    registry_server   = var.registry_server
+    registry_username = var.registry_username
+    registry_password = var.registry_password
+    db_host           = aws_db_instance.this.address
+    db_port           = aws_db_instance.this.port
+    db_name           = var.db_name
+    db_username       = var.db_username
+    db_password       = random_password.db.result
+    otel_host         = local.monitoring_private_ip
+    otel_token        = random_password.otel_token.result
+    app_env           = var.app_env
+    hikari_pool       = 4
+  })
+
+  dynamic "credit_specification" {
+    for_each = startswith(var.sut_instance_type, "t") ? [1] : []
+    content { cpu_credits = "unlimited" }
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-sut" })
+
+  depends_on = [aws_db_instance.this, aws_instance.monitoring]
+}
+
+# 생성기 — k6 설치 (실행은 수동)
+resource "aws_instance" "generator" {
+  ami                         = data.aws_ssm_parameter.ami.value
+  instance_type               = var.generator_instance_type
+  subnet_id                   = aws_subnet.primary.id
+  private_ip                  = local.generator_private_ip
+  vpc_security_group_ids      = [aws_security_group.generator.id]
+  key_name                    = var.key_name
+  user_data_replace_on_change = true
+
+  user_data = templatefile("${path.module}/user-data/generator.sh.tftpl", {
+    git_repo_url = var.git_repo_url
+    sut_host     = local.sut_private_ip
+    prom_rw_url  = "http://${local.monitoring_private_ip}:${local.prometheus_port}/api/v1/write"
+  })
+
+  dynamic "credit_specification" {
+    for_each = startswith(var.generator_instance_type, "t") ? [1] : []
+    content { cpu_credits = "unlimited" }
+  }
+
+  tags = merge(local.tags, { Name = "${local.name}-generator" })
+
+  depends_on = [aws_instance.sut, aws_instance.monitoring]
+}

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -70,7 +70,8 @@ resource "aws_instance" "sut" {
   # 이렇게 해야 매 테스트가 같은 DB/관측/풀 크기 조건에서 시작한다.
   user_data = templatefile("${path.module}/user-data/sut.sh.tftpl", {
     app_image                       = var.app_image
-    registry_server                 = var.registry_server
+    registry_type                   = var.registry_type
+    registry_server                 = local.resolved_registry_server
     registry_credentials_secret_arn = var.registry_credentials_secret_arn
     app_env_secret_arn              = var.app_env_secret_arn
     region                          = var.region

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -12,7 +12,7 @@ resource "random_password" "grafana_admin" {
 }
 
 resource "aws_instance" "monitoring" {
-  ami                    = data.aws_ssm_parameter.ami.value
+  ami                    = data.aws_ssm_parameter.monitoring_ami.value
   instance_type          = var.monitoring_instance_type
   subnet_id              = aws_subnet.primary.id
   private_ip             = local.monitoring_private_ip
@@ -56,7 +56,7 @@ resource "aws_instance" "monitoring" {
 # SUT — 앱(dev) + valkey, DB 는 RDS
 # SUT 는 측정 대상이므로 여기의 instance_type, Hikari pool, RDS 스펙이 실험 조건이다.
 resource "aws_instance" "sut" {
-  ami                         = data.aws_ssm_parameter.ami.value
+  ami                         = data.aws_ssm_parameter.sut_ami.value
   instance_type               = var.sut_instance_type
   subnet_id                   = aws_subnet.primary.id
   private_ip                  = local.sut_private_ip
@@ -97,7 +97,7 @@ resource "aws_instance" "sut" {
 # 생성기 — k6 설치 (실행은 수동)
 # generator 는 측정 대상이 아니므로 SUT 보다 넉넉하게 잡아 k6 CPU 가 먼저 병목나지 않게 한다.
 resource "aws_instance" "generator" {
-  ami                         = data.aws_ssm_parameter.ami.value
+  ami                         = data.aws_ssm_parameter.generator_ami.value
   instance_type               = var.generator_instance_type
   subnet_id                   = aws_subnet.primary.id
   private_ip                  = local.generator_private_ip

--- a/infra/terraform/load-test/compute.tf
+++ b/infra/terraform/load-test/compute.tf
@@ -109,7 +109,7 @@ resource "aws_instance" "generator" {
   # 실행 결과는 monitoring Prometheus remote-write endpoint 로 바로 보낸다.
   user_data = templatefile("${path.module}/user-data/generator.sh.tftpl", {
     git_repo_url = var.git_repo_url
-    sut_host     = local.sut_private_ip
+    base_url     = "http://${aws_lb.sut.dns_name}"
     prom_rw_url  = "http://${local.monitoring_private_ip}:${local.prometheus_port}/api/v1/write"
   })
 
@@ -121,6 +121,6 @@ resource "aws_instance" "generator" {
 
   tags = merge(local.tags, { Name = "${local.name}-generator" })
 
-  # RUN.md 와 run-umc-k6 가 SUT/Prometheus private endpoint 를 내장하므로 두 인스턴스 이후 생성한다.
-  depends_on = [aws_instance.sut, aws_instance.monitoring]
+  # RUN.md 와 run-umc-k6 가 ALB/Prometheus endpoint 를 내장하므로 listener 준비 이후 생성한다.
+  depends_on = [aws_lb_listener.http, aws_instance.monitoring]
 }

--- a/infra/terraform/load-test/iam.tf
+++ b/infra/terraform/load-test/iam.tf
@@ -1,4 +1,4 @@
-# SUT EC2 가 부팅 중 Secrets Manager 에서 앱 env/registry credential 을 직접 읽기 위한 최소 IAM 권한.
+# SUT EC2 가 부팅 중 Secrets Manager/ECR 을 직접 호출하기 위한 최소 IAM 권한.
 # Terraform state 에 secret 원문을 넣지 않으려면 user-data 에 값 대신 ARN 만 전달해야 한다.
 data "aws_iam_policy_document" "sut_assume_role" {
   statement {
@@ -20,8 +20,26 @@ data "aws_iam_policy_document" "sut_secret_access" {
   }
 }
 
+data "aws_iam_policy_document" "sut_ecr_pull" {
+  count = var.registry_type == "ecr" ? 1 : 0
+
+  statement {
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = ["arn:aws:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
+  }
+}
+
 resource "aws_iam_role" "sut" {
-  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+  count = local.sut_needs_iam_role ? 1 : 0
 
   name               = "${local.name}-sut-secrets"
   assume_role_policy = data.aws_iam_policy_document.sut_assume_role.json
@@ -37,8 +55,16 @@ resource "aws_iam_role_policy" "sut_secret_access" {
   policy = data.aws_iam_policy_document.sut_secret_access[0].json
 }
 
+resource "aws_iam_role_policy" "sut_ecr_pull" {
+  count = var.registry_type == "ecr" ? 1 : 0
+
+  name   = "${local.name}-sut-ecr-pull"
+  role   = aws_iam_role.sut[0].id
+  policy = data.aws_iam_policy_document.sut_ecr_pull[0].json
+}
+
 resource "aws_iam_instance_profile" "sut" {
-  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+  count = local.sut_needs_iam_role ? 1 : 0
 
   name = "${local.name}-sut-secrets"
   role = aws_iam_role.sut[0].name

--- a/infra/terraform/load-test/iam.tf
+++ b/infra/terraform/load-test/iam.tf
@@ -1,0 +1,47 @@
+# SUT EC2 가 부팅 중 Secrets Manager 에서 앱 env/registry credential 을 직접 읽기 위한 최소 IAM 권한.
+# Terraform state 에 secret 원문을 넣지 않으려면 user-data 에 값 대신 ARN 만 전달해야 한다.
+data "aws_iam_policy_document" "sut_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sut_secret_access" {
+  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = local.sut_secret_arns
+  }
+}
+
+resource "aws_iam_role" "sut" {
+  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+
+  name               = "${local.name}-sut-secrets"
+  assume_role_policy = data.aws_iam_policy_document.sut_assume_role.json
+
+  tags = merge(local.tags, { Name = "${local.name}-sut-secrets" })
+}
+
+resource "aws_iam_role_policy" "sut_secret_access" {
+  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+
+  name   = "${local.name}-sut-secret-access"
+  role   = aws_iam_role.sut[0].id
+  policy = data.aws_iam_policy_document.sut_secret_access[0].json
+}
+
+resource "aws_iam_instance_profile" "sut" {
+  count = length(local.sut_secret_arns) > 0 ? 1 : 0
+
+  name = "${local.name}-sut-secrets"
+  role = aws_iam_role.sut[0].name
+
+  tags = merge(local.tags, { Name = "${local.name}-sut-secrets" })
+}

--- a/infra/terraform/load-test/main.tf
+++ b/infra/terraform/load-test/main.tf
@@ -25,6 +25,8 @@ provider "aws" {
   region = var.region
 }
 
+data "aws_caller_identity" "current" {}
+
 # EC2 AMI: 역할별 instance type 이 서로 다른 CPU architecture 일 수 있다.
 # 예: prod-like SUT 는 t4g.small(arm64), generator 는 c5.large(x86_64).
 # AMI 를 하나로 공유하면 한쪽이 부팅되지 않으므로 역할별 SSM parameter 를 분리한다.
@@ -69,4 +71,11 @@ locals {
     var.app_env_secret_arn,
     var.registry_credentials_secret_arn,
   ])
+
+  # 개인 계정에서 ECR 을 쓰는 경우 registry_server 를 비워두면 현재 AWS 계정의 ECR registry 를 사용한다.
+  ecr_registry_server      = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com"
+  resolved_registry_server = var.registry_server != "" ? var.registry_server : local.ecr_registry_server
+
+  # SUT 가 Secrets Manager 또는 ECR 중 하나라도 런타임 AWS API 를 호출하면 instance profile 이 필요하다.
+  sut_needs_iam_role = length(local.sut_secret_arns) > 0 || var.registry_type == "ecr"
 }

--- a/infra/terraform/load-test/main.tf
+++ b/infra/terraform/load-test/main.tf
@@ -62,4 +62,11 @@ locals {
   # 포트를 바꾸면 security group, outputs, user-data health check 를 함께 바꿔야 한다.
   grafana_port    = 13000
   prometheus_port = 19090
+
+  # Terraform state 에 secret 원문을 넣지 않기 위해 SUT user-data 는 ARN 만 받고,
+  # EC2 role 로 Secrets Manager 에서 런타임 조회한다.
+  sut_secret_arns = compact([
+    var.app_env_secret_arn,
+    var.registry_credentials_secret_arn,
+  ])
 }

--- a/infra/terraform/load-test/main.tf
+++ b/infra/terraform/load-test/main.tf
@@ -25,10 +25,19 @@ provider "aws" {
   region = var.region
 }
 
-# EC2 AMI: Amazon Linux 2023 (x86_64). Graviton(t4g 등) 인스턴스면 variables 의
-# ami_ssm_parameter 를 arm64 파라미터로 교체할 것.
-data "aws_ssm_parameter" "ami" {
-  name = var.ami_ssm_parameter
+# EC2 AMI: 역할별 instance type 이 서로 다른 CPU architecture 일 수 있다.
+# 예: prod-like SUT 는 t4g.small(arm64), generator 는 c5.large(x86_64).
+# AMI 를 하나로 공유하면 한쪽이 부팅되지 않으므로 역할별 SSM parameter 를 분리한다.
+data "aws_ssm_parameter" "monitoring_ami" {
+  name = var.monitoring_ami_ssm_parameter
+}
+
+data "aws_ssm_parameter" "sut_ami" {
+  name = var.sut_ami_ssm_parameter
+}
+
+data "aws_ssm_parameter" "generator_ami" {
+  name = var.generator_ami_ssm_parameter
 }
 
 locals {

--- a/infra/terraform/load-test/main.tf
+++ b/infra/terraform/load-test/main.tf
@@ -1,16 +1,18 @@
 # 부하 테스트 전용 ephemeral 환경 (Phase 01)
 # 3-tier: 생성기(k6) → SUT(앱+RDS) → 관측(otel-collector+prom/tempo/loki/grafana)
-# apply 로 서고 destroy 로 통째 정리.
+# apply 로 테스트 환경을 만들고, 테스트가 끝나면 destroy 로 비용/데이터를 통째 정리한다.
 
 terraform {
   required_version = ">= 1.6"
 
+  # AWS 리소스와 랜덤 비밀번호만 만든다. 외부 모듈은 아직 쓰지 않아 구조를 단순하게 유지한다.
   required_providers {
     aws    = { source = "hashicorp/aws", version = "~> 5.0" }
     random = { source = "hashicorp/random", version = "~> 3.0" }
   }
 
-  # state: 로컬로 시작. 팀 공유/lock 필요하면 아래 S3 backend 로 교체.
+  # 현재는 개인이 한 번 띄웠다가 내리는 부하 테스트용이라 local state 로 시작한다.
+  # 여러 명이 동시에 apply/destroy 하거나 CI 에서 돌릴 계획이 생기면 S3 backend + DynamoDB lock 으로 교체한다.
   # backend "s3" {
   #   bucket         = "<state-bucket>"
   #   key            = "load-test/terraform.tfstate"
@@ -30,7 +32,10 @@ data "aws_ssm_parameter" "ami" {
 }
 
 locals {
+  # 모든 리소스 이름 prefix. AWS 콘솔에서 ephemeral 부하 테스트 리소스를 쉽게 찾기 위한 값이다.
   name = "umc-loadtest"
+
+  # 비용/정리 대상을 식별하기 위한 공통 tag. destroy 전에도 콘솔에서 Ephemeral=true 로 검색 가능하다.
   tags = {
     Project   = "umc-product"
     Purpose   = "load-test"
@@ -38,10 +43,14 @@ locals {
     Ephemeral = "true"
   }
 
+  # Prometheus scrape target 과 app OTLP endpoint 를 user-data 렌더링 시점에 알아야 한다.
+  # Terraform 리소스 간 private_ip 참조로 엮으면 monitoring ↔ SUT/generator 순환 의존이 생기므로 고정 IP 를 쓴다.
   monitoring_private_ip = "10.20.1.10"
   sut_private_ip        = "10.20.1.20"
   generator_private_ip  = "10.20.1.30"
 
+  # 기존 monitoring compose 의 host port 매핑을 그대로 따른다.
+  # 포트를 바꾸면 security group, outputs, user-data health check 를 함께 바꿔야 한다.
   grafana_port    = 13000
   prometheus_port = 19090
 }

--- a/infra/terraform/load-test/main.tf
+++ b/infra/terraform/load-test/main.tf
@@ -1,0 +1,47 @@
+# 부하 테스트 전용 ephemeral 환경 (Phase 01)
+# 3-tier: 생성기(k6) → SUT(앱+RDS) → 관측(otel-collector+prom/tempo/loki/grafana)
+# apply 로 서고 destroy 로 통째 정리.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws    = { source = "hashicorp/aws", version = "~> 5.0" }
+    random = { source = "hashicorp/random", version = "~> 3.0" }
+  }
+
+  # state: 로컬로 시작. 팀 공유/lock 필요하면 아래 S3 backend 로 교체.
+  # backend "s3" {
+  #   bucket         = "<state-bucket>"
+  #   key            = "load-test/terraform.tfstate"
+  #   region         = "ap-northeast-2"
+  #   dynamodb_table = "<lock-table>"
+  # }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# EC2 AMI: Amazon Linux 2023 (x86_64). Graviton(t4g 등) 인스턴스면 variables 의
+# ami_ssm_parameter 를 arm64 파라미터로 교체할 것.
+data "aws_ssm_parameter" "ami" {
+  name = var.ami_ssm_parameter
+}
+
+locals {
+  name = "umc-loadtest"
+  tags = {
+    Project   = "umc-product"
+    Purpose   = "load-test"
+    ManagedBy = "terraform"
+    Ephemeral = "true"
+  }
+
+  monitoring_private_ip = "10.20.1.10"
+  sut_private_ip        = "10.20.1.20"
+  generator_private_ip  = "10.20.1.30"
+
+  grafana_port    = 13000
+  prometheus_port = 19090
+}

--- a/infra/terraform/load-test/network.tf
+++ b/infra/terraform/load-test/network.tf
@@ -23,6 +23,15 @@ resource "aws_subnet" "primary" {
   tags                    = merge(local.tags, { Name = "${local.name}-subnet-primary" })
 }
 
+# ALB 는 public subnet 2개 이상이 필요하다. EC2 는 primary 에만 두고, 이 subnet 은 ALB 용도로만 사용한다.
+resource "aws_subnet" "public_secondary" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.20.2.0/24"
+  availability_zone       = var.az_secondary
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { Name = "${local.name}-subnet-public-secondary" })
+}
+
 # RDS subnet group 은 >=2 AZ 필요. DB 는 public route table 에 연결하지 않는다.
 # private subnet 에 route table association 을 만들지 않아 인터넷에서 DB 로 직접 접근할 경로를 만들지 않는다.
 resource "aws_subnet" "rds_primary" {
@@ -51,6 +60,11 @@ resource "aws_route_table" "public" {
 # public subnet 의 EC2 만 인터넷으로 나간다. RDS subnet 은 이 route table 에 연결하지 않는다.
 resource "aws_route_table_association" "primary" {
   subnet_id      = aws_subnet.primary.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_secondary" {
+  subnet_id      = aws_subnet.public_secondary.id
   route_table_id = aws_route_table.public.id
 }
 
@@ -110,6 +124,20 @@ resource "aws_security_group" "monitoring" {
   tags = merge(local.tags, { Name = "${local.name}-mon" })
 }
 
+# ALB 는 운영과 같은 HTTP 진입점을 재현한다. 외부 공개는 allowed_cidr, 내부 부하는 generator SG 로 제한한다.
+resource "aws_security_group" "alb" {
+  name_prefix = "${local.name}-alb-"
+  description = "ALB in front of load test SUT"
+  vpc_id      = aws_vpc.this.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, { Name = "${local.name}-alb" })
+}
+
 # SSH (전 인스턴스) — 내 IP 에서만
 # SSM Session Manager 를 붙이면 22번을 닫을 수 있다. 지금은 빠른 디버깅을 위해 allowed_cidr 에만 연다.
 resource "aws_security_group_rule" "ssh_generator" {
@@ -137,23 +165,15 @@ resource "aws_security_group_rule" "ssh_monitoring" {
   security_group_id = aws_security_group.monitoring.id
 }
 
-# SUT: 8080 ← 생성기/관리자, 9090(management) ← 관측/관리자, 9100(node) ← 관측
-# 8080 은 실제 k6 트래픽 진입점이다. 관리자 CIDR 은 smoke/debug curl 용도로만 허용한다.
-resource "aws_security_group_rule" "sut_app_from_gen" {
+# SUT: 8080 ← ALB, 9090(management) ← 관측/관리자/ALB health check, 9100(node) ← 관측
+# 실제 k6 트래픽은 generator 에서 SUT 로 직접 가지 않고 ALB 를 통과한다.
+resource "aws_security_group_rule" "sut_app_from_alb" {
   type                     = "ingress"
   from_port                = 8080
   to_port                  = 8080
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.generator.id
+  source_security_group_id = aws_security_group.alb.id
   security_group_id        = aws_security_group.sut.id
-}
-resource "aws_security_group_rule" "sut_app_from_me" {
-  type              = "ingress"
-  from_port         = 8080
-  to_port           = 8080
-  protocol          = "tcp"
-  cidr_blocks       = [var.allowed_cidr]
-  security_group_id = aws_security_group.sut.id
 }
 resource "aws_security_group_rule" "sut_mgmt_from_mon" {
   type                     = "ingress"
@@ -161,6 +181,14 @@ resource "aws_security_group_rule" "sut_mgmt_from_mon" {
   to_port                  = 9090
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "sut_mgmt_from_alb" {
+  type                     = "ingress"
+  from_port                = 9090
+  to_port                  = 9090
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
   security_group_id        = aws_security_group.sut.id
 }
 resource "aws_security_group_rule" "sut_mgmt_from_me" {
@@ -244,4 +272,23 @@ resource "aws_security_group_rule" "mon_grafana_from_me" {
   protocol          = "tcp"
   cidr_blocks       = [var.allowed_cidr]
   security_group_id = aws_security_group.monitoring.id
+}
+
+# ALB: 80 ← 생성기 + 관리자. k6 와 smoke curl 모두 운영과 같은 HTTP entrypoint 를 사용한다.
+resource "aws_security_group_rule" "alb_http_from_gen" {
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.generator.id
+  security_group_id        = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_http_from_me" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.alb.id
 }

--- a/infra/terraform/load-test/network.tf
+++ b/infra/terraform/load-test/network.tf
@@ -1,4 +1,6 @@
 # ── VPC / 서브넷 / 라우팅 ────────────────────────────────────
+# 부하 테스트끼리 충돌하지 않도록 독립 VPC 를 만든다.
+# 기존 dev/prod 네트워크를 재사용하지 않아 라우팅, SG, 데이터가 운영 환경과 섞이지 않는다.
 resource "aws_vpc" "this" {
   cidr_block           = "10.20.0.0/16"
   enable_dns_hostnames = true
@@ -12,6 +14,7 @@ resource "aws_internet_gateway" "this" {
 }
 
 # EC2 가 사는 public subnet. Docker image / package 다운로드를 위해 인터넷 egress 가 필요하다.
+# NAT Gateway 를 두면 비용과 구성이 늘어나므로 v1 에서는 EC2 에 public IP 를 부여하고 SG 로 inbound 를 제한한다.
 resource "aws_subnet" "primary" {
   vpc_id                  = aws_vpc.this.id
   cidr_block              = "10.20.1.0/24"
@@ -21,6 +24,7 @@ resource "aws_subnet" "primary" {
 }
 
 # RDS subnet group 은 >=2 AZ 필요. DB 는 public route table 에 연결하지 않는다.
+# private subnet 에 route table association 을 만들지 않아 인터넷에서 DB 로 직접 접근할 경로를 만들지 않는다.
 resource "aws_subnet" "rds_primary" {
   vpc_id            = aws_vpc.this.id
   cidr_block        = "10.20.11.0/24"
@@ -44,6 +48,7 @@ resource "aws_route_table" "public" {
   tags = merge(local.tags, { Name = "${local.name}-rt" })
 }
 
+# public subnet 의 EC2 만 인터넷으로 나간다. RDS subnet 은 이 route table 에 연결하지 않는다.
 resource "aws_route_table_association" "primary" {
   subnet_id      = aws_subnet.primary.id
   route_table_id = aws_route_table.public.id
@@ -51,6 +56,8 @@ resource "aws_route_table_association" "primary" {
 
 # ── Security Groups ──────────────────────────────────────────
 # SG 끼리 상호 참조 → cycle 방지 위해 SG 본체는 egress 만, 인바운드는 별도 rule 로.
+# 각 SG 의 egress 는 package/image 다운로드와 OTLP/DB 통신을 단순화하기 위해 전체 허용한다.
+# 실제 노출면은 아래 ingress rule 들이 결정한다.
 resource "aws_security_group" "generator" {
   name_prefix = "${local.name}-gen-"
   description = "k6 부하 생성기"
@@ -79,7 +86,7 @@ resource "aws_security_group" "sut" {
 
 resource "aws_security_group" "rds" {
   name_prefix = "${local.name}-rds-"
-  description = "RDS - SUT 에서만"
+  description = "RDS - SUT and monitoring exporter only"
   vpc_id      = aws_vpc.this.id
   egress {
     from_port   = 0
@@ -104,6 +111,7 @@ resource "aws_security_group" "monitoring" {
 }
 
 # SSH (전 인스턴스) — 내 IP 에서만
+# SSM Session Manager 를 붙이면 22번을 닫을 수 있다. 지금은 빠른 디버깅을 위해 allowed_cidr 에만 연다.
 resource "aws_security_group_rule" "ssh_generator" {
   type              = "ingress"
   from_port         = 22
@@ -130,6 +138,7 @@ resource "aws_security_group_rule" "ssh_monitoring" {
 }
 
 # SUT: 8080 ← 생성기/관리자, 9090(management) ← 관측/관리자, 9100(node) ← 관측
+# 8080 은 실제 k6 트래픽 진입점이다. 관리자 CIDR 은 smoke/debug curl 용도로만 허용한다.
 resource "aws_security_group_rule" "sut_app_from_gen" {
   type                     = "ingress"
   from_port                = 8080
@@ -172,6 +181,7 @@ resource "aws_security_group_rule" "sut_node_from_mon" {
 }
 
 # 생성기: 9100(node) ← 관측
+# generator 도 병목이 될 수 있으므로 node-exporter 로 CPU/메모리/네트워크를 같이 본다.
 resource "aws_security_group_rule" "generator_node_from_mon" {
   type                     = "ingress"
   from_port                = 9100
@@ -182,6 +192,7 @@ resource "aws_security_group_rule" "generator_node_from_mon" {
 }
 
 # RDS: 5432 ← SUT + postgres_exporter(관측)
+# monitoring 에서 직접 DB 를 scrape 해야 pg connection/lock/cache hit 지표를 같은 시간축에 올릴 수 있다.
 resource "aws_security_group_rule" "rds_from_sut" {
   type                     = "ingress"
   from_port                = 5432
@@ -201,6 +212,7 @@ resource "aws_security_group_rule" "rds_from_monitoring" {
 
 # 관측: OTLP(4317/4318) ← SUT, Prometheus(19090) ← 생성기+내IP, Grafana(13000) ← 내IP
 # (포트는 infra/monitoring/grafana/docker-compose.yml 의 호스트 매핑 기준)
+# 4317/4318 은 앱이 metrics/traces/logs 를 collector 로 push 하는 경로다.
 resource "aws_security_group_rule" "mon_otlp_from_sut" {
   type                     = "ingress"
   from_port                = 4317

--- a/infra/terraform/load-test/network.tf
+++ b/infra/terraform/load-test/network.tf
@@ -1,0 +1,235 @@
+# ── VPC / 서브넷 / 라우팅 ────────────────────────────────────
+resource "aws_vpc" "this" {
+  cidr_block           = "10.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(local.tags, { Name = "${local.name}-vpc" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.tags, { Name = "${local.name}-igw" })
+}
+
+# EC2 가 사는 public subnet. Docker image / package 다운로드를 위해 인터넷 egress 가 필요하다.
+resource "aws_subnet" "primary" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.20.1.0/24"
+  availability_zone       = var.az
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { Name = "${local.name}-subnet-primary" })
+}
+
+# RDS subnet group 은 >=2 AZ 필요. DB 는 public route table 에 연결하지 않는다.
+resource "aws_subnet" "rds_primary" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.20.11.0/24"
+  availability_zone = var.az
+  tags              = merge(local.tags, { Name = "${local.name}-subnet-rds-primary" })
+}
+
+resource "aws_subnet" "rds_secondary" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.20.12.0/24"
+  availability_zone = var.az_secondary
+  tags              = merge(local.tags, { Name = "${local.name}-subnet-rds-secondary" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = merge(local.tags, { Name = "${local.name}-rt" })
+}
+
+resource "aws_route_table_association" "primary" {
+  subnet_id      = aws_subnet.primary.id
+  route_table_id = aws_route_table.public.id
+}
+
+# ── Security Groups ──────────────────────────────────────────
+# SG 끼리 상호 참조 → cycle 방지 위해 SG 본체는 egress 만, 인바운드는 별도 rule 로.
+resource "aws_security_group" "generator" {
+  name_prefix = "${local.name}-gen-"
+  description = "k6 부하 생성기"
+  vpc_id      = aws_vpc.this.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, { Name = "${local.name}-gen" })
+}
+
+resource "aws_security_group" "sut" {
+  name_prefix = "${local.name}-sut-"
+  description = "측정 대상 앱"
+  vpc_id      = aws_vpc.this.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, { Name = "${local.name}-sut" })
+}
+
+resource "aws_security_group" "rds" {
+  name_prefix = "${local.name}-rds-"
+  description = "RDS - SUT 에서만"
+  vpc_id      = aws_vpc.this.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, { Name = "${local.name}-rds" })
+}
+
+resource "aws_security_group" "monitoring" {
+  name_prefix = "${local.name}-mon-"
+  description = "관측 스택"
+  vpc_id      = aws_vpc.this.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, { Name = "${local.name}-mon" })
+}
+
+# SSH (전 인스턴스) — 내 IP 에서만
+resource "aws_security_group_rule" "ssh_generator" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.generator.id
+}
+resource "aws_security_group_rule" "ssh_sut" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "ssh_monitoring" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.monitoring.id
+}
+
+# SUT: 8080 ← 생성기/관리자, 9090(management) ← 관측/관리자, 9100(node) ← 관측
+resource "aws_security_group_rule" "sut_app_from_gen" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.generator.id
+  security_group_id        = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "sut_app_from_me" {
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "sut_mgmt_from_mon" {
+  type                     = "ingress"
+  from_port                = 9090
+  to_port                  = 9090
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "sut_mgmt_from_me" {
+  type              = "ingress"
+  from_port         = 9090
+  to_port           = 9090
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.sut.id
+}
+resource "aws_security_group_rule" "sut_node_from_mon" {
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.sut.id
+}
+
+# 생성기: 9100(node) ← 관측
+resource "aws_security_group_rule" "generator_node_from_mon" {
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.generator.id
+}
+
+# RDS: 5432 ← SUT + postgres_exporter(관측)
+resource "aws_security_group_rule" "rds_from_sut" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.sut.id
+  security_group_id        = aws_security_group.rds.id
+}
+resource "aws_security_group_rule" "rds_from_monitoring" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.rds.id
+}
+
+# 관측: OTLP(4317/4318) ← SUT, Prometheus(19090) ← 생성기+내IP, Grafana(13000) ← 내IP
+# (포트는 infra/monitoring/grafana/docker-compose.yml 의 호스트 매핑 기준)
+resource "aws_security_group_rule" "mon_otlp_from_sut" {
+  type                     = "ingress"
+  from_port                = 4317
+  to_port                  = 4318
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.sut.id
+  security_group_id        = aws_security_group.monitoring.id
+}
+resource "aws_security_group_rule" "mon_prom_from_gen" {
+  type                     = "ingress"
+  from_port                = 19090
+  to_port                  = 19090
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.generator.id
+  security_group_id        = aws_security_group.monitoring.id
+}
+resource "aws_security_group_rule" "mon_prom_from_me" {
+  type              = "ingress"
+  from_port         = 19090
+  to_port           = 19090
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.monitoring.id
+}
+resource "aws_security_group_rule" "mon_grafana_from_me" {
+  type              = "ingress"
+  from_port         = 13000
+  to_port           = 13000
+  protocol          = "tcp"
+  cidr_blocks       = [var.allowed_cidr]
+  security_group_id = aws_security_group.monitoring.id
+}

--- a/infra/terraform/load-test/outputs.tf
+++ b/infra/terraform/load-test/outputs.tf
@@ -1,0 +1,59 @@
+output "sut_public_ip" {
+  description = "SUT 공인 IP"
+  value       = aws_instance.sut.public_ip
+}
+
+output "sut_app_url" {
+  description = "앱 엔드포인트 (생성기는 private IP 로 접근, 이건 디버그용)"
+  value       = "http://${aws_instance.sut.public_ip}:8080"
+}
+
+output "sut_private_ip" {
+  value = aws_instance.sut.private_ip
+}
+
+output "grafana_url" {
+  description = "관측 Grafana (allowed_cidr 에서만 접근)"
+  value       = "http://${aws_instance.monitoring.public_ip}:${local.grafana_port}"
+}
+
+output "prometheus_url" {
+  description = "관측 Prometheus (allowed_cidr 에서만 접근)"
+  value       = "http://${aws_instance.monitoring.public_ip}:${local.prometheus_port}"
+}
+
+output "grafana_admin_user" {
+  value = "admin"
+}
+
+output "grafana_admin_password" {
+  value     = random_password.grafana_admin.result
+  sensitive = true
+}
+
+output "generator_ssh" {
+  description = "생성기 SSH (여기서 k6 실행)"
+  value       = "ssh ec2-user@${aws_instance.generator.public_ip}"
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.this.endpoint
+}
+
+output "db_password" {
+  description = "RDS 비밀번호 (랜덤 생성)"
+  value       = random_password.db.result
+  sensitive   = true
+}
+
+output "next_steps" {
+  value = <<-EOT
+    1) SUT 헬스: curl http://${aws_instance.sut.public_ip}:9090/actuator/health  (또는 SSH 후 로컬)
+    2) Grafana: http://${aws_instance.monitoring.public_ip}:${local.grafana_port}
+       비밀번호: terraform output -raw grafana_admin_password
+    3) 생성기 접속 후 k6 실행:
+       ssh ec2-user@${aws_instance.generator.public_ip}
+       run-umc-k6 smoke 1
+    4) 끝나면: terraform destroy
+  EOT
+}

--- a/infra/terraform/load-test/outputs.tf
+++ b/infra/terraform/load-test/outputs.tf
@@ -1,15 +1,18 @@
+# output 은 apply 직후 smoke/debug 에 필요한 접속 정보만 노출한다.
+# 비밀번호류는 sensitive 로 표시되지만 state 에는 남으므로 state 파일 관리는 별도로 주의한다.
 output "sut_public_ip" {
   description = "SUT 공인 IP"
   value       = aws_instance.sut.public_ip
 }
 
 output "sut_app_url" {
-  description = "앱 엔드포인트 (생성기는 private IP 로 접근, 이건 디버그용)"
+  description = "관리자 CIDR 에서만 쓰는 디버그용 앱 엔드포인트. k6 는 private IP 로 접근한다."
   value       = "http://${aws_instance.sut.public_ip}:8080"
 }
 
 output "sut_private_ip" {
-  value = aws_instance.sut.private_ip
+  description = "generator 가 실제 부하를 보내는 SUT private IP"
+  value       = aws_instance.sut.private_ip
 }
 
 output "grafana_url" {
@@ -27,8 +30,9 @@ output "grafana_admin_user" {
 }
 
 output "grafana_admin_password" {
-  value     = random_password.grafana_admin.result
-  sensitive = true
+  description = "Grafana 초기 admin password. `terraform output -raw grafana_admin_password` 로 조회한다."
+  value       = random_password.grafana_admin.result
+  sensitive   = true
 }
 
 output "generator_ssh" {
@@ -37,7 +41,8 @@ output "generator_ssh" {
 }
 
 output "rds_endpoint" {
-  value = aws_db_instance.this.endpoint
+  description = "RDS endpoint. 앱과 postgres_exporter 가 같은 DB 를 바라보는지 확인할 때 사용한다."
+  value       = aws_db_instance.this.endpoint
 }
 
 output "db_password" {
@@ -47,7 +52,8 @@ output "db_password" {
 }
 
 output "next_steps" {
-  value = <<-EOT
+  description = "apply 직후 사람이 실행할 최소 검증 순서"
+  value       = <<-EOT
     1) SUT 헬스: curl http://${aws_instance.sut.public_ip}:9090/actuator/health  (또는 SSH 후 로컬)
     2) Grafana: http://${aws_instance.monitoring.public_ip}:${local.grafana_port}
        비밀번호: terraform output -raw grafana_admin_password

--- a/infra/terraform/load-test/outputs.tf
+++ b/infra/terraform/load-test/outputs.tf
@@ -1,18 +1,23 @@
 # output 은 apply 직후 smoke/debug 에 필요한 접속 정보만 노출한다.
 # 비밀번호류는 sensitive 로 표시되지만 state 에는 남으므로 state 파일 관리는 별도로 주의한다.
 output "sut_public_ip" {
-  description = "SUT 공인 IP"
+  description = "SUT 공인 IP. 앱 트래픽은 ALB 를 사용하고, 이 값은 SSH/debug 용도다."
   value       = aws_instance.sut.public_ip
 }
 
 output "sut_app_url" {
-  description = "관리자 CIDR 에서만 쓰는 디버그용 앱 엔드포인트. k6 는 private IP 로 접근한다."
-  value       = "http://${aws_instance.sut.public_ip}:8080"
+  description = "운영과 같은 ALB 기반 앱 엔드포인트. k6 와 smoke curl 이 이 URL 을 사용한다."
+  value       = "http://${aws_lb.sut.dns_name}"
 }
 
 output "sut_private_ip" {
-  description = "generator 가 실제 부하를 보내는 SUT private IP"
+  description = "SUT private IP. Prometheus scrape/debug 확인용이며 k6 트래픽은 ALB 로 보낸다."
   value       = aws_instance.sut.private_ip
+}
+
+output "alb_dns_name" {
+  description = "SUT 앞단 ALB DNS name"
+  value       = aws_lb.sut.dns_name
 }
 
 output "grafana_url" {
@@ -54,7 +59,8 @@ output "db_password" {
 output "next_steps" {
   description = "apply 직후 사람이 실행할 최소 검증 순서"
   value       = <<-EOT
-    1) SUT 헬스: curl http://${aws_instance.sut.public_ip}:9090/actuator/health  (또는 SSH 후 로컬)
+    1) ALB 앱 스모크: curl http://${aws_lb.sut.dns_name}
+       SUT 헬스 직접 확인: curl http://${aws_instance.sut.public_ip}:9090/actuator/health
     2) Grafana: http://${aws_instance.monitoring.public_ip}:${local.grafana_port}
        비밀번호: terraform output -raw grafana_admin_password
     3) 생성기 접속 후 k6 실행:

--- a/infra/terraform/load-test/rds.tf
+++ b/infra/terraform/load-test/rds.tf
@@ -22,6 +22,8 @@ resource "aws_db_instance" "this" {
   allocated_storage = var.db_allocated_storage
   storage_type      = "gp3"
 
+  # RDS 인스턴스를 만들 때 앱이 접속할 PostgreSQL database 까지 같이 만든다.
+  # 이 값이 없으면 RDS 인스턴스만 생기고 DATABASE_URL 의 umc_product DB 가 없어 앱/Flyway 가 실패한다.
   db_name  = var.db_name
   username = var.db_username
   password = random_password.db.result

--- a/infra/terraform/load-test/rds.tf
+++ b/infra/terraform/load-test/rds.tf
@@ -1,3 +1,5 @@
+# RDS 는 DB subnet group 에 최소 2개 AZ 의 subnet 이 필요하다.
+# 실제 DB 인스턴스는 availability_zone 으로 primary AZ 에 고정해 SUT 와 같은 AZ 에 둔다.
 resource "aws_db_subnet_group" "this" {
   name       = "${local.name}-db"
   subnet_ids = [aws_subnet.rds_primary.id, aws_subnet.rds_secondary.id]
@@ -9,12 +11,14 @@ resource "random_password" "db" {
   special = false # 일부 클라이언트 URL 인코딩 이슈 회피
 }
 
+# 측정 대상 DB. 부하 테스트 후 destroy 로 제거되는 ephemeral 인스턴스다.
 resource "aws_db_instance" "this" {
   identifier     = "${local.name}-pg"
   engine         = "postgres"
   engine_version = var.db_engine_version
   instance_class = var.db_instance_class
 
+  # gp3 는 기본 IOPS/throughput 이 명시적이라 재측정 시 스토리지 조건을 비교하기 쉽다.
   allocated_storage = var.db_allocated_storage
   storage_type      = "gp3"
 
@@ -23,12 +27,12 @@ resource "aws_db_instance" "this" {
   password = random_password.db.result
 
   availability_zone      = var.az # SUT 와 같은 AZ
-  multi_az               = false
+  multi_az               = false  # 임계점 탐색용 단일 DB 스펙을 고정한다.
   db_subnet_group_name   = aws_db_subnet_group.this.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   publicly_accessible    = false
 
-  # ephemeral: 빠른 생성/삭제
+  # ephemeral: 테스트 데이터는 재생성/스냅샷 복원 대상으로 보고, destroy 를 막지 않는다.
   skip_final_snapshot = true
   deletion_protection = false
   apply_immediately   = true

--- a/infra/terraform/load-test/rds.tf
+++ b/infra/terraform/load-test/rds.tf
@@ -1,0 +1,43 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${local.name}-db"
+  subnet_ids = [aws_subnet.rds_primary.id, aws_subnet.rds_secondary.id]
+  tags       = merge(local.tags, { Name = "${local.name}-db" })
+}
+
+resource "random_password" "db" {
+  length  = 24
+  special = false # 일부 클라이언트 URL 인코딩 이슈 회피
+}
+
+resource "aws_db_instance" "this" {
+  identifier     = "${local.name}-pg"
+  engine         = "postgres"
+  engine_version = var.db_engine_version
+  instance_class = var.db_instance_class
+
+  allocated_storage = var.db_allocated_storage
+  storage_type      = "gp3"
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db.result
+
+  availability_zone      = var.az # SUT 와 같은 AZ
+  multi_az               = false
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+
+  # ephemeral: 빠른 생성/삭제
+  skip_final_snapshot = true
+  deletion_protection = false
+  apply_immediately   = true
+
+  tags = merge(local.tags, { Name = "${local.name}-pg" })
+
+  # ⚠️ 크레딧 모드(unlimited): aws_db_instance 에 직접 인자가 없다.
+  #   db.t4g 는 RDS 기본이 unlimited 인 경우가 많으나, 생성 후
+  #   `aws rds describe-db-instances` 로 ProcessorFeatures/credit 확인하고
+  #   필요하면 콘솔/CLI(modify-db-instance)로 unlimited 설정할 것.
+  # ⚠️ PostGIS: 앱 Flyway 마이그레이션이 CREATE EXTENSION 으로 만든다(별도 작업 불필요).
+}

--- a/infra/terraform/load-test/terraform.tfvars.example
+++ b/infra/terraform/load-test/terraform.tfvars.example
@@ -16,21 +16,18 @@ db_name           = "umc_product"
 db_username       = "postgres"
 
 # ── 앱 이미지 / 레지스트리 ──
-app_image       = "ghcr.io/umc-product/umc-product-server:develop-20260628"
-registry_server = "ghcr.io"
+app_image       = "docker.io/<namespace>/umc-product-server:develop-20260628"
+registry_server = "docker.io"
 
+# private image면 Secrets Manager 에 아래 JSON 을 저장하고 ARN 을 넣는다.
+# {"username":"<docker-user>","password":"<read-only-token>"}
 # public image면 빈 문자열로 둔다.
-registry_username = ""
-registry_password = ""
+registry_credentials_secret_arn = ""
 
 # ── compose/config·k6 스크립트를 가져올 레포 (private면 토큰 포함) ──
 git_repo_url = "https://github.com/umc-product/umc-product-server.git"
 
 # ── 앱 부팅 env (dev) — DB/OTEL/HIKARI 외 부팅 필수 env 만 ──
-# 멀티라인. valkey/redis 호스트는 'valkey' 로.
-app_env = <<-ENV
-# 예시 — 실제 dev app.env 내용으로 채우기
-# KAKAO_CLIENT_ID=...
-# APPLE_CLIENT_ID=...
-# (외부 연동·시크릿 중 부팅에 필요한 것)
-ENV
+# .env.local 전체 또는 필요한 키만 Secrets Manager secret string 으로 저장하고 ARN 을 넣는다.
+# valkey/redis 호스트가 필요하면 compose 서비스명 'valkey' 를 사용한다.
+app_env_secret_arn = ""

--- a/infra/terraform/load-test/terraform.tfvars.example
+++ b/infra/terraform/load-test/terraform.tfvars.example
@@ -1,0 +1,34 @@
+# 복사해서 terraform.tfvars 로 쓰고 값 채우기 (terraform.tfvars 는 커밋 금지 — .gitignore 확인)
+
+# ── 접근 ──
+key_name     = "my-keypair"        # AWS 에 등록된 EC2 키페어 이름
+allowed_cidr = "1.2.3.4/32"        # 내 공인 IP/32 (curl ifconfig.me 로 확인)
+
+# ── 인스턴스 타입 ── (SUT 는 prod 앱과 동일하게!)
+sut_instance_type        = "t3.small"
+generator_instance_type  = "c5.large"
+monitoring_instance_type = "t3.large"
+
+# ── RDS ──
+db_instance_class = "db.t4g.small"
+db_engine_version = "16.4"
+
+# ── 앱 이미지 / 레지스트리 ──
+app_image       = "ghcr.io/umc-product/umc-product-server:develop-20260628"
+registry_server = "ghcr.io"
+
+# public image면 빈 문자열로 둔다.
+registry_username = ""
+registry_password = ""
+
+# ── compose/config·k6 스크립트를 가져올 레포 (private면 토큰 포함) ──
+git_repo_url = "https://github.com/umc-product/umc-product-server.git"
+
+# ── 앱 부팅 env (dev) — DB/OTEL/HIKARI 외 부팅 필수 env 만 ──
+# 멀티라인. valkey/redis 호스트는 'valkey' 로.
+app_env = <<-ENV
+# 예시 — 실제 dev app.env 내용으로 채우기
+# KAKAO_CLIENT_ID=...
+# APPLE_CLIENT_ID=...
+# (외부 연동·시크릿 중 부팅에 필요한 것)
+ENV

--- a/infra/terraform/load-test/terraform.tfvars.example
+++ b/infra/terraform/load-test/terraform.tfvars.example
@@ -12,11 +12,8 @@ monitoring_instance_type = "t3.large"
 # ── RDS ──
 db_instance_class = "db.t4g.small"
 db_engine_version = "18.3"
+db_name           = "umc_product"
 db_username       = "postgres"
-
-# prod RDS 콘솔의 DB name 이 '-' 라면 초기 DB 이름이 없는 상태다.
-# 앱 JDBC URL 이 실제로 어느 DB 를 쓰는지 확인한 뒤 맞춘다. 흔한 후보는 "postgres" 또는 앱 전용 DB 이름이다.
-# db_name = "postgres"
 
 # ── 앱 이미지 / 레지스트리 ──
 app_image       = "ghcr.io/umc-product/umc-product-server:develop-20260628"

--- a/infra/terraform/load-test/terraform.tfvars.example
+++ b/infra/terraform/load-test/terraform.tfvars.example
@@ -5,13 +5,18 @@ key_name     = "my-keypair"        # AWS 에 등록된 EC2 키페어 이름
 allowed_cidr = "1.2.3.4/32"        # 내 공인 IP/32 (curl ifconfig.me 로 확인)
 
 # ── 인스턴스 타입 ── (SUT 는 prod 앱과 동일하게!)
-sut_instance_type        = "t3.small"
+sut_instance_type        = "t4g.small"
 generator_instance_type  = "c5.large"
 monitoring_instance_type = "t3.large"
 
 # ── RDS ──
 db_instance_class = "db.t4g.small"
-db_engine_version = "16.4"
+db_engine_version = "18.3"
+db_username       = "postgres"
+
+# prod RDS 콘솔의 DB name 이 '-' 라면 초기 DB 이름이 없는 상태다.
+# 앱 JDBC URL 이 실제로 어느 DB 를 쓰는지 확인한 뒤 맞춘다. 흔한 후보는 "postgres" 또는 앱 전용 DB 이름이다.
+# db_name = "postgres"
 
 # ── 앱 이미지 / 레지스트리 ──
 app_image       = "ghcr.io/umc-product/umc-product-server:develop-20260628"

--- a/infra/terraform/load-test/terraform.tfvars.example
+++ b/infra/terraform/load-test/terraform.tfvars.example
@@ -16,12 +16,15 @@ db_name           = "umc_product"
 db_username       = "postgres"
 
 # ── 앱 이미지 / 레지스트리 ──
-app_image       = "docker.io/<namespace>/umc-product-server:develop-20260628"
-registry_server = "docker.io"
+# 기본은 현재 AWS 계정 ECR 에서 pull 한다. ECR repository 에 이미지를 먼저 push 해야 한다.
+app_image           = "<account-id>.dkr.ecr.ap-northeast-2.amazonaws.com/umc-product-server:development-latest"
+registry_type       = "ecr"
+registry_server     = "" # ecr 이고 빈 문자열이면 현재 AWS 계정 ECR registry 로 계산
+ecr_repository_name = "umc-product-server"
 
-# private image면 Secrets Manager 에 아래 JSON 을 저장하고 ARN 을 넣는다.
+# registry_type=generic private image면 Secrets Manager 에 아래 JSON 을 저장하고 ARN 을 넣는다.
 # {"username":"<docker-user>","password":"<read-only-token>"}
-# public image면 빈 문자열로 둔다.
+# ecr/public image면 빈 문자열로 둔다.
 registry_credentials_secret_arn = ""
 
 # ── compose/config·k6 스크립트를 가져올 레포 (private면 토큰 포함) ──

--- a/infra/terraform/load-test/user-data/generator.sh.tftpl
+++ b/infra/terraform/load-test/user-data/generator.sh.tftpl
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# cloud-init 로그와 EC2 콘솔 로그 양쪽에서 부팅 실패 원인을 볼 수 있게 남긴다.
 exec > >(tee /var/log/umc-load-test-generator-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
+# generator 는 k6 실행과 host metric 수집만 담당한다. 앱/관측 컨테이너는 올리지 않는다.
 dnf -y install docker git curl
 systemctl enable --now docker
 
 # k6 설치 (공식 repo)
+# Amazon Linux 기본 repo 에 k6 가 없어 Grafana 공식 RPM repo 를 등록한다.
 cat > /etc/yum.repos.d/k6.repo <<'REPO'
 [k6]
 name=k6
@@ -17,6 +20,7 @@ gpgkey=https://dl.k6.io/key.gpg
 REPO
 dnf -y install k6
 
+# generator 자체가 먼저 병목나는지 보기 위해 node-exporter 를 같이 올린다.
 docker run -d \
   --name umc-load-test-generator-node-exporter \
   --restart unless-stopped \
@@ -29,17 +33,21 @@ docker run -d \
 
 cd /home/ec2-user
 %{ if git_repo_url != "" ~}
+# k6 script 와 seed template 은 repo 의 docs/guides/load-test/k6 에서 가져온다.
 git clone ${git_repo_url} umc-product
 cp -r umc-product/docs/guides/load-test/k6 ./k6 2>/dev/null || mkdir -p k6
 %{ else ~}
 echo "⚠️ git_repo_url 미설정 — k6 스크립트(script.js)·seed.json 을 ~/k6 에 수동으로 올리세요."
 mkdir -p k6
 %{ endif ~}
+# 첫 smoke 를 바로 실행할 수 있게 example 을 seed.json 으로 복사한다.
+# 실제 측정 전에는 Phase 03 시딩 결과로 이 파일을 교체해야 한다.
 if [ -f /home/ec2-user/k6/data/seed.example.json ] && [ ! -f /home/ec2-user/k6/data/seed.json ]; then
   cp /home/ec2-user/k6/data/seed.example.json /home/ec2-user/k6/data/seed.json
 fi
 chown -R ec2-user:ec2-user /home/ec2-user/k6
 
+# 반복 실행 명령을 고정해 사람이 매번 remote-write 환경변수를 입력하지 않도록 한다.
 cat > /usr/local/bin/run-umc-k6 <<'RUNNER'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -53,6 +61,7 @@ export K6_OUT=experimental-prometheus-rw
 export K6_PROMETHEUS_RW_SERVER_URL="${prom_rw_url}"
 export K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg"
 
+# BASE_URL 은 public IP 가 아니라 SUT private IP 를 사용한다. 외부 네트워크 변수를 제거하기 위해서다.
 k6 run \
   -e BASE_URL="http://${sut_host}:8080" \
   -e PROFILE="$${PROFILE}" \

--- a/infra/terraform/load-test/user-data/generator.sh.tftpl
+++ b/infra/terraform/load-test/user-data/generator.sh.tftpl
@@ -69,9 +69,9 @@ export K6_OUT=experimental-prometheus-rw
 export K6_PROMETHEUS_RW_SERVER_URL="${prom_rw_url}"
 export K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg"
 
-# BASE_URL 은 public IP 가 아니라 SUT private IP 를 사용한다. 외부 네트워크 변수를 제거하기 위해서다.
+# BASE_URL 은 운영과 같은 HTTP 진입점인 ALB 를 사용한다.
 k6 run \
-  -e BASE_URL="http://${sut_host}:8080" \
+  -e BASE_URL="${base_url}" \
   -e PROFILE="$${PROFILE}" \
   -e RATE="$${RATE}" \
   -e SEED_FILE="./data/seed.json" \
@@ -81,7 +81,7 @@ chmod +x /usr/local/bin/run-umc-k6
 
 # 실행 힌트
 cat > /home/ec2-user/k6/RUN.md <<HINT
-SUT(private): http://${sut_host}:8080
+SUT(ALB): ${base_url}
 Prometheus remote-write: ${prom_rw_url}
 
 # smoke

--- a/infra/terraform/load-test/user-data/generator.sh.tftpl
+++ b/infra/terraform/load-test/user-data/generator.sh.tftpl
@@ -8,12 +8,20 @@ exec > >(tee /var/log/umc-load-test-generator-user-data.log | logger -t user-dat
 dnf -y install docker git curl
 systemctl enable --now docker
 
+case "$(uname -m)" in
+  x86_64|aarch64|arm64) ;;
+  *)
+    echo "Unsupported CPU architecture: $(uname -m)"
+    exit 1
+    ;;
+esac
+
 # k6 설치 (공식 repo)
 # Amazon Linux 기본 repo 에 k6 가 없어 Grafana 공식 RPM repo 를 등록한다.
 cat > /etc/yum.repos.d/k6.repo <<'REPO'
 [k6]
 name=k6
-baseurl=https://dl.k6.io/rpm/x86_64
+baseurl=https://dl.k6.io/rpm/$basearch
 enabled=1
 gpgcheck=1
 gpgkey=https://dl.k6.io/key.gpg

--- a/infra/terraform/load-test/user-data/generator.sh.tftpl
+++ b/infra/terraform/load-test/user-data/generator.sh.tftpl
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec > >(tee /var/log/umc-load-test-generator-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
+dnf -y install docker git curl
+systemctl enable --now docker
+
+# k6 설치 (공식 repo)
+cat > /etc/yum.repos.d/k6.repo <<'REPO'
+[k6]
+name=k6
+baseurl=https://dl.k6.io/rpm/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://dl.k6.io/key.gpg
+REPO
+dnf -y install k6
+
+docker run -d \
+  --name umc-load-test-generator-node-exporter \
+  --restart unless-stopped \
+  --pid host \
+  -p 9100:9100 \
+  -v /:/host:ro,rslave \
+  prom/node-exporter:v1.11.1 \
+  --path.rootfs=/host \
+  '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+
+cd /home/ec2-user
+%{ if git_repo_url != "" ~}
+git clone ${git_repo_url} umc-product
+cp -r umc-product/docs/guides/load-test/k6 ./k6 2>/dev/null || mkdir -p k6
+%{ else ~}
+echo "⚠️ git_repo_url 미설정 — k6 스크립트(script.js)·seed.json 을 ~/k6 에 수동으로 올리세요."
+mkdir -p k6
+%{ endif ~}
+if [ -f /home/ec2-user/k6/data/seed.example.json ] && [ ! -f /home/ec2-user/k6/data/seed.json ]; then
+  cp /home/ec2-user/k6/data/seed.example.json /home/ec2-user/k6/data/seed.json
+fi
+chown -R ec2-user:ec2-user /home/ec2-user/k6
+
+cat > /usr/local/bin/run-umc-k6 <<'RUNNER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="$${1:-smoke}"
+RATE="$${2:-50}"
+
+cd /home/ec2-user/k6
+
+export K6_OUT=experimental-prometheus-rw
+export K6_PROMETHEUS_RW_SERVER_URL="${prom_rw_url}"
+export K6_PROMETHEUS_RW_TREND_STATS="p(50),p(90),p(95),p(99),min,max,avg"
+
+k6 run \
+  -e BASE_URL="http://${sut_host}:8080" \
+  -e PROFILE="$${PROFILE}" \
+  -e RATE="$${RATE}" \
+  -e SEED_FILE="./data/seed.json" \
+  script.js
+RUNNER
+chmod +x /usr/local/bin/run-umc-k6
+
+# 실행 힌트
+cat > /home/ec2-user/k6/RUN.md <<HINT
+SUT(private): http://${sut_host}:8080
+Prometheus remote-write: ${prom_rw_url}
+
+# smoke
+run-umc-k6 smoke 1
+# read 램프 (메트릭 적재)
+run-umc-k6 read 300
+HINT
+chown ec2-user:ec2-user /home/ec2-user/k6/RUN.md

--- a/infra/terraform/load-test/user-data/monitoring.sh.tftpl
+++ b/infra/terraform/load-test/user-data/monitoring.sh.tftpl
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# monitoring 은 부하 중 문제가 생겼을 때 가장 먼저 봐야 하는 박스라 user-data 로그를 파일/콘솔에 남긴다.
 exec > >(tee /var/log/umc-load-test-monitoring-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
+# Docker compose 기반 기존 monitoring stack 을 그대로 재사용한다.
 dnf -y install docker git curl
 systemctl enable --now docker
 mkdir -p /usr/libexec/docker/cli-plugins
@@ -12,6 +14,8 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 
 cd /opt
 %{ if git_repo_url != "" ~}
+# infra/monitoring/grafana 의 compose/config/provisioning 을 가져온다.
+# private repo URL 에 토큰을 넣으면 EC2 user-data 와 Terraform state 에 남으므로 read-only 토큰만 사용한다.
 git clone ${git_repo_url} umc-product
 cd umc-product/infra/monitoring/grafana
 %{ else ~}
@@ -21,6 +25,7 @@ cd umc-product/infra/monitoring/grafana
 %{ endif ~}
 
 # 전용 스택용 .env (외부에서 접근 가능하도록 0.0.0.0 바인드)
+# 이 스택은 부하 테스트 전용이므로 localhost bind 가 아니라 VPC/SUT 에서 접근 가능한 bind 로 바꾼다.
 cat > .env <<ENV
 OTEL_INGEST_TOKEN=${otel_token}
 MONITORING_BIND_ADDRESS=0.0.0.0
@@ -30,6 +35,8 @@ GRAFANA_ADMIN_PASSWORD=${grafana_admin_password}
 DISCORD_ALERT_WEBHOOK=http://127.0.0.1:65535/load-test-alert-disabled
 ENV
 
+# 기존 prometheus.yml 은 운영/로컬 공용 설정이다.
+# 부하 테스트에서는 SUT/generator node-exporter, postgres_exporter, k6 remote-write 를 같은 Prometheus 에 모아야 한다.
 cat > config/prometheus/prometheus.yml <<'PROMETHEUS'
 global:
   scrape_interval: 15s
@@ -88,6 +95,7 @@ PROMETHEUS
 cat > docker-compose.load-test.override.yml <<'COMPOSE'
 services:
   prometheus:
+    # k6 는 Prometheus remote-write 로 결과를 밀어 넣으므로 receiver 플래그가 필요하다.
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
@@ -97,6 +105,7 @@ services:
       - --web.enable-lifecycle
 
   postgres-exporter:
+    # RDS 내부 지표(connection, lock, xact, cache hit)를 Prometheus scrape metric 으로 변환한다.
     image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: umc-load-test-postgres-exporter
     environment:
@@ -107,9 +116,11 @@ services:
     restart: unless-stopped
 COMPOSE
 
-# linux 프로필로 node-exporter 까지 기동
+# linux 프로필로 monitoring host 의 node-exporter 까지 같이 기동한다.
 docker compose -f docker-compose.yml -f docker-compose.load-test.override.yml --profile linux up -d
 
+# Grafana/Prometheus 가 뜨기 전 apply 가 성공 처리되면 이후 단계에서 원인 파악이 어렵다.
+# 최소 health endpoint 를 확인해 부팅 실패를 user-data 실패로 드러낸다.
 for i in {1..60}; do
   if curl -fsS http://localhost:13000/api/health >/dev/null &&
      curl -fsS http://localhost:19090/-/ready >/dev/null; then

--- a/infra/terraform/load-test/user-data/monitoring.sh.tftpl
+++ b/infra/terraform/load-test/user-data/monitoring.sh.tftpl
@@ -7,8 +7,18 @@ exec > >(tee /var/log/umc-load-test-monitoring-user-data.log | logger -t user-da
 # Docker compose 기반 기존 monitoring stack 을 그대로 재사용한다.
 dnf -y install docker git curl
 systemctl enable --now docker
+
+case "$(uname -m)" in
+  x86_64) compose_arch="x86_64" ;;
+  aarch64|arm64) compose_arch="aarch64" ;;
+  *)
+    echo "Unsupported CPU architecture: $(uname -m)"
+    exit 1
+    ;;
+esac
+
 mkdir -p /usr/libexec/docker/cli-plugins
-curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$${compose_arch}" \
   -o /usr/libexec/docker/cli-plugins/docker-compose
 chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 

--- a/infra/terraform/load-test/user-data/monitoring.sh.tftpl
+++ b/infra/terraform/load-test/user-data/monitoring.sh.tftpl
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec > >(tee /var/log/umc-load-test-monitoring-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
+dnf -y install docker git curl
+systemctl enable --now docker
+mkdir -p /usr/libexec/docker/cli-plugins
+curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+  -o /usr/libexec/docker/cli-plugins/docker-compose
+chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+
+cd /opt
+%{ if git_repo_url != "" ~}
+git clone ${git_repo_url} umc-product
+cd umc-product/infra/monitoring/grafana
+%{ else ~}
+echo "⚠️ git_repo_url 미설정 — infra/monitoring/grafana 의 compose+config 를 이 경로에 수동으로 올린 뒤 compose up 하세요."
+mkdir -p umc-product/infra/monitoring/grafana
+cd umc-product/infra/monitoring/grafana
+%{ endif ~}
+
+# 전용 스택용 .env (외부에서 접근 가능하도록 0.0.0.0 바인드)
+cat > .env <<ENV
+OTEL_INGEST_TOKEN=${otel_token}
+MONITORING_BIND_ADDRESS=0.0.0.0
+OTEL_BIND_ADDRESS=0.0.0.0
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=${grafana_admin_password}
+DISCORD_ALERT_WEBHOOK=http://127.0.0.1:65535/load-test-alert-disabled
+ENV
+
+cat > config/prometheus/prometheus.yml <<'PROMETHEUS'
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: umc-product-load-test
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: [ 'node-exporter:9100' ]
+        labels:
+          role: monitoring
+      - targets: [ '${sut_private_ip}:9100' ]
+        labels:
+          role: sut
+      - targets: [ '${generator_private_ip}:9100' ]
+        labels:
+          role: generator
+
+  - job_name: postgres-exporter
+    static_configs:
+      - targets: [ 'postgres-exporter:9187' ]
+        labels:
+          role: rds
+
+  - job_name: alertmanager
+    static_configs:
+      - targets: [ 'alertmanager:9093' ]
+
+  - job_name: grafana
+    static_configs:
+      - targets: [ 'grafana:3000' ]
+
+  - job_name: loki
+    static_configs:
+      - targets: [ 'loki:3100' ]
+
+  - job_name: otel-collector
+    static_configs:
+      - targets: [ 'otel-collector:8888' ]
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: [ 'alertmanager:9093' ]
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+PROMETHEUS
+
+cat > docker-compose.load-test.override.yml <<'COMPOSE'
+services:
+  prometheus:
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=3d
+      - --web.enable-otlp-receiver
+      - --web.enable-remote-write-receiver
+      - --web.enable-lifecycle
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.17.1
+    container_name: umc-load-test-postgres-exporter
+    environment:
+      DATA_SOURCE_URI: "${db_host}:${db_port}/${db_name}?sslmode=require"
+      DATA_SOURCE_USER: "${db_username}"
+      DATA_SOURCE_PASS: "${db_password}"
+    networks: [monitoring]
+    restart: unless-stopped
+COMPOSE
+
+# linux 프로필로 node-exporter 까지 기동
+docker compose -f docker-compose.yml -f docker-compose.load-test.override.yml --profile linux up -d
+
+for i in {1..60}; do
+  if curl -fsS http://localhost:13000/api/health >/dev/null &&
+     curl -fsS http://localhost:19090/-/ready >/dev/null; then
+    echo "monitoring stack is ready"
+    exit 0
+  fi
+  echo "waiting for monitoring stack... $i/60"
+  sleep 5
+done
+
+echo "monitoring stack failed to become ready"
+docker compose -f docker-compose.yml -f docker-compose.load-test.override.yml ps
+docker compose -f docker-compose.yml -f docker-compose.load-test.override.yml logs --tail=200
+exit 1

--- a/infra/terraform/load-test/user-data/sut.sh.tftpl
+++ b/infra/terraform/load-test/user-data/sut.sh.tftpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# 앱이 안 뜰 때 EC2 콘솔과 /var/log 에서 바로 원인을 볼 수 있게 로그를 남긴다.
 exec > >(tee /var/log/umc-load-test-sut-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 # Docker + compose (Amazon Linux 2023)
@@ -14,11 +15,14 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 mkdir -p /opt/umc
 cd /opt/umc
 
+# public image 는 로그인 없이 pull 가능하므로 credential 이 있을 때만 login 한다.
 if [ -n "${registry_username}" ] && [ -n "${registry_password}" ]; then
   echo "${registry_password}" | docker login ${registry_server} -u "${registry_username}" --password-stdin
 fi
 
 # 앱 런타임 env: 기본(app_env) + 부하테스트 오버라이드
+# app_env 는 외부 연동 secret 등 "앱 부팅에 필요한 값"만 받는다.
+# DB/OTLP/Hikari/dev profile 은 부하 테스트 조건 고정을 위해 아래 OVERRIDE_ENV 에서 항상 덮어쓴다.
 cat > app.env <<'BASE_ENV'
 ${app_env}
 BASE_ENV
@@ -27,6 +31,7 @@ SPRING_PROFILES_ACTIVE=dev
 SERVER_PORT=8080
 MANAGEMENT_PORT=9090
 APP_ENVIRONMENT=load-test
+# SeedController 와 /test/token/access 는 dev/test 용이다. 부하 테스트 시딩과 토큰 발급을 위해 켠다.
 APP_SEED_ENABLED=true
 P6SPY_ENABLE_LOGGING=false
 TRACE_SAMPLING_PROBABILITY=1.0
@@ -41,9 +46,11 @@ OVERRIDE_ENV
 
 # compose: 앱 + valkey (DB 는 RDS). prod 에 nginx 앞단이 있으면 여기 추가.
 # ⚠️ app_env 의 valkey/redis 호스트는 아래 서비스명 'valkey' 를 가리켜야 함.
+# 현재는 Nginx 없이 앱 8080 을 직접 노출한다. prod 앞단까지 재현해야 하면 여기에 nginx service 를 추가한다.
 cat > docker-compose.yml <<'COMPOSE'
 services:
   valkey:
+    # 앱 캐시/세션 의존성을 compose 내부 서비스로 해결한다. DB 는 compose 가 아니라 RDS 를 사용한다.
     image: valkey/valkey:9.1
     restart: unless-stopped
     command: ["valkey-server", "--appendonly", "yes"]
@@ -55,6 +62,7 @@ services:
       timeout: 5s
       retries: 10
   app:
+    # image 는 terraform.tfvars 의 app_image 값이다. Terraform 은 빌드하지 않고 pull 만 수행한다.
     image: ${app_image}
     restart: unless-stopped
     env_file: [app.env]
@@ -72,6 +80,7 @@ services:
       start_period: 60s
 
   node-exporter:
+    # SUT host 의 CPU/memory/network 를 Prometheus 에 노출해 USE 분석에 사용한다.
     image: prom/node-exporter:v1.11.1
     restart: unless-stopped
     command:
@@ -90,6 +99,7 @@ COMPOSE
 docker compose pull
 docker compose up -d
 
+# Flyway, DB 연결, actuator health 가 정상인지 apply 단계에서 확인한다.
 for i in {1..90}; do
   if curl -fsS http://localhost:9090/actuator/health >/dev/null; then
     echo "SUT is healthy"

--- a/infra/terraform/load-test/user-data/sut.sh.tftpl
+++ b/infra/terraform/load-test/user-data/sut.sh.tftpl
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec > >(tee /var/log/umc-load-test-sut-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
+# Docker + compose (Amazon Linux 2023)
+dnf -y install docker curl
+systemctl enable --now docker
+mkdir -p /usr/libexec/docker/cli-plugins
+curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+  -o /usr/libexec/docker/cli-plugins/docker-compose
+chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+
+mkdir -p /opt/umc
+cd /opt/umc
+
+if [ -n "${registry_username}" ] && [ -n "${registry_password}" ]; then
+  echo "${registry_password}" | docker login ${registry_server} -u "${registry_username}" --password-stdin
+fi
+
+# 앱 런타임 env: 기본(app_env) + 부하테스트 오버라이드
+cat > app.env <<'BASE_ENV'
+${app_env}
+BASE_ENV
+cat >> app.env <<OVERRIDE_ENV
+SPRING_PROFILES_ACTIVE=dev
+SERVER_PORT=8080
+MANAGEMENT_PORT=9090
+APP_ENVIRONMENT=load-test
+APP_SEED_ENABLED=true
+P6SPY_ENABLE_LOGGING=false
+TRACE_SAMPLING_PROBABILITY=1.0
+DATABASE_URL=jdbc:postgresql://${db_host}:${db_port}/${db_name}
+DATABASE_USERNAME=${db_username}
+DATABASE_PASSWORD=${db_password}
+HIKARI_MAX_POOL_SIZE=${hikari_pool}
+HIKARI_MIN_IDLE=${hikari_pool}
+OTEL_URL=http://${otel_host}:4318
+OTEL_AUTH_HEADER=Bearer ${otel_token}
+OVERRIDE_ENV
+
+# compose: 앱 + valkey (DB 는 RDS). prod 에 nginx 앞단이 있으면 여기 추가.
+# ⚠️ app_env 의 valkey/redis 호스트는 아래 서비스명 'valkey' 를 가리켜야 함.
+cat > docker-compose.yml <<'COMPOSE'
+services:
+  valkey:
+    image: valkey/valkey:9.1
+    restart: unless-stopped
+    command: ["valkey-server", "--appendonly", "yes"]
+    volumes:
+      - valkey-data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+  app:
+    image: ${app_image}
+    restart: unless-stopped
+    env_file: [app.env]
+    depends_on:
+      valkey:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9090/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+  node-exporter:
+    image: prom/node-exporter:v1.11.1
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+    ports:
+      - "9100:9100"
+
+volumes:
+  valkey-data:
+COMPOSE
+
+docker compose pull
+docker compose up -d
+
+for i in {1..90}; do
+  if curl -fsS http://localhost:9090/actuator/health >/dev/null; then
+    echo "SUT is healthy"
+    exit 0
+  fi
+  echo "waiting for SUT... $i/90"
+  sleep 5
+done
+
+echo "SUT failed to become healthy"
+docker compose ps
+docker compose logs --tail=300
+exit 1

--- a/infra/terraform/load-test/user-data/sut.sh.tftpl
+++ b/infra/terraform/load-test/user-data/sut.sh.tftpl
@@ -7,8 +7,18 @@ exec > >(tee /var/log/umc-load-test-sut-user-data.log | logger -t user-data -s 2
 # Docker + compose (Amazon Linux 2023)
 dnf -y install docker curl
 systemctl enable --now docker
+
+case "$(uname -m)" in
+  x86_64) compose_arch="x86_64" ;;
+  aarch64|arm64) compose_arch="aarch64" ;;
+  *)
+    echo "Unsupported CPU architecture: $(uname -m)"
+    exit 1
+    ;;
+esac
+
 mkdir -p /usr/libexec/docker/cli-plugins
-curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$${compose_arch}" \
   -o /usr/libexec/docker/cli-plugins/docker-compose
 chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 

--- a/infra/terraform/load-test/user-data/sut.sh.tftpl
+++ b/infra/terraform/load-test/user-data/sut.sh.tftpl
@@ -25,9 +25,13 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 mkdir -p /opt/umc
 cd /opt/umc
 
-# private image 는 Secrets Manager 의 JSON credential 로 로그인한다.
-# secret 예: {"username":"docker-user","password":"read-only-token"}
-if [ -n "${registry_credentials_secret_arn}" ]; then
+# registry_type=ecr 이면 SUT EC2 role 로 ECR 에 로그인한다.
+# generic private registry 는 Secrets Manager 의 JSON credential 로 로그인한다.
+if [ "${registry_type}" = "ecr" ]; then
+  aws --region "${region}" ecr get-login-password \
+    | docker login --username AWS --password-stdin "${registry_server}"
+elif [ -n "${registry_credentials_secret_arn}" ]; then
+  # secret 예: {"username":"docker-user","password":"read-only-token"}
   registry_json="$(aws --region "${region}" secretsmanager get-secret-value \
     --secret-id "${registry_credentials_secret_arn}" \
     --query SecretString \

--- a/infra/terraform/load-test/user-data/sut.sh.tftpl
+++ b/infra/terraform/load-test/user-data/sut.sh.tftpl
@@ -4,8 +4,8 @@ set -euo pipefail
 # 앱이 안 뜰 때 EC2 콘솔과 /var/log 에서 바로 원인을 볼 수 있게 로그를 남긴다.
 exec > >(tee /var/log/umc-load-test-sut-user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
-# Docker + compose (Amazon Linux 2023)
-dnf -y install docker curl
+# Docker + compose + AWS CLI (Amazon Linux 2023)
+dnf -y install docker curl awscli jq
 systemctl enable --now docker
 
 case "$(uname -m)" in
@@ -25,17 +25,36 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 mkdir -p /opt/umc
 cd /opt/umc
 
-# public image 는 로그인 없이 pull 가능하므로 credential 이 있을 때만 login 한다.
-if [ -n "${registry_username}" ] && [ -n "${registry_password}" ]; then
-  echo "${registry_password}" | docker login ${registry_server} -u "${registry_username}" --password-stdin
+# private image 는 Secrets Manager 의 JSON credential 로 로그인한다.
+# secret 예: {"username":"docker-user","password":"read-only-token"}
+if [ -n "${registry_credentials_secret_arn}" ]; then
+  registry_json="$(aws --region "${region}" secretsmanager get-secret-value \
+    --secret-id "${registry_credentials_secret_arn}" \
+    --query SecretString \
+    --output text)"
+  registry_username="$(printf '%s' "$${registry_json}" | jq -r '.username // ""')"
+  registry_password="$(printf '%s' "$${registry_json}" | jq -r '.password // ""')"
+
+  if [ -z "$${registry_username}" ] || [ -z "$${registry_password}" ]; then
+    echo "Registry credential secret must contain username and password"
+    exit 1
+  fi
+
+  printf '%s' "$${registry_password}" | docker login "${registry_server}" -u "$${registry_username}" --password-stdin
 fi
 
-# 앱 런타임 env: 기본(app_env) + 부하테스트 오버라이드
-# app_env 는 외부 연동 secret 등 "앱 부팅에 필요한 값"만 받는다.
+# 앱 런타임 env: Secrets Manager 의 app.env + 부하테스트 오버라이드
+# app_env secret 은 외부 연동 secret 등 "앱 부팅에 필요한 값"만 받는다.
 # DB/OTLP/Hikari/dev profile 은 부하 테스트 조건 고정을 위해 아래 OVERRIDE_ENV 에서 항상 덮어쓴다.
-cat > app.env <<'BASE_ENV'
-${app_env}
-BASE_ENV
+if [ -n "${app_env_secret_arn}" ]; then
+  aws --region "${region}" secretsmanager get-secret-value \
+    --secret-id "${app_env_secret_arn}" \
+    --query SecretString \
+    --output text > app.env
+else
+  : > app.env
+fi
+
 cat >> app.env <<OVERRIDE_ENV
 SPRING_PROFILES_ACTIVE=dev
 SERVER_PORT=8080

--- a/infra/terraform/load-test/variables.tf
+++ b/infra/terraform/load-test/variables.tf
@@ -117,18 +117,15 @@ variable "registry_server" {
   default     = "docker.io"
 }
 
-variable "registry_username" {
-  description = "레지스트리 로그인 사용자명. public image면 빈 문자열."
+variable "registry_credentials_secret_arn" {
+  description = "Docker registry credential JSON 을 담은 AWS Secrets Manager secret ARN. public image면 빈 문자열."
   type        = string
-  sensitive   = true
   default     = ""
-}
 
-variable "registry_password" {
-  description = "레지스트리 로그인 토큰/비밀번호. public image면 빈 문자열."
-  type        = string
-  sensitive   = true
-  default     = ""
+  validation {
+    condition     = var.registry_credentials_secret_arn == "" || can(regex("^arn:aws[a-zA-Z-]*:secretsmanager:", var.registry_credentials_secret_arn))
+    error_message = "registry_credentials_secret_arn 은 빈 문자열이거나 Secrets Manager secret ARN 이어야 합니다."
+  }
 }
 
 variable "git_repo_url" {
@@ -143,14 +140,18 @@ variable "git_repo_url" {
   }
 }
 
-variable "app_env" {
+variable "app_env_secret_arn" {
   description = <<-EOT
-    앱 런타임 env(app.env) 내용 (dev 프로필 기준, 멀티라인).
+    앱 런타임 env(app.env) 내용을 담은 AWS Secrets Manager secret ARN.
     DATABASE_URL/USERNAME/PASSWORD · OTEL_URL · SPRING_PROFILES_ACTIVE · HIKARI_MAX_POOL_SIZE 는
-    user_data 가 부하테스트 값으로 덮어쓰므로 여기엔 그 외 부팅 필수 env(외부 연동 등)만 넣으면 됨.
-    주의: 현재 방식은 Terraform state 와 EC2 user-data 에 값이 남는다. 운영 수준 보안이 필요하면 Secrets Manager ARN 방식으로 바꾼다.
+    user_data 가 부하 테스트 값으로 덮어쓰므로 secret 에는 그 외 부팅 필수 env(외부 연동 등)를 넣는다.
+    빈 문자열이면 빈 app.env 에 부하 테스트 오버라이드만 추가한다.
   EOT
   type        = string
-  sensitive   = true
   default     = ""
+
+  validation {
+    condition     = var.app_env_secret_arn == "" || can(regex("^arn:aws[a-zA-Z-]*:secretsmanager:", var.app_env_secret_arn))
+    error_message = "app_env_secret_arn 은 빈 문자열이거나 Secrets Manager secret ARN 이어야 합니다."
+  }
 }

--- a/infra/terraform/load-test/variables.tf
+++ b/infra/terraform/load-test/variables.tf
@@ -1,0 +1,130 @@
+# ── 리전 / AZ ────────────────────────────────────────────────
+variable "region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "az" {
+  description = "모든 인스턴스·RDS를 둘 단일 AZ (네트워크 레이턴시 변수 제거)"
+  type        = string
+  default     = "ap-northeast-2a"
+}
+
+variable "az_secondary" {
+  description = "RDS subnet group 요건(>=2 AZ)을 위한 보조 AZ. 인스턴스는 안 둠"
+  type        = string
+  default     = "ap-northeast-2c"
+}
+
+variable "ami_ssm_parameter" {
+  description = "EC2 AMI SSM 파라미터. Graviton(arm64) 인스턴스면 .../al2023-ami-kernel-default-arm64 로 교체"
+  type        = string
+  default     = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+# ── 접근 ─────────────────────────────────────────────────────
+variable "key_name" {
+  description = "기존 EC2 키페어 이름 (SSH 접속용)"
+  type        = string
+}
+
+variable "allowed_cidr" {
+  description = "SSH·Grafana 접근 허용 CIDR (예: 내 공인 IP/32)"
+  type        = string
+}
+
+# ── 인스턴스 타입 ────────────────────────────────────────────
+variable "sut_instance_type" {
+  description = "SUT(앱) — prod 앱과 동일 타입으로 (현재 스펙 fidelity 핵심)"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "generator_instance_type" {
+  description = "k6 부하 생성기 — 생성기가 먼저 병목나지 않게 넉넉히"
+  type        = string
+  default     = "c5.large"
+}
+
+variable "monitoring_instance_type" {
+  description = "관측 스택(otel-collector+prom+tempo+loki+grafana)"
+  type        = string
+  default     = "t3.large"
+}
+
+# ── RDS ──────────────────────────────────────────────────────
+variable "db_instance_class" {
+  description = "RDS 인스턴스 클래스 (측정 대상 DB 스펙)"
+  type        = string
+  default     = "db.t4g.small"
+}
+
+variable "db_engine_version" {
+  description = "RDS PostgreSQL 버전. `aws rds describe-db-engine-versions --engine postgres` 로 가용 버전 확인"
+  type        = string
+  default     = "16.4"
+}
+
+variable "db_allocated_storage" {
+  description = "RDS 스토리지(GB)"
+  type        = number
+  default     = 50
+}
+
+variable "db_name" {
+  type    = string
+  default = "umc_product"
+}
+
+variable "db_username" {
+  type    = string
+  default = "umc_product"
+}
+
+# ── 앱 이미지 / 배포 ─────────────────────────────────────────
+variable "app_image" {
+  description = "앱 Docker 이미지 (예: docker.io/<repo>:<dev-tag>)"
+  type        = string
+}
+
+variable "registry_server" {
+  description = "컨테이너 레지스트리 (docker.io 또는 ghcr.io)"
+  type        = string
+  default     = "docker.io"
+}
+
+variable "registry_username" {
+  description = "레지스트리 로그인 사용자명. public image면 빈 문자열."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "registry_password" {
+  description = "레지스트리 로그인 토큰/비밀번호. public image면 빈 문자열."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "git_repo_url" {
+  description = "compose/관측 config 와 k6 스크립트를 가져올 레포 URL. private repo면 read-only 토큰을 포함한 HTTPS URL."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.git_repo_url)) > 0
+    error_message = "git_repo_url 은 필수입니다. 현재 구조는 EC2 user-data 에서 레포를 clone 해 monitoring config 와 k6 script 를 가져옵니다."
+  }
+}
+
+variable "app_env" {
+  description = <<-EOT
+    앱 런타임 env(app.env) 내용 (dev 프로필 기준, 멀티라인).
+    DATABASE_URL/USERNAME/PASSWORD · OTEL_URL · SPRING_PROFILES_ACTIVE · HIKARI_MAX_POOL_SIZE 는
+    user_data 가 부하테스트 값으로 덮어쓰므로 여기엔 그 외 부팅 필수 env(외부 연동 등)만 넣으면 됨.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/infra/terraform/load-test/variables.tf
+++ b/infra/terraform/load-test/variables.tf
@@ -1,4 +1,5 @@
 # ── 리전 / AZ ────────────────────────────────────────────────
+# 모든 기본값은 서울 리전 기준이다. 다른 리전에서 실행하면 AMI, AZ, RDS engine version 가용성을 같이 확인해야 한다.
 variable "region" {
   description = "AWS 리전"
   type        = string
@@ -6,13 +7,13 @@ variable "region" {
 }
 
 variable "az" {
-  description = "모든 인스턴스·RDS를 둘 단일 AZ (네트워크 레이턴시 변수 제거)"
+  description = "EC2와 RDS primary를 둘 AZ. 네트워크 레이턴시 변수를 줄이기 위해 한 AZ에 모은다."
   type        = string
   default     = "ap-northeast-2a"
 }
 
 variable "az_secondary" {
-  description = "RDS subnet group 요건(>=2 AZ)을 위한 보조 AZ. 인스턴스는 안 둠"
+  description = "RDS subnet group 요건(>=2 AZ)을 위한 보조 AZ. EC2는 두지 않는다."
   type        = string
   default     = "ap-northeast-2c"
 }
@@ -24,6 +25,8 @@ variable "ami_ssm_parameter" {
 }
 
 # ── 접근 ─────────────────────────────────────────────────────
+# allowed_cidr 은 public endpoint 의 유일한 외부 접근 제어다.
+# 0.0.0.0/0 으로 열면 Grafana/Prometheus/SUT debug port 가 인터넷에 노출되므로 금지한다.
 variable "key_name" {
   description = "기존 EC2 키페어 이름 (SSH 접속용)"
   type        = string
@@ -35,6 +38,8 @@ variable "allowed_cidr" {
 }
 
 # ── 인스턴스 타입 ────────────────────────────────────────────
+# SUT 타입은 측정 대상 스펙 자체라 임의로 키우면 안 된다.
+# 반대로 generator/monitoring 은 측정 대상이 아니므로 먼저 병목나지 않게 SUT보다 여유 있게 잡는다.
 variable "sut_instance_type" {
   description = "SUT(앱) — prod 앱과 동일 타입으로 (현재 스펙 fidelity 핵심)"
   type        = string
@@ -54,6 +59,7 @@ variable "monitoring_instance_type" {
 }
 
 # ── RDS ──────────────────────────────────────────────────────
+# 이 블록은 "측정하고 싶은 DB 스펙"을 정의한다. 현재 이슈 기준 목표는 db.t4g.small 이다.
 variable "db_instance_class" {
   description = "RDS 인스턴스 클래스 (측정 대상 DB 스펙)"
   type        = string
@@ -61,7 +67,7 @@ variable "db_instance_class" {
 }
 
 variable "db_engine_version" {
-  description = "RDS PostgreSQL 버전. `aws rds describe-db-engine-versions --engine postgres` 로 가용 버전 확인"
+  description = "RDS PostgreSQL 버전. apply 전에 해당 리전에서 가용한 정확한 버전 문자열을 확인한다."
   type        = string
   default     = "16.4"
 }
@@ -83,6 +89,8 @@ variable "db_username" {
 }
 
 # ── 앱 이미지 / 배포 ─────────────────────────────────────────
+# app_image 는 이미 registry 에 push 된 dev profile 실행 가능 이미지를 가리켜야 한다.
+# Terraform 은 이미지를 빌드하지 않고 EC2 에서 docker compose pull 만 수행한다.
 variable "app_image" {
   description = "앱 Docker 이미지 (예: docker.io/<repo>:<dev-tag>)"
   type        = string
@@ -112,6 +120,8 @@ variable "git_repo_url" {
   description = "compose/관측 config 와 k6 스크립트를 가져올 레포 URL. private repo면 read-only 토큰을 포함한 HTTPS URL."
   type        = string
 
+  # monitoring EC2 는 infra/monitoring/grafana 를, generator EC2 는 docs/guides/load-test/k6 를 clone 해서 사용한다.
+  # 지금 구조에서는 이 값이 비면 EC2 가 필요한 파일을 받을 수 없다.
   validation {
     condition     = length(trimspace(var.git_repo_url)) > 0
     error_message = "git_repo_url 은 필수입니다. 현재 구조는 EC2 user-data 에서 레포를 clone 해 monitoring config 와 k6 script 를 가져옵니다."
@@ -123,6 +133,7 @@ variable "app_env" {
     앱 런타임 env(app.env) 내용 (dev 프로필 기준, 멀티라인).
     DATABASE_URL/USERNAME/PASSWORD · OTEL_URL · SPRING_PROFILES_ACTIVE · HIKARI_MAX_POOL_SIZE 는
     user_data 가 부하테스트 값으로 덮어쓰므로 여기엔 그 외 부팅 필수 env(외부 연동 등)만 넣으면 됨.
+    주의: 현재 방식은 Terraform state 와 EC2 user-data 에 값이 남는다. 운영 수준 보안이 필요하면 Secrets Manager ARN 방식으로 바꾼다.
   EOT
   type        = string
   sensitive   = true

--- a/infra/terraform/load-test/variables.tf
+++ b/infra/terraform/load-test/variables.tf
@@ -107,18 +107,35 @@ variable "db_username" {
 # Terraform 은 이미지를 빌드하지 않고 EC2 에서 docker compose pull 만 수행한다.
 # 기본 SUT 가 t4g.small(arm64)이므로 이미지가 linux/arm64 또는 multi-arch 로 push 되어 있어야 한다.
 variable "app_image" {
-  description = "앱 Docker 이미지 (예: docker.io/<repo>:<dev-tag>)"
+  description = "앱 Docker 이미지 (예: <account>.dkr.ecr.ap-northeast-2.amazonaws.com/umc-product-server:development-latest)"
   type        = string
+}
+
+variable "registry_type" {
+  description = "이미지 레지스트리 인증 방식. ecr이면 EC2 IAM role 로 로그인하고, generic이면 Secrets Manager credential 을 사용한다."
+  type        = string
+  default     = "ecr"
+
+  validation {
+    condition     = contains(["ecr", "generic", "public"], var.registry_type)
+    error_message = "registry_type 은 ecr, generic, public 중 하나여야 합니다."
+  }
 }
 
 variable "registry_server" {
-  description = "컨테이너 레지스트리 (docker.io 또는 ghcr.io)"
+  description = "컨테이너 레지스트리 호스트. registry_type=ecr 이고 빈 문자열이면 현재 AWS 계정 ECR registry 로 계산한다."
   type        = string
-  default     = "docker.io"
+  default     = ""
+}
+
+variable "ecr_repository_name" {
+  description = "registry_type=ecr 일 때 SUT EC2 role 에 pull 권한을 줄 ECR repository 이름"
+  type        = string
+  default     = "umc-product-server"
 }
 
 variable "registry_credentials_secret_arn" {
-  description = "Docker registry credential JSON 을 담은 AWS Secrets Manager secret ARN. public image면 빈 문자열."
+  description = "registry_type=generic 일 때 Docker registry credential JSON 을 담은 AWS Secrets Manager secret ARN. ECR/public image면 빈 문자열."
   type        = string
   default     = ""
 

--- a/infra/terraform/load-test/variables.tf
+++ b/infra/terraform/load-test/variables.tf
@@ -18,8 +18,20 @@ variable "az_secondary" {
   default     = "ap-northeast-2c"
 }
 
-variable "ami_ssm_parameter" {
-  description = "EC2 AMI SSM 파라미터. Graviton(arm64) 인스턴스면 .../al2023-ami-kernel-default-arm64 로 교체"
+variable "monitoring_ami_ssm_parameter" {
+  description = "Monitoring EC2 AMI SSM 파라미터. 기본값은 x86_64 Amazon Linux 2023."
+  type        = string
+  default     = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+variable "sut_ami_ssm_parameter" {
+  description = "SUT EC2 AMI SSM 파라미터. t4g.small 같은 Graviton 인스턴스를 쓰므로 기본값은 arm64."
+  type        = string
+  default     = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
+}
+
+variable "generator_ami_ssm_parameter" {
+  description = "Generator EC2 AMI SSM 파라미터. 기본 generator_instance_type(c5.large)에 맞춰 x86_64."
   type        = string
   default     = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 }
@@ -43,7 +55,7 @@ variable "allowed_cidr" {
 variable "sut_instance_type" {
   description = "SUT(앱) — prod 앱과 동일 타입으로 (현재 스펙 fidelity 핵심)"
   type        = string
-  default     = "t3.small"
+  default     = "t4g.small"
 }
 
 variable "generator_instance_type" {
@@ -69,7 +81,7 @@ variable "db_instance_class" {
 variable "db_engine_version" {
   description = "RDS PostgreSQL 버전. apply 전에 해당 리전에서 가용한 정확한 버전 문자열을 확인한다."
   type        = string
-  default     = "16.4"
+  default     = "18.3"
 }
 
 variable "db_allocated_storage" {
@@ -79,18 +91,21 @@ variable "db_allocated_storage" {
 }
 
 variable "db_name" {
-  type    = string
-  default = "umc_product"
+  description = "앱이 JDBC URL 에서 접속할 DB 이름. prod 콘솔 DB name '-'는 초기 DB 없음이라는 뜻이라 실제 앱 접속 DB명을 확인해야 한다."
+  type        = string
+  default     = "umc_product"
 }
 
 variable "db_username" {
-  type    = string
-  default = "umc_product"
+  description = "RDS master username. 제공된 prod 값 기준 기본값은 postgres."
+  type        = string
+  default     = "postgres"
 }
 
 # ── 앱 이미지 / 배포 ─────────────────────────────────────────
 # app_image 는 이미 registry 에 push 된 dev profile 실행 가능 이미지를 가리켜야 한다.
 # Terraform 은 이미지를 빌드하지 않고 EC2 에서 docker compose pull 만 수행한다.
+# 기본 SUT 가 t4g.small(arm64)이므로 이미지가 linux/arm64 또는 multi-arch 로 push 되어 있어야 한다.
 variable "app_image" {
   description = "앱 Docker 이미지 (예: docker.io/<repo>:<dev-tag>)"
   type        = string


### PR DESCRIPTION
## 🚀 작업 내용

Closes #1106

부하 테스트용 ephemeral Terraform 환경을 추가했습니다.

이번 PR의 목적은 운영 공유 서버나 운영 관측 스택을 재사용하지 않고, 테스트할 때만 SUT · 부하 생성기 · 전용 관측 스택 · RDS를 띄운 뒤 테스트 종료 후 정리할 수 있게 하는 것입니다.

- 부하 테스트 전용 VPC, public subnet, private RDS subnet, route table, security group을 구성했습니다.
- SUT 앞단에 ALB를 추가해 `generator -> ALB -> SUT -> RDS` 경로로 요청이 들어가도록 구성했습니다.
- SUT EC2에는 앱 dev profile, Valkey, node-exporter를 올리도록 bootstrap을 추가했습니다.
- RDS PostgreSQL `db.t4g.small`, engine `18.3`, 초기 DB `umc_product`를 생성하도록 구성했습니다.
- HikariCP pool size는 `4`로 고정했습니다.
- 부하 생성기는 별도 EC2에 k6와 node-exporter를 설치하도록 구성했습니다.
- 관측 스택은 별도 EC2에 Prometheus, Grafana, Tempo, Loki, otel-collector, postgres_exporter를 띄우도록 구성했습니다.
- 앱 이미지는 Terraform이 build하지 않고, EC2가 registry에서 pull하도록 구성했습니다.
- SUT가 ECR과 Secrets Manager를 읽을 수 있도록 IAM role/policy를 추가했습니다.
- `terraform.tfvars`, state, plan 파일이 커밋되지 않도록 load-test Terraform 경로의 `.gitignore`를 추가했습니다.

검증한 내용입니다.

- `terraform -chdir=infra/terraform/load-test fmt -check -recursive`
- `terraform -chdir=infra/terraform/load-test validate`
- `git diff --check`
- 로컬 plan 기준 `47 to add, 0 to change, 0 to destroy` 확인
- 실제 apply는 수행하지 않았습니다.

## 💬 리뷰 중점사항

- Security group 범위를 봐주세요.
  - ALB 80은 generator와 관리자 CIDR만 허용합니다.
  - SUT 8080은 ALB에서만 접근 가능합니다.
  - RDS 5432는 SUT와 monitoring postgres_exporter에서만 접근 가능합니다.
  - Grafana/Prometheus/SSH는 관리자 CIDR 기준으로 제한했습니다.

- SUT 측정 조건을 봐주세요.
  - 앱 서버는 `t4g.small`
  - RDS는 `db.t4g.small`
  - HikariCP pool size는 `4`
  - 앱은 부하 테스트 토큰/시딩을 위해 dev profile로 실행합니다.