### PR TITLE
[Chore] GitHub Release 자동화 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-release:
@@ -28,6 +28,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: GitHub App token 생성
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.UMC_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.UMC_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Release tag 검증
         id: release-target
@@ -73,7 +80,7 @@ jobs:
 
       - name: GitHub Release 생성
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.release-target.outputs.tag_name }}
           TARGET_SHA: ${{ steps.release-target.outputs.sha }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release를 생성할 기존 v* tag 이름"
+        required: true
+        type: string
+
+concurrency:
+  group: github-release-${{ github.event.inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드베이스 체크아웃
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Release tag 검증
+        id: release-target
+        env:
+          INPUT_TAG_NAME: ${{ github.event.inputs.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          TAG_NAME="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TAG_NAME="${INPUT_TAG_NAME}"
+          fi
+
+          if [[ "${TAG_NAME}" != v* ]]; then
+            echo "::error::Release tag '${TAG_NAME}' must start with 'v'."
+            exit 1
+          fi
+
+          git fetch --force --tags origin "+refs/heads/main:refs/remotes/origin/main"
+
+          if ! git show-ref --verify --quiet "refs/tags/${TAG_NAME}"; then
+            echo "::error::Tag '${TAG_NAME}' does not exist."
+            exit 1
+          fi
+
+          TAG_SHA="$(git rev-parse --verify "refs/tags/${TAG_NAME}^{commit}")"
+
+          if ! git rev-list --first-parent origin/main | awk -v target="${TAG_SHA}" '$0 == target { found = 1 } END { exit found ? 0 : 1 }'; then
+            echo "::error::Tag '${TAG_NAME}' must point to a commit on main's first-parent history."
+            exit 1
+          fi
+
+          PARENT_COUNT="$(git show -s --format=%P "${TAG_SHA}" | wc -w | tr -d ' ')"
+          if (( PARENT_COUNT < 2 )); then
+            echo "::error::Tag '${TAG_NAME}' must point to a merge commit on main."
+            exit 1
+          fi
+
+          {
+            echo "tag_name=${TAG_NAME}"
+            echo "sha=${TAG_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: GitHub Release 생성
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.release-target.outputs.tag_name }}
+          TARGET_SHA: ${{ steps.release-target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Release '${TAG_NAME}' already exists. Skipping."
+            exit 0
+          fi
+
+          gh release create "${TAG_NAME}" \
+            --target "${TARGET_SHA}" \
+            --title "${TAG_NAME}" \
+            --verify-tag \
+            --generate-notes
+
+      - name: Release summary
+        run: |
+          {
+            echo "### GitHub Release"
+            echo ""
+            echo "| 항목 | 값 |"
+            echo "|------|-----|"
+            echo "| Tag | \`${{ steps.release-target.outputs.tag_name }}\` |"
+            echo "| Target SHA | \`${{ steps.release-target.outputs.sha }}\` |"
+            echo "| Repository | \`${{ github.repository }}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## 🚀 작업 내용

- `.github/workflows/release.yml`에 GitHub Release 생성 워크플로를 추가했어요.
- `v*` 태그 push 또는 수동 실행으로 동작하고, Release 생성 전에 태그 존재 여부와 `main` first-parent 포함 여부, merge commit 여부를 검증해요.
- Release 조회/생성은 `GITHUB_TOKEN`이 아니라 `actions/create-github-app-token`으로 발급한 UMC GitHub App token을 사용해요.
- 이미 같은 태그의 Release가 있으면 중복 생성하지 않고 skip하며, 신규 Release는 `gh release create --generate-notes`로 생성해요.

## 💬 리뷰 중점사항

- 운영 태그 정책이 `v*` prefix와 `main` merge commit 기준으로 충분한지 확인해주세요.
- UMC GitHub App에 해당 repository 설치와 `Contents: Read and write` 권한이 필요해요.
- 검증은 YAML 파싱과 기존 `v2.2.0` 태그 기준 검증 스크립트 통과까지 확인했어요.
- `actionlint`는 로컬에 설치되어 있지 않아 실행하지 못했고, Java 코드 변경이 없는 GitHub Actions 설정 추가라 Gradle 테스트는 실행하지 않았어요.
