### PR TITLE
[Chore] k6 부하테스트 하네스 및 결과 기록 구조 도입

### DIFF
--- a/docs/loadtest/README.md
+++ b/docs/loadtest/README.md
@@ -1,12 +1,14 @@
 # 부하 테스트 결과 인덱스
 
 [ADR-013](../adr/013-k6-load-and-performance-testing-strategy.md) §2 에 따라, 부하 테스트 실행 결과를
-`runs/<YYYY-MM-DD-label>/` 아래에 **실행 단위 디렉터리**로 영구 보존합니다.
+`runs/<YYYY-MM-DD-HHmmss>-<label>/` 아래에 **실행 단위 디렉터리**로 영구 보존합니다.
+(디렉터리명에 시각을 포함해 같은 날 같은 label 로 재실행해도 이전 결과가 덮어써지지 않습니다.)
 
-각 실행 디렉터리에는 최소 다음을 둡니다.
+각 실행 디렉터리에는 다음이 생성됩니다. `loadtest/run.sh` 로 실행하면 모두 자동 생성됩니다.
 
-- `summary.md` — 환경 / 가설 / 결과 요약 / 후속 액션 (raw 숫자만이 아니라 사고 과정을 남김)
-- `summary.json` — `k6 run --summary-export` 로 생성한 raw 결과
+- `summary.md` — 환경 / 가설 / 결과 요약 / 후속 액션 (시나리오의 `handleSummary` 가 자동 생성, 가설·시드 칸은 수기 보완)
+- `summary.json` — k6 raw 결과 (`handleSummary` 가 생성)
+- `run-meta.txt` — k6 버전 / Git SHA / 실행 env 요약 (`run.sh` 가 생성)
 
 스크립트와 실행법은 [loadtest/README.md](../../loadtest/README.md) 참고.
 

