### PR TITLE
[Refactor] 인증 정보 처리 유틸 GraphQL 대응

### DIFF
--- a/src/main/java/com/umc/product/global/config/WebMvcConfig.java
+++ b/src/main/java/com/umc/product/global/config/WebMvcConfig.java
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import com.umc.product.global.client.ClientContextConfig;
 import com.umc.product.global.logging.OperationalMetricsConfig;
 import com.umc.product.global.ratelimit.ApiRateLimitInterceptor;
+import com.umc.product.global.security.CurrentMemberSecurityConfig;
 import com.umc.product.global.security.resolver.CurrentMemberArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @Import({
     ClientContextConfig.class,
-    OperationalMetricsConfig.class
+    OperationalMetricsConfig.class,
+    CurrentMemberSecurityConfig.class
 })
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {

--- a/src/main/java/com/umc/product/global/security/CurrentMemberProvider.java
+++ b/src/main/java/com/umc/product/global/security/CurrentMemberProvider.java
@@ -1,0 +1,36 @@
+package com.umc.product.global.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class CurrentMemberProvider {
+
+    public MemberPrincipal getRequiredCurrentMember() {
+        MemberPrincipal memberPrincipal = getNullableCurrentMember();
+        if (memberPrincipal == null) {
+            throw new AccessDeniedException("로그인이 필요해요. 로그인 후 다시 시도해주세요.");
+        }
+        return memberPrincipal;
+    }
+
+    public Long getRequiredCurrentMemberId() {
+        return getRequiredCurrentMember().getMemberId();
+    }
+
+    public MemberPrincipal getNullableCurrentMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+        if (authentication.getPrincipal() instanceof MemberPrincipal principal) {
+            return principal;
+        }
+        return null;
+    }
+
+    public Long getNullableCurrentMemberId() {
+        MemberPrincipal memberPrincipal = getNullableCurrentMember();
+        return memberPrincipal == null ? null : memberPrincipal.getMemberId();
+    }
+}

--- a/src/main/java/com/umc/product/global/security/CurrentMemberSecurityConfig.java
+++ b/src/main/java/com/umc/product/global/security/CurrentMemberSecurityConfig.java
@@ -1,0 +1,13 @@
+package com.umc.product.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CurrentMemberSecurityConfig {
+
+    @Bean
+    public CurrentMemberProvider currentMemberProvider() {
+        return new CurrentMemberProvider();
+    }
+}

--- a/src/main/java/com/umc/product/global/security/resolver/CurrentMemberArgumentResolver.java
+++ b/src/main/java/com/umc/product/global/security/resolver/CurrentMemberArgumentResolver.java
@@ -1,24 +1,27 @@
 package com.umc.product.global.security.resolver;
 
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.global.security.annotation.CurrentMember;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import com.umc.product.global.security.CurrentMemberProvider;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final CurrentMemberProvider currentMemberProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // 1. 파라미터에 @CurrentUser 어노테이션이 붙어 있는지 확인
         boolean hasAnnotation = parameter.hasParameterAnnotation(CurrentMember.class);
-        // 2. 파라미터 타입이 UserPrincipal인지 확인
         boolean hasUserType = MemberPrincipal.class.isAssignableFrom(parameter.getParameterType());
 
         return hasAnnotation && hasUserType;
@@ -27,21 +30,6 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        // 인증 정보가 없거나, 익명 사용자("anonymousUser" 문자열)인 경우 null 반환
-        if (authentication == null || !authentication.isAuthenticated() ||
-                authentication.getPrincipal().equals("anonymousUser")) {
-            return null;
-        }
-
-        // 실제 MemberPrincipal 객체 반환
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof MemberPrincipal) {
-            return principal;
-        }
-
-        return null;
+        return currentMemberProvider.getNullableCurrentMember();
     }
 }

--- a/src/main/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlController.java
+++ b/src/main/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlController.java
@@ -13,9 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.lang.Nullable;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
@@ -25,7 +24,9 @@ import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerBasicInfo;
+import com.umc.product.global.security.CurrentMemberProvider;
 import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.member.adapter.in.graphql.dto.MemberChallengerGraphQlResponse;
 import com.umc.product.member.adapter.in.graphql.dto.MemberGisuGraphQlResponse;
 import com.umc.product.member.adapter.in.graphql.dto.MemberGraphQlResponse;
