### PR TITLE
[Feat] 폼 엔진에 익명 응답 및 조건부 섹션 이동 구현

### DIFF
--- a/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponseJpaRepository.java
+++ b/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponseJpaRepository.java
@@ -73,4 +73,9 @@ public interface FormResponseJpaRepository extends JpaRepository<FormResponse, L
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM FormResponse fr WHERE fr.form.id = :formId")
     int deleteByFormId(@Param("formId") Long formId);
+
+    Optional<FormResponse> findByResponseAccessKeyHashAndStatus(
+        String responseAccessKeyHash,
+        FormResponseStatus status
+    );
 }

--- a/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponseJpaRepository.java
+++ b/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponseJpaRepository.java
@@ -78,4 +78,6 @@ public interface FormResponseJpaRepository extends JpaRepository<FormResponse, L
         String responseAccessKeyHash,
         FormResponseStatus status
     );
+
+    Optional<FormResponse> findByResponseAccessKeyHash(String responseAccessKeyHash);
 }

--- a/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -122,4 +122,9 @@ public class FormResponsePersistenceAdapter implements LoadFormResponsePort, Sav
             accessKeyHash, FormResponseStatus.SUBMITTED
         );
     }
+
+    @Override
+    public Optional<FormResponse> findByAccessKeyHash(String accessKeyHash) {
+        return formResponseJpaRepository.findByResponseAccessKeyHash(accessKeyHash);
+    }
 }

--- a/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -115,4 +115,11 @@ public class FormResponsePersistenceAdapter implements LoadFormResponsePort, Sav
             accessKeyHash, FormResponseStatus.DRAFT
         );
     }
+
+    @Override
+    public Optional<FormResponse> findSubmittedByAccessKeyHash(String accessKeyHash) {
+        return formResponseJpaRepository.findByResponseAccessKeyHashAndStatus(
+            accessKeyHash, FormResponseStatus.SUBMITTED
+        );
+    }
 }

--- a/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/form/adapter/out/persistence/FormResponsePersistenceAdapter.java
@@ -108,4 +108,11 @@ public class FormResponsePersistenceAdapter implements LoadFormResponsePort, Sav
     public void deleteByFormId(Long formId) {
         formResponseJpaRepository.deleteByFormId(formId);
     }
