### PR TITLE
[Chore] GraphQL 모니터링 대시보드 추가

### DIFF
--- a/infra/monitoring/grafana/README.md
+++ b/infra/monitoring/grafana/README.md
@@ -78,6 +78,17 @@ HTTP request counter / duration histogram 에서 요청 총량, 요청 수 Top 1
 p95 latency Top 10 을 계산한다. Top 10 테이블의 행 링크는 해당 `uri` 에 대응하는
 Loki 로그를 열며, 로그의 `traceId` derived field 를 통해 Tempo 요청 flow 로 이동할 수 있다.
 
+## GraphQL 대시보드
+
+Grafana 의 **UMC PRODUCT** 폴더 > **UMC PRODUCT — GraphQL** 대시보드
+(`config/grafana/dashboards/graphql.json`)에서 GraphQL 요청률, 오류율, p95/p99 지연,
+operation type/outcome 분포, resolver와 DataLoader의 호출량·지연·오류를 확인할 수 있다.
+
+GraphQL metric에는 요청 본문, variables, raw query를 넣지 않는다. `operationName`과
+`executionId`는 trace의 high-cardinality attribute로만 기록되므로 Prometheus 패널에는
+노출하지 않는다. 개별 요청의 operation name과 실행 흐름이 필요하면 대시보드 상단의
+Tempo 링크에서 해당 trace를 확인한다.
+
 ## API 처리 흐름 보기 (Tempo + Node graph)
 
 각 API 요청이 어떤 계층을 거치는지(`controller -> usecase -> adapter -> db`)와, 아웃박스 relay 가 원 요청 trace 와 어떻게 span link 로 이어지는지를 Tempo 로 추적한다. 계층별 span 은 앱의 `TraceFlowAspect` 가 자동 생성하며 `app.layer` / `app.domain` / `app.usecase` / `app.adapter.type` 태그를 단다.

