### PR TITLE
[Fix] DB Query Observability 민감정보 마스킹 강화

### DIFF
--- a/docs/guides/P6Spy_SQL_로그_보안_정책.md
+++ b/docs/guides/P6Spy_SQL_로그_보안_정책.md
@@ -1,0 +1,26 @@
+# P6Spy SQL 로그 보안 정책
+
+## 기본 원칙
+
+P6Spy 로그와 DB tracing span에는 SQL 구조만 남기고 바인딩 값은 남기지 않는다. 이메일, 토큰, 지원 키뿐 아니라 모든 prepared statement parameter가 같은 정책을 적용받는다.
+
+- prepared statement는 P6Spy의 `prepared` SQL을 선택해 `?` placeholder를 유지한다.
+- plain statement에 포함된 문자열 literal, dollar-quoted literal, SQL comment 내용은 `[REDACTED]`로 치환한다.
+- 선택적으로 `db.statement` span을 활성화해도 같은 `SqlLogRedactor`를 적용한다.
+- `spy.properties`에서 formatter를 등록해 Spring `@PostConstruct`보다 먼저 실행되는 Flyway/JPA bootstrap SQL에도 정책을 적용한다.
+
+## 운영 디버깅 가치
+
+테이블, 컬럼, JOIN, predicate 형태, placeholder 수, SQL operation과 실행 시간은 유지한다. 따라서 N+1, 잘못된 JOIN, 인덱스 후보, query shape와 latency는 분석할 수 있다. 실제 parameter 값이 필요한 장애 분석은 로그 설정을 완화하지 않고 재현 가능한 비식별 fixture와 DB-side 제한 조회를 사용한다.
+
+## 금지 사항
+
+- 운영 또는 local 환경에서 bound SQL 원문을 출력하도록 formatter를 교체하지 않는다.
+- application key, access token, email 등 민감값을 임시 debug log에 기록하지 않는다.
+- 테스트 transcript에는 생성 결과의 `applicationKey`를 반드시 `[REDACTED]`로 치환한다.
+
+## 검증
+
+- `P6SpyConfigTest`: prepared INSERT/SELECT와 plain SQL redaction, 비민감 SQL 구조 보존.
+- `QueryStatsJdbcEventListenerTest`: DB span의 inline literal redaction.
+- `RecruitingApplicationRandomPortIntegrationTest`: 실제 PostgreSQL P6Spy INSERT/SELECT 출력과 random-port HTTP transcript 검증.

--- a/docs/guides/P6Spy_SQL_로그_보안_정책.md
+++ b/docs/guides/P6Spy_SQL_로그_보안_정책.md
@@ -23,4 +23,4 @@ P6Spy 로그와 DB tracing span에는 SQL 구조만 남기고 바인딩 값은 �
 
 - `P6SpyConfigTest`: prepared INSERT/SELECT와 plain SQL redaction, 비민감 SQL 구조 보존.
 - `QueryStatsJdbcEventListenerTest`: DB span의 inline literal redaction.
-- `RecruitingApplicationRandomPortIntegrationTest`: 실제 PostgreSQL P6Spy INSERT/SELECT 출력과 random-port HTTP transcript 검증.
+- `P6SpyLogRedactionIntegrationTest`: 실제 PostgreSQL P6Spy INSERT/SELECT 출력의 parameter 비노출 검증.

--- a/src/main/java/com/umc/product/global/config/P6SpyConfig.java
+++ b/src/main/java/com/umc/product/global/config/P6SpyConfig.java
@@ -1,12 +1,8 @@
-package com.umc.product.global.config; // 패키지명 확인
+package com.umc.product.global.config;
 
-import java.util.Locale;
-
-import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.springframework.context.annotation.Configuration;
 
 import com.p6spy.engine.spy.P6SpyOptions;
-import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
 
 import jakarta.annotation.PostConstruct;
 
@@ -15,37 +11,6 @@ public class P6SpyConfig {
 
     @PostConstruct
     public void setLogMessageFormat() {
-        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6SpyFormatter.class.getName());
-    }
-
-    // 내부 클래스로 포맷터 정의
-    public static class P6SpyFormatter implements MessageFormattingStrategy {
-
-        @Override
-        public String formatMessage(int connectionId, String now, long elapsed, String category,
-                                    String prepared, String sql, String url) {
-            String formatted = formatSql(category, sql);
-            // [카테고리] | 실행시간 ms | SQL
-            return String.format("[%s] | %d ms | %s", category, elapsed, formatted);
-        }
-
-        private String formatSql(String category, String sql) {
-            if (sql == null || sql.trim().isEmpty()) {
-                return sql;
-            }
-
-            // Only format Statement, PreparedStatement
-            if ("statement".equals(category)) {
-                String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
-                if (trimmedSQL.startsWith("create") || trimmedSQL.startsWith("alter")
-                        || trimmedSQL.startsWith("comment")) {
-                    sql = FormatStyle.DDL.getFormatter().format(sql);
-                } else {
-                    sql = FormatStyle.BASIC.getFormatter().format(sql);
-                }
-                return sql;
-            }
-            return sql;
-        }
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(RedactingP6SpyFormatter.class.getName());
     }
 }

--- a/src/main/java/com/umc/product/global/config/QueryStatsJdbcEventListener.java
+++ b/src/main/java/com/umc/product/global/config/QueryStatsJdbcEventListener.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.p6spy.engine.common.PreparedStatementInformation;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.event.JdbcEventListener;
+import com.umc.product.global.observability.ObservabilityErrorSanitizer;
 import com.umc.product.global.observability.ObservabilityTracingProperties;
 
 import io.micrometer.tracing.Span;
