### PR TITLE
[Fix] Codecov가 정상 동작하도록 수정

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: 🧑‍💻 JDK 21 Corretto 설정
         uses: actions/setup-java@v4


### PR DESCRIPTION
## 🚀 작업 내용

- Codecov workflow의 `actions/checkout@v4`에 `fetch-depth: 0`을 설정했어요.
- PR 이벤트에서 merge ref만 얕게 checkout되면 Gradle Spotless의 `ratchetFrom("origin/develop")`가 `No such reference 'origin/develop'`로 실패하던 문제를 막아요.
- 검증으로 `./gradlew spotlessMiscCheck`와 `git diff --check -- .github/workflows/codecov.yml`를 확인했어요.

## 💬 리뷰 중점사항

- 변경 범위는 `.github/workflows/codecov.yml`의 checkout 설정뿐이에요.
- Codecov 실패 로그상 업로드 단계가 아니라 `./gradlew test jacocoTestReport` 실행 전 Spotless ref 해석에서 실패했는지 확인해주세요.
- 로컬 전체 `./gradlew test jacocoTestReport`는 이전 detached HEAD에서 기존 `ExternalApiCallLoggerTest` 3건 실패로 완료하지 못했어요. 최신 `develop`의 push Codecov run은 성공 상태였어요.