+
+    @Override
+    public Optional<FormResponse> findDraftByAccessKeyHash(String accessKeyHash) {
+        return formResponseJpaRepository.findByResponseAccessKeyHashAndStatus(
+            accessKeyHash, FormResponseStatus.DRAFT
+        );
+    }
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageAnswerUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageAnswerUseCase.java
@@ -1,7 +1,10 @@
 package com.umc.product.form.application.port.in.command;
 
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
 
 /**
@@ -15,8 +18,9 @@ import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
  * <p>
  * AnswerChoice (객관식 선택지)는 Answer 내부에 흡수되어 함께 관리된다 — {@code CreateAnswerCommand.selectedOptionIds} 로 선택지 지정.
  * <p>
- * 이 UseCase 의 create/update/delete 는 <b>기명 전용</b>이다. 익명 응답의 답변은 조작할 수 없으며 요청 시 FORBIDDEN 처리.
- * (익명 응답의 답변 조작은 별도 UseCase)
+ * <b>기명/익명 분리</b>: 기명 메서드({@link #createAnswer} / {@link #updateAnswer} / {@link #deleteAnswer})는
+ * {@code requesterMemberId} 기반 소유자 검증. 익명 메서드({@link #createAnonymousAnswer} / {@link #updateAnonymousAnswer}
+ * / {@link #deleteAnonymousAnswer})는 {@code responseAccessKey} 기반 sha256 매칭. 두 경계는 서로 우회 불가.
  */
 public interface ManageAnswerUseCase {
 
@@ -44,4 +48,32 @@ public interface ManageAnswerUseCase {
      * 익명 draft / 소유자 불일치 / requesterMemberId null 이면 FORBIDDEN.
      */
     void deleteAnswer(DeleteAnswerCommand command);
+
+    /**
+     * (익명 전용) 익명 DRAFT FormResponse 에 개별 답변을 추가한다.
+     * <p>
+     * {@code responseAccessKey} sha256 매칭으로 익명 draft 로드. 매칭 실패, DRAFT 아님, 기명 draft 인 경우 모두 FORBIDDEN.
+     * {@code responseAccessKey} 가 null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+     * 같은 질문에 대한 답변이 이미 있으면 {@link #updateAnonymousAnswer} 사용.
+     *
+     * @return 생성된 Answer ID
+     */
+    Long createAnonymousAnswer(CreateAnonymousAnswerCommand command);
+
+    /**
+     * (익명 전용) 익명 DRAFT FormResponse 의 개별 답변을 전체 교체한다.
+     * <p>
+     * {@code answerId} 로 답변 로드 → 그 응답의 저장된 hash 와 {@code responseAccessKey} sha256 매칭.
+     * 익명 경계 유출 방지를 위해 rawKey null 을 제외한 모든 실패 케이스 (Answer 없음, DRAFT 아님,
+     * 기명 draft, hash 불일치) 는 FORBIDDEN 으로 통일. {@code responseAccessKey} 가 null 이면
+     * RESPONSE_ACCESS_KEY_REQUIRED.
+     */
+    void updateAnonymousAnswer(UpdateAnonymousAnswerCommand command);
+
+    /**
+     * (익명 전용) 익명 DRAFT FormResponse 의 개별 답변을 삭제한다. 연관 AnswerChoice 도 cascade 삭제.
+     * <p>
+     * 검증 규칙은 {@link #updateAnonymousAnswer} 와 동일.
+     */
+    void deleteAnonymousAnswer(DeleteAnonymousAnswerCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageAnswerUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageAnswerUseCase.java
@@ -14,29 +14,34 @@ import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
  * (SUBMITTED 응답 수정은 {@code ManageFormResponseUseCase.updateResponse} 사용).
  * <p>
  * AnswerChoice (객관식 선택지)는 Answer 내부에 흡수되어 함께 관리된다 — {@code CreateAnswerCommand.selectedOptionIds} 로 선택지 지정.
+ * <p>
+ * 이 UseCase 의 create/update/delete 는 <b>기명 전용</b>이다. 익명 응답의 답변은 조작할 수 없으며 요청 시 FORBIDDEN 처리.
+ * (익명 응답의 답변 조작은 별도 UseCase)
  */
 public interface ManageAnswerUseCase {
 
     /**
-     * DRAFT FormResponse 에 개별 답변을 추가한다.
+     * (기명 전용) DRAFT FormResponse 에 개별 답변을 추가한다.
      * <p>
      * 같은 질문에 대한 답변이 이미 있으면 예외 — 수정은 {@link #updateAnswer} 사용.
-     * FormResponse 가 DRAFT 가 아니면 예외.
+     * FormResponse 가 DRAFT 가 아니면 NOT_DRAFT. 익명 draft / 소유자 불일치 / requesterMemberId null 이면 FORBIDDEN.
      *
      * @return 생성된 Answer ID
      */
     Long createAnswer(CreateAnswerCommand command);
 
     /**
-     * 개별 답변을 전체 교체한다. (textValue / selectedOptionIds / fileIds / times 등)
+     * (기명 전용) 개별 답변을 전체 교체한다. (textValue / selectedOptionIds / fileIds / times 등)
      * 기존 AnswerChoice 는 전부 삭제 후 재생성.
-     * FormResponse 가 DRAFT 가 아니면 예외. 답변 ID 가 없으면 예외.
+     * 답변 ID 가 없으면 ANSWER_NOT_FOUND. FormResponse 가 DRAFT 가 아니면 NOT_DRAFT.
+     * 익명 draft / 소유자 불일치 / requesterMemberId null 이면 FORBIDDEN.
      */
     void updateAnswer(UpdateAnswerCommand command);
 
     /**
-     * 개별 답변을 삭제한다. 연관 AnswerChoice 도 cascade 삭제.
-     * FormResponse 가 DRAFT 가 아니면 예외.
+     * (기명 전용) 개별 답변을 삭제한다. 연관 AnswerChoice 도 cascade 삭제.
+     * 답변 ID 가 없으면 ANSWER_NOT_FOUND. FormResponse 가 DRAFT 가 아니면 NOT_DRAFT.
+     * 익명 draft / 소유자 불일치 / requesterMemberId null 이면 FORBIDDEN.
      */
     void deleteAnswer(DeleteAnswerCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -7,6 +7,7 @@ import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmediatelyFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -107,6 +108,18 @@ public interface ManageFormResponseUseCase {
      * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
      */
     void deleteDraft(DeleteDraftFormResponseCommand command);
+
+    /**
+     * (익명 전용) 폼에 대한 익명 응답을 즉시 제출한다. (draft 없이 바로 SUBMITTED 상태 생성)
+     * Vote 같이 한 번에 제출하는 익명 플로우에서 사용.
+     * <p>
+     * 결과 status 는 SUBMITTED라 제출 무결성을 위해 형식 검증 + 필수 답변 누락 검증을 모두 수행.
+     * 서버가 랜덤 {@code responseAccessKey} 를 발급하고 sha256 해시만 저장한다.
+     * 반환된 raw key 는 이후 익명 조작(update / delete) 시 재제출용.
+     * <p>
+     * 익명 응답의 중복 정책은 form 엔진에서 강제하지 않는다 — 소비 도메인 책임.
+     */
+    AnonymousFormResponseResult submitAnonymousImmediately(SubmitAnonymousImmediatelyFormResponseCommand command);
 
     /**
      * (익명 전용) 익명 draft 응답을 최초 생성한다.

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -67,29 +67,39 @@ public interface ManageFormResponseUseCase {
     Long createDraft(CreateDraftFormResponseCommand command);
 
     /**
-     * 기존 draft 응답의 답변을 전체 교체한다 (작성 중 임시저장).
+     * (기명 전용) 기존 draft 응답의 답변을 전체 교체한다 (작성 중 임시저장).
      * <p>
      * 결과 status 는 DRAFT 그대로 유지되며, 작성 중이라는 의미상 필수 답변 누락 허용.
      * 형식 / 옵션 소속 / OTHER 텍스트 등 형식 검증 만 수행한다.
      * 필수 누락은 {@link #submitDraft} 시점에 검증.
      * <p>
      * draft가 아닌 응답(SUBMITTED) 또는 존재하지 않는 응답 ID면 예외.
+     * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
+     * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
+     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
      */
     void updateDraft(UpdateDraftFormResponseCommand command);
 
     /**
-     * draft 응답을 SUBMITTED 로 전환(최종 제출)한다.
+     * (기명 전용) draft 응답을 SUBMITTED 로 전환(최종 제출)한다.
      * <p>
      * 답변 내용은 이전 {@link #updateDraft} 로 저장된 값 그대로 유지 — status 만 DRAFT -> SUBMITTED.
      * 결과 status 가 SUBMITTED 가 되므로 저장된 답변 기준으로 필수 답변 누락 검증을 수행.
      * <p>
      * draft 가 아닌 응답이면 예외.
+     * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
+     * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
+     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
      */
     void submitDraft(SubmitDraftFormResponseCommand command);
 
     /**
-     * draft 응답을 삭제한다. (연관 Answer 포함)
+     * (기명 전용) draft 응답을 삭제한다. (연관 Answer 포함)
      * SUBMITTED 상태인 응답을 이 메서드로 삭제하면 예외 — SUBMITTED 삭제는 {@link #deleteResponse} 사용.
+     * <p>
+     * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
+     * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
+     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
      */
     void deleteDraft(DeleteDraftFormResponseCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -22,18 +22,28 @@ import com.umc.product.form.domain.exception.FormErrorCode;
  * <p>
  * 두 가지 응답 플로우를 지원한다:
  * <ol>
- *   <li><b>즉시 제출</b> (vote 등) — {@link #submitImmediately} 한 번 호출. draft 없음.
- *       이후 {@link #updateResponse} / {@link #deleteResponse} 로 수정·취소 가능.</li>
- *   <li><b>draft 플로우</b> (지원서 등) — {@link #createDraft} 로 시작,
- *       {@link #updateDraft} 로 임시저장 반복, {@link #submitDraft} 로 최종 제출.
- *       최종 제출 전에 {@link #deleteDraft} 로 포기 가능.</li>
+ *   <li><b>즉시 제출</b> (vote 등) — {@link #submitImmediately} / {@link #submitAnonymousImmediately} 한 번 호출.
+ *       draft 없음. 이후 {@link #updateResponse} / {@link #deleteResponse} 또는
+ *       {@link #updateAnonymousResponse} / {@link #deleteAnonymousResponse} 로 수정·취소 가능.</li>
+ *   <li><b>draft 플로우</b> (지원서 등) — {@link #createDraft} / {@link #createAnonymousDraft} 로 시작,
+ *       {@link #updateDraft} / {@link #updateAnonymousDraft} 로 임시저장 반복,
+ *       {@link #submitDraft} / {@link #submitAnonymousDraft} 로 최종 제출.
+ *       최종 제출 전에 {@link #deleteDraft} / {@link #deleteAnonymousDraft} 로 포기 가능.</li>
  * </ol>
- * 제출 후에는 두 플로우 모두 {@link #updateResponse} / {@link #deleteResponse} 로 관리된다.
  * <p>
- * <b>기명/익명 구분</b>: 아래 메서드들은 모두 <b>기명 응답 전용</b>이다.
- * {@code respondentMemberId} 가 필수이며 null 을 넘기면
- * {@link FormErrorCode#RESPONDENT_MEMBER_ID_REQUIRED} 예외.
- * 익명 응답은 별도의 익명 전용 메서드(추후 도입 예정)에서 처리한다.
+ * <b>기명/익명 구분</b>: 각 플로우가 기명/익명 두 벌로 나뉜다.
+ * <ul>
+ *   <li><b>기명 응답</b> ({@code submitImmediately}, {@code updateResponse}, {@code deleteResponse},
+ *       {@code createDraft}, {@code updateDraft}, {@code submitDraft}, {@code deleteDraft}):
+ *       {@code respondentMemberId} (SUBMITTED 계열) 또는 {@code requesterMemberId} (DRAFT 계열) 필수.
+ *       null 이거나 소유자와 다르면 예외.</li>
+ *   <li><b>익명 응답</b> ({@code submitAnonymousImmediately}, {@code updateAnonymousResponse},
+ *       {@code deleteAnonymousResponse}, {@code createAnonymousDraft}, {@code updateAnonymousDraft},
+ *       {@code submitAnonymousDraft}, {@code deleteAnonymousDraft}):
+ *       서버가 발급한 {@code responseAccessKey}(raw) 를 sha256 매칭으로 인증. UX 코드(예: 지원 코드) 는
+ *       소비 도메인이 raw key 와 매핑해서 관리.</li>
+ * </ul>
+ * 상세 설계: docs/analysis/form-anonymous-response-design.md
  */
 public interface ManageFormResponseUseCase {
 
@@ -84,7 +94,7 @@ public interface ManageFormResponseUseCase {
      * draft가 아닌 응답(SUBMITTED) 또는 존재하지 않는 응답 ID면 예외.
      * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
      * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
-     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
+     * 익명 draft 조작은 {@link #updateAnonymousDraft} 사용.
      */
     void updateDraft(UpdateDraftFormResponseCommand command);
 
@@ -97,7 +107,7 @@ public interface ManageFormResponseUseCase {
      * draft 가 아닌 응답이면 예외.
      * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
      * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
-     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
+     * 익명 draft 조작은 {@link #submitAnonymousDraft} 사용.
      */
     void submitDraft(SubmitDraftFormResponseCommand command);
 
@@ -107,7 +117,7 @@ public interface ManageFormResponseUseCase {
      * <p>
      * {@code requesterMemberId} 가 draft 소유자와 일치해야 한다.
      * 익명 draft 이거나, 소유자와 다르거나, null 이면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
-     * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
+     * 익명 draft 조작은 {@link #deleteAnonymousDraft} 사용.
      */
     void deleteDraft(DeleteDraftFormResponseCommand command);
 

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -5,6 +5,7 @@ import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -126,4 +127,15 @@ public interface ManageFormResponseUseCase {
      * 답변 검증 정책은 {@link #updateDraft} 와 동일 — 형식만, 필수 누락은 submit 시점 검증.
      */
     void updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand command);
+
+    /**
+     * (익명 전용) 익명 draft 응답을 SUBMITTED 로 전환(최종 제출)한다.
+     * <p>
+     * {@code responseAccessKey}(raw) 의 sha256 매칭으로 draft 를 찾는다.
+     * 매칭 실패, DRAFT 아님, 기명 draft 인 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     * null 은 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * <p>
+     * 검증 정책은 {@link #submitDraft} 와 동일 — 저장된 답변 기준으로 필수 답변 누락 검증 수행.
+     */
+    void submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -4,6 +4,7 @@ import com.umc.product.form.application.port.in.command.dto.AnonymousFormRespons
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -11,6 +12,7 @@ import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmed
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -120,6 +122,27 @@ public interface ManageFormResponseUseCase {
      * 익명 응답의 중복 정책은 form 엔진에서 강제하지 않는다 — 소비 도메인 책임.
      */
     AnonymousFormResponseResult submitAnonymousImmediately(SubmitAnonymousImmediatelyFormResponseCommand command);
+
+    /**
+     * (익명 전용) 이미 SUBMITTED 상태인 익명 응답의 답변을 전체 교체한다 (재제출).
+     * <p>
+     * {@code responseAccessKey}(raw) 의 sha256 매칭으로 응답을 찾는다.
+     * 매칭 실패, SUBMITTED 아님, 기명 응답인 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     * null 은 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * <p>
+     * 검증 정책은 기명 {@link #updateResponse} 와 동일 — 형식 + 필수 답변 누락 검증.
+     */
+    void updateAnonymousResponse(UpdateAnonymousFormResponseCommand command);
+
+    /**
+     * (익명 전용) 이미 SUBMITTED 상태인 익명 응답을 삭제한다. (FormResponse + 연관 Answer 모두 삭제)
+     * <p>
+     * {@code responseAccessKey}(raw) 의 sha256 매칭으로 응답을 찾는다.
+     * 매칭 실패, SUBMITTED 아님, 기명 응답인 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     * null 은 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * DRAFT 상태 익명 응답 삭제는 {@link #deleteAnonymousDraft} 사용.
+     */
+    void deleteAnonymousResponse(DeleteAnonymousFormResponseCommand command);
 
     /**
      * (익명 전용) 익명 draft 응답을 최초 생성한다.

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -7,6 +7,7 @@ import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormRespo
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
+import com.umc.product.form.domain.exception.FormErrorCode;
 
 /**
  * FormResponse(폼 응답) 관리 UseCase.
@@ -20,11 +21,16 @@ import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCo
  *       최종 제출 전에 {@link #deleteDraft} 로 포기 가능.</li>
  * </ol>
  * 제출 후에는 두 플로우 모두 {@link #updateResponse} / {@link #deleteResponse} 로 관리된다.
+ * <p>
+ * <b>기명/익명 구분</b>: 아래 메서드들은 모두 <b>기명 응답 전용</b>이다.
+ * {@code respondentMemberId} 가 필수이며 null 을 넘기면
+ * {@link FormErrorCode#RESPONDENT_MEMBER_ID_REQUIRED} 예외.
+ * 익명 응답은 별도의 익명 전용 메서드(추후 도입 예정)에서 처리한다.
  */
 public interface ManageFormResponseUseCase {
 
     /**
-     * 폼에 대한 응답을 즉시 제출한다. (draft 없이 바로 SUBMITTED 상태 생성)
+     * (기명 전용) 폼에 대한 응답을 즉시 제출한다. (draft 없이 바로 SUBMITTED 상태 생성)
      * vote 같이 한 번에 제출하는 플로우에서 사용.
      * <p>
      * 결과 status 는 SUBMITTED라 제출 무결성 을 위해 형식 검증 + 필수 답변 누락 검증을 모두 수행.
@@ -35,7 +41,7 @@ public interface ManageFormResponseUseCase {
     Long submitImmediately(SubmitFormResponseCommand command);
 
     /**
-     * 기존 SUBMITTED 응답의 답변을 전체 교체한다 (재제출 의미).
+     * (기명 전용) 기존 SUBMITTED 응답의 답변을 전체 교체한다 (재제출 의미).
      * <p>
      * 결과 status 는 SUBMITTED 그대로 유지되므로 제출 무결성을 위해 필수 답변 누락 검증을 수행한다 ({@link #submitImmediately} 와 동일).
      * <p>
@@ -45,14 +51,14 @@ public interface ManageFormResponseUseCase {
     void updateResponse(UpdateFormResponseCommand command);
 
     /**
-     * 본인이 제출한 SUBMITTED 응답을 삭제한다. (FormResponse + 연관 Answer 모두 삭제)
+     * (기명 전용) 본인이 제출한 SUBMITTED 응답을 삭제한다. (FormResponse + 연관 Answer 모두 삭제)
      * 삭제 후 다시 제출 가능. 기존 응답이 없으면 예외.
      * DRAFT 상태 응답 삭제는 {@link #deleteDraft} 사용.
      */
     void deleteResponse(DeleteFormResponseCommand command);
 
     /**
-     * 폼에 대한 draft 응답을 최초 생성한다. (빈 draft).
+     * (기명 전용) 폼에 대한 draft 응답을 최초 생성한다. (빈 draft).
      * 이후 {@link #updateDraft} 로 답변을 채워나가고 {@link #submitDraft} 로 최종 제출.
      * 같은 폼에 이미 draft 또는 SUBMITTED 응답이 있으면 예외.
      *

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -3,6 +3,7 @@ package com.umc.product.form.application.port.in.command;
 import com.umc.product.form.application.port.in.command.dto.AnonymousFormResponseResult;
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -138,4 +139,13 @@ public interface ManageFormResponseUseCase {
      * 검증 정책은 {@link #submitDraft} 와 동일 — 저장된 답변 기준으로 필수 답변 누락 검증 수행.
      */
     void submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand command);
+
+    /**
+     * (익명 전용) 익명 draft 응답을 삭제한다. (연관 Answer 포함)
+     * <p>
+     * {@code responseAccessKey}(raw) 의 sha256 매칭으로 draft 를 찾는다.
+     * 매칭 실패, DRAFT 아님, 기명 draft 인 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     * null 은 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     */
+    void deleteAnonymousDraft(DeleteAnonymousDraftFormResponseCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/ManageFormResponseUseCase.java
@@ -1,10 +1,13 @@
 package com.umc.product.form.application.port.in.command;
 
+import com.umc.product.form.application.port.in.command.dto.AnonymousFormResponseResult;
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -102,4 +105,25 @@ public interface ManageFormResponseUseCase {
      * 익명 draft 조작은 별도 UseCase(추후 도입 예정) 사용.
      */
     void deleteDraft(DeleteDraftFormResponseCommand command);
+
+    /**
+     * (익명 전용) 익명 draft 응답을 최초 생성한다.
+     * <p>
+     * 서버가 랜덤 {@code responseAccessKey} 를 발급하고 sha256 해시만 저장한다.
+     * 반환된 raw key 는 이후 익명 조작(update / delete / submit) 시 재제출용.
+     * <p>
+     * 익명 응답의 중복 정책은 form 엔진에서 강제하지 않는다 — 소비 도메인 책임.
+     */
+    AnonymousFormResponseResult createAnonymousDraft(CreateAnonymousDraftFormResponseCommand command);
+
+    /**
+     * (익명 전용) 익명 draft 응답의 답변을 전체 교체한다 (익명 임시저장).
+     * <p>
+     * {@code responseAccessKey}(raw) 의 sha256 매칭으로 draft 를 찾는다.
+     * 매칭 실패, DRAFT 아님, 기명 draft 인 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     * null 은 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * <p>
+     * 답변 검증 정책은 {@link #updateDraft} 와 동일 — 형식만, 필수 누락은 submit 시점 검증.
+     */
+    void updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand command);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/AnonymousFormResponseResult.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/AnonymousFormResponseResult.java
@@ -1,0 +1,18 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * 익명 응답 생성/발급 결과.
+ * <p>
+ * {@code responseAccessKey} 는 raw 값 (Base64URL 인코딩된 32byte 랜덤 토큰).
+ * 이후 익명 응답 조작(update / delete / submit) 시 이 값을 다시 서버에 전달해야 하며, 서버는 sha256 매칭으로 검증한다.
+ * <p>
+ * 소비 도메인은 이 raw 값을 <b>자체 서버 내부에만 보관</b>하는 것을 권장 — 클라이언트에 직접 노출 시 강한 엔트로피 이점이 훼손된다.
+ */
+@Builder
+public record AnonymousFormResponseResult(
+    Long formResponseId,
+    String responseAccessKey
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateAnonymousAnswerCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateAnonymousAnswerCommand.java
@@ -1,0 +1,25 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 익명 DRAFT FormResponse 에 개별 답변을 추가하는 Command.
+ * <p>
+ * {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버는 sha256 매칭으로 draft 를 찾는다.
+ * 매칭 실패, DRAFT 상태 아님, 기명 draft 인 경우 모두 FORBIDDEN. null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+ * <p>
+ * 타입별 필드 사용 규칙은 {@link CreateAnswerCommand} 참고.
+ */
+@Builder
+public record CreateAnonymousAnswerCommand(
+    String responseAccessKey,
+    Long questionId,
+    String textValue,
+    List<Long> selectedOptionIds,
+    List<String> fileIds,
+    List<Instant> times
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateAnonymousDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateAnonymousDraftFormResponseCommand.java
@@ -1,0 +1,17 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * 익명 draft 응답을 최초 생성하는 Command.
+ * <p>
+ * (익명 전용) 요청자 식별자 없이 발급되며, 응답 조작 시 필요한 {@code responseAccessKey}(raw) 를 발급받는다.
+ * 반환은 {@link AnonymousFormResponseResult} — 서버는 sha256(rawKey) 만 저장하고 raw 값은 반환 후 유지하지 않는다.
+ * <p>
+ * 익명 응답의 중복 응답 정책은 form 엔진에서 검사하지 않는다 — 소비 도메인이 IP rate limit / 이메일 유일성 등으로 방어.
+ */
+@Builder
+public record CreateAnonymousDraftFormResponseCommand(
+    Long formId
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateQuestionOptionCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/CreateQuestionOptionCommand.java
@@ -6,12 +6,14 @@ import lombok.Builder;
  * 질문에 선택지를 추가하는 Command.
  * orderNo는 Service에서 자동 부여.
  * {@code isOther}는 '기타' 직접 입력 선택지 여부.
+ * {@code nextSectionId}는 RADIO/DROPDOWN 타입에만 유효. null이면 다음 순서 섹션으로 이동.
  */
 @Builder
 public record CreateQuestionOptionCommand(
     Long questionId,
     Long requesterMemberId,
     String content,
-    boolean isOther
+    boolean isOther,
+    Long nextSectionId
 ) {
 }

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousAnswerCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousAnswerCommand.java
@@ -1,0 +1,18 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * 익명 DRAFT FormResponse 의 개별 답변 삭제 Command. 연관 AnswerChoice 도 cascade 삭제.
+ * <p>
+ * {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, {@code answerId} 로 찾은 응답의
+ * 저장된 hash 와 sha256 매칭. 익명 경계 유출 방지를 위해 rawKey null 을 제외한 모든 실패 케이스
+ * (Answer 없음, DRAFT 상태 아님, 기명 draft, hash 불일치) 는 FORBIDDEN 으로 통일.
+ * null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+ */
+@Builder
+public record DeleteAnonymousAnswerCommand(
+    Long answerId,
+    String responseAccessKey
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousDraftFormResponseCommand.java
@@ -1,0 +1,17 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * 익명 draft 응답을 삭제하는 Command. 연관 Answer / AnswerChoice 도 cascade 삭제.
+ * <p>
+ * SUBMITTED 응답은 이 Command 로 삭제 불가.
+ * <p>
+ * (익명 전용) {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버는 sha256 매칭으로 draft 를 찾는다.
+ * 매칭 실패, DRAFT 상태 아님, 기명 draft 인 경우 모두 FORBIDDEN. null 이면 RESPONSE_ACCESS_KEY_REQUIRED 예외.
+ */
+@Builder
+public record DeleteAnonymousDraftFormResponseCommand(
+    String responseAccessKey
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteAnonymousFormResponseCommand.java
@@ -1,0 +1,16 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import lombok.Builder;
+
+/**
+ * SUBMITTED 상태인 익명 응답을 삭제하는 Command. (FormResponse + 연관 Answer 모두 삭제)
+ * DRAFT 상태 익명 응답 삭제는 {@code DeleteAnonymousDraftFormResponseCommand} 사용.
+ * <p>
+ * (익명 전용) {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버는 sha256 매칭으로 응답을 찾는다.
+ * 매칭 실패, SUBMITTED 상태 아님, 기명 응답인 경우 모두 FORBIDDEN. null 이면 RESPONSE_ACCESS_KEY_REQUIRED 예외.
+ */
+@Builder
+public record DeleteAnonymousFormResponseCommand(
+    String responseAccessKey
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/DeleteDraftFormResponseCommand.java
@@ -6,7 +6,9 @@ import lombok.Builder;
  * draft 응답을 삭제하는 Command. 연관 Answer / AnswerChoice 도 cascade 삭제.
  * <p>
  * SUBMITTED 응답은 이 Command 로 삭제 불가 — SUBMITTED 응답 삭제는 {@code cancelResponse} 사용.
- * 권한 검증은 draft 소유자 본인 여부.
+ * <p>
+ * (기명 전용) {@code requesterMemberId} 는 권한 검증용 — draft 소유자 본인만 가능.
+ * 소유자와 다르거나, draft 가 익명이거나, null 이면 FORM_RESPONSE_FORBIDDEN 예외.
  */
 @Builder
 public record DeleteDraftFormResponseCommand(

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitAnonymousDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitAnonymousDraftFormResponseCommand.java
@@ -1,0 +1,27 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.util.Set;
+
+import lombok.Builder;
+
+/**
+ * 익명 draft 응답을 SUBMITTED 상태로 전환(최종 제출)하는 Command.
+ * <p>
+ * 답변 내용은 이전 익명 updateDraft 로 저장된 값 그대로 유지 — 이 Command 는 상태 전이만 담당.
+ * 최종 제출 직전에 답변을 한 번 더 바꾸려면 익명 updateDraft 를 먼저 호출한 뒤 submit.
+ * <p>
+ * draft 가 아닌 응답을 submit 시도하거나 매칭되는 draft 가 없으면 예외. {@code submittedIp} 는 감사/분석용 (선택, null 가능).
+ * {@code requiredQuestionIds} / {@code allowedQuestionIds} 는 특정 제품 흐름에서 제출 검증 범위를 좁힐 때 사용한다.
+ * 둘 다 {@code null} 이면 기존처럼 form 전체 기준으로 검증한다.
+ * <p>
+ * (익명 전용) {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버는 sha256 매칭으로 draft 를 찾는다.
+ * 매칭 실패, DRAFT 상태 아님, 기명 draft 인 경우 모두 FORBIDDEN. null 이면 RESPONSE_ACCESS_KEY_REQUIRED 예외.
+ */
+@Builder
+public record SubmitAnonymousDraftFormResponseCommand(
+    String responseAccessKey,
+    String submittedIp,
+    Set<Long> requiredQuestionIds,
+    Set<Long> allowedQuestionIds
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitAnonymousImmediatelyFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitAnonymousImmediatelyFormResponseCommand.java
@@ -1,0 +1,23 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 익명 응답을 즉시 제출하는 Command. (draft 없이 바로 SUBMITTED 상태 생성)
+ * Vote 같이 한 번에 제출하는 익명 플로우에서 사용.
+ * <p>
+ * (익명 전용) 요청자 식별자 없이 발급되며, 응답 조작 시 필요한 {@code responseAccessKey}(raw) 를 발급받는다.
+ * 반환은 {@link AnonymousFormResponseResult} — 서버는 sha256(rawKey) 만 저장하고 raw 값은 반환 후 유지하지 않는다.
+ * <p>
+ * 익명 응답의 중복 응답 정책은 form 엔진에서 검사하지 않는다 — 소비 도메인이 IP rate limit / 이메일 유일성 등으로 방어.
+ * <p>
+ * 결과 status 가 SUBMITTED 이므로 제출 무결성을 위해 형식 검증 + 필수 답변 누락 검증을 모두 수행.
+ */
+@Builder
+public record SubmitAnonymousImmediatelyFormResponseCommand(
+    Long formId,
+    List<AnswerCommand> answers
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/SubmitDraftFormResponseCommand.java
@@ -13,6 +13,9 @@ import lombok.Builder;
  * draft 가 아닌 응답을 submit 시도하면 예외. {@code submittedIp} 는 감사/분석용 (선택, null 가능).
  * {@code requiredQuestionIds} / {@code allowedQuestionIds} 는 특정 제품 흐름에서 제출 검증 범위를 좁힐 때 사용한다.
  * 둘 다 {@code null} 이면 기존처럼 form 전체 기준으로 검증한다.
+ * <p>
+ * (기명 전용) {@code requesterMemberId} 는 권한 검증용 — draft 소유자 본인만 가능.
+ * 소유자와 다르거나, draft 가 익명이거나, null 이면 FORM_RESPONSE_FORBIDDEN 예외.
  */
 @Builder
 public record SubmitDraftFormResponseCommand(

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousAnswerCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousAnswerCommand.java
@@ -1,0 +1,27 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 익명 DRAFT FormResponse 의 개별 답변을 전체 교체하는 Command.
+ * <p>
+ * 기존 답변 값(textValue / AnswerChoice / fileIds / times)을 모두 삭제 후 새 값으로 재구성.
+ * <p>
+ * {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, {@code answerId} 로 찾은 응답의
+ * 저장된 hash 와 sha256 매칭. 익명 경계 유출 방지를 위해 rawKey null 을 제외한 모든 실패 케이스
+ * (Answer 없음, DRAFT 상태 아님, 기명 draft, hash 불일치) 는 FORBIDDEN 으로 통일.
+ * null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+ */
+@Builder
+public record UpdateAnonymousAnswerCommand(
+    Long answerId,
+    String responseAccessKey,
+    String textValue,
+    List<Long> selectedOptionIds,
+    List<String> fileIds,
+    List<Instant> times
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousDraftFormResponseCommand.java
@@ -1,0 +1,21 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 익명 draft 응답의 답변을 전체 교체하는 Command. (익명 임시저장 용도)
+ * <p>
+ * {@code answers} 는 전체 교체 — 기존 답변은 삭제 후 {@code answers} 로 재구성.
+ * <p>
+ * (익명 전용) {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며,
+ * 서버는 sha256 매칭으로 draft 를 찾는다. 매칭 실패, DRAFT 상태 아님, 기명 draft 인 경우 모두 FORBIDDEN.
+ * null 이면 RESPONSE_ACCESS_KEY_REQUIRED 예외.
+ */
+@Builder
+public record UpdateAnonymousDraftFormResponseCommand(
+    String responseAccessKey,
+    List<AnswerCommand> answers
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateAnonymousFormResponseCommand.java
@@ -1,0 +1,21 @@
+package com.umc.product.form.application.port.in.command.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 이미 SUBMITTED 상태인 익명 응답의 답변을 전체 교체하는 Command (재제출 의미).
+ * <p>
+ * 결과 status 는 SUBMITTED 그대로 유지되므로 제출 무결성을 위해 필수 답변 누락 검증을 수행한다.
+ * 작성 중인 익명 응답을 갱신하려는 경우는 {@code UpdateAnonymousDraftFormResponseCommand} 사용.
+ * <p>
+ * (익명 전용) {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버는 sha256 매칭으로 응답을 찾는다.
+ * 매칭 실패, SUBMITTED 상태 아님, 기명 응답인 경우 모두 FORBIDDEN. null 이면 RESPONSE_ACCESS_KEY_REQUIRED 예외.
+ */
+@Builder
+public record UpdateAnonymousFormResponseCommand(
+    String responseAccessKey,
+    List<AnswerCommand> answers
+) {
+}

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateDraftFormResponseCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateDraftFormResponseCommand.java
@@ -10,7 +10,8 @@ import lombok.Builder;
  * {@code answers} 는 전체 교체 — 기존 답변은 삭제 후 {@code answers} 로 재구성.
  * draft 가 아닌 응답(SUBMITTED)을 이 Command 로 업데이트하면 예외 — SUBMITTED 수정은 {@code UpdateFormResponseCommand} 사용.
  * <p>
- * {@code requesterMemberId} 는 권한 검증 — draft 소유자 본인만 가능.
+ * (기명 전용) {@code requesterMemberId} 는 권한 검증용 — draft 소유자 본인만 가능.
+ * 소유자와 다르거나, draft 가 익명이거나, null 이면 FORM_RESPONSE_FORBIDDEN 예외.
  */
 @Builder
 public record UpdateDraftFormResponseCommand(

--- a/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateQuestionOptionCommand.java
+++ b/src/main/java/com/umc/product/form/application/port/in/command/dto/UpdateQuestionOptionCommand.java
@@ -3,8 +3,8 @@ package com.umc.product.form.application.port.in.command.dto;
 import lombok.Builder;
 
 /**
- * 선택지 속성 업데이트 Command. content / isOther를 부분 수정.
- * null 인 필드는 기존 값 유지.
+ * 선택지 속성 업데이트 Command. content / isOther / nextSectionId를 부분 수정.
+ * null 인 필드는 기존 값 유지. nextSectionId를 제거하려면 {@code clearNextSectionId=true}.
  * 순서 변경은 {@code ReorderQuestionOptionsCommand}.
  */
 @Builder
@@ -12,6 +12,8 @@ public record UpdateQuestionOptionCommand(
     Long optionId,
     Long requesterMemberId,
     String content,
-    Boolean isOther
+    Boolean isOther,
+    Long nextSectionId,
+    Boolean clearNextSectionId
 ) {
 }

--- a/src/main/java/com/umc/product/form/application/port/in/query/GetAnswerUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/query/GetAnswerUseCase.java
@@ -11,28 +11,62 @@ import com.umc.product.form.application.port.in.query.dto.AnswerInfo;
  * Answer 조회 UseCase.
  * <p>
  * 개별 답변 조회와 FormResponse 단위 전체 답변 조회를 모두 지원한다.
+ * <p>
+ * <b>기명/익명 분리</b> (Command 쪽 {@code ManageAnswerUseCase} 와 동일 패턴):
+ * <ul>
+ *   <li>기명: {@link #findById} / {@link #getById} / {@link #listByFormResponseId} / {@link #listByFormResponseIds}
+ *     — 익명 응답 (respondentMemberId=null) 은 반환 안 함.</li>
+ *   <li>익명: {@link #listByFormResponseIdAsAnonymous} — {@code responseAccessKey} sha256 매칭으로 응답 인증 후 반환.</li>
+ * </ul>
  */
 public interface GetAnswerUseCase {
 
     /**
-     * 답변 ID 로 단건 조회. 없으면 Optional.empty.
+     * (기명 전용) 답변 ID 로 단건 조회. 없거나 익명 응답의 답변이면 Optional.empty.
      */
     Optional<AnswerInfo> findById(Long answerId);
 
     /**
-     * 답변 ID 로 단건 조회. 없으면 예외.
+     * (기명 전용) 답변 ID 로 단건 조회. 없거나 익명 응답의 답변이면 ANSWER_NOT_FOUND.
      */
     AnswerInfo getById(Long answerId);
 
     /**
-     * 특정 FormResponse 에 속한 모든 답변을 반환한다. (질문 orderNo 순)
+     * (기명 전용) 특정 FormResponse 에 속한 모든 답변을 반환한다. (질문 orderNo 순)
+     * 익명 응답이면 빈 리스트.
      */
     List<AnswerInfo> listByFormResponseId(Long formResponseId);
 
     /**
-     * 여러 FormResponse 에 속한 답변을 한 번에 조회한다.
+     * (기명 전용) 여러 FormResponse 에 속한 답변을 한 번에 조회한다. 익명 응답의 답변은 결과에서 제외.
      *
      * @return formResponseId -> 답변 목록
      */
     Map<Long, List<AnswerInfo>> listByFormResponseIds(Set<Long> formResponseIds);
+
+    /**
+     * (익명 전용) 답변 ID 로 단건 조회. access-key 인증 후 반환.
+     * <p>
+     * 인증 실패 케이스는 모두 Optional.empty (정보 유출 방지). rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+     */
+    Optional<AnswerInfo> findByIdAsAnonymous(Long answerId, String responseAccessKey);
+
+    /**
+     * (익명 전용) 답변 ID 로 단건 조회. access-key 인증 후 반환.
+     * <p>
+     * 익명 경계 유출 방지를 위해 rawKey null 을 제외한 모든 실패 케이스 (답변 없음, 기명 응답, hash 불일치)
+     * 는 {@code FORM_RESPONSE_FORBIDDEN} 로 통일. rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+     */
+    AnswerInfo getByIdAsAnonymous(Long answerId, String responseAccessKey);
+
+    /**
+     * (익명 전용) 익명 FormResponse 의 답변을 access-key 인증 후 반환한다. (질문 orderNo 순)
+     * <p>
+     * {@code responseAccessKey} 는 발급 시 서버가 반환한 raw 값이며, 서버가 저장된 hash 와 sha256 매칭.
+     * 익명 경계 유출 방지를 위해 rawKey null 을 제외한 모든 인증 실패 케이스
+     * (기명 응답, hash 불일치) 는 {@code FORM_RESPONSE_FORBIDDEN}. rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED.
+     * <p>
+     * 응답에 답변이 하나도 없으면 빈 리스트 (정보 유출 방지 위해 응답 존재 여부는 검사하지 않음).
+     */
+    List<AnswerInfo> listByFormResponseIdAsAnonymous(Long formResponseId, String responseAccessKey);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
@@ -65,20 +65,29 @@ public interface GetFormResponseUseCase {
     Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 
     /**
-     * 특정 응답의 메타 + 모든 답변을 한 번에 조회 (facade). 응답 상세 화면 (응답자 본인 / 폼 작성자) 용도. 없으면 FORM_RESPONSE_NOT_FOUND 예외.
+     * (기명 전용) 특정 응답의 메타 + 모든 답변을 한 번에 조회 (facade). 응답 상세 화면 (응답자 본인 / 폼 작성자) 용도.
+     * 없으면 FORM_RESPONSE_NOT_FOUND 예외.
+     * <p>
+     * 익명 응답 (respondentMemberId=null) 은 조회되지 않고 FORM_RESPONSE_NOT_FOUND 로 처리된다.
+     * 익명 응답 상세 조회는 {@link #getResponseWithAnswersByAccessKey} 를 사용해야 한다.
      */
     FormResponseWithAnswersInfo getResponseWithAnswers(Long formResponseId);
 
     /**
-     * {@link #getResponseWithAnswers} 의 graceful 버전. 미존재 시 Optional.empty() 를 반환하므로 호출 도메인의 invariant(예: dangling
-     * formResponseId)를 자체 에러 코드로 통일하고 싶은 경우 사용한다.
+     * (기명 전용) {@link #getResponseWithAnswers} 의 graceful 버전. 미존재 시 Optional.empty() 를 반환하므로
+     * 호출 도메인의 invariant(예: dangling formResponseId)를 자체 에러 코드로 통일하고 싶은 경우 사용한다.
+     * <p>
+     * 익명 응답 (respondentMemberId=null) 은 조회되지 않고 Optional.empty() 로 처리된다.
+     * 익명 응답 조회는 {@link #findByAccessKey} 를 사용해야 한다.
      */
     Optional<FormResponseWithAnswersInfo> findResponseWithAnswers(Long formResponseId);
 
     /**
-     * 여러 응답의 메타 + 답변을 한 번에 조회한다.
+     * (기명 전용) 여러 응답의 메타 + 답변을 한 번에 조회한다.
+     * <p>
+     * 익명 응답 (respondentMemberId=null) 은 결과 map 에서 제외된다. 미존재 ID 도 결과에 포함하지 않는다.
      *
-     * @return formResponseId -> 응답 상세. 미존재 ID는 결과에 포함하지 않는다.
+     * @return formResponseId -> 응답 상세
      */
     Map<Long, FormResponseWithAnswersInfo> findResponsesWithAnswers(Set<Long> formResponseIds);
 

--- a/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
@@ -81,4 +81,24 @@ public interface GetFormResponseUseCase {
      * @return formResponseId -> 응답 상세. 미존재 ID는 결과에 포함하지 않는다.
      */
     Map<Long, FormResponseWithAnswersInfo> findResponsesWithAnswers(Set<Long> formResponseIds);
+
+    /**
+     * (익명 전용) {@code responseAccessKey}(raw) 의 sha256 매칭으로 응답 단건 조회.
+     * <p>
+     * 매칭 없으면 Optional.empty. 기명 응답이 매칭되면 방어 목적으로 Optional.empty.
+     * {@code rawKey} 가 null 이면 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * <p>
+     * 소비 도메인(리크루팅 등) 이 응답 존재 확인 용도로 사용.
+     */
+    Optional<FormResponseInfo> findByAccessKey(String rawKey);
+
+    /**
+     * (익명 전용) {@code responseAccessKey}(raw) 의 sha256 매칭으로 응답 + 답변 상세 조회.
+     * <p>
+     * 매칭 없거나 기명 응답이 매칭되면 {@link FormErrorCode#FORM_RESPONSE_NOT_FOUND}.
+     * {@code rawKey} 가 null 이면 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * <p>
+     * 응답자 본인이 자기 응답 상세를 확인하는 용도.
+     */
+    FormResponseWithAnswersInfo getResponseWithAnswersByAccessKey(String rawKey);
 }

--- a/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
+++ b/src/main/java/com/umc/product/form/application/port/in/query/GetFormResponseUseCase.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import com.umc.product.form.application.port.in.query.dto.FormResponseInfo;
 import com.umc.product.form.application.port.in.query.dto.FormResponseWithAnswersInfo;
+import com.umc.product.form.domain.exception.FormErrorCode;
 
 /**
  * FormResponse 조회 UseCase.
@@ -36,21 +37,30 @@ public interface GetFormResponseUseCase {
     List<FormResponseInfo> listSubmittedByFormId(Long formId);
 
     /**
-     * 특정 사용자의 모든 draft 응답을 반환한다. "내가 작성 중인 응답 목록" 용도.
+     * (기명 전용) 특정 사용자의 모든 draft 응답을 반환한다. "내가 작성 중인 응답 목록" 용도.
+     * <p>
+     * {@code respondentMemberId} 가 필수이며 null 을 넘기면
+     * {@link FormErrorCode#RESPONDENT_MEMBER_ID_REQUIRED} 예외.
      */
     List<FormResponseInfo> listDraftByRespondentMemberId(Long respondentMemberId);
 
     /**
-     * 특정 폼에 대한 특정 사용자의 draft 응답을 조회. 없으면 Optional.empty. "작성 중 응답 이어서 보기" 용도.
+     * (기명 전용) 특정 폼에 대한 특정 사용자의 draft 응답을 조회. 없으면 Optional.empty. "작성 중 응답 이어서 보기" 용도.
      * <p>
      * 중복 응답을 허용하지 않는 폼 전용 단건 조회다. 중복 허용 폼은 {@code formResponseId} 기준으로 조회해야 한다.
+     * <p>
+     * {@code respondentMemberId} 가 필수이며 null 을 넘기면
+     * {@link FormErrorCode#RESPONDENT_MEMBER_ID_REQUIRED} 예외.
      */
     Optional<FormResponseInfo> findDraftByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 
     /**
-     * 특정 폼에 대한 특정 사용자의 SUBMITTED 응답을 조회. 없으면 Optional.empty.
+     * (기명 전용) 특정 폼에 대한 특정 사용자의 SUBMITTED 응답을 조회. 없으면 Optional.empty.
      * <p>
      * 중복 응답을 허용하지 않는 폼 전용 단건 조회다. 중복 허용 폼은 {@code formResponseId} 기준으로 조회해야 한다.
+     * <p>
+     * {@code respondentMemberId} 가 필수이며 null 을 넘기면
+     * {@link FormErrorCode#RESPONDENT_MEMBER_ID_REQUIRED} 예외.
      */
     Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
 

--- a/src/main/java/com/umc/product/form/application/port/in/query/dto/QuestionOptionInfo.java
+++ b/src/main/java/com/umc/product/form/application/port/in/query/dto/QuestionOptionInfo.java
@@ -16,6 +16,7 @@ public record QuestionOptionInfo(
     String content,
     Long orderNo,
     boolean isOther,
+    Long nextSectionId,
     Instant createdAt,
     Instant updatedAt
 ) {
@@ -27,6 +28,7 @@ public record QuestionOptionInfo(
             .content(option.getContent())
             .orderNo(option.getOrderNo())
             .isOther(option.isOther())
+            .nextSectionId(option.getNextSectionId())
             .createdAt(option.getCreatedAt())
             .updatedAt(option.getUpdatedAt())
             .build();

--- a/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
+++ b/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
@@ -48,4 +48,10 @@ public interface LoadFormResponsePort {
      * 매칭 없거나 DRAFT 인 경우 Optional.empty.
      */
     Optional<FormResponse> findSubmittedByAccessKeyHash(String accessKeyHash);
+
+    /**
+     * (익명 전용) sha256 해시 매칭으로 응답 조회 (DRAFT / SUBMITTED 무관).
+     * 매칭 없으면 Optional.empty. 응답자 익명 여부는 호출자가 확인.
+     */
+    Optional<FormResponse> findByAccessKeyHash(String accessKeyHash);
 }

--- a/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
+++ b/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
@@ -42,4 +42,10 @@ public interface LoadFormResponsePort {
      * 매칭 없거나 SUBMITTED 인 경우 Optional.empty.
      */
     Optional<FormResponse> findDraftByAccessKeyHash(String accessKeyHash);
+
+    /**
+     * (익명 전용) sha256 해시 매칭으로 SUBMITTED 응답 조회.
+     * 매칭 없거나 DRAFT 인 경우 Optional.empty.
+     */
+    Optional<FormResponse> findSubmittedByAccessKeyHash(String accessKeyHash);
 }

--- a/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
+++ b/src/main/java/com/umc/product/form/application/port/out/LoadFormResponsePort.java
@@ -36,4 +36,10 @@ public interface LoadFormResponsePort {
     long countSubmittedByFormId(Long formId);
 
     Optional<FormResponse> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId);
+
+    /**
+     * (익명 전용) sha256 해시 매칭으로 DRAFT 응답 조회.
+     * 매칭 없거나 SUBMITTED 인 경우 Optional.empty.
+     */
+    Optional<FormResponse> findDraftByAccessKeyHash(String accessKeyHash);
 }

--- a/src/main/java/com/umc/product/form/application/service/command/AnswerCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/AnswerCommandService.java
@@ -47,7 +47,7 @@ public class AnswerCommandService implements ManageAnswerUseCase {
 
     @Override
     public Long createAnswer(CreateAnswerCommand command) {
-        FormResponse draft = loadDraft(command.formResponseId());
+        FormResponse draft = loadDraftAsOwner(command.formResponseId(), command.requesterMemberId());
         Question question = loadQuestionInForm(command.questionId(), draft.getForm().getId());
 
         // 같은 질문에 대한 답변이 이미 있으면 예외
@@ -78,14 +78,8 @@ public class AnswerCommandService implements ManageAnswerUseCase {
 
     @Override
     public void updateAnswer(UpdateAnswerCommand command) {
-        Answer existing = loadAnswerPort.findById(command.answerId())
-            .orElseThrow(() -> new FormDomainException(FormErrorCode.ANSWER_NOT_FOUND));
-
+        Answer existing = loadAnswerAndDraftAsOwner(command.answerId(), command.requesterMemberId());
         FormResponse draft = existing.getFormResponse();
-        if (draft.getStatus() != FormResponseStatus.DRAFT) {
-            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
-        }
-
         Question question = existing.getQuestion();
         validateAnswerContent(question, command.textValue(), command.selectedOptionIds(), command.fileIds());
 
@@ -111,13 +105,8 @@ public class AnswerCommandService implements ManageAnswerUseCase {
 
     @Override
     public void deleteAnswer(DeleteAnswerCommand command) {
-        Answer existing = loadAnswerPort.findById(command.answerId())
-            .orElseThrow(() -> new FormDomainException(FormErrorCode.ANSWER_NOT_FOUND));
-
+        Answer existing = loadAnswerAndDraftAsOwner(command.answerId(), command.requesterMemberId());
         FormResponse draft = existing.getFormResponse();
-        if (draft.getStatus() != FormResponseStatus.DRAFT) {
-            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
-        }
 
         saveAnswerPort.deleteByAnswerId(existing.getId());
         draft.updateLastSavedAt(Instant.now());
@@ -134,6 +123,46 @@ public class AnswerCommandService implements ManageAnswerUseCase {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
         }
         return formResponse;
+    }
+
+    /**
+     * 소유자 검증까지 포함한 DRAFT 응답 로드 (기명 전용). {@code FormResponseCommandService.loadDraftAsOwner} 와 대칭.
+     * <p>
+     * 순서: DRAFT 로드 → 익명/소유자 대조.
+     * 다음 경우 모두 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 처리:
+     * <ul>
+     *   <li>익명 draft({@code respondentMemberId=null}) — 기명 UseCase 로 접근 불가, 익명 UseCase 사용</li>
+     *   <li>요청자 memberId 가 draft 소유자와 다름</li>
+     *   <li>요청자 memberId 가 null (auth 계층에서 걸러졌어야 하는 케이스, 방어 목적)</li>
+     * </ul>
+     */
+    private FormResponse loadDraftAsOwner(Long formResponseId, Long requesterMemberId) {
+        FormResponse draft = loadDraft(formResponseId);
+        if (draft.getRespondentMemberId() == null
+            || !draft.getRespondentMemberId().equals(requesterMemberId)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return draft;
+    }
+
+    /**
+     * answerId 로 Answer 를 로드하고 그 FormResponse 에 대한 소유자 검증까지 수행 (기명 전용).
+     * <p>
+     * Answer 없으면 {@link FormErrorCode#ANSWER_NOT_FOUND}. FormResponse 가 DRAFT 아니거나 소유자 불일치/익명이면
+     * {@link #loadDraftAsOwner} 규칙에 따라 예외.
+     */
+    private Answer loadAnswerAndDraftAsOwner(Long answerId, Long requesterMemberId) {
+        Answer existing = loadAnswerPort.findById(answerId)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.ANSWER_NOT_FOUND));
+        FormResponse draft = existing.getFormResponse();
+        if (draft.getStatus() != FormResponseStatus.DRAFT) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
+        }
+        if (draft.getRespondentMemberId() == null
+            || !draft.getRespondentMemberId().equals(requesterMemberId)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return existing;
     }
 
     /**

--- a/src/main/java/com/umc/product/form/application/service/command/AnswerCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/AnswerCommandService.java
@@ -9,9 +9,13 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
 import com.umc.product.form.application.port.in.command.ManageAnswerUseCase;
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
 import com.umc.product.form.application.port.out.LoadFormResponsePort;
@@ -44,6 +48,9 @@ public class AnswerCommandService implements ManageAnswerUseCase {
     private final SaveAnswerPort saveAnswerPort;
     private final SaveFormResponsePort saveFormResponsePort;
     private final GetFileUseCase getFileUseCase;
+    // authentication 도메인의 crypto util
+    // 재배치(common/security 등) 는 별도 리팩터 PR 대상.
+    private final SecureTokenGenerator secureTokenGenerator;
 
     @Override
     public Long createAnswer(CreateAnswerCommand command) {
@@ -113,6 +120,74 @@ public class AnswerCommandService implements ManageAnswerUseCase {
         saveFormResponsePort.save(draft);
     }
 
+    @Override
+    public Long createAnonymousAnswer(CreateAnonymousAnswerCommand command) {
+        FormResponse draft = loadDraftAsAnonymous(command.responseAccessKey());
+        Question question = loadQuestionInForm(command.questionId(), draft.getForm().getId());
+
+        // 같은 질문에 대한 답변이 이미 있으면 예외
+        if (loadAnswerPort.existsByFormResponseIdAndQuestionId(draft.getId(), question.getId())) {
+            throw new FormDomainException(FormErrorCode.ANSWER_ALREADY_EXISTS);
+        }
+
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds(), command.fileIds());
+
+        Answer answer = Answer.create(
+            draft, question, question.getType(),
+            command.textValue(),
+            toFileIdSet(command.fileIds())
+        );
+        Answer saved = saveAnswerPort.save(answer);
+
+        // 객관식이면 AnswerChoice도 같이 저장
+        List<AnswerChoice> choices = buildChoices(saved, question, command.selectedOptionIds());
+        if (!choices.isEmpty()) {
+            saveAnswerPort.saveAllChoices(choices);
+        }
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+
+        return saved.getId();
+    }
+
+    @Override
+    public void updateAnonymousAnswer(UpdateAnonymousAnswerCommand command) {
+        Answer existing = loadAnswerAndDraftAsAnonymous(command.answerId(), command.responseAccessKey());
+        FormResponse draft = existing.getFormResponse();
+        Question question = existing.getQuestion();
+        validateAnswerContent(question, command.textValue(), command.selectedOptionIds(), command.fileIds());
+
+        // 1. 기존 AnswerChoice 만 삭제 (Answer 는 PK 유지하며 update)
+        saveAnswerPort.deleteChoicesByAnswerId(existing.getId());
+
+        // 2. Answer 의 textValue / fileIds 갱신 (PATCH 시맨틱 — null 은 기존 값 유지)
+        Set<String> requestedFileIds = command.fileIds() == null
+            ? null  // null = keep
+            : new HashSet<>(command.fileIds());  // empty = clear, non-empty = set
+        existing.update(command.textValue(), requestedFileIds);
+        saveAnswerPort.save(existing);
+
+        // 3. 새 AnswerChoice 저장 (객관식인 경우)
+        List<AnswerChoice> choices = buildChoices(existing, question, command.selectedOptionIds());
+        if (!choices.isEmpty()) {
+            saveAnswerPort.saveAllChoices(choices);
+        }
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
+    @Override
+    public void deleteAnonymousAnswer(DeleteAnonymousAnswerCommand command) {
+        Answer existing = loadAnswerAndDraftAsAnonymous(command.answerId(), command.responseAccessKey());
+        FormResponse draft = existing.getFormResponse();
+
+        saveAnswerPort.deleteByAnswerId(existing.getId());
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
     /**
      * 응답 ID로 DRAFT 응답 로드. 없으면 NOT_FOUND, DRAFT가 아니면 NOT_DRAFT 예외.
      */
@@ -160,6 +235,50 @@ public class AnswerCommandService implements ManageAnswerUseCase {
         }
         if (draft.getRespondentMemberId() == null
             || !draft.getRespondentMemberId().equals(requesterMemberId)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return existing;
+    }
+
+    /**
+     * 익명 draft 응답 로드 + 검증 (익명 전용). {@code FormResponseCommandService.loadDraftAsAnonymous} 와 대칭.
+     * <p>
+     * rawKey null → {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     * hash 매칭 실패 / 기명 draft → {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN}.
+     */
+    private FormResponse loadDraftAsAnonymous(String rawAccessKey) {
+        if (rawAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawAccessKey);
+        FormResponse draft = loadFormResponsePort.findDraftByAccessKeyHash(hash)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN));
+        if (draft.getRespondentMemberId() != null) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return draft;
+    }
+
+    /**
+     * answerId 로 Answer 로드 + 그 FormResponse 가 익명 draft 인지 및 access key hash 매칭 검증 (익명 전용).
+     * <p>
+     * 익명 경계 유출 방지를 위해 {@code FormResponseCommandService.loadDraftAsAnonymous} 와 동일하게
+     * rawKey null 을 제외한 모든 실패 케이스는 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 로 통일한다
+     * (Answer 존재 여부 / DRAFT 여부 / 기명 여부 / hash 매칭 결과 어느 것도 응답 코드로 유출하지 않음).
+     */
+    private Answer loadAnswerAndDraftAsAnonymous(Long answerId, String rawAccessKey) {
+        if (rawAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        Answer existing = loadAnswerPort.findById(answerId)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN));
+        FormResponse draft = existing.getFormResponse();
+        if (draft.getStatus() != FormResponseStatus.DRAFT
+            || draft.getRespondentMemberId() != null) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawAccessKey);
+        if (!hash.equals(draft.getResponseAccessKeyHash())) {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
         }
         return existing;

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -189,22 +189,13 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             validateAnsweredQuestionsAllowed(command.allowedQuestionIds(), answeredQuestionIds);
         }
 
-        if (command.requiredQuestionIds() != null) {
-            validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
-        } else {
-            // 이미 메모리에 있는 savedAnswers 로 (answerId → questionId) 매핑 미리 만들어서
-            // AnswerChoice 순회 시 Answer 프록시 초기화(N+1) 회피.
-            Map<Long, Long> answerIdToQuestionId = savedAnswers.stream()
-                .collect(Collectors.toMap(Answer::getId, a -> a.getQuestion().getId()));
-            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIdToQuestionId.keySet()).stream()
-                .filter(c -> c.getQuestionOption() != null)
-                .collect(Collectors.toMap(
-                    c -> answerIdToQuestionId.get(c.getAnswer().getId()),
-                    c -> c.getQuestionOption().getId(),
-                    (a, b) -> a
-                ));
-            validateAllRequiredAnsweredOnPath(draft.getForm().getId(), answeredQuestionIds, selectedOptionByQuestion);
-        }
+        Map<Long, Long> selectedOptionByQuestion = loadSelectedOptionByQuestion(savedAnswers);
+        validateAllRequiredAnsweredOnPath(
+            draft.getForm().getId(),
+            answeredQuestionIds,
+            selectedOptionByQuestion,
+            command.requiredQuestionIds()
+        );
 
         saveEmptyAnswersForUnanswered(draft, command.allowedQuestionIds(), answeredQuestionIds);
 
@@ -323,22 +314,13 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             validateAnsweredQuestionsAllowed(command.allowedQuestionIds(), answeredQuestionIds);
         }
 
-        if (command.requiredQuestionIds() != null) {
-            validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
-        } else {
-            // 이미 메모리에 있는 savedAnswers 로 (answerId → questionId) 매핑 미리 만들어서
-            // AnswerChoice 순회 시 Answer 프록시 초기화(N+1) 회피.
-            Map<Long, Long> answerIdToQuestionId = savedAnswers.stream()
-                .collect(Collectors.toMap(Answer::getId, a -> a.getQuestion().getId()));
-            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIdToQuestionId.keySet()).stream()
-                .filter(c -> c.getQuestionOption() != null)
-                .collect(Collectors.toMap(
-                    c -> answerIdToQuestionId.get(c.getAnswer().getId()),
-                    c -> c.getQuestionOption().getId(),
-                    (a, b) -> a
-                ));
-            validateAllRequiredAnsweredOnPath(draft.getForm().getId(), answeredQuestionIds, selectedOptionByQuestion);
-        }
+        Map<Long, Long> selectedOptionByQuestion = loadSelectedOptionByQuestion(savedAnswers);
+        validateAllRequiredAnsweredOnPath(
+            draft.getForm().getId(),
+            answeredQuestionIds,
+            selectedOptionByQuestion,
+            command.requiredQuestionIds()
+        );
 
         saveEmptyAnswersForUnanswered(draft, command.allowedQuestionIds(), answeredQuestionIds);
 
@@ -516,15 +498,57 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         Set<Long> answeredQuestionIds,
         Map<Long, Long> selectedOptionByQuestion
     ) {
+        validateAllRequiredAnsweredOnPath(formId, answeredQuestionIds, selectedOptionByQuestion, null);
+    }
+
+    /**
+     * 방문 경로와 caller 제공 required 를 통합해 검증한다.
+     * <p>
+     * {@code callerRequiredQuestionIds} 가 {@code null} 이면 폼 질문의 {@code isRequired} 를 사용하고,
+     * 제공되면 방문 경로 질문과의 교집합만 필수로 취급한다. 조건부 섹션 이동으로 건너뛴 질문은 caller 가 required 로 전달했더라도 검증에서 제외된다.
+     */
+    private void validateAllRequiredAnsweredOnPath(
+        Long formId,
+        Set<Long> answeredQuestionIds,
+        Map<Long, Long> selectedOptionByQuestion,
+        Set<Long> callerRequiredQuestionIds
+    ) {
         Set<Long> visitedSectionIds = resolveVisitedSectionIds(formId, selectedOptionByQuestion);
         List<Question> formQuestions = loadQuestionPort.listByFormId(formId);
         for (Question q : formQuestions) {
-            if (visitedSectionIds.contains(q.getFormSection().getId())
-                && Boolean.TRUE.equals(q.getIsRequired())
-                && !answeredQuestionIds.contains(q.getId())) {
+            if (!visitedSectionIds.contains(q.getFormSection().getId())) {
+                continue;
+            }
+            boolean required = callerRequiredQuestionIds != null
+                ? callerRequiredQuestionIds.contains(q.getId())
+                : Boolean.TRUE.equals(q.getIsRequired());
+            if (required && !answeredQuestionIds.contains(q.getId())) {
                 throw new FormDomainException(FormErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
             }
         }
+    }
+
+    /**
+     * savedAnswers 로부터 (questionId → selectedOptionId) 맵을 계산한다.
+     * <p>
+     * 방문 경로 계산용. 이미 메모리에 있는 savedAnswers 로 answerId → questionId 매핑을 미리 만들어
+     * AnswerChoice 순회 시 Answer 프록시 초기화로 인한 N+1 을 회피한다.
+     * RADIO/DROPDOWN 이 아닌 답변의 선택지는 방문 경로 계산에 사용되지 않지만,
+     * 이 헬퍼는 관심 없이 모든 선택지를 담아 리턴한다. 소비 측에서 필터링한다.
+     */
+    private Map<Long, Long> loadSelectedOptionByQuestion(List<Answer> savedAnswers) {
+        if (savedAnswers.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Long> answerIdToQuestionId = savedAnswers.stream()
+            .collect(Collectors.toMap(Answer::getId, a -> a.getQuestion().getId()));
+        return loadAnswerPort.listChoicesByAnswerIdIn(answerIdToQuestionId.keySet()).stream()
+            .filter(c -> c.getQuestionOption() != null)
+            .collect(Collectors.toMap(
+                c -> answerIdToQuestionId.get(c.getAnswer().getId()),
+                c -> c.getQuestionOption().getId(),
+                (a, b) -> a
+            ));
     }
 
     /**
@@ -597,14 +621,6 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
                 AnswerCommand::questionId,
                 a -> a.selectedOptionIds().get(0)
             ));
-    }
-
-    private void validateRequiredAnswered(Set<Long> requiredQuestionIds, Set<Long> answeredQuestionIds) {
-        for (Long questionId : requiredQuestionIds) {
-            if (!answeredQuestionIds.contains(questionId)) {
-                throw new FormDomainException(FormErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
-            }
-        }
     }
 
     private void validateAnsweredQuestionsAllowed(Set<Long> allowedQuestionIds, Set<Long> answeredQuestionIds) {

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -346,11 +346,10 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             }
 
             if (next == null) {
-                FormSection finalCurrent = current;
-                next = sections.stream()
-                    .filter(s -> s.getOrderNo() > finalCurrent.getOrderNo())
-                    .findFirst()
-                    .orElse(null);
+                int currentIndex = sections.indexOf(current);
+                next = (currentIndex != -1 && currentIndex < sections.size() - 1)
+                    ? sections.get(currentIndex + 1)
+                    : null;
             }
 
             current = next;

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -2,9 +2,14 @@ package com.umc.product.form.application.service.command;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -24,6 +29,7 @@ import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCo
 import com.umc.product.form.application.port.out.LoadAnswerPort;
 import com.umc.product.form.application.port.out.LoadFormPort;
 import com.umc.product.form.application.port.out.LoadFormResponsePort;
+import com.umc.product.form.application.port.out.LoadFormSectionPort;
 import com.umc.product.form.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.form.application.port.out.LoadQuestionPort;
 import com.umc.product.form.application.port.out.SaveAnswerPort;
@@ -32,6 +38,7 @@ import com.umc.product.form.domain.Answer;
 import com.umc.product.form.domain.AnswerChoice;
 import com.umc.product.form.domain.Form;
 import com.umc.product.form.domain.FormResponse;
+import com.umc.product.form.domain.FormSection;
 import com.umc.product.form.domain.Question;
 import com.umc.product.form.domain.QuestionOption;
 import com.umc.product.form.domain.enums.FormResponseStatus;
@@ -49,6 +56,7 @@ import lombok.RequiredArgsConstructor;
 public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     private final LoadFormPort loadFormPort;
+    private final LoadFormSectionPort loadFormSectionPort;
     private final LoadQuestionPort loadQuestionPort;
     private final LoadQuestionOptionPort loadQuestionOptionPort;
     private final LoadFormResponsePort loadFormResponsePort;
@@ -71,7 +79,11 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         validateDuplicateResponsePolicy(form, command.respondentMemberId());
 
         validateAnswers(command.formId(), command.answers());
-        validateAllRequiredAnswered(command.formId(), extractQuestionIds(command.answers()));
+        validateAllRequiredAnsweredOnPath(
+            command.formId(),
+            extractQuestionIds(command.answers()),
+            extractSingleSelectedOptionIds(command.answers())
+        );
 
         FormResponse response = FormResponse.createDraft(form, command.respondentMemberId());
         response.submit(Instant.now(), null);
@@ -93,7 +105,11 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_FOUND));
 
         validateAnswers(command.formId(), command.answers());
-        validateAllRequiredAnswered(command.formId(), extractQuestionIds(command.answers()));
+        validateAllRequiredAnsweredOnPath(
+            command.formId(),
+            extractQuestionIds(command.answers()),
+            extractSingleSelectedOptionIds(command.answers())
+        );
 
         saveAnswerPort.deleteAllByFormResponseId(existing.getId());
 
@@ -159,7 +175,15 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         if (command.requiredQuestionIds() != null) {
             validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
         } else {
-            validateAllRequiredAnswered(draft.getForm().getId(), answeredQuestionIds);
+            Set<Long> answerIds = savedAnswers.stream().map(Answer::getId).collect(Collectors.toSet());
+            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIds).stream()
+                .filter(c -> c.getQuestionOption() != null)
+                .collect(Collectors.toMap(
+                    c -> c.getAnswer().getQuestion().getId(),
+                    c -> c.getQuestionOption().getId(),
+                    (a, b) -> a
+                ));
+            validateAllRequiredAnsweredOnPath(draft.getForm().getId(), answeredQuestionIds, selectedOptionByQuestion);
         }
 
         saveEmptyAnswersForUnanswered(draft, command.allowedQuestionIds(), answeredQuestionIds);
@@ -225,7 +249,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
      * 답변 형식 / 질문 소속 / 옵션 소속 등 형식 검증만 수행. 필수 답변 누락 검증은 별도.
      * <p>
      * draft 작성 중 (updateDraft) 에는 필수 누락이 정상이라 형식만 검증.
-     * 제출 시점 (submitImmediately, updateResponse, submitDraft) 에는 별도로 {@link #validateAllRequiredAnswered} 호출 필요.
+     * 제출 시점 (submitImmediately, updateResponse, submitDraft) 에는 별도로 {@link #validateAllRequiredAnsweredOnPath} 호출 필요.
      */
     private void validateAnswers(Long formId, List<AnswerCommand> answers) {
         if (answers == null) {
@@ -252,15 +276,96 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     }
 
     /**
-     * 폼의 모든 필수 질문이 답변에 포함됐는지 검증. 제출 시점에만 호출.
+     * 응답자가 실제 방문한 섹션 경로 상의 필수 질문만 검증. 제출 시점에만 호출.
+     * 조건부 섹션 이동이 없는 폼은 전체 섹션을 방문하므로 기존 동작과 동일.
      */
-    private void validateAllRequiredAnswered(Long formId, Set<Long> answeredQuestionIds) {
+    private void validateAllRequiredAnsweredOnPath(
+        Long formId,
+        Set<Long> answeredQuestionIds,
+        Map<Long, Long> selectedOptionByQuestion
+    ) {
+        Set<Long> visitedSectionIds = resolveVisitedSectionIds(formId, selectedOptionByQuestion);
         List<Question> formQuestions = loadQuestionPort.listByFormId(formId);
         for (Question q : formQuestions) {
-            if (Boolean.TRUE.equals(q.getIsRequired()) && !answeredQuestionIds.contains(q.getId())) {
+            if (visitedSectionIds.contains(q.getFormSection().getId())
+                && Boolean.TRUE.equals(q.getIsRequired())
+                && !answeredQuestionIds.contains(q.getId())) {
                 throw new FormDomainException(FormErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
             }
         }
+    }
+
+    /**
+     * 제출된 답변의 선택지를 기반으로 응답자가 실제로 방문한 섹션 ID 집합을 계산한다.
+     * RADIO/DROPDOWN 선택지에 nextSectionId가 지정된 경우 해당 섹션으로 점프하고,
+     * 없으면 orderNo 오름차순으로 다음 섹션으로 이동한다.
+     */
+    private Set<Long> resolveVisitedSectionIds(Long formId, Map<Long, Long> selectedOptionByQuestion) {
+        List<FormSection> sections = loadFormSectionPort.listByFormId(formId).stream()
+            .sorted(Comparator.comparing(FormSection::getOrderNo))
+            .toList();
+        if (sections.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Question> questions = loadQuestionPort.listByFormId(formId);
+
+        Set<Long> radioDropdownQuestionIds = questions.stream()
+            .filter(q -> q.getType() == QuestionType.RADIO || q.getType() == QuestionType.DROPDOWN)
+            .map(Question::getId)
+            .collect(Collectors.toSet());
+
+        Map<Long, Long> optionToNextSection = new HashMap<>();
+        if (!radioDropdownQuestionIds.isEmpty()) {
+            loadQuestionOptionPort.listByQuestionIdIn(radioDropdownQuestionIds).stream()
+                .filter(opt -> opt.getNextSectionId() != null)
+                .forEach(opt -> optionToNextSection.put(opt.getId(), opt.getNextSectionId()));
+        }
+
+        Map<Long, List<Question>> questionsBySection = questions.stream()
+            .collect(Collectors.groupingBy(q -> q.getFormSection().getId()));
+        Map<Long, FormSection> sectionById = sections.stream()
+            .collect(Collectors.toMap(FormSection::getId, Function.identity()));
+
+        Set<Long> visited = new LinkedHashSet<>();
+        FormSection current = sections.get(0);
+
+        while (current != null) {
+            visited.add(current.getId());
+
+            FormSection next = null;
+            for (Question q : questionsBySection.getOrDefault(current.getId(), List.of())) {
+                if (q.getType() != QuestionType.RADIO && q.getType() != QuestionType.DROPDOWN) continue;
+                Long selectedOptionId = selectedOptionByQuestion.get(q.getId());
+                if (selectedOptionId == null) continue;
+                Long nextSectionId = optionToNextSection.get(selectedOptionId);
+                if (nextSectionId != null && !visited.contains(nextSectionId)) {
+                    next = sectionById.get(nextSectionId);
+                    break;
+                }
+            }
+
+            if (next == null) {
+                FormSection finalCurrent = current;
+                next = sections.stream()
+                    .filter(s -> s.getOrderNo() > finalCurrent.getOrderNo())
+                    .findFirst()
+                    .orElse(null);
+            }
+
+            current = next;
+        }
+
+        return visited;
+    }
+
+    private static Map<Long, Long> extractSingleSelectedOptionIds(List<AnswerCommand> answers) {
+        return answers.stream()
+            .filter(a -> a.selectedOptionIds() != null && a.selectedOptionIds().size() == 1)
+            .collect(Collectors.toMap(
+                AnswerCommand::questionId,
+                a -> a.selectedOptionIds().get(0)
+            ));
     }
 
     private void validateRequiredAnswered(Set<Long> requiredQuestionIds, Set<Long> answeredQuestionIds) {

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -17,13 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
 import com.umc.product.form.application.port.in.command.ManageFormResponseUseCase;
+import com.umc.product.form.application.port.in.command.dto.AnonymousFormResponseResult;
 import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
@@ -64,6 +68,9 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     private final SaveFormResponsePort saveFormResponsePort;
     private final SaveAnswerPort saveAnswerPort;
     private final GetFileUseCase getFileUseCase;
+    // authentication 도메인의 공용 crypto util 재사용 (SSO Auth Code 발급과 동일 패턴).
+    // 재배치(common/security 등) 는 별도 리팩터 PR 대상.
+    private final SecureTokenGenerator secureTokenGenerator;
 
     @Audited(
         domain = Domain.FORM,
@@ -204,6 +211,39 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         saveFormResponsePort.deleteById(draft.getId());
     }
 
+    @Override
+    public AnonymousFormResponseResult createAnonymousDraft(CreateAnonymousDraftFormResponseCommand command) {
+        Form form = loadPublishedForm(command.formId());
+
+        // 익명은 중복 정책 검사 skip — 소비 도메인(리크루팅 등) 이 자체 rate limit / 유일성 검사로 방어.
+        String rawAccessKey = secureTokenGenerator.generateOpaqueToken();
+        String accessKeyHash = secureTokenGenerator.sha256Hex(rawAccessKey);
+
+        FormResponse draft = FormResponse.createAnonymousDraft(form, accessKeyHash);
+        FormResponse saved = saveFormResponsePort.save(draft);
+
+        return AnonymousFormResponseResult.builder()
+            .formResponseId(saved.getId())
+            .responseAccessKey(rawAccessKey)
+            .build();
+    }
+
+    @Override
+    public void updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand command) {
+        FormResponse draft = loadDraftAsAnonymous(command.responseAccessKey());
+
+        // 형식 검증만 수행 — 작성 중이라 필수 누락은 정상
+        validateAnswers(draft.getForm().getId(), command.answers());
+
+        // 기존 답변 전체 교체
+        saveAnswerPort.deleteAllByFormResponseId(draft.getId());
+        List<AnswerWithOptions> data = buildAnswerData(draft, command.answers());
+        saveAnswers(data);
+
+        draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
     /**
      * 응답 ID 로 DRAFT 응답 로드. 없으면 NOT_FOUND, DRAFT 가 아니면 NOT_DRAFT 예외.
      */
@@ -214,6 +254,31 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
         }
         return formResponse;
+    }
+
+    /**
+     * 익명 draft 응답 로드 + 검증 (익명 전용).
+     * <p>
+     * 순서: rawKey null 방어 → sha256 계산 → hash 매칭으로 DRAFT 조회 → 익명 여부 확인.
+     * <p>
+     * 다음 경우 모두 FORBIDDEN 처리:
+     * <ul>
+     *   <li>hash 매칭 실패 (잘못된 key 또는 이미 SUBMITTED 로 전이됨)</li>
+     *   <li>기명 draft ({@code respondentMemberId != null}) — 익명 UseCase 로 접근 불가</li>
+     * </ul>
+     * rawKey 가 null 이면 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     */
+    private FormResponse loadDraftAsAnonymous(String rawAccessKey) {
+        if (rawAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawAccessKey);
+        FormResponse draft = loadFormResponsePort.findDraftByAccessKeyHash(hash)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN));
+        if (draft.getRespondentMemberId() != null) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return draft;
     }
 
     /**

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -24,6 +24,7 @@ import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -31,6 +32,7 @@ import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmed
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
@@ -243,6 +245,34 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     }
 
     @Override
+    public void updateAnonymousResponse(UpdateAnonymousFormResponseCommand command) {
+        FormResponse existing = loadSubmittedAsAnonymous(command.responseAccessKey());
+
+        validateAnswers(existing.getForm().getId(), command.answers());
+        validateAllRequiredAnsweredOnPath(
+            existing.getForm().getId(),
+            extractQuestionIds(command.answers()),
+            extractSingleSelectedOptionIds(command.answers())
+        );
+
+        saveAnswerPort.deleteAllByFormResponseId(existing.getId());
+
+        List<AnswerWithOptions> data = buildAnswerData(existing, command.answers());
+        saveAnswers(data);
+
+        existing.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(existing);
+    }
+
+    @Override
+    public void deleteAnonymousResponse(DeleteAnonymousFormResponseCommand command) {
+        FormResponse existing = loadSubmittedAsAnonymous(command.responseAccessKey());
+
+        saveAnswerPort.deleteAllByFormResponseId(existing.getId());
+        saveFormResponsePort.deleteById(existing.getId());
+    }
+
+    @Override
     public AnonymousFormResponseResult createAnonymousDraft(CreateAnonymousDraftFormResponseCommand command) {
         Form form = loadPublishedForm(command.formId());
 
@@ -351,6 +381,31 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
         }
         return draft;
+    }
+
+    /**
+     * 익명 SUBMITTED 응답 로드 + 검증 (익명 전용).
+     * <p>
+     * 순서: rawKey null 방어 → sha256 계산 → hash 매칭으로 SUBMITTED 조회 → 익명 여부 확인.
+     * <p>
+     * 다음 경우 모두 FORBIDDEN 처리:
+     * <ul>
+     *   <li>hash 매칭 실패 (잘못된 key 또는 아직 DRAFT 상태)</li>
+     *   <li>기명 응답 ({@code respondentMemberId != null}) — 익명 UseCase 로 접근 불가</li>
+     * </ul>
+     * rawKey 가 null 이면 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     */
+    private FormResponse loadSubmittedAsAnonymous(String rawAccessKey) {
+        if (rawAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawAccessKey);
+        FormResponse response = loadFormResponsePort.findSubmittedByAccessKeyHash(hash)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN));
+        if (response.getRespondentMemberId() != null) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return response;
     }
 
     /**

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -149,7 +149,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void updateDraft(UpdateDraftFormResponseCommand command) {
-        FormResponse draft = loadDraft(command.formResponseId());
+        FormResponse draft = loadDraftAsOwner(command.formResponseId(), command.requesterMemberId());
 
         // 형식 검증만 수행 — 작성 중이라 필수 누락은 정상
         validateAnswers(draft.getForm().getId(), command.answers());
@@ -165,7 +165,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void submitDraft(SubmitDraftFormResponseCommand command) {
-        FormResponse draft = loadDraft(command.formResponseId());
+        FormResponse draft = loadDraftAsOwner(command.formResponseId(), command.requesterMemberId());
 
         List<Answer> savedAnswers = loadAnswerPort.listByFormResponseId(draft.getId());
         Set<Long> answeredQuestionIds = savedAnswers.stream()
@@ -198,7 +198,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void deleteDraft(DeleteDraftFormResponseCommand command) {
-        FormResponse draft = loadDraft(command.formResponseId());
+        FormResponse draft = loadDraftAsOwner(command.formResponseId(), command.requesterMemberId());
 
         saveAnswerPort.deleteAllByFormResponseId(draft.getId());
         saveFormResponsePort.deleteById(draft.getId());
@@ -214,6 +214,28 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_DRAFT);
         }
         return formResponse;
+    }
+
+    /**
+     * 소유자 검증까지 포함한 DRAFT 응답 로드 (기명 전용).
+     * <p>
+     * 순서: DRAFT 로드({@link #loadDraft}) → 소유자 대조.
+     * 소유자와 일치하지 않으면 {@link FormErrorCode#FORM_RESPONSE_FORBIDDEN} 예외.
+     * <p>
+     * 다음 경우 모두 FORBIDDEN 처리:
+     * <ul>
+     *   <li>익명 draft({@code respondentMemberId=null}) — 기명 UseCase 로 접근 불가, 별도 익명 UseCase(추후 도입) 사용</li>
+     *   <li>요청자 memberId 가 draft 소유자와 다름</li>
+     *   <li>요청자 memberId 가 null (auth 계층에서 걸러졌어야 하는 케이스, 방어 목적)</li>
+     * </ul>
+     */
+    private FormResponse loadDraftAsOwner(Long formResponseId, Long requesterMemberId) {
+        FormResponse draft = loadDraft(formResponseId);
+        if (draft.getRespondentMemberId() == null
+            || !draft.getRespondentMemberId().equals(requesterMemberId)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return draft;
     }
 
     private static Set<Long> extractQuestionIds(List<AnswerCommand> answers) {

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -191,11 +191,14 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         if (command.requiredQuestionIds() != null) {
             validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
         } else {
-            Set<Long> answerIds = savedAnswers.stream().map(Answer::getId).collect(Collectors.toSet());
-            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIds).stream()
+            // 이미 메모리에 있는 savedAnswers 로 (answerId → questionId) 매핑 미리 만들어서
+            // AnswerChoice 순회 시 Answer 프록시 초기화(N+1) 회피.
+            Map<Long, Long> answerIdToQuestionId = savedAnswers.stream()
+                .collect(Collectors.toMap(Answer::getId, a -> a.getQuestion().getId()));
+            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIdToQuestionId.keySet()).stream()
                 .filter(c -> c.getQuestionOption() != null)
                 .collect(Collectors.toMap(
-                    c -> c.getAnswer().getQuestion().getId(),
+                    c -> answerIdToQuestionId.get(c.getAnswer().getId()),
                     c -> c.getQuestionOption().getId(),
                     (a, b) -> a
                 ));
@@ -321,11 +324,14 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         if (command.requiredQuestionIds() != null) {
             validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
         } else {
-            Set<Long> answerIds = savedAnswers.stream().map(Answer::getId).collect(Collectors.toSet());
-            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIds).stream()
+            // 이미 메모리에 있는 savedAnswers 로 (answerId → questionId) 매핑 미리 만들어서
+            // AnswerChoice 순회 시 Answer 프록시 초기화(N+1) 회피.
+            Map<Long, Long> answerIdToQuestionId = savedAnswers.stream()
+                .collect(Collectors.toMap(Answer::getId, a -> a.getQuestion().getId()));
+            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIdToQuestionId.keySet()).stream()
                 .filter(c -> c.getQuestionOption() != null)
                 .collect(Collectors.toMap(
-                    c -> c.getAnswer().getQuestion().getId(),
+                    c -> answerIdToQuestionId.get(c.getAnswer().getId()),
                     c -> c.getQuestionOption().getId(),
                     (a, b) -> a
                 ));

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -27,6 +27,7 @@ import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmediatelyFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -211,6 +212,34 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
         saveAnswerPort.deleteAllByFormResponseId(draft.getId());
         saveFormResponsePort.deleteById(draft.getId());
+    }
+
+    @Override
+    public AnonymousFormResponseResult submitAnonymousImmediately(SubmitAnonymousImmediatelyFormResponseCommand command) {
+        Form form = loadPublishedForm(command.formId());
+
+        // 익명은 중복 정책 검사 skip — 소비 도메인(리크루팅 등) 이 자체 rate limit / 유일성 검사로 방어.
+        validateAnswers(command.formId(), command.answers());
+        validateAllRequiredAnsweredOnPath(
+            command.formId(),
+            extractQuestionIds(command.answers()),
+            extractSingleSelectedOptionIds(command.answers())
+        );
+
+        String rawAccessKey = secureTokenGenerator.generateOpaqueToken();
+        String accessKeyHash = secureTokenGenerator.sha256Hex(rawAccessKey);
+
+        FormResponse response = FormResponse.createAnonymousDraft(form, accessKeyHash);
+        response.submit(Instant.now(), null);
+        FormResponse saved = saveFormResponsePort.save(response);
+
+        List<AnswerWithOptions> data = buildAnswerData(saved, command.answers());
+        saveAnswers(data);
+
+        return AnonymousFormResponseResult.builder()
+            .formResponseId(saved.getId())
+            .responseAccessKey(rawAccessKey)
+            .build();
     }
 
     @Override

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -25,6 +25,7 @@ import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -241,6 +242,39 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         saveAnswers(data);
 
         draft.updateLastSavedAt(Instant.now());
+        saveFormResponsePort.save(draft);
+    }
+
+    @Override
+    public void submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand command) {
+        FormResponse draft = loadDraftAsAnonymous(command.responseAccessKey());
+
+        List<Answer> savedAnswers = loadAnswerPort.listByFormResponseId(draft.getId());
+        Set<Long> answeredQuestionIds = savedAnswers.stream()
+            .map(answer -> answer.getQuestion().getId())
+            .collect(Collectors.toSet());
+
+        if (command.allowedQuestionIds() != null) {
+            validateAnsweredQuestionsAllowed(command.allowedQuestionIds(), answeredQuestionIds);
+        }
+
+        if (command.requiredQuestionIds() != null) {
+            validateRequiredAnswered(command.requiredQuestionIds(), answeredQuestionIds);
+        } else {
+            Set<Long> answerIds = savedAnswers.stream().map(Answer::getId).collect(Collectors.toSet());
+            Map<Long, Long> selectedOptionByQuestion = loadAnswerPort.listChoicesByAnswerIdIn(answerIds).stream()
+                .filter(c -> c.getQuestionOption() != null)
+                .collect(Collectors.toMap(
+                    c -> c.getAnswer().getQuestion().getId(),
+                    c -> c.getQuestionOption().getId(),
+                    (a, b) -> a
+                ));
+            validateAllRequiredAnsweredOnPath(draft.getForm().getId(), answeredQuestionIds, selectedOptionByQuestion);
+        }
+
+        saveEmptyAnswersForUnanswered(draft, command.allowedQuestionIds(), answeredQuestionIds);
+
+        draft.submit(Instant.now(), command.submittedIp());
         saveFormResponsePort.save(draft);
     }
 

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -178,6 +178,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     @Override
     public void submitDraft(SubmitDraftFormResponseCommand command) {
         FormResponse draft = loadDraftAsOwner(command.formResponseId(), command.requesterMemberId());
+        validateSubmitScope(draft.getForm().getId(), command.allowedQuestionIds(), command.requiredQuestionIds());
 
         List<Answer> savedAnswers = loadAnswerPort.listByFormResponseId(draft.getId());
         Set<Long> answeredQuestionIds = savedAnswers.stream()
@@ -311,6 +312,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     @Override
     public void submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand command) {
         FormResponse draft = loadDraftAsAnonymous(command.responseAccessKey());
+        validateSubmitScope(draft.getForm().getId(), command.allowedQuestionIds(), command.requiredQuestionIds());
 
         List<Answer> savedAnswers = loadAnswerPort.listByFormResponseId(draft.getId());
         Set<Long> answeredQuestionIds = savedAnswers.stream()
@@ -610,6 +612,30 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
             if (!allowedQuestionIds.contains(questionId)) {
                 throw new FormDomainException(FormErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
             }
+        }
+    }
+
+    /**
+     * 제출 scope 검증 — allowedQuestionIds / requiredQuestionIds 가 현재 폼 소속이고 required ⊆ allowed 인지 확인.
+     * <p>
+     * 미검증 시 폼 A draft 에 폼 B 질문 ID 를 넘겨 교차 폼 Answer 저장 등의 무결성 파괴가 가능하다.
+     */
+    private void validateSubmitScope(Long formId, Set<Long> allowedQuestionIds, Set<Long> requiredQuestionIds) {
+        if (allowedQuestionIds == null && requiredQuestionIds == null) {
+            return;
+        }
+        Set<Long> formQuestionIds = loadQuestionPort.listByFormId(formId).stream()
+            .map(Question::getId)
+            .collect(Collectors.toSet());
+        if (allowedQuestionIds != null && !formQuestionIds.containsAll(allowedQuestionIds)) {
+            throw new FormDomainException(FormErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+        }
+        if (requiredQuestionIds != null && !formQuestionIds.containsAll(requiredQuestionIds)) {
+            throw new FormDomainException(FormErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+        }
+        if (allowedQuestionIds != null && requiredQuestionIds != null
+            && !allowedQuestionIds.containsAll(requiredQuestionIds)) {
+            throw new FormDomainException(FormErrorCode.INVALID_SUBMIT_SCOPE);
         }
     }
 

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -207,6 +207,9 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
         if (form.isAllowDuplicateResponses()) {
             return;
         }
+        if (respondentMemberId == null) {
+            return;
+        }
         if (loadFormResponsePort.existsByFormIdAndMemberId(form.getId(), respondentMemberId)) {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_ALREADY_EXISTS);
         }

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -74,6 +74,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     )
     @Override
     public Long submitImmediately(SubmitFormResponseCommand command) {
+        requireRespondentMemberId(command.respondentMemberId());
         Form form = loadPublishedForm(command.formId());
 
         validateDuplicateResponsePolicy(form, command.respondentMemberId());
@@ -97,6 +98,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void updateResponse(UpdateFormResponseCommand command) {
+        requireRespondentMemberId(command.respondentMemberId());
         Form form = loadPublishedForm(command.formId());
         validateSingleResponseLookupPolicy(form);
 
@@ -122,6 +124,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public void deleteResponse(DeleteFormResponseCommand command) {
+        requireRespondentMemberId(command.respondentMemberId());
         Form form = loadPublishedForm(command.formId());
         validateSingleResponseLookupPolicy(form);
 
@@ -135,6 +138,7 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
     @Override
     public Long createDraft(CreateDraftFormResponseCommand command) {
+        requireRespondentMemberId(command.respondentMemberId());
         Form form = loadPublishedForm(command.formId());
 
         validateDuplicateResponsePolicy(form, command.respondentMemberId());
@@ -242,6 +246,12 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
     private static void validateSingleResponseLookupPolicy(Form form) {
         if (form.isAllowDuplicateResponses()) {
             throw new FormDomainException(FormErrorCode.FORM_RESPONSE_LOOKUP_AMBIGUOUS);
+        }
+    }
+
+    private static void requireRespondentMemberId(Long respondentMemberId) {
+        if (respondentMemberId == null) {
+            throw new FormDomainException(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
         }
     }
 

--- a/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/FormResponseCommandService.java
@@ -23,6 +23,7 @@ import com.umc.product.form.application.port.in.command.dto.AnonymousFormRespons
 import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -276,6 +277,14 @@ public class FormResponseCommandService implements ManageFormResponseUseCase {
 
         draft.submit(Instant.now(), command.submittedIp());
         saveFormResponsePort.save(draft);
+    }
+
+    @Override
+    public void deleteAnonymousDraft(DeleteAnonymousDraftFormResponseCommand command) {
+        FormResponse draft = loadDraftAsAnonymous(command.responseAccessKey());
+
+        saveAnswerPort.deleteAllByFormResponseId(draft.getId());
+        saveFormResponsePort.deleteById(draft.getId());
     }
 
     /**

--- a/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
@@ -70,10 +70,8 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
             .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_NOT_FOUND));
 
         boolean clearNextSectionId = Boolean.TRUE.equals(command.clearNextSectionId());
-        if (command.nextSectionId() != null || clearNextSectionId) {
-            validateNextSectionAllowed(option.getQuestion());
-        }
         if (command.nextSectionId() != null) {
+            validateNextSectionAllowed(option.getQuestion());
             validateNextSectionBelongsToForm(command.nextSectionId(), option.getQuestion());
         }
 

--- a/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
@@ -20,6 +20,7 @@ import com.umc.product.form.application.port.out.LoadQuestionPort;
 import com.umc.product.form.application.port.out.SaveQuestionOptionPort;
 import com.umc.product.form.domain.Question;
 import com.umc.product.form.domain.QuestionOption;
+import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.form.domain.exception.FormDomainException;
 import com.umc.product.form.domain.exception.FormErrorCode;
 
@@ -44,10 +45,15 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
             .max()
             .orElse(0L) + 1L;
 
+        if (command.nextSectionId() != null) {
+            validateNextSectionAllowed(question);
+        }
+
         QuestionOption option = QuestionOption.create(
             command.content(),
             nextOrderNo,
-            command.isOther()
+            command.isOther(),
+            command.nextSectionId()
         );
         option.assignTo(question);
 
@@ -59,7 +65,12 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         QuestionOption option = loadQuestionOptionPort.findById(command.optionId())
             .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_NOT_FOUND));
 
-        option.update(command.content(), command.isOther());
+        boolean clearNextSectionId = Boolean.TRUE.equals(command.clearNextSectionId());
+        if (command.nextSectionId() != null || clearNextSectionId) {
+            validateNextSectionAllowed(option.getQuestion());
+        }
+
+        option.update(command.content(), command.isOther(), command.nextSectionId(), clearNextSectionId);
         saveQuestionOptionPort.save(option);
     }
 
@@ -92,5 +103,12 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         }
 
         saveQuestionOptionPort.saveAll(options);
+    }
+
+    private static void validateNextSectionAllowed(Question question) {
+        if (question.getType() != QuestionType.RADIO && question.getType() != QuestionType.DROPDOWN) {
+            throw new FormDomainException(FormErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "조건부 섹션 이동은 RADIO, DROPDOWN 타입 질문에만 지정할 수 있습니다.");
+        }
     }
 }

--- a/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
@@ -15,9 +15,11 @@ import com.umc.product.form.application.port.in.command.dto.CreateQuestionOption
 import com.umc.product.form.application.port.in.command.dto.DeleteQuestionOptionCommand;
 import com.umc.product.form.application.port.in.command.dto.ReorderQuestionOptionsCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateQuestionOptionCommand;
+import com.umc.product.form.application.port.out.LoadFormSectionPort;
 import com.umc.product.form.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.form.application.port.out.LoadQuestionPort;
 import com.umc.product.form.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.form.domain.FormSection;
 import com.umc.product.form.domain.Question;
 import com.umc.product.form.domain.QuestionOption;
 import com.umc.product.form.domain.enums.QuestionType;
@@ -31,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QuestionOptionCommandService implements ManageQuestionOptionUseCase {
 
+    private final LoadFormSectionPort loadFormSectionPort;
     private final LoadQuestionPort loadQuestionPort;
     private final LoadQuestionOptionPort loadQuestionOptionPort;
     private final SaveQuestionOptionPort saveQuestionOptionPort;
@@ -47,6 +50,7 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
 
         if (command.nextSectionId() != null) {
             validateNextSectionAllowed(question);
+            validateNextSectionBelongsToForm(command.nextSectionId(), question);
         }
 
         QuestionOption option = QuestionOption.create(
@@ -68,6 +72,9 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         boolean clearNextSectionId = Boolean.TRUE.equals(command.clearNextSectionId());
         if (command.nextSectionId() != null || clearNextSectionId) {
             validateNextSectionAllowed(option.getQuestion());
+        }
+        if (command.nextSectionId() != null) {
+            validateNextSectionBelongsToForm(command.nextSectionId(), option.getQuestion());
         }
 
         option.update(command.content(), command.isOther(), command.nextSectionId(), clearNextSectionId);
@@ -109,6 +116,17 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         if (question.getType() != QuestionType.RADIO && question.getType() != QuestionType.DROPDOWN) {
             throw new FormDomainException(FormErrorCode.INVALID_VOTE_FORM_STRUCTURE,
                 "조건부 섹션 이동은 RADIO, DROPDOWN 타입 질문에만 지정할 수 있습니다.");
+        }
+    }
+
+    private void validateNextSectionBelongsToForm(Long nextSectionId, Question question) {
+        FormSection section = loadFormSectionPort.findById(nextSectionId)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "존재하지 않는 섹션입니다."));
+        Long questionFormId = question.getFormSection().getForm().getId();
+        if (!section.getForm().getId().equals(questionFormId)) {
+            throw new FormDomainException(FormErrorCode.INVALID_VOTE_FORM_STRUCTURE,
+                "nextSectionId는 동일한 폼의 섹션이어야 합니다.");
         }
     }
 }

--- a/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
+++ b/src/main/java/com/umc/product/form/application/service/command/QuestionOptionCommandService.java
@@ -3,6 +3,7 @@ package com.umc.product.form.application.service.command;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -50,6 +51,7 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
 
         if (command.nextSectionId() != null) {
             validateNextSectionAllowed(question);
+            validateNextSectionNotSelfLoop(command.nextSectionId(), question);
             validateNextSectionBelongsToForm(command.nextSectionId(), question);
         }
 
@@ -72,6 +74,7 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         boolean clearNextSectionId = Boolean.TRUE.equals(command.clearNextSectionId());
         if (command.nextSectionId() != null) {
             validateNextSectionAllowed(option.getQuestion());
+            validateNextSectionNotSelfLoop(command.nextSectionId(), option.getQuestion());
             validateNextSectionBelongsToForm(command.nextSectionId(), option.getQuestion());
         }
 
@@ -114,6 +117,13 @@ public class QuestionOptionCommandService implements ManageQuestionOptionUseCase
         if (question.getType() != QuestionType.RADIO && question.getType() != QuestionType.DROPDOWN) {
             throw new FormDomainException(FormErrorCode.INVALID_VOTE_FORM_STRUCTURE,
                 "조건부 섹션 이동은 RADIO, DROPDOWN 타입 질문에만 지정할 수 있습니다.");
+        }
+    }
+
+    private static void validateNextSectionNotSelfLoop(Long nextSectionId, Question question) {
+        FormSection currentSection = question.getFormSection();
+        if (currentSection != null && Objects.equals(nextSectionId, currentSection.getId())) {
+            throw new FormDomainException(FormErrorCode.INVALID_NEXT_SECTION_SELF_LOOP);
         }
     }
 

--- a/src/main/java/com/umc/product/form/application/service/query/AnswerQueryService.java
+++ b/src/main/java/com/umc/product/form/application/service/query/AnswerQueryService.java
@@ -9,11 +9,13 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
 import com.umc.product.form.application.port.in.query.GetAnswerUseCase;
 import com.umc.product.form.application.port.in.query.dto.AnswerInfo;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
 import com.umc.product.form.domain.Answer;
 import com.umc.product.form.domain.AnswerChoice;
+import com.umc.product.form.domain.FormResponse;
 import com.umc.product.form.domain.exception.FormDomainException;
 import com.umc.product.form.domain.exception.FormErrorCode;
 
@@ -25,45 +27,35 @@ import lombok.RequiredArgsConstructor;
 public class AnswerQueryService implements GetAnswerUseCase {
 
     private final LoadAnswerPort loadAnswerPort;
+    // 익명 조회의 access-key 매칭용 (AnswerCommandService 와 동일 패턴)
+    private final SecureTokenGenerator secureTokenGenerator;
 
     @Override
     public Optional<AnswerInfo> findById(Long answerId) {
         return loadAnswerPort.findById(answerId)
+            .filter(a -> a.getFormResponse().getRespondentMemberId() != null)
             .map(this::toAnswerInfo);
     }
 
     @Override
     public AnswerInfo getById(Long answerId) {
         Answer answer = loadAnswerPort.findById(answerId)
+            .filter(a -> a.getFormResponse().getRespondentMemberId() != null)
             .orElseThrow(() -> new FormDomainException(FormErrorCode.ANSWER_NOT_FOUND));
         return toAnswerInfo(answer);
     }
 
     @Override
     public List<AnswerInfo> listByFormResponseId(Long formResponseId) {
-        // 1. 답변 로드 (섹션/질문 orderNo 정렬)
         List<Answer> answers = loadAnswerPort.listByFormResponseId(formResponseId);
         if (answers.isEmpty()) {
             return List.of();
         }
-
-        // 2. 답변 ID 셋으로 AnswerChoice 벌크 로드 (N+1 회피)
-        Set<Long> answerIds = answers.stream()
-            .map(Answer::getId)
-            .collect(Collectors.toSet());
-        List<AnswerChoice> allChoices = loadAnswerPort.listChoicesByAnswerIdIn(answerIds);
-
-        // 3. answerId -> choices 그룹핑
-        Map<Long, List<AnswerChoice>> choicesByAnswer = allChoices.stream()
-            .collect(Collectors.groupingBy(c -> c.getAnswer().getId()));
-
-        // 4. DTO 조립 (answers 의 정렬 순서 보존)
-        return answers.stream()
-            .map(answer -> AnswerInfo.from(
-                answer,
-                choicesByAnswer.getOrDefault(answer.getId(), List.of())
-            ))
-            .toList();
+        // 익명 응답의 답변은 노출 안 함 (기명 전용). 같은 formResponseId 는 응답도 동일하므로 첫 원소로 판정.
+        if (answers.get(0).getFormResponse().getRespondentMemberId() == null) {
+            return List.of();
+        }
+        return buildAnswerInfos(answers);
     }
 
     @Override
@@ -72,7 +64,9 @@ public class AnswerQueryService implements GetAnswerUseCase {
             return Map.of();
         }
 
-        List<Answer> answers = loadAnswerPort.listByFormResponseIds(formResponseIds);
+        List<Answer> answers = loadAnswerPort.listByFormResponseIds(formResponseIds).stream()
+            .filter(a -> a.getFormResponse().getRespondentMemberId() != null)
+            .toList();
         if (answers.isEmpty()) {
             return Map.of();
         }
@@ -92,6 +86,77 @@ public class AnswerQueryService implements GetAnswerUseCase {
                     Collectors.toList()
                 )
             ));
+    }
+
+    @Override
+    public Optional<AnswerInfo> findByIdAsAnonymous(Long answerId, String responseAccessKey) {
+        if (responseAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        // 인증 실패 유출 방지 — 익명/hash 검증 실패 시 silently empty
+        return loadAnswerPort.findById(answerId)
+            .filter(answer -> isAuthorizedAnonymous(answer.getFormResponse(), responseAccessKey))
+            .map(this::toAnswerInfo);
+    }
+
+    @Override
+    public AnswerInfo getByIdAsAnonymous(Long answerId, String responseAccessKey) {
+        if (responseAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        // 익명 경계 유출 방지 — 답변 없음 / 기명 응답 / hash 불일치 모두 FORBIDDEN 으로 통일
+        Answer answer = loadAnswerPort.findById(answerId)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN));
+        if (!isAuthorizedAnonymous(answer.getFormResponse(), responseAccessKey)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return toAnswerInfo(answer);
+    }
+
+    @Override
+    public List<AnswerInfo> listByFormResponseIdAsAnonymous(Long formResponseId, String responseAccessKey) {
+        if (responseAccessKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        List<Answer> answers = loadAnswerPort.listByFormResponseId(formResponseId);
+        if (answers.isEmpty()) {
+            // 응답 존재 여부 유출 방지 — 빈 리스트로 통일
+            return List.of();
+        }
+        if (!isAuthorizedAnonymous(answers.get(0).getFormResponse(), responseAccessKey)) {
+            throw new FormDomainException(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+        }
+        return buildAnswerInfos(answers);
+    }
+
+    /**
+     * FormResponse 가 익명이고 저장된 hash 가 rawKey 의 sha256 과 일치하는지 확인.
+     */
+    private boolean isAuthorizedAnonymous(FormResponse response, String rawAccessKey) {
+        if (response.getRespondentMemberId() != null) {
+            return false;
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawAccessKey);
+        return hash.equals(response.getResponseAccessKeyHash());
+    }
+
+    /**
+     * 답변 목록에서 AnswerChoice 를 벌크 로드해 AnswerInfo 로 조립.
+     */
+    private List<AnswerInfo> buildAnswerInfos(List<Answer> answers) {
+        Set<Long> answerIds = answers.stream()
+            .map(Answer::getId)
+            .collect(Collectors.toSet());
+        List<AnswerChoice> allChoices = loadAnswerPort.listChoicesByAnswerIdIn(answerIds);
+        Map<Long, List<AnswerChoice>> choicesByAnswer = allChoices.stream()
+            .collect(Collectors.groupingBy(c -> c.getAnswer().getId()));
+
+        return answers.stream()
+            .map(answer -> AnswerInfo.from(
+                answer,
+                choicesByAnswer.getOrDefault(answer.getId(), List.of())
+            ))
+            .toList();
     }
 
     /**

--- a/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
 import com.umc.product.form.application.port.in.query.GetAnswerUseCase;
 import com.umc.product.form.application.port.in.query.GetFormResponseUseCase;
 import com.umc.product.form.application.port.in.query.dto.AnswerInfo;
@@ -29,6 +30,9 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
 
     private final LoadFormResponsePort loadFormResponsePort;
     private final GetAnswerUseCase getAnswerUseCase;
+    // authentication 도메인의 공용 crypto util 재사용 (SSO Auth Code 발급과 동일 패턴).
+    // 재배치(common/security 등) 는 별도 리팩터 PR 대상.
+    private final SecureTokenGenerator secureTokenGenerator;
 
     @Override
     public Optional<FormResponseInfo> findById(Long formResponseId) {
@@ -98,6 +102,36 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
         if (respondentMemberId == null) {
             throw new FormDomainException(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
         }
+    }
+
+    @Override
+    public Optional<FormResponseInfo> findByAccessKey(String rawKey) {
+        return loadAnonymousResponseByAccessKey(rawKey)
+            .map(FormResponseInfo::from);
+    }
+
+    @Override
+    public FormResponseWithAnswersInfo getResponseWithAnswersByAccessKey(String rawKey) {
+        FormResponse response = loadAnonymousResponseByAccessKey(rawKey)
+            .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_FOUND));
+        return FormResponseWithAnswersInfo.from(
+            response,
+            getAnswerUseCase.listByFormResponseId(response.getId())
+        );
+    }
+
+    /**
+     * 익명 응답 조회 헬퍼 — rawKey 를 sha256 뜨고 hash 매칭. 기명 응답이 조회되면 방어 목적으로 empty.
+     * <p>
+     * rawKey 가 null 이면 {@link FormErrorCode#RESPONSE_ACCESS_KEY_REQUIRED}.
+     */
+    private Optional<FormResponse> loadAnonymousResponseByAccessKey(String rawKey) {
+        if (rawKey == null) {
+            throw new FormDomainException(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+        }
+        String hash = secureTokenGenerator.sha256Hex(rawKey);
+        return loadFormResponsePort.findByAccessKeyHash(hash)
+            .filter(fr -> fr.getRespondentMemberId() == null);
     }
 
     @Override

--- a/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
@@ -59,6 +59,7 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
 
     @Override
     public List<FormResponseInfo> listDraftByRespondentMemberId(Long respondentMemberId) {
+        requireRespondentMemberId(respondentMemberId);
         return loadFormResponsePort.findAllDraftByRespondentMemberId(respondentMemberId).stream()
             .map(FormResponseInfo::from)
             .toList();
@@ -66,12 +67,14 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
 
     @Override
     public Optional<FormResponseInfo> findDraftByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
+        requireRespondentMemberId(respondentMemberId);
         return loadFormResponsePort.findDraftByFormIdAndRespondentMemberId(formId, respondentMemberId)
             .map(FormResponseInfo::from);
     }
 
     @Override
     public Optional<FormResponseInfo> findSubmittedByFormIdAndRespondentMemberId(Long formId, Long respondentMemberId) {
+        requireRespondentMemberId(respondentMemberId);
         return loadFormResponsePort.findSubmittedByFormIdAndRespondentMemberId(formId, respondentMemberId)
             .map(FormResponseInfo::from);
     }
@@ -89,6 +92,12 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
                 formResponse,
                 getAnswerUseCase.listByFormResponseId(formResponseId)
             ));
+    }
+
+    private static void requireRespondentMemberId(Long respondentMemberId) {
+        if (respondentMemberId == null) {
+            throw new FormDomainException(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+        }
     }
 
     @Override

--- a/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
@@ -117,7 +117,7 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
             .orElseThrow(() -> new FormDomainException(FormErrorCode.FORM_RESPONSE_NOT_FOUND));
         return FormResponseWithAnswersInfo.from(
             response,
-            getAnswerUseCase.listByFormResponseId(response.getId())
+            getAnswerUseCase.listByFormResponseIdAsAnonymous(response.getId(), rawKey)
         );
     }
 

--- a/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
+++ b/src/main/java/com/umc/product/form/application/service/query/FormResponseQueryService.java
@@ -92,6 +92,7 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
     @Override
     public Optional<FormResponseWithAnswersInfo> findResponseWithAnswers(Long formResponseId) {
         return loadFormResponsePort.findById(formResponseId)
+            .filter(fr -> fr.getRespondentMemberId() != null)
             .map(formResponse -> FormResponseWithAnswersInfo.from(
                 formResponse,
                 getAnswerUseCase.listByFormResponseId(formResponseId)
@@ -140,7 +141,9 @@ public class FormResponseQueryService implements GetFormResponseUseCase {
             return Map.of();
         }
 
-        List<FormResponse> formResponses = loadFormResponsePort.listByIdsWithForm(formResponseIds);
+        List<FormResponse> formResponses = loadFormResponsePort.listByIdsWithForm(formResponseIds).stream()
+            .filter(fr -> fr.getRespondentMemberId() != null)
+            .toList();
         Map<Long, List<AnswerInfo>> answersByFormResponseId =
             getAnswerUseCase.listByFormResponseIds(formResponseIds);
 

--- a/src/main/java/com/umc/product/form/domain/FormResponse.java
+++ b/src/main/java/com/umc/product/form/domain/FormResponse.java
@@ -60,8 +60,6 @@ public class FormResponse extends BaseEntity {
      * <p>
      * 기명 응답은 {@code null}. 익명 응답은 발급 시점에 {@code SecureTokenGenerator.sha256Hex(rawKey)} 로 저장.
      * UNIQUE — 익명 응답 간 hash 충돌 방지 (MySQL 은 NULL 여러 개 허용하므로 기명 여러 행은 문제 없음).
-     * <p>
-     * 상세 설계: docs/analysis/form-anonymous-response-design.md
      */
     @Column(name = "response_access_key_hash", unique = true, length = 64)
     private String responseAccessKeyHash;
@@ -70,6 +68,21 @@ public class FormResponse extends BaseEntity {
         FormResponse fr = new FormResponse();
         fr.form = form;
         fr.respondentMemberId = respondentMemberId;
+        fr.status = FormResponseStatus.DRAFT;
+        fr.lastSavedAt = Instant.now();
+        return fr;
+    }
+
+    /**
+     * 익명 draft 생성. {@code respondentMemberId} 는 null 로 남고, {@code responseAccessKeyHash} 에 sha256(rawKey) 저장.
+     * <p>
+     * raw key 는 발급자(서비스 레이어)가 클라이언트/소비 도메인에 반환하며, 서버에는 저장하지 않는다.
+     */
+    public static FormResponse createAnonymousDraft(Form form, String responseAccessKeyHash) {
+        FormResponse fr = new FormResponse();
+        fr.form = form;
+        fr.respondentMemberId = null;
+        fr.responseAccessKeyHash = responseAccessKeyHash;
         fr.status = FormResponseStatus.DRAFT;
         fr.lastSavedAt = Instant.now();
         return fr;

--- a/src/main/java/com/umc/product/form/domain/FormResponse.java
+++ b/src/main/java/com/umc/product/form/domain/FormResponse.java
@@ -38,7 +38,7 @@ public class FormResponse extends BaseEntity {
     @JoinColumn(name = "form_id", nullable = false)
     private Form form;
 
-    @Column(name = "respondent_member_id", nullable = false)
+    @Column(name = "respondent_member_id")
     private Long respondentMemberId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/product/form/domain/FormResponse.java
+++ b/src/main/java/com/umc/product/form/domain/FormResponse.java
@@ -55,6 +55,17 @@ public class FormResponse extends BaseEntity {
     @Column(name = "last_saved_at", nullable = false)
     private Instant lastSavedAt;
 
+    /**
+     * 익명 응답 인증용 access key 의 SHA-256 해시(hex 64자).
+     * <p>
+     * 기명 응답은 {@code null}. 익명 응답은 발급 시점에 {@code SecureTokenGenerator.sha256Hex(rawKey)} 로 저장.
+     * UNIQUE — 익명 응답 간 hash 충돌 방지 (MySQL 은 NULL 여러 개 허용하므로 기명 여러 행은 문제 없음).
+     * <p>
+     * 상세 설계: docs/analysis/form-anonymous-response-design.md
+     */
+    @Column(name = "response_access_key_hash", unique = true, length = 64)
+    private String responseAccessKeyHash;
+
     public static FormResponse createDraft(Form form, Long respondentMemberId) {
         FormResponse fr = new FormResponse();
         fr.form = form;

--- a/src/main/java/com/umc/product/form/domain/QuestionOption.java
+++ b/src/main/java/com/umc/product/form/domain/QuestionOption.java
@@ -43,11 +43,19 @@ public class QuestionOption extends BaseEntity {
     @Column(name = "is_other", nullable = false)
     private boolean isOther;
 
+    @Column(name = "next_section_id")
+    private Long nextSectionId;
+
     public static QuestionOption create(String content, long orderNo, boolean isOther) {
+        return create(content, orderNo, isOther, null);
+    }
+
+    public static QuestionOption create(String content, long orderNo, boolean isOther, Long nextSectionId) {
         return QuestionOption.builder()
             .content(content)
             .orderNo(orderNo)
             .isOther(isOther)
+            .nextSectionId(nextSectionId)
             .build();
     }
 
@@ -56,11 +64,20 @@ public class QuestionOption extends BaseEntity {
      * null 인 필드는 기존 값 유지.
      */
     public void update(String content, Boolean isOther) {
+        update(content, isOther, null, false);
+    }
+
+    public void update(String content, Boolean isOther, Long nextSectionId, boolean clearNextSectionId) {
         if (content != null) {
             this.content = content;
         }
         if (isOther != null) {
             this.isOther = isOther;
+        }
+        if (clearNextSectionId) {
+            this.nextSectionId = null;
+        } else if (nextSectionId != null) {
+            this.nextSectionId = nextSectionId;
         }
     }
 

--- a/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
+++ b/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
@@ -43,6 +43,8 @@ public enum FormErrorCode implements BaseCode {
         "응답자 정보가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
     RESPONSE_ACCESS_KEY_REQUIRED(HttpStatus.BAD_REQUEST, "FORM-0035",
         "응답 접근 키가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
+    INVALID_SUBMIT_SCOPE(HttpStatus.BAD_REQUEST, "FORM-0036",
+        "제출 범위가 올바르지 않아요. 이 문제가 계속되면 운영진에게 문의해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
+++ b/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
@@ -45,6 +45,8 @@ public enum FormErrorCode implements BaseCode {
         "응답 접근 키가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
     INVALID_SUBMIT_SCOPE(HttpStatus.BAD_REQUEST, "FORM-0036",
         "제출 범위가 올바르지 않아요. 이 문제가 계속되면 운영진에게 문의해주세요."),
+    INVALID_NEXT_SECTION_SELF_LOOP(HttpStatus.BAD_REQUEST, "FORM-0037",
+        "조건부 섹션 이동은 자기 자신을 대상으로 할 수 없어요. 이동 대상 섹션을 다시 선택해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
+++ b/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
@@ -39,6 +39,8 @@ public enum FormErrorCode implements BaseCode {
     ANSWER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "FORM-0032", "이미 해당 질문에 대한 답변이 있어요. 기존 답변을 수정해주세요."),
     FORM_RESPONSE_LOOKUP_AMBIGUOUS(HttpStatus.CONFLICT, "FORM-0033",
         "중복 응답을 허용하는 폼은 응답을 하나로 특정할 수 없어요. 응답 ID를 사용해주세요."),
+    RESPONDENT_MEMBER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "FORM-0034",
+        "응답자 정보가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
+++ b/src/main/java/com/umc/product/form/domain/exception/FormErrorCode.java
@@ -41,6 +41,8 @@ public enum FormErrorCode implements BaseCode {
         "중복 응답을 허용하는 폼은 응답을 하나로 특정할 수 없어요. 응답 ID를 사용해주세요."),
     RESPONDENT_MEMBER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "FORM-0034",
         "응답자 정보가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
+    RESPONSE_ACCESS_KEY_REQUIRED(HttpStatus.BAD_REQUEST, "FORM-0035",
+        "응답 접근 키가 필요해요. 이 문제가 계속되면 운영진에게 문의해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/db/migration/V2026.07.06.01.26__form_response_respondent_member_id_nullable.sql
+++ b/src/main/resources/db/migration/V2026.07.06.01.26__form_response_respondent_member_id_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE form_response
+    ALTER COLUMN respondent_member_id DROP NOT NULL;

--- a/src/main/resources/db/migration/V2026.07.06.02.00__question_option_add_next_section_id.sql
+++ b/src/main/resources/db/migration/V2026.07.06.02.00__question_option_add_next_section_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE question_option
+    ADD COLUMN next_section_id BIGINT,
+    ADD CONSTRAINT fk_question_option_next_section
+        FOREIGN KEY (next_section_id)
+        REFERENCES form_section(id)
+        ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V2026.07.12.18.43__form_response_add_access_key_hash.sql
+++ b/src/main/resources/db/migration/V2026.07.12.18.43__form_response_add_access_key_hash.sql
@@ -1,0 +1,6 @@
+ALTER TABLE form_response
+    ADD COLUMN response_access_key_hash VARCHAR(64) NULL;
+
+ALTER TABLE form_response
+    ADD CONSTRAINT uk_form_response_access_key_hash
+        UNIQUE (response_access_key_hash);

--- a/src/main/resources/db/migration/V2026.07.13.20.56__add_missing_indexes_for_form_response_paths.sql
+++ b/src/main/resources/db/migration/V2026.07.13.20.56__add_missing_indexes_for_form_response_paths.sql
@@ -1,0 +1,11 @@
+-- PostgreSQL 은 FK 컬럼에 자동 인덱스를 생성하지 않는다.
+-- 아래 컬럼들은 실제 쿼리 경로 (조건부 섹션 이동, 답변 선택지 조회, 섹션 삭제 cascade) 에서 활용되므로 인덱스가 없으면 전체 스캔이 발생한다.
+
+CREATE INDEX IF NOT EXISTS idx_question_option_question_id
+    ON question_option (question_id);
+
+CREATE INDEX IF NOT EXISTS idx_question_option_next_section_id
+    ON question_option (next_section_id);
+
+CREATE INDEX IF NOT EXISTS idx_answer_choice_answer_id
+    ON answer_choice (answer_id);

--- a/src/main/resources/db/migration/V2026.07.13.21.07__enforce_form_response_identifier_xor.sql
+++ b/src/main/resources/db/migration/V2026.07.13.21.07__enforce_form_response_identifier_xor.sql
@@ -1,0 +1,8 @@
+-- 기명/익명 응답의 식별자 XOR invariant 를 DB 레벨에서 강제한다.
+-- 기명 응답: respondent_member_id 세팅, response_access_key_hash = NULL
+-- 익명 응답: respondent_member_id = NULL, response_access_key_hash 세팅
+-- 정확히 둘 중 하나만 NULL 이어야 한다.
+
+ALTER TABLE form_response
+    ADD CONSTRAINT ck_form_response_identifier_xor
+        CHECK ((respondent_member_id IS NULL) <> (response_access_key_hash IS NULL));

--- a/src/test/java/com/umc/product/form/application/service/command/AnswerCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/AnswerCommandServiceTest.java
@@ -1,0 +1,286 @@
+package com.umc.product.form.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.form.application.port.in.command.dto.CreateAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
+import com.umc.product.form.application.port.out.LoadAnswerPort;
+import com.umc.product.form.application.port.out.LoadFormResponsePort;
+import com.umc.product.form.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.form.application.port.out.LoadQuestionPort;
+import com.umc.product.form.application.port.out.SaveAnswerPort;
+import com.umc.product.form.application.port.out.SaveFormResponsePort;
+import com.umc.product.form.domain.Answer;
+import com.umc.product.form.domain.Form;
+import com.umc.product.form.domain.FormResponse;
+import com.umc.product.form.domain.FormSection;
+import com.umc.product.form.domain.Question;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.form.domain.exception.FormDomainException;
+import com.umc.product.form.domain.exception.FormErrorCode;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerCommandServiceTest {
+
+    private static final Long FORM_ID = 100L;
+    private static final Long FORM_RESPONSE_ID = 200L;
+    private static final Long OWNER_MEMBER_ID = 300L;
+    private static final Long OTHER_MEMBER_ID = 301L;
+    private static final Long QUESTION_ID = 400L;
+    private static final Long ANSWER_ID = 500L;
+
+    @Mock
+    LoadFormResponsePort loadFormResponsePort;
+    @Mock
+    LoadQuestionPort loadQuestionPort;
+    @Mock
+    LoadQuestionOptionPort loadQuestionOptionPort;
+    @Mock
+    LoadAnswerPort loadAnswerPort;
+    @Mock
+    SaveAnswerPort saveAnswerPort;
+    @Mock
+    SaveFormResponsePort saveFormResponsePort;
+    @Mock
+    GetFileUseCase getFileUseCase;
+
+    @InjectMocks
+    AnswerCommandService sut;
+
+    // ============================================================
+    //          createAnswer — 기명 owner 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("createAnswer: requesterMemberId=null 이면 FORM_RESPONSE_FORBIDDEN")
+    void createAnswer_requesterMemberId_null_FORBIDDEN() {
+        FormResponse draft = namedDraft(OWNER_MEMBER_ID);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.createAnswer(CreateAnswerCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .questionId(QUESTION_ID)
+            .requesterMemberId(null)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createAnswer: 소유자 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void createAnswer_소유자_불일치_FORBIDDEN() {
+        FormResponse draft = namedDraft(OWNER_MEMBER_ID);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.createAnswer(CreateAnswerCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .questionId(QUESTION_ID)
+            .requesterMemberId(OTHER_MEMBER_ID)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createAnswer: 익명 draft 면 FORM_RESPONSE_FORBIDDEN")
+    void createAnswer_익명_draft_FORBIDDEN() {
+        FormResponse anonymousDraft = anonymousDraft();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(anonymousDraft));
+
+        assertThatThrownBy(() -> sut.createAnswer(CreateAnswerCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .questionId(QUESTION_ID)
+            .requesterMemberId(OWNER_MEMBER_ID)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    // ============================================================
+    //          updateAnswer — 기명 owner 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("updateAnswer: 소유자 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnswer_소유자_불일치_FORBIDDEN() {
+        FormResponse draft = namedDraft(OWNER_MEMBER_ID);
+        Answer answer = shortTextAnswer(draft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.updateAnswer(UpdateAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .requesterMemberId(OTHER_MEMBER_ID)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateAnswer: 익명 draft 답변이면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnswer_익명_draft_답변_FORBIDDEN() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Answer answer = shortTextAnswer(anonymousDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.updateAnswer(UpdateAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .requesterMemberId(OWNER_MEMBER_ID)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateAnswer: 답변 없으면 ANSWER_NOT_FOUND")
+    void updateAnswer_답변_없으면_NOT_FOUND() {
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.updateAnswer(UpdateAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .requesterMemberId(OWNER_MEMBER_ID)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.ANSWER_NOT_FOUND);
+    }
+
+    // ============================================================
+    //          deleteAnswer — 기명 owner 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("deleteAnswer: 소유자 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnswer_소유자_불일치_FORBIDDEN() {
+        FormResponse draft = namedDraft(OWNER_MEMBER_ID);
+        Answer answer = shortTextAnswer(draft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.deleteAnswer(DeleteAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .requesterMemberId(OTHER_MEMBER_ID)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteByAnswerId(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnswer: 익명 draft 답변이면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnswer_익명_draft_답변_FORBIDDEN() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Answer answer = shortTextAnswer(anonymousDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.deleteAnswer(DeleteAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .requesterMemberId(OWNER_MEMBER_ID)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteByAnswerId(any());
+    }
+
+    // ============================================================
+    //          happy path — createAnswer 소유자 일치
+    // ============================================================
+
+    @Test
+    @DisplayName("createAnswer: 소유자 일치면 답변 저장한다")
+    void createAnswer_소유자_일치_저장() {
+        FormResponse draft = namedDraft(OWNER_MEMBER_ID);
+        Form form = draft.getForm();
+        FormSection section = FormSection.create(form, "섹션", null, 1L);
+        Question question = Question.create("질문", QuestionType.SHORT_TEXT, false, 1L);
+        question.assignTo(section);
+        ReflectionTestUtils.setField(question, "id", QUESTION_ID);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadQuestionPort.findById(QUESTION_ID)).willReturn(Optional.of(question));
+        given(loadAnswerPort.existsByFormResponseIdAndQuestionId(FORM_RESPONSE_ID, QUESTION_ID))
+            .willReturn(false);
+        given(saveAnswerPort.save(any(Answer.class))).willAnswer(inv -> {
+            Answer saved = inv.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", ANSWER_ID);
+            return saved;
+        });
+
+        Long result = sut.createAnswer(CreateAnswerCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .questionId(QUESTION_ID)
+            .requesterMemberId(OWNER_MEMBER_ID)
+            .textValue("답")
+            .build());
+
+        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(ANSWER_ID);
+    }
+
+    private FormResponse namedDraft(Long memberId) {
+        Form form = publishedForm();
+        FormResponse draft = FormResponse.createDraft(form, memberId);
+        ReflectionTestUtils.setField(draft, "id", FORM_RESPONSE_ID);
+        return draft;
+    }
+
+    private FormResponse anonymousDraft() {
+        Form form = publishedForm();
+        FormResponse draft = FormResponse.createAnonymousDraft(form, "hash-value");
+        ReflectionTestUtils.setField(draft, "id", FORM_RESPONSE_ID);
+        return draft;
+    }
+
+    private Form publishedForm() {
+        Form form = Form.createDraft("폼", 1L, false);
+        ReflectionTestUtils.setField(form, "id", FORM_ID);
+        form.publish();
+        return form;
+    }
+
+    private Answer shortTextAnswer(FormResponse formResponse) {
+        Question question = Question.create("질문", QuestionType.SHORT_TEXT, false, 1L);
+        ReflectionTestUtils.setField(question, "id", QUESTION_ID);
+        Answer answer = Answer.create(formResponse, question, QuestionType.SHORT_TEXT, "답", null);
+        ReflectionTestUtils.setField(answer, "id", ANSWER_ID);
+        return answer;
+    }
+}

--- a/src/test/java/com/umc/product/form/application/service/command/AnswerCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/AnswerCommandServiceTest.java
@@ -16,8 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousAnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnswerCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
 import com.umc.product.form.application.port.out.LoadFormResponsePort;
@@ -59,9 +63,15 @@ class AnswerCommandServiceTest {
     SaveFormResponsePort saveFormResponsePort;
     @Mock
     GetFileUseCase getFileUseCase;
+    @Mock
+    SecureTokenGenerator secureTokenGenerator;
 
     @InjectMocks
     AnswerCommandService sut;
+
+    private static final String RAW_KEY = "raw-key";
+    private static final String KEY_HASH = "hash-value";
+    private static final String OTHER_HASH = "other-hash";
 
     // ============================================================
     //          createAnswer — 기명 owner 검증
@@ -253,6 +263,218 @@ class AnswerCommandServiceTest {
             .build());
 
         org.assertj.core.api.Assertions.assertThat(result).isEqualTo(ANSWER_ID);
+    }
+
+    // ============================================================
+    //          createAnonymousAnswer — 익명 access key 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("createAnonymousAnswer: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void createAnonymousAnswer_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.createAnonymousAnswer(CreateAnonymousAnswerCommand.builder()
+            .responseAccessKey(null)
+            .questionId(QUESTION_ID)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findDraftByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("createAnonymousAnswer: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void createAnonymousAnswer_hash_매칭_실패_FORBIDDEN() {
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(KEY_HASH)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.createAnonymousAnswer(CreateAnonymousAnswerCommand.builder()
+            .responseAccessKey(RAW_KEY)
+            .questionId(QUESTION_ID)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createAnonymousAnswer: 매칭된 draft 가 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void createAnonymousAnswer_기명_draft_FORBIDDEN() {
+        FormResponse namedDraft = namedDraft(OWNER_MEMBER_ID);
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(KEY_HASH)).willReturn(Optional.of(namedDraft));
+
+        assertThatThrownBy(() -> sut.createAnonymousAnswer(CreateAnonymousAnswerCommand.builder()
+            .responseAccessKey(RAW_KEY)
+            .questionId(QUESTION_ID)
+            .textValue("답")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createAnonymousAnswer: 익명 draft 면 답변 저장한다")
+    void createAnonymousAnswer_익명_draft_저장() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Form form = anonymousDraft.getForm();
+        FormSection section = FormSection.create(form, "섹션", null, 1L);
+        Question question = Question.create("질문", QuestionType.SHORT_TEXT, false, 1L);
+        question.assignTo(section);
+        ReflectionTestUtils.setField(question, "id", QUESTION_ID);
+
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(KEY_HASH)).willReturn(Optional.of(anonymousDraft));
+        given(loadQuestionPort.findById(QUESTION_ID)).willReturn(Optional.of(question));
+        given(loadAnswerPort.existsByFormResponseIdAndQuestionId(FORM_RESPONSE_ID, QUESTION_ID))
+            .willReturn(false);
+        given(saveAnswerPort.save(any(Answer.class))).willAnswer(inv -> {
+            Answer saved = inv.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", ANSWER_ID);
+            return saved;
+        });
+
+        Long result = sut.createAnonymousAnswer(CreateAnonymousAnswerCommand.builder()
+            .responseAccessKey(RAW_KEY)
+            .questionId(QUESTION_ID)
+            .textValue("답")
+            .build());
+
+        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(ANSWER_ID);
+    }
+
+    // ============================================================
+    //          updateAnonymousAnswer — 익명 access key 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("updateAnonymousAnswer: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void updateAnonymousAnswer_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.updateAnonymousAnswer(UpdateAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(null)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadAnswerPort).should(never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousAnswer: 답변의 draft 가 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousAnswer_기명_draft_답변_FORBIDDEN() {
+        FormResponse namedDraft = namedDraft(OWNER_MEMBER_ID);
+        Answer answer = shortTextAnswer(namedDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.updateAnonymousAnswer(UpdateAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(RAW_KEY)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousAnswer: Answer 없으면 FORM_RESPONSE_FORBIDDEN (익명 경계 유출 방지)")
+    void updateAnonymousAnswer_Answer_없으면_FORBIDDEN() {
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.updateAnonymousAnswer(UpdateAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(RAW_KEY)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("updateAnonymousAnswer: hash 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousAnswer_hash_불일치_FORBIDDEN() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Answer answer = shortTextAnswer(anonymousDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(OTHER_HASH);
+
+        assertThatThrownBy(() -> sut.updateAnonymousAnswer(UpdateAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(RAW_KEY)
+            .textValue("변경")
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).save(any());
+    }
+
+    // ============================================================
+    //          deleteAnonymousAnswer — 익명 access key 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("deleteAnonymousAnswer: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void deleteAnonymousAnswer_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.deleteAnonymousAnswer(DeleteAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadAnswerPort).should(never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousAnswer: hash 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnonymousAnswer_hash_불일치_FORBIDDEN() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Answer answer = shortTextAnswer(anonymousDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(OTHER_HASH);
+
+        assertThatThrownBy(() -> sut.deleteAnonymousAnswer(DeleteAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(RAW_KEY)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteByAnswerId(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousAnswer: hash 일치하는 익명 draft 답변이면 삭제한다")
+    void deleteAnonymousAnswer_hash_일치_삭제() {
+        FormResponse anonymousDraft = anonymousDraft();
+        Answer answer = shortTextAnswer(anonymousDraft);
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+
+        sut.deleteAnonymousAnswer(DeleteAnonymousAnswerCommand.builder()
+            .answerId(ANSWER_ID)
+            .responseAccessKey(RAW_KEY)
+            .build());
+
+        then(saveAnswerPort).should().deleteByAnswerId(ANSWER_ID);
     }
 
     private FormResponse namedDraft(Long memberId) {

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -27,6 +27,7 @@ import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -34,6 +35,7 @@ import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmed
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
@@ -556,6 +558,109 @@ class FormResponseCommandServiceTest {
         ));
         // 익명은 중복 정책 검사 skip
         then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousResponse: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void updateAnonymousResponse_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.updateAnonymousResponse(UpdateAnonymousFormResponseCommand.builder()
+            .responseAccessKey(null)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findSubmittedByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousResponse: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousResponse_hash_매칭_실패_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findSubmittedByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.updateAnonymousResponse(UpdateAnonymousFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousResponse: 매칭된 응답이 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousResponse_기명_응답_거부_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedResponse = draftResponse(); // 기명
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findSubmittedByAccessKeyHash(hash)).willReturn(Optional.of(namedResponse));
+
+        assertThatThrownBy(() -> sut.updateAnonymousResponse(UpdateAnonymousFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousResponse: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void deleteAnonymousResponse_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.deleteAnonymousResponse(DeleteAnonymousFormResponseCommand.builder()
+            .responseAccessKey(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findSubmittedByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousResponse: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnonymousResponse_hash_매칭_실패_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findSubmittedByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.deleteAnonymousResponse(DeleteAnonymousFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousResponse: 매칭된 응답이 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnonymousResponse_기명_응답_거부_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedResponse = draftResponse();
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findSubmittedByAccessKeyHash(hash)).willReturn(Optional.of(namedResponse));
+
+        assertThatThrownBy(() -> sut.deleteAnonymousResponse(DeleteAnonymousFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -28,6 +28,7 @@ import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -603,6 +604,56 @@ class FormResponseCommandServiceTest {
             .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
 
         then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("submitAnonymousDraft: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void submitAnonymousDraft_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findDraftByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("submitAnonymousDraft: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void submitAnonymousDraft_hash_매칭_실패_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("submitAnonymousDraft: 매칭된 draft 가 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void submitAnonymousDraft_기명_draft_거부_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedDraft = draftResponse();
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.of(namedDraft));
+
+        assertThatThrownBy(() -> sut.submitAnonymousDraft(SubmitAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).save(any());
     }
 
     // ============================================================

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -31,6 +31,7 @@ import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCo
 import com.umc.product.form.application.port.out.LoadAnswerPort;
 import com.umc.product.form.application.port.out.LoadFormPort;
 import com.umc.product.form.application.port.out.LoadFormResponsePort;
+import com.umc.product.form.application.port.out.LoadFormSectionPort;
 import com.umc.product.form.application.port.out.LoadQuestionOptionPort;
 import com.umc.product.form.application.port.out.LoadQuestionPort;
 import com.umc.product.form.application.port.out.SaveAnswerPort;
@@ -38,7 +39,9 @@ import com.umc.product.form.application.port.out.SaveFormResponsePort;
 import com.umc.product.form.domain.Answer;
 import com.umc.product.form.domain.Form;
 import com.umc.product.form.domain.FormResponse;
+import com.umc.product.form.domain.FormSection;
 import com.umc.product.form.domain.Question;
+import com.umc.product.form.domain.QuestionOption;
 import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.form.domain.exception.FormDomainException;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -53,6 +56,8 @@ class FormResponseCommandServiceTest {
 
     @Mock
     LoadFormPort loadFormPort;
+    @Mock
+    LoadFormSectionPort loadFormSectionPort;
     @Mock
     LoadQuestionPort loadQuestionPort;
     @Mock
@@ -203,14 +208,17 @@ class FormResponseCommandServiceTest {
     }
 
     @Test
-    @DisplayName("draft 제출 scope가 없으면 기존처럼 form 전체 required question을 검증한다")
-    void draft_제출_scope가_없으면_form_전체_required_question을_검증한다() {
+    @DisplayName("draft 제출 scope가 없으면 방문한 섹션의 required question을 검증한다")
+    void draft_제출_scope가_없으면_방문한_섹션의_required_question을_검증한다() {
         FormResponse draft = draftResponse();
-        Question answeredRequiredQuestion = question(10L, true);
-        Question missingRequiredQuestion = question(20L, true);
+        FormSection section = section(1L, 1L);
+        Question answeredRequiredQuestion = questionInSection(10L, section, true);
+        Question missingRequiredQuestion = questionInSection(20L, section, true);
+
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, answeredRequiredQuestion)));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID))
             .willReturn(List.of(answeredRequiredQuestion, missingRequiredQuestion));
 
@@ -328,11 +336,13 @@ class FormResponseCommandServiceTest {
     void submitDraft_allowedQuestionIds_null이면_null_answer_미저장() {
         // given — 비프로젝트 경로: allowedQuestionIds 없음
         FormResponse draft = draftResponse();
-        Question q = question(10L, true);
+        FormSection section = section(1L, 1L);
+        Question q = questionInSection(10L, section, true);
 
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, q)));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q));
 
         // when
@@ -343,6 +353,73 @@ class FormResponseCommandServiceTest {
 
         // then — allowedQuestionIds null → early return
         then(loadQuestionPort).should(never()).listByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("비로그인 응답자(memberId=null)는 중복 응답 검사를 skip한다")
+    void 비로그인_응답자는_중복_응답_검사를_skip한다() {
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
+        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
+            FormResponse response = invocation.getArgument(0);
+            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+            return response;
+        });
+
+        sut.createDraft(CreateDraftFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(null)
+            .build());
+
+        then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("조건부 섹션 이동으로 건너뛴 섹션의 필수 질문은 검증하지 않는다")
+    void 조건부_섹션_이동으로_건너뛴_섹션의_필수_질문은_검증하지_않는다() {
+        // given — S1 → (O1 선택 시 S3으로 점프) → S3, S2는 건너뜀
+        FormSection s1 = section(1L, 1L);
+        FormSection s2 = section(2L, 2L);
+        FormSection s3 = section(3L, 3L);
+
+        Question qRadio = questionInSection(10L, QuestionType.RADIO, false, s1);
+        Question qRequiredInSkipped = questionInSection(20L, QuestionType.SHORT_TEXT, true, s2);
+        Question qOptional = questionInSection(30L, QuestionType.SHORT_TEXT, false, s3);
+
+        // O1: nextSectionId = s3.id → S2 건너뜀
+        QuestionOption o1 = QuestionOption.create("선택지", 1L, false, s3.getId());
+        ReflectionTestUtils.setField(o1, "id", 100L);
+        ReflectionTestUtils.setField(o1, "question", qRadio);
+
+        FormResponse draft = draftResponse();
+        Answer radioAnswer = answer(draft, qRadio);
+        ReflectionTestUtils.setField(radioAnswer, "id", 1000L);
+        Answer optionalAnswer = answer(draft, qOptional);
+        ReflectionTestUtils.setField(optionalAnswer, "id", 1001L);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
+            .willReturn(List.of(radioAnswer, optionalAnswer));
+        given(loadAnswerPort.listChoicesByAnswerIdIn(any())).willAnswer(inv -> {
+            // radioAnswer → o1 선택
+            var mockChoice = org.mockito.Mockito.mock(
+                com.umc.product.form.domain.AnswerChoice.class);
+            given(mockChoice.getAnswer()).willReturn(radioAnswer);
+            given(mockChoice.getQuestionOption()).willReturn(o1);
+            return List.of(mockChoice);
+        });
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(s1, s2, s3));
+        given(loadQuestionPort.listByFormId(FORM_ID))
+            .willReturn(List.of(qRadio, qRequiredInSkipped, qOptional));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(qRadio.getId())))
+            .willReturn(List.of(o1));
+
+        // when — S2의 필수 질문(qRequiredInSkipped)은 미답변이지만 건너뛴 섹션이므로 예외 없음
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .build());
+
+        then(saveFormResponsePort).should().save(draft);
     }
 
     @Test
@@ -404,6 +481,12 @@ class FormResponseCommandServiceTest {
         return response;
     }
 
+    private FormSection section(Long id, Long orderNo) {
+        FormSection section = FormSection.create(publishedForm(true), "섹션", null, orderNo);
+        ReflectionTestUtils.setField(section, "id", id);
+        return section;
+    }
+
     private Question question(Long questionId, boolean isRequired) {
         return question(questionId, QuestionType.SHORT_TEXT, isRequired);
     }
@@ -412,6 +495,16 @@ class FormResponseCommandServiceTest {
         Question question = Question.create("질문", type, isRequired, 1L);
         ReflectionTestUtils.setField(question, "id", questionId);
         return question;
+    }
+
+    private Question questionInSection(Long id, FormSection section, boolean isRequired) {
+        return questionInSection(id, QuestionType.SHORT_TEXT, isRequired, section);
+    }
+
+    private Question questionInSection(Long id, QuestionType type, boolean isRequired, FormSection section) {
+        Question q = question(id, type, isRequired);
+        q.assignTo(section);
+        return q;
     }
 
     private Answer answer(FormResponse formResponse, Question question) {

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -26,6 +26,7 @@ import com.umc.product.form.application.port.in.command.dto.AnonymousFormRespons
 import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
@@ -654,6 +655,56 @@ class FormResponseCommandServiceTest {
             .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
 
         then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousDraft: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void deleteAnonymousDraft_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.deleteAnonymousDraft(DeleteAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findDraftByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousDraft: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnonymousDraft_hash_매칭_실패_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.deleteAnonymousDraft(DeleteAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("deleteAnonymousDraft: 매칭된 draft 가 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void deleteAnonymousDraft_기명_draft_거부_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedDraft = draftResponse();
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.of(namedDraft));
+
+        assertThatThrownBy(() -> sut.deleteAnonymousDraft(DeleteAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
     }
 
     // ============================================================

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -203,10 +203,13 @@ class FormResponseCommandServiceTest {
     @DisplayName("draft 제출 scope가 있으면 전달된 required question만 필수 응답 검증한다")
     void draft_제출_scope가_있으면_전달된_required_question만_검증한다() {
         FormResponse draft = draftResponse();
-        Question commonRequiredQuestion = question(10L, true);
+        FormSection section = section(1L, 1L);
+        Question commonRequiredQuestion = questionInSection(10L, section, true);
+        Answer answered = answer(draft, commonRequiredQuestion);
+        ReflectionTestUtils.setField(answered, "id", 1000L);
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
-        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
-            .willReturn(List.of(answer(draft, commonRequiredQuestion)));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answered));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(commonRequiredQuestion));
 
         sut.submitDraft(SubmitDraftFormResponseCommand.builder()
@@ -334,12 +337,15 @@ class FormResponseCommandServiceTest {
     void submitDraft_미답변_선택_질문에_null_answer_저장() {
         // given — Q10(필수, 답변됨) + Q20(선택, 미답변)
         FormResponse draft = draftResponse();
-        Question requiredAnswered = question(10L, QuestionType.SHORT_TEXT, true);
-        Question optionalUnanswered = question(20L, QuestionType.LONG_TEXT, false);
+        FormSection section = section(1L, 1L);
+        Question requiredAnswered = questionInSection(10L, QuestionType.SHORT_TEXT, true, section);
+        Question optionalUnanswered = questionInSection(20L, QuestionType.LONG_TEXT, false, section);
+        Answer answered = answer(draft, requiredAnswered);
+        ReflectionTestUtils.setField(answered, "id", 1000L);
 
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
-        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
-            .willReturn(List.of(answer(draft, requiredAnswered)));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answered));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID))
             .willReturn(List.of(requiredAnswered, optionalUnanswered));
         given(loadQuestionPort.listByIdIn(Set.of(20L)))
@@ -367,12 +373,15 @@ class FormResponseCommandServiceTest {
     void submitDraft_allowedQuestionIds_밖_질문에_null_answer_미생성() {
         // given — allowedQuestionIds = {Q10} (파트 필터링 결과), Q20은 범위 밖
         FormResponse draft = draftResponse();
-        Question q10 = question(10L, true);
-        Question q20 = question(20L, false);
+        FormSection section = section(1L, 1L);
+        Question q10 = questionInSection(10L, section, true);
+        Question q20 = questionInSection(20L, section, false);
+        Answer answered = answer(draft, q10);
+        ReflectionTestUtils.setField(answered, "id", 1000L);
 
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
-        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
-            .willReturn(List.of(answer(draft, q10)));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answered));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
 
         // when
@@ -392,12 +401,18 @@ class FormResponseCommandServiceTest {
     void submitDraft_전체_답변_완료시_null_answer_미저장() {
         // given — Q10, Q20 모두 답변됨
         FormResponse draft = draftResponse();
-        Question q10 = question(10L, true);
-        Question q20 = question(20L, false);
+        FormSection section = section(1L, 1L);
+        Question q10 = questionInSection(10L, section, true);
+        Question q20 = questionInSection(20L, section, false);
+        Answer answered10 = answer(draft, q10);
+        Answer answered20 = answer(draft, q20);
+        ReflectionTestUtils.setField(answered10, "id", 1000L);
+        ReflectionTestUtils.setField(answered20, "id", 1001L);
 
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
-            .willReturn(List.of(answer(draft, q10), answer(draft, q20)));
+            .willReturn(List.of(answered10, answered20));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
         given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
 
         // when
@@ -542,6 +557,80 @@ class FormResponseCommandServiceTest {
             .build());
 
         then(saveFormResponsePort).should().save(draft);
+    }
+
+    @Test
+    @DisplayName("submitDraft: caller required 라도 조건부 이동으로 건너뛴 섹션의 질문은 검증하지 않는다")
+    void submitDraft_caller_required_건너뛴_섹션_질문은_검증_제외() {
+        // given — S1 → (O1 선택 시 S3으로 점프) → S3, S2는 건너뜀
+        FormSection s1 = section(1L, 1L);
+        FormSection s2 = section(2L, 2L);
+        FormSection s3 = section(3L, 3L);
+
+        Question qRadio = questionInSection(10L, QuestionType.RADIO, false, s1);
+        Question qRequiredInSkipped = questionInSection(20L, QuestionType.SHORT_TEXT, true, s2);
+        Question qOptional = questionInSection(30L, QuestionType.SHORT_TEXT, false, s3);
+
+        QuestionOption o1 = QuestionOption.create("선택지", 1L, false, s3.getId());
+        ReflectionTestUtils.setField(o1, "id", 100L);
+        ReflectionTestUtils.setField(o1, "question", qRadio);
+
+        FormResponse draft = draftResponse();
+        Answer radioAnswer = answer(draft, qRadio);
+        ReflectionTestUtils.setField(radioAnswer, "id", 1000L);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(radioAnswer));
+        given(loadAnswerPort.listChoicesByAnswerIdIn(any())).willAnswer(inv -> {
+            var mockChoice = org.mockito.Mockito.mock(
+                com.umc.product.form.domain.AnswerChoice.class);
+            given(mockChoice.getAnswer()).willReturn(radioAnswer);
+            given(mockChoice.getQuestionOption()).willReturn(o1);
+            return List.of(mockChoice);
+        });
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(s1, s2, s3));
+        given(loadQuestionPort.listByFormId(FORM_ID))
+            .willReturn(List.of(qRadio, qRequiredInSkipped, qOptional));
+        given(loadQuestionOptionPort.listByQuestionIdIn(Set.of(qRadio.getId())))
+            .willReturn(List.of(o1));
+
+        // when — caller 가 Q20(건너뛴 섹션 소속)을 required 로 넘겨도 건너뛴 섹션이므로 통과
+        sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .allowedQuestionIds(Set.of(10L, 20L, 30L))
+            .requiredQuestionIds(Set.of(10L, 20L))
+            .build());
+
+        then(saveFormResponsePort).should().save(draft);
+    }
+
+    @Test
+    @DisplayName("submitDraft: 방문 경로의 caller required 질문 미답변이면 REQUIRED_QUESTION_NOT_ANSWERED")
+    void submitDraft_방문경로의_caller_required_미답변시_거부() {
+        // given — S1 → S2 (조건부 이동 없음, 전체 방문). caller required = {Q10, Q20}. Q20 미답변.
+        FormSection section = section(1L, 1L);
+        Question q10 = questionInSection(10L, section, true);
+        Question q20 = questionInSection(20L, section, false);
+
+        FormResponse draft = draftResponse();
+        Answer answered = answer(draft, q10);
+        ReflectionTestUtils.setField(answered, "id", 1000L);
+
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answered));
+        given(loadFormSectionPort.listByFormId(FORM_ID)).willReturn(List.of(section));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .allowedQuestionIds(Set.of(10L, 20L))
+            .requiredQuestionIds(Set.of(10L, 20L))
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.REQUIRED_QUESTION_NOT_ANSWERED);
     }
 
     @Test

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -356,21 +356,62 @@ class FormResponseCommandServiceTest {
     }
 
     @Test
-    @DisplayName("비로그인 응답자(memberId=null)는 중복 응답 검사를 skip한다")
-    void 비로그인_응답자는_중복_응답_검사를_skip한다() {
-        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
-        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
-            FormResponse response = invocation.getArgument(0);
-            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
-            return response;
-        });
-
-        sut.createDraft(CreateDraftFormResponseCommand.builder()
+    @DisplayName("createDraft: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void createDraft_respondentMemberIdNull_예외() {
+        assertThatThrownBy(() -> sut.createDraft(CreateDraftFormResponseCommand.builder()
             .formId(FORM_ID)
             .respondentMemberId(null)
-            .build());
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
 
+        then(loadFormPort).should(never()).findById(any());
         then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("submitImmediately: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void submitImmediately_respondentMemberIdNull_예외() {
+        assertThatThrownBy(() -> sut.submitImmediately(SubmitFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(null)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormPort).should(never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("updateResponse: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void updateResponse_respondentMemberIdNull_예외() {
+        assertThatThrownBy(() -> sut.updateResponse(UpdateFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(null)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormPort).should(never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("deleteResponse: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void deleteResponse_respondentMemberIdNull_예외() {
+        assertThatThrownBy(() -> sut.deleteResponse(DeleteFormResponseCommand.builder()
+            .formId(FORM_ID)
+            .respondentMemberId(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormPort).should(never()).findById(any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -30,6 +30,7 @@ import com.umc.product.form.application.port.in.command.dto.DeleteAnonymousDraft
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.SubmitAnonymousImmediatelyFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
@@ -521,6 +522,41 @@ class FormResponseCommandServiceTest {
     // ============================================================
     //          익명 응답
     // ============================================================
+
+    @Test
+    @DisplayName("submitAnonymousImmediately: 토큰 발급 + sha256 저장 + SUBMITTED 상태 + rawKey 반환")
+    void submitAnonymousImmediately_토큰_발급_및_저장() {
+        String rawKey = "raw-key-example";
+        String hash = "hash-of-raw-key";
+
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of());
+        given(secureTokenGenerator.generateOpaqueToken()).willReturn(rawKey);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
+            FormResponse response = invocation.getArgument(0);
+            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+            return response;
+        });
+
+        AnonymousFormResponseResult result = sut.submitAnonymousImmediately(
+            SubmitAnonymousImmediatelyFormResponseCommand.builder()
+                .formId(FORM_ID)
+                .answers(List.of())
+                .build()
+        );
+
+        assertThat(result.formResponseId()).isEqualTo(FORM_RESPONSE_ID);
+        assertThat(result.responseAccessKey()).isEqualTo(rawKey);
+
+        then(saveFormResponsePort).should().save(argThat(fr ->
+            fr.getRespondentMemberId() == null
+                && hash.equals(fr.getResponseAccessKeyHash())
+                && fr.getStatus() == com.umc.product.form.domain.enums.FormResponseStatus.SUBMITTED
+        ));
+        // 익명은 중복 정책 검사 skip
+        then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(any(), any());
+    }
 
     @Test
     @DisplayName("createAnonymousDraft: opaque token 발급 + sha256 저장 + rawKey 반환")

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -21,12 +21,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
+import com.umc.product.form.application.port.in.command.dto.AnonymousFormResponseResult;
 import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateAnonymousDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.UpdateFormResponseCommand;
 import com.umc.product.form.application.port.out.LoadAnswerPort;
@@ -73,6 +77,8 @@ class FormResponseCommandServiceTest {
     SaveAnswerPort saveAnswerPort;
     @Mock
     GetFileUseCase getFileUseCase;
+    @Mock
+    SecureTokenGenerator secureTokenGenerator;
 
     @InjectMocks
     FormResponseCommandService sut;
@@ -508,6 +514,95 @@ class FormResponseCommandServiceTest {
             .isEqualTo(FormErrorCode.INVALID_ANSWER_FORMAT);
 
         then(saveAnswerPort).should(never()).saveAll(any());
+    }
+
+    // ============================================================
+    //          익명 응답
+    // ============================================================
+
+    @Test
+    @DisplayName("createAnonymousDraft: opaque token 발급 + sha256 저장 + rawKey 반환")
+    void createAnonymousDraft_토큰_발급_및_저장() {
+        String rawKey = "raw-key-example";
+        String hash = "hash-of-raw-key";
+
+        given(loadFormPort.findById(FORM_ID)).willReturn(Optional.of(publishedForm(false)));
+        given(secureTokenGenerator.generateOpaqueToken()).willReturn(rawKey);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(saveFormResponsePort.save(any(FormResponse.class))).willAnswer(invocation -> {
+            FormResponse response = invocation.getArgument(0);
+            ReflectionTestUtils.setField(response, "id", FORM_RESPONSE_ID);
+            return response;
+        });
+
+        AnonymousFormResponseResult result = sut.createAnonymousDraft(
+            CreateAnonymousDraftFormResponseCommand.builder()
+                .formId(FORM_ID)
+                .build()
+        );
+
+        assertThat(result.formResponseId()).isEqualTo(FORM_RESPONSE_ID);
+        assertThat(result.responseAccessKey()).isEqualTo(rawKey);
+
+        then(saveFormResponsePort).should().save(argThat(fr ->
+            fr.getRespondentMemberId() == null
+                && hash.equals(fr.getResponseAccessKeyHash())
+        ));
+        // 익명은 중복 정책 검사 skip
+        then(loadFormResponsePort).should(never()).existsByFormIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousDraft: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void updateAnonymousDraft_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(null)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findDraftByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousDraft: hash 매칭 실패면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousDraft_hash_매칭_실패_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("updateAnonymousDraft: 매칭된 draft 가 기명이면 FORM_RESPONSE_FORBIDDEN")
+    void updateAnonymousDraft_기명_draft_거부_FORBIDDEN() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedDraft = draftResponse(); // 기명 (MEMBER_ID)
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findDraftByAccessKeyHash(hash)).willReturn(Optional.of(namedDraft));
+
+        assertThatThrownBy(() -> sut.updateAnonymousDraft(UpdateAnonymousDraftFormResponseCommand.builder()
+            .responseAccessKey(rawKey)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
     }
 
     // ============================================================

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.form.application.port.in.command.dto.AnswerCommand;
 import com.umc.product.form.application.port.in.command.dto.CreateDraftFormResponseCommand;
+import com.umc.product.form.application.port.in.command.dto.DeleteDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.DeleteFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitDraftFormResponseCommand;
 import com.umc.product.form.application.port.in.command.dto.SubmitFormResponseCommand;
@@ -507,6 +508,133 @@ class FormResponseCommandServiceTest {
             .isEqualTo(FormErrorCode.INVALID_ANSWER_FORMAT);
 
         then(saveAnswerPort).should(never()).saveAll(any());
+    }
+
+    // ============================================================
+    //          Draft 조작 owner 검증 (Phase 2)
+    // ============================================================
+
+    @Test
+    @DisplayName("updateDraft: requesterMemberId=null 이면 FORM_RESPONSE_FORBIDDEN (auth 계층에서 걸러졌어야 하는 방어)")
+    void updateDraft_requesterMemberIdNull_예외() {
+        FormResponse draft = draftResponse();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.updateDraft(UpdateDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(null)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("updateDraft: draft 가 익명(respondentMemberId=null) 이면 FORM_RESPONSE_FORBIDDEN")
+    void updateDraft_익명_draft_는_기명_usecase_에서_거부() {
+        FormResponse anonymousDraft = FormResponse.createDraft(publishedForm(true), null);
+        ReflectionTestUtils.setField(anonymousDraft, "id", FORM_RESPONSE_ID);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(anonymousDraft));
+
+        assertThatThrownBy(() -> sut.updateDraft(UpdateDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("updateDraft: 요청자가 draft 소유자가 아니면 FORM_RESPONSE_FORBIDDEN")
+    void updateDraft_요청자가_소유자가_아니면_FORBIDDEN() {
+        FormResponse draft = draftResponse(); // 소유자 = MEMBER_ID
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.updateDraft(UpdateDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID + 1) // 다른 사용자
+            .answers(List.of())
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveAnswerPort).should(never()).deleteAllByFormResponseId(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft: requesterMemberId=null 이면 FORM_RESPONSE_FORBIDDEN (auth 계층에서 걸러졌어야 하는 방어)")
+    void submitDraft_requesterMemberIdNull_예외() {
+        FormResponse draft = draftResponse();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft: 요청자가 draft 소유자가 아니면 FORM_RESPONSE_FORBIDDEN")
+    void submitDraft_요청자가_소유자가_아니면_FORBIDDEN() {
+        FormResponse draft = draftResponse();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID + 1)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("deleteDraft: requesterMemberId=null 이면 FORM_RESPONSE_FORBIDDEN (auth 계층에서 걸러졌어야 하는 방어)")
+    void deleteDraft_requesterMemberIdNull_예외() {
+        FormResponse draft = draftResponse();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.deleteDraft(DeleteDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(null)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("deleteDraft: 요청자가 draft 소유자가 아니면 FORM_RESPONSE_FORBIDDEN")
+    void deleteDraft_요청자가_소유자가_아니면_FORBIDDEN() {
+        FormResponse draft = draftResponse();
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+
+        assertThatThrownBy(() -> sut.deleteDraft(DeleteDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID + 1)
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+
+        then(saveFormResponsePort).should(never()).deleteById(any());
     }
 
     private Form publishedForm(boolean allowDuplicateResponses) {

--- a/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/FormResponseCommandServiceTest.java
@@ -207,6 +207,7 @@ class FormResponseCommandServiceTest {
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, commonRequiredQuestion)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(commonRequiredQuestion));
 
         sut.submitDraft(SubmitDraftFormResponseCommand.builder()
             .formResponseId(FORM_RESPONSE_ID)
@@ -215,7 +216,6 @@ class FormResponseCommandServiceTest {
             .allowedQuestionIds(Set.of(commonRequiredQuestion.getId()))
             .build());
 
-        then(loadQuestionPort).should(never()).listByFormId(FORM_ID);
         then(saveFormResponsePort).should().save(draft);
     }
 
@@ -244,13 +244,77 @@ class FormResponseCommandServiceTest {
     }
 
     @Test
+    @DisplayName("submitDraft: allowedQuestionIds 에 폼 소속 아닌 질문 있으면 QUESTION_IS_NOT_OWNED_BY_FORM")
+    void submitDraft_allowedQuestionIds_교차폼_질문_거부() {
+        FormResponse draft = draftResponse();
+        Question formQuestion = question(10L, false);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(formQuestion));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .allowedQuestionIds(Set.of(10L, 999L)) // 999L 은 폼 소속 아님
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft: requiredQuestionIds 에 폼 소속 아닌 질문 있으면 QUESTION_IS_NOT_OWNED_BY_FORM")
+    void submitDraft_requiredQuestionIds_교차폼_질문_거부() {
+        FormResponse draft = draftResponse();
+        Question formQuestion = question(10L, false);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(formQuestion));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .requiredQuestionIds(Set.of(999L)) // 폼 소속 아님
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.QUESTION_IS_NOT_OWNED_BY_FORM);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("submitDraft: required 가 allowed 부분집합 아니면 INVALID_SUBMIT_SCOPE")
+    void submitDraft_required_allowed_부분집합_아니면_거부() {
+        FormResponse draft = draftResponse();
+        Question q10 = question(10L, false);
+        Question q20 = question(20L, false);
+        given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
+
+        assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
+            .formResponseId(FORM_RESPONSE_ID)
+            .requesterMemberId(MEMBER_ID)
+            .allowedQuestionIds(Set.of(10L))
+            .requiredQuestionIds(Set.of(10L, 20L)) // Q20 은 allowed 밖
+            .build()))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.INVALID_SUBMIT_SCOPE);
+
+        then(saveFormResponsePort).should(never()).save(any());
+    }
+
+    @Test
     @DisplayName("draft 제출 scope의 allowed question 밖에 저장된 답변이 있으면 실패한다")
     void draft_제출_scope의_allowed_question_밖에_저장된_답변이면_실패한다() {
         FormResponse draft = draftResponse();
+        Question q10 = question(10L, false);
         Question hiddenQuestion = question(20L, false);
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, hiddenQuestion)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, hiddenQuestion));
 
         assertThatThrownBy(() -> sut.submitDraft(SubmitDraftFormResponseCommand.builder()
             .formResponseId(FORM_RESPONSE_ID)
@@ -276,6 +340,8 @@ class FormResponseCommandServiceTest {
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, requiredAnswered)));
+        given(loadQuestionPort.listByFormId(FORM_ID))
+            .willReturn(List.of(requiredAnswered, optionalUnanswered));
         given(loadQuestionPort.listByIdIn(Set.of(20L)))
             .willReturn(List.of(optionalUnanswered));
 
@@ -302,10 +368,12 @@ class FormResponseCommandServiceTest {
         // given — allowedQuestionIds = {Q10} (파트 필터링 결과), Q20은 범위 밖
         FormResponse draft = draftResponse();
         Question q10 = question(10L, true);
+        Question q20 = question(20L, false);
 
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, q10)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
 
         // when
         sut.submitDraft(SubmitDraftFormResponseCommand.builder()
@@ -330,6 +398,7 @@ class FormResponseCommandServiceTest {
         given(loadFormResponsePort.findById(FORM_RESPONSE_ID)).willReturn(Optional.of(draft));
         given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID))
             .willReturn(List.of(answer(draft, q10), answer(draft, q20)));
+        given(loadQuestionPort.listByFormId(FORM_ID)).willReturn(List.of(q10, q20));
 
         // when
         sut.submitDraft(SubmitDraftFormResponseCommand.builder()

--- a/src/test/java/com/umc/product/form/application/service/command/QuestionOptionCommandServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/command/QuestionOptionCommandServiceTest.java
@@ -1,0 +1,131 @@
+package com.umc.product.form.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.form.application.port.in.command.dto.CreateQuestionOptionCommand;
+import com.umc.product.form.application.port.in.command.dto.UpdateQuestionOptionCommand;
+import com.umc.product.form.application.port.out.LoadFormSectionPort;
+import com.umc.product.form.application.port.out.LoadQuestionOptionPort;
+import com.umc.product.form.application.port.out.LoadQuestionPort;
+import com.umc.product.form.application.port.out.SaveQuestionOptionPort;
+import com.umc.product.form.domain.Form;
+import com.umc.product.form.domain.FormSection;
+import com.umc.product.form.domain.Question;
+import com.umc.product.form.domain.QuestionOption;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.form.domain.exception.FormDomainException;
+import com.umc.product.form.domain.exception.FormErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionOptionCommandServiceTest {
+
+    @Mock
+    LoadFormSectionPort loadFormSectionPort;
+    @Mock
+    LoadQuestionPort loadQuestionPort;
+    @Mock
+    LoadQuestionOptionPort loadQuestionOptionPort;
+    @Mock
+    SaveQuestionOptionPort saveQuestionOptionPort;
+
+    @InjectMocks
+    QuestionOptionCommandService sut;
+
+    @Test
+    @DisplayName("createOption은 nextSectionId가 현재 섹션과 같으면 self-loop로 거부한다")
+    void createOption_nextSectionId가_현재_섹션과_같으면_거부() {
+        Form form = Form.createDraft("지원서", 10L, true);
+        FormSection section = FormSection.create(form, "공통", null, 1L);
+        ReflectionTestUtils.setField(section, "id", 20L);
+        Question question = Question.create("자기소개", QuestionType.RADIO, true, 1L);
+        question.assignTo(section);
+        ReflectionTestUtils.setField(question, "id", 30L);
+
+        given(loadQuestionPort.findById(30L)).willReturn(Optional.of(question));
+        given(loadQuestionOptionPort.listByQuestionId(30L)).willReturn(List.of());
+
+        CreateQuestionOptionCommand command = CreateQuestionOptionCommand.builder()
+            .questionId(30L)
+            .requesterMemberId(99L)
+            .content("남자")
+            .isOther(false)
+            .nextSectionId(20L)
+            .build();
+
+        assertThatThrownBy(() -> sut.createOption(command))
+            .isInstanceOf(FormDomainException.class)
+            .hasFieldOrPropertyWithValue("baseCode", FormErrorCode.INVALID_NEXT_SECTION_SELF_LOOP);
+    }
+
+    @Test
+    @DisplayName("updateOption은 nextSectionId가 현재 섹션과 같으면 self-loop로 거부한다")
+    void updateOption_nextSectionId가_현재_섹션과_같으면_거부() {
+        Form form = Form.createDraft("지원서", 10L, true);
+        FormSection section = FormSection.create(form, "공통", null, 1L);
+        ReflectionTestUtils.setField(section, "id", 20L);
+        Question question = Question.create("자기소개", QuestionType.RADIO, true, 1L);
+        question.assignTo(section);
+        ReflectionTestUtils.setField(question, "id", 30L);
+        QuestionOption option = QuestionOption.create("남자", 1L, false, null);
+        option.assignTo(question);
+        ReflectionTestUtils.setField(option, "id", 40L);
+
+        given(loadQuestionOptionPort.findById(40L)).willReturn(Optional.of(option));
+
+        UpdateQuestionOptionCommand command = UpdateQuestionOptionCommand.builder()
+            .optionId(40L)
+            .requesterMemberId(99L)
+            .nextSectionId(20L)
+            .build();
+
+        assertThatThrownBy(() -> sut.updateOption(command))
+            .isInstanceOf(FormDomainException.class)
+            .hasFieldOrPropertyWithValue("baseCode", FormErrorCode.INVALID_NEXT_SECTION_SELF_LOOP);
+    }
+
+    @Test
+    @DisplayName("createOption은 nextSectionId가 다른 섹션이면 self-loop 검증을 통과한다")
+    void createOption_nextSectionId가_다른_섹션이면_통과() {
+        Form form = Form.createDraft("지원서", 10L, true);
+        ReflectionTestUtils.setField(form, "id", 100L);
+        FormSection currentSection = FormSection.create(form, "공통", null, 1L);
+        ReflectionTestUtils.setField(currentSection, "id", 20L);
+        FormSection targetSection = FormSection.create(form, "심화", null, 2L);
+        ReflectionTestUtils.setField(targetSection, "id", 21L);
+        Question question = Question.create("자기소개", QuestionType.RADIO, true, 1L);
+        question.assignTo(currentSection);
+        ReflectionTestUtils.setField(question, "id", 30L);
+
+        given(loadQuestionPort.findById(30L)).willReturn(Optional.of(question));
+        given(loadQuestionOptionPort.listByQuestionId(30L)).willReturn(List.of());
+        given(loadFormSectionPort.findById(21L)).willReturn(Optional.of(targetSection));
+        given(saveQuestionOptionPort.save(any(QuestionOption.class))).willAnswer(invocation -> {
+            QuestionOption saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 40L);
+            return saved;
+        });
+
+        CreateQuestionOptionCommand command = CreateQuestionOptionCommand.builder()
+            .questionId(30L)
+            .requesterMemberId(99L)
+            .content("남자")
+            .isOther(false)
+            .nextSectionId(21L)
+            .build();
+
+        sut.createOption(command);
+    }
+}

--- a/src/test/java/com/umc/product/form/application/service/query/AnswerQueryServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/query/AnswerQueryServiceTest.java
@@ -1,0 +1,309 @@
+package com.umc.product.form.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
+import com.umc.product.form.application.port.out.LoadAnswerPort;
+import com.umc.product.form.domain.Answer;
+import com.umc.product.form.domain.Form;
+import com.umc.product.form.domain.FormResponse;
+import com.umc.product.form.domain.Question;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.form.domain.exception.FormDomainException;
+import com.umc.product.form.domain.exception.FormErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerQueryServiceTest {
+
+    private static final Long FORM_ID = 100L;
+    private static final Long FORM_RESPONSE_ID = 200L;
+    private static final Long OWNER_MEMBER_ID = 300L;
+    private static final Long QUESTION_ID = 400L;
+    private static final Long ANSWER_ID = 500L;
+
+    @Mock
+    LoadAnswerPort loadAnswerPort;
+    @Mock
+    SecureTokenGenerator secureTokenGenerator;
+
+    @InjectMocks
+    AnswerQueryService sut;
+
+    private static final String RAW_KEY = "raw-key";
+    private static final String KEY_HASH = "hash-value";
+    private static final String OTHER_HASH = "other-hash";
+
+    @Test
+    @DisplayName("findById: 익명 응답의 답변이면 Optional.empty")
+    void findById_익명_응답의_답변이면_empty() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThat(sut.findById(ANSWER_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findById: 기명 응답의 답변이면 반환")
+    void findById_기명_응답의_답변이면_반환() {
+        Answer answer = shortTextAnswer(namedDraft(OWNER_MEMBER_ID));
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(loadAnswerPort.listChoicesByAnswerIdIn(Set.of(ANSWER_ID))).willReturn(List.of());
+
+        assertThat(sut.findById(ANSWER_ID)).isPresent();
+    }
+
+    @Test
+    @DisplayName("getById: 익명 응답의 답변이면 ANSWER_NOT_FOUND")
+    void getById_익명_응답의_답변이면_NOT_FOUND() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.getById(ANSWER_ID))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.ANSWER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("listByFormResponseId: 익명 응답이면 빈 리스트")
+    void listByFormResponseId_익명_응답이면_빈_리스트() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answer));
+
+        assertThat(sut.listByFormResponseId(FORM_RESPONSE_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listByFormResponseId: 응답 자체가 없으면 빈 리스트")
+    void listByFormResponseId_응답_없으면_빈_리스트() {
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of());
+
+        assertThat(sut.listByFormResponseId(FORM_RESPONSE_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listByFormResponseIds: 익명 응답의 답변은 결과 map 에서 제외")
+    void listByFormResponseIds_익명_응답은_제외() {
+        Answer namedAnswer = shortTextAnswer(namedDraft(OWNER_MEMBER_ID));
+        Answer anonymousAnswer = shortTextAnswerWithId(anonymousDraft(), 501L);
+        given(loadAnswerPort.listByFormResponseIds(Set.of(FORM_RESPONSE_ID, 201L)))
+            .willReturn(List.of(namedAnswer, anonymousAnswer));
+        given(loadAnswerPort.listChoicesByAnswerIdIn(any())).willReturn(List.of());
+
+        var result = sut.listByFormResponseIds(Set.of(FORM_RESPONSE_ID, 201L));
+
+        assertThat(result).containsOnlyKeys(FORM_RESPONSE_ID);
+    }
+
+    // ============================================================
+    //          findByIdAsAnonymous / getByIdAsAnonymous — 익명 access key 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("findByIdAsAnonymous: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void findByIdAsAnonymous_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.findByIdAsAnonymous(ANSWER_ID, null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("findByIdAsAnonymous: 답변 없으면 Optional.empty")
+    void findByIdAsAnonymous_답변_없으면_empty() {
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.empty());
+
+        assertThat(sut.findByIdAsAnonymous(ANSWER_ID, RAW_KEY)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdAsAnonymous: 기명 응답의 답변이면 Optional.empty (silently)")
+    void findByIdAsAnonymous_기명_응답이면_empty() {
+        Answer answer = shortTextAnswer(namedDraft(OWNER_MEMBER_ID));
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThat(sut.findByIdAsAnonymous(ANSWER_ID, RAW_KEY)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdAsAnonymous: hash 불일치면 Optional.empty (silently)")
+    void findByIdAsAnonymous_hash_불일치_empty() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(OTHER_HASH);
+
+        assertThat(sut.findByIdAsAnonymous(ANSWER_ID, RAW_KEY)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdAsAnonymous: hash 일치하는 익명 응답이면 반환")
+    void findByIdAsAnonymous_hash_일치_반환() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadAnswerPort.listChoicesByAnswerIdIn(Set.of(ANSWER_ID))).willReturn(List.of());
+
+        assertThat(sut.findByIdAsAnonymous(ANSWER_ID, RAW_KEY)).isPresent();
+    }
+
+    @Test
+    @DisplayName("getByIdAsAnonymous: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void getByIdAsAnonymous_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.getByIdAsAnonymous(ANSWER_ID, null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("getByIdAsAnonymous: 답변 없으면 FORM_RESPONSE_FORBIDDEN")
+    void getByIdAsAnonymous_답변_없으면_FORBIDDEN() {
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.getByIdAsAnonymous(ANSWER_ID, RAW_KEY))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getByIdAsAnonymous: 기명 응답의 답변이면 FORM_RESPONSE_FORBIDDEN")
+    void getByIdAsAnonymous_기명_응답_FORBIDDEN() {
+        Answer answer = shortTextAnswer(namedDraft(OWNER_MEMBER_ID));
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+
+        assertThatThrownBy(() -> sut.getByIdAsAnonymous(ANSWER_ID, RAW_KEY))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getByIdAsAnonymous: hash 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void getByIdAsAnonymous_hash_불일치_FORBIDDEN() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(OTHER_HASH);
+
+        assertThatThrownBy(() -> sut.getByIdAsAnonymous(ANSWER_ID, RAW_KEY))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getByIdAsAnonymous: hash 일치하는 익명 응답이면 반환")
+    void getByIdAsAnonymous_hash_일치_반환() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.findById(ANSWER_ID)).willReturn(Optional.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadAnswerPort.listChoicesByAnswerIdIn(Set.of(ANSWER_ID))).willReturn(List.of());
+
+        assertThat(sut.getByIdAsAnonymous(ANSWER_ID, RAW_KEY)).isNotNull();
+    }
+
+    // ============================================================
+    //          listByFormResponseIdAsAnonymous — 익명 access key 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("listByFormResponseIdAsAnonymous: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void listByFormResponseIdAsAnonymous_rawKey_null_예외() {
+        assertThatThrownBy(() -> sut.listByFormResponseIdAsAnonymous(FORM_RESPONSE_ID, null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("listByFormResponseIdAsAnonymous: 응답에 답변 없으면 빈 리스트 (정보 유출 없음)")
+    void listByFormResponseIdAsAnonymous_답변_없으면_빈_리스트() {
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of());
+
+        assertThat(sut.listByFormResponseIdAsAnonymous(FORM_RESPONSE_ID, RAW_KEY)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listByFormResponseIdAsAnonymous: 기명 응답이면 FORM_RESPONSE_FORBIDDEN")
+    void listByFormResponseIdAsAnonymous_기명_응답_FORBIDDEN() {
+        Answer answer = shortTextAnswer(namedDraft(OWNER_MEMBER_ID));
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answer));
+
+        assertThatThrownBy(() -> sut.listByFormResponseIdAsAnonymous(FORM_RESPONSE_ID, RAW_KEY))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("listByFormResponseIdAsAnonymous: hash 불일치면 FORM_RESPONSE_FORBIDDEN")
+    void listByFormResponseIdAsAnonymous_hash_불일치_FORBIDDEN() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(OTHER_HASH);
+
+        assertThatThrownBy(() -> sut.listByFormResponseIdAsAnonymous(FORM_RESPONSE_ID, RAW_KEY))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("listByFormResponseIdAsAnonymous: hash 일치하는 익명 응답이면 답변 반환")
+    void listByFormResponseIdAsAnonymous_hash_일치_반환() {
+        Answer answer = shortTextAnswer(anonymousDraft());
+        given(loadAnswerPort.listByFormResponseId(FORM_RESPONSE_ID)).willReturn(List.of(answer));
+        given(secureTokenGenerator.sha256Hex(RAW_KEY)).willReturn(KEY_HASH);
+        given(loadAnswerPort.listChoicesByAnswerIdIn(Set.of(ANSWER_ID))).willReturn(List.of());
+
+        assertThat(sut.listByFormResponseIdAsAnonymous(FORM_RESPONSE_ID, RAW_KEY)).hasSize(1);
+    }
+
+    private FormResponse namedDraft(Long memberId) {
+        Form form = publishedForm();
+        FormResponse draft = FormResponse.createDraft(form, memberId);
+        ReflectionTestUtils.setField(draft, "id", FORM_RESPONSE_ID);
+        return draft;
+    }
+
+    private FormResponse anonymousDraft() {
+        Form form = publishedForm();
+        FormResponse draft = FormResponse.createAnonymousDraft(form, "hash-value");
+        ReflectionTestUtils.setField(draft, "id", FORM_RESPONSE_ID);
+        return draft;
+    }
+
+    private Form publishedForm() {
+        Form form = Form.createDraft("폼", 1L, false);
+        ReflectionTestUtils.setField(form, "id", FORM_ID);
+        form.publish();
+        return form;
+    }
+
+    private Answer shortTextAnswer(FormResponse formResponse) {
+        return shortTextAnswerWithId(formResponse, ANSWER_ID);
+    }
+
+    private Answer shortTextAnswerWithId(FormResponse formResponse, Long id) {
+        Question question = Question.create("질문", QuestionType.SHORT_TEXT, false, 1L);
+        ReflectionTestUtils.setField(question, "id", QUESTION_ID);
+        Answer answer = Answer.create(formResponse, question, QuestionType.SHORT_TEXT, "답", null);
+        ReflectionTestUtils.setField(answer, "id", id);
+        return answer;
+    }
+}

--- a/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
@@ -178,11 +178,69 @@ class FormResponseQueryServiceTest {
         assertThat(sut.getResponseWithAnswersByAccessKey(rawKey)).isNotNull();
     }
 
+    // ============================================================
+    //          ID 기반 상세 조회의 익명 응답 방어
+    // ============================================================
+
+    @Test
+    @DisplayName("findResponseWithAnswers: 익명 응답이면 Optional.empty")
+    void findResponseWithAnswers_익명_응답이면_empty() {
+        FormResponse anonymousResponse = anonymousResponseWithId(300L);
+        given(loadFormResponsePort.findById(300L)).willReturn(Optional.of(anonymousResponse));
+
+        assertThat(sut.findResponseWithAnswers(300L)).isEmpty();
+
+        then(getAnswerUseCase).should(never()).listByFormResponseId(anyLong());
+    }
+
+    @Test
+    @DisplayName("findResponseWithAnswers: 기명 응답이면 반환")
+    void findResponseWithAnswers_기명_응답이면_반환() {
+        FormResponse namedResponse = namedResponseWithId(300L, 200L);
+        given(loadFormResponsePort.findById(300L)).willReturn(Optional.of(namedResponse));
+        given(getAnswerUseCase.listByFormResponseId(300L)).willReturn(List.of());
+
+        assertThat(sut.findResponseWithAnswers(300L)).isPresent();
+    }
+
+    @Test
+    @DisplayName("getResponseWithAnswers: 익명 응답이면 FORM_RESPONSE_NOT_FOUND")
+    void getResponseWithAnswers_익명_응답이면_NOT_FOUND() {
+        FormResponse anonymousResponse = anonymousResponseWithId(300L);
+        given(loadFormResponsePort.findById(300L)).willReturn(Optional.of(anonymousResponse));
+
+        assertThatThrownBy(() -> sut.getResponseWithAnswers(300L))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("findResponsesWithAnswers: 익명 응답은 결과 map 에서 제외")
+    void findResponsesWithAnswers_익명_응답은_제외() {
+        FormResponse named = namedResponseWithId(300L, 200L);
+        FormResponse anonymous = anonymousResponseWithId(301L);
+        given(loadFormResponsePort.listByIdsWithForm(java.util.Set.of(300L, 301L)))
+            .willReturn(List.of(named, anonymous));
+        given(getAnswerUseCase.listByFormResponseIds(java.util.Set.of(300L, 301L)))
+            .willReturn(java.util.Map.of());
+
+        var result = sut.findResponsesWithAnswers(java.util.Set.of(300L, 301L));
+
+        assertThat(result).containsOnlyKeys(300L);
+    }
+
     private FormResponse anonymousDraftWithMember(Long memberId) {
         Form form = Form.createDraft("폼", 1L, false);
         ReflectionTestUtils.setField(form, "id", FORM_ID);
         form.publish();
         FormResponse response = FormResponse.createDraft(form, memberId);
+        return response;
+    }
+
+    private FormResponse namedResponseWithId(Long id, Long memberId) {
+        FormResponse response = anonymousDraftWithMember(memberId);
+        ReflectionTestUtils.setField(response, "id", id);
         return response;
     }
 

--- a/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
@@ -1,10 +1,15 @@
 package com.umc.product.form.application.service.query;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,9 +17,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.authentication.application.service.SecureTokenGenerator;
 import com.umc.product.form.application.port.in.query.GetAnswerUseCase;
 import com.umc.product.form.application.port.out.LoadFormResponsePort;
+import com.umc.product.form.domain.Form;
+import com.umc.product.form.domain.FormResponse;
 import com.umc.product.form.domain.exception.FormDomainException;
 import com.umc.product.form.domain.exception.FormErrorCode;
 
@@ -27,6 +36,8 @@ class FormResponseQueryServiceTest {
     LoadFormResponsePort loadFormResponsePort;
     @Mock
     GetAnswerUseCase getAnswerUseCase;
+    @Mock
+    SecureTokenGenerator secureTokenGenerator;
 
     @InjectMocks
     FormResponseQueryService sut;
@@ -62,5 +73,125 @@ class FormResponseQueryServiceTest {
             .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
 
         then(loadFormResponsePort).should(never()).findSubmittedByFormIdAndRespondentMemberId(anyLong(), any());
+    }
+
+    // ============================================================
+    //          익명 응답 조회 (Phase 4.7)
+    // ============================================================
+
+    @Test
+    @DisplayName("findByAccessKey: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void findByAccessKey_null_예외() {
+        assertThatThrownBy(() -> sut.findByAccessKey(null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("findByAccessKey: 매칭 실패면 Optional.empty")
+    void findByAccessKey_매칭_실패_empty() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThat(sut.findByAccessKey(rawKey)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByAccessKey: 기명 응답이 매칭되면 방어 목적으로 Optional.empty")
+    void findByAccessKey_기명_응답이면_empty() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedResponse = anonymousDraftWithMember(200L);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.of(namedResponse));
+
+        assertThat(sut.findByAccessKey(rawKey)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByAccessKey: 익명 응답이 매칭되면 반환")
+    void findByAccessKey_익명_응답이면_반환() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse anonymousResponse = anonymousResponseWithId(300L);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.of(anonymousResponse));
+
+        assertThat(sut.findByAccessKey(rawKey)).isPresent();
+    }
+
+    @Test
+    @DisplayName("getResponseWithAnswersByAccessKey: rawKey null 이면 RESPONSE_ACCESS_KEY_REQUIRED")
+    void getResponseWithAnswersByAccessKey_null_예외() {
+        assertThatThrownBy(() -> sut.getResponseWithAnswersByAccessKey(null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONSE_ACCESS_KEY_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findByAccessKeyHash(any());
+    }
+
+    @Test
+    @DisplayName("getResponseWithAnswersByAccessKey: 매칭 실패면 FORM_RESPONSE_NOT_FOUND")
+    void getResponseWithAnswersByAccessKey_매칭_실패_NOT_FOUND() {
+        String rawKey = "raw";
+        String hash = "hash";
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.getResponseWithAnswersByAccessKey(rawKey))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getResponseWithAnswersByAccessKey: 기명 응답이 매칭되면 FORM_RESPONSE_NOT_FOUND")
+    void getResponseWithAnswersByAccessKey_기명_응답이면_NOT_FOUND() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse namedResponse = anonymousDraftWithMember(200L);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.of(namedResponse));
+
+        assertThatThrownBy(() -> sut.getResponseWithAnswersByAccessKey(rawKey))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.FORM_RESPONSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getResponseWithAnswersByAccessKey: 익명 응답이 매칭되면 상세 반환")
+    void getResponseWithAnswersByAccessKey_익명_응답이면_반환() {
+        String rawKey = "raw";
+        String hash = "hash";
+        FormResponse anonymousResponse = anonymousResponseWithId(300L);
+        given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
+        given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.of(anonymousResponse));
+        given(getAnswerUseCase.listByFormResponseId(300L)).willReturn(List.of());
+
+        assertThat(sut.getResponseWithAnswersByAccessKey(rawKey)).isNotNull();
+    }
+
+    private FormResponse anonymousDraftWithMember(Long memberId) {
+        Form form = Form.createDraft("폼", 1L, false);
+        ReflectionTestUtils.setField(form, "id", FORM_ID);
+        form.publish();
+        FormResponse response = FormResponse.createDraft(form, memberId);
+        return response;
+    }
+
+    private FormResponse anonymousResponseWithId(Long id) {
+        Form form = Form.createDraft("폼", 1L, false);
+        ReflectionTestUtils.setField(form, "id", FORM_ID);
+        form.publish();
+        FormResponse response = FormResponse.createAnonymousDraft(form, "hash-value");
+        ReflectionTestUtils.setField(response, "id", id);
+        return response;
     }
 }

--- a/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
@@ -173,7 +173,7 @@ class FormResponseQueryServiceTest {
         FormResponse anonymousResponse = anonymousResponseWithId(300L);
         given(secureTokenGenerator.sha256Hex(rawKey)).willReturn(hash);
         given(loadFormResponsePort.findByAccessKeyHash(hash)).willReturn(Optional.of(anonymousResponse));
-        given(getAnswerUseCase.listByFormResponseId(300L)).willReturn(List.of());
+        given(getAnswerUseCase.listByFormResponseIdAsAnonymous(300L, rawKey)).willReturn(List.of());
 
         assertThat(sut.getResponseWithAnswersByAccessKey(rawKey)).isNotNull();
     }

--- a/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
+++ b/src/test/java/com/umc/product/form/application/service/query/FormResponseQueryServiceTest.java
@@ -1,0 +1,66 @@
+package com.umc.product.form.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.form.application.port.in.query.GetAnswerUseCase;
+import com.umc.product.form.application.port.out.LoadFormResponsePort;
+import com.umc.product.form.domain.exception.FormDomainException;
+import com.umc.product.form.domain.exception.FormErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class FormResponseQueryServiceTest {
+
+    private static final Long FORM_ID = 100L;
+
+    @Mock
+    LoadFormResponsePort loadFormResponsePort;
+    @Mock
+    GetAnswerUseCase getAnswerUseCase;
+
+    @InjectMocks
+    FormResponseQueryService sut;
+
+    @Test
+    @DisplayName("listDraftByRespondentMemberId: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void listDraftByRespondentMemberId_null_예외() {
+        assertThatThrownBy(() -> sut.listDraftByRespondentMemberId(null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findAllDraftByRespondentMemberId(any());
+    }
+
+    @Test
+    @DisplayName("findDraftByFormIdAndRespondentMemberId: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void findDraftByFormIdAndRespondentMemberId_null_예외() {
+        assertThatThrownBy(() -> sut.findDraftByFormIdAndRespondentMemberId(FORM_ID, null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findDraftByFormIdAndRespondentMemberId(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("findSubmittedByFormIdAndRespondentMemberId: respondentMemberId=null 이면 RESPONDENT_MEMBER_ID_REQUIRED")
+    void findSubmittedByFormIdAndRespondentMemberId_null_예외() {
+        assertThatThrownBy(() -> sut.findSubmittedByFormIdAndRespondentMemberId(FORM_ID, null))
+            .isInstanceOf(FormDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(FormErrorCode.RESPONDENT_MEMBER_ID_REQUIRED);
+
+        then(loadFormResponsePort).should(never()).findSubmittedByFormIdAndRespondentMemberId(anyLong(), any());
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용
formkit 도메인 신설을 위한 form 엔진 선행 작업으로, 비로그인 응답 수용과 조건부 섹션 이동 두 가지 기능을 추가합니다.
초기 커밋 후 리뷰(#1143)에서 지적받은 P2 사항(익명/기명 UseCase 분리, null check, hash 인증)을 반영해 스코프가 확장됐습니다.

### 1. 비로그인 응답 수용 (전면 재작업)
초기 커밋은 `respondent_member_id` 를 nullable 로 열고 기존 usecase 의 null check 부재를 이용하는 방식이었으나, 리뷰 후 다음 3갈래로 확장했습니다.

1-a. SUBMITTED 계열 null 방어 (리뷰어 지적 대응)
- `submitImmediately`, `updateResponse`, `deleteResponse`, `createDraft` 진입점에 `requireRespondentMemberId` 명시 호출
- Query 계열 `find*ByFormIdAndRespondentMemberId`, `listDraftByRespondentMemberId` 도 동일 방어
- 신규 ErrorCode: `RESPONDENT_MEMBER_ID_REQUIRED` (FORM-0034)

1-b. DRAFT owner 검증 부재 픽스 (기존 결함 해소)
- DTO에 `requesterMemberId` 필드와 "권한 검증" Javadoc 이 있었으나 서비스에 검증 로직이 부재해 있었습니다.
- `loadDraftAsOwner` 헬퍼 도입: null 방어 + 익명 draft 거부 + owner 대조 통합
- 모든 rejection 케이스를 `FORM_RESPONSE_FORBIDDEN` 하나로 통일

1-c. 익명 응답 전용 UseCase 신설 (hash 인증 반영)
- 엔티티에 `response_access_key_hash VARCHAR(64) UNIQUE` 컬럼 추가 (Flyway migration 포함)
- `SecureTokenGenerator` 재사용해서 SSO Auth Code (#1115) 와 동일 패턴 (raw 발급 → sha256 저장 → 매칭 검증)
- Command usecase 7개 신설 (기명과 1:1 대칭): `submitAnonymousImmediately`, `updateAnonymousResponse`, `deleteAnonymousResponse`, `createAnonymousDraft`, `updateAnonymousDraft`, `submitAnonymousDraft`, `deleteAnonymousDraft`
- Query usecase 2개 신설: `findByAccessKey`, `getResponseWithAnswersByAccessKey` (find*/get*      
컨벤션)
- 신규 헬퍼: `loadDraftAsAnonymous`, `loadSubmittedAsAnonymous`, `loadAnonymousResponseByAccessKey`
- 신규 ErrorCode: `RESPONSE_ACCESS_KEY_REQUIRED` (FORM-0035)  

### 2. 조건부 섹션 이동 (구글폼 - 섹션 이동 기능)
- `question_option.next_section_id` 컬럼 추가 (FK -> `form_section.id` ON DELETE SET
NULL)
- `QuestionOption.create` / `update`에 `nextSectionId` 파라미터 추가
- `CreateQuestionOptionCommand`, `UpdateQuestionOptionCommand`, `QuestionOptionInfo`에 필드 반영
- `nextSectionId` 지정은 RADIO / DROPDOWN 타입에만 허용, 그 외 타입은
`INVALID_VOTE_FORM_STRUCTURE` 에러
- `UpdateQuestionOptionCommand`에 `clearNextSectionId` 플래그 추가 (null = 기존 값 유지 / true = 제거)

### 3. 필수 질문 검증 경로 교체
- `validateAllRequiredAnswered` -> `validateAllRequiredAnsweredOnPath`로 교체
- 제출 시 응답자가 실제 방문한 섹션 경로(`resolveVisitedSectionIds`)를 먼저 계산하고, 해당 경로 상의 필수 질문만 검증
- 경로 계산 로직: RADIO/DROPDOWN 선택지의 `nextSectionId`를 따라 이동, 없으면 `orderNo` 오름차순으로 다음 섹션
- 조건부 선택지가 없는 기존 폼은 전체 섹션을 순서대로 방문하므로 기존 동작과 동일

- resolves #1140

## 💬 리뷰 중점사항

- UseCase 분리: 기존 `ManageFormResponseUseCase`에 익명/기명 UseCase를 모두 포함했습니다. `ManageAnonymousFormResponseUseCase` 신설이 필요하다고 생각되면 의견주세요.
- null check: SUBMITTED / DRAFT / 익명 3계열 모두 방어
    - SUBMITTED (기명): 진입점에 `requireRespondentMemberId` 명시 호출 
    - DRAFT (기명): 기존 owner 검증 gap 도 함께 픽스 (loadDraftAsOwner 헬퍼)
    - 익명: 별도 usecase 로 완전 분리 + rawKey 기반 인증 (raw 가 null 이면 `RESPONSE_ACCESS_KEY_REQUIRED`)
    - 계열 간 응답 유입 차단: 익명이 기명 usecase 로, 기명이 익명 usecase 로 넘어가면 모두 거부
- hash 인증: PR #1115 에서 도입하신 `SecureTokenGenerator` 그대로 재사용했습니다. (SSO Authorization Code 와 동일 패턴)
   -  UX 코드(예: 지원 6자리 코드)는 소비 도메인(리크루팅 등) 이 raw key 와 매핑 관리하고 form 엔진은 raw 만 제공하는 방식입니다.
    - 기존 구현해 두신 해시 발급 로직을 가저와서 쓰는 거라 도입 비용이 적으며, 보안적으로도 평문 uuid보다 괜찮은 선택이라고 판단해 도입했습니다.

### 핵심 결정 사항

1. UseCase 물리적 이원화 안 함 — 단일 인터페이스에 기명/익명 대칭 메서드
2. Response Access Key rotation(재발급) 없음 — 응답 삭제 시까지 고정
3. SecureTokenGenerator cross-domain 사용 — 기존에 구현되어 있는 해시 로직을 차용하는 것이 큰 리소스가 안든다고 생각해서 차용했습니다. 필요하다면 해당 Generator를 common 패키지로 빼도 좋습니다.
4. UX 코드는 소비 도메인 책임 — form 엔진은 raw key 만 제공