@@ -170,7 +171,7 @@ public class QueryStatsJdbcEventListener extends JdbcEventListener {
             .start();
 
         if (tracingProperties.isIncludeSql()) {
-            span.tag("db.statement", limitSql(sql));
+            span.tag("db.statement", limitSql(SqlLogRedactor.redact(sql)));
         }
 
         Tracer.SpanInScope scope = tracer.withSpan(span);
@@ -188,7 +189,7 @@ public class QueryStatsJdbcEventListener extends JdbcEventListener {
         try {
             context.span().tag("db.query.elapsed_ms", String.valueOf(timeElapsedNanos / 1_000_000L));
             if (e != null) {
-                context.span().error(e);
+                ObservabilityErrorSanitizer.record(context.span(), e);
             }
         } finally {
             context.scope().close();

--- a/src/main/java/com/umc/product/global/config/RedactingP6SpyFormatter.java
+++ b/src/main/java/com/umc/product/global/config/RedactingP6SpyFormatter.java
@@ -1,0 +1,33 @@
+package com.umc.product.global.config;
+
+import java.util.Locale;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+public class RedactingP6SpyFormatter implements MessageFormattingStrategy {
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category,
+                                String prepared, String sql, String url) {
+        String formatted = formatSql(category, SqlLogRedactor.redact(prepared, sql));
+        return String.format("[%s] | %d ms | %s", category, elapsed, formatted);
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql == null || sql.trim().isEmpty()) {
+            return sql;
+        }
+
+        if ("statement".equals(category)) {
+            String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
+            if (trimmedSQL.startsWith("create") || trimmedSQL.startsWith("alter")
+                    || trimmedSQL.startsWith("comment")) {
+                return FormatStyle.DDL.getFormatter().format(sql);
+            }
+            return FormatStyle.BASIC.getFormatter().format(sql);
+        }
+        return sql;
+    }
+}

--- a/src/main/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilter.java
+++ b/src/main/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilter.java
@@ -1,0 +1,94 @@
+package com.umc.product.global.config;
+
+import java.util.Objects;
+
+import org.slf4j.Marker;
+import org.slf4j.helpers.MessageFormatter;
+
+import com.umc.product.global.observability.ObservabilityErrorSanitizer;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class SensitiveDataSanitizingTurboFilter extends TurboFilter {
+
+    @Override
+    public FilterReply decide(
+        Marker marker,
+        Logger logger,
+        Level level,
+        String format,
+        Object[] parameters,
+        Throwable throwable
+    ) {
+        SanitizedArguments sanitized = sanitize(format, parameters, throwable);
+        if (!sanitized.changed()) {
+            return FilterReply.NEUTRAL;
+        }
+
+        String message = MessageFormatter.arrayFormat(sanitized.format(), sanitized.parameters()).getMessage();
+        LoggingEvent event = new LoggingEvent(
+            SensitiveDataSanitizingTurboFilter.class.getName(),
+            logger,
+            level,
+            message,
+            sanitized.throwable(),
+            null
+        );
+        if (marker != null) {
+            event.addMarker(marker);
+        }
+        logger.callAppenders(event);
+        return FilterReply.DENY;
+    }
+
+    private SanitizedArguments sanitize(String format, Object[] parameters, Throwable throwable) {
+        String sanitizedFormat = ObservabilityErrorSanitizer.sanitizeMessage(format);
+        boolean changed = !Objects.equals(format, sanitizedFormat);
+
+        Object[] sanitizedParameters = parameters;
+        if (parameters != null) {
+            sanitizedParameters = parameters.clone();
+            for (int index = 0; index < parameters.length; index++) {
+                Object parameter = parameters[index];
+                Object sanitizedParameter = sanitizeParameter(parameter);
+                sanitizedParameters[index] = sanitizedParameter;
+                changed |= sanitizedParameter != parameter;
+            }
+        }
+
+        Throwable sanitizedThrowable = ObservabilityErrorSanitizer.sanitize(throwable);
+        changed |= sanitizedThrowable != throwable;
+        if (sanitizedThrowable == null && sanitizedParameters != null && sanitizedParameters.length > 0) {
+            Object lastParameter = sanitizedParameters[sanitizedParameters.length - 1];
+            if (lastParameter instanceof Throwable parameterThrowable) {
+                sanitizedThrowable = parameterThrowable;
+            }
+        }
+        return new SanitizedArguments(sanitizedFormat, sanitizedParameters, sanitizedThrowable, changed);
+    }
+
+    private Object sanitizeParameter(Object parameter) {
+        if (parameter instanceof Throwable error) {
+            return ObservabilityErrorSanitizer.sanitize(error);
+        }
+        if (parameter == null) {
+            return null;
+        }
+
+        String rendered = String.valueOf(parameter);
+        String sanitized = ObservabilityErrorSanitizer.sanitizeMessage(rendered);
+        return rendered.equals(sanitized) ? parameter : sanitized;
+    }
+
+    private record SanitizedArguments(
+        String format,
+        Object[] parameters,
+        Throwable throwable,
+        boolean changed
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilter.java
+++ b/src/main/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilter.java
@@ -3,7 +3,6 @@ package com.umc.product.global.config;
 import java.util.Objects;
 
 import org.slf4j.Marker;
-import org.slf4j.helpers.MessageFormatter;
 
 import com.umc.product.global.observability.ObservabilityErrorSanitizer;
 
@@ -29,14 +28,13 @@ public class SensitiveDataSanitizingTurboFilter extends TurboFilter {
             return FilterReply.NEUTRAL;
         }
 
-        String message = MessageFormatter.arrayFormat(sanitized.format(), sanitized.parameters()).getMessage();
         LoggingEvent event = new LoggingEvent(
             SensitiveDataSanitizingTurboFilter.class.getName(),
             logger,
             level,
-            message,
+            sanitized.format(),
             sanitized.throwable(),
-            null
+            sanitized.parameters()
         );
         if (marker != null) {
             event.addMarker(marker);

--- a/src/main/java/com/umc/product/global/config/SqlLogRedactor.java
+++ b/src/main/java/com/umc/product/global/config/SqlLogRedactor.java
@@ -1,5 +1,6 @@
 package com.umc.product.global.config;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.util.StringUtils;
@@ -8,14 +9,9 @@ public final class SqlLogRedactor {
 
     public static final String REDACTED = "[REDACTED]";
 
-    private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
-    private static final Pattern LINE_COMMENT = Pattern.compile("--[^\\r\\n]*");
-    private static final Pattern TAGGED_DOLLAR_QUOTED = Pattern.compile(
-        "\\$([A-Za-z_][A-Za-z0-9_]*)\\$.*?\\$\\1\\$",
-        Pattern.DOTALL
+    private static final Pattern SQL_TOKEN_PATTERN = Pattern.compile(
+        "(?s)(/\\*.*?\\*/)|(--[^\\r\\n]*)|(\\$([A-Za-z_][A-Za-z0-9_]*)\\$.*?\\$\\4\\$)|(\\$\\$.*?\\$\\$)|('(?:''|[^'])*')"
     );
-    private static final Pattern DOLLAR_QUOTED = Pattern.compile("\\$\\$.*?\\$\\$", Pattern.DOTALL);
-    private static final Pattern STRING_LITERAL = Pattern.compile("'(?:''|[^'])*'", Pattern.DOTALL);
 
     private SqlLogRedactor() {
     }
@@ -30,10 +26,20 @@ public final class SqlLogRedactor {
             return sql;
         }
 
-        String redacted = BLOCK_COMMENT.matcher(sql).replaceAll("/* " + REDACTED + " */");
-        redacted = LINE_COMMENT.matcher(redacted).replaceAll("-- " + REDACTED);
-        redacted = TAGGED_DOLLAR_QUOTED.matcher(redacted).replaceAll("'" + REDACTED + "'");
-        redacted = DOLLAR_QUOTED.matcher(redacted).replaceAll("'" + REDACTED + "'");
-        return STRING_LITERAL.matcher(redacted).replaceAll("'" + REDACTED + "'");
+        Matcher matcher = SQL_TOKEN_PATTERN.matcher(sql);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String replacement;
+            if (matcher.group(1) != null) {
+                replacement = "/* " + REDACTED + " */";
+            } else if (matcher.group(2) != null) {
+                replacement = "-- " + REDACTED;
+            } else {
+                replacement = "'" + REDACTED + "'";
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 }

--- a/src/main/java/com/umc/product/global/config/SqlLogRedactor.java
+++ b/src/main/java/com/umc/product/global/config/SqlLogRedactor.java
@@ -1,0 +1,39 @@
+package com.umc.product.global.config;
+
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+public final class SqlLogRedactor {
+
+    public static final String REDACTED = "[REDACTED]";
+
+    private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+    private static final Pattern LINE_COMMENT = Pattern.compile("--[^\\r\\n]*");
+    private static final Pattern TAGGED_DOLLAR_QUOTED = Pattern.compile(
+        "\\$([A-Za-z_][A-Za-z0-9_]*)\\$.*?\\$\\1\\$",
+        Pattern.DOTALL
+    );
+    private static final Pattern DOLLAR_QUOTED = Pattern.compile("\\$\\$.*?\\$\\$", Pattern.DOTALL);
+    private static final Pattern STRING_LITERAL = Pattern.compile("'(?:''|[^'])*'", Pattern.DOTALL);
+
+    private SqlLogRedactor() {
+    }
+
+    public static String redact(String prepared, String boundSql) {
+        String sqlStructure = StringUtils.hasText(prepared) ? prepared : boundSql;
+        return redact(sqlStructure);
+    }
+
+    public static String redact(String sql) {
+        if (!StringUtils.hasText(sql)) {
+            return sql;
+        }
+
+        String redacted = BLOCK_COMMENT.matcher(sql).replaceAll("/* " + REDACTED + " */");
+        redacted = LINE_COMMENT.matcher(redacted).replaceAll("-- " + REDACTED);
+        redacted = TAGGED_DOLLAR_QUOTED.matcher(redacted).replaceAll("'" + REDACTED + "'");
+        redacted = DOLLAR_QUOTED.matcher(redacted).replaceAll("'" + REDACTED + "'");
+        return STRING_LITERAL.matcher(redacted).replaceAll("'" + REDACTED + "'");
+    }
+}

--- a/src/main/java/com/umc/product/global/event/application/service/EventOutboxRelayService.java
+++ b/src/main/java/com/umc/product/global/event/application/service/EventOutboxRelayService.java
@@ -20,6 +20,7 @@ import com.umc.product.global.event.application.port.out.SaveEventOutboxPort;
 import com.umc.product.global.event.domain.DomainEvent;
 import com.umc.product.global.event.domain.EventOutbox;
 import com.umc.product.global.event.domain.OutboxDispatchMode;
+import com.umc.product.global.observability.ObservabilityErrorSanitizer;
 import com.umc.product.global.observability.W3CTraceparent;
 
 import io.micrometer.tracing.Link;
@@ -138,7 +139,7 @@ public class EventOutboxRelayService {
         try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
             doPublish(outbox);
         } catch (RuntimeException e) {
-            span.error(e);
+            ObservabilityErrorSanitizer.record(span, e);
             throw e;
         } finally {
             span.end();

--- a/src/main/java/com/umc/product/global/observability/ObservabilityErrorSanitizer.java
+++ b/src/main/java/com/umc/product/global/observability/ObservabilityErrorSanitizer.java
@@ -1,0 +1,229 @@
+package com.umc.product.global.observability;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.micrometer.tracing.Span;
+
+public final class ObservabilityErrorSanitizer {
+
+    public static final String REDACTED = "[REDACTED]";
+
+    private static final Pattern POSTGRES_KEY_DETAIL = Pattern.compile(
+        "(?is)(\\bDetail:\\s*Key\\s*\\([^\\r\\n)]*\\)\\s*=\\s*)\\([^\\r\\n)]*\\)"
+    );
+    private static final Pattern BIND_DETAIL = Pattern.compile(
+        "(?i)(\\bbinding parameter \\[\\d+] as \\[[^]\\r\\n]+]\\s*-\\s*)\\[[^]\\r\\n]*]"
+    );
+    private static final Pattern APPLICATION_KEY_VALUE = Pattern.compile(
+        "(?i)(\\bapplication[_ ]?key\\b\\s*[=:]\\s*)[A-Z0-9]{6}"
+    );
+    private static final Pattern EMAIL = Pattern.compile(
+        "(?i)(?<![A-Z0-9._%+-])[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}(?![A-Z0-9._%+-])"
+    );
+    private static final Pattern BEARER_TOKEN = Pattern.compile("(?i)(\\bBearer\\s+)[A-Za-z0-9._~+/-]+=*");
+    private static final Pattern JWT = Pattern.compile(
+        "\\beyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\b"
+    );
+    private static final Pattern SINGLE_QUOTED_VALUE = Pattern.compile("'(?:''|[^'])*'", Pattern.DOTALL);
+    private static final Pattern DOUBLE_QUOTED_VALUE = Pattern.compile("\"(?:\"\"|[^\"])*\"", Pattern.DOTALL);
+    private static final Pattern CONSTRAINT_PREFIX = Pattern.compile("(?i)\\bconstraint\\s*$");
+    private static final Pattern MIXED_APPLICATION_KEY = Pattern.compile(
+        "\\b(?=[A-Z0-9]{6}\\b)(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*\\d)[A-Z0-9]{6}\\b"
+    );
+    private static final Pattern CONSTRAINT_NAME = Pattern.compile(
+        "(?i)\\bconstraint\\s+\"([A-Za-z0-9_.-]+)\""
+    );
+
+    private ObservabilityErrorSanitizer() {
+    }
+
+    public static void record(Span span, Throwable error) {
+        ErrorMetadata metadata = ErrorMetadata.from(error);
+        span.tag("app.error.class", metadata.errorClass());
+        if (metadata.sqlErrorClass() != null) {
+            span.tag("db.error.class", metadata.sqlErrorClass());
+            tagIfPresent(span, "db.response.sql_state", metadata.sqlState());
+            span.tag("db.response.vendor_code", String.valueOf(metadata.vendorCode()));
+            tagIfPresent(span, "db.constraint.name", metadata.constraintName());
+        }
+        span.error(sanitize(error));
+    }
+
+    public static Throwable sanitize(Throwable error) {
+        if (error == null || !containsSensitiveMessage(error, newIdentitySet())) {
+            return error;
+        }
+        return copy(error, new IdentityHashMap<>());
+    }
+
+    public static String sanitizeMessage(String message) {
+        if (message == null || message.isEmpty()) {
+            return message;
+        }
+
+        String sanitized = POSTGRES_KEY_DETAIL.matcher(message).replaceAll("$1(" + REDACTED + ")");
+        sanitized = BIND_DETAIL.matcher(sanitized).replaceAll("$1[" + REDACTED + "]");
+        sanitized = APPLICATION_KEY_VALUE.matcher(sanitized).replaceAll("$1" + REDACTED);
+        sanitized = EMAIL.matcher(sanitized).replaceAll(REDACTED);
+        sanitized = BEARER_TOKEN.matcher(sanitized).replaceAll("$1" + REDACTED);
+        sanitized = JWT.matcher(sanitized).replaceAll(REDACTED);
+        sanitized = SINGLE_QUOTED_VALUE.matcher(sanitized).replaceAll("'" + REDACTED + "'");
+        sanitized = redactDoubleQuotedValues(sanitized);
+        return MIXED_APPLICATION_KEY.matcher(sanitized).replaceAll(REDACTED);
+    }
+
+    private static String redactDoubleQuotedValues(String message) {
+        Matcher matcher = DOUBLE_QUOTED_VALUE.matcher(message);
+        StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            String prefix = message.substring(Math.max(0, matcher.start() - 32), matcher.start());
+            String replacement = CONSTRAINT_PREFIX.matcher(prefix).find() ? matcher.group() : "\"" + REDACTED + "\"";
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private static boolean containsSensitiveMessage(Throwable error, Set<Throwable> visited) {
+        if (error == null || !visited.add(error)) {
+            return false;
+        }
+        String message = error.getMessage();
+        if (message != null && !message.equals(sanitizeMessage(message))) {
+            return true;
+        }
+        if (containsSensitiveMessage(error.getCause(), visited)) {
+            return true;
+        }
+        for (Throwable suppressed : error.getSuppressed()) {
+            if (containsSensitiveMessage(suppressed, visited)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Throwable copy(Throwable source, IdentityHashMap<Throwable, Throwable> copies) {
+        Throwable existing = copies.get(source);
+        if (existing != null) {
+            return existing;
+        }
+
+        ErrorMetadata metadata = ErrorMetadata.from(source);
+        SanitizedObservabilityException copy = new SanitizedObservabilityException(metadata.summary(source));
+        copy.setStackTrace(source.getStackTrace());
+        copies.put(source, copy);
+
+        if (source.getCause() != null) {
+            copy.initCause(copy(source.getCause(), copies));
+        }
+        for (Throwable suppressed : source.getSuppressed()) {
+            copy.addSuppressed(copy(suppressed, copies));
+        }
+        return copy;
+    }
+
+    private static Set<Throwable> newIdentitySet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    private static void tagIfPresent(Span span, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            span.tag(key, value);
+        }
+    }
+
+    public record ErrorMetadata(
+        String errorClass,
+        String sqlErrorClass,
+        String sqlState,
+        int vendorCode,
+        String constraintName
+    ) {
+
+        private static ErrorMetadata from(Throwable error) {
+            String errorClass = error == null ? "unknown" : error.getClass().getName();
+            SQLException sqlException = findSqlException(error, newIdentitySet());
+            String constraintName = findConstraintName(error, newIdentitySet());
+            if (sqlException == null) {
+                return new ErrorMetadata(errorClass, null, null, 0, constraintName);
+            }
+            return new ErrorMetadata(
+                errorClass,
+                sqlException.getClass().getName(),
+                sqlException.getSQLState(),
+                sqlException.getErrorCode(),
+                constraintName
+            );
+        }
+
+        private String summary(Throwable error) {
+            StringBuilder summary = new StringBuilder("errorClass=").append(errorClass);
+            if (sqlErrorClass != null) {
+                summary.append(", sqlErrorClass=").append(sqlErrorClass);
+            }
+            if (sqlState != null) {
+                summary.append(", sqlState=").append(sqlState);
+            }
+            summary.append(", vendorCode=").append(vendorCode);
+            if (constraintName != null) {
+                summary.append(", constraint=").append(constraintName);
+            }
+            summary.append(", message=").append(sanitizeMessage(error.getMessage()));
+            return summary.toString();
+        }
+
+        private static SQLException findSqlException(Throwable error, Set<Throwable> visited) {
+            if (error == null || !visited.add(error)) {
+                return null;
+            }
+            if (error instanceof SQLException sqlException) {
+                return sqlException;
+            }
+            SQLException cause = findSqlException(error.getCause(), visited);
+            if (cause != null) {
+                return cause;
+            }
+            for (Throwable suppressed : error.getSuppressed()) {
+                SQLException found = findSqlException(suppressed, visited);
+                if (found != null) {
+                    return found;
+                }
+            }
+            return null;
+        }
+
+        private static String findConstraintName(Throwable error, Set<Throwable> visited) {
+            if (error == null || !visited.add(error)) {
+                return null;
+            }
+            Matcher matcher = CONSTRAINT_NAME.matcher(String.valueOf(error.getMessage()));
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+            String cause = findConstraintName(error.getCause(), visited);
+            if (cause != null) {
+                return cause;
+            }
+            for (Throwable suppressed : error.getSuppressed()) {
+                String found = findConstraintName(suppressed, visited);
+                if (found != null) {
+                    return found;
+                }
+            }
+            return null;
+        }
+    }
+
+    private static final class SanitizedObservabilityException extends RuntimeException {
+
+        private SanitizedObservabilityException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/global/observability/ObservabilityErrorSanitizer.java
+++ b/src/main/java/com/umc/product/global/observability/ObservabilityErrorSanitizer.java
@@ -79,7 +79,7 @@ public final class ObservabilityErrorSanitizer {
 
     private static String redactDoubleQuotedValues(String message) {
         Matcher matcher = DOUBLE_QUOTED_VALUE.matcher(message);
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         while (matcher.find()) {
             String prefix = message.substring(Math.max(0, matcher.start() - 32), matcher.start());
             String replacement = CONSTRAINT_PREFIX.matcher(prefix).find() ? matcher.group() : "\"" + REDACTED + "\"";

--- a/src/main/java/com/umc/product/global/observability/ScheduledTaskTracer.java
+++ b/src/main/java/com/umc/product/global/observability/ScheduledTaskTracer.java
@@ -49,7 +49,7 @@ public class ScheduledTaskTracer {
             try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
                 task.run();
             } catch (RuntimeException e) {
-                span.error(e);
+                ObservabilityErrorSanitizer.record(span, e);
                 throw e;
             } finally {
                 span.end();

--- a/src/main/java/com/umc/product/global/observability/TraceFlowAspect.java
+++ b/src/main/java/com/umc/product/global/observability/TraceFlowAspect.java
@@ -1,13 +1,12 @@
 package com.umc.product.global.observability;
 
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.Tracer;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -17,6 +16,9 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
 
 @Aspect
 @Component
@@ -78,7 +80,7 @@ public class TraceFlowAspect {
         try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
             return joinPoint.proceed();
         } catch (Throwable throwable) {
-            span.error(throwable);
+            ObservabilityErrorSanitizer.record(span, throwable);
             throw throwable;
         } finally {
             span.end();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -183,6 +183,8 @@ decorator:
   datasource:
     p6spy:
       enable-logging: ${P6SPY_ENABLE_LOGGING:false}
+      tracing:
+        include-parameter-values: false
 
 logging:
   level:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,8 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
+    <turboFilter class="com.umc.product.global.config.SensitiveDataSanitizingTurboFilter"/>
+
     <!-- ========== Custom Converter ========== -->
     <conversionRule conversionWord="customHighlight"
                     class="com.umc.product.global.config.CustomHighlightConverter"/>

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,1 @@
+logMessageFormat=com.umc.product.global.config.RedactingP6SpyFormatter

--- a/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
@@ -74,6 +74,28 @@ class P6SpyConfigTest {
             .contains("select", "count(*)", "recruiting_application");
     }
 
+    @Test
+    @DisplayName("문자열 내부 주석 기호와 주석 내부 따옴표를 SQL token 경계에 맞게 치환한다")
+    void 문자열과_주석의_token_경계를_보존한다() {
+        String sql = """
+            select '%s -- not a comment' as applicant_email,
+                   application_key /* comment with '%s' */
+            from recruiting_application
+            """.formatted(PROBE_EMAIL, PROBE_KEY);
+
+        String output = format("", sql);
+
+        assertThat(output)
+            .contains(
+                "select",
+                "'[REDACTED]' as applicant_email",
+                "application_key /* [REDACTED] */",
+                "from",
+                "recruiting_application"
+            )
+            .doesNotContain(PROBE_EMAIL, PROBE_KEY);
+    }
+
     private String format(String prepared, String sql) {
         return formatter.formatMessage(1, "now", 3L, "statement", prepared, sql, "jdbc:postgresql:test");
     }

--- a/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
@@ -1,0 +1,80 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class P6SpyConfigTest {
+
+    private static final String PROBE_EMAIL = "sql-probe@example.invalid";
+    private static final String PROBE_KEY = "R4SAFE";
+
+    private final RedactingP6SpyFormatter formatter = new RedactingP6SpyFormatter();
+
+    @Test
+    @DisplayName("prepared INSERT는 바인딩 값 대신 SQL 구조만 출력한다")
+    void prepared_INSERT는_바인딩_값_대신_SQL_구조만_출력한다() {
+        String prepared = """
+            insert into recruiting_application (applicant_email, application_key, status)
+            values (?, ?, ?)
+            """;
+        String bound = """
+            insert into recruiting_application (applicant_email, application_key, status)
+            values ('%s', '%s', 'DRAFT')
+            """.formatted(PROBE_EMAIL, PROBE_KEY);
+
+        String output = format(prepared, bound);
+
+        assertThat(output)
+            .contains("recruiting_application", "applicant_email", "application_key", "?")
+            .doesNotContain(PROBE_EMAIL, PROBE_KEY, "DRAFT");
+    }
+
+    @Test
+    @DisplayName("prepared SELECT는 조건의 이메일과 지원 키를 출력하지 않는다")
+    void prepared_SELECT는_조건의_이메일과_지원_키를_출력하지_않는다() {
+        String prepared = """
+            select id from recruiting_application
+            where applicant_email = ? and application_key = ?
+            """;
+        String bound = """
+            select id from recruiting_application
+            where applicant_email = '%s' and application_key = '%s'
+            """.formatted(PROBE_EMAIL, PROBE_KEY);
+
+        String output = format(prepared, bound);
+
+        assertThat(output)
+            .contains("recruiting_application", "applicant_email", "application_key", "?")
+            .doesNotContain(PROBE_EMAIL, PROBE_KEY);
+    }
+
+    @Test
+    @DisplayName("plain SQL 문자열 literal은 deterministic marker로 치환한다")
+    void plain_SQL_문자열_literal은_deterministic_marker로_치환한다() {
+        String sql = """
+            select id from recruiting_application
+            where applicant_email = '%s' and application_key = '%s'
+            """.formatted(PROBE_EMAIL, PROBE_KEY);
+
+        String output = format("", sql);
+
+        assertThat(output)
+            .contains("'[REDACTED]'")
+            .doesNotContain(PROBE_EMAIL, PROBE_KEY);
+    }
+
+    @Test
+    @DisplayName("비민감 SQL의 operation과 table 구조는 유지한다")
+    void 비민감_SQL의_operation과_table_구조는_유지한다() {
+        String output = format("select count(*) from recruiting_application", "select count(*) from recruiting_application");
+
+        assertThat(output)
+            .contains("select", "count(*)", "recruiting_application");
+    }
+
+    private String format(String prepared, String sql) {
+        return formatter.formatMessage(1, "now", 3L, "statement", prepared, sql, "jdbc:postgresql:test");
+    }
+}

--- a/src/test/java/com/umc/product/global/config/P6SpyLogRedactionIntegrationTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyLogRedactionIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.p6spy.engine.logging.P6LogFactory;
+import com.p6spy.engine.spy.P6ModuleManager;
+import com.p6spy.engine.spy.P6SpyFactory;
+import com.p6spy.engine.spy.appender.Slf4JLogger;
+import com.umc.product.support.IntegrationTestSupport;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+@ContextConfiguration(initializers = P6SpyLogRedactionIntegrationTest.P6SpyLoggingInitializer.class)
+@DisplayName("P6Spy SQL 로그 보안 통합 테스트")
+class P6SpyLogRedactionIntegrationTest extends IntegrationTestSupport {
+
+    private static final String PROBE_EMAIL = "sql-probe@example.invalid";
+    private static final String PROBE_KEY = "R4SAFE";
+    private static String previousP6SpyModuleList;
+    private static String previousP6SpyAppender;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("실제 PostgreSQL INSERT와 SELECT 로그는 바인딩 값을 노출하지 않는다")
+    void 실제_PostgreSQL_INSERT와_SELECT_로그는_바인딩_값을_노출하지_않는다() {
+        ch.qos.logback.classic.Logger p6spyLogger =
+            (ch.qos.logback.classic.Logger)LoggerFactory.getLogger("p6spy");
+        Level previousLevel = p6spyLogger.getLevel();
+        boolean previousAdditive = p6spyLogger.isAdditive();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        p6spyLogger.addAppender(appender);
+        p6spyLogger.setLevel(Level.INFO);
+        p6spyLogger.setAdditive(false);
+
+        try {
+            jdbcTemplate.execute("drop table if exists sql_redaction_probe");
+            jdbcTemplate.execute("create table sql_redaction_probe (email_address text, access_key text)");
+            jdbcTemplate.update(
+                "insert into sql_redaction_probe (email_address, access_key) values (?, ?)",
+                PROBE_EMAIL,
+                PROBE_KEY
+            );
+            Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from sql_redaction_probe where email_address = ? and access_key = ?",
+                Integer.class,
+                PROBE_EMAIL,
+                PROBE_KEY
+            );
+
+            assertThat(count).isEqualTo(1);
+            String formattedSql = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .reduce("", (left, right) -> left + "\n" + right);
+            assertThat(formattedSql)
+                .contains("sql_redaction_probe", "email_address", "access_key", "?")
+                .doesNotContain(PROBE_EMAIL, PROBE_KEY);
+        } finally {
+            jdbcTemplate.execute("drop table if exists sql_redaction_probe");
+            p6spyLogger.detachAppender(appender);
+            appender.stop();
+            p6spyLogger.setLevel(previousLevel);
+            p6spyLogger.setAdditive(previousAdditive);
+        }
+    }
+
+    @AfterAll
+    static void restoreP6SpyConfiguration() {
+        restoreSystemProperty("p6spy.config.modulelist", previousP6SpyModuleList);
+        restoreSystemProperty("p6spy.config.appender", previousP6SpyAppender);
+        P6ModuleManager.getInstance().reload();
+    }
+
+    private static void restoreSystemProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+            return;
+        }
+        System.setProperty(name, value);
+    }
+
+    static final class P6SpyLoggingInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+            previousP6SpyModuleList = System.getProperty("p6spy.config.modulelist");
+            previousP6SpyAppender = System.getProperty("p6spy.config.appender");
+            System.setProperty(
+                "p6spy.config.modulelist",
+                String.join(",", P6SpyFactory.class.getName(), P6LogFactory.class.getName())
+            );
+            System.setProperty("p6spy.config.appender", Slf4JLogger.class.getName());
+            P6ModuleManager.getInstance().reload();
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/config/QueryStatsJdbcEventListenerTest.java
+++ b/src/test/java/com/umc/product/global/config/QueryStatsJdbcEventListenerTest.java
@@ -5,17 +5,25 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
-import com.p6spy.engine.common.PreparedStatementInformation;
-import com.umc.product.global.observability.ObservabilityTracingProperties;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.Tracer;
 import java.sql.SQLException;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.p6spy.engine.common.PreparedStatementInformation;
+import com.umc.product.global.observability.ObservabilityTracingProperties;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
 
 class QueryStatsJdbcEventListenerTest {
+
+    private static final String PROBE_EMAIL = "span-probe@example.invalid";
+    private static final String PROBE_KEY = "R4S8F2";
+    private static final String CONSTRAINT_NAME = "uk_recruiting_application_email_key";
 
     private Tracer tracer;
     private Span span;
@@ -77,10 +85,30 @@ class QueryStatsJdbcEventListenerTest {
     }
 
     @Test
-    @DisplayName("DB 쿼리 실패 시 span에 예외를 기록하고 요청 통계에는 성공 쿼리만 반영한다")
-    void db_쿼리_실패_span_error_기록() {
+    @DisplayName("DB span에 SQL을 포함해도 문자열 literal은 노출하지 않는다")
+    void db_span_SQL_문자열_literal_redaction() {
+        ObservabilityTracingProperties properties = new ObservabilityTracingProperties();
+        properties.setIncludeSql(true);
+        sut = new QueryStatsJdbcEventListener(tracer, properties);
         PreparedStatementInformation info = mock(PreparedStatementInformation.class);
-        SQLException exception = new SQLException("boom");
+        given(info.getSql()).willReturn(
+            "select id from recruiting_application where applicant_email = 'sql-span@example.invalid'"
+        );
+
+        sut.onBeforeExecuteQuery(info);
+        sut.onAfterExecuteQuery(info, 1_000_000L, null);
+
+        then(span).should().tag(
+            "db.statement",
+            "select id from recruiting_application where applicant_email = '[REDACTED]'"
+        );
+    }
+
+    @Test
+    @DisplayName("민감 DB 쿼리 실패는 span에서 값만 치환하고 진단 메타데이터를 유지한다")
+    void 민감_DB_쿼리_실패_span_error_redaction() {
+        PreparedStatementInformation info = mock(PreparedStatementInformation.class);
+        SQLException exception = duplicateException();
 
         QueryStatsHolder.init();
 
@@ -88,9 +116,35 @@ class QueryStatsJdbcEventListenerTest {
         sut.onAfterExecuteQuery(info, 3_000_000L, exception);
 
         assertThat(QueryStatsHolder.getQueryCount()).isZero();
-        then(span).should().error(exception);
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        then(span).should().error(errorCaptor.capture());
+        assertThat(errorCaptor.getValue())
+            .isNotSameAs(exception)
+            .hasMessageContaining(SQLException.class.getName())
+            .hasMessageContaining("sqlState=23505")
+            .hasMessageContaining("vendorCode=0")
+            .hasMessageContaining("constraint=" + CONSTRAINT_NAME)
+            .hasMessageNotContaining(PROBE_EMAIL)
+            .hasMessageNotContaining(PROBE_KEY)
+            .hasMessageNotContaining("=(42,");
+        then(span).should().tag("app.error.class", SQLException.class.getName());
+        then(span).should().tag("db.error.class", SQLException.class.getName());
+        then(span).should().tag("db.response.sql_state", "23505");
+        then(span).should().tag("db.response.vendor_code", "0");
+        then(span).should().tag("db.constraint.name", CONSTRAINT_NAME);
         then(span).should().tag("db.query.elapsed_ms", "3");
         then(span).should().end();
         then(spanInScope).should().close();
+    }
+
+    private SQLException duplicateException() {
+        return new SQLException(
+            """
+                ERROR: duplicate key value violates unique constraint "%s"
+                  Detail: Key (recruiting_round_id, applicant_email, application_key)=(42, %s, %s) already exists.
+                """.formatted(CONSTRAINT_NAME, PROBE_EMAIL, PROBE_KEY),
+            "23505",
+            0
+        );
     }
 }

--- a/src/test/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilterTest.java
+++ b/src/test/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilterTest.java
@@ -84,6 +84,18 @@ class SensitiveDataSanitizingTurboFilterTest {
         assertThat(exception.getMostSpecificCause().getMessage()).contains(PROBE_EMAIL, PROBE_KEY);
     }
 
+    @Test
+    @DisplayName("민감값을 정제한 뒤에도 로그 format과 parameter 배열을 보존한다")
+    void 정제된_로그_parameter_보존() {
+        logger.error("Rejected email: {}", PROBE_EMAIL);
+
+        assertThat(appender.list).hasSize(1);
+        ILoggingEvent event = appender.list.getFirst();
+        assertThat(event.getMessage()).isEqualTo("Rejected email: {}");
+        assertThat(event.getArgumentArray()).containsExactly("[REDACTED]");
+        assertThat(event.getFormattedMessage()).isEqualTo("Rejected email: [REDACTED]");
+    }
+
     private String throwableText(IThrowableProxy throwable) {
         if (throwable == null) {
             return "";

--- a/src/test/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilterTest.java
+++ b/src/test/java/com/umc/product/global/config/SensitiveDataSanitizingTurboFilterTest.java
@@ -1,0 +1,93 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.read.ListAppender;
+
+class SensitiveDataSanitizingTurboFilterTest {
+
+    private static final String PROBE_EMAIL = "log-probe@example.invalid";
+    private static final String PROBE_KEY = "L0G8K2";
+    private static final String CONSTRAINT_NAME = "uk_recruiting_application_email_key";
+
+    private LoggerContext context;
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        context = new LoggerContext();
+        SensitiveDataSanitizingTurboFilter filter = new SensitiveDataSanitizingTurboFilter();
+        filter.setContext(context);
+        filter.start();
+        context.addTurboFilter(filter);
+
+        logger = context.getLogger("security-db-error-test");
+        logger.setAdditive(false);
+        logger.setLevel(Level.ERROR);
+
+        appender = new ListAppender<>();
+        appender.setContext(context);
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        context.stop();
+    }
+
+    @Test
+    @DisplayName("DataIntegrityViolation 로그는 PostgreSQL 진단 정보만 남기고 바인딩 값을 치환한다")
+    void dataIntegrityViolation_로그_redaction() {
+        SQLException sqlException = new SQLException(
+            """
+                ERROR: duplicate key value violates unique constraint "%s"
+                  Detail: Key (applicant_email, application_key)=(%s, %s) already exists.
+                """.formatted(CONSTRAINT_NAME, PROBE_EMAIL, PROBE_KEY),
+            "23505",
+            0
+        );
+        DataIntegrityViolationException exception = new DataIntegrityViolationException(
+            "지원서 저장 중 duplicate constraint",
+            sqlException
+        );
+
+        logger.error("DB persistence failed: {}", exception.getMessage(), exception);
+
+        assertThat(appender.list).hasSize(1);
+        ILoggingEvent event = appender.list.getFirst();
+        String output = event.getFormattedMessage() + "\n" + throwableText(event.getThrowableProxy());
+        assertThat(output)
+            .contains(
+                DataIntegrityViolationException.class.getName(),
+                SQLException.class.getName(),
+                "sqlState=23505",
+                "vendorCode=0",
+                "constraint=" + CONSTRAINT_NAME,
+                "[REDACTED]"
+            )
+            .doesNotContain(PROBE_EMAIL, PROBE_KEY, "=(" + PROBE_EMAIL);
+        assertThat(exception.getMostSpecificCause().getMessage()).contains(PROBE_EMAIL, PROBE_KEY);
+    }
+
+    private String throwableText(IThrowableProxy throwable) {
+        if (throwable == null) {
+            return "";
+        }
+        return throwable.getClassName() + ": " + throwable.getMessage() + "\n" + throwableText(throwable.getCause());
+    }
+}

--- a/src/test/java/com/umc/product/global/observability/ObservabilityErrorSanitizerTest.java
+++ b/src/test/java/com/umc/product/global/observability/ObservabilityErrorSanitizerTest.java
@@ -1,0 +1,40 @@
+package com.umc.product.global.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ObservabilityErrorSanitizerTest {
+
+    @Test
+    @DisplayName("quoted value와 이메일, 지원 키, bind detail, token을 일관된 marker로 치환한다")
+    void 민감_메시지_redaction() {
+        String raw = """
+            value='secret', quoted="private", email=person@example.invalid, application_key=A1B2C3
+            binding parameter [2] as [VARCHAR] - [bound-secret]
+            Authorization: Bearer opaque.secret-token
+            """;
+
+        String sanitized = ObservabilityErrorSanitizer.sanitizeMessage(raw);
+
+        assertThat(sanitized)
+            .contains("'[REDACTED]'", "\"[REDACTED]\"", "application_key=[REDACTED]", "Bearer [REDACTED]")
+            .doesNotContain("secret", "private", "person@example.invalid", "A1B2C3", "bound-secret");
+    }
+
+    @Test
+    @DisplayName("PostgreSQL constraint 이름은 보존하고 key detail tuple만 치환한다")
+    void postgres_constraint_진단정보_보존() {
+        String raw = """
+            ERROR: duplicate key value violates unique constraint "uk_recruiting_application_email_key"
+              Detail: Key (applicant_email, application_key)=(person@example.invalid, A1B2C3) already exists.
+            """;
+
+        String sanitized = ObservabilityErrorSanitizer.sanitizeMessage(raw);
+
+        assertThat(sanitized)
+            .contains("constraint \"uk_recruiting_application_email_key\"", "Detail: Key", "([REDACTED])")
+            .doesNotContain("person@example.invalid", "A1B2C3");
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,6 +1,8 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
+    <turboFilter class="com.umc.product.global.config.SensitiveDataSanitizingTurboFilter"/>
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} : %msg%n</pattern>


### PR DESCRIPTION
## 🚀 작업 내용

- P6Spy가 prepared SQL의 실제 바인딩 값을 출력하지 않고 `?` placeholder와 query shape만 남기도록 변경했어요. plain SQL의 문자열 literal, dollar-quoted literal, comment도 `[REDACTED]`로 치환해요.
- Spring 초기화 전 Flyway/JPA SQL에도 동일 정책이 적용되도록 `spy.properties`에 전용 formatter를 등록했어요. DB tracing의 `db.statement`에도 같은 redactor를 적용했어요.
- SQLException과 일반 예외의 message, cause, suppressed 정보를 observability 전용 안전 형식으로 변환하고 Logback TurboFilter, scheduled task, outbox, trace aspect에 일관되게 적용했어요.
- SQL 로그 보안 정책과 실제 PostgreSQL INSERT/SELECT redaction 통합 테스트를 추가했어요. 이 PR은 Recruiting PR #1125보다 먼저 병합되어야 해요.

### 검증

- `./gradlew test --tests com.umc.product.global.config.P6SpyConfigTest --tests com.umc.product.global.config.P6SpyLogRedactionIntegrationTest --tests com.umc.product.global.config.QueryStatsJdbcEventListenerTest --tests com.umc.product.global.config.SensitiveDataSanitizingTurboFilterTest --tests com.umc.product.global.observability.ObservabilityErrorSanitizerTest`
- `./gradlew test`

## 💬 리뷰 중점사항

- 이메일·토큰·지원 키에 한정하지 않고 모든 prepared statement parameter를 숨겨요. 테이블, 컬럼, JOIN, predicate, placeholder 수, 실행 시간은 유지하지만 실제 파라미터 값 기반 디버깅은 의도적으로 지원하지 않아요.
- Logback TurboFilter는 예외 객체를 직접 변경하지 않고 로깅 이벤트의 message와 throwable proxy만 sanitization해요. 원래 예외는 애플리케이션 흐름과 트랜잭션 처리에 그대로 전달돼요.
- 별도 PR로 분리했기 때문에 #1125에는 병합 전까지 동일 변경이 임시로 보일 수 있어요. 이 PR 병합 후 #1125를 최신 `develop`에 rebase하면서 기존 보안 커밋을 제거할 예정이에요.