@@ -56,23 +57,30 @@ public class MemberGraphQlController {
     private final GetChallengerUseCase getChallengerUseCase;
     private final GetGisuUseCase getGisuUseCase;
     private final SearchMemberUseCase searchMemberUseCase;
+    private final CurrentMemberProvider currentMemberProvider;
 
     @QueryMapping
-    public MemberGraphQlResponse me() {
-        Long requesterMemberId = currentMemberId();
+    public MemberGraphQlResponse me(@Nullable @CurrentMember MemberPrincipal memberPrincipal) {
+        Long requesterMemberId = currentMemberId(memberPrincipal);
         return MemberGraphQlResponse.privateFrom(getMemberUseCase.getById(requesterMemberId));
     }
 
     @QueryMapping
-    public MemberGraphQlResponse member(@Argument Long id) {
-        Long requesterMemberId = currentMemberId();
+    public MemberGraphQlResponse member(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
+        @Argument Long id
+    ) {
+        Long requesterMemberId = currentMemberId(memberPrincipal);
         checkPermissionUseCase.checkOrThrow(requesterMemberId, memberReadPermission(id));
         return MemberGraphQlResponse.publicFrom(getMemberUseCase.getById(id));
     }
 
     @QueryMapping
-    public List<MemberGraphQlResponse> members(@Argument List<Long> ids) {
-        Long requesterMemberId = currentMemberId();
+    public List<MemberGraphQlResponse> members(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
+        @Argument List<Long> ids
+    ) {
+        Long requesterMemberId = currentMemberId(memberPrincipal);
         List<Long> uniqueMemberIds = uniqueMemberIds(ids);
         if (uniqueMemberIds.isEmpty()) {
             return List.of();
@@ -229,15 +237,14 @@ public class MemberGraphQlController {
         return result;
     }
 
+    private Long currentMemberId(MemberPrincipal memberPrincipal) {
+        return memberPrincipal == null
+            ? currentMemberProvider.getRequiredCurrentMemberId()
+            : memberPrincipal.getMemberId();
+    }
+
     private Long currentMemberId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new AccessDeniedException("로그인이 필요해요. 로그인 후 다시 시도해주세요.");
-        }
-        if (authentication.getPrincipal() instanceof MemberPrincipal principal) {
-            return principal.getMemberId();
-        }
-        throw new AccessDeniedException("인증 정보가 올바르지 않아요. 다시 로그인해주세요.");
+        return currentMemberProvider.getRequiredCurrentMemberId();
     }
 
     private List<Long> uniqueMemberIds(List<Long> memberIds) {

--- a/src/main/java/com/umc/product/project/adapter/in/graphql/ProjectGraphQlController.java
+++ b/src/main/java/com/umc/product/project/adapter/in/graphql/ProjectGraphQlController.java
@@ -14,9 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.lang.Nullable;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
@@ -24,7 +23,9 @@ import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.global.security.CurrentMemberProvider;
 import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.project.adapter.in.graphql.dto.MemberBriefGraphQlResponse;
@@ -59,20 +60,25 @@ public class ProjectGraphQlController {
     private final GetProjectApplicationDetailUseCase getProjectApplicationDetailUseCase;
     private final GetMemberUseCase getMemberUseCase;
     private final CheckPermissionUseCase checkPermissionUseCase;
+    private final CurrentMemberProvider currentMemberProvider;
 
     @QueryMapping
-    public ProjectGraphQlResponse project(@Argument Long id) {
-        Long requesterMemberId = currentMemberId();
+    public ProjectGraphQlResponse project(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
+        @Argument Long id
+    ) {
+        Long requesterMemberId = currentMemberId(memberPrincipal);
         checkPermissionUseCase.checkOrThrow(requesterMemberId, projectReadPermission(id));
         return ProjectGraphQlResponse.from(getProjectUseCase.getById(id));
     }
 
     @QueryMapping
     public ProjectPageGraphQlResponse projects(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
         @Argument ProjectSearchGraphQlRequest input,
         @Argument ProjectPageGraphQlRequest page
     ) {
-        Long requesterMemberId = currentMemberId();
+        Long requesterMemberId = currentMemberId(memberPrincipal);
         checkPermissionUseCase.checkOrThrow(
             requesterMemberId,
             ResourcePermission.ofType(ResourceType.PROJECT, PermissionType.READ)
@@ -222,15 +228,14 @@ public class ProjectGraphQlController {
         return result;
     }
 
+    private Long currentMemberId(MemberPrincipal memberPrincipal) {
+        return memberPrincipal == null
+            ? currentMemberProvider.getRequiredCurrentMemberId()
+            : memberPrincipal.getMemberId();
+    }
+
     private Long currentMemberId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new AccessDeniedException("로그인이 필요해요. 로그인 후 다시 시도해주세요.");
-        }
-        if (authentication.getPrincipal() instanceof MemberPrincipal principal) {
-            return principal.getMemberId();
-        }
-        throw new AccessDeniedException("인증 정보가 올바르지 않아요. 다시 로그인해주세요.");
+        return currentMemberProvider.getRequiredCurrentMemberId();
     }
 
     private void assertProjectRead(SubjectAttributes subject, Long projectId) {

--- a/src/test/java/com/umc/product/global/security/CurrentMemberProviderTest.java
+++ b/src/test/java/com/umc/product/global/security/CurrentMemberProviderTest.java
@@ -1,0 +1,54 @@
+package com.umc.product.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class CurrentMemberProviderTest {
+
+    CurrentMemberProvider sut = new CurrentMemberProvider();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증된 MemberPrincipal을 현재 회원으로 반환한다")
+    void 인증된_MemberPrincipal을_현재_회원으로_반환한다() {
+        // Given
+        MemberPrincipal principal = new MemberPrincipal(10L);
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of())
+        );
+
+        // When
+        MemberPrincipal result = sut.getNullableCurrentMember();
+
+        // Then
+        assertThat(result).isSameAs(principal);
+        assertThat(sut.getRequiredCurrentMemberId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("익명 사용자는 nullable 현재 회원에서 null로 반환한다")
+    void 익명_사용자는_nullable_현재_회원에서_null로_반환한다() {
+        // Given
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("anonymousUser", null, List.of())
+        );
+
+        // When & Then
+        assertThat(sut.getNullableCurrentMember()).isNull();
+        assertThatThrownBy(() -> sut.getRequiredCurrentMember())
+            .isInstanceOf(AccessDeniedException.class);
+    }
+}

--- a/src/test/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/member/adapter/in/graphql/MemberGraphQlControllerTest.java
@@ -41,6 +41,7 @@ import com.umc.product.common.domain.enums.MemberStatus;
 import com.umc.product.global.config.GraphQlRuntimeWiringConfig;
 import com.umc.product.global.exception.GraphQlExceptionAdvice;
 import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.security.CurrentMemberSecurityConfig;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.SearchMemberUseCase;
@@ -60,7 +61,7 @@ import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 
 @GraphQlTest({MemberGraphQlController.class, OrganizationGraphQlController.class})
-@Import({GraphQlRuntimeWiringConfig.class, GraphQlExceptionAdvice.class})
+@Import({GraphQlRuntimeWiringConfig.class, GraphQlExceptionAdvice.class, CurrentMemberSecurityConfig.class})
 @DisplayName("MemberGraphQlController")
 class MemberGraphQlControllerTest {
 

--- a/src/test/java/com/umc/product/project/adapter/in/graphql/ProjectGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/in/graphql/ProjectGraphQlControllerTest.java
@@ -37,6 +37,7 @@ import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.global.config.GraphQlRuntimeWiringConfig;
 import com.umc.product.global.exception.GraphQlExceptionAdvice;
 import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.security.CurrentMemberSecurityConfig;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.project.application.port.in.query.GetProjectApplicationDetailUseCase;
@@ -58,7 +59,7 @@ import com.umc.product.project.domain.enums.ProjectMemberStatus;
 import com.umc.product.project.domain.enums.ProjectStatus;
 
 @GraphQlTest(ProjectGraphQlController.class)
-@Import({GraphQlRuntimeWiringConfig.class, GraphQlExceptionAdvice.class})
+@Import({GraphQlRuntimeWiringConfig.class, GraphQlExceptionAdvice.class, CurrentMemberSecurityConfig.class})
 @DisplayName("ProjectGraphQlController")
 class ProjectGraphQlControllerTest {
 


### PR DESCRIPTION
## 🚀 작업 내용

- Spring MVC와 GraphQL이 동일한 현재 회원 조회 정책을 사용하도록 `CurrentMemberProvider`와 설정을 추가했어요.
- 기존 MVC `CurrentMemberArgumentResolver`가 공용 provider를 사용하도록 변경했어요.
- Member/Project GraphQL Query에서 직접 `SecurityContextHolder`를 조회하던 코드를 `@CurrentMember` 파라미터와 공용 provider 사용으로 교체했어요.
- 인증 정보가 없거나 `MemberPrincipal`이 아닌 경우 기존과 동일하게 접근 거부 오류로 처리해요.
- Recruiting PR #1125에서 공용 인증 변경만 분리했으며, 이 PR 병합 후 #1125를 rebase해 중복 변경을 제거할 예정이에요.

### 검증

- `./gradlew test --tests com.umc.product.global.security.CurrentMemberProviderTest --tests com.umc.product.member.adapter.in.graphql.MemberGraphQlControllerTest --tests com.umc.product.project.adapter.in.graphql.ProjectGraphQlControllerTest`
- `./gradlew test`
- `./gradlew spotlessCheck checkstyleMain checkstyleTest`

## 💬 리뷰 중점사항

- 기존 `@CurrentMember`가 `@AuthenticationPrincipal`의 메타 어노테이션이므로 Spring GraphQL에서도 동일한 선언형 파라미터 주입을 사용해요.
- Query 파라미터 주입과 BatchMapping 등 내부 조회가 같은 `CurrentMemberProvider` 정책을 공유하는지 확인 부탁드려요.
- GraphQL schema와 외부 API 계약 변경은 없어요.

Related to #1125