### PR TITLE
[Fix] WebSocket Broker 방식 검증 완화

### DIFF
--- a/docs/adr/026-separate-chat-engine-consumer-realtime-responsibilities.md
+++ b/docs/adr/026-separate-chat-engine-consumer-realtime-responsibilities.md
@@ -545,17 +545,19 @@ FCM/APNs, token, deeplink, title/name, mute/offline/DND 결정과 notification d
 
 ### Broker, readiness, and observability gates
 
-- `WebSocketMessageBrokerConfig`는 local/test의 `SIMPLE` broker와 dev/prod의 shared external
-  `RELAY`를 분기한다. `WebSocketBrokerPropertiesValidator`는 dev/prod에서 simple mode를 거부하고
-  relay host/virtual-host/system·client credential 누락과 port 범위를 fail-fast로 검증한다.
-- dev/prod relay는 `tls-enabled=true`여야 한다. `StompRelayTcpClientFactory`가 Reactor Netty TLS와
-  HTTPS hostname verification을 적용하며, `WebSocketBrokerProperties.Relay.toString()`은 credential을
-  redacted한다. secret은 환경/secret injection에서만 읽고 로그에 남기지 않는다.
+- `WebSocketMessageBrokerConfig`는 모든 프로필에서 선택 가능한 instance-local `SIMPLE` broker와 shared
+  external `RELAY`를 분기한다. `WebSocketBrokerPropertiesValidator`는 `RELAY`를 선택한 경우에만 relay
+  host/virtual-host/system·client credential 누락과 port 범위를 fail-fast로 검증한다.
+- dev/prod에서 relay를 선택하면 `tls-enabled=true`여야 한다. `StompRelayTcpClientFactory`가 Reactor Netty
+  TLS와 HTTPS hostname verification을 적용하며, `WebSocketBrokerProperties.Relay.toString()`은
+  credential을 redacted한다. secret은 환경/secret injection에서만 읽고 로그에 남기지 않는다.
 - `StompBrokerRelayMonitor`의 availability/reconnect 관측과 `WebSocketBrokerRelayStartupValidator`의
-  `startup-timeout` 내 readiness가 운영 기동 조건이다.
-- shared RabbitMQ STOMP plugin/relay provisioning, secret injection, ALB SockJS fallback stickiness,
-  configured heartbeat보다 긴 idle timeout, multi-instance readiness/전환 증거는 로컬 코드만으로
-  증명할 수 없는 외부 인프라 증거다. 이 증거가 없으면 PR3 merge/deploy를 차단한다.
+  `startup-timeout` 내 readiness가 relay 운영 기동 조건이다.
+- simple broker의 구독과 session registry는 instance-local이다. rolling deploy의 일시적 instance 중첩을
+  포함해 다중 instance에서 무손실 실시간 전달이 필요해지면 shared RabbitMQ STOMP plugin/relay
+  provisioning, secret injection, ALB SockJS fallback stickiness, configured heartbeat보다 긴 idle timeout과
+  전환 검증을 scale-out 선행 조건으로 갖춘다. simple 운영 중 연결 종료·전달 공백은 client reconnect와
+  REST backfill로 복구한다.
 - `CommunityThreadRealtimeMetrics`는 send/reject/rate-limit/fan-out/broadcast-failure/backfill을
   유한한 `operation`/`outcome`/`reason` bucket으로만 기록한다. `threadId`, `memberId`, `messageId`,
   `eventId`, raw destination은 metric tag가 될 수 없다. relay availability/reconnect 및

--- a/docs/guides/community-thread-client-contract.md
+++ b/docs/guides/community-thread-client-contract.md
@@ -180,18 +180,20 @@ message/reaction/read gap은 history endpoint로, metadata/member/settings gap�
 query로 backfill한다. kick/leave/delete terminal event는 broker replay가 아니라 REST terminal state를
 기준으로 한다.
 
-## Broker 운영 전제와 merge/deploy blocker
+## Broker 운영 전제와 확장 조건
 
-- local/test는 `app.websocket.broker.mode=SIMPLE`을 허용한다. `dev`/`prod`는 shared external STOMP
-  relay(`RELAY`)만 허용하며 `WebSocketBrokerPropertiesValidator`가 simple mode를 거부하고
+- 단일 application instance 운영에서는 모든 프로필이 `app.websocket.broker.mode=SIMPLE`을 허용한다.
+  `WebSocketBrokerPropertiesValidator`는 `RELAY`를 선택한 경우에만
   host/virtual-host/system·client credentials 누락과 port 범위를 fail-fast로 검증한다.