--- a/infra/monitoring/grafana/config/grafana/dashboards/graphql.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/graphql.json
@@ -1,0 +1,1005 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Spring GraphQL Micrometer metric 기반 운영 대시보드. 요청 본문, variables, raw query는 metric에 수집하지 않는다. operationName과 executionId는 trace의 high-cardinality attribute로만 확인하며, Prometheus에서는 operation type/outcome, resolver field/error type, DataLoader name을 집계한다.",
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Tempo에서 요청 trace 확인",
+      "type": "link",
+      "url": "/d/umc-product-api-flow"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 서비스, 환경, 인스턴스, operation type의 초당 GraphQL 요청 수.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))",
+          "legendFormat": "requests/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GraphQL 요청률",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "REQUEST_ERROR 또는 INTERNAL_ERROR 요청 비율. GraphQL은 오류가 있어도 HTTP 200일 수 있으므로 HTTP status 대신 이 값을 사용한다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\", graphql_outcome=~\"REQUEST_ERROR|INTERNAL_ERROR\"}[$__rate_interval])) / clamp_min(sum(rate(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval])), 0.000000001)",
+          "legendFormat": "error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GraphQL 오류율",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "GraphQL 요청 전체 실행 시간의 p95.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(graphql_request_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "요청 지연 p95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "GraphQL 요청 전체 실행 시간의 p99.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(graphql_request_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "요청 지연 p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "SUCCESS, REQUEST_ERROR, INTERNAL_ERROR별 요청률 추이.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (graphql_outcome) (rate(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))",
+          "legendFormat": "{{graphql_outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "요청률 추이 — outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "GraphQL 요청 전체 실행 시간의 p50, p95, p99 추이.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(graphql_request_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(graphql_request_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(graphql_request_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "요청 지연 추이",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 시간 범위의 operation type별 총 요청 수. operationName은 metric label이 아니므로 표시하지 않는다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (graphql_operation_type) (increase(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__range]))",
+          "legendFormat": "{{graphql_operation_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "요청 수 — operation type",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 시간 범위의 outcome별 총 요청 수.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (graphql_outcome) (increase(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__range]))",
+          "legendFormat": "{{graphql_outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "요청 수 — outcome",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Grafana에서 선택한 시간 범위의 전체 GraphQL 요청 수.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_operation_type=~\"$operation_type\"}[$__range]))",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "선택 범위 전체 요청",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "non-trivial DataFetcher field별 초당 실행 수 Top 10. 단순 property fetcher와 DataLoader 기반 field는 별도로 계측된다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(10, sum by (graphql_field_name) (rate(graphql_datafetcher_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{graphql_field_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resolver 호출률 Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "field별 DataFetcher 실행 시간 p95 Top 10.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, graphql_field_name) (rate(graphql_datafetcher_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}[$__rate_interval])))) / 1000",
+          "legendFormat": "{{graphql_field_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resolver 지연 p95 Top 10",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 시간 범위의 DataFetcher 오류 Top 10. field와 예외 class를 함께 표시한다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(10, sum by (graphql_field_name, graphql_error_type) (increase(graphql_datafetcher_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_outcome=\"ERROR\"}[$__range])))",
+          "legendFormat": "{{graphql_field_name}} — {{graphql_error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resolver 오류 Top 10",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "DataLoader name별 초당 batch 실행 수.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (graphql_loader_name) (rate(graphql_dataloader_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{graphql_loader_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DataLoader 호출률",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "DataLoader name별 batch 실행 시간 p95.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, graphql_loader_name) (rate(graphql_dataloader_milliseconds_bucket{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "{{graphql_loader_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DataLoader 지연 p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 시간 범위의 DataLoader 오류. loader name과 예외 class를 함께 표시한다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (graphql_loader_name, graphql_error_type) (increase(graphql_dataloader_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\", graphql_outcome=\"ERROR\"}[$__range]))",
+          "legendFormat": "{{graphql_loader_name}} — {{graphql_error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DataLoader 오류",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "umc-product",
+    "graphql",
+    "spring-graphql",
+    "prometheus",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(graphql_request_milliseconds_count, application)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "query": {
+          "query": "label_values(graphql_request_milliseconds_count, application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(graphql_request_milliseconds_count{application=~\"$service\"}, environment)",
+        "includeAll": true,
+        "label": "Environment",
+        "multi": true,
+        "name": "environment",
+        "query": {
+          "query": "label_values(graphql_request_milliseconds_count{application=~\"$service\"}, environment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\"}, instance)",
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "query": {
+          "query": "label_values(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}, graphql_operation_type)",
+        "includeAll": true,
+        "label": "Operation type",
+        "multi": true,
+        "name": "operation_type",
+        "query": {
+          "query": "label_values(graphql_request_milliseconds_count{application=~\"$service\", environment=~\"$environment\", instance=~\"$instance\"}, graphql_operation_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "UMC PRODUCT — GraphQL",
+  "uid": "umc-product-graphql",
+  "version": 1
+}


### PR DESCRIPTION
## 🚀 작업 내용

- GraphQL 요청률, 오류율, p95/p99 지연, operation type/outcome 분포를 확인할 수 있는 Grafana 대시보드를 추가했어요.
- Resolver와 DataLoader의 호출률, 지연, 오류를 포함해 총 15개 Prometheus 패널을 구성했어요.
- 프로젝트의 OTLP 형식에 맞춰 `graphql_*_milliseconds_*` metric을 사용하고, 지연 값은 초 단위로 변환했어요.
- `service`, `environment`, `instance`, `operation_type` 변수를 추가해 관측 대상을 필터링할 수 있도록 했어요.
- raw query와 variables는 metric에 저장하지 않고, `operationName`과 `executionId`는 Tempo trace에서 확인하도록 링크와 운영 문서를 추가했어요.
- dashboard JSON 구조와 패널 배치를 검증하고, 17개 PromQL의 Prometheus 파싱, Grafana provisioning, Tempo 링크 이동, 데스크톱·1024px 화면 표시를 확인했어요.
- JSON과 문서 변경만 포함되어 Gradle 테스트는 실행하지 않았어요.

## 💬 리뷰 중점사항

- Micrometer OTLP에서 GraphQL Timer가 `_milliseconds_*` 이름으로 노출되는 것을 기준으로 PromQL을 작성했으니 metric 이름과 단위 변환을 중점적으로 확인해 주세요.
- raw query와 variables를 수집하지 않는 것은 보안과 cardinality를 고려한 의도적인 설계예요.
- 로컬 환경에 실제 GraphQL 트래픽이 없어 데이터가 채워진 시계열과 legend 상태는 확인하지 못했어요.
