### PR TITLE
[Feat] Member Search GraphQL Query 추가

### DIFF
--- a/docs/onboarding/graphql.md
+++ b/docs/onboarding/graphql.md
@@ -9,7 +9,7 @@ GraphQL은 아직 pilot 범위다. 현재는 Query만 제공하고 Mutation은 �
 제공 중인 도메인은 다음이다.
 
 - `organization`: `gisu`, `chapter`, `school` 공개 조회
-- `member`: `me`, `member`, `members` 조회와 `school`, `challengers`, `gisu` nested field
+- `member`: `me`, `member`, `members`, `memberSearch` 조회와 `school`, `challengers`, `gisu` nested field
 - `project`: `project`, `projects` 조회와 `members`, `application`, `applicationForm` nested field
 
 스키마 파일은 `src/main/resources/graphql` 아래에 있다.
@@ -21,6 +21,157 @@ src/main/resources/graphql/project.graphqls
 ```
 
 Spring GraphQL은 이 디렉터리의 `*.graphqls` 파일을 합쳐 하나의 schema로 로드한다. `extend type Query`로 root query를 도메인별 파일에서 확장한다.
+
+## Schema 구성 및 연관 관계
+
+### 통합 schema 조립
+
+파일은 도메인별로 나뉘지만 endpoint와 실행 schema는 하나다. `organization.graphqls`가 root `Query`를 선언하고,
+`member.graphqls`와 `project.graphqls`가 `extend type Query`로 field를 추가한다.
+
+```mermaid
+flowchart TB
+    ORG["organization.graphqls<br/>type Query<br/>organization types"]
+    MEMBER["member.graphqls<br/>extend type Query<br/>member types"]
+    PROJECT["project.graphqls<br/>extend type Query<br/>project types<br/>shared scalar and enums"]
+    LOADER["Spring GraphQL schema loader<br/>classpath graphql/*.graphqls"]
+    QUERY["통합 Query"]
+
+    ORG --> LOADER
+    MEMBER --> LOADER
+    PROJECT --> LOADER
+    LOADER --> QUERY
+
+    QUERY --> OQ["gisuOrganizations, gisu, activeGisu<br/>chapters, chapter, schools, school"]
+    QUERY --> MQ["me, member, members, memberSearch"]
+    QUERY --> PQ["project, projects"]
+```
+
+SDL 파일 경계는 Java package나 Hexagonal Architecture의 의존성 경계가 아니다. 모든 파일이 합쳐진 뒤 type 이름은
+전역 namespace를 사용한다. 따라서 다른 파일에 선언된 type, scalar, enum도 이름으로 참조할 수 있다.
+
+현재 공유 선언 위치는 다음과 같다.
+
+| 공유 선언 | 선언 파일 | 사용하는 schema |
+| --- | --- | --- |
+| `Gisu`, `SchoolDetail` | `organization.graphqls` | `organization`, `member` |
+| `Long`, `ChallengerPart` | `project.graphqls` | `project`, `member` |
+
+### 주요 type 관계
+
+실선은 object field가 다른 object type을 선택하는 관계이고, 점선은 input, scalar, enum을 공유하는 관계다.
+`Project`는 `Member` type을 직접 재사용하지 않고 project 조회 목적에 맞춘 `MemberBrief`, `ProjectApplicant`를 사용한다.
+
+```mermaid
+flowchart LR
+    subgraph ORG_SCHEMA["organization.graphqls"]
+        Gisu["Gisu"]
+        GisuChapter["GisuChapter"]
+        ChapterSchool["ChapterSchool"]
+        GisuSchool["GisuSchool"]
+        SchoolDetail["SchoolDetail"]
+        SchoolLink["SchoolLink"]
+
+        Gisu -->|"chapters"| GisuChapter
+        Gisu -->|"schools"| GisuSchool
+        GisuChapter -->|"schools"| ChapterSchool
+        GisuSchool -->|"links"| SchoolLink
+        SchoolDetail -->|"links"| SchoolLink
+    end
+
+    subgraph MEMBER_SCHEMA["member.graphqls"]
+        Member["Member"]
+        MemberChallenger["MemberChallenger"]
+        MemberPage["MemberPage"]
+        MemberSearchResult["MemberSearchResult"]
+        MemberSearchChallenger["MemberSearchChallenger"]
+        MemberSearchInput["MemberSearchInput"]
+
+        Member -->|"challengers"| MemberChallenger
+        MemberPage -->|"content"| MemberSearchResult
+        MemberSearchResult -->|"currentChallenger"| MemberSearchChallenger
+        MemberSearchResult -->|"challengerRecords"| MemberSearchChallenger
+    end
+
+    subgraph PROJECT_SCHEMA["project.graphqls"]
+        ProjectPage["ProjectPage"]
+        Project["Project"]
+        ProjectMember["ProjectMember"]
+        MemberBrief["MemberBrief"]
+        ProjectApplication["ProjectApplication"]
+        ProjectApplicationForm["ProjectApplicationForm"]
+        FormSection["ApplicationFormSection"]
+        FormQuestion["ApplicationFormQuestion"]
+        LongScalar["scalar Long"]
+        ChallengerPart["enum ChallengerPart"]
+
+        ProjectPage -->|"content"| Project
+        Project -->|"productOwner, coProductOwners"| MemberBrief
+        Project -->|"members"| ProjectMember
+        Project -->|"applicationForm"| ProjectApplicationForm
+        ProjectMember -->|"member"| MemberBrief
+        ProjectMember -->|"application"| ProjectApplication
+        ProjectApplicationForm -->|"sections"| FormSection
+        FormSection -->|"questions"| FormQuestion
+    end
+
+    Member -->|"school"| SchoolDetail
+    MemberChallenger -->|"gisu"| Gisu
+    MemberSearchResult -->|"school"| SchoolDetail
+    MemberSearchChallenger -->|"gisu"| Gisu
+    MemberSearchInput -.->|"part"| ChallengerPart
+    MemberPage -.->|"totalElements"| LongScalar
+```
+
+### Resolver와 BatchMapping 연결
+
+root field는 같은 도메인의 `@QueryMapping`이 처리한다. nested field는 selection set에 포함된 경우에만
+`@BatchMapping`이 실행되며, 여러 parent의 ID를 모아 application query usecase를 한 번에 호출한다.
+
+```mermaid
+flowchart TB
+    CLIENT["Client selection set"]
+    SCHEMA["통합 GraphQL schema"]
+
+    subgraph MEMBER_ADAPTER["MemberGraphQlController"]
+        MEMBER_QUERY["QueryMapping<br/>me, member, members, memberSearch"]
+        MEMBER_BATCH["BatchMapping<br/>Member.school<br/>Member.challengers<br/>MemberChallenger.gisu<br/>MemberSearchResult.school<br/>MemberSearchChallenger.gisu"]
+    end
+
+    subgraph ORG_ADAPTER["OrganizationGraphQlController"]
+        ORG_QUERY["QueryMapping<br/>organization root fields"]
+        ORG_BATCH["BatchMapping<br/>Gisu.chapters<br/>Gisu.schools<br/>GisuChapter.schools"]
+    end
+
+    subgraph PROJECT_ADAPTER["ProjectGraphQlController"]
+        PROJECT_QUERY["QueryMapping<br/>project, projects"]
+        PROJECT_BATCH["BatchMapping<br/>Project.members<br/>Project.applicationForm<br/>Project.productOwner<br/>Project.coProductOwners<br/>ProjectMember.member<br/>ProjectMember.application"]
+    end
+
+    PORTS["application/port/in/query<br/>Query UseCases"]
+
+    CLIENT --> SCHEMA
+    SCHEMA --> MEMBER_QUERY
+    SCHEMA --> ORG_QUERY
+    SCHEMA --> PROJECT_QUERY
+    SCHEMA --> MEMBER_BATCH
+    SCHEMA --> ORG_BATCH
+    SCHEMA --> PROJECT_BATCH
+
+    MEMBER_QUERY --> PORTS
+    MEMBER_BATCH --> PORTS
+    ORG_QUERY --> PORTS
+    ORG_BATCH --> PORTS
+    PROJECT_QUERY --> PORTS
+    PROJECT_BATCH --> PORTS
+
+    MEMBER_BATCH -->|"MemberSearchChallenger.gisu returns Gisu"| ORG_BATCH
+```
+
+마지막 연결은 controller끼리 직접 호출한다는 뜻이 아니다. `MemberGraphQlController`가
+`MemberSearchChallenger.gisu`를 공용 GraphQL type인 `Gisu`로 반환하면, 더 깊은 `Gisu.chapters` 또는
+`Gisu.schools` selection은 GraphQL runtime이 `OrganizationGraphQlController`의 BatchMapping에 전달한다.
+각 adapter는 서로를 주입하지 않고 필요한 application inbound port만 사용한다.
 
 ## 실행 경로
 

--- a/docs/onboarding/graphql.md
+++ b/docs/onboarding/graphql.md
@@ -30,6 +30,9 @@ GraphQL endpoint는 하나다.
 POST /graphql
 ```
 
+`/graphql`은 transport 계층 rate limit 대상이다. 기본 한도는 인증 요청 초당 20회·분당 300회,
+익명 요청 초당 5회·분당 60회이며, 한도 초과 시 HTTP 429를 반환한다. `OPTIONS`와 제외 경로에는 적용하지 않는다.
+
 로컬 실행 예시는 다음과 같다.
 
 ```bash
@@ -255,6 +258,72 @@ query {
 ```
 
 `members`는 입력 ID를 중복 제거한 뒤 batch 조회한다.
+
+회원 검색은 `memberSearch`에 검색 조건과 페이지를 전달한다. 관계 필드는 필요한 항목만 선택할 수 있으며,
+`school`, `currentChallenger.gisu`, `challengerRecords.gisu`는 batch resolver로 조회한다.
+
+```graphql
+query {
+  memberSearch(
+    input: { keyword: "kim", part: SPRINGBOOT }
+    page: { page: 0, size: 20 }
+  ) {
+    content {
+      memberId
+      name
+      nickname
+      email
+      school {
+        schoolId
+        schoolName
+      }
+      currentChallenger {
+        challengerId
+        part
+        challengerStatus
+        gisu {
+          gisuId
+          generation
+        }
+      }
+      challengerRecords {
+        challengerId
+        part
+        challengerStatus
+        gisu {
+          gisuId
+          generation
+        }
+      }
+    }
+    page
+    size
+    totalElements
+    totalPages
+    hasNext
+  }
+}
+```
+
+`memberSearch`의 검색 가능 범위는 현재 활성 기수가 아니라 요청자의 전체 챌린저·운영진 이력을 기준으로 계산한다.
+
+| 요청자 이력 또는 역할 | 검색 가능 범위 |
+| --- | --- |
+| 챌린저 이력과 상위 역할이 모두 없는 단순 회원 | 검색 거부 |
+| 챌린저 이력 보유 | 본인이 보유한 기수 ID에 속한 회원만 조회 |
+| 과거 교내 회장 또는 부회장 | 본인 학교의 모든 기수 조회 |
+| 중앙운영사무국 총괄 또는 부총괄 기록, `SUPER_ADMIN` | 기존 member-search 모집단 내 제한 없이 조회 |
+
+학교 범위와 기수 범위를 동시에 가지면 두 범위를 OR로 결합한다. 사용자 검색 조건은 이 권한 범위와
+AND로 결합되며, 권한 scope는 pagination과 count보다 먼저 DB query에 적용된다. 따라서
+`totalElements`, `totalPages`, `hasNext`는 응답 후 필터링된 값이 아니라 동일한 scoped DB count를 반영한다.
+
+페이지 입력을 생략하면 `page: 0`, `size: 20`을 사용한다. `size`는 최대 100이며 첫 버전은 sort 입력을
+지원하지 않고 서버의 안정 정렬을 따른다. `page * size`로 계산한 offset은 최대 10,000이며, 10,000은 허용하고
+초과하면 `BAD_REQUEST`로 거부한다. 검색 결과의 `email`은 `null`이면 `null`로 유지하고, 값이 있으면
+원문을 마스킹해 반환한다. 한 글자 local-part처럼 원문과 달라지지 않는 값은 `[masked-email]`으로 대체하며,
+raw email은 응답하지 않는다. `memberSearch` 복잡도는 요청한 `size`에 가중되며, alias별 비용은 전역 최대 복잡도까지
+누적된다. 잘못된 입력은 최대 크기 비용으로 처리한다.
 
 ## Project 예시
 