-- dev/prod relay는 `tls-enabled=true`여야 한다. `StompRelayTcpClientFactory`가 TLS hostname
+- dev/prod에서 relay를 선택하면 `tls-enabled=true`여야 한다. `StompRelayTcpClientFactory`가 TLS hostname
   verification(`HTTPS`)을 사용하고 `WebSocketBrokerProperties.Relay.toString()`은 credential을
   redacted한다. secret은 환경/secret injection으로만 주입하고 로그에 남기지 않는다.
-- `StompBrokerRelayMonitor` availability/reconnect와 `WebSocketBrokerRelayStartupValidator`의
-  `startup-timeout` 내 readiness를 확인한다. RabbitMQ STOMP plugin/relay provisioning, secret injection,
-  ALB SockJS fallback stickiness, configured heartbeat보다 긴 idle timeout, multi-instance readiness/전환
-  증거는 로컬에서 입증할 수 없는 외부 인프라 산출물이며, 누락 시 PR3 merge/deploy blocker다.
+- relay 운영에서는 `StompBrokerRelayMonitor` availability/reconnect와
+  `WebSocketBrokerRelayStartupValidator`의 `startup-timeout` 내 readiness를 확인한다. simple broker의
+  구독과 session registry는 instance-local이므로 rolling deploy의 일시적 instance 중첩을 포함해 다중
+  instance에서 무손실 전달이 필요해지면 RabbitMQ STOMP plugin/relay provisioning, secret injection,
+  ALB SockJS fallback stickiness, configured heartbeat보다 긴 idle timeout과 전환 검증을 scale-out 선행
+  조건으로 갖춘다. simple 운영 중 연결 종료·전달 공백은 client reconnect와 REST backfill로 복구한다.
 
 ## Metrics cardinality
 

--- a/docs/onboarding/domain/community.md
+++ b/docs/onboarding/domain/community.md
@@ -139,20 +139,22 @@ event와 분리된 alarm-ready snapshot으로 realtime relay가 다시 소비하
 `CommunityThreadInvitedEvent`는 thread/inviter/invited member ID snapshot만 보관한다. 알림 발송, FCM/APNs,
 token/deeplink consumer는 이 문서의 구현 범위가 아니다.
 
-## Broker와 운영 blocker
+## Broker와 운영 조건
 
-- local/test는 `app.websocket.broker.mode=SIMPLE`을 사용할 수 있다. `dev`/`prod`는 shared external
-  STOMP relay(`RELAY`)만 허용한다. `WebSocketBrokerPropertiesValidator`가 simple mode를 거부하고
-  relay host/virtual-host/system·client credentials 누락과 port 범위를 startup에서 fail-fast로
-  검증한다.
-- `dev`/`prod`는 `tls-enabled=true`를 요구한다. `StompRelayTcpClientFactory`가 TLS hostname
-  verification(`HTTPS`)을 적용하고, `WebSocketBrokerProperties.Relay.toString()`은 credentials를
-  redacted한다. 비밀번호는 환경변수/secret injection으로만 주입하고 로그에 남기지 않는다.
-- `StompBrokerRelayMonitor`의 availability/reconnect metric과
+- 단일 application instance 운영에서는 모든 프로필이 `app.websocket.broker.mode=SIMPLE`을 사용할 수
+  있다. `WebSocketBrokerPropertiesValidator`는 `RELAY`를 선택한 경우에만 relay
+  host/virtual-host/system·client credentials 누락과 port 범위를 startup에서 fail-fast로 검증한다.
+- `dev`/`prod`에서 `RELAY`를 선택하면 `tls-enabled=true`를 요구한다.
+  `StompRelayTcpClientFactory`가 TLS hostname verification(`HTTPS`)을 적용하고,
+  `WebSocketBrokerProperties.Relay.toString()`은 credentials를 redacted한다. 비밀번호는
+  환경변수/secret injection으로만 주입하고 로그에 남기지 않는다.
+- relay 운영에서는 `StompBrokerRelayMonitor`의 availability/reconnect metric과
   `WebSocketBrokerRelayStartupValidator`의 startup-timeout readiness 검증을 통과해야 한다.
