### PR TITLE
[Feat] Admin API 경로 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,9 @@ Java LSP (`jdtls`) was unavailable; CodeGraph was available for review, but refe
 - Command UseCases and Query UseCases stay separate. Command services use `@Transactional`; Query services use `@Transactional(readOnly = true)`.
 - Controllers return adapter `Response` records or application `Info` values. They do not return entities and do not wrap success responses in `ApiResponse`.
 - REST controllers live under `adapter/in/web`; GraphQL controllers live under `adapter/in/graphql`.
+- REST API URIs must be resource-first: start with `/api/v{version}/{domain}` and use stable, kebab-case resource nouns after the domain segment.
+- Admin REST APIs must use `/api/v{version}/{domain}/admin/...`; do not create new admin APIs under `/api/v{version}/admin/{domain}/...`.
+- Treat `admin` as an access/control surface inside the owning domain, not as a top-level domain. When changing controller paths, update REST Docs, controller tests, security/maintenance allow paths, and onboarding/API guide documents together.
 - GraphQL schema files in `src/main/resources/graphql` are API contracts and must stay aligned with GraphQL DTOs.
 - SSO/PKCE flows must not log authorization codes, login tokens, refresh tokens, or client secrets.
 - Request records live under `adapter/in/web/dto/request` and convert to command/query objects near the adapter boundary.

--- a/docs/guides/감사_로그_FE_API_가이드.md
+++ b/docs/guides/감사_로그_FE_API_가이드.md
@@ -16,7 +16,7 @@
 - **누가 볼 수 있는가?** **중앙운영사무국 국원**만 조회 가능합니다.
   ([AuditLogPermissionEvaluator.java](src/main/java/com/umc/product/audit/application/service/AuditLogPermissionEvaluator.java))
 - **데이터는 어떻게 쌓이나?** 백엔드 메서드에 붙은 `@Audited` 어노테이션이 메서드 정상 종료 후 이벤트를 발행하고, 트랜잭션 커밋 이후 **비동기로** DB 에 저장합니다.
-- **호출해야 할 엔드포인트는?** `GET /api/v1/admin/audit-logs` 단 하나입니다. 필터 파라미터로 좁혀 검색합니다.
+- **호출해야 할 엔드포인트는?** `GET /api/v1/audit/admin/audit-logs` 입니다.
 
 ---
 
@@ -149,7 +149,7 @@ FE 가 화면을 만들 때 다음 설계 의도를 알고 있으면 더 자연�
 ### 3.1 엔드포인트
 
 ```
-GET /api/v1/admin/audit-logs
+GET /api/v1/audit/admin/audit-logs
 ```
 
 [AuditLogController.java](src/main/java/com/umc/product/audit/adapter/in/web/AuditLogController.java)
