### PR TITLE
[Feat] 프로젝트 완료 배치 API 추가

### DIFF
--- a/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/ProjectCommandController.java
@@ -18,6 +18,7 @@ import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.AddProjectMemberRequest;
 import com.umc.product.project.adapter.in.web.dto.request.ChangeProjectMemberStatusRequest;
+import com.umc.product.project.adapter.in.web.dto.request.CompleteProjectsRequest;
 import com.umc.product.project.adapter.in.web.dto.request.CreateDraftProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.TransferProjectOwnershipRequest;
 import com.umc.product.project.adapter.in.web.dto.request.UpdatePartQuotasRequest;
@@ -26,6 +27,7 @@ import com.umc.product.project.adapter.in.web.dto.response.ProjectStatusResponse
 import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
 import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.ChangeProjectMemberStatusUseCase;
+import com.umc.product.project.application.port.in.command.CompleteProjectsUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
@@ -62,6 +64,7 @@ public class ProjectCommandController {
     private final PublishProjectUseCase publishProjectUseCase;
     private final DeleteProjectUseCase deleteProjectUseCase;
     private final AbortProjectUseCase abortProjectUseCase;
+    private final CompleteProjectsUseCase completeProjectsUseCase;
 
     @PostMapping
     @Operation(
@@ -252,6 +255,24 @@ public class ProjectCommandController {
         @Valid @RequestBody AbortProjectRequest request
     ) {
         abortProjectUseCase.abort(request.toCommand(projectId, memberPrincipal.getMemberId()));
+    }
+
+    @PostMapping("/complete")
+    @Operation(
+        operationId = "PROJECT-111",
+        summary = "프로젝트 완료 (배치)",
+        description = "기수 종료 시 IN_PROGRESS 상태의 프로젝트들을 COMPLETED 로 일괄 전이합니다. ACTIVE ProjectMember 는 COMPLETED, 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 동기화. 대상마다 MANAGE 권한을 검증하며 하나라도 조건 미충족 시 전체 롤백. 운영진(본인 지부장 또는 Central Core) 만 호출 가능."
+    )
+    @CheckAccess(
+        resourceType = ResourceType.PROJECT,
+        permission = PermissionType.MANAGE,
+        message = "프로젝트를 완료할 권한이 없어요. 필요한 권한이 있다면 운영진에게 문의해주세요."
+    )
+    public void complete(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @Valid @RequestBody CompleteProjectsRequest request
+    ) {
+        completeProjectsUseCase.complete(request.toCommand(memberPrincipal.getMemberId()));
     }
 
     @DeleteMapping("/{projectId}/members/{memberId}")

--- a/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CompleteProjectsRequest.java
+++ b/src/main/java/com/umc/product/project/adapter/in/web/dto/request/CompleteProjectsRequest.java
@@ -1,0 +1,21 @@
+package com.umc.product.project.adapter.in.web.dto.request;
+
+import java.util.List;
+
+import com.umc.product.project.application.port.in.command.dto.CompleteProjectsCommand;
+
+import jakarta.validation.constraints.NotEmpty;
+
+/**
+ * 프로젝트 완료(complete) 요청 DTO. 기수 종료 시 여러 프로젝트를 한 번에 완료 처리합니다.
+ */
+public record CompleteProjectsRequest(
+    @NotEmpty List<Long> projectIds
+) {
+    public CompleteProjectsCommand toCommand(Long requesterMemberId) {
+        return CompleteProjectsCommand.builder()
+            .projectIds(projectIds)
+            .requesterMemberId(requesterMemberId)
+            .build();
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/CompleteProjectsUseCase.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/CompleteProjectsUseCase.java
@@ -1,0 +1,19 @@
+package com.umc.product.project.application.port.in.command;
+
+import com.umc.product.project.application.port.in.command.dto.CompleteProjectsCommand;
+
+/**
+ * 프로젝트 완료(complete) UseCase.
+ * <p>
+ * IN_PROGRESS 상태 프로젝트들을 COMPLETED 로 전이합니다. ACTIVE ProjectMember 는 COMPLETED,
+ * 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 일괄 동기화합니다.
+ * <p>
+ * 배치 처리이며, 대상 중 하나라도 MANAGE 권한이 없거나 IN_PROGRESS 가 아니면 전체 롤백합니다.
+ */
+public interface CompleteProjectsUseCase {
+
+    /**
+     * 프로젝트들을 완료 처리합니다.
+     */
+    void complete(CompleteProjectsCommand command);
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CompleteProjectsCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CompleteProjectsCommand.java
@@ -1,0 +1,27 @@
+package com.umc.product.project.application.port.in.command.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+import lombok.Builder;
+
+/**
+ * 프로젝트 완료(complete) Command.
+ * <p>
+ * 기수 종료 시 여러 IN_PROGRESS 프로젝트를 한 번에 COMPLETED 로 전이합니다. ACTIVE 멤버는 COMPLETED,
+ * 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 동기화합니다.
+ * <p>
+ * 원자적으로 처리되며, 대상 중 하나라도 상태/권한 조건을 만족하지 못하면 전체 롤백됩니다.
+ */
+@Builder
+public record CompleteProjectsCommand(
+    List<Long> projectIds,
+    Long requesterMemberId
+) {
+    public CompleteProjectsCommand {
+        Objects.requireNonNull(requesterMemberId, "requesterMemberId must not be null");
+        if (projectIds == null || projectIds.isEmpty()) {
+            throw new IllegalArgumentException("projectIds must not be empty");
+        }
+    }
+}

--- a/src/main/java/com/umc/product/project/application/port/in/command/dto/CompleteProjectsCommand.java
+++ b/src/main/java/com/umc/product/project/application/port/in/command/dto/CompleteProjectsCommand.java
@@ -23,5 +23,8 @@ public record CompleteProjectsCommand(
         if (projectIds == null || projectIds.isEmpty()) {
             throw new IllegalArgumentException("projectIds must not be empty");
         }
+        if (projectIds.stream().distinct().count() != projectIds.size()) {
+            throw new IllegalArgumentException("projectIds must not contain duplicates");
+        }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -351,22 +351,26 @@ public class ProjectCommandService implements
     )
     @Override
     public void complete(CompleteProjectsCommand command) {
-        for (Long projectId : command.projectIds()) {
+        List<Project> projects = loadProjectPort.listByIds(command.projectIds());
+        if (projects.size() != command.projectIds().size()) {
+            throw new ProjectDomainException(ProjectErrorCode.PROJECT_NOT_FOUND);
+        }
+
+        for (Project project : projects) {
             checkPermissionUseCase.checkOrThrow(
                 command.requesterMemberId(),
-                ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.MANAGE)
+                ResourcePermission.of(ResourceType.PROJECT, project.getId(), PermissionType.MANAGE)
             );
 
-            Project project = loadProjectPort.getById(projectId);
             project.complete(command.requesterMemberId());
 
-            List<ProjectMember> activeMembers = loadProjectMemberPort.listByProjectId(projectId);
+            List<ProjectMember> activeMembers = loadProjectMemberPort.listByProjectId(project.getId());
             for (ProjectMember member : activeMembers) {
                 member.complete(command.requesterMemberId());
             }
 
             List<ProjectApplication> inProgressApplications =
-                loadProjectApplicationPort.listInProgressByProjectId(projectId);
+                loadProjectApplicationPort.listInProgressByProjectId(project.getId());
             for (ProjectApplication application : inProgressApplications) {
                 application.cancel(command.requesterMemberId(), COMPLETE_APPLICATION_CANCEL_REASON);
             }

--- a/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
+++ b/src/main/java/com/umc/product/project/application/service/command/ProjectCommandService.java
@@ -8,8 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.umc.product.audit.application.port.in.annotation.Audited;
 import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourcePermission;
+import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -24,6 +28,7 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
+import com.umc.product.project.application.port.in.command.CompleteProjectsUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
@@ -31,6 +36,7 @@ import com.umc.product.project.application.port.in.command.SubmitProjectUseCase;
 import com.umc.product.project.application.port.in.command.TransferProjectOwnershipUseCase;
 import com.umc.product.project.application.port.in.command.UpdateProjectUseCase;
 import com.umc.product.project.application.port.in.command.dto.AbortProjectCommand;
+import com.umc.product.project.application.port.in.command.dto.CompleteProjectsCommand;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.DeleteProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.PublishProjectCommand;
@@ -68,7 +74,10 @@ public class ProjectCommandService implements
     TransferProjectOwnershipUseCase,
     PublishProjectUseCase,
     DeleteProjectUseCase,
-    AbortProjectUseCase {
+    AbortProjectUseCase,
+    CompleteProjectsUseCase {
+
+    private static final String COMPLETE_APPLICATION_CANCEL_REASON = "프로젝트가 완료되어 자동 취소되었습니다.";
 
     private final LoadProjectPort loadProjectPort;
     private final SaveProjectPort saveProjectPort;
@@ -80,6 +89,7 @@ public class ProjectCommandService implements
     private final SaveProjectPartQuotaPort saveProjectPartQuotaPort;
     private final SaveProjectApplicationFormPort saveProjectApplicationFormPort;
     private final SaveProjectApplicationFormPolicyPort saveProjectApplicationFormPolicyPort;
+    private final CheckPermissionUseCase checkPermissionUseCase;
 
     // Cross-domain UseCases
     private final GetMemberUseCase getMemberUseCase;
@@ -319,6 +329,47 @@ public class ProjectCommandService implements
             loadProjectApplicationPort.listInProgressByProjectId(project.getId());
         for (ProjectApplication application : inProgressApplications) {
             application.cancel(command.requesterMemberId(), command.reason());
+        }
+    }
+
+    /**
+     * 프로젝트 완료(complete). 기수 종료 시 여러 IN_PROGRESS 프로젝트를 COMPLETED 로 일괄 전이 + 자식 도메인 동기화.
+     * <ul>
+     *   <li>대상 프로젝트마다 MANAGE 권한을 검증 (배열 입력이라 Controller {@code @CheckAccess} 로는 단건 바인딩 불가)</li>
+     *   <li>{@link Project#complete} 로 상태 전이 (IN_PROGRESS 가 아니면 도메인 가드가 거부)</li>
+     *   <li>ACTIVE 인 ProjectMember 는 모두 COMPLETED (정상 졸업이므로 사유 없음)</li>
+     *   <li>진행 중(DRAFT/SUBMITTED) ProjectApplication 은 모두 CANCELLED, 사유에 완료 자동 취소 명시</li>
+     * </ul>
+     * {@code @Transactional} 이므로 대상 중 하나라도 권한/상태 조건을 만족하지 못하면 전체 롤백된다.
+     */
+    @Audited(
+        domain = Domain.PROJECT,
+        action = AuditAction.FINALIZE,
+        targetType = "Project",
+        targetId = "#command.projectIds()",
+        description = "'프로젝트를 완료 처리했습니다.'"
+    )
+    @Override
+    public void complete(CompleteProjectsCommand command) {
+        for (Long projectId : command.projectIds()) {
+            checkPermissionUseCase.checkOrThrow(
+                command.requesterMemberId(),
+                ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.MANAGE)
+            );
+
+            Project project = loadProjectPort.getById(projectId);
+            project.complete(command.requesterMemberId());
+
+            List<ProjectMember> activeMembers = loadProjectMemberPort.listByProjectId(projectId);
+            for (ProjectMember member : activeMembers) {
+                member.complete(command.requesterMemberId());
+            }
+
+            List<ProjectApplication> inProgressApplications =
+                loadProjectApplicationPort.listInProgressByProjectId(projectId);
+            for (ProjectApplication application : inProgressApplications) {
+                application.cancel(command.requesterMemberId(), COMPLETE_APPLICATION_CANCEL_REASON);
+            }
         }
     }
 }

--- a/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluator.java
@@ -133,13 +133,30 @@ public class ProjectPermissionEvaluator implements ResourcePermissionEvaluator {
      * <p>
      * 해당 기수의 총괄단(SUPER_ADMIN 은 글로벌) 또는 본인 지부장(해당 기수)만 통과.
      * 종료 상태(COMPLETED/ABORTED)는 절대 차단.
+     * <p>
+     * {@code resourceId} 가 없으면 특정 프로젝트가 아닌 타입 전체에 대한 진입 게이트로 동작한다
+     * (배치 complete 등 다건 액션의 Controller 관문). 이때는 리소스를 로드하지 않고 운영진 자격만 본다.
+     * 프로젝트별 상태·scope 검증은 각 리소스 id 로 다시 evaluate 하는 Service 레이어가 담당한다.
      */
     private boolean canManage(SubjectAttributes subject, ResourcePermission permission) {
+        if (permission.resourceId() == null) {
+            return hasAnyProjectAdminRole(subject);
+        }
         Project project = loadProject(permission);
         return switch (project.getStatus()) {
             case PENDING_REVIEW, IN_PROGRESS -> isProjectAdmin(subject, project);
             case DRAFT, COMPLETED, ABORTED -> false;
         };
+    }
+
+    /**
+     * 특정 프로젝트와 무관하게, 어느 기수/지부에서든 프로젝트 운영진(총괄단 또는 지부장) 역할을 가졌는지 여부.
+     * 타입 전체 MANAGE 진입 게이트 판정에 사용한다.
+     */
+    private boolean hasAnyProjectAdminRole(SubjectAttributes subject) {
+        return subject.roleAttributes().stream()
+            .anyMatch(role -> role.roleType().isAtLeastCentralCore()
+                || role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT);
     }
 
     /**

--- a/src/main/java/com/umc/product/project/application/service/query/ProjectPermissionQueryService.java
+++ b/src/main/java/com/umc/product/project/application/service/query/ProjectPermissionQueryService.java
@@ -64,11 +64,6 @@ public class ProjectPermissionQueryService implements GetProjectPermissionsUseCa
             ProjectPermissionReason.NOT_IMPLEMENTED,
             "아직은 지원 폼 삭제를 별도로 지원하지 않아요."
         );
-    private static final ProjectPermissionCapabilityInfo NOT_IMPLEMENTED_PROJECT_COMPLETE =
-        ProjectPermissionCapabilityInfo.denied(
-            ProjectPermissionReason.NOT_IMPLEMENTED,
-            "아직 프로젝트 완료 처리를 지원하지 않아요."
-        );
 
     private final CheckPermissionUseCase checkPermissionUseCase;
     private final LoadProjectPort loadProjectPort;
@@ -228,7 +223,7 @@ public class ProjectPermissionQueryService implements GetProjectPermissionsUseCa
         return new StatusPermissions(
             canRequestReview(context),
             canPublishProject(context),
-            NOT_IMPLEMENTED_PROJECT_COMPLETE,
+            canCompleteProject(context),
             canAbortProject(context)
         );
     }
@@ -270,6 +265,18 @@ public class ProjectPermissionQueryService implements GetProjectPermissionsUseCa
                 return ProjectPermissionCapabilityInfo.denied(
                     ProjectPermissionReason.INVALID_PROJECT_STATUS,
                     "현재 진행 중인 프로젝트만 중단 시킬 수 있어요."
+                );
+            }
+            return ProjectPermissionCapabilityInfo.allow();
+        });
+    }
+
+    private ProjectPermissionCapabilityInfo canCompleteProject(ProjectCapabilityContext context) {
+        return requirePermission(context.projectPermission(PermissionType.MANAGE), () -> {
+            if (context.project().getStatus() != ProjectStatus.IN_PROGRESS) {
+                return ProjectPermissionCapabilityInfo.denied(
+                    ProjectPermissionReason.INVALID_PROJECT_STATUS,
+                    "현재 진행 중인 프로젝트만 완료 처리할 수 있어요."
                 );
             }
             return ProjectPermissionCapabilityInfo.allow();

--- a/src/main/java/com/umc/product/project/domain/Project.java
+++ b/src/main/java/com/umc/product/project/domain/Project.java
@@ -259,11 +259,14 @@ public class Project extends BaseEntity {
     }
 
     /**
-     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다.
+     * 기수가 종료되었을 때, 프로젝트를 완료 처리 합니다. IN_PROGRESS 상태에서만 허용합니다.
+     *
+     * @param decidedByMemberId 완료 처리한 운영진 Member ID (audit 용)
      */
-    public void complete() {
+    public void complete(Long decidedByMemberId) {
         validateStatus(ProjectStatus.IN_PROGRESS);
         this.status = ProjectStatus.COMPLETED;
+        this.statusChangedByMemberId = decidedByMemberId;
     }
 
     /**

--- a/src/main/java/com/umc/product/project/domain/ProjectMember.java
+++ b/src/main/java/com/umc/product/project/domain/ProjectMember.java
@@ -150,4 +150,14 @@ public class ProjectMember extends BaseEntity {
     public void withdraw(String reason, Long decidedByMemberId) {
         changeStatus(ProjectMemberStatus.WITHDRAWN, decidedByMemberId, reason);
     }
+
+    /**
+     * 멤버 활동을 정상 완료 처리합니다.
+     * status 를 {@link ProjectMemberStatus#COMPLETED} 로 바꾸고 변경 메타데이터를 기록합니다.
+     * <p>
+     * 프로젝트 완료(complete) 시 ACTIVE 멤버 일괄 처리에 사용합니다.
+     */
+    public void complete(Long decidedByMemberId) {
+        changeStatus(ProjectMemberStatus.COMPLETED, decidedByMemberId, null);
+    }
 }

--- a/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/web/ProjectCommandControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +28,11 @@ import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.project.adapter.in.web.dto.request.AbortProjectRequest;
 import com.umc.product.project.adapter.in.web.dto.request.ChangeProjectMemberStatusRequest;
+import com.umc.product.project.adapter.in.web.dto.request.CompleteProjectsRequest;
 import com.umc.product.project.application.port.in.command.AbortProjectUseCase;
 import com.umc.product.project.application.port.in.command.AddProjectMemberUseCase;
 import com.umc.product.project.application.port.in.command.ChangeProjectMemberStatusUseCase;
+import com.umc.product.project.application.port.in.command.CompleteProjectsUseCase;
 import com.umc.product.project.application.port.in.command.CreateDraftProjectUseCase;
 import com.umc.product.project.application.port.in.command.DeleteProjectUseCase;
 import com.umc.product.project.application.port.in.command.PublishProjectUseCase;
@@ -78,6 +82,8 @@ class ProjectCommandControllerTest {
     DeleteProjectUseCase deleteProjectUseCase;
     @MockitoBean
     AbortProjectUseCase abortProjectUseCase;
+    @MockitoBean
+    CompleteProjectsUseCase completeProjectsUseCase;
 
     @BeforeEach
     void setUpSecurityContext() {
@@ -128,6 +134,39 @@ class ProjectCommandControllerTest {
             .andExpect(status().isBadRequest());
 
         then(abortProjectUseCase).should(never()).abort(any());
+    }
+
+    @Test
+    void POST_프로젝트_완료_200() throws Exception {
+        CompleteProjectsRequest request = new CompleteProjectsRequest(List.of(1L, 2L, 3L));
+
+        mockMvc.perform(post("/api/v1/projects/complete")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        then(completeProjectsUseCase).should().complete(any());
+    }
+
+    @Test
+    void POST_프로젝트_완료_projectIds_비어있으면_400() throws Exception {
+        CompleteProjectsRequest request = new CompleteProjectsRequest(List.of());
+
+        mockMvc.perform(post("/api/v1/projects/complete")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(completeProjectsUseCase).should(never()).complete(any());
+    }
+
+    @Test
+    void POST_프로젝트_완료_body_누락이면_400() throws Exception {
+        mockMvc.perform(post("/api/v1/projects/complete")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+
+        then(completeProjectsUseCase).should(never()).complete(any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -3,9 +3,15 @@ package com.umc.product.project.application.service.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,6 +23,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.authorization.application.port.in.query.GetChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.authorization.domain.PermissionType;
+import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
+import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -28,6 +38,7 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+import com.umc.product.project.application.port.in.command.dto.CompleteProjectsCommand;
 import com.umc.product.project.application.port.in.command.dto.CreateDraftProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.SubmitProjectCommand;
 import com.umc.product.project.application.port.in.command.dto.TransferProjectOwnershipCommand;
@@ -36,6 +47,9 @@ import com.umc.product.project.application.port.out.LoadProjectApplicationFormPo
 import com.umc.product.project.application.port.out.LoadProjectPort;
 import com.umc.product.project.application.port.out.SaveProjectPort;
 import com.umc.product.project.domain.Project;
+import com.umc.product.project.domain.ProjectApplication;
+import com.umc.product.project.domain.ProjectMember;
+import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 import com.umc.product.project.domain.exception.ProjectDomainException;
 import com.umc.product.project.domain.exception.ProjectErrorCode;
@@ -75,6 +89,8 @@ class ProjectCommandServiceTest {
     GetChapterUseCase getChapterUseCase;
     @Mock
     com.umc.product.form.application.port.in.command.ManageFormUseCase manageFormUseCase;
+    @Mock
+    com.umc.product.authorization.application.port.in.CheckPermissionUseCase checkPermissionUseCase;
 
     @InjectMocks
     ProjectCommandService sut;
@@ -764,6 +780,109 @@ class ProjectCommandServiceTest {
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_ABORT_REASON_REQUIRED);
+        }
+    }
+
+    @Nested
+    class complete {
+
+        private CompleteProjectsCommand command(List<Long> projectIds) {
+            return CompleteProjectsCommand.builder()
+                .projectIds(projectIds).requesterMemberId(99L).build();
+        }
+
+        @Test
+        void IN_PROGRESS_상태에서_멤버_COMPLETED_application_CANCELLED() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            ProjectMember activeMember = ProjectMember.create(project, 500L, ChallengerPart.WEB, 100L);
+
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of(activeMember));
+            given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of());
+
+            sut.complete(command(List.of(1L)));
+
+            assertThat(project.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
+            assertThat(project.getStatusChangedByMemberId()).isEqualTo(99L);
+            assertThat(activeMember.getStatus()).isEqualTo(ProjectMemberStatus.COMPLETED);
+            assertThat(activeMember.getStatusChangedMemberId()).isEqualTo(99L);
+        }
+
+        @Test
+        void 진행중_지원서는_완료_자동취소_사유와_함께_CANCELLED된다() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            ProjectApplication application = mock(ProjectApplication.class);
+
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of());
+            given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of(application));
+
+            sut.complete(command(List.of(1L)));
+
+            then(application).should().cancel(eq(99L), eq("프로젝트가 완료되어 자동 취소되었습니다."));
+        }
+
+        @Test
+        void 여러_프로젝트를_한번에_완료_처리한다() {
+            Project first = createProject(ProjectStatus.IN_PROGRESS);
+            Project second = createProject(ProjectStatus.IN_PROGRESS);
+            ReflectionTestUtils.setField(second, "id", 2L);
+
+            given(loadProjectPort.getById(1L)).willReturn(first);
+            given(loadProjectPort.getById(2L)).willReturn(second);
+            given(loadProjectMemberPort.listByProjectId(any())).willReturn(List.of());
+            given(loadProjectApplicationPort.listInProgressByProjectId(any())).willReturn(List.of());
+
+            sut.complete(command(List.of(1L, 2L)));
+
+            assertThat(first.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
+            assertThat(second.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
+        }
+
+        @Test
+        void 대상_프로젝트마다_MANAGE_권한을_검증한다() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of());
+            given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of());
+
+            sut.complete(command(List.of(1L)));
+
+            then(checkPermissionUseCase).should()
+                .checkOrThrow(eq(99L), argThat(permission ->
+                    permission.resourceType() == ResourceType.PROJECT
+                        && permission.permission() == PermissionType.MANAGE
+                        && permission.getResourceIdAsLong().equals(1L)));
+        }
+
+        @Test
+        void 권한이_없으면_예외가_전파되고_상태전이가_일어나지_않는다() {
+            willThrow(new AuthorizationDomainException(AuthorizationErrorCode.PERMISSION_DENIED))
+                .given(checkPermissionUseCase)
+                .checkOrThrow(eq(99L), any());
+
+            assertThatThrownBy(() -> sut.complete(command(List.of(1L, 2L))))
+                .isInstanceOf(AuthorizationDomainException.class);
+
+            // 권한 검증이 상태 전이보다 앞서므로, 프로젝트 로드/전이 자체가 시작되지 않는다.
+            then(loadProjectPort).should(never()).getById(any());
+        }
+
+        @Test
+        void IN_PROGRESS가_아니면_PROJECT_INVALID_STATE로_롤백된다() {
+            Project project = createProject(ProjectStatus.PENDING_REVIEW);
+            given(loadProjectPort.getById(1L)).willReturn(project);
+
+            assertThatThrownBy(() -> sut.complete(command(List.of(1L))))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void projectIds가_비어있으면_Command_생성_단계에서_예외() {
+            assertThatThrownBy(() -> command(List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
         }
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -884,5 +884,11 @@ class ProjectCommandServiceTest {
             assertThatThrownBy(() -> command(List.of()))
                 .isInstanceOf(IllegalArgumentException.class);
         }
+
+        @Test
+        void projectIds에_중복이_있으면_Command_생성_단계에서_예외() {
+            assertThatThrownBy(() -> command(List.of(1L, 1L, 2L)))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 }

--- a/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/command/ProjectCommandServiceTest.java
@@ -796,7 +796,7 @@ class ProjectCommandServiceTest {
             Project project = createProject(ProjectStatus.IN_PROGRESS);
             ProjectMember activeMember = ProjectMember.create(project, 500L, ChallengerPart.WEB, 100L);
 
-            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectPort.listByIds(List.of(1L))).willReturn(List.of(project));
             given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of(activeMember));
             given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of());
 
@@ -813,7 +813,7 @@ class ProjectCommandServiceTest {
             Project project = createProject(ProjectStatus.IN_PROGRESS);
             ProjectApplication application = mock(ProjectApplication.class);
 
-            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectPort.listByIds(List.of(1L))).willReturn(List.of(project));
             given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of());
             given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of(application));
 
@@ -828,8 +828,7 @@ class ProjectCommandServiceTest {
             Project second = createProject(ProjectStatus.IN_PROGRESS);
             ReflectionTestUtils.setField(second, "id", 2L);
 
-            given(loadProjectPort.getById(1L)).willReturn(first);
-            given(loadProjectPort.getById(2L)).willReturn(second);
+            given(loadProjectPort.listByIds(List.of(1L, 2L))).willReturn(List.of(first, second));
             given(loadProjectMemberPort.listByProjectId(any())).willReturn(List.of());
             given(loadProjectApplicationPort.listInProgressByProjectId(any())).willReturn(List.of());
 
@@ -842,7 +841,7 @@ class ProjectCommandServiceTest {
         @Test
         void 대상_프로젝트마다_MANAGE_권한을_검증한다() {
             Project project = createProject(ProjectStatus.IN_PROGRESS);
-            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectPort.listByIds(List.of(1L))).willReturn(List.of(project));
             given(loadProjectMemberPort.listByProjectId(1L)).willReturn(List.of());
             given(loadProjectApplicationPort.listInProgressByProjectId(1L)).willReturn(List.of());
 
@@ -857,26 +856,38 @@ class ProjectCommandServiceTest {
 
         @Test
         void 권한이_없으면_예외가_전파되고_상태전이가_일어나지_않는다() {
+            Project first = createProject(ProjectStatus.IN_PROGRESS);
+            given(loadProjectPort.listByIds(List.of(1L))).willReturn(List.of(first));
             willThrow(new AuthorizationDomainException(AuthorizationErrorCode.PERMISSION_DENIED))
                 .given(checkPermissionUseCase)
                 .checkOrThrow(eq(99L), any());
 
-            assertThatThrownBy(() -> sut.complete(command(List.of(1L, 2L))))
+            assertThatThrownBy(() -> sut.complete(command(List.of(1L))))
                 .isInstanceOf(AuthorizationDomainException.class);
 
-            // 권한 검증이 상태 전이보다 앞서므로, 프로젝트 로드/전이 자체가 시작되지 않는다.
-            then(loadProjectPort).should(never()).getById(any());
+            assertThat(first.getStatus()).isEqualTo(ProjectStatus.IN_PROGRESS);
         }
 
         @Test
         void IN_PROGRESS가_아니면_PROJECT_INVALID_STATE로_롤백된다() {
             Project project = createProject(ProjectStatus.PENDING_REVIEW);
-            given(loadProjectPort.getById(1L)).willReturn(project);
+            given(loadProjectPort.listByIds(List.of(1L))).willReturn(List.of(project));
 
             assertThatThrownBy(() -> sut.complete(command(List.of(1L))))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);
+        }
+
+        @Test
+        void 존재하지_않는_프로젝트가_섞여있으면_PROJECT_NOT_FOUND로_롤백된다() {
+            Project project = createProject(ProjectStatus.IN_PROGRESS);
+            given(loadProjectPort.listByIds(List.of(1L, 2L))).willReturn(List.of(project));
+
+            assertThatThrownBy(() -> sut.complete(command(List.of(1L, 2L))))
+                .isInstanceOf(ProjectDomainException.class)
+                .extracting("baseCode")
+                .isEqualTo(ProjectErrorCode.PROJECT_NOT_FOUND);
         }
 
         @Test

--- a/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/project/application/service/evaluator/ProjectPermissionEvaluatorTest.java
@@ -750,6 +750,42 @@ class ProjectPermissionEvaluatorTest {
         assertThat(sut.evaluate(subject, permission)).isFalse();
     }
 
+    // --- MANAGE 진입 게이트 (resourceId 없음 — 배치 complete 등 다건 액션의 Controller 관문) ---
+
+    @Test
+    void MANAGE_진입게이트는_중앙총괄이면_리소스_로드없이_허용() {
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(centralCoreRole()));
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        // 리소스 로드 없이 통과 — findById stubbing 없이도 성공하는 것으로 증명된다.
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void MANAGE_진입게이트는_지부장이면_허용() {
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(chapterPresidentRole(1L, 1L)));
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        assertThat(sut.evaluate(subject, permission)).isTrue();
+    }
+
+    @Test
+    void MANAGE_진입게이트는_운영진_역할이_없으면_거부() {
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of());
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
+    @Test
+    void MANAGE_진입게이트는_학교_회장단이면_거부() {
+        // 학교 회장단은 프로젝트 MANAGE(publish/abort/complete) 자격이 아니다 — 총괄단/지부장만 통과.
+        SubjectAttributes subject = subjectWith(20L, List.of(), List.of(schoolPresidentRole(1L, 1L)));
+        ResourcePermission permission = ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.MANAGE);
+
+        assertThat(sut.evaluate(subject, permission)).isFalse();
+    }
+
     // --- DELETE ---
 
     @Test

--- a/src/test/java/com/umc/product/project/application/service/query/ProjectPermissionQueryServiceTest.java
+++ b/src/test/java/com/umc/product/project/application/service/query/ProjectPermissionQueryServiceTest.java
@@ -106,10 +106,10 @@ class ProjectPermissionQueryServiceTest {
             .isEqualTo("아직은 지원 폼 공개를 별도로 지원하지 않아요.");
         assertThat(result.applicationForm().canDelete().reason())
             .isEqualTo("아직은 지원 폼 삭제를 별도로 지원하지 않아요.");
+        // MANAGE 권한이 없으면 상태와 무관하게 완료 불가 — 권한이 상태 검사보다 우선한다.
+        assertThat(result.status().canComplete().allowed()).isFalse();
         assertThat(result.status().canComplete().reasonCode())
-            .isEqualTo(ProjectPermissionReason.NOT_IMPLEMENTED.name());
-        assertThat(result.status().canComplete().reason())
-            .isEqualTo("아직 프로젝트 완료 처리를 지원하지 않아요.");
+            .isEqualTo(ProjectPermissionReason.PERMISSION_DENIED.name());
     }
 
     @Test
@@ -157,6 +157,12 @@ class ProjectPermissionQueryServiceTest {
         assertThat(result.status().canAbort().allowed()).isFalse();
         assertThat(result.status().canAbort().reasonCode()).isEqualTo(ProjectPermissionReason.INVALID_PROJECT_STATUS.name());
         assertThat(result.status().canAbort().reason()).isEqualTo("현재 진행 중인 프로젝트만 중단 시킬 수 있어요.");
+        // 운영진이어도 PENDING_REVIEW 는 완료 불가 — 완료는 IN_PROGRESS 에서만 열린다.
+        assertThat(result.status().canComplete().allowed()).isFalse();
+        assertThat(result.status().canComplete().reasonCode())
+            .isEqualTo(ProjectPermissionReason.INVALID_PROJECT_STATUS.name());
+        assertThat(result.status().canComplete().reason())
+            .isEqualTo("현재 진행 중인 프로젝트만 완료 처리할 수 있어요.");
     }
 
     @Test
@@ -179,6 +185,8 @@ class ProjectPermissionQueryServiceTest {
         ProjectPermissionInfo result = sut.listByProjectIds(REQUESTER_ID, List.of(PROJECT_ID)).get(0);
 
         assertThat(result.status().canAbort().allowed()).isTrue();
+        // IN_PROGRESS + 운영진(MANAGE) 이면 완료도 가능하다 — 여기서 열린다.
+        assertThat(result.status().canComplete().allowed()).isTrue();
         assertThat(result.applicationForm().canEdit().allowed()).isFalse();
         assertThat(result.applicationForm().canEdit().reasonCode())
             .isEqualTo(ProjectPermissionReason.ACTIVE_MATCHING_ROUND_EXISTS.name());

--- a/src/test/java/com/umc/product/project/domain/ProjectTest.java
+++ b/src/test/java/com/umc/product/project/domain/ProjectTest.java
@@ -3,12 +3,13 @@ package com.umc.product.project.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.umc.product.project.domain.enums.ProjectStatus;
-import com.umc.product.project.domain.exception.ProjectDomainException;
-import com.umc.product.project.domain.exception.ProjectErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import com.umc.product.project.domain.enums.ProjectStatus;
+import com.umc.product.project.domain.exception.ProjectDomainException;
+import com.umc.product.project.domain.exception.ProjectErrorCode;
 
 class ProjectTest {
 
@@ -173,17 +174,18 @@ class ProjectTest {
     class complete {
 
         @Test
-        void IN_PROGRESS에서_COMPLETED로_전이된다() {
+        void IN_PROGRESS에서_COMPLETED로_전이되고_완료자를_기록한다() {
             setStatus(project, ProjectStatus.IN_PROGRESS);
 
-            project.complete();
+            project.complete(999L);
 
             assertThat(project.getStatus()).isEqualTo(ProjectStatus.COMPLETED);
+            assertThat(project.getStatusChangedByMemberId()).isEqualTo(999L);
         }
 
         @Test
         void IN_PROGRESS가_아니면_PROJECT_INVALID_STATE() {
-            assertThatThrownBy(() -> project.complete())
+            assertThatThrownBy(() -> project.complete(999L))
                 .isInstanceOf(ProjectDomainException.class)
                 .extracting("baseCode")
                 .isEqualTo(ProjectErrorCode.PROJECT_INVALID_STATE);


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

기수 종료 시 `IN_PROGRESS` 프로젝트들을 `COMPLETED`로 넘겨야 하는데, 도메인 메서드만 있고 UseCase·Service·API가 전부 비어 있었어요. 운영진이 여러 프로젝트를 한 번에 완료 처리하는 배치 API가 필요했어요. (#815, PROJECT-111)

## 어떻게 해결했나요?

`POST /api/v1/projects/complete` — 배열로 받아 프로젝트별 권한 검증 후 원자적(`@Transactional`)으로 완료 처리해요. 멤버는 `COMPLETED`, 진행 중 지원서는 자동 취소 사유와 함께 `CANCELLED`.

```java
public void complete(CompleteProjectsCommand command) {
    for (Long projectId : command.projectIds()) {
        checkPermissionUseCase.checkOrThrow(command.requesterMemberId(),   // 프로젝트별 MANAGE 검증
            ResourcePermission.of(ResourceType.PROJECT, projectId, PermissionType.MANAGE));
        loadProjectPort.getById(projectId).complete(command.requesterMemberId());
        // ACTIVE 멤버 → COMPLETED, 진행 중 지원서 → CANCELLED
    }
}
```

## 변경 요약

| 계층 | 변경 |
|------|------|
| Domain | `Project.complete(Long)` 완료자 기록 / `ProjectMember.complete(Long)` 신규 |
| Application | `CompleteProjectsUseCase`·`Command` 신규, Service 배치 구현(`@Audited`), `canComplete` 실제 판정 교체, `canManage` 진입 게이트 |
| Adapter | `CompleteProjectsRequest` 신규, `POST /projects/complete` (PROJECT-111) |

- 완료 조건: `IN_PROGRESS` + 호출자가 SUPER_ADMIN / 해당 기수 총괄단 / 해당 지부 지부장 (abort와 동일)

## 리뷰 포인트

동작 스펙은 테스트에 다 있어요. 테스트 위주로 봐주세요.

- **`ProjectCommandServiceTest > complete`** — 멤버·지원서 동기화 / 일괄 처리 / 권한 없으면 롤백 / 상태 오류 롤백
- **`ProjectPermissionEvaluatorTest > MANAGE 진입 게이트`** — 새로 뚫은 경로가 총괄단·지부장만 열리고 학교 회장단·역할 없음은 거부됨
- **`ProjectPermissionQueryServiceTest`** — `canComplete`가 상태·권한별로 열리고 막히는 조건

resolves #815