-- 운영 provisioning(공유 RabbitMQ STOMP plugin/relay 및 secret injection), ALB SockJS fallback
-  stickiness, configured heartbeat보다 긴 idle timeout, 다중 application instance readiness/전환
-  증거는 로컬에서 증명할 수 없는 외부 인프라 산출물이다. 이 증거가 없으면 PR3 merge/deploy blocker다.
+- simple broker의 구독과 session registry는 instance-local이다. rolling deploy의 일시적 instance 중첩을
+  포함해 다중 instance에서 무손실 실시간 전달이 필요해지면, 공유 RabbitMQ STOMP plugin/relay,
+  secret injection, ALB SockJS fallback stickiness, configured heartbeat보다 긴 idle timeout과 전환
+  검증을 scale-out 선행 조건으로 갖춘다. simple 운영 중 연결 종료·전달 공백은 client reconnect와 REST
+  backfill로 복구한다.
 
 ## Observability 규칙
 

--- a/src/main/java/com/umc/product/community/AGENTS.md
+++ b/src/main/java/com/umc/product/community/AGENTS.md
@@ -159,17 +159,20 @@ consumer는 이 범위에 없다.
 
 ## BROKER, READINESS, AND METRICS
 
-- local/test는 `app.websocket.broker.mode=SIMPLE`을 사용할 수 있다. `dev`/`prod`는 shared external
-  STOMP relay(`RELAY`)만 허용한다. `WebSocketBrokerPropertiesValidator`가 simple mode를 거부하고,
-  host/virtual-host/system·client credential 누락과 port 범위를 startup에서 fail-fast로 검증한다.
-- `dev`/`prod`에서는 `relay.tls-enabled=true`가 필수다. `StompRelayTcpClientFactory`는 TLS hostname
-  verification(`HTTPS`)을 적용하며, `WebSocketBrokerProperties.Relay.toString()`은 credentials를
-  redacted한다. secret은 환경변수/secret injection으로만 주입하고 로그에 기록하지 않는다.
+- 단일 application instance 운영에서는 모든 프로필이 `app.websocket.broker.mode=SIMPLE`을 사용할 수
+  있다. `WebSocketBrokerPropertiesValidator`는 `RELAY`를 선택한 경우에만 host/virtual-host/system·client
+  credential 누락과 port 범위를 startup에서 fail-fast로 검증한다.
+- `dev`/`prod`에서 `RELAY`를 선택하면 `relay.tls-enabled=true`가 필수다.
+  `StompRelayTcpClientFactory`는 TLS hostname verification(`HTTPS`)을 적용하며,
+  `WebSocketBrokerProperties.Relay.toString()`은 credentials를 redacted한다. secret은 환경변수/secret
+  injection으로만 주입하고 로그에 기록하지 않는다.
 - `StompBrokerRelayMonitor`의 availability/reconnect와 `WebSocketBrokerRelayStartupValidator`의
   `startup-timeout` readiness 대기는 운영 broker가 실제로 연결된 경우에만 통과한다.
-- production provisioning(공유 RabbitMQ STOMP plugin/relay, secret injection), ALB SockJS fallback
-  stickiness, configured heartbeat보다 긴 idle timeout, multi-instance readiness/전환 증거는 로컬
-  코드만으로 증명할 수 없는 외부 인프라 산출물이다. 이 증거가 없으면 PR3 merge/deploy blocker다.
+- simple broker의 구독과 session registry는 instance-local이다. rolling deploy의 일시적 instance 중첩을
+  포함해 다중 instance에서 무손실 실시간 전달이 필요해지면, shared RabbitMQ STOMP plugin/relay,
+  secret injection, ALB SockJS fallback stickiness, configured heartbeat보다 긴 idle timeout과 전환
+  검증을 scale-out 선행 조건으로 갖춘다. simple 운영 중 연결 종료·전달 공백은 client reconnect와 REST
+  backfill로 복구한다.
 - `CommunityThreadRealtimeMetrics`는 send/reject/rate-limit/fan-out/broadcast-failure/backfill을
   `operation`, `outcome`, `reason` 같은 고정 bucket으로만 기록한다. `threadId`, `memberId`,
   `messageId`, `eventId` 등 ID를 metric tag로 사용하지 않는다. broker availability/reconnect 및