@@ -278,14 +278,14 @@ GET /api/v1/admin/audit-logs
 ### 4.1 cURL — 가장 단순한 호출 (모든 도메인, 최근 20건)
 
 ```bash
-curl -X GET 'https://{HOST}/api/v1/admin/audit-logs' \
+curl -X GET 'https://{HOST}/api/v1/audit/admin/audit-logs' \
   -H 'Authorization: Bearer eyJhbGciOi...'
 ```
 
 ### 4.2 cURL — 특정 기간의 SCHEDULE 도메인 CREATE 만
 
 ```bash
-curl -G 'https://{HOST}/api/v1/admin/audit-logs' \
+curl -G 'https://{HOST}/api/v1/audit/admin/audit-logs' \
   -H 'Authorization: Bearer eyJhbGciOi...' \
   --data-urlencode 'domain=SCHEDULE' \
   --data-urlencode 'action=CREATE' \
@@ -320,7 +320,7 @@ export async function searchAuditLogs(
   });
 
   const res = await fetch(
-    `/api/v1/admin/audit-logs?${params.toString()}`,
+    `/api/v1/audit/admin/audit-logs?${params.toString()}`,
     {
       method: "GET",
       headers: { Authorization: `Bearer ${accessToken}` },

--- a/docs/onboarding/test/README.md
+++ b/docs/onboarding/test/README.md
@@ -6,7 +6,7 @@
 | 도메인 | 테스트 파일 수 | 테스트 케이스 수 | 문서 |
 |---|---:|---:|---|
 | Analytics | 8 | 26 | [analytics.md](analytics.md) |
-| Audit | 1 | 3 | [audit.md](audit.md) |
+| Audit | 2 | 5 | [audit.md](audit.md) |
 | Authentication | 14 | 71 | [authentication.md](authentication.md) |
 | Authorization | 2 | 19 | [authorization.md](authorization.md) |
 | Blog | 3 | 33 | [blog.md](blog.md) |
@@ -27,8 +27,8 @@
 | Term | 8 | 23 | [term.md](term.md) |
 | Test Seed | 11 | 58 | [test.md](test.md) |
 
-- 총 실행 테스트 파일: 210개
-- 총 테스트 케이스: 1386개
+- 총 실행 테스트 파일: 211개
+- 총 테스트 케이스: 1388개
 
 ## 참고: 실행 테스트 메서드가 없는 지원 파일
 

--- a/docs/onboarding/test/analytics.md
+++ b/docs/onboarding/test/analytics.md
@@ -18,11 +18,11 @@
 
 | 라인 | 테스트 케이스 | 입력/조건 | 기대 결과 |
 |---:|---|---|---|
-| [104](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L104) | AdminDashboardController / 대시보드 summary API 문서화 | HTTP GET /api/v1/admin/dashboard/summary; param gisuId="7" | 성공: HTTP 200 OK |
-| [126](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L126) | AdminDashboardController / 대시보드 actionQueue API는 대상 도메인의 처리 대기 항목만 반환한다 | HTTP GET /api/v1/admin/dashboard/action-queue; param gisuId="7" | 성공: HTTP 200 OK |
-| [143](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L143) | 대시보드 context API 응답 | HTTP GET /api/v1/admin/dashboard/context | 성공: HTTP 200 OK |
-| [162](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L162) | 대시보드 riskChallengers API 응답 | HTTP GET /api/v1/admin/dashboard/risk-challengers; param gisuId="7" | 성공: HTTP 200 OK |
-| [174](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L174) | 대시보드 operations API 응답 | HTTP GET /api/v1/admin/dashboard/operations; param gisuId="7"; param from="2026-05-01T00:00:00Z"; param to="2026-05-13T00:00:00Z" | 성공: HTTP 200 OK |
+| [104](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L104) | AdminDashboardController / 대시보드 summary API 문서화 | HTTP GET /api/v1/analytics/admin/dashboard/summary; param gisuId="7" | 성공: HTTP 200 OK |
+| [126](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L126) | AdminDashboardController / 대시보드 actionQueue API는 대상 도메인의 처리 대기 항목만 반환한다 | HTTP GET /api/v1/analytics/admin/dashboard/action-queue; param gisuId="7" | 성공: HTTP 200 OK |
+| [143](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L143) | 대시보드 context API 응답 | HTTP GET /api/v1/analytics/admin/dashboard/context | 성공: HTTP 200 OK |
+| [162](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L162) | 대시보드 riskChallengers API 응답 | HTTP GET /api/v1/analytics/admin/dashboard/risk-challengers; param gisuId="7" | 성공: HTTP 200 OK |
+| [174](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java#L174) | 대시보드 operations API 응답 | HTTP GET /api/v1/analytics/admin/dashboard/operations; param gisuId="7"; param from="2026-05-01T00:00:00Z"; param to="2026-05-13T00:00:00Z" | 성공: HTTP 200 OK |
 
 ### AdminSchoolAnalyticsControllerTest
 - 테스트 설명: AdminSchoolAnalyticsController
@@ -30,7 +30,7 @@
 
 | 라인 | 테스트 케이스 | 입력/조건 | 기대 결과 |
 |---:|---|---|---|
-| [57](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java#L57) | AdminSchoolAnalyticsController / 학교별 summary API 문서화 | HTTP GET /api/v1/admin/schools/summary; param gisuId="7" | 성공: HTTP 200 OK |
+| [57](../../../src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java#L57) | AdminSchoolAnalyticsController / 학교별 summary API 문서화 | HTTP GET /api/v1/analytics/admin/schools/summary; param gisuId="7" | 성공: HTTP 200 OK |
 
 ## UseCase / Application Service
 

--- a/docs/onboarding/test/audit.md
+++ b/docs/onboarding/test/audit.md
@@ -1,12 +1,23 @@
 # Audit 테스트 케이스
 
-- 테스트 파일: 1개
-- 테스트 케이스: 3개
+- 테스트 파일: 2개
+- 테스트 케이스: 5개
 - 분류 기준: `Controller`, `UseCase`, `Repository`, `E2E`, `Scheduler`, `Domain`, `External Adapter`, `Support`
 
 | 카테고리 | 케이스 수 |
 |---|---:|
+| Controller | 2 |
 | Domain | 3 |
+
+## Controller
+
+### AuditLogControllerTest
+- 위치: `src/test/java/com/umc/product/audit/adapter/in/web/AuditLogControllerTest.java`
+
+| 라인 | 테스트 케이스 | 입력/조건 | 기대 결과 |
+|---:|---|---|---|
+| [35](../../../src/test/java/com/umc/product/audit/adapter/in/web/AuditLogControllerTest.java#L35) | 신규 감사 로그 admin 경로로 검색한다 | HTTP GET /api/v1/audit/admin/audit-logs | 성공: HTTP 200 OK |
+| [50](../../../src/test/java/com/umc/product/audit/adapter/in/web/AuditLogControllerTest.java#L50) | 기존 감사 로그 admin 경로는 더 이상 지원하지 않는다 | HTTP GET /api/v1/admin/audit-logs | 실패: HTTP 404 Not Found |
 
 ## Domain
 

--- a/docs/onboarding/test/maintenance.md
+++ b/docs/onboarding/test/maintenance.md
@@ -53,11 +53,11 @@
 
 | 라인 | 테스트 케이스 | 입력/조건 | 기대 결과 |
 |---:|---|---|---|
-| [64](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L64) | AdminMaintenanceController 통합 테스트 / SUPER ADMIN 은 점검을 생성하고 종료할 수 있다 | HTTP POST /api/v1/admin/maintenance; HTTP PATCH /api/v1/admin/maintenance/ | 성공: HTTP 200 OK |
-| [93](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L93) | AdminMaintenanceController 통합 테스트 / 일반 사용자는 점검 생성 시도시 403 | HTTP POST /api/v1/admin/maintenance | 실패: HTTP 403 Forbidden |
-| [110](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L110) | 겹치는 시간대의 점검을 만들면 409 | HTTP POST /api/v1/admin/maintenance | 실패: HTTP 200 OK; HTTP 409 Conflict |
-| [138](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L138) | 종료가 시작보다 빠르면 400 | HTTP POST /api/v1/admin/maintenance | 실패: HTTP 400 Bad Request |
-| [156](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L156) | 윈도우 목록은 SUPER ADMIN 만 조회 가능 | HTTP GET /api/v1/admin/maintenance | 실패: HTTP 200 OK; HTTP 403 Forbidden |
+| [64](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L64) | AdminMaintenanceController 통합 테스트 / SUPER ADMIN 은 점검을 생성하고 종료할 수 있다 | HTTP POST /api/v1/maintenance/admin; HTTP PATCH /api/v1/maintenance/admin/ | 성공: HTTP 200 OK |
+| [93](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L93) | AdminMaintenanceController 통합 테스트 / 일반 사용자는 점검 생성 시도시 403 | HTTP POST /api/v1/maintenance/admin | 실패: HTTP 403 Forbidden |
+| [110](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L110) | 겹치는 시간대의 점검을 만들면 409 | HTTP POST /api/v1/maintenance/admin | 실패: HTTP 200 OK; HTTP 409 Conflict |
+| [138](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L138) | 종료가 시작보다 빠르면 400 | HTTP POST /api/v1/maintenance/admin | 실패: HTTP 400 Bad Request |
+| [156](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java#L156) | 윈도우 목록은 SUPER ADMIN 만 조회 가능 | HTTP GET /api/v1/maintenance/admin | 실패: HTTP 200 OK; HTTP 403 Forbidden |
 
 ### MaintenanceFilterIntegrationTest
 - 테스트 설명: MaintenanceFilter 통합 테스트
@@ -71,7 +71,7 @@
 | [82](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L82) | MaintenanceFilter 통합 테스트 / FULL 점검중 SUPER ADMIN 토큰이면 필터를 통과한다 | HTTP GET /api/v1/challenger/me | 성공: 검증 assertThat(actualStatus).isNotEqualTo(503); |
 | [101](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L101) | MaintenanceFilter 통합 테스트 / PER DOMAIN 점검은 지정되지 않은 도메인 요청을 차단하지 않는다 | HTTP GET /api/v1/challenger/me | 성공: 검증 assertThat(actualStatus).isNotEqualTo(503); |
 | [112](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L112) | PER DOMAIN 점검은 지정된 도메인 요청을 503으로 차단 | HTTP GET /api/v1/notices/1 | 성공: isServiceUnavailable |
-| [123](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L123) | 어드민 점검 관리 경로는 점검중에도 항상 통과 | HTTP GET /api/v1/admin/maintenance | 성공: 검증 assertThat(actualStatus).isNotEqualTo(503); |
+| [123](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L123) | 어드민 점검 관리 경로는 점검중에도 항상 통과 | HTTP GET /api/v1/maintenance/admin | 성공: 검증 assertThat(actualStatus).isNotEqualTo(503); |
 | [135](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L135) | Actuator 경로는 점검중에도 항상 통과 | HTTP GET /actuator/health | 성공: 검증 assertThat(actualStatus).isNotEqualTo(503); |
 | [145](../../../src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java#L145) | FULL 점검 중에도 약관 조회는 점검 필터를 통과한다 | HTTP GET /api/v1/terms | 성공: HTTP 200 OK |
 

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminDashboardController.java
@@ -47,7 +47,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/admin/dashboard")
+@RequestMapping("/api/v1/analytics/admin/dashboard")
 @RequiredArgsConstructor
 @Tag(name = "Analytics | 운영진 종합 대시보드", description = "운영진이 주요 운영 지표와 액션 큐를 확인합니다.")
 public class AdminDashboardController {

--- a/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
+++ b/src/main/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsController.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/admin/schools")
+@RequestMapping("/api/v1/analytics/admin/schools")
 @RequiredArgsConstructor
 @Tag(name = "Analytics | 학교별 현황", description = "운영진이 학교별 운영 현황을 확인합니다.")
 public class AdminSchoolAnalyticsController {

--- a/src/main/java/com/umc/product/audit/adapter/in/web/AuditLogController.java
+++ b/src/main/java/com/umc/product/audit/adapter/in/web/AuditLogController.java
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/admin/audit-logs")
+@RequestMapping("/api/v1/audit/admin/audit-logs")
 @RequiredArgsConstructor
 @Tag(name = "Audit | 감사 로그 조회", description = "관리자가 감사 로그를 검색합니다.")
 public class AuditLogController {

--- a/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityPathConfig.java
@@ -55,7 +55,7 @@ public final class SecurityPathConfig {
     public static final List<String> MAINTENANCE_ALWAYS_ALLOW_PATHS = Stream.concat(
         Stream.of(
             "/api/v1/system/status",
-            "/api/v1/admin/maintenance/**",
+            "/api/v1/maintenance/admin/**",
             "/api/v1/auth/sso/oauth/**",
             "/api/v1/auth/sso/**",
             "/api/v1/auth/**",

--- a/src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java
+++ b/src/main/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceController.java
@@ -26,7 +26,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/admin/maintenance")
+@RequestMapping("/api/v1/maintenance/admin")
 @RequiredArgsConstructor
 @Tag(name = "Maintenance | 점검 관리 (어드민)", description = "SUPER_ADMIN이 점검 윈도우를 관리합니다.")
 public class AdminMaintenanceController {

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminDashboardControllerTest.java
@@ -116,7 +116,7 @@ class AdminDashboardControllerTest {
             Map.of()
         ));
 
-        mockMvc.perform(get("/api/v1/admin/dashboard/summary")
+        mockMvc.perform(get("/api/v1/analytics/admin/dashboard/summary")
                 .param("gisuId", "7"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.activeChallengerCount").value(10L))
@@ -131,7 +131,7 @@ class AdminDashboardControllerTest {
         given(getAdminDashboardActionQueueUseCase.getActionQueue(any()))
             .willReturn(AdminDashboardActionQueueInfo.of(4L, 3L, 5L));
 
-        mockMvc.perform(get("/api/v1/admin/dashboard/action-queue")
+        mockMvc.perform(get("/api/v1/analytics/admin/dashboard/action-queue")
                 .param("gisuId", "7"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.pendingAttendanceDecisionCount").value(4L))
@@ -154,7 +154,7 @@ class AdminDashboardControllerTest {
             AdminAnalyticsScopeType.CENTRAL
         ));
 
-        mockMvc.perform(get("/api/v1/admin/dashboard/context"))
+        mockMvc.perform(get("/api/v1/analytics/admin/dashboard/context"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.roleType").value("CENTRAL_PRESIDENT"))
             .andExpect(jsonPath("$.result.scopeType").value("CENTRAL"))
@@ -166,7 +166,7 @@ class AdminDashboardControllerTest {
     void 대시보드_riskChallengers_API_응답() throws Exception {
         given(getAdminRiskChallengerUseCase.getRiskChallengers(any())).willReturn(Page.empty());
 
-        mockMvc.perform(get("/api/v1/admin/dashboard/risk-challengers")
+        mockMvc.perform(get("/api/v1/analytics/admin/dashboard/risk-challengers")
                 .param("gisuId", "7"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.content").isArray())
@@ -206,7 +206,7 @@ class AdminDashboardControllerTest {
             )
         );
 
-        mockMvc.perform(get("/api/v1/admin/dashboard/operations")
+        mockMvc.perform(get("/api/v1/analytics/admin/dashboard/operations")
                 .param("gisuId", "7")
                 .param("from", "2026-05-01T00:00:00Z")
                 .param("to", "2026-05-13T00:00:00Z"))

--- a/src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java
+++ b/src/test/java/com/umc/product/analytics/adapter/in/web/AdminSchoolAnalyticsControllerTest.java
@@ -6,13 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
-import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
-import com.umc.product.global.config.JacksonConfig;
-import com.umc.product.global.security.JwtTokenProvider;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.support.RestDocsConfig;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +23,13 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.analytics.application.port.in.query.GetAdminSchoolSummaryUseCase;
+import com.umc.product.analytics.application.port.in.query.dto.AdminSchoolSummaryInfo;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.support.RestDocsConfig;
 
 @WebMvcTest(controllers = AdminSchoolAnalyticsController.class)
 @Import({JacksonConfig.class, RestDocsConfig.class})
@@ -75,7 +77,7 @@ class AdminSchoolAnalyticsControllerTest {
         given(getAdminSchoolSummaryUseCase.getSchoolSummaries(any()))
             .willReturn(new PageImpl<>(List.of(info), PageRequest.of(0, 20), 1));
 
-        mockMvc.perform(get("/api/v1/admin/schools/summary")
+        mockMvc.perform(get("/api/v1/analytics/admin/schools/summary")
                 .param("gisuId", "7"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.content[0].schoolName").value("가천대학교"))

--- a/src/test/java/com/umc/product/audit/adapter/in/web/AuditLogControllerTest.java
+++ b/src/test/java/com/umc/product/audit/adapter/in/web/AuditLogControllerTest.java
@@ -1,0 +1,57 @@
+package com.umc.product.audit.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.audit.application.port.in.query.GetAuditLogUseCase;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+
+@WebMvcTest(controllers = AuditLogController.class)
+@Import(JacksonConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("AuditLogController")
+class AuditLogControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    GetAuditLogUseCase getAuditLogUseCase;
+
+    @Test
+    @DisplayName("신규 감사 로그 admin 경로로 검색한다")
+    void 신규_감사_로그_admin_경로로_검색한다() throws Exception {
+        given(getAuditLogUseCase.search(any(), any())).willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/v1/audit/admin/audit-logs")
+                .param("domain", "SCHEDULE")
+                .param("action", "CREATE"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.content").isArray());
+    }
+
+    @Test
+    @DisplayName("기존 감사 로그 admin 경로는 더 이상 지원하지 않는다")
+    void 기존_감사_로그_admin_경로는_더_이상_지원하지_않는다() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/audit-logs"))
+            .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/maintenance/adapter/in/web/AdminMaintenanceControllerIntegrationTest.java
@@ -7,6 +7,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
 import com.umc.product.authorization.application.port.out.SaveChallengerRolePort;
 import com.umc.product.authorization.domain.ChallengerRole;
 import com.umc.product.challenger.domain.Challenger;
@@ -20,14 +30,6 @@ import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.ChallengerFixture;
 import com.umc.product.support.fixture.GisuFixture;
 import com.umc.product.support.fixture.MemberFixture;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 
 @DisplayName("AdminMaintenanceController 통합 테스트")
 class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
@@ -75,7 +77,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
             "더 나은 서비스를 위한 점검입니다"
         );
 
-        String created = mockMvc.perform(post("/api/v1/admin/maintenance")
+        String created = mockMvc.perform(post("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + superAdminToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(body)))
@@ -86,7 +88,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
 
         Long createdId = objectMapper.readTree(created).path("result").path("id").asLong();
 
-        mockMvc.perform(patch("/api/v1/admin/maintenance/" + createdId + "/end")
+        mockMvc.perform(patch("/api/v1/maintenance/admin/" + createdId + "/end")
                 .header("Authorization", "Bearer " + superAdminToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.forcedEndedAt").isNotEmpty());
@@ -101,7 +103,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
             "t", "m"
         );
 
-        mockMvc.perform(post("/api/v1/admin/maintenance")
+        mockMvc.perform(post("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + normalUserToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(body)))
@@ -117,7 +119,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
             now.plusSeconds(30), now.plus(Duration.ofHours(2)),
             "first", "m"
         );
-        mockMvc.perform(post("/api/v1/admin/maintenance")
+        mockMvc.perform(post("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + superAdminToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(first)))
@@ -129,7 +131,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
             now.plus(Duration.ofHours(3)),
             "overlap", "m"
         );
-        mockMvc.perform(post("/api/v1/admin/maintenance")
+        mockMvc.perform(post("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + superAdminToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(overlapping)))
@@ -147,7 +149,7 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
             "invalid", "m"
         );
 
-        mockMvc.perform(post("/api/v1/admin/maintenance")
+        mockMvc.perform(post("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + superAdminToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(body)))
@@ -157,11 +159,11 @@ class AdminMaintenanceControllerIntegrationTest extends IntegrationTestSupport {
 
     @Test
     void 윈도우_목록은_SUPER_ADMIN_만_조회_가능() throws Exception {
-        mockMvc.perform(get("/api/v1/admin/maintenance")
+        mockMvc.perform(get("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + superAdminToken))
             .andExpect(status().isOk());
 
-        mockMvc.perform(get("/api/v1/admin/maintenance")
+        mockMvc.perform(get("/api/v1/maintenance/admin")
                 .header("Authorization", "Bearer " + normalUserToken))
             .andExpect(status().isForbidden());
     }

--- a/src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java
+++ b/src/test/java/com/umc/product/maintenance/adapter/in/web/filter/MaintenanceFilterIntegrationTest.java
@@ -128,7 +128,7 @@ class MaintenanceFilterIntegrationTest extends IntegrationTestSupport {
 
         // 비인증 호출이라 권한 검증으로 인해 403/401 등 다른 코드가 반환되어도
         // 필터에서 차단되지 않았음을 확인한다.
-        int actualStatus = mockMvc.perform(get("/api/v1/admin/maintenance"))
+        int actualStatus = mockMvc.perform(get("/api/v1/maintenance/admin"))
             .andReturn().getResponse().getStatus();
 
         assertThat(actualStatus).isNotEqualTo(503);


### PR DESCRIPTION
## 🚀 작업 내용

- Related to #1131
- admin REST API 경로 규칙을 `/api/v1/{domain}/admin/...` 형태로 통일하기 위해 analytics, maintenance, audit controller 경로를 변경했어요.
  - analytics: `/api/v1/admin/dashboard` → `/api/v1/analytics/admin/dashboard`, `/api/v1/admin/schools` → `/api/v1/analytics/admin/schools`
  - maintenance: `/api/v1/admin/maintenance` → `/api/v1/maintenance/admin`
  - audit: `/api/v1/admin/audit-logs` → `/api/v1/audit/admin/audit-logs`
- audit log도 하위호환 경로를 남기지 않기로 한 최신 요구사항에 맞춰 기존 `/api/v1/admin/audit-logs` 경로를 제거했어요.
- `AGENTS.md`에 RESTful URI 제작 규칙을 추가해 신규 admin REST API는 `/api/v{version}/{domain}/admin/...` 형태로 만들도록 명시했어요.
- maintenance 점검 필터 allow path, controller test, REST Docs snippet, 테스트 온보딩 문서를 신규 경로 기준으로 갱신했어요.
- Figma admin 경로는 이 PR에서 변경하지 않고, Figma 도메인 제거 변경이 반영된 최신 `origin/develop` 위로 rebase했어요.

## 💬 리뷰 중점사항

- 기존 `/api/v1/admin/...` 경로를 유지하지 않는 breaking change라서 프론트엔드와 운영 문서의 호출 경로 변경이 함께 맞는지 확인해 주세요.
- audit 경로는 이슈에서 선택지로 남아 있던 안 중 `/api/v1/audit/admin/audit-logs`를 사용했어요. 도메인 segment를 `audit`, resource segment를 `audit-logs`로 분리한 결정이 적절한지 봐 주세요.
- `AGENTS.md`는 canonical agent rule 파일이라 `.github/copilot-instructions.md`에는 중복 규칙을 추가하지 않았어요.
- maintenance 점검 모드 예외 경로가 `SecurityPathConfig`와 필터 테스트에 함께 반영되어 있어요.
- 검증은 아래 명령으로 확인했어요.
  - `./gradlew test --tests 'com.umc.product.analytics.adapter.in.web.AdminDashboardControllerTest' --tests 'com.umc.product.analytics.adapter.in.web.AdminSchoolAnalyticsControllerTest' --tests 'com.umc.product.audit.adapter.in.web.AuditLogControllerTest' --tests 'com.umc.product.maintenance.adapter.in.web.AdminMaintenanceControllerIntegrationTest' --tests 'com.umc.product.maintenance.adapter.in.web.filter.MaintenanceFilterIntegrationTest'`