--- a/docs/loadtest/README.md
+++ b/docs/loadtest/README.md
@@ -1,0 +1,17 @@
+# 부하 테스트 결과 인덱스
+
+[ADR-013](../adr/013-k6-load-and-performance-testing-strategy.md) §2 에 따라, 부하 테스트 실행 결과를
+`runs/<YYYY-MM-DD-label>/` 아래에 **실행 단위 디렉터리**로 영구 보존합니다.
+
+각 실행 디렉터리에는 최소 다음을 둡니다.
+
+- `summary.md` — 환경 / 가설 / 결과 요약 / 후속 액션 (raw 숫자만이 아니라 사고 과정을 남김)
+- `summary.json` — `k6 run --summary-export` 로 생성한 raw 결과
+
+스크립트와 실행법은 [loadtest/README.md](../../loadtest/README.md) 참고.
+
+## 실행 목록
+
+| 실행 | 도메인 | 시나리오 | 목적 |
+|------|--------|----------|------|
+| _(아직 없음)_ | notice | read-status load | P0 리팩토링 전/후 비교 예정 |

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,115 @@
+# loadtest — k6 부하 테스트 하네스
+
+[ADR-013](../docs/adr/013-k6-load-and-performance-testing-strategy.md)을 기반으로 한 최소 하네스입니다.
+현재는 **notice 도메인 성능 리팩토링의 전/후 비교**를 위해 `notice/read-status` 시나리오만 구현돼 있습니다.
+
+> **디렉토리 구조 참고:** ADR-013 은 `scenarios/{smoke,load}/` + `domains/` 분리를 제안하지만,
+> 도메인이 하나뿐인 현재 규모에서는 **도메인별 디렉토리 + `<대상>.<type>.js` 네이밍**
+> (`scenarios/notice/read-status.load.js`)이 더 단순해 이 방식을 택했습니다. 시나리오/도메인이
+> 늘어나면 ADR 의 `smoke|load|...` 분리로 재정렬하고 ADR 을 실제 구조에 맞게 갱신합니다.
+
+## 구조
+
+```text
+loadtest/
+├── run.sh          # 실행 래퍼: 사전조건 확인 + k6 버전/GitSHA/env 기록 + 결과 디렉토리 생성
+├── compare.sh      # 두 실행(summary.json)의 p95/p99/에러율/RPS 비교 (jq 필요)
+├── lib/
+│   ├── config.js   # BASE_URL / NOTICE_ID / 인증정보를 env 로 주입
+│   ├── auth.js     # setup()에서 토큰 발급 (하드코딩 제거)
+│   ├── checks.js   # 공통 check + 커스텀 메트릭(endpoint_duration, endpoint_success)
+│   └── summary.js  # handleSummary: 종료 시 summary.md/json 자동 생성
+└── scenarios/
+    └── notice/
+        ├── read-status.smoke.js   # VU=1, 1분 — 정상 동작 확인
+        └── read-status.load.js    # 평시 부하 — 전/후 비교 본체
+
+../docs/loadtest/runs/   # 실행 결과 보존 (실행당 디렉토리: summary.md/json + run-meta.txt)
+```
+
+## 사전 준비 (local 기준)
+
+1. **DB 기동** — docker-compose 의 PostgreSQL (호스트 포트 54321)
+
+   ```bash
+   docker compose up -d umc-product-postgres
+   ```
+
+2. **앱 기동** — bootRun (포트 8080)
+
+   ```bash
+   ./gradlew bootRun
+   ```
+
+3. **인증 토큰** — `notice/{id}/read-status`는 해당 공지에 CHECK 권한이 있는 계정의 토큰이
+   필요합니다. local 에서는 `K6_MEMBER_ID`(권장)로 `GET /test/token/access?memberId=` 를 통해
+   비밀번호 없이 발급합니다. 대상 공지·챌린저 데이터는 시딩 API(ADR-017)로 준비합니다.
+
+## 실행
+
+환경변수로 대상·인증을 주입합니다. 인증 우선순위는 `K6_TOKEN > K6_MEMBER_ID > K6_EMAIL/K6_PASSWORD` 입니다.
+(Git Bash 등 bash 환경 기준. `run.sh` 가 결과 디렉토리·메타 기록을 처리합니다.)
+
+```bash
+# smoke — 먼저 이걸로 토큰/경로/응답이 정상인지 확인 (local: memberId 로 토큰 발급)
+K6_MEMBER_ID=1 K6_NOTICE_ID=1 \
+  k6 run loadtest/scenarios/notice/read-status.smoke.js
+
+# load (권장: run.sh) — 전/후 비교 본체. 결과가 docs/loadtest/runs/<날짜>-<label>/ 에 자동 저장
+K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
+  loadtest/run.sh loadtest/scenarios/notice/read-status.load.js notice-read-status-before
+
+# 리팩토링 후 동일 조건으로 재실행
+K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
+  loadtest/run.sh loadtest/scenarios/notice/read-status.load.js notice-read-status-after
+
+# 전/후 비교
+loadtest/compare.sh \
+  docs/loadtest/runs/2026-07-27-notice-read-status-before \
+  docs/loadtest/runs/2026-07-27-notice-read-status-after
+```
+
+주요 env:
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `K6_BASE_URL` | `http://localhost:8080` | 대상 서버 origin |
+| `K6_NOTICE_ID` | `1` | 테스트 대상 공지 ID |
+| `K6_MEMBER_ID` | (없음) | (권장, local) `/test/token/access` 로 토큰 발급할 memberId |
+| `K6_EMAIL` / `K6_PASSWORD` | (없음) | 이메일 로그인 계정 (test 토큰 API 가 없는 staging 등) |
+| `K6_TOKEN` | (없음) | 직접 주입 시 발급 과정 생략 |
+| `K6_TOKEN_TTL_MIN` | (없음) | 발급 토큰 만료(분). soak 시 테스트 길이보다 크게(예: `120`) |
+| `K6_RATE` | `20` | (load) 목표 RPS |
+| `K6_DURATION` | `2m` | (load) 평시 부하 유지 구간 |
+| `K6_PREALLOC_VUS` / `K6_MAX_VUS` | `50` / `200` | (load) arrival-rate 용 VU 풀 |
+| `K6_TESTID` | `local-adhoc` | 실행 식별 태그(전/후 구분) |
+
+## 부하 모델 (load)
+
+- **executor: `ramping-arrival-rate`** — VU 수가 아니라 **목표 RPS(도착률)** 로 부하를 정의한다.
+  응답 시간이 변해도 제공 부하가 일정하므로, 리팩토링 전/후를 **동일 부하**에서 비교할 수 있다.
+  (`ramping-vus + sleep` 은 응답이 빨라질수록 실제 RPS 가 올라가 비교가 오염된다.)
+- **기본 20 RPS** 는 read-status 가 운영진 조회 엔드포인트(ADR-013 Tier 3, 평시 트래픽 작음)라는
+  가정에 근거한 임시값이다. 실제 capacity 측정 시 `K6_RATE` 로 조정하고 근거를 summary.md 에 남긴다.
+- `dropped_iterations` 임계로 **부하 생성기가 목표 RPS 를 못 따라가는지**(maxVUs 부족/서버 과포화) 감시한다.
+- 장기 실행(soak): 아직 soak 시나리오는 없다. 추가 시 `K6_TOKEN_TTL_MIN` 을 테스트 길이보다 크게 주면
+  local(test 토큰 API) 에서는 만료 없이 돈다. staging 로그인 기반 장기 soak 은 토큰 갱신 로직이 별도로
+  필요하다(향후 확장).
+
+## 전/후 비교 워크플로우
+
+1. 리팩토링 **전** 상태에서 `run.sh` 로 load 실행 → `docs/loadtest/runs/<날짜>-...-before/` 에
+   `summary.json` + `summary.md` + `run-meta.txt` 자동 생성. 생성된 `summary.md` 의 가설/시드 버전 칸을 채운다.
+2. 리팩토링 적용
+3. **후** 상태에서 **같은 시드·같은 옵션(K6_RATE·K6_DURATION 동일)** 으로 재실행 → `...-after/`
+4. `compare.sh` 로 **p95 / p99 / 에러율 / 실측 RPS** 를 나란히 비교
+
+### 지표 범위 (중요)
+
+- **k6 로 측정되는 것**: 응답 시간(p95/p99/avg), 성공률, HTTP 실패율, 실측 RPS, dropped_iterations, checks.
+- **k6 로 측정되지 않는 것**: **요청당 SQL 실행 수, DB connection 사용량 등 서버 내부 지표**.
+  이 값들은 k6 summary 에 포함되지 않으므로 **P6Spy 로그 / Actuator / Prometheus** 에서 별도로 확인해
+  각 `summary.md` 의 "서버측 지표" 칸에 기입한다. (P0 리팩토링의 "쿼리 수 감소" 근거는 여기서 나온다.)
+
+> 비교가 오염되지 않으려면 시드 데이터 규모(대상 챌린저 수)와 목표 RPS 를 두 실행에서 동일하게 고정해야 합니다.
+> 특히 read-status 의 성능 개선 효과는 회원 수가 클수록 크게 드러납니다.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -52,8 +52,9 @@ loadtest/
 
 ```bash
 # smoke — 먼저 이걸로 토큰/경로/응답이 정상인지 확인 (local: memberId 로 토큰 발급)
+# run.sh 로 실행하면 결과가 시각 포함 디렉토리에 남아 덮어쓰기가 없다.
 K6_MEMBER_ID=1 K6_NOTICE_ID=1 \
-  k6 run loadtest/scenarios/notice/read-status.smoke.js
+  loadtest/run.sh loadtest/scenarios/notice/read-status.smoke.js notice-read-status-smoke
 
 # load (권장: run.sh) — 전/후 비교 본체.
 # 결과는 docs/loadtest/runs/<YYYY-MM-DD-HHmmss>-<label>/ 에 자동 저장(시각 포함 → 재실행해도 덮어쓰지 않음)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -55,7 +55,8 @@ loadtest/
 K6_MEMBER_ID=1 K6_NOTICE_ID=1 \
   k6 run loadtest/scenarios/notice/read-status.smoke.js
 
-# load (권장: run.sh) — 전/후 비교 본체. 결과가 docs/loadtest/runs/<날짜>-<label>/ 에 자동 저장
+# load (권장: run.sh) — 전/후 비교 본체.
+# 결과는 docs/loadtest/runs/<YYYY-MM-DD-HHmmss>-<label>/ 에 자동 저장(시각 포함 → 재실행해도 덮어쓰지 않음)
 K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
   loadtest/run.sh loadtest/scenarios/notice/read-status.load.js notice-read-status-before
 
@@ -63,10 +64,10 @@ K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
 K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
   loadtest/run.sh loadtest/scenarios/notice/read-status.load.js notice-read-status-after
 
-# 전/후 비교
+# 전/후 비교 (run.sh 가 출력한 실제 디렉토리 경로를 사용)
 loadtest/compare.sh \
-  docs/loadtest/runs/2026-07-27-notice-read-status-before \
-  docs/loadtest/runs/2026-07-27-notice-read-status-after
+  docs/loadtest/runs/2026-07-27-101500-notice-read-status-before \
+  docs/loadtest/runs/2026-07-27-142230-notice-read-status-after
 ```
 
 주요 env:

--- a/loadtest/compare.sh
+++ b/loadtest/compare.sh
@@ -3,9 +3,10 @@
 # jq 가 필요하다. 없으면 각 디렉토리의 summary.md 를 직접 비교하면 된다.
 #
 # usage: loadtest/compare.sh <before_dir> <after_dir>
+#   (run.sh 가 출력한 실제 디렉토리 경로를 사용. 디렉토리명에 시각이 포함된다.)
 # 예:    loadtest/compare.sh \
-#          docs/loadtest/runs/2026-07-27-notice-read-status-before \
-#          docs/loadtest/runs/2026-07-27-notice-read-status-after
+#          docs/loadtest/runs/2026-07-27-101500-notice-read-status-before \
+#          docs/loadtest/runs/2026-07-27-142230-notice-read-status-after
 set -euo pipefail
 
 [ $# -eq 2 ] || { echo "usage: loadtest/compare.sh <before_dir> <after_dir>"; exit 1; }

--- a/loadtest/compare.sh
+++ b/loadtest/compare.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# 두 실행 결과(summary.json)의 핵심 지표를 나란히 비교한다.
+# jq 가 필요하다. 없으면 각 디렉토리의 summary.md 를 직접 비교하면 된다.
+#
+# usage: loadtest/compare.sh <before_dir> <after_dir>
+# 예:    loadtest/compare.sh \
+#          docs/loadtest/runs/2026-07-27-notice-read-status-before \
+#          docs/loadtest/runs/2026-07-27-notice-read-status-after
+set -euo pipefail
+
+[ $# -eq 2 ] || { echo "usage: loadtest/compare.sh <before_dir> <after_dir>"; exit 1; }
+BEFORE="$1"; AFTER="$2"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "[안내] jq 가 없어 자동 비교를 건너뜁니다. 각 summary.md 를 직접 비교하세요:";
+  echo "  ${BEFORE}/summary.md"; echo "  ${AFTER}/summary.md"; exit 1;
+}
+for d in "$BEFORE" "$AFTER"; do
+  [ -f "$d/summary.json" ] || { echo "[에러] $d/summary.json 없음"; exit 1; }
+done
+
+metric() { # dir metric key
+  jq -r --arg m "$2" --arg k "$3" '.metrics[$m].values[$k] // "n/a"' "$1/summary.json"
+}
+
+printf "%-26s %-16s %-16s\n" "지표" "before" "after"
+printf "%-26s %-16s %-16s\n" "--------------------------" "----------------" "----------------"
+# label metric key
+while IFS='|' read -r label m k; do
+  b=$(metric "$BEFORE" "$m" "$k")
+  a=$(metric "$AFTER" "$m" "$k")
+  printf "%-26s %-16s %-16s\n" "$label" "$b" "$a"
+done <<'ROWS'
+p95 (ms)|endpoint_duration|p(95)
+p99 (ms)|endpoint_duration|p(99)
+avg (ms)|endpoint_duration|avg
+success rate|endpoint_success|rate
+http_req_failed|http_req_failed|rate
+rps (http_reqs/s)|http_reqs|rate
+dropped_iterations|dropped_iterations|count
+ROWS

--- a/loadtest/lib/auth.js
+++ b/loadtest/lib/auth.js
@@ -1,0 +1,97 @@
+// 인증 helper. k6 의 setup() 단계에서 1회 호출해 토큰을 발급하고,
+// 각 VU 는 default() 에서 authHeaders() 로 그 토큰을 재사용한다.
+//
+// 하드코딩 토큰(만료 시 수동 교체)을 없애기 위한 하네스의 핵심 조각.
+// 우선순위: RAW_TOKEN > MEMBER_ID(test 토큰 API) > EMAIL/PASSWORD(로그인 API)
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+import { BASE_URL, MEMBER_ID, EMAIL, PASSWORD, RAW_TOKEN, TOKEN_TTL_MIN } from './config.js';
+
+// 오류 메시지에 raw 응답 본문을 그대로 노출하지 않는다(민감정보 방어).
+// 상태 코드와, JSON 래퍼라면 비민감 필드(code/message)만 요약한다.
+function describeRes(res) {
+  let detail = '';
+  try {
+    const code = res.json('code');
+    const message = res.json('message');
+    if (code != null || message != null) {
+      detail = ` code=${code} message=${message}`;
+    }
+  } catch (e) {
+    // 비JSON 본문(예: raw 토큰 문자열) → 상태 코드만 노출
+  }
+  return `status=${res.status}${detail}`;
+}
+
+// AccessToken 문자열을 반환한다. setup() 안에서만 호출할 것.
+export function issueToken() {
+  // 방식 C: 직접 주입된 토큰이 있으면 그대로 사용
+  if (RAW_TOKEN) {
+    return RAW_TOKEN;
+  }
+  // 방식 A(권장, local 전용): test 도메인 토큰 발급 API
+  if (MEMBER_ID) {
+    return issueTokenByMemberId();
+  }
+  // 방식 B: 이메일 로그인 API
+  if (EMAIL && PASSWORD) {
+    return issueTokenByLogin();
+  }
+
+  throw new Error(
+    'K6_TOKEN / K6_MEMBER_ID / (K6_EMAIL + K6_PASSWORD) 중 하나가 필요합니다. loadtest/README.md 참고.'
+  );
+}
+
+// GET /test/token/access?memberId=... ( @Profile("local | dev") 전용 )
+// 이 엔드포인트는 응답 래퍼(ApiResponse) 없이 raw 토큰 문자열을 반환한다.
+function issueTokenByMemberId() {
+  // TOKEN_TTL_MIN 을 주면 만료를 늘려 장기 실행(soak) 중 토큰 만료를 방지한다.
+  let url = `${BASE_URL}/test/token/access?memberId=${MEMBER_ID}`;
+  if (TOKEN_TTL_MIN) {
+    url += `&expirationInMinutes=${TOKEN_TTL_MIN}`;
+  }
+  const res = http.get(url);
+
+  const ok = check(res, { 'test token 200': (r) => r.status === 200 });
+  if (!ok) {
+    throw new Error(`토큰 발급 실패(memberId=${MEMBER_ID}): ${describeRes(res)}`);
+  }
+
+  // raw 문자열. 혹시 따옴표로 감싸여 오는 경우까지 방어적으로 벗겨낸다.
+  const token = (res.body || '').trim().replace(/^"|"$/g, '');
+  if (!token) {
+    throw new Error(`발급된 토큰이 비어 있습니다: ${describeRes(res)}`);
+  }
+  return token;
+}
+
+// POST /api/v1/auth/login/email — 응답 래퍼: { success, code, message, result: { accessToken, ... } }
+function issueTokenByLogin() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login/email`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD, clientType: 'WEB' }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+
+  const ok = check(res, { 'login 200': (r) => r.status === 200 });
+  if (!ok) {
+    throw new Error(`로그인 실패: ${describeRes(res)}`);
+  }
+
+  const token = res.json('result.accessToken');
+  if (!token) {
+    throw new Error(`accessToken 파싱 실패: ${describeRes(res)}`);
+  }
+  return token;
+}
+
+// default() 에서 요청 헤더를 만들 때 사용
+export function authHeaders(token) {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+}

--- a/loadtest/lib/checks.js
+++ b/loadtest/lib/checks.js
@@ -1,0 +1,48 @@
+// 공통 check / 커스텀 메트릭. 모든 시나리오가 동일한 지표 이름으로 기록해야
+// 전/후 비교 시 같은 축으로 나란히 볼 수 있다.
+
+import { check } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+// 엔드포인트 응답 시간(ms). true = k6 summary 에 avg/min/max/p(90)/p(95) 표시
+export const endpointDuration = new Trend('endpoint_duration', true);
+
+// 성공률(check 통과 비율)
+export const endpointSuccess = new Rate('endpoint_success');
+
+// 비JSON 응답이어도 예외 없이 JSON 경로 값을 꺼낸다(없으면 undefined).
+export function jsonPath(res, path) {
+  try {
+    return res.json(path);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+// 응답을 검증하고 커스텀 메트릭에 기록한다. 성공 여부(boolean) 반환.
+// 기본 검증: HTTP 200 + 응답 래퍼 success=true.
+// extraChecks 로 엔드포인트별 body 구조 검증을 추가한다.
+export function recordResponse(res, name, extraChecks = {}) {
+  const checks = {
+    [`${name} status 200`]: (r) => r.status === 200,
+    [`${name} success=true`]: (r) => jsonPath(r, 'success') === true,
+    ...extraChecks,
+  };
+  const ok = check(res, checks);
+  endpointDuration.add(res.timings.duration);
+  endpointSuccess.add(ok);
+  return ok;
+}
+
+// 커서 페이지네이션 응답(CursorResponse: content/nextCursor/hasNext) 구조 검증.
+// recordResponse 의 extraChecks 로 넘겨 사용한다.
+export function cursorResponseChecks(name) {
+  return {
+    [`${name} result.content is array`]: (r) => Array.isArray(jsonPath(r, 'result.content')),
+    [`${name} result.hasNext is boolean`]: (r) => typeof jsonPath(r, 'result.hasNext') === 'boolean',
+    [`${name} result.nextCursor is number or null`]: (r) => {
+      const cursor = jsonPath(r, 'result.nextCursor');
+      return cursor === null || typeof cursor === 'number';
+    },
+  };
+}

--- a/loadtest/lib/config.js
+++ b/loadtest/lib/config.js
@@ -1,0 +1,25 @@
+// 부하 테스트 공통 설정. 모든 값은 환경변수(__ENV)로 주입하고, 없으면 local 기본값을 쓴다.
+// 같은 스크립트를 local / staging 에 재사용하기 위한 단일 진입점.
+
+// 대상 서버 origin. local bootRun 기본 포트 8080.
+export const BASE_URL = __ENV.K6_BASE_URL || 'http://localhost:8080';
+
+// 테스트 대상 공지 ID.
+export const NOTICE_ID = __ENV.K6_NOTICE_ID || '1';
+
+// --- 토큰 발급용 (auth.js 에서 사용). 우선순위: RAW_TOKEN > MEMBER_ID > EMAIL/PASSWORD ---
+
+// 방식 A(권장, local 전용): test 도메인 토큰 발급 API 로 memberId 만으로 비번 없이 발급.
+//   GET /test/token/access?memberId=... ( @Profile("local | dev") 에서만 활성 )
+export const MEMBER_ID = __ENV.K6_MEMBER_ID || '';
+
+// 방식 B: 이메일 로그인 API 로 실시간 발급 (staging 등 test 토큰 API 가 없는 환경).
+export const EMAIL = __ENV.K6_EMAIL || '';
+export const PASSWORD = __ENV.K6_PASSWORD || '';
+
+// 방식 C(대체): 이미 발급받은 AccessToken 을 직접 주입. 지정 시 발급 과정을 건너뛴다.
+export const RAW_TOKEN = __ENV.K6_TOKEN || '';
+
+// 발급 토큰 만료(분). 장기 실행(soak) 시 토큰 만료로 인한 401 을 막기 위해 테스트 길이보다 크게 잡는다.
+// test 토큰 API(방식 A)에만 적용된다. (로그인 API 는 서버 고정 만료를 따름)
+export const TOKEN_TTL_MIN = __ENV.K6_TOKEN_TTL_MIN || '';

--- a/loadtest/lib/summary.js
+++ b/loadtest/lib/summary.js
@@ -1,0 +1,86 @@
+// k6 종료 시(handleSummary) 결과를 요약 파일로 자동 생성한다.
+// 외부 도구(jq 등) 없이 summary.json + summary.md 를 남겨 전/후 비교를 쉽게 한다.
+// 출력 위치: K6_OUT_DIR (기본 docs/loadtest/runs/local-adhoc). run.sh 가 날짜/라벨 디렉토리를 지정한다.
+
+function metricValue(data, metric, key) {
+  const m = data.metrics[metric];
+  if (!m || m.values == null) {
+    return undefined;
+  }
+  return m.values[key];
+}
+
+function fmt(x, digits = 2) {
+  return x == null || Number.isNaN(x) ? 'n/a' : Number(x).toFixed(digits);
+}
+
+function pct(x) {
+  return x == null || Number.isNaN(x) ? 'n/a' : (Number(x) * 100).toFixed(2) + '%';
+}
+
+function metricsTable(data) {
+  const rows = [
+    ['endpoint_duration p95 (ms)', fmt(metricValue(data, 'endpoint_duration', 'p(95)'))],
+    ['endpoint_duration p99 (ms)', fmt(metricValue(data, 'endpoint_duration', 'p(99)'))],
+    ['endpoint_duration avg (ms)', fmt(metricValue(data, 'endpoint_duration', 'avg'))],
+    ['성공률 endpoint_success', pct(metricValue(data, 'endpoint_success', 'rate'))],
+    ['HTTP 실패율 http_req_failed', pct(metricValue(data, 'http_req_failed', 'rate'))],
+    ['총 요청 http_reqs', fmt(metricValue(data, 'http_reqs', 'count'), 0)],
+    ['실측 RPS http_reqs/s', fmt(metricValue(data, 'http_reqs', 'rate'))],
+    ['dropped_iterations', fmt(metricValue(data, 'dropped_iterations', 'count'), 0)],
+    ['checks 통과율', pct(metricValue(data, 'checks', 'rate'))],
+  ];
+  return rows.map(([k, v]) => `| ${k} | ${v} |`).join('\n');
+}
+
+function renderMarkdown(data) {
+  return `# 부하 테스트 결과: ${__ENV.K6_TESTID || 'local-adhoc'}
+
+## 환경
+- 일시: ${new Date().toISOString()}
+- Git ref: ${__ENV.K6_GITREF || 'unknown'}
+- 대상: ${__ENV.K6_BASE_URL || 'http://localhost:8080'}
+- 공지 ID: ${__ENV.K6_NOTICE_ID || '1'}
+- 목표 RPS(K6_RATE): ${__ENV.K6_RATE || '(scenario 기본)'}
+- 시드 데이터 버전: (직접 기입 — 대상 챌린저 수 등)
+
+## 가설
+- (직접 기입)
+
+## 결과 — k6 측정 지표
+| 지표 | 값 |
+|------|-----|
+${metricsTable(data)}
+
+## 서버측 지표 (k6 밖에서 확인 — 직접 기입)
+> k6 summary 에는 서버 내부 SQL 실행 횟수/DB 풀 사용량이 포함되지 않는다.
+> 아래는 P6Spy 로그, Actuator, Prometheus 등에서 확인해 기입한다.
+- 요청당 SQL 실행 수:
+- DB connection peak:
+
+## 후속 액션
+- (직접 기입)
+`;
+}
+
+function renderStdout(data) {
+  return (
+    [
+      `p95=${fmt(metricValue(data, 'endpoint_duration', 'p(95)'))}ms`,
+      `p99=${fmt(metricValue(data, 'endpoint_duration', 'p(99)'))}ms`,
+      `success=${pct(metricValue(data, 'endpoint_success', 'rate'))}`,
+      `http_fail=${pct(metricValue(data, 'http_req_failed', 'rate'))}`,
+      `rps=${fmt(metricValue(data, 'http_reqs', 'rate'))}`,
+      `dropped=${fmt(metricValue(data, 'dropped_iterations', 'count'), 0)}`,
+    ].join('  ') + '\n'
+  );
+}
+
+export function handleSummary(data) {
+  const outDir = __ENV.K6_OUT_DIR || 'docs/loadtest/runs/local-adhoc';
+  const out = {};
+  out['stdout'] = renderStdout(data);
+  out[`${outDir}/summary.json`] = JSON.stringify(data, null, 2);
+  out[`${outDir}/summary.md`] = renderMarkdown(data);
+  return out;
+}

--- a/loadtest/run.sh
+++ b/loadtest/run.sh
@@ -21,8 +21,9 @@ if command -v curl >/dev/null 2>&1; then
     || echo "[경고] ${BASE_URL} 헬스체크 실패 — 앱이 떠 있는지 확인하세요(계속 진행)."
 fi
 
-DATE=$(date +%Y-%m-%d)
-OUT="docs/loadtest/runs/${DATE}-${LABEL}"
+# 시각(HHmmss)까지 포함해 같은 날 같은 label 재실행 시 이전 결과가 덮어써지지 않게 한다.
+TS=$(date +%Y-%m-%d-%H%M%S)
+OUT="docs/loadtest/runs/${TS}-${LABEL}"
 mkdir -p "$OUT"
 GITREF=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
 

--- a/loadtest/run.sh
+++ b/loadtest/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# k6 시나리오를 실행하고 결과를 날짜/라벨 디렉토리에 보존한다.
+# k6 버전·Git SHA·환경변수 요약을 run-meta.txt 로 함께 남긴다(재현성).
+# summary.md / summary.json 은 시나리오의 handleSummary 가 K6_OUT_DIR 로 자동 생성한다.
+#
+# usage: loadtest/run.sh <scenario.js> <label> [추가 k6 인자...]
+# 예:    K6_MEMBER_ID=1 K6_RATE=20 loadtest/run.sh \
+#          loadtest/scenarios/notice/read-status.load.js notice-read-status-before
+set -euo pipefail
+
+[ $# -ge 2 ] || { echo "usage: loadtest/run.sh <scenario.js> <label> [k6 args...]"; exit 1; }
+SCENARIO="$1"; LABEL="$2"; shift 2
+
+command -v k6 >/dev/null 2>&1 || { echo "[에러] k6 가 설치되어 있지 않습니다."; exit 1; }
+[ -f "$SCENARIO" ] || { echo "[에러] 시나리오 파일 없음: $SCENARIO"; exit 1; }
+
+BASE_URL="${K6_BASE_URL:-http://localhost:8080}"
+# 사전조건: 대상 서버 응답 확인(있으면). curl 없으면 건너뜀.
+if command -v curl >/dev/null 2>&1; then
+  curl -fsS -o /dev/null "${BASE_URL}/actuator/health" 2>/dev/null \
+    || echo "[경고] ${BASE_URL} 헬스체크 실패 — 앱이 떠 있는지 확인하세요(계속 진행)."
+fi
+
+DATE=$(date +%Y-%m-%d)
+OUT="docs/loadtest/runs/${DATE}-${LABEL}"
+mkdir -p "$OUT"
+GITREF=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+{
+  echo "date: $(date -Iseconds 2>/dev/null || date)"
+  echo "gitref: ${GITREF}"
+  echo "k6: $(k6 version | head -1)"
+  echo "scenario: ${SCENARIO}"
+  echo "env: BASE_URL=${BASE_URL} NOTICE_ID=${K6_NOTICE_ID:-1} RATE=${K6_RATE:-} DURATION=${K6_DURATION:-} TESTID=${K6_TESTID:-$LABEL}"
+} | tee "$OUT/run-meta.txt"
+
+K6_OUT_DIR="$OUT" K6_GITREF="$GITREF" K6_TESTID="${K6_TESTID:-$LABEL}" \
+  k6 run "$@" "$SCENARIO"
+
+echo "결과: ${OUT}/ (summary.md, summary.json, run-meta.txt)"

--- a/loadtest/run.sh
+++ b/loadtest/run.sh
@@ -22,8 +22,12 @@ if command -v curl >/dev/null 2>&1; then
 fi
 
 # 시각(HHmmss)까지 포함해 같은 날 같은 label 재실행 시 이전 결과가 덮어써지지 않게 한다.
+# 같은 초에 동일 label 로 실행하는 극단적 충돌까지 막기 위해, 이미 존재하면 랜덤 suffix 를 붙인다.
 TS=$(date +%Y-%m-%d-%H%M%S)
 OUT="docs/loadtest/runs/${TS}-${LABEL}"
+if [ -e "$OUT" ]; then
+  OUT="${OUT}-${RANDOM}"
+fi
 mkdir -p "$OUT"
 GITREF=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
 
@@ -35,7 +39,26 @@ GITREF=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
   echo "env: BASE_URL=${BASE_URL} NOTICE_ID=${K6_NOTICE_ID:-1} RATE=${K6_RATE:-} DURATION=${K6_DURATION:-} TESTID=${K6_TESTID:-$LABEL}"
 } | tee "$OUT/run-meta.txt"
 
+# threshold 미달 시 k6 는 non-zero 로 종료하지만 handleSummary 는 그래도 실행되므로,
+# set -e 로 즉시 중단하지 않고 종료코드를 잡아 결과 검증/보고 후 그대로 전파한다.
+set +e
 K6_OUT_DIR="$OUT" K6_GITREF="$GITREF" K6_TESTID="${K6_TESTID:-$LABEL}" \
   k6 run "$@" "$SCENARIO"
+K6_EXIT=$?
+set -e
+
+# 공통 실행 래퍼 계약: 시나리오가 handleSummary 를 export 하지 않으면 결과 파일이 없다 → 명확히 실패시킨다.
+[ -f "$OUT/summary.json" ] || {
+  echo "[에러] summary.json 이 생성되지 않았습니다. 시나리오가 handleSummary 를 export 하는지 확인하세요."
+  exit 1
+}
+[ -f "$OUT/summary.md" ] || {
+  echo "[에러] summary.md 가 생성되지 않았습니다. 시나리오가 handleSummary 를 export 하는지 확인하세요."
+  exit 1
+}
 
 echo "결과: ${OUT}/ (summary.md, summary.json, run-meta.txt)"
+if [ "$K6_EXIT" -ne 0 ]; then
+  echo "[안내] k6 종료코드=${K6_EXIT} (threshold 미달 등). 결과 파일은 정상 생성됨."
+fi
+exit "$K6_EXIT"

--- a/loadtest/scenarios/notice/read-status.load.js
+++ b/loadtest/scenarios/notice/read-status.load.js
@@ -1,0 +1,69 @@
+// load: 평시 부하에서 SLO(p95 latency, error rate)를 검증한다.
+// 이 스크립트가 성능 리팩토링 "전/후 비교"의 본체다.
+//
+// 부하 모델은 arrival-rate(개방형)이다. 목표 RPS를 고정하므로 응답 시간이 변해도
+// 제공 부하가 일정하다 → 리팩토링 전/후를 "동일 부하"에서 비교할 수 있다.
+// (ramping-vus + sleep 은 응답이 빨라질수록 실제 RPS가 올라가 비교가 오염된다.)
+//
+// 실행: loadtest/README.md 참고
+//   k6 run -e K6_MEMBER_ID=1 -e K6_RATE=20 --tag gitref=$(git rev-parse --short HEAD) \
+//     --summary-export docs/loadtest/runs/<날짜-label>/summary.json \
+//     loadtest/scenarios/notice/read-status.load.js
+
+import http from 'k6/http';
+
+import { BASE_URL, NOTICE_ID } from '../../lib/config.js';
+import { issueToken, authHeaders } from '../../lib/auth.js';
+import { recordResponse, cursorResponseChecks } from '../../lib/checks.js';
+
+// 종료 시 summary.md/json 자동 생성(K6_OUT_DIR)
+export { handleSummary } from '../../lib/summary.js';
+
+// 목표 RPS. read-status 는 운영진 조회 엔드포인트(ADR-013 Tier 3, 평시 트래픽 작음)라
+// 기본 20 RPS 를 평시 가정으로 둔다. 실제 capacity 측정 시 K6_RATE 로 조정한다.
+const RATE = Number(__ENV.K6_RATE || 20);
+const HOLD = __ENV.K6_DURATION || '2m';
+
+export const options = {
+  scenarios: {
+    read_status_load: {
+      executor: 'ramping-arrival-rate',
+      startRate: 5,
+      timeUnit: '1s',
+      preAllocatedVUs: Number(__ENV.K6_PREALLOC_VUS || 50),
+      maxVUs: Number(__ENV.K6_MAX_VUS || 200),
+      stages: [
+        { target: 5, duration: '20s' }, // 워밍업(JVM JIT 안정화)
+        { target: RATE, duration: '20s' }, // 목표 RPS 램프업
+        { target: RATE, duration: HOLD }, // 평시 부하 유지(측정 구간)
+        { target: 0, duration: '10s' }, // 종료
+      ],
+    },
+  },
+  // 전/후 비교 시 실행을 구분하기 위한 태그. gitref 등은 CLI --tag 로 추가한다.
+  tags: {
+    endpoint: 'notice-read-status',
+    testid: __ENV.K6_TESTID || 'local-adhoc',
+  },
+  // summary 에 p99 를 포함시키기 위해 명시(기본값엔 p90/p95 만 있음)
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+  thresholds: {
+    // ADR-013 기준(p95<500ms). baseline 이 이를 넘으면 곧 개선 대상이라는 신호.
+    endpoint_duration: ['p(95)<500', 'p(99)<1000'],
+    endpoint_success: ['rate>0.99'],
+    http_req_failed: ['rate<0.01'],
+    // 부하 생성기가 목표 RPS 를 못 따라가 요청을 흘리면 측정이 왜곡됨 → 감시
+    dropped_iterations: ['count<1'],
+  },
+};
+
+export function setup() {
+  return { token: issueToken() };
+}
+
+export default function (data) {
+  const url = `${BASE_URL}/api/v1/notices/${NOTICE_ID}/read-status?filterType=ALL&status=UNREAD`;
+  const res = http.get(url, { headers: authHeaders(data.token) });
+  recordResponse(res, 'notice-read-status', cursorResponseChecks('notice-read-status'));
+  // arrival-rate 모델은 도착률로 페이싱하므로 sleep 을 두지 않는다(VU 를 빨리 반환).
+}

--- a/loadtest/scenarios/notice/read-status.load.js
+++ b/loadtest/scenarios/notice/read-status.load.js
@@ -5,10 +5,9 @@
 // 제공 부하가 일정하다 → 리팩토링 전/후를 "동일 부하"에서 비교할 수 있다.
 // (ramping-vus + sleep 은 응답이 빨라질수록 실제 RPS가 올라가 비교가 오염된다.)
 //
-// 실행: loadtest/README.md 참고
-//   k6 run -e K6_MEMBER_ID=1 -e K6_RATE=20 --tag gitref=$(git rev-parse --short HEAD) \
-//     --summary-export docs/loadtest/runs/<날짜-label>/summary.json \
-//     loadtest/scenarios/notice/read-status.load.js
+// 실행(권장: run.sh — 결과 디렉토리/메타/summary 자동 생성). loadtest/README.md 참고
+//   K6_MEMBER_ID=1 K6_NOTICE_ID=1 K6_RATE=20 \
+//     loadtest/run.sh loadtest/scenarios/notice/read-status.load.js notice-read-status-before
 
 import http from 'k6/http';
 

--- a/loadtest/scenarios/notice/read-status.smoke.js
+++ b/loadtest/scenarios/notice/read-status.smoke.js
@@ -2,7 +2,7 @@
 // load 를 돌리기 전에 토큰 발급 / 엔드포인트 경로 / 응답 형태가 맞는지 검증하는 용도.
 //
 // 실행: loadtest/README.md 참고
-//   k6 run -e K6_EMAIL=... -e K6_PASSWORD=... loadtest/scenarios/notice/read-status.smoke.js
+//   k6 run -e K6_MEMBER_ID=1 -e K6_NOTICE_ID=1 loadtest/scenarios/notice/read-status.smoke.js
 
 import http from 'k6/http';
 import { sleep } from 'k6';
@@ -10,6 +10,9 @@ import { sleep } from 'k6';
 import { BASE_URL, NOTICE_ID } from '../../lib/config.js';
 import { issueToken, authHeaders } from '../../lib/auth.js';
 import { recordResponse, cursorResponseChecks } from '../../lib/checks.js';
+
+// 종료 시 summary.md/json 자동 생성(run.sh 로 실행 시에도 결과 파일이 남도록 load 와 동일하게 export)
+export { handleSummary } from '../../lib/summary.js';
 
 export const options = {
   vus: 1,

--- a/loadtest/scenarios/notice/read-status.smoke.js
+++ b/loadtest/scenarios/notice/read-status.smoke.js
@@ -1,0 +1,32 @@
+// smoke: VU=1, 1분. "정상 동작하는가"만 확인한다(부하가 목적이 아님).
+// load 를 돌리기 전에 토큰 발급 / 엔드포인트 경로 / 응답 형태가 맞는지 검증하는 용도.
+//
+// 실행: loadtest/README.md 참고
+//   k6 run -e K6_EMAIL=... -e K6_PASSWORD=... loadtest/scenarios/notice/read-status.smoke.js
+
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+import { BASE_URL, NOTICE_ID } from '../../lib/config.js';
+import { issueToken, authHeaders } from '../../lib/auth.js';
+import { recordResponse, cursorResponseChecks } from '../../lib/checks.js';
+
+export const options = {
+  vus: 1,
+  duration: '1m',
+  thresholds: {
+    endpoint_success: ['rate>0.99'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export function setup() {
+  return { token: issueToken() };
+}
+
+export default function (data) {
+  const url = `${BASE_URL}/api/v1/notices/${NOTICE_ID}/read-status?filterType=ALL&status=UNREAD`;
+  const res = http.get(url, { headers: authHeaders(data.token) });
+  recordResponse(res, 'notice-read-status', cursorResponseChecks('notice-read-status'));
+  sleep(1);
+}

--- a/loadtest/scenarios/notice/read-status.smoke.js
+++ b/loadtest/scenarios/notice/read-status.smoke.js
@@ -1,8 +1,9 @@
 // smoke: VU=1, 1분. "정상 동작하는가"만 확인한다(부하가 목적이 아님).
 // load 를 돌리기 전에 토큰 발급 / 엔드포인트 경로 / 응답 형태가 맞는지 검증하는 용도.
 //
-// 실행: loadtest/README.md 참고
-//   k6 run -e K6_MEMBER_ID=1 -e K6_NOTICE_ID=1 loadtest/scenarios/notice/read-status.smoke.js
+// 실행(권장: run.sh — 결과 디렉토리/메타/summary 자동 생성). loadtest/README.md 참고
+//   K6_MEMBER_ID=1 K6_NOTICE_ID=1 \
+//     loadtest/run.sh loadtest/scenarios/notice/read-status.smoke.js notice-read-status-smoke
 
 import http from 'k6/http';
 import { sleep } from 'k6';


### PR DESCRIPTION
## 🚀 작업 내용

closes #1186

공지 도메인 조회 성능 리팩토링 **전/후 성능을 정량 비교**하기 위한
k6 부하테스트 하네스와 결과 보존 구조를 도입합니다. 이 PR은 인프라만 담고, 실제 성능 개선과
before/after 측정 결과는 후속 리팩토링 PR에서 이 하네스를 사용해 첨부합니다.

 현재 저장소에는 커밋된 부하테스트가 없었습니다. ADR-013에 전략만 정의돼 있고, 기존에 사용한 애드혹 스크립트는 토큰이 하드코딩돼 만료되고 결과도 보존되지 않는다는 문제가 있었습니다.

### 구성

- **`loadtest/lib/`** — 공용 helper
  - `config.js` — BASE_URL·인증을 `__ENV`로 주입 (도메인 특화 값은 각 시나리오가 직접 읽음)
  - `auth.js` — `setup()`에서 토큰 발급. 우선순위 `K6_TOKEN > K6_MEMBER_ID(test 토큰 API) > K6_EMAIL/PASSWORD`. 오류 메시지는 raw 본문 대신 status/code/message만 노출
  - `checks.js` — HTTP 200 + `success=true` + 커서 응답 구조(content/nextCursor/hasNext) 검증
  - `summary.js` — 종료 시 `summary.md`/`summary.json` 자동 생성
- **`loadtest/scenarios/notice/`** — read-status smoke/load 시나리오
  - load: `ramping-arrival-rate`(목표 RPS 고정)로 전/후를 **동일 부하**에서 비교
- **`loadtest/run.sh`** — 사전조건 확인 + k6버전/GitSHA/env 기록 + 결과 디렉토리(시각 포함) 생성 + summary 생성 검증
- **`loadtest/compare.sh`** — 두 실행의 p95/p99/에러율/RPS 비교
- **`docs/loadtest/`** — 실행 단위 결과 보존 구조

### 재사용성

`lib/*`·`run.sh`·`compare.sh` 는 도메인 무관하게 설계했습니다. 새 도메인은 이들을 그대로 재사용하고
`scenarios/<도메인>/<엔드포인트>.load.js` 시나리오 파일만 추가하면 됩니다. 도메인 특화 파라미터는
공통 config 가 아니라 각 시나리오가 `__ENV` 로 직접 읽습니다.


## 💬 리뷰 중점사항
- 이 PR은 **인프라 도입만** 담습니다. 실제 부하 실행 결과(before/after)는 후속 성능 PR에서 첨부합니다.
- 부하 모델을 `ramping-arrival-rate`(RPS 고정)로 잡은 이유: 응답시간이 변해도 제공 부하가 일정해야
  리팩토링 전/후 비교가 오염되지 않기 때문입니다. 기본 RPS(20)는 read-status가 운영진 조회
  엔드포인트(ADR-013 Tier 3)라는 가정에 근거한 임시값이며 `K6_RATE`로 조정합니다.
- **k6로 측정 안 되는 것**: 요청당 SQL 실행 수·DB 풀 사용량 등 서버 내부 지표는 P6Spy/Actuator/
  Prometheus에서 별도 확인해 summary.md에 기입하는 구조입니다.
- staging 로그인 기반 장기 soak 시 토큰 갱신(refresh)은 미구현 상태입니다.
  `K6_TOKEN_TTL_MIN`(test 토큰 API 전용)으로 local soak은 커버되며, soak 시나리오 추가 시 확장 예정입니다.
- 실행 전제: 로컬 DB에 활성 기수·Chapter/School 매핑 + 시딩(ADR-017) 데이터가 필요합니다.