--- a/src/main/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidator.java
+++ b/src/main/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidator.java
@@ -16,16 +16,11 @@ public final class WebSocketBrokerPropertiesValidator {
     }
 
     public static void validate(WebSocketBrokerProperties properties, Environment environment) {
-        boolean sharedEnvironment = environment.acceptsProfiles(SHARED_ENVIRONMENT_PROFILES);
         if (properties.mode() == WebSocketBrokerProperties.Mode.SIMPLE) {
-            if (sharedEnvironment) {
-                throw new IllegalStateException(
-                    "dev/prod 프로필에서는 app.websocket.broker.mode=relay가 필요합니다."
-                );
-            }
             return;
         }
 
+        boolean sharedEnvironment = environment.acceptsProfiles(SHARED_ENVIRONMENT_PROFILES);
         validateRelay(properties.relay(), sharedEnvironment);
     }
 

--- a/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
+++ b/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
@@ -26,34 +26,30 @@ class WebSocketBrokerPropertiesValidatorTest {
     }
 
     @Test
-    @DisplayName("dev와 prod 프로필은 simple broker로 시작할 수 없다")
-    void validate_sharedEnvironmentRejectsSimpleBroker() {
+    @DisplayName("dev와 prod 프로필도 single instance에서는 simple broker로 시작할 수 있다")
+    void validate_sharedEnvironmentAllowsSimpleBroker() {
         for (String profile : new String[] {"dev", "prod"}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profile);
 
-            assertThatThrownBy(() -> WebSocketBrokerPropertiesValidator.validate(
+            assertThatCode(() -> WebSocketBrokerPropertiesValidator.validate(
                 new WebSocketBrokerProperties(WebSocketBrokerProperties.Mode.SIMPLE, null),
                 environment
-            ))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("app.websocket.broker.mode=relay");
+            )).doesNotThrowAnyException();
         }
     }
 
     @Test
-    @DisplayName("dev 또는 prod가 포함된 혼합 프로필은 simple broker로 시작할 수 없다")
-    void validate_mixedSharedProfilesRejectSimpleBroker() {
+    @DisplayName("dev 또는 prod가 포함된 혼합 프로필도 simple broker로 시작할 수 있다")
+    void validate_mixedSharedProfilesAllowsSimpleBroker() {
         for (String[] profiles : new String[][] {{"test", "dev"}, {"local", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profiles);
 
-            assertThatThrownBy(() -> WebSocketBrokerPropertiesValidator.validate(
+            assertThatCode(() -> WebSocketBrokerPropertiesValidator.validate(
                 new WebSocketBrokerProperties(WebSocketBrokerProperties.Mode.SIMPLE, null),
                 environment
-            ))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("app.websocket.broker.mode=relay");
+            )).doesNotThrowAnyException();
         }
     }
 


### PR DESCRIPTION
## 🚀 작업 내용

- 단일 application instance로 운영하는 dev/prod에서도 `SIMPLE` broker로 부팅할 수 있도록 `WebSocketBrokerPropertiesValidator`의 프로필 강제를 제거했어요.
- `RELAY`를 명시적으로 선택한 경우에는 기존 host, port, credentials, TLS, readiness 검증을 그대로 유지했어요.
- dev/prod 및 혼합 프로필에서 simple broker가 허용되는 회귀 테스트를 추가하고, ADR과 Community 운영 문서를 현재 정책에 맞췄어요.
- `SIMPLE`의 구독 정보는 instance-local이므로 rolling deploy 중 연결 종료와 전달 공백은 client reconnect 및 REST backfill로 복구하고, 무손실 multi-instance가 필요해지는 시점에는 relay를 scale-out 선행 조건으로 두었어요.

## 💬 리뷰 중점사항

- S3 `.env`에서 `WEBSOCKET_BROKER_MODE`가 없거나 `simple`이면 relay credentials 없이 기동하고, `relay`를 선택한 경우에는 기존 fail-fast가 유지되는지 봐주세요.
- WebSocket 설정·종료 관련 테스트 17개가 통과했어요: `./gradlew test --tests com.umc.product.global.config.WebSocketBrokerPropertiesValidatorTest --tests com.umc.product.global.config.WebSocketMessageBrokerConfigTest --tests com.umc.product.global.websocket.interceptor.ShutdownAwareHandshakeInterceptorTest -x spotlessJavaCheck`
- 로컬 전체 Spotless는 커밋에서 제외한 기존 `RateLimitRouteResolverTest`의 trailing whitespace 때문에 중단됐고, 이번 커밋 6개 파일의 diff 검사는 통과했어요.