### PR TITLE
[Chore] Prometheus 설정을 주기적으로 자동 갱신하도록 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 🌿 Spotless 기준 브랜치 fetch
+        run: git fetch origin develop:refs/remotes/origin/develop
+
       - name: 🎯 배포 환경 설정
         id: set-env
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🌿 Spotless 기준 브랜치 fetch
+        run: git fetch origin develop:refs/remotes/origin/develop
 
       - name: 🧑‍💻 JDK 21 Corretto 설정
         uses: actions/setup-java@v4

--- a/infra/monitoring/grafana/README.md
+++ b/infra/monitoring/grafana/README.md
@@ -150,6 +150,7 @@ docker/monitoring/
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | `otel-collector` | 앱의 OTLP metrics / traces / logs 송신을 받아 prometheus / tempo / loki 로 분배. 향후 Cloud + Self dual-write 가 필요해지면 exporter 추가만 하면 된다.                 |
 | `prometheus`     | OTLP write receiver (`/api/v1/otlp/v1/metrics`) 활성. 자체 scrape 는 prometheus / node-exporter / alertmanager / grafana / loki / otel-collector.  |
+| `prometheus-config-reloader` | `prometheus.yml` / alert rule bind mount 변경을 감지해 Prometheus `/-/reload` 를 호출. 시작 시에도 1회 reload 하므로 PR 반영 후 컨테이너 재생성 없이 기존 rule 평가가 남아 알람을 계속 보내는 상황을 방지. |
 | `tempo`          | OTLP 4317/4318 native 수신. 로컬 디스크 backend, 기본 7일 보존.                                                                                           |
 | `loki`           | OTLP logs receiver 를 통해 Collector 에서 들어온 로그 저장. 기본 30일 보존.                                                                                    |
 | `grafana`        | Prometheus / Alertmanager / Loki / Tempo datasource 와 ADR-016 의 api-performance dashboard 자동 provisioning.                                    |

--- a/infra/monitoring/grafana/docker-compose.yml
+++ b/infra/monitoring/grafana/docker-compose.yml
@@ -32,6 +32,47 @@ services:
     networks: [monitoring]
     restart: unless-stopped
 
+  # --- Prometheus config/rule reload ---
+  # Prometheus는 bind mount 된 prometheus.yml / alert rule 파일이 바뀌어도
+  # 자동으로 다시 읽지 않는다. git pull / rsync 로 PR 변경사항만 반영된 뒤
+  # 컨테이너가 재생성되지 않으면 이전 rule 이 계속 평가되어 오래된 알람이
+  # Discord 로 전송될 수 있으므로, 설정 파일 checksum 변경 시 /-/reload 를 호출한다.
+  prometheus-config-reloader:
+    image: alpine:3.22
+    container_name: umc-product-prometheus-config-reloader
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        interval="$${PROMETHEUS_RELOAD_INTERVAL_SECONDS:-30}"
+        checksum="$$(find /etc/prometheus -type f \( -name '*.yml' -o -name '*.yaml' \) -print | sort | xargs sha256sum | sha256sum)"
+
+        echo "Prometheus config reloader started; reloading current config"
+        wget -qO- --post-data='' http://prometheus:9090/-/reload >/dev/null \
+          || echo "Initial Prometheus reload request failed"
+
+        while true; do
+          new_checksum="$$(find /etc/prometheus -type f \( -name '*.yml' -o -name '*.yaml' \) -print | sort | xargs sha256sum | sha256sum)"
+
+          if [ "$$new_checksum" != "$$checksum" ]; then
+            echo "Prometheus config changed; reloading"
+            wget -qO- --post-data='' http://prometheus:9090/-/reload >/dev/null \
+              || echo "Prometheus reload request failed"
+          fi
+
+          checksum="$$new_checksum"
+          sleep "$$interval"
+        done
+    environment:
+      PROMETHEUS_RELOAD_INTERVAL_SECONDS: ${PROMETHEUS_RELOAD_INTERVAL_SECONDS:-30}
+    volumes:
+      - ./config/prometheus:/etc/prometheus:ro
+    depends_on:
+      - prometheus
+    networks: [monitoring]
+    restart: unless-stopped
+
   # --- Trace backend ---
   # 4317 (gRPC) / 4318 (HTTP) 로 OTLP 직접 수신 가능. 단, 운영 앱은 본 ADR-014 의
   # 권장대로 otel-collector 를 거치게 하고, tempo 의 OTLP 포트는 호스트로 노출만 해둔다.


### PR DESCRIPTION
## 🚀 작업 내용

- **누가(Who)**: 프로덕트팀 LGTM/self-hosted monitoring stack의 Prometheus가
- **언제(When)**: PR 반영/배포 후 `prometheus.yml` 또는 alert rule 파일만 bind mount로 갱신되고 Prometheus 컨테이너가 재생성되지 않는 시점에
- **어디서(Where)**: `infra/monitoring/grafana/docker-compose.yml` 기반 모니터링 스택에서
- **무엇을(What)**: `prometheus-config-reloader` 서비스를 추가해 Prometheus 설정/룰 파일 checksum 변경을 감지하면 `/-/reload`를 호출하도록 했습니다.
- **어떻게(How)**: reloader 컨테이너가 `./config/prometheus`를 read-only로 마운트하고 시작 시 1회 reload한 뒤, 30초 주기로 `*.yml`, `*.yaml` checksum을 비교해 변경 시 Prometheus lifecycle reload API를 호출합니다.
- **왜(Why)**: 기존 Node Exporter filesystem alert 기준 완화가 코드에 반영되어도 Prometheus가 오래된 rule을 계속 평가하면 Discord 알람이 계속 전송될 수 있어, rule 변경사항이 컨테이너 재생성 없이도 운영 중인 Prometheus에 적용되도록 하기 위함입니다.

추가로 README의 컴포넌트 표에 reloader 역할을 문서화했습니다.

CI/Codecov에서 Spotless `ratchetFrom("origin/develop")`가 `origin/develop` ref를 찾지 못해 실패하는 문제도 함께 확인되어, checkout 직후 develop 원격 ref를 명시적으로 fetch하도록 보강했습니다.

## 💬 리뷰 중점사항

- `alpine` 기반 reloader shell command의 Compose interpolation(`$$`)과 checksum/reload 흐름이 적절한지 확인 부탁드립니다.
- `PROMETHEUS_RELOAD_INTERVAL_SECONDS` 기본값은 30초로 두었습니다. 운영 환경에서 너무 짧거나 길면 조정 가능합니다.
- CI 보강은 Spotless ratchet 기준 ref 확보만 추가한 변경입니다.

검증:

- `git diff --check`
- `OTEL_INGEST_TOKEN=dummy docker compose -f infra/monitoring/grafana/docker-compose.yml config`
- `docker run --rm --entrypoint promtool -v "$PWD/infra/monitoring/grafana/config/prometheus:/etc/prometheus:ro" prom/prometheus:v3.11.3 check config /etc/prometheus/prometheus.yml`
