### PR TITLE
[Fix] Event Outbox 및 Maintenance polling SQL 로그 노이즈 제거

### DIFF
--- a/src/main/java/com/umc/product/global/event/adapter/out/persistence/EventOutboxJpaRepository.java
+++ b/src/main/java/com/umc/product/global/event/adapter/out/persistence/EventOutboxJpaRepository.java
@@ -12,7 +12,7 @@ import com.umc.product.global.event.domain.EventOutbox;
 public interface EventOutboxJpaRepository extends JpaRepository<EventOutbox, Long> {
 
     @Query(value = """
-        SELECT *
+        SELECT /* p6spy:exclude */ *
         FROM event_outbox
         WHERE status IN ('PENDING', 'PROCESSING')
           AND next_attempt_at <= :now

--- a/src/main/java/com/umc/product/maintenance/adapter/out/persistence/MaintenanceWindowRepository.java
+++ b/src/main/java/com/umc/product/maintenance/adapter/out/persistence/MaintenanceWindowRepository.java
@@ -1,22 +1,25 @@
 package com.umc.product.maintenance.adapter.out.persistence;
 
-import com.umc.product.maintenance.domain.MaintenanceWindow;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.umc.product.maintenance.domain.MaintenanceWindow;
+
 public interface MaintenanceWindowRepository extends JpaRepository<MaintenanceWindow, Long> {
 
-    @Query("""
-        SELECT w FROM MaintenanceWindow w
-        WHERE w.forcedEndedAt IS NULL
-          AND w.startAt <= :now
-          AND w.endAt > :now
-        ORDER BY w.startAt DESC
-        """)
+    @Query(value = """
+        SELECT /* p6spy:exclude */ *
+        FROM maintenance_window
+        WHERE forced_ended_at IS NULL
+          AND start_at <= :now
+          AND end_at > :now
+        ORDER BY start_at DESC
+        """, nativeQuery = true)
     List<MaintenanceWindow> findActiveAt(@Param("now") Instant now);
 
     @Query("""

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -183,6 +183,10 @@ decorator:
   datasource:
     p6spy:
       enable-logging: ${P6SPY_ENABLE_LOGGING:false}
+      # 명시적으로 p6spy:exclude tag를 붙인 반복 SQL만 라인 로그에서 제외한다.
+      # query 통계와 DB span에는 영향이 없으며, 새로운 제외 대상에는 반드시 의도를 드러내는 tag를 붙인다.
+      log-filter:
+        pattern: '(?s)^(?!.*p6spy:exclude).*$'
       tracing:
         include-parameter-values: false
 

--- a/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
@@ -13,6 +13,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.jpa.repository.Query;
 
 import com.umc.product.global.event.adapter.out.persistence.EventOutboxJpaRepository;
+import com.umc.product.maintenance.adapter.out.persistence.MaintenanceWindowRepository;
 
 class P6SpyConfigTest {
 
@@ -119,6 +120,21 @@ class P6SpyConfigTest {
         assertThat(logFilter.matcher(pollingSql).matches()).isFalse();
         assertThat(logFilter.matcher(pollingSql.replace("/* p6spy:exclude */", "")).matches()).isTrue();
         assertThat(logFilter.matcher("select * from member where id = ?").matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("P6Spy는 명시적인 제외 tag가 붙은 maintenance 상태 조회 SQL만 로그에서 제외한다")
+    void P6Spy는_명시적인_제외_tag가_붙은_maintenance_상태_조회_SQL만_로그에서_제외한다()
+        throws NoSuchMethodException {
+        Pattern logFilter = loadSqlLogFilter();
+        Query maintenanceQuery = MaintenanceWindowRepository.class
+            .getMethod("findActiveAt", Instant.class)
+            .getAnnotation(Query.class);
+        String maintenanceSql = maintenanceQuery.value();
+
+        assertThat(maintenanceSql).contains("/* p6spy:exclude */");
+        assertThat(logFilter.matcher(maintenanceSql).matches()).isFalse();
+        assertThat(logFilter.matcher(maintenanceSql.replace("/* p6spy:exclude */", "")).matches()).isTrue();
     }
 
     private Pattern loadSqlLogFilter() {

--- a/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyConfigTest.java
@@ -2,8 +2,17 @@ package com.umc.product.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.jpa.repository.Query;
+
+import com.umc.product.global.event.adapter.out.persistence.EventOutboxJpaRepository;
 
 class P6SpyConfigTest {
 
@@ -94,6 +103,30 @@ class P6SpyConfigTest {
                 "recruiting_application"
             )
             .doesNotContain(PROBE_EMAIL, PROBE_KEY);
+    }
+
+    @Test
+    @DisplayName("P6Spy는 명시적인 제외 tag가 붙은 event outbox polling SQL만 로그에서 제외한다")
+    void P6Spy는_명시적인_제외_tag가_붙은_event_outbox_polling_SQL만_로그에서_제외한다()
+        throws NoSuchMethodException {
+        Pattern logFilter = loadSqlLogFilter();
+        Query pollingQuery = EventOutboxJpaRepository.class
+            .getMethod("findPublishableForUpdate", int.class, Instant.class)
+            .getAnnotation(Query.class);
+        String pollingSql = pollingQuery.value();
+
+        assertThat(pollingSql).contains("/* p6spy:exclude */");
+        assertThat(logFilter.matcher(pollingSql).matches()).isFalse();
+        assertThat(logFilter.matcher(pollingSql.replace("/* p6spy:exclude */", "")).matches()).isTrue();
+        assertThat(logFilter.matcher("select * from member where id = ?").matches()).isTrue();
+    }
+
+    private Pattern loadSqlLogFilter() {
+        YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+        yaml.setResources(new ClassPathResource("application.yml"));
+        Properties properties = yaml.getObject();
+        assertThat(properties).isNotNull();
+        return Pattern.compile(properties.getProperty("decorator.datasource.p6spy.log-filter.pattern"));
     }
 
     private String format(String prepared, String sql) {

--- a/src/test/java/com/umc/product/global/config/P6SpyLogRedactionIntegrationTest.java
+++ b/src/test/java/com/umc/product/global/config/P6SpyLogRedactionIntegrationTest.java
@@ -2,6 +2,8 @@ package com.umc.product.global.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import com.p6spy.engine.logging.P6LogFactory;
 import com.p6spy.engine.spy.P6ModuleManager;
 import com.p6spy.engine.spy.P6SpyFactory;
 import com.p6spy.engine.spy.appender.Slf4JLogger;
+import com.umc.product.maintenance.adapter.out.persistence.MaintenanceWindowRepository;
 import com.umc.product.support.IntegrationTestSupport;
 
 import ch.qos.logback.classic.Level;
@@ -33,6 +36,9 @@ class P6SpyLogRedactionIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    MaintenanceWindowRepository maintenanceWindowRepository;
 
     @Test
     @DisplayName("실제 PostgreSQL INSERT와 SELECT 로그는 바인딩 값을 노출하지 않는다")
@@ -71,6 +77,37 @@ class P6SpyLogRedactionIntegrationTest extends IntegrationTestSupport {
                 .doesNotContain(PROBE_EMAIL, PROBE_KEY);
         } finally {
             jdbcTemplate.execute("drop table if exists sql_redaction_probe");
+            p6spyLogger.detachAppender(appender);
+            appender.stop();
+            p6spyLogger.setLevel(previousLevel);
+            p6spyLogger.setAdditive(previousAdditive);
+        }
+    }
+
+    @Test
+    @DisplayName("명시적인 제외 tag가 붙은 maintenance polling SQL은 P6Spy 로그에 남지 않는다")
+    void 명시적인_제외_tag가_붙은_maintenance_polling_SQL은_P6Spy_로그에_남지_않는다() {
+        ch.qos.logback.classic.Logger p6spyLogger =
+            (ch.qos.logback.classic.Logger)LoggerFactory.getLogger("p6spy");
+        Level previousLevel = p6spyLogger.getLevel();
+        boolean previousAdditive = p6spyLogger.isAdditive();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        p6spyLogger.addAppender(appender);
+        p6spyLogger.setLevel(Level.INFO);
+        p6spyLogger.setAdditive(false);
+
+        try {
+            jdbcTemplate.queryForObject("select 1 as p6spy_visible_probe", Integer.class);
+            maintenanceWindowRepository.findActiveAt(Instant.now());
+
+            String formattedSql = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .reduce("", (left, right) -> left + "\n" + right);
+            assertThat(formattedSql)
+                .contains("p6spy_visible_probe")
+                .doesNotContain("maintenance_window");
+        } finally {
             p6spyLogger.detachAppender(appender);
             appender.stop();
             p6spyLogger.setLevel(previousLevel);


### PR DESCRIPTION
## 🚀 작업 내용

- 1초 주기 Event Outbox와 10초 주기 Maintenance 상태 조회가 로컬 P6Spy 로그를 지속적으로 채우는 문제를 줄였어요.
- 각 polling query에 `/* p6spy:exclude */` tag를 명시하고, P6Spy가 SQL 구조가 아닌 해당 tag만 기준으로 라인 로그에서 제외하도록 변경했어요.
- repository의 실제 query에 tag가 존재하는지 검증하고, PostgreSQL/P6Spy 통합 테스트로 일반 SQL은 남으면서 Maintenance polling SQL만 숨겨지는지 확인했어요.
- `./gradlew test --tests com.umc.product.global.config.P6SpyConfigTest --tests com.umc.product.global.config.P6SpyLogRedactionIntegrationTest --tests com.umc.product.maintenance.adapter.in.scheduler.MaintenanceStateRefreshSchedulerTest`를 통과했어요.

## 💬 리뷰 중점사항

- `p6spy:exclude` tag는 P6Spy SQL 원문 라인만 숨기며 `queryCount`, `queryTimeMs`, DB span 수집에는 영향을 주지 않아요.
- 추가로 제외할 반복 SQL은 구조 기반 정규식을 늘리지 않고 동일한 명시적 tag를 붙이는 방식으로 관리해요.