--- a/src/main/java/com/umc/product/authorization/application/port/in/query/GetChallengerRoleUseCase.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/query/GetChallengerRoleUseCase.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleBasicInfo;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -18,6 +19,8 @@ public interface GetChallengerRoleUseCase {
     ChallengerRoleInfo getById(Long challengerRoleId);
 
     List<ChallengerRoleInfo> findAllByMemberId(Long memberId);
+
+    List<ChallengerRoleBasicInfo> findAllBasicByMemberId(Long memberId);
 
     /**
      * 슈퍼어드민 여부를 확인합니다. 기수와 무관하게 모든 권한을 가집니다.

--- a/src/main/java/com/umc/product/authorization/application/port/in/query/dto/ChallengerRoleBasicInfo.java
+++ b/src/main/java/com/umc/product/authorization/application/port/in/query/dto/ChallengerRoleBasicInfo.java
@@ -1,0 +1,20 @@
+package com.umc.product.authorization.application.port.in.query.dto;
+
+import com.umc.product.authorization.domain.ChallengerRole;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+
+public record ChallengerRoleBasicInfo(
+    ChallengerRoleType roleType,
+    OrganizationType organizationType,
+    Long organizationId
+) {
+
+    public static ChallengerRoleBasicInfo from(ChallengerRole role) {
+        return new ChallengerRoleBasicInfo(
+            role.getChallengerRoleType(),
+            role.getOrganizationType(),
+            role.getOrganizationId()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleBasicInfo;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
 import com.umc.product.authorization.application.port.out.LoadChallengerRolePort;
 import com.umc.product.authorization.domain.ChallengerRole;
@@ -54,6 +55,13 @@ public class ChallengerRoleQueryService implements GetChallengerRoleUseCase {
     public List<ChallengerRoleInfo> findAllByMemberId(Long memberId) {
         return loadChallengerRolePort.findByMemberId(memberId).stream()
             .map(this::getChallengerRoleInfoFromEntity)
+            .toList();
+    }
+
+    @Override
+    public List<ChallengerRoleBasicInfo> findAllBasicByMemberId(Long memberId) {
+        return loadChallengerRolePort.findByMemberId(memberId).stream()
+            .map(ChallengerRoleBasicInfo::from)
             .toList();
     }
 

--- a/src/main/java/com/umc/product/global/config/GraphQlExecutionConfig.java
+++ b/src/main/java/com/umc/product/global/config/GraphQlExecutionConfig.java
@@ -49,6 +49,9 @@ public class GraphQlExecutionConfig {
         }
 
         Object size = pageMap.get("size");
+        if (size == null) {
+            return DEFAULT_SIZE;
+        }
         if (!(size instanceof Number number)) {
             return MAX_SIZE;
         }

--- a/src/main/java/com/umc/product/global/config/GraphQlExecutionConfig.java
+++ b/src/main/java/com/umc/product/global/config/GraphQlExecutionConfig.java
@@ -1,16 +1,23 @@
 package com.umc.product.global.config;
 
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.server.TimeoutWebGraphQlInterceptor;
 import org.springframework.graphql.server.WebGraphQlInterceptor;
 
+import graphql.analysis.FieldComplexityCalculator;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.analysis.MaxQueryDepthInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 
 @Configuration
 public class GraphQlExecutionConfig {
+
+    private static final String MEMBER_SEARCH_FIELD = "memberSearch";
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
 
     @Bean
     public WebGraphQlInterceptor graphQlTimeoutWebGraphQlInterceptor(GraphQlExecutionProperties properties) {
@@ -24,6 +31,35 @@ public class GraphQlExecutionConfig {
 
     @Bean
     public Instrumentation graphQlMaxQueryComplexityInstrumentation(GraphQlExecutionProperties properties) {
-        return new MaxQueryComplexityInstrumentation(properties.maxComplexity());
+        FieldComplexityCalculator calculator = (environment, childComplexity) -> {
+            if (!MEMBER_SEARCH_FIELD.equals(environment.getField().getName())) {
+                return childComplexity + 1;
+            }
+            return childComplexity + 1 + resolveMemberSearchSize(environment.getArguments().get("page"));
+        };
+        return new MaxQueryComplexityInstrumentation(properties.maxComplexity(), calculator);
+    }
+
+    private static int resolveMemberSearchSize(Object page) {
+        if (page == null) {
+            return DEFAULT_SIZE;
+        }
+        if (!(page instanceof Map<?, ?> pageMap)) {
+            return MAX_SIZE;
+        }
+
+        Object size = pageMap.get("size");
+        if (!(size instanceof Number number)) {
+            return MAX_SIZE;
+        }
+
+        double numericSize = number.doubleValue();
+        if (!Double.isFinite(numericSize) || numericSize < 1 || numericSize > MAX_SIZE
+            || numericSize != Math.rint(numericSize)) {
+            return MAX_SIZE;
+        }
+
+        int resolvedSize = number.intValue();
+        return resolvedSize;
     }
 }

--- a/src/main/java/com/umc/product/global/ratelimit/ApiRateLimitProperties.java
+++ b/src/main/java/com/umc/product/global/ratelimit/ApiRateLimitProperties.java
@@ -18,7 +18,7 @@ public record ApiRateLimitProperties(
 
     public ApiRateLimitProperties {
         enabled = enabled == null || enabled;
-        includePaths = copyOrDefault(includePaths, List.of("/api/**"));
+        includePaths = copyOrDefault(includePaths, List.of("/api/**", "/graphql"));
         excludePaths = copyOrDefault(excludePaths, defaultExcludedPaths());
         authenticatedDefault = authenticatedDefault == null ? new Limit(20, 300) : authenticatedDefault;
         anonymousDefault = anonymousDefault == null ? new Limit(5, 60) : anonymousDefault;
@@ -29,7 +29,7 @@ public record ApiRateLimitProperties(
     public static ApiRateLimitProperties defaults() {
         return new ApiRateLimitProperties(
             true,
-            List.of("/api/**"),
+            List.of("/api/**", "/graphql"),
             defaultExcludedPaths(),
             new Limit(20, 300),
             new Limit(5, 60),

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlController.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
@@ -28,9 +29,16 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.adapter.in.graphql.dto.MemberChallengerGraphQlResponse;
 import com.umc.product.member.adapter.in.graphql.dto.MemberGisuGraphQlResponse;
 import com.umc.product.member.adapter.in.graphql.dto.MemberGraphQlResponse;
+import com.umc.product.member.adapter.in.graphql.dto.MemberPageGraphQlRequest;
+import com.umc.product.member.adapter.in.graphql.dto.MemberPageGraphQlResponse;
 import com.umc.product.member.adapter.in.graphql.dto.MemberSchoolGraphQlResponse;
+import com.umc.product.member.adapter.in.graphql.dto.MemberSearchChallengerGraphQlResponse;
+import com.umc.product.member.adapter.in.graphql.dto.MemberSearchGraphQlRequest;
+import com.umc.product.member.adapter.in.graphql.dto.MemberSearchResultGraphQlResponse;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.adapter.in.graphql.dto.GisuGraphQlResponse;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
@@ -47,6 +55,7 @@ public class MemberGraphQlController {
     private final GetSchoolUseCase getSchoolUseCase;
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetGisuUseCase getGisuUseCase;
+    private final SearchMemberUseCase searchMemberUseCase;
 
     @QueryMapping
     public MemberGraphQlResponse me() {
@@ -78,6 +87,18 @@ public class MemberGraphQlController {
             .filter(Objects::nonNull)
             .map(MemberGraphQlResponse::publicFrom)
             .toList();
+    }
+
+    @QueryMapping
+    public MemberPageGraphQlResponse memberSearch(
+        @Argument MemberSearchGraphQlRequest input,
+        @Argument MemberPageGraphQlRequest page
+    ) {
+        Long requesterMemberId = currentMemberId();
+        Pageable pageable = (page == null ? new MemberPageGraphQlRequest(null, null) : page).toPageable();
+        return MemberPageGraphQlResponse.from(
+            searchMemberUseCase.searchByV2ForGraphQl(input.toQuery(), requesterMemberId, pageable).page()
+        );
     }
 
     @BatchMapping(typeName = "Member", field = "school")
@@ -154,6 +175,56 @@ public class MemberGraphQlController {
         for (MemberChallengerGraphQlResponse challenger : challengers) {
             GisuInfo gisu = gisusById.get(challenger.gisuId());
             result.put(challenger, gisu == null ? null : MemberGisuGraphQlResponse.from(gisu));
+        }
+        return result;
+    }
+
+    @BatchMapping(typeName = "MemberSearchResult", field = "school")
+    public Map<MemberSearchResultGraphQlResponse, MemberSchoolGraphQlResponse> schoolByMemberSearchResult(
+        List<MemberSearchResultGraphQlResponse> members
+    ) {
+        Set<Long> schoolIds = members.stream()
+            .map(MemberSearchResultGraphQlResponse::schoolId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        Map<Long, SchoolDetailInfo> schoolsById = schoolIds.isEmpty()
+            ? Map.of()
+            : getSchoolUseCase.listDetailsByIds(schoolIds).stream()
+                .collect(Collectors.toMap(
+                    SchoolDetailInfo::schoolId,
+                    Function.identity(),
+                    (left, right) -> left
+                ));
+
+        Map<MemberSearchResultGraphQlResponse, MemberSchoolGraphQlResponse> result = new LinkedHashMap<>();
+        for (MemberSearchResultGraphQlResponse member : members) {
+            SchoolDetailInfo school = member.schoolId() == null ? null : schoolsById.get(member.schoolId());
+            result.put(member, school == null ? null : MemberSchoolGraphQlResponse.from(school));
+        }
+        return result;
+    }
+
+    @BatchMapping(typeName = "MemberSearchChallenger", field = "gisu")
+    public Map<MemberSearchChallengerGraphQlResponse, GisuGraphQlResponse> gisuByMemberSearchChallenger(
+        List<MemberSearchChallengerGraphQlResponse> challengers
+    ) {
+        Set<Long> gisuIds = challengers.stream()
+            .map(MemberSearchChallengerGraphQlResponse::gisuId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        Map<Long, GisuInfo> gisusById = gisuIds.isEmpty()
+            ? Map.of()
+            : getGisuUseCase.getByIds(gisuIds).stream()
+                .collect(Collectors.toMap(
+                    GisuInfo::gisuId,
+                    Function.identity(),
+                    (left, right) -> left
+                ));
+
+        Map<MemberSearchChallengerGraphQlResponse, GisuGraphQlResponse> result = new LinkedHashMap<>();
+        for (MemberSearchChallengerGraphQlResponse challenger : challengers) {
+            GisuInfo gisu = challenger.gisuId() == null ? null : gisusById.get(challenger.gisuId());
+            result.put(challenger, gisu == null ? null : GisuGraphQlResponse.from(gisu));
         }
         return result;
     }

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberPageGraphQlRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberPageGraphQlRequest.java
@@ -1,0 +1,30 @@
+package com.umc.product.member.adapter.in.graphql.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public record MemberPageGraphQlRequest(
+    Integer page,
+    Integer size
+) {
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+    private static final long MAX_OFFSET = 10_000L;
+
+    public Pageable toPageable() {
+        int pageNumber = page == null ? DEFAULT_PAGE : page;
+        int pageSize = size == null ? DEFAULT_SIZE : size;
+        if (pageNumber < 0) {
+            throw new IllegalArgumentException("page must be greater than or equal to 0");
+        }
+        if (pageSize <= 0 || pageSize > MAX_SIZE) {
+            throw new IllegalArgumentException("size must be between 1 and " + MAX_SIZE);
+        }
+        long offset = (long) pageNumber * pageSize;
+        if (offset > MAX_OFFSET) {
+            throw new IllegalArgumentException("page offset must be less than or equal to " + MAX_OFFSET);
+        }
+        return PageRequest.of(pageNumber, pageSize);
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberPageGraphQlResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberPageGraphQlResponse.java
@@ -1,0 +1,28 @@
+package com.umc.product.member.adapter.in.graphql.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+
+public record MemberPageGraphQlResponse(
+    List<MemberSearchResultGraphQlResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+
+    public static MemberPageGraphQlResponse from(Page<SearchMemberItemV2Info> page) {
+        return new MemberPageGraphQlResponse(
+            page.getContent().stream().map(MemberSearchResultGraphQlResponse::from).toList(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.hasNext()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchChallengerGraphQlResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchChallengerGraphQlResponse.java
@@ -1,0 +1,35 @@
+package com.umc.product.member.adapter.in.graphql.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.Participation;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info.PrimaryChallenger;
+
+public record MemberSearchChallengerGraphQlResponse(
+    Long challengerId,
+    Long gisuId,
+    Long generation,
+    ChallengerPart part,
+    ChallengerStatus challengerStatus
+) {
+
+    public static MemberSearchChallengerGraphQlResponse from(PrimaryChallenger info) {
+        return new MemberSearchChallengerGraphQlResponse(
+            info.challengerId(),
+            info.gisuId(),
+            info.generation(),
+            info.part(),
+            info.challengerStatus()
+        );
+    }
+
+    public static MemberSearchChallengerGraphQlResponse from(Participation info) {
+        return new MemberSearchChallengerGraphQlResponse(
+            info.challengerId(),
+            info.gisuId(),
+            info.generation(),
+            info.part(),
+            info.challengerStatus()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchGraphQlRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchGraphQlRequest.java
@@ -1,0 +1,17 @@
+package com.umc.product.member.adapter.in.graphql.dto;
+
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+
+public record MemberSearchGraphQlRequest(
+    String keyword,
+    Long gisuId,
+    ChallengerPart part,
+    Long chapterId,
+    Long schoolId
+) {
+
+    public SearchMemberQuery toQuery() {
+        return new SearchMemberQuery(keyword, gisuId, part, chapterId, schoolId);
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchResultGraphQlResponse.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/dto/MemberSearchResultGraphQlResponse.java
@@ -1,0 +1,46 @@
+package com.umc.product.member.adapter.in.graphql.dto;
+
+import java.util.List;
+
+import com.umc.product.global.util.EmailMasker;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+
+public record MemberSearchResultGraphQlResponse(
+    Long memberId,
+    String name,
+    String nickname,
+    String email,
+    Long schoolId,
+    String profileImageLink,
+    MemberSearchChallengerGraphQlResponse currentChallenger,
+    boolean isAdminInActiveGisu,
+    List<MemberSearchChallengerGraphQlResponse> challengerRecords
+) {
+
+    public static MemberSearchResultGraphQlResponse from(SearchMemberItemV2Info info) {
+        return new MemberSearchResultGraphQlResponse(
+            info.memberId(),
+            info.name(),
+            info.nickname(),
+            maskEmail(info.email()),
+            info.schoolId(),
+            info.profileImageLink(),
+            info.primaryChallenger() == null
+                ? null
+                : MemberSearchChallengerGraphQlResponse.from(info.primaryChallenger()),
+            info.isAdminInActiveGisu(),
+            info.participations().stream()
+                .map(MemberSearchChallengerGraphQlResponse::from)
+                .toList()
+        );
+    }
+
+    private static String maskEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+
+        String maskedEmail = EmailMasker.mask(email);
+        return !email.isBlank() && email.equals(maskedEmail) ? "[masked-email]" : maskedEmail;
+    }
+}

--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -1,21 +1,25 @@
 package com.umc.product.member.adapter.out.persistence;
 
-import com.umc.product.challenger.domain.Challenger;
-import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
-import com.umc.product.member.application.port.out.LoadMemberPort;
-import com.umc.product.member.application.port.out.SaveMemberPort;
-import com.umc.product.member.application.port.out.SearchMemberPort;
-import com.umc.product.member.domain.Member;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.application.port.out.SaveMemberPort;
+import com.umc.product.member.application.port.out.SearchMemberPort;
+import com.umc.product.member.domain.Member;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -106,6 +110,11 @@ public class MemberPersistenceAdapter implements LoadMemberPort, SaveMemberPort,
     @Override
     public Page<Long> searchMemberIds(SearchMemberQuery query, Pageable pageable) {
         return memberQueryRepository.searchMemberIdsBy(query, pageable);
+    }
+
+    @Override
+    public Page<Long> searchMemberIds(SearchMemberQuery query, MemberSearchAccessScope scope, Pageable pageable) {
+        return memberQueryRepository.searchMemberIdsBy(query, scope, pageable);
     }
 
     @Override

--- a/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
+++ b/src/main/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepository.java
@@ -16,6 +16,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.QChallenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.domain.Member;
 import com.umc.product.member.domain.QMember;
@@ -121,6 +122,48 @@ public class MemberQueryRepository {
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
+    public Page<Long> searchMemberIdsBy(
+        SearchMemberQuery query,
+        MemberSearchAccessScope scope,
+        Pageable pageable
+    ) {
+        if (scope.denied()) {
+            return Page.empty(pageable);
+        }
+        if (scope.unrestricted()) {
+            return searchMemberIdsBy(query, pageable);
+        }
+
+        QChallenger challenger = QChallenger.challenger;
+        QMember member = QMember.member;
+        BooleanBuilder condition = buildSearchCondition(query, challenger, member);
+        condition.and(buildAccessCondition(scope, challenger, member));
+
+        List<Tuple> rows = queryFactory
+            .select(member.id, member.schoolId, member.name)
+            .distinct()
+            .from(member)
+            .leftJoin(challenger).on(challenger.memberId.eq(member.id))
+            .where(condition)
+            .orderBy(member.schoolId.asc(), member.name.asc(), member.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        List<Long> content = rows.stream()
+            .map(tuple -> tuple.get(member.id))
+            .toList();
+
+        Long total = queryFactory
+            .select(member.id.countDistinct())
+            .from(member)
+            .leftJoin(challenger).on(challenger.memberId.eq(member.id))
+            .where(condition)
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
     // ========= PRIVATE ============
 
     // 필터링
@@ -134,6 +177,24 @@ public class MemberQueryRepository {
         builder.and(partEq(query.part(), challenger));
 
         return builder;
+    }
+
+    private BooleanExpression buildAccessCondition(
+        MemberSearchAccessScope scope,
+        QChallenger challenger,
+        QMember member
+    ) {
+        BooleanExpression schoolCondition = scope.allowedSchoolIds().isEmpty()
+            ? null
+            : member.schoolId.in(scope.allowedSchoolIds());
+        BooleanExpression gisuCondition = scope.allowedGisuIds().isEmpty()
+            ? null
+            : challenger.gisuId.in(scope.allowedGisuIds());
+
+        if (schoolCondition == null) {
+            return gisuCondition != null ? gisuCondition : member.id.isNull();
+        }
+        return gisuCondition == null ? schoolCondition : schoolCondition.or(gisuCondition);
     }
 
     // 검색 관련 조건

--- a/src/main/java/com/umc/product/member/application/dto/MemberSearchAccessScope.java
+++ b/src/main/java/com/umc/product/member/application/dto/MemberSearchAccessScope.java
@@ -1,0 +1,71 @@
+package com.umc.product.member.application.dto;
+
+import java.util.Objects;
+import java.util.Set;
+
+public final class MemberSearchAccessScope {
+
+    private static final MemberSearchAccessScope DENIED = new MemberSearchAccessScope(true, false, Set.of(), Set.of());
+    private static final MemberSearchAccessScope UNRESTRICTED =
+        new MemberSearchAccessScope(false, true, Set.of(), Set.of());
+
+    private final boolean denied;
+    private final boolean unrestricted;
+    private final Set<Long> allowedSchoolIds;
+    private final Set<Long> allowedGisuIds;
+
+    private MemberSearchAccessScope(
+        boolean denied,
+        boolean unrestricted,
+        Set<Long> allowedSchoolIds,
+        Set<Long> allowedGisuIds
+    ) {
+        this.denied = denied;
+        this.unrestricted = unrestricted;
+        this.allowedSchoolIds = Set.copyOf(allowedSchoolIds);
+        this.allowedGisuIds = Set.copyOf(allowedGisuIds);
+    }
+
+    public static MemberSearchAccessScope denyAll() {
+        return DENIED;
+    }
+
+    public static MemberSearchAccessScope allowAll() {
+        return UNRESTRICTED;
+    }
+
+    public static MemberSearchAccessScope restrictedTo(Set<Long> allowedSchoolIds, Set<Long> allowedGisuIds) {
+        Objects.requireNonNull(allowedSchoolIds, "allowedSchoolIds must not be null");
+        Objects.requireNonNull(allowedGisuIds, "allowedGisuIds must not be null");
+        validateIds(allowedSchoolIds, "allowedSchoolIds");
+        validateIds(allowedGisuIds, "allowedGisuIds");
+
+        if (allowedSchoolIds.isEmpty() && allowedGisuIds.isEmpty()) {
+            throw new IllegalArgumentException("Restricted scope must allow at least one school or gisu");
+        }
+
+        return new MemberSearchAccessScope(false, false, allowedSchoolIds, allowedGisuIds);
+    }
+
+    public boolean denied() {
+        return denied;
+    }
+
+    public boolean unrestricted() {
+        return unrestricted;
+    }
+
+    public Set<Long> allowedSchoolIds() {
+        return allowedSchoolIds;
+    }
+
+    public Set<Long> allowedGisuIds() {
+        return allowedGisuIds;
+    }
+
+    private static void validateIds(Set<Long> ids, String fieldName) {
+        if (ids.stream().anyMatch(id -> id == null || id <= 0)) {
+            throw new IllegalArgumentException(fieldName + " must contain only positive IDs");
+        }
+    }
+}

--- a/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/query/SearchMemberUseCase.java
@@ -17,6 +17,8 @@ public interface SearchMemberUseCase {
      */
     SearchMemberV2Result searchByV2(SearchMemberQuery query, Long requesterMemberId, Pageable pageable);
 
+    SearchMemberV2Result searchByV2ForGraphQl(SearchMemberQuery query, Long requesterMemberId, Pageable pageable);
+
     /**
      * v2 챌린저 검색 — 챌린저 단위 페이지네이션. 같은 회원의 여러 기수 챌린저 이력은
      * 각각 별도 row로 반환됩니다. v1 검색 응답 + challengerStatus + isAdminInActiveGisu 필드를 포함합니다.

--- a/src/main/java/com/umc/product/member/application/port/out/SearchMemberPort.java
+++ b/src/main/java/com/umc/product/member/application/port/out/SearchMemberPort.java
@@ -1,9 +1,11 @@
 package com.umc.product.member.application.port.out;
 
-import com.umc.product.challenger.domain.Challenger;
-import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 
 public interface SearchMemberPort {
 
@@ -16,4 +18,6 @@ public interface SearchMemberPort {
      * 회원 단위 검색 (v2). 같은 회원이 여러 챌린저 이력을 가지더라도 1개 row(memberId)로만 반환합니다.
      */
     Page<Long> searchMemberIds(SearchMemberQuery query, Pageable pageable);
+
+    Page<Long> searchMemberIds(SearchMemberQuery query, MemberSearchAccessScope scope, Pageable pageable);
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolver.java
@@ -1,0 +1,59 @@
+package com.umc.product.member.application.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleBasicInfo;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberSearchAccessScopeResolver {
+
+    private final GetChallengerRoleUseCase getChallengerRoleUseCase;
+    private final GetChallengerUseCase getChallengerUseCase;
+
+    public MemberSearchAccessScope resolve(Long memberId) {
+        List<ChallengerRoleBasicInfo> roles = getChallengerRoleUseCase.findAllBasicByMemberId(memberId);
+
+        if (roles.stream().map(ChallengerRoleBasicInfo::roleType).anyMatch(this::grantsUnrestrictedAccess)) {
+            return MemberSearchAccessScope.allowAll();
+        }
+
+        Set<Long> allowedSchoolIds = roles.stream()
+            .filter(role -> grantsSchoolAccess(role.roleType()))
+            .map(ChallengerRoleBasicInfo::organizationId)
+            .collect(Collectors.toUnmodifiableSet());
+
+        Set<Long> allowedGisuIds = getChallengerUseCase.getAllBasicByMemberIds(Set.of(memberId))
+            .getOrDefault(memberId, List.of()).stream()
+            .map(ChallengerBasicInfo::gisuId)
+            .collect(Collectors.toUnmodifiableSet());
+
+        if (allowedSchoolIds.isEmpty() && allowedGisuIds.isEmpty()) {
+            return MemberSearchAccessScope.denyAll();
+        }
+
+        return MemberSearchAccessScope.restrictedTo(allowedSchoolIds, allowedGisuIds);
+    }
+
+    private boolean grantsUnrestrictedAccess(ChallengerRoleType roleType) {
+        return roleType == ChallengerRoleType.SUPER_ADMIN
+            || roleType == ChallengerRoleType.CENTRAL_PRESIDENT
+            || roleType == ChallengerRoleType.CENTRAL_VICE_PRESIDENT;
+    }
+
+    private boolean grantsSchoolAccess(ChallengerRoleType roleType) {
+        return roleType == ChallengerRoleType.SCHOOL_PRESIDENT
+            || roleType == ChallengerRoleType.SCHOOL_VICE_PRESIDENT;
+    }
+}

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolver.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolver.java
@@ -32,11 +32,13 @@ public class MemberSearchAccessScopeResolver {
         Set<Long> allowedSchoolIds = roles.stream()
             .filter(role -> grantsSchoolAccess(role.roleType()))
             .map(ChallengerRoleBasicInfo::organizationId)
+            .filter(this::isPositiveId)
             .collect(Collectors.toUnmodifiableSet());
 
         Set<Long> allowedGisuIds = getChallengerUseCase.getAllBasicByMemberIds(Set.of(memberId))
             .getOrDefault(memberId, List.of()).stream()
             .map(ChallengerBasicInfo::gisuId)
+            .filter(this::isPositiveId)
             .collect(Collectors.toUnmodifiableSet());
 
         if (allowedSchoolIds.isEmpty() && allowedGisuIds.isEmpty()) {
@@ -55,5 +57,9 @@ public class MemberSearchAccessScopeResolver {
     private boolean grantsSchoolAccess(ChallengerRoleType roleType) {
         return roleType == ChallengerRoleType.SCHOOL_PRESIDENT
             || roleType == ChallengerRoleType.SCHOOL_VICE_PRESIDENT;
+    }
+
+    private boolean isPositiveId(Long id) {
+        return id != null && id > 0;
     }
 }

--- a/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberSearchService.java
@@ -19,6 +19,7 @@ import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.ChallengerSearchItemV2Info;
@@ -51,6 +52,7 @@ public class MemberSearchService implements SearchMemberUseCase {
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetChallengerRoleUseCase getChallengerRoleUseCase;
     private final GetGisuUseCase getGisuUseCase;
+    private final MemberSearchAccessScopeResolver memberSearchAccessScopeResolver;
 
     @Override
     public SearchMemberResult searchBy(SearchMemberQuery query, Long requesterMemberId, Pageable pageable) {
@@ -104,6 +106,25 @@ public class MemberSearchService implements SearchMemberUseCase {
     public SearchMemberV2Result searchByV2(SearchMemberQuery query, Long requesterMemberId, Pageable pageable) {
         assertMemberSearchAccess(requesterMemberId);
         Page<Long> memberIdPage = searchMemberPort.searchMemberIds(query, pageable);
+        return assembleV2Result(memberIdPage);
+    }
+
+    @Override
+    public SearchMemberV2Result searchByV2ForGraphQl(
+        SearchMemberQuery query,
+        Long requesterMemberId,
+        Pageable pageable
+    ) {
+        MemberSearchAccessScope scope = memberSearchAccessScopeResolver.resolve(requesterMemberId);
+        if (scope.denied()) {
+            throw new MemberDomainException(MemberErrorCode.MEMBER_SEARCH_ACCESS_DENIED);
+        }
+
+        Page<Long> memberIdPage = searchMemberPort.searchMemberIds(query, scope, pageable);
+        return assembleV2Result(memberIdPage);
+    }
+
+    private SearchMemberV2Result assembleV2Result(Page<Long> memberIdPage) {
         List<Long> memberIds = memberIdPage.getContent();
 
         if (memberIds.isEmpty()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -392,6 +392,7 @@ app:
     enabled: ${API_RATE_LIMIT_ENABLED:true}
     include-paths:
       - /api/**
+      - /graphql
     exclude-paths:
       - /actuator/**
       - /docs

--- a/src/main/resources/graphql/member.graphqls
+++ b/src/main/resources/graphql/member.graphqls
@@ -2,6 +2,51 @@ extend type Query {
   me: Member!
   member(id: ID!): Member
   members(ids: [ID!]!): [Member!]!
+  memberSearch(input: MemberSearchInput!, page: MemberPageInput): MemberPage!
+}
+
+input MemberSearchInput {
+  keyword: String
+  gisuId: ID
+  part: ChallengerPart
+  chapterId: ID
+  schoolId: ID
+}
+
+input MemberPageInput {
+  page: Int = 0
+  size: Int = 20
+}
+
+type MemberPage {
+  content: [MemberSearchResult!]!
+  page: Int!
+  size: Int!
+  totalElements: Long!
+  totalPages: Int!
+  hasNext: Boolean!
+}
+
+type MemberSearchResult {
+  memberId: ID!
+  name: String
+  nickname: String
+  email: String
+  schoolId: ID
+  school: SchoolDetail
+  profileImageLink: String
+  currentChallenger: MemberSearchChallenger
+  isAdminInActiveGisu: Boolean!
+  challengerRecords: [MemberSearchChallenger!]!
+}
+
+type MemberSearchChallenger {
+  challengerId: ID!
+  gisuId: ID!
+  gisu: Gisu
+  generation: ID!
+  part: ChallengerPart!
+  challengerStatus: ChallengerStatus!
 }
 
 type Member {

--- a/src/test/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryServiceTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/query/ChallengerRoleQueryServiceTest.java
@@ -1,0 +1,61 @@
+package com.umc.product.authorization.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleBasicInfo;
+import com.umc.product.authorization.application.port.out.LoadChallengerRolePort;
+import com.umc.product.authorization.domain.ChallengerRole;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengerRoleQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock
+    LoadChallengerRolePort loadChallengerRolePort;
+
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+
+    @InjectMocks
+    ChallengerRoleQueryService service;
+
+    @Test
+    @DisplayName("경량 역할 조회는 역할 범위만 매핑하고 기수 상세를 조회하지 않는다")
+    void 경량_역할_조회는_기수_상세를_조회하지_않는다() {
+        // given
+        ChallengerRole centralRole = ChallengerRole.create(
+            10L, ChallengerRoleType.CENTRAL_PRESIDENT, null, null, 3L
+        );
+        ChallengerRole schoolRole = ChallengerRole.create(
+            11L, ChallengerRoleType.SCHOOL_VICE_PRESIDENT, 7L, null, 4L
+        );
+        given(loadChallengerRolePort.findByMemberId(MEMBER_ID)).willReturn(List.of(centralRole, schoolRole));
+
+        // when
+        List<ChallengerRoleBasicInfo> result = service.findAllBasicByMemberId(MEMBER_ID);
+
+        // then
+        assertThat(result).containsExactly(
+            new ChallengerRoleBasicInfo(ChallengerRoleType.CENTRAL_PRESIDENT, OrganizationType.CENTRAL, null),
+            new ChallengerRoleBasicInfo(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, 7L)
+        );
+        then(loadChallengerRolePort).should().findByMemberId(MEMBER_ID);
+        then(loadChallengerRolePort).shouldHaveNoMoreInteractions();
+        then(getGisuUseCase).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/com/umc/product/global/config/GraphQlExecutionConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/GraphQlExecutionConfigTest.java
@@ -1,0 +1,187 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.graphql.execution.GraphQlSource;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.Scalars;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+class GraphQlExecutionConfigTest {
+
+    @Test
+    @DisplayName("memberSearch는 기본 page.size 비용을 포함한 설정 한도에서 실행된다")
+    void memberSearch는_기본_page_size_비용을_포함한_설정_한도에서_실행된다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 22).execute("""
+            query {
+              memberSearch(input: { keyword: "kim" }) { page }
+            }
+            """);
+
+        assertThat(result.getErrors()).isEmpty();
+        Map<String, Object> data = result.getData();
+        assertThat(data).isEqualTo(Map.of("memberSearch", Map.of("page", 0)));
+        assertThat(dataFetcherInvocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("memberSearch alias 두 개와 큰 page.size는 data fetcher 전에 거부된다")
+    void memberSearch_alias_두_개와_큰_page_size는_data_fetcher_전에_거부된다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 203).execute("""
+            query {
+              first: memberSearch(input: { keyword: "kim" }, page: { size: 100 }) { page }
+              second: memberSearch(input: { keyword: "lee" }, page: { size: 100 }) { page }
+            }
+            """);
+
+        assertRejected(result);
+        assertThat(dataFetcherInvocations.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("size 1은 정확한 복잡도 한도에서 실행된다")
+    void size_1은_정확한_복잡도_한도에서_실행된다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 3).execute("""
+            query {
+              memberSearch(input: { keyword: "kim" }, page: { size: 1 }) { page }
+            }
+            """);
+
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(dataFetcherInvocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("size 100은 size 1의 정확한 복잡도 한도를 초과한다")
+    void size_100은_size_1의_정확한_복잡도_한도를_초과한다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 3).execute("""
+            query {
+              memberSearch(input: { keyword: "kim" }, page: { size: 100 }) { page }
+            }
+            """);
+
+        assertRejected(result);
+        assertThat(dataFetcherInvocations.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("범위를 벗어난 size는 최대 크기 비용으로 계산되어 우회할 수 없다")
+    void 범위를_벗어난_size는_최대_크기_비용으로_계산되어_우회할_수_없다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 22).execute("""
+            query {
+              memberSearch(input: { keyword: "kim" }, page: { size: 101 }) { page }
+            }
+            """);
+
+        assertRejected(result);
+        assertThat(dataFetcherInvocations.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("page가 맵이 아니면 최대 크기 비용으로 계산되어 우회할 수 없다")
+    void page가_맵이_아니면_최대_크기_비용으로_계산되어_우회할_수_없다() {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = malformedPageGraphQl(dataFetcherInvocations, 2).execute("""
+            query {
+              memberSearch(input: "kim", page: "not-a-map") { page }
+            }
+            """);
+
+        assertRejected(result);
+        assertThat(dataFetcherInvocations.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("memberSearch가 아닌 필드는 기본 child complexity + 1 비용을 유지한다")
+    void memberSearch가_아닌_필드는_기본_child_complexity_1_비용을_유지한다() throws IOException {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = actualGraphQl(dataFetcherInvocations, 2).execute("""
+            query {
+              me { memberId }
+            }
+            """);
+
+        assertThat(result.getErrors()).isEmpty();
+        Map<String, Object> data = result.getData();
+        assertThat(data).isEqualTo(Map.of("me", Map.of("memberId", "1")));
+        assertThat(dataFetcherInvocations.get()).isEqualTo(1);
+    }
+
+    private static GraphQL actualGraphQl(AtomicInteger dataFetcherInvocations, int maxComplexity) throws IOException {
+        Resource[] schemaResources = new PathMatchingResourcePatternResolver()
+            .getResources("classpath*:graphql/**/*.graphqls");
+
+        GraphQlSource graphQlSource = GraphQlSource.schemaResourceBuilder()
+            .schemaResources(schemaResources)
+            .configureRuntimeWiring(new GraphQlRuntimeWiringConfig().graphQlRuntimeWiringConfigurer())
+            .configureRuntimeWiring(builder -> builder.type("Query", type -> {
+                type.dataFetcher("memberSearch", environment -> {
+                    dataFetcherInvocations.incrementAndGet();
+                    return Map.of("page", 0);
+                });
+                type.dataFetcher("me", environment -> {
+                    dataFetcherInvocations.incrementAndGet();
+                    return Map.of("memberId", "1");
+                });
+                return type;
+            }))
+            .configureGraphQl(graphQl -> graphQl.instrumentation(complexityInstrumentation(maxComplexity)))
+            .build();
+
+        return graphQlSource.graphQl();
+    }
+
+    private static GraphQL malformedPageGraphQl(AtomicInteger dataFetcherInvocations, int maxComplexity) {
+        GraphQLObjectType pageType = GraphQLObjectType.newObject()
+            .name("MemberPage")
+            .field(field -> field.name("page").type(Scalars.GraphQLInt))
+            .build();
+        GraphQLObjectType queryType = GraphQLObjectType.newObject()
+            .name("Query")
+            .field(field -> field
+                .name("memberSearch")
+                .type(pageType)
+                .argument(argument -> argument.name("input").type(Scalars.GraphQLString))
+                .argument(argument -> argument.name("page").type(Scalars.GraphQLString))
+                .dataFetcher(environment -> {
+                    dataFetcherInvocations.incrementAndGet();
+                    return Map.of("page", 0);
+                }))
+            .build();
+        GraphQLSchema schema = GraphQLSchema.newSchema().query(queryType).build();
+
+        return GraphQL.newGraphQL(schema)
+            .instrumentation(complexityInstrumentation(maxComplexity))
+            .build();
+    }
+
+    private static Instrumentation complexityInstrumentation(int maxComplexity) {
+        GraphQlExecutionProperties properties = new GraphQlExecutionProperties(Duration.ofSeconds(5), 10, maxComplexity);
+        return new GraphQlExecutionConfig().graphQlMaxQueryComplexityInstrumentation(properties);
+    }
+
+    private static void assertRejected(ExecutionResult result) {
+        assertThat(result.getErrors())
+            .anySatisfy(error -> assertThat(error.getMessage()).contains("maximum query complexity exceeded"));
+        Object data = result.getData();
+        assertThat(data).isNull();
+    }
+}

--- a/src/test/java/com/umc/product/global/config/GraphQlExecutionConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/GraphQlExecutionConfigTest.java
@@ -17,6 +17,7 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.Scalars;
 import graphql.execution.instrumentation.Instrumentation;
+import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 
@@ -35,6 +36,20 @@ class GraphQlExecutionConfigTest {
         assertThat(result.getErrors()).isEmpty();
         Map<String, Object> data = result.getData();
         assertThat(data).isEqualTo(Map.of("memberSearch", Map.of("page", 0)));
+        assertThat(dataFetcherInvocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("page에서 size를 생략하면 기본 page.size 비용으로 실행된다")
+    void page에서_size를_생략하면_기본_page_size_비용으로_실행된다() {
+        AtomicInteger dataFetcherInvocations = new AtomicInteger();
+        ExecutionResult result = pageWithoutSizeDefaultGraphQl(dataFetcherInvocations, 22).execute("""
+            query {
+              memberSearch(input: { keyword: "kim" }, page: { page: 1 }) { page }
+            }
+            """);
+
+        assertThat(result.getErrors()).isEmpty();
         assertThat(dataFetcherInvocations.get()).isEqualTo(1);
     }
 
@@ -164,6 +179,42 @@ class GraphQlExecutionConfigTest {
                 .dataFetcher(environment -> {
                     dataFetcherInvocations.incrementAndGet();
                     return Map.of("page", 0);
+                }))
+            .build();
+        GraphQLSchema schema = GraphQLSchema.newSchema().query(queryType).build();
+
+        return GraphQL.newGraphQL(schema)
+            .instrumentation(complexityInstrumentation(maxComplexity))
+            .build();
+    }
+
+    private static GraphQL pageWithoutSizeDefaultGraphQl(
+        AtomicInteger dataFetcherInvocations,
+        int maxComplexity
+    ) {
+        GraphQLInputObjectType searchInputType = GraphQLInputObjectType.newInputObject()
+            .name("MemberSearchInput")
+            .field(field -> field.name("keyword").type(Scalars.GraphQLString))
+            .build();
+        GraphQLInputObjectType pageInputType = GraphQLInputObjectType.newInputObject()
+            .name("MemberPageInput")
+            .field(field -> field.name("page").type(Scalars.GraphQLInt))
+            .field(field -> field.name("size").type(Scalars.GraphQLInt))
+            .build();
+        GraphQLObjectType pageType = GraphQLObjectType.newObject()
+            .name("MemberPage")
+            .field(field -> field.name("page").type(Scalars.GraphQLInt))
+            .build();
+        GraphQLObjectType queryType = GraphQLObjectType.newObject()
+            .name("Query")
+            .field(field -> field
+                .name("memberSearch")
+                .type(pageType)
+                .argument(argument -> argument.name("input").type(searchInputType))
+                .argument(argument -> argument.name("page").type(pageInputType))
+                .dataFetcher(environment -> {
+                    dataFetcherInvocations.incrementAndGet();
+                    return Map.of("page", 1);
                 }))
             .build();
         GraphQLSchema schema = GraphQLSchema.newSchema().query(queryType).build();

--- a/src/test/java/com/umc/product/global/ratelimit/ApiRateLimitInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/ratelimit/ApiRateLimitInterceptorTest.java
@@ -3,6 +3,7 @@ package com.umc.product.global.ratelimit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,9 +12,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,10 +34,52 @@ import com.umc.product.global.config.LoggingInterceptor;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.logging.OperationalMetrics;
 import com.umc.product.global.response.ApiErrorResponseWriter;
+import com.umc.product.global.security.MemberPrincipal;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class ApiRateLimitInterceptorTest {
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증된 POST /graphql 요청은 인증 사용자 기본 한도를 적용한다")
+    void graphql_authenticated_request_uses_authenticated_default_policy() throws Exception {
+        GraphQlController controller = new GraphQlController();
+        MockMvc mockMvc = mockMvc(controller, ApiRateLimitProperties.defaults());
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(new MemberPrincipal(1L), null, List.of())
+        );
+
+        mockMvc.perform(post("/graphql"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("X-RateLimit-Limit", "20"));
+
+        assertThat(controller.invocations()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("익명 POST /graphql 요청은 익명 기본 한도 초과 시 429를 반환한다")
+    void graphql_anonymous_request_returns_429_after_default_limit() throws Exception {
+        GraphQlController controller = new GraphQlController();
+        MockMvc mockMvc = mockMvc(controller, ApiRateLimitProperties.defaults());
+
+        for (int request = 0; request < 5; request++) {
+            mockMvc.perform(post("/graphql"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-RateLimit-Limit", "5"));
+        }
+        mockMvc.perform(post("/graphql"))
+            .andExpect(status().isTooManyRequests())
+            .andExpect(header().exists("Retry-After"))
+            .andExpect(header().string("X-RateLimit-Limit", "5"))
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.TOO_MANY_REQUESTS.getCode()));
+
+        assertThat(controller.invocations()).isEqualTo(5);
+    }
 
     @Test
     @DisplayName("path variable 값이 달라도 같은 route pattern bucket을 공유해 한도 초과 시 429를 반환한다")
@@ -82,7 +128,7 @@ class ApiRateLimitInterceptorTest {
         assertThat(controller.invocations()).isEqualTo(1);
     }
 
-    private static MockMvc mockMvc(ProductController controller, ApiRateLimitProperties properties) {
+    private static MockMvc mockMvc(Object controller, ApiRateLimitProperties properties) {
         ApiRateLimitMetrics metrics = new ApiRateLimitMetrics(new SimpleMeterRegistry());
         ApiRateLimitInterceptor rateLimitInterceptor = new ApiRateLimitInterceptor(
             new RateLimitClientKeyResolver(),
@@ -135,6 +181,22 @@ class ApiRateLimitInterceptorTest {
 
         @RequestMapping(method = RequestMethod.OPTIONS, path = "/api/v1/products/{productId}")
         void options() {
+        }
+
+        int invocations() {
+            return invocations.get();
+        }
+    }
+
+    @RestController
+    private static class GraphQlController {
+
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        @RequestMapping(method = RequestMethod.POST, path = "/graphql")
+        String graphql() {
+            invocations.incrementAndGet();
+            return "graphql";
         }
 
         int invocations() {

--- a/src/test/java/com/umc/product/global/ratelimit/RateLimitPolicyResolverTest.java
+++ b/src/test/java/com/umc/product/global/ratelimit/RateLimitPolicyResolverTest.java
@@ -11,6 +11,30 @@ import org.junit.jupiter.api.Test;
 class RateLimitPolicyResolverTest {
 
     @Test
+    @DisplayName("기본 설정은 POST /graphql에 인증 사용자 기본 정책을 적용한다")
+    void resolve_graphql_authenticated_default_policy() {
+        RateLimitPolicyResolver resolver = new RateLimitPolicyResolver(ApiRateLimitProperties.defaults());
+
+        RateLimitPolicy policy = resolver.resolve("POST", "/graphql", "/graphql", true).orElseThrow();
+
+        assertThat(policy.name()).isEqualTo("authenticated-default");
+        assertThat(policy.requestsPerSecond()).isEqualTo(20);
+        assertThat(policy.requestsPerMinute()).isEqualTo(300);
+    }
+
+    @Test
+    @DisplayName("기본 설정은 POST /graphql에 익명 사용자 기본 정책을 적용한다")
+    void resolve_graphql_anonymous_default_policy() {
+        RateLimitPolicyResolver resolver = new RateLimitPolicyResolver(ApiRateLimitProperties.defaults());
+
+        RateLimitPolicy policy = resolver.resolve("POST", "/graphql", "/graphql", false).orElseThrow();
+
+        assertThat(policy.name()).isEqualTo("anonymous-default");
+        assertThat(policy.requestsPerSecond()).isEqualTo(5);
+        assertThat(policy.requestsPerMinute()).isEqualTo(60);
+    }
+
+    @Test
     @DisplayName("기본 설정은 활성화되어 있고 /api/** GET 요청에는 인증 사용자 기본 정책을 적용한다")
     void resolve_authenticated_default_policy() {
         RateLimitPolicyResolver resolver = new RateLimitPolicyResolver(ApiRateLimitProperties.defaults());
@@ -82,6 +106,7 @@ class RateLimitPolicyResolverTest {
         RateLimitPolicyResolver resolver = new RateLimitPolicyResolver(ApiRateLimitProperties.defaults());
 
         assertThat(resolver.resolve("OPTIONS", "/api/v1/projects", "/api/v1/projects", false)).isEmpty();
+        assertThat(resolver.resolve("OPTIONS", "/graphql", "/graphql", false)).isEmpty();
         assertThat(resolver.resolve("GET", "/docs/scalar.html", "/docs/scalar.html", false)).isEmpty();
         assertThat(resolver.resolve("GET", "/actuator/health", "/actuator/health", false)).isEmpty();
     }

--- a/src/test/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
 
 import java.time.Instant;
 import java.util.LinkedHashSet;
@@ -18,6 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.graphql.execution.ErrorType;
 import org.springframework.graphql.test.tester.GraphQlTester;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -39,13 +43,23 @@ import com.umc.product.global.exception.GraphQlExceptionAdvice;
 import com.umc.product.global.exception.constant.CommonErrorCode;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberItemV2Info;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
+import com.umc.product.member.application.port.in.query.dto.SearchMemberV2Result;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+import com.umc.product.organization.adapter.in.graphql.OrganizationGraphQlController;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuOrganizationUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 
-@GraphQlTest(MemberGraphQlController.class)
+@GraphQlTest({MemberGraphQlController.class, OrganizationGraphQlController.class})
 @Import({GraphQlRuntimeWiringConfig.class, GraphQlExceptionAdvice.class})
 @DisplayName("MemberGraphQlController")
 class MemberGraphQlControllerTest {
@@ -70,6 +84,15 @@ class MemberGraphQlControllerTest {
 
     @MockitoBean
     GetGisuUseCase getGisuUseCase;
+
+    @MockitoBean
+    GetGisuOrganizationUseCase getGisuOrganizationUseCase;
+
+    @MockitoBean
+    GetChapterUseCase getChapterUseCase;
+
+    @MockitoBean
+    SearchMemberUseCase searchMemberUseCase;
 
     @BeforeEach
     void setUpSecurityContext() {
@@ -208,6 +231,642 @@ class MemberGraphQlControllerTest {
     }
 
     @Test
+    @DisplayName("memberSearch는 요청자 권한 범위의 회원을 페이지로 조회하고 이메일을 마스킹한다")
+    void memberSearch는_요청자_권한_범위의_회원을_페이지로_조회하고_이메일을_마스킹한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", 100L, ChallengerPart.SPRINGBOOT, 20L, 10L);
+        PageRequest pageable = PageRequest.of(1, 2);
+        SearchMemberItemV2Info item = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            "member2@example.com",
+            10L,
+            "중앙대학교",
+            "https://cdn.example.com/profile-2.png",
+            new SearchMemberItemV2Info.PrimaryChallenger(
+                200L,
+                100L,
+                6L,
+                ChallengerPart.SPRINGBOOT,
+                ChallengerStatus.ACTIVE
+            ),
+            true,
+            List.of(new SearchMemberItemV2Info.Participation(
+                201L,
+                90L,
+                5L,
+                ChallengerPart.NODEJS,
+                ChallengerStatus.GRADUATED
+            ))
+        );
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(item), pageable, 5)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(
+                    input: { keyword: "kim", gisuId: 100, part: SPRINGBOOT, chapterId: 20, schoolId: 10 }
+                    page: { page: 1, size: 2 }
+                  ) {
+                    content {
+                      memberId
+                      name
+                      nickname
+                      email
+                      schoolId
+                      profileImageLink
+                      currentChallenger {
+                        challengerId
+                        gisuId
+                        generation
+                        part
+                        challengerStatus
+                      }
+                      isAdminInActiveGisu
+                      challengerRecords {
+                        challengerId
+                        gisuId
+                        generation
+                        part
+                        challengerStatus
+                      }
+                    }
+                    page
+                    size
+                    totalElements
+                    totalPages
+                    hasNext
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].memberId").entity(String.class).isEqualTo("2")
+            .path("memberSearch.content[0].name").entity(String.class).isEqualTo("김회원")
+            .path("memberSearch.content[0].nickname").entity(String.class).isEqualTo("키미")
+            .path("memberSearch.content[0].email").entity(String.class).isEqualTo("mem****@example.com")
+            .path("memberSearch.content[0].schoolId").entity(String.class).isEqualTo("10")
+            .path("memberSearch.content[0].profileImageLink").entity(String.class)
+                .isEqualTo("https://cdn.example.com/profile-2.png")
+            .path("memberSearch.content[0].currentChallenger.challengerId").entity(String.class).isEqualTo("200")
+            .path("memberSearch.content[0].currentChallenger.gisuId").entity(String.class).isEqualTo("100")
+            .path("memberSearch.content[0].currentChallenger.generation").entity(String.class).isEqualTo("6")
+            .path("memberSearch.content[0].currentChallenger.part").entity(String.class).isEqualTo("SPRINGBOOT")
+            .path("memberSearch.content[0].currentChallenger.challengerStatus")
+                .entity(String.class).isEqualTo("ACTIVE")
+            .path("memberSearch.content[0].isAdminInActiveGisu").entity(Boolean.class).isEqualTo(true)
+            .path("memberSearch.content[0].challengerRecords[0].challengerId")
+                .entity(String.class).isEqualTo("201")
+            .path("memberSearch.content[0].challengerRecords[0].gisuId").entity(String.class).isEqualTo("90")
+            .path("memberSearch.content[0].challengerRecords[0].generation").entity(String.class).isEqualTo("5")
+            .path("memberSearch.content[0].challengerRecords[0].part").entity(String.class).isEqualTo("NODEJS")
+            .path("memberSearch.content[0].challengerRecords[0].challengerStatus")
+                .entity(String.class).isEqualTo("GRADUATED")
+            .path("memberSearch.page").entity(Integer.class).isEqualTo(1)
+            .path("memberSearch.size").entity(Integer.class).isEqualTo(2)
+            .path("memberSearch.totalElements").entity(Long.class).isEqualTo(5L)
+            .path("memberSearch.totalPages").entity(Integer.class).isEqualTo(3)
+            .path("memberSearch.hasNext").entity(Boolean.class).isEqualTo(true)
+            .path("memberSearch").entity(Object.class)
+                .satisfies(data -> assertThat(data.toString()).doesNotContain("member2@example.com"));
+
+        then(searchMemberUseCase).should().searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 로컬 파트가 한 글자인 이메일도 원문을 노출하지 않는다")
+    void memberSearch는_로컬_파트가_한_글자인_이메일도_원문을_노출하지_않는다() {
+        String rawEmail = "a@umc.com";
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchMemberItemV2Info item = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            rawEmail,
+            10L,
+            "중앙대학교",
+            "https://cdn.example.com/profile-2.png",
+            null,
+            false,
+            List.of()
+        );
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(item), pageable, 1)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) {
+                    content { email }
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].email").entity(String.class)
+                .isEqualTo("[masked-email]")
+            .path("memberSearch").entity(Object.class)
+                .satisfies(data -> assertThat(data.toString()).doesNotContain(rawEmail));
+
+        then(searchMemberUseCase).should().searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 null 이메일과 currentChallenger를 null로 유지한다")
+    void memberSearch는_null_이메일과_currentChallenger를_null로_유지한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchMemberItemV2Info item = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            null,
+            10L,
+            "중앙대학교",
+            "https://cdn.example.com/profile-2.png",
+            null,
+            false,
+            List.of()
+        );
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(item), pageable, 1)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) {
+                    content {
+                      email
+                      currentChallenger { challengerId }
+                      challengerRecords { challengerId }
+                    }
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].email").valueIsNull()
+            .path("memberSearch.content[0].currentChallenger").valueIsNull()
+            .path("memberSearch.content[0].challengerRecords").entityList(Object.class).hasSize(0);
+
+        then(searchMemberUseCase).should().searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 page 입력을 생략하면 0페이지 20개를 조회한다")
+    void memberSearch는_page_입력을_생략하면_기본값으로_조회한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(), pageable, 0)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) {
+                    content { memberId }
+                    page
+                    size
+                    totalElements
+                    totalPages
+                    hasNext
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content").entityList(Object.class).hasSize(0)
+            .path("memberSearch.page").entity(Integer.class).isEqualTo(0)
+            .path("memberSearch.size").entity(Integer.class).isEqualTo(20)
+            .path("memberSearch.totalElements").entity(Long.class).isEqualTo(0L)
+            .path("memberSearch.totalPages").entity(Integer.class).isEqualTo(0)
+            .path("memberSearch.hasNext").entity(Boolean.class).isEqualTo(false);
+
+        then(searchMemberUseCase).should().searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 음수 page를 거부한다")
+    void memberSearch는_음수_page를_거부한다() {
+        assertInvalidMemberPage("page: -1, size: 20");
+    }
+
+    @Test
+    @DisplayName("memberSearch는 0인 size를 거부한다")
+    void memberSearch는_0인_size를_거부한다() {
+        assertInvalidMemberPage("page: 0, size: 0");
+    }
+
+    @Test
+    @DisplayName("memberSearch는 100을 초과한 size를 거부한다")
+    void memberSearch는_100을_초과한_size를_거부한다() {
+        assertInvalidMemberPage("page: 0, size: 101");
+    }
+
+    @Test
+    @DisplayName("memberSearch는 offset이 10000인 페이지를 허용한다")
+    void memberSearch는_offset이_10000인_페이지를_허용한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(100, 100);
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(), pageable, 0)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }, page: { page: 100, size: 100 }) {
+                    totalElements
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.totalElements").entity(Long.class).isEqualTo(0L);
+
+        then(searchMemberUseCase).should().searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 offset이 10000을 초과하면 BAD_REQUEST를 반환하고 검색하지 않는다")
+    void memberSearch는_offset이_10000을_초과하면_거부한다() {
+        assertInvalidMemberPage("page: 101, size: 100");
+    }
+
+    @Test
+    @DisplayName("memberSearch 접근 권한이 거부되면 MEMBER-0014 FORBIDDEN 오류로 매핑한다")
+    void memberSearch_접근_권한이_거부되면_MEMBER_0014_FORBIDDEN_오류로_매핑한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        willThrow(new MemberDomainException(MemberErrorCode.MEMBER_SEARCH_ACCESS_DENIED))
+            .given(searchMemberUseCase)
+            .searchByV2ForGraphQl(query, REQUESTER_ID, pageable);
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) { totalElements }
+                }
+                """)
+            .execute()
+            .errors()
+            .satisfy(errors -> {
+                assertThat(errors).hasSize(1);
+                assertThat(errors.get(0).getPath()).isEqualTo("memberSearch");
+                assertThat(errors.get(0).getErrorType()).isEqualTo(ErrorType.FORBIDDEN);
+                assertThat(errors.get(0).getExtensions())
+                    .containsEntry("code", MemberErrorCode.MEMBER_SEARCH_ACCESS_DENIED.getCode());
+            });
+    }
+
+    @Test
+    @DisplayName("memberSearch는 잘못된 part enum을 실행 전에 거부한다")
+    void memberSearch는_잘못된_part_enum을_실행_전에_거부한다() {
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { part: INVALID_PART }) { totalElements }
+                }
+                """)
+            .execute()
+            .errors()
+            .satisfy(errors -> assertThat(errors).hasSize(1));
+
+        then(searchMemberUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("memberSearch는 숫자가 아닌 ID를 실행 전에 거부한다")
+    void memberSearch는_숫자가_아닌_ID를_실행_전에_거부한다() {
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { gisuId: "invalid-id" }) { totalElements }
+                }
+                """)
+            .execute()
+            .errors()
+            .satisfy(errors -> assertThat(errors).hasSize(1));
+
+        then(searchMemberUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("memberSearch는 school과 현재 및 이력 challenger의 gisu를 batch 조회한다")
+    void memberSearch는_school과_현재_및_이력_challenger의_gisu를_batch_조회한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, ChallengerPart.SPRINGBOOT, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchMemberItemV2Info first = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            "member2@example.com",
+            10L,
+            "중앙대학교",
+            "https://cdn.example.com/profile-2.png",
+            new SearchMemberItemV2Info.PrimaryChallenger(
+                200L,
+                100L,
+                6L,
+                ChallengerPart.SPRINGBOOT,
+                ChallengerStatus.ACTIVE
+            ),
+            false,
+            List.of(
+                new SearchMemberItemV2Info.Participation(
+                    201L,
+                    90L,
+                    5L,
+                    ChallengerPart.NODEJS,
+                    ChallengerStatus.GRADUATED
+                ),
+                new SearchMemberItemV2Info.Participation(
+                    202L,
+                    100L,
+                    6L,
+                    ChallengerPart.SPRINGBOOT,
+                    ChallengerStatus.ACTIVE
+                )
+            )
+        );
+        SearchMemberItemV2Info second = new SearchMemberItemV2Info(
+            3L,
+            "이회원",
+            "리미",
+            null,
+            10L,
+            "중앙대학교",
+            null,
+            new SearchMemberItemV2Info.PrimaryChallenger(
+                300L,
+                100L,
+                6L,
+                ChallengerPart.DESIGN,
+                ChallengerStatus.ACTIVE
+            ),
+            false,
+            List.of(
+                new SearchMemberItemV2Info.Participation(
+                    301L,
+                    999L,
+                    99L,
+                    ChallengerPart.DESIGN,
+                    ChallengerStatus.GRADUATED
+                ),
+                new SearchMemberItemV2Info.Participation(
+                    302L,
+                    null,
+                    null,
+                    ChallengerPart.DESIGN,
+                    ChallengerStatus.GRADUATED
+                )
+            )
+        );
+        SearchMemberItemV2Info missingSchool = new SearchMemberItemV2Info(
+            4L,
+            "박회원",
+            "파미",
+            null,
+            999L,
+            "미등록학교",
+            null,
+            null,
+            false,
+            List.of()
+        );
+        SearchMemberItemV2Info nullSchool = new SearchMemberItemV2Info(
+            5L,
+            "최회원",
+            "초미",
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            List.of()
+        );
+        LinkedHashSet<Long> schoolIds = new LinkedHashSet<>(List.of(10L, 999L));
+        LinkedHashSet<Long> gisuIds = new LinkedHashSet<>(List.of(100L, 90L, 999L));
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(
+                new PageImpl<>(List.of(first, second, missingSchool, nullSchool), pageable, 4)
+            ));
+        given(getSchoolUseCase.listDetailsByIds(schoolIds))
+            .willReturn(List.of(school(10L, "중앙대학교")));
+        given(getGisuUseCase.getByIds(gisuIds))
+            .willReturn(List.of(gisu(100L, 6L), gisu(90L, 5L)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(
+                    input: { keyword: "kim", part: SPRINGBOOT }
+                    page: { page: 0, size: 20 }
+                  ) {
+                    content {
+                      memberId
+                      name
+                      nickname
+                      email
+                      profileImageLink
+                      school {
+                        schoolId
+                        schoolName
+                      }
+                      currentChallenger {
+                        challengerId
+                        part
+                        challengerStatus
+                        gisu {
+                          gisuId
+                          generation
+                        }
+                      }
+                      challengerRecords {
+                        challengerId
+                        part
+                        challengerStatus
+                        gisu {
+                          gisuId
+                          generation
+                        }
+                      }
+                    }
+                    page
+                    size
+                    totalElements
+                    totalPages
+                    hasNext
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].memberId").entity(String.class).isEqualTo("2")
+            .path("memberSearch.content[0].name").entity(String.class).isEqualTo("김회원")
+            .path("memberSearch.content[0].nickname").entity(String.class).isEqualTo("키미")
+            .path("memberSearch.content[0].email").entity(String.class).isEqualTo("mem****@example.com")
+            .path("memberSearch.content[0].profileImageLink").entity(String.class)
+                .isEqualTo("https://cdn.example.com/profile-2.png")
+            .path("memberSearch.content[0].school.schoolId").entity(String.class).isEqualTo("10")
+            .path("memberSearch.content[0].school.schoolName").entity(String.class).isEqualTo("중앙대학교")
+            .path("memberSearch.content[0].currentChallenger.challengerId")
+                .entity(String.class).isEqualTo("200")
+            .path("memberSearch.content[0].currentChallenger.part")
+                .entity(String.class).isEqualTo("SPRINGBOOT")
+            .path("memberSearch.content[0].currentChallenger.challengerStatus")
+                .entity(String.class).isEqualTo("ACTIVE")
+            .path("memberSearch.content[0].currentChallenger.gisu.gisuId")
+                .entity(String.class).isEqualTo("100")
+            .path("memberSearch.content[0].currentChallenger.gisu.generation")
+                .entity(String.class).isEqualTo("6")
+            .path("memberSearch.content[0].challengerRecords[0].gisu.gisuId")
+                .entity(String.class).isEqualTo("90")
+            .path("memberSearch.content[0].challengerRecords[0].gisu.generation")
+                .entity(String.class).isEqualTo("5")
+            .path("memberSearch.content[0].challengerRecords[0].challengerId")
+                .entity(String.class).isEqualTo("201")
+            .path("memberSearch.content[0].challengerRecords[0].part")
+                .entity(String.class).isEqualTo("NODEJS")
+            .path("memberSearch.content[0].challengerRecords[0].challengerStatus")
+                .entity(String.class).isEqualTo("GRADUATED")
+            .path("memberSearch.content[0].challengerRecords[1].gisu.gisuId")
+                .entity(String.class).isEqualTo("100")
+            .path("memberSearch.content[0].challengerRecords[1].gisu.generation")
+                .entity(String.class).isEqualTo("6")
+            .path("memberSearch.content[1].school.schoolId").entity(String.class).isEqualTo("10")
+            .path("memberSearch.content[1].currentChallenger.gisu.gisuId")
+                .entity(String.class).isEqualTo("100")
+            .path("memberSearch.content[1].challengerRecords[0].gisu").valueIsNull()
+            .path("memberSearch.content[1].challengerRecords[1].gisu").valueIsNull()
+            .path("memberSearch.content[2].school").valueIsNull()
+            .path("memberSearch.content[2].currentChallenger").valueIsNull()
+            .path("memberSearch.content[3].school").valueIsNull()
+            .path("memberSearch.page").entity(Integer.class).isEqualTo(0)
+            .path("memberSearch.size").entity(Integer.class).isEqualTo(20)
+            .path("memberSearch.totalElements").entity(Long.class).isEqualTo(4L)
+            .path("memberSearch.totalPages").entity(Integer.class).isEqualTo(1)
+            .path("memberSearch.hasNext").entity(Boolean.class).isEqualTo(false)
+            .path("memberSearch").entity(Object.class)
+                .satisfies(data -> assertThat(data.toString()).doesNotContain("member2@example.com"));
+
+        then(getSchoolUseCase).should().listDetailsByIds(schoolIds);
+        then(getGisuUseCase).should().getByIds(gisuIds);
+    }
+
+    @Test
+    @DisplayName("memberSearch는 공용 Gisu의 chapters와 schools를 nested batch로 조회한다")
+    void memberSearch는_공용_Gisu의_chapters와_schools를_nested_batch로_조회한다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchMemberItemV2Info item = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            null,
+            10L,
+            "중앙대학교",
+            null,
+            new SearchMemberItemV2Info.PrimaryChallenger(
+                200L,
+                100L,
+                6L,
+                ChallengerPart.SPRINGBOOT,
+                ChallengerStatus.ACTIVE
+            ),
+            false,
+            List.of(new SearchMemberItemV2Info.Participation(
+                201L,
+                100L,
+                6L,
+                ChallengerPart.NODEJS,
+                ChallengerStatus.GRADUATED
+            ))
+        );
+        Set<Long> gisuIds = Set.of(100L);
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(item), pageable, 1)));
+        given(getGisuUseCase.getByIds(gisuIds)).willReturn(List.of(gisu(100L, 6L)));
+        given(getChapterUseCase.listByGisuIds(gisuIds)).willReturn(Map.of(
+            100L, List.of(new ChapterInfo(20L, "Ain 지부"))
+        ));
+        given(getSchoolUseCase.getSchoolListByGisuIds(gisuIds)).willReturn(Map.of(
+            100L, List.of(school(10L, "중앙대학교"))
+        ));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) {
+                    content {
+                      currentChallenger {
+                        gisu {
+                          chapters { chapterId chapterName }
+                          schools { schoolId schoolName }
+                        }
+                      }
+                      challengerRecords {
+                        gisu {
+                          chapters { chapterId chapterName }
+                          schools { schoolId schoolName }
+                        }
+                      }
+                    }
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].currentChallenger.gisu.chapters[0].chapterId")
+                .entity(String.class).isEqualTo("20")
+            .path("memberSearch.content[0].currentChallenger.gisu.chapters[0].chapterName")
+                .entity(String.class).isEqualTo("Ain 지부")
+            .path("memberSearch.content[0].currentChallenger.gisu.schools[0].schoolId")
+                .entity(String.class).isEqualTo("10")
+            .path("memberSearch.content[0].currentChallenger.gisu.schools[0].schoolName")
+                .entity(String.class).isEqualTo("중앙대학교")
+            .path("memberSearch.content[0].challengerRecords[0].gisu.chapters[0].chapterId")
+                .entity(String.class).isEqualTo("20")
+            .path("memberSearch.content[0].challengerRecords[0].gisu.schools[0].schoolId")
+                .entity(String.class).isEqualTo("10");
+
+        then(getGisuUseCase).should(times(1)).getByIds(gisuIds);
+        then(getChapterUseCase).should(times(1)).listByGisuIds(gisuIds);
+        then(getSchoolUseCase).should(times(1)).getSchoolListByGisuIds(gisuIds);
+    }
+
+    @Test
+    @DisplayName("memberSearch nested parent ID가 모두 null이면 관련 조회를 호출하지 않는다")
+    void memberSearch_nested_parent_ID가_모두_null이면_관련_조회를_호출하지_않는다() {
+        SearchMemberQuery query = new SearchMemberQuery("kim", null, null, null, null);
+        PageRequest pageable = PageRequest.of(0, 20);
+        SearchMemberItemV2Info item = new SearchMemberItemV2Info(
+            2L,
+            "김회원",
+            "키미",
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            List.of(new SearchMemberItemV2Info.Participation(
+                201L,
+                null,
+                null,
+                ChallengerPart.NODEJS,
+                ChallengerStatus.GRADUATED
+            ))
+        );
+        given(searchMemberUseCase.searchByV2ForGraphQl(query, REQUESTER_ID, pageable))
+            .willReturn(new SearchMemberV2Result(new PageImpl<>(List.of(item), pageable, 1)));
+
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }) {
+                    content {
+                      school { schoolId }
+                      currentChallenger { gisu { gisuId } }
+                      challengerRecords { gisu { gisuId } }
+                    }
+                  }
+                }
+                """)
+            .execute()
+            .path("memberSearch.content[0].school").valueIsNull()
+            .path("memberSearch.content[0].currentChallenger").valueIsNull()
+            .path("memberSearch.content[0].challengerRecords[0].gisu").valueIsNull();
+
+        then(getSchoolUseCase).shouldHaveNoInteractions();
+        then(getGisuUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
     @DisplayName("members는 school과 challengers와 gisu를 nested field로 batch 조회한다")
     void members는_school과_challengers와_gisu를_nested_field로_batch_조회한다() {
         SubjectAttributes subject = subject();
@@ -301,6 +960,19 @@ class MemberGraphQlControllerTest {
         assertThat(errors).hasSize(1);
         assertThat(errors.get(0).getPath()).isEqualTo(path);
         assertThat(errors.get(0).getExtensions()).containsEntry("code", code.getCode());
+    }
+
+    private void assertInvalidMemberPage(String pageInput) {
+        graphQlTester.document("""
+                query {
+                  memberSearch(input: { keyword: "kim" }, page: { %s }) { totalElements }
+                }
+                """.formatted(pageInput))
+            .execute()
+            .errors()
+            .satisfy(errors -> assertCommonError(errors, "memberSearch", CommonErrorCode.BAD_REQUEST));
+
+        then(searchMemberUseCase).shouldHaveNoInteractions();
     }
 
     private MemberInfo memberInfo(Long memberId) {

--- a/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/member/adapter/out/persistence/MemberQueryRepositoryTest.java
@@ -2,6 +2,8 @@ package com.umc.product.member.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.domain.School;
@@ -28,6 +31,174 @@ class MemberQueryRepositoryTest {
 
     @Autowired
     MemberQueryRepository sut;
+
+    @Test
+    @DisplayName("기존 회원 검색은 중복 챌린저를 제거한 안정 순서와 전체 개수로 페이지한다")
+    void 기존_회원_검색은_distinct_회원_기준으로_페이지한다() {
+        // given
+        School school = persistSchool("기존대학교");
+        Member first = persistMember("가회원", "first", "first@test.com", school.getId());
+        Member second = persistMember("나회원", "second", "second@test.com", school.getId());
+        Member third = persistMember("다회원", "third", "third@test.com", school.getId());
+        persistChallenger(first.getId(), ChallengerPart.PLAN, 1L);
+        persistChallenger(first.getId(), ChallengerPart.WEB, 2L);
+        persistChallenger(second.getId(), ChallengerPart.DESIGN, 1L);
+        persistChallenger(third.getId(), ChallengerPart.SPRINGBOOT, 1L);
+        em.flush();
+        em.clear();
+
+        SearchMemberQuery query = new SearchMemberQuery(null, null, null, null, null);
+
+        // when
+        var page = sut.searchMemberIdsBy(query, PageRequest.of(0, 2));
+
+        // then
+        assertThat(page.getContent()).containsExactly(first.getId(), second.getId());
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getSize()).isEqualTo(2);
+        assertThat(page.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기수 범위는 해당 기수 챌린저가 있는 회원만 집계한다")
+    void 기수_범위는_해당_기수_회원만_집계한다() {
+        School school = persistSchool("기수대학교");
+        Member allowed = persistMember("가허용", "allowed", "allowed-gisu@test.com", school.getId());
+        Member denied = persistMember("나제한", "denied", "denied-gisu@test.com", school.getId());
+        persistChallenger(allowed.getId(), ChallengerPart.PLAN, 3L);
+        persistChallenger(denied.getId(), ChallengerPart.PLAN, 9L);
+        em.flush();
+        em.clear();
+
+        var page = sut.searchMemberIdsBy(emptyQuery(),
+            MemberSearchAccessScope.restrictedTo(Set.of(), Set.of(3L)),
+            PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).containsExactly(allowed.getId());
+        assertThat(page.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("학교 범위는 챌린저 이력이 없는 회원도 기수와 무관하게 포함한다")
+    void 학교_범위는_챌린저_없는_회원도_포함한다() {
+        School allowedSchool = persistSchool("허용대학교");
+        School deniedSchool = persistSchool("제한대학교");
+        Member withoutChallenger = persistMember("가무이력", "none", "none@test.com", allowedSchool.getId());
+        Member otherGisu = persistMember("나타기수", "other", "other@test.com", allowedSchool.getId());
+        Member outside = persistMember("다외부", "outside", "outside@test.com", deniedSchool.getId());
+        persistChallenger(otherGisu.getId(), ChallengerPart.WEB, 99L);
+        persistChallenger(outside.getId(), ChallengerPart.WEB, 3L);
+        em.flush();
+        em.clear();
+
+        var page = sut.searchMemberIdsBy(emptyQuery(),
+            MemberSearchAccessScope.restrictedTo(Set.of(allowedSchool.getId()), Set.of()),
+            PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).containsExactly(withoutChallenger.getId(), otherGisu.getId());
+        assertThat(page.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("학교와 기수 범위는 OR로 결합하고 중복 챌린저는 한 회원으로 집계한다")
+    void 학교와_기수_범위는_or이고_중복은_distinct로_집계한다() {
+        School allowedSchool = persistSchool("학교범위대학교");
+        School outsideSchool = persistSchool("외부대학교");
+        Member schoolMember = persistMember("가학교", "school", "school@test.com", allowedSchool.getId());
+        Member gisuMember = persistMember("나기수", "gisu", "gisu@test.com", outsideSchool.getId());
+        Member denied = persistMember("다제한", "denied", "denied@test.com", outsideSchool.getId());
+        persistChallenger(schoolMember.getId(), ChallengerPart.PLAN, 3L);
+        persistChallenger(schoolMember.getId(), ChallengerPart.WEB, 4L);
+        persistChallenger(gisuMember.getId(), ChallengerPart.DESIGN, 3L);
+        persistChallenger(denied.getId(), ChallengerPart.IOS, 9L);
+        em.flush();
+        em.clear();
+
+        var page = sut.searchMemberIdsBy(emptyQuery(),
+            MemberSearchAccessScope.restrictedTo(Set.of(allowedSchool.getId()), Set.of(3L)),
+            PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).containsExactly(schoolMember.getId(), gisuMember.getId());
+        assertThat(page.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("무제한 범위는 기존 회원 검색의 내용과 개수를 보존한다")
+    void 무제한_범위는_기존_검색과_같다() {
+        School school = persistSchool("무제한대학교");
+        Member first = persistMember("가회원", "first-all", "first-all@test.com", school.getId());
+        Member second = persistMember("나회원", "second-all", "second-all@test.com", school.getId());
+        persistChallenger(first.getId(), ChallengerPart.PLAN, 1L);
+        persistChallenger(first.getId(), ChallengerPart.WEB, 2L);
+        persistChallenger(second.getId(), ChallengerPart.DESIGN, 1L);
+        em.flush();
+        em.clear();
+
+        var oldPage = sut.searchMemberIdsBy(emptyQuery(), PageRequest.of(0, 10));
+        var scopedPage = sut.searchMemberIdsBy(emptyQuery(), MemberSearchAccessScope.allowAll(),
+            PageRequest.of(0, 10));
+
+        assertThat(scopedPage.getContent()).isEqualTo(oldPage.getContent());
+        assertThat(scopedPage.getTotalElements()).isEqualTo(oldPage.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("사용자 필터는 접근 범위와 AND로 결합한다")
+    void 사용자_필터는_scope와_and로_결합한다() {
+        School school = persistSchool("필터대학교");
+        Member matched = persistMember("검색허용", "match", "match@test.com", school.getId());
+        Member keywordMiss = persistMember("다른이름", "other-filter", "other-filter@test.com", school.getId());
+        Member scopeMiss = persistMember("검색제한", "match-denied", "match-denied@test.com", school.getId());
+        persistChallenger(matched.getId(), ChallengerPart.PLAN, 3L);
+        persistChallenger(keywordMiss.getId(), ChallengerPart.PLAN, 3L);
+        persistChallenger(scopeMiss.getId(), ChallengerPart.PLAN, 9L);
+        em.flush();
+        em.clear();
+
+        SearchMemberQuery query = new SearchMemberQuery("검색", null, null, null, null);
+        var page = sut.searchMemberIdsBy(query,
+            MemberSearchAccessScope.restrictedTo(Set.of(), Set.of(3L)),
+            PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).containsExactly(matched.getId());
+        assertThat(page.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("제한 범위 페이지의 크기 다음 페이지 여부 전체 개수는 DB 범위 집계를 따른다")
+    void 제한_범위_페이지_메타데이터는_db_집계를_따른다() {
+        School school = persistSchool("페이지대학교");
+        for (int index = 1; index <= 4; index++) {
+            Member member = persistMember("회원" + index, "page" + index, "page" + index + "@test.com", school.getId());
+            persistChallenger(member.getId(), ChallengerPart.PLAN, index <= 3 ? 3L : 9L);
+        }
+        em.flush();
+        em.clear();
+
+        var page = sut.searchMemberIdsBy(emptyQuery(),
+            MemberSearchAccessScope.restrictedTo(Set.of(), Set.of(3L)),
+            PageRequest.of(0, 2));
+
+        assertThat(page.getContent()).hasSize(2);
+        assertThat(page.getSize()).isEqualTo(2);
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("방어적으로 거부 범위가 저장소에 전달되어도 빈 페이지를 반환한다")
+    void 거부_범위는_빈_페이지를_반환한다() {
+        School school = persistSchool("거부대학교");
+        Member member = persistMember("거부회원", "denied-scope", "denied-scope@test.com", school.getId());
+        persistChallenger(member.getId(), ChallengerPart.PLAN, 3L);
+        em.flush();
+        em.clear();
+
+        var page = sut.searchMemberIdsBy(emptyQuery(), MemberSearchAccessScope.denyAll(), PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
 
     @Test
     @DisplayName("keyword는 학교명만 일치하는 회원을 검색하지 않는다")
@@ -112,6 +283,10 @@ class MemberQueryRepositoryTest {
         School school = School.create(name, null);
         em.persist(school);
         return school;
+    }
+
+    private SearchMemberQuery emptyQuery() {
+        return new SearchMemberQuery(null, null, null, null, null);
     }
 
     private Member persistMember(String name, String nickname, String email, Long schoolId) {

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolverTest.java
@@ -139,6 +139,49 @@ class MemberSearchAccessScopeResolverTest {
     }
 
     @Test
+    @DisplayName("유효하지 않은 학교와 기수 ID는 권한 범위에서 제외한다")
+    void 유효하지_않은_학교와_기수_ID는_권한_범위에서_제외한다() {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of(
+            role(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, null),
+            role(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, 0L),
+            role(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, 7L)
+        ));
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of(
+            MEMBER_ID, List.of(challenger(10L, null), challenger(11L, -1L), challenger(12L, 3L))
+        ));
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isFalse();
+        assertThat(scope.allowedSchoolIds()).containsExactly(7L);
+        assertThat(scope.allowedGisuIds()).containsExactly(3L);
+    }
+
+    @Test
+    @DisplayName("학교와 기수 ID가 모두 유효하지 않으면 검색 범위가 거부된다")
+    void 학교와_기수_ID가_모두_유효하지_않으면_거부된다() {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of(
+            role(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, null),
+            role(ChallengerRoleType.SCHOOL_VICE_PRESIDENT, OrganizationType.SCHOOL, 0L)
+        ));
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of(
+            MEMBER_ID, List.of(challenger(10L, null), challenger(11L, -1L))
+        ));
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isTrue();
+        assertThat(scope.allowedSchoolIds()).isEmpty();
+        assertThat(scope.allowedGisuIds()).isEmpty();
+    }
+
+    @Test
     @DisplayName("제한 범위는 입력 Set을 방어적으로 복사하고 수정 불가능하게 노출한다")
     void 제한_범위는_입력_set을_방어적으로_복사한다() {
         // given

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolverTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeResolverTest.java
@@ -1,0 +1,225 @@
+package com.umc.product.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleBasicInfo;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
+
+@ExtendWith(MockitoExtension.class)
+class MemberSearchAccessScopeResolverTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock
+    GetChallengerRoleUseCase getChallengerRoleUseCase;
+
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+
+    @InjectMocks
+    MemberSearchAccessScopeResolver resolver;
+
+    @Test
+    @DisplayName("역할과 챌린저 이력이 없으면 검색 범위가 거부된다")
+    void 역할과_챌린저_이력이_없으면_거부된다() {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of());
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of());
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isTrue();
+        assertThat(scope.unrestricted()).isFalse();
+        assertThat(scope.allowedSchoolIds()).isEmpty();
+        assertThat(scope.allowedGisuIds()).isEmpty();
+        then(getChallengerRoleUseCase).should().findAllBasicByMemberId(MEMBER_ID);
+        then(getChallengerUseCase).should().getAllBasicByMemberIds(Set.of(MEMBER_ID));
+        then(getChallengerRoleUseCase).shouldHaveNoMoreInteractions();
+        then(getChallengerUseCase).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("챌린저 이력은 참여한 모든 기수만 허용한다")
+    void 챌린저_이력은_참여한_모든_기수만_허용한다() {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of());
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of(
+            MEMBER_ID, List.of(challenger(10L, 3L), challenger(11L, 4L), challenger(12L, 3L))
+        ));
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isFalse();
+        assertThat(scope.unrestricted()).isFalse();
+        assertThat(scope.allowedSchoolIds()).isEmpty();
+        assertThat(scope.allowedGisuIds()).containsExactlyInAnyOrder(3L, 4L);
+        then(getChallengerRoleUseCase).should().findAllBasicByMemberId(MEMBER_ID);
+        then(getChallengerUseCase).should().getAllBasicByMemberIds(Set.of(MEMBER_ID));
+        then(getChallengerRoleUseCase).shouldHaveNoMoreInteractions();
+        then(getChallengerUseCase).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("과거 학교 회장 역할은 해당 학교의 모든 기수를 허용한다")
+    void 과거_학교_회장_역할은_해당_학교를_허용한다() {
+        assertSchoolRoleGrantsSchool(ChallengerRoleType.SCHOOL_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("과거 학교 부회장 역할은 해당 학교의 모든 기수를 허용한다")
+    void 과거_학교_부회장_역할은_해당_학교를_허용한다() {
+        assertSchoolRoleGrantsSchool(ChallengerRoleType.SCHOOL_VICE_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("과거 중앙 총괄 역할은 챌린저 이력 없이도 무제한 범위를 허용한다")
+    void 과거_중앙_총괄_역할은_무제한_범위를_허용한다() {
+        assertCentralRoleGrantsUnrestricted(ChallengerRoleType.CENTRAL_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("과거 중앙 부총괄 역할은 챌린저 이력 없이도 무제한 범위를 허용한다")
+    void 과거_중앙_부총괄_역할은_무제한_범위를_허용한다() {
+        assertCentralRoleGrantsUnrestricted(ChallengerRoleType.CENTRAL_VICE_PRESIDENT);
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN 역할은 챌린저 이력 없이도 무제한 범위를 허용한다")
+    void superAdmin_역할은_무제한_범위를_허용한다() {
+        assertCentralRoleGrantsUnrestricted(ChallengerRoleType.SUPER_ADMIN);
+    }
+
+    @Test
+    @DisplayName("학교 범위와 챌린저 기수 범위 두 집합이 함께 보존된다")
+    void 학교와_기수_범위_두_집합이_함께_보존된다() {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of(
+            role(ChallengerRoleType.SCHOOL_PRESIDENT, OrganizationType.SCHOOL, 7L)
+        ));
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of(
+            MEMBER_ID, List.of(challenger(10L, 3L), challenger(11L, 4L))
+        ));
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isFalse();
+        assertThat(scope.unrestricted()).isFalse();
+        assertThat(scope.allowedSchoolIds()).containsExactly(7L);
+        assertThat(scope.allowedGisuIds()).containsExactlyInAnyOrder(3L, 4L);
+        then(getChallengerRoleUseCase).should().findAllBasicByMemberId(MEMBER_ID);
+        then(getChallengerUseCase).should().getAllBasicByMemberIds(Set.of(MEMBER_ID));
+        then(getChallengerRoleUseCase).shouldHaveNoMoreInteractions();
+        then(getChallengerUseCase).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("제한 범위는 입력 Set을 방어적으로 복사하고 수정 불가능하게 노출한다")
+    void 제한_범위는_입력_set을_방어적으로_복사한다() {
+        // given
+        Set<Long> schoolIds = new HashSet<>(Set.of(7L));
+        Set<Long> gisuIds = new HashSet<>(Set.of(3L, 4L));
+
+        // when
+        MemberSearchAccessScope scope = MemberSearchAccessScope.restrictedTo(schoolIds, gisuIds);
+        schoolIds.add(8L);
+        gisuIds.clear();
+
+        // then
+        assertThat(scope.allowedSchoolIds()).containsExactly(7L);
+        assertThat(scope.allowedGisuIds()).containsExactlyInAnyOrder(3L, 4L);
+        assertThatThrownBy(() -> scope.allowedSchoolIds().add(9L))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("제한 범위 factory는 null Set과 유효하지 않은 ID를 거부한다")
+    void 제한_범위_factory는_잘못된_입력을_거부한다() {
+        // when & then
+        assertThatThrownBy(() -> MemberSearchAccessScope.restrictedTo(null, Set.of()))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> MemberSearchAccessScope.restrictedTo(Set.of(), Set.of(0L)))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MemberSearchAccessScope.restrictedTo(Set.of(-1L), Set.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MemberSearchAccessScope.restrictedTo(Set.of(), Set.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void assertSchoolRoleGrantsSchool(ChallengerRoleType roleType) {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of(
+            role(roleType, OrganizationType.SCHOOL, 7L)
+        ));
+        given(getChallengerUseCase.getAllBasicByMemberIds(Set.of(MEMBER_ID))).willReturn(Map.of());
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isFalse();
+        assertThat(scope.unrestricted()).isFalse();
+        assertThat(scope.allowedSchoolIds()).containsExactly(7L);
+        assertThat(scope.allowedGisuIds()).isEmpty();
+        then(getChallengerRoleUseCase).should().findAllBasicByMemberId(MEMBER_ID);
+        then(getChallengerUseCase).should().getAllBasicByMemberIds(Set.of(MEMBER_ID));
+        then(getChallengerRoleUseCase).shouldHaveNoMoreInteractions();
+        then(getChallengerUseCase).shouldHaveNoMoreInteractions();
+    }
+
+    private void assertCentralRoleGrantsUnrestricted(ChallengerRoleType roleType) {
+        // given
+        given(getChallengerRoleUseCase.findAllBasicByMemberId(MEMBER_ID)).willReturn(List.of(
+            role(roleType, OrganizationType.CENTRAL, null)
+        ));
+
+        // when
+        MemberSearchAccessScope scope = resolver.resolve(MEMBER_ID);
+
+        // then
+        assertThat(scope.denied()).isFalse();
+        assertThat(scope.unrestricted()).isTrue();
+        assertThat(scope.allowedSchoolIds()).isEmpty();
+        assertThat(scope.allowedGisuIds()).isEmpty();
+        then(getChallengerRoleUseCase).should().findAllBasicByMemberId(MEMBER_ID);
+        then(getChallengerRoleUseCase).shouldHaveNoMoreInteractions();
+        then(getChallengerUseCase).shouldHaveNoInteractions();
+    }
+
+    private ChallengerRoleBasicInfo role(
+        ChallengerRoleType roleType,
+        OrganizationType organizationType,
+        Long organizationId
+    ) {
+        return new ChallengerRoleBasicInfo(roleType, organizationType, organizationId);
+    }
+
+    private ChallengerBasicInfo challenger(Long challengerId, Long gisuId) {
+        return new ChallengerBasicInfo(challengerId, MEMBER_ID, gisuId, null, null);
+    }
+}

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchAccessScopeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.CheckChallengerHistoryUseCase;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.member.application.dto.MemberSearchAccessScope;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.SearchMemberQuery;
 import com.umc.product.member.application.port.out.SearchMemberPort;
@@ -53,8 +56,62 @@ class MemberSearchAccessScopeTest {
     @Mock
     GetGisuUseCase getGisuUseCase;
 
+    @Mock
+    MemberSearchAccessScopeResolver memberSearchAccessScopeResolver;
+
     @InjectMocks
     MemberSearchService sut;
+
+    @Test
+    @DisplayName("GraphQL 검색 범위가 거부되면 포트를 호출하기 전에 예외를 던진다")
+    void graphql_검색_범위가_거부되면_포트_호출_전에_예외를_던진다() {
+        SearchMemberQuery query = new SearchMemberQuery(null, null, null, null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        given(memberSearchAccessScopeResolver.resolve(REQUESTER_MEMBER_ID))
+            .willReturn(MemberSearchAccessScope.denyAll());
+
+        assertThatThrownBy(() -> sut.searchByV2ForGraphQl(query, REQUESTER_MEMBER_ID, pageable))
+            .isInstanceOf(MemberDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(MemberErrorCode.MEMBER_SEARCH_ACCESS_DENIED);
+
+        then(searchMemberPort).shouldHaveNoInteractions();
+        then(checkChallengerHistoryUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("GraphQL 제한 검색은 학교와 기수 범위를 범위 포트에 전달한다")
+    void graphql_제한_검색은_scope를_범위_포트에_전달한다() {
+        SearchMemberQuery query = new SearchMemberQuery(null, null, null, null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        MemberSearchAccessScope scope = MemberSearchAccessScope.restrictedTo(Set.of(7L), Set.of(3L, 4L));
+        given(memberSearchAccessScopeResolver.resolve(REQUESTER_MEMBER_ID)).willReturn(scope);
+        given(searchMemberPort.searchMemberIds(query, scope, pageable)).willReturn(Page.empty(pageable));
+
+        var result = sut.searchByV2ForGraphQl(query, REQUESTER_MEMBER_ID, pageable);
+
+        assertThat(result.page()).isEmpty();
+        then(searchMemberPort).should().searchMemberIds(query, scope, pageable);
+        then(searchMemberPort).shouldHaveNoMoreInteractions();
+        then(checkChallengerHistoryUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("GraphQL 무제한 검색도 범위 포트에 무제한 범위를 전달한다")
+    void graphql_무제한_검색은_무제한_scope를_범위_포트에_전달한다() {
+        SearchMemberQuery query = new SearchMemberQuery(null, null, null, null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        MemberSearchAccessScope scope = MemberSearchAccessScope.allowAll();
+        given(memberSearchAccessScopeResolver.resolve(REQUESTER_MEMBER_ID)).willReturn(scope);
+        given(searchMemberPort.searchMemberIds(query, scope, pageable)).willReturn(Page.empty(pageable));
+
+        var result = sut.searchByV2ForGraphQl(query, REQUESTER_MEMBER_ID, pageable);
+
+        assertThat(result.page()).isEmpty();
+        then(searchMemberPort).should().searchMemberIds(query, scope, pageable);
+        then(searchMemberPort).shouldHaveNoMoreInteractions();
+        then(checkChallengerHistoryUseCase).shouldHaveNoInteractions();
+    }
 
     @Test
     @DisplayName("챌린저 기록이 없으면 회원 검색을 거부한다")

--- a/src/test/java/com/umc/product/member/application/service/MemberSearchServiceTest.java
+++ b/src/test/java/com/umc/product/member/application/service/MemberSearchServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.time.Instant;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.query.CheckChallengerHistoryUseCase;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
@@ -51,6 +53,9 @@ class MemberSearchServiceTest {
 
     @Mock
     CheckChallengerHistoryUseCase checkChallengerHistoryUseCase;
+
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
 
     @Mock
     GetChallengerRoleUseCase getChallengerRoleUseCase;
@@ -118,6 +123,23 @@ class MemberSearchServiceTest {
     @Nested
     @DisplayName("search")
     class SearchTest {
+
+        @Test
+        @DisplayName("기존 REST V2 검색은 챌린저 이력을 확인한 뒤 비범위 포트를 호출한다")
+        void 기존_rest_v2_검색은_챌린저_이력_확인_후_비범위_포트를_호출한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            given(searchMemberPort.searchMemberIds(defaultQuery, pageable))
+                .willReturn(Page.empty(pageable));
+
+            // when
+            var result = memberSearchService.searchByV2(defaultQuery, REQUESTER_MEMBER_ID, pageable);
+
+            // then
+            assertThat(result.page()).isEmpty();
+            then(checkChallengerHistoryUseCase).should().hasChallengerHistory(REQUESTER_MEMBER_ID);
+            then(searchMemberPort).should().searchMemberIds(defaultQuery, pageable);
+        }
 
         @Test
         void 첫_페이지_조회_시_정상적으로_결과를_반환한다() {


### PR DESCRIPTION
## 🚀 작업 내용

- 클라이언트가 필요한 관계만 선택할 수 있도록 `memberSearch(input, page)` GraphQL query와 page metadata를 추가했어요. 검색 결과의 `school`, 현재/과거 challenger의 `gisu`, `chapters`, `schools`는 batch resolver로 조회해요.
- 요청자의 전체 이력을 기준으로 검색 범위를 계산해요. 챌린저 이력이 없으면 거부하고, 챌린저 이력은 해당 기수, 과거 교내 회장/부회장은 본인 학교 전체 기수, 중앙 총괄/부총괄 및 `SUPER_ADMIN`은 기존 member-search 모집단 전체를 조회할 수 있어요.
- 학교와 기수 범위는 OR, 사용자 검색 조건은 AND로 결합하고, 동일한 QueryDSL predicate를 content와 count에 적용한 뒤 pagination을 수행해요. 기존 REST v2 검색과 `members(ids)` 계약은 유지했어요.
- email은 GraphQL DTO 경계에서 항상 마스킹하고, 한 글자 local-part처럼 원문과 같아지는 경우에는 `[masked-email]`로 대체해요.
- 고비용 검색 보호를 위해 `/graphql`을 기존 rate limit에 포함하고, member search offset을 10,000으로 제한했어요. 요청 `size`와 alias 수를 GraphQL complexity에 반영해 data fetcher 실행 전에 과도한 query를 거부해요.

## 💬 리뷰 중점사항

- 권한 범위가 활성 기수가 아닌 전체 role/challenger 이력을 사용하며, school/gisu OR와 사용자 filter AND가 DB pagination/count 전에 적용되는지 확인해 주세요.
- `MemberSearchChallenger.gisu`는 공용 `GisuGraphQlResponse`를 반환해 `Gisu.chapters/schools` resolver와 동일한 parent type을 사용해요.
- `/graphql` rate limit은 기존 인증/익명 기본 정책을 사용하고, `memberSearch`만 page-size 가중 complexity를 적용해요. 전역 timeout/depth 제한과 다른 GraphQL field의 기본 complexity는 유지해요.
- canonical 검증은 13 suites, 107 tests가 failures/errors/skipped 없이 통과했고 compile, Spotless, Checkstyle, diff check도 통과했어요.
- 실제 HTTP에서 익명 `/graphql` 요청 1~5회는 200/FORBIDDEN, 6회는 429/COMMON-429를 확인했어요. 두 개의 `size: 100` alias는 complexity `204 > 200`, offset 10,100은 BAD_REQUEST로 거부되는 것도 확인했어요.
- 최종 debugging audit의 권한, persistence pagination/count, GraphQL 보호 3개 가설은 9 suites, 86 tests로 재검증했고 owned process, port, container를 정리했어요.
