### PR TITLE
[Feat] Recruiting 지원현황에 파트별 집계 추가

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingStatusSummaryGraphQlResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingStatusSummaryGraphQlResponse.java
@@ -4,6 +4,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
@@ -13,6 +15,7 @@ import com.umc.product.recruiting.domain.enums.RecruitingRoundType;
 public record RecruitingStatusSummaryGraphQlResponse(
     Long totalCount,
     List<RecruitingStatusCountGraphQlResponse> countByStatus,
+    List<PartSummary> parts,
     List<SchoolSummary> schools
 ) {
 
@@ -26,6 +29,7 @@ public record RecruitingStatusSummaryGraphQlResponse(
                 .sorted(Comparator.comparing(entry -> entry.getKey().ordinal()))
                 .map(entry -> new RecruitingStatusCountGraphQlResponse(entry.getKey(), entry.getValue()))
                 .toList(),
+            toParts(info.parts()),
             info.schools().stream().map(SchoolSummary::from).toList()
         );
     }
@@ -37,6 +41,7 @@ public record RecruitingStatusSummaryGraphQlResponse(
         String chapterName,
         Long totalCount,
         List<RecruitingStatusCountGraphQlResponse> countByStatus,
+        List<PartSummary> parts,
         List<RoundSummary> rounds
     ) {
 
@@ -48,6 +53,7 @@ public record RecruitingStatusSummaryGraphQlResponse(
                 info.chapterName(),
                 info.totalCount(),
                 toStatusCounts(info.countByStatus()),
+                toParts(info.parts()),
                 info.rounds().stream().map(RoundSummary::from).toList()
             );
         }
@@ -59,7 +65,8 @@ public record RecruitingStatusSummaryGraphQlResponse(
         RecruitingRoundType roundType,
         Integer roundNo,
         Long totalCount,
-        List<RecruitingStatusCountGraphQlResponse> countByStatus
+        List<RecruitingStatusCountGraphQlResponse> countByStatus,
+        List<PartSummary> parts
     ) {
 
         private static RoundSummary from(RecruitingRoundStatusSummaryInfo info) {
@@ -69,9 +76,29 @@ public record RecruitingStatusSummaryGraphQlResponse(
                 info.roundType(),
                 info.roundNo(),
                 info.totalCount(),
+                toStatusCounts(info.countByStatus()),
+                toParts(info.parts())
+            );
+        }
+    }
+
+    public record PartSummary(
+        ChallengerTrack part,
+        Long totalCount,
+        List<RecruitingStatusCountGraphQlResponse> countByStatus
+    ) {
+
+        private static PartSummary from(RecruitingPartStatusSummaryInfo info) {
+            return new PartSummary(
+                info.part(),
+                info.totalCount(),
                 toStatusCounts(info.countByStatus())
             );
         }
+    }
+
+    private static List<PartSummary> toParts(List<RecruitingPartStatusSummaryInfo> parts) {
+        return parts == null ? List.of() : parts.stream().map(PartSummary::from).toList();
     }
 
     private static List<RecruitingStatusCountGraphQlResponse> toStatusCounts(

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingStatusSummaryResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingStatusSummaryResponse.java
@@ -3,6 +3,8 @@ package com.umc.product.recruiting.adapter.in.web.dto.response;
 import java.util.List;
 import java.util.Map;
 
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
@@ -17,6 +19,8 @@ public record RecruitingStatusSummaryResponse(
     Long totalCount,
     @Schema(description = "지원서 상태별 지원서 수")
     Map<RecruitingApplicationStatus, Long> countByStatus,
+    @Schema(description = "1지망 파트별 상태 교차집계")
+    List<PartSummaryResponse> parts,
     List<SchoolSummaryResponse> schools
 ) {
 
@@ -24,6 +28,7 @@ public record RecruitingStatusSummaryResponse(
         return new RecruitingStatusSummaryResponse(
             info.totalCount(),
             info.countByStatus(),
+            info.parts().stream().map(PartSummaryResponse::from).toList(),
             info.schools().stream().map(SchoolSummaryResponse::from).toList()
         );
     }
@@ -35,6 +40,7 @@ public record RecruitingStatusSummaryResponse(
         String chapterName,
         Long totalCount,
         Map<RecruitingApplicationStatus, Long> countByStatus,
+        List<PartSummaryResponse> parts,
         List<RoundSummaryResponse> rounds
     ) {
 
@@ -46,6 +52,7 @@ public record RecruitingStatusSummaryResponse(
                 info.chapterName(),
                 info.totalCount(),
                 info.countByStatus(),
+                info.parts().stream().map(PartSummaryResponse::from).toList(),
                 info.rounds().stream().map(RoundSummaryResponse::from).toList()
             );
         }
@@ -57,7 +64,8 @@ public record RecruitingStatusSummaryResponse(
         RecruitingRoundType roundType,
         Integer roundNo,
         Long totalCount,
-        Map<RecruitingApplicationStatus, Long> countByStatus
+        Map<RecruitingApplicationStatus, Long> countByStatus,
+        List<PartSummaryResponse> parts
     ) {
 
         private static RoundSummaryResponse from(RecruitingRoundStatusSummaryInfo info) {
@@ -66,6 +74,26 @@ public record RecruitingStatusSummaryResponse(
                 info.roundTitle(),
                 info.roundType(),
                 info.roundNo(),
+                info.totalCount(),
+                info.countByStatus(),
+                info.parts().stream().map(PartSummaryResponse::from).toList()
+            );
+        }
+    }
+
+    @Schema(description = "1지망 파트별 상태 교차집계 항목")
+    public record PartSummaryResponse(
+        @Schema(description = "1지망 파트")
+        ChallengerTrack part,
+        @Schema(description = "파트 지원서 수", example = "24")
+        Long totalCount,
+        @Schema(description = "파트 내 지원서 상태별 수")
+        Map<RecruitingApplicationStatus, Long> countByStatus
+    ) {
+
+        private static PartSummaryResponse from(RecruitingPartStatusSummaryInfo info) {
+            return new PartSummaryResponse(
+                info.part(),
                 info.totalCount(),
                 info.countByStatus()
             );

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingPartStatusSummaryInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingPartStatusSummaryInfo.java
@@ -1,0 +1,19 @@
+package com.umc.product.recruiting.application.port.in.query.dto;
+
+import java.util.Map;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
+
+/**
+ * 1지망(firstChoice) 파트 기준 지원서 상태 교차집계.
+ * <p>
+ * DRAFT, CANCELLED 를 제외한 지원서를 파트별로 묶어 상태별 개수를 집계한다.
+ * 파트별 합계는 각 계층의 totalCount 와 일치한다.
+ */
+public record RecruitingPartStatusSummaryInfo(
+    ChallengerTrack part,
+    Long totalCount,
+    Map<RecruitingApplicationStatus, Long> countByStatus
+) {
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundStatusSummaryInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundStatusSummaryInfo.java
@@ -1,5 +1,6 @@
 package com.umc.product.recruiting.application.port.in.query.dto;
 
+import java.util.List;
 import java.util.Map;
 
 import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
@@ -11,6 +12,7 @@ public record RecruitingRoundStatusSummaryInfo(
     RecruitingRoundType roundType,
     Integer roundNo,
     Long totalCount,
-    Map<RecruitingApplicationStatus, Long> countByStatus
+    Map<RecruitingApplicationStatus, Long> countByStatus,
+    List<RecruitingPartStatusSummaryInfo> parts
 ) {
 }

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingSchoolStatusSummaryInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingSchoolStatusSummaryInfo.java
@@ -12,6 +12,7 @@ public record RecruitingSchoolStatusSummaryInfo(
     String chapterName,
     Long totalCount,
     Map<RecruitingApplicationStatus, Long> countByStatus,
+    List<RecruitingPartStatusSummaryInfo> parts,
     List<RecruitingRoundStatusSummaryInfo> rounds
 ) {
 }

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingStatusSummaryInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingStatusSummaryInfo.java
@@ -8,6 +8,7 @@ import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
 public record RecruitingStatusSummaryInfo(
     Long totalCount,
     Map<RecruitingApplicationStatus, Long> countByStatus,
+    List<RecruitingPartStatusSummaryInfo> parts,
     List<RecruitingSchoolStatusSummaryInfo> schools
 ) {
 }

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -2,6 +2,7 @@ package com.umc.product.recruiting.application.service.query;
 
 import java.util.Comparator;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,6 +52,12 @@ public class RecruitingQueryService implements
     GetRecruitingFormQueryUseCase,
     ValidateRecruitingApplicationScopeUseCase,
     ValidateRecruitingFormScopeUseCase {
+
+    /** 지원 현황 집계 대상 상태. 작성 중(DRAFT)·지원 취소(CANCELLED)는 제외한다. */
+    private static final Set<RecruitingApplicationStatus> SUMMARY_STATUSES = EnumSet.complementOf(EnumSet.of(
+        RecruitingApplicationStatus.DRAFT,
+        RecruitingApplicationStatus.CANCELLED
+    ));
 
     private final LoadRecruitingApplicationPort loadApplicationPort;
     private final LoadRecruitingRoundPort loadRoundPort;
@@ -147,7 +154,7 @@ public class RecruitingQueryService implements
                 query.gisuId(),
                 schoolIds,
                 query.roundIds().isEmpty() ? null : roundIds,
-                null
+                SUMMARY_STATUSES
             );
 
         Map<Long, List<RecruitingApplicationSummaryRow>> rowsBySchool = rows.stream()

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -1,5 +1,6 @@
 package com.umc.product.recruiting.application.service.query;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -59,6 +60,12 @@ public class RecruitingQueryService implements
         RecruitingApplicationStatus.DRAFT,
         RecruitingApplicationStatus.CANCELLED
     ));
+
+    /** 파트별 집계 고정 슬롯. 모집 불가 트랙(INFRA_PLUS)을 제외한 파트를 sortOrder 순으로 항상 노출한다. */
+    private static final List<ChallengerTrack> SUMMARY_PART_TRACKS = Arrays.stream(ChallengerTrack.values())
+        .filter(track -> track != ChallengerTrack.INFRA_PLUS)
+        .sorted(Comparator.comparingInt(ChallengerTrack::getSortOrder))
+        .toList();
 
     private final LoadRecruitingApplicationPort loadApplicationPort;
     private final LoadRecruitingRoundPort loadRoundPort;
@@ -243,19 +250,17 @@ public class RecruitingQueryService implements
 
     /**
      * 1지망(firstChoice) 파트 기준으로 상태별 개수를 교차집계한다.
-     * rows에 실제로 존재하는 파트만 ChallengerTrack.sortOrder 순으로 반환하므로 파트별 합계는 totalCount와 일치한다.
+     * 지원자가 없는 파트도 0건으로 항상 포함하며(SUMMARY_PART_TRACKS 고정 슬롯), 파트별 합계는 totalCount와 일치한다.
      */
     private List<RecruitingPartStatusSummaryInfo> partSummaries(List<RecruitingApplicationSummaryRow> rows) {
         Map<ChallengerTrack, List<RecruitingApplicationSummaryRow>> rowsByPart = rows.stream()
             .filter(row -> row.firstChoice() != null)
             .collect(java.util.stream.Collectors.groupingBy(RecruitingApplicationSummaryRow::firstChoice));
-        return rowsByPart.entrySet().stream()
-            .sorted(Comparator.comparingInt(entry -> entry.getKey().getSortOrder()))
-            .map(entry -> new RecruitingPartStatusSummaryInfo(
-                entry.getKey(),
-                (long) entry.getValue().size(),
-                countByStatus(entry.getValue())
-            ))
+        return SUMMARY_PART_TRACKS.stream()
+            .map(track -> {
+                List<RecruitingApplicationSummaryRow> partRows = rowsByPart.getOrDefault(track, List.of());
+                return new RecruitingPartStatusSummaryInfo(track, (long) partRows.size(), countByStatus(partRows));
+            })
             .toList();
     }
 

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -24,6 +24,7 @@ import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQue
 import com.umc.product.recruiting.application.port.in.query.ValidateRecruitingApplicationScopeUseCase;
 import com.umc.product.recruiting.application.port.in.query.ValidateRecruitingFormScopeUseCase;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
@@ -168,7 +169,12 @@ public class RecruitingQueryService implements
                 roundsBySchool.getOrDefault(school.schoolId(), List.of())
             ))
             .toList();
-        return new RecruitingStatusSummaryInfo((long) rows.size(), countByStatus(rows), schoolSummaries);
+        return new RecruitingStatusSummaryInfo(
+            (long) rows.size(),
+            countByStatus(rows),
+            partSummaries(rows),
+            schoolSummaries
+        );
     }
 
     private List<SchoolDetailInfo> listSummarySchools(RecruitingStatusSummaryQuery query) {
@@ -212,7 +218,8 @@ public class RecruitingQueryService implements
                     round.getType(),
                     round.getRoundNo(),
                     (long) roundRows.size(),
-                    countByStatus(roundRows)
+                    countByStatus(roundRows),
+                    partSummaries(roundRows)
                 );
             })
             .toList();
@@ -223,6 +230,7 @@ public class RecruitingQueryService implements
             school.chapterName(),
             (long) rows.size(),
             countByStatus(rows),
+            partSummaries(rows),
             roundSummaries
         );
     }
@@ -231,6 +239,24 @@ public class RecruitingQueryService implements
         Map<RecruitingApplicationStatus, Long> result = new EnumMap<>(RecruitingApplicationStatus.class);
         rows.forEach(row -> result.merge(row.applicationStatus(), 1L, Long::sum));
         return result;
+    }
+
+    /**
+     * 1지망(firstChoice) 파트 기준으로 상태별 개수를 교차집계한다.
+     * rows에 실제로 존재하는 파트만 ChallengerTrack.sortOrder 순으로 반환하므로 파트별 합계는 totalCount와 일치한다.
+     */
+    private List<RecruitingPartStatusSummaryInfo> partSummaries(List<RecruitingApplicationSummaryRow> rows) {
+        Map<ChallengerTrack, List<RecruitingApplicationSummaryRow>> rowsByPart = rows.stream()
+            .filter(row -> row.firstChoice() != null)
+            .collect(java.util.stream.Collectors.groupingBy(RecruitingApplicationSummaryRow::firstChoice));
+        return rowsByPart.entrySet().stream()
+            .sorted(Comparator.comparingInt(entry -> entry.getKey().getSortOrder()))
+            .map(entry -> new RecruitingPartStatusSummaryInfo(
+                entry.getKey(),
+                (long) entry.getValue().size(),
+                countByStatus(entry.getValue())
+            ))
+            .toList();
     }
 
     private void validateCentralGisuAccess(Long requesterMemberId, Long gisuId) {

--- a/src/main/resources/graphql/recruiting.graphqls
+++ b/src/main/resources/graphql/recruiting.graphqls
@@ -576,6 +576,7 @@ type RecruitingInterviewSchedule {
 type RecruitingStatusSummary {
   totalCount: Long!
   countByStatus: [RecruitingStatusCount!]!
+  parts: [RecruitingPartStatusSummary!]!
   schools: [RecruitingSchoolStatusSummary!]!
 }
 
@@ -586,6 +587,7 @@ type RecruitingSchoolStatusSummary {
   chapterName: String!
   totalCount: Long!
   countByStatus: [RecruitingStatusCount!]!
+  parts: [RecruitingPartStatusSummary!]!
   rounds: [RecruitingRoundStatusSummary!]!
 }
 
@@ -594,6 +596,13 @@ type RecruitingRoundStatusSummary {
   roundTitle: String!
   roundType: RecruitingRoundType!
   roundNo: Int!
+  totalCount: Long!
+  countByStatus: [RecruitingStatusCount!]!
+  parts: [RecruitingPartStatusSummary!]!
+}
+
+type RecruitingPartStatusSummary {
+  part: ChallengerTrack!
   totalCount: Long!
   countByStatus: [RecruitingStatusCount!]!
 }

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
@@ -48,8 +48,10 @@ import com.umc.product.recruiting.application.port.in.query.SearchRecruitingSeas
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingChapterEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundConfigurationInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundGroupSearchQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
@@ -174,14 +176,24 @@ class RecruitingSeasonAdminGraphQlControllerTest {
     @Test
     @DisplayName("GraphQL 상태 요약은 CurrentMember와 요청 기수를 public UseCase에 전달한다")
     void statusSummaryBindsCurrentMemberAndRequestedGisu() {
+        List<RecruitingPartStatusSummaryInfo> parts = List.of(
+            new RecruitingPartStatusSummaryInfo(
+                ChallengerTrack.PLAN, 3L, Map.of(RecruitingApplicationStatus.SUBMITTED, 3L)),
+            new RecruitingPartStatusSummaryInfo(
+                ChallengerTrack.DESIGN, 0L, Map.of())
+        );
+        RecruitingRoundStatusSummaryInfo round = new RecruitingRoundStatusSummaryInfo(
+            31L, "1차 서류", RecruitingRoundType.REGULAR, 1, 3L,
+            Map.of(RecruitingApplicationStatus.SUBMITTED, 3L), parts
+        );
         given(getApplicationQueryUseCase.getStatusSummary(any()))
             .willReturn(new RecruitingStatusSummaryInfo(
                 3L,
                 Map.of(RecruitingApplicationStatus.SUBMITTED, 3L),
-                List.of(),
+                parts,
                 List.of(new RecruitingSchoolStatusSummaryInfo(
                     22L, "테스트대학교", 3L, "중앙", 3L,
-                    Map.of(RecruitingApplicationStatus.SUBMITTED, 3L), List.of(), List.of()
+                    Map.of(RecruitingApplicationStatus.SUBMITTED, 3L), parts, List.of(round)
                 ))
             ));
 
@@ -195,14 +207,25 @@ class RecruitingSeasonAdminGraphQlControllerTest {
                   }) {
                     totalCount
                     countByStatus { status count }
-                    schools { schoolId schoolName totalCount }
+                    parts { part totalCount countByStatus { status count } }
+                    schools {
+                      schoolId schoolName totalCount
+                      parts { part totalCount }
+                      rounds { roundId parts { part totalCount } }
+                    }
                   }
                 }
                 """)
             .execute()
-            .path("recruitingStatusSummary.totalCount")
-            .entity(Long.class)
-            .isEqualTo(3L);
+            .path("recruitingStatusSummary.totalCount").entity(Long.class).isEqualTo(3L)
+            .path("recruitingStatusSummary.parts[0].part").entity(String.class).isEqualTo("PLAN")
+            .path("recruitingStatusSummary.parts[0].totalCount").entity(Long.class).isEqualTo(3L)
+            .path("recruitingStatusSummary.parts[0].countByStatus[0].status").entity(String.class).isEqualTo("SUBMITTED")
+            .path("recruitingStatusSummary.parts[0].countByStatus[0].count").entity(Long.class).isEqualTo(3L)
+            .path("recruitingStatusSummary.parts[1].part").entity(String.class).isEqualTo("DESIGN")
+            .path("recruitingStatusSummary.parts[1].totalCount").entity(Long.class).isEqualTo(0L)
+            .path("recruitingStatusSummary.schools[0].parts[0].part").entity(String.class).isEqualTo("PLAN")
+            .path("recruitingStatusSummary.schools[0].rounds[0].parts[0].part").entity(String.class).isEqualTo("PLAN");
 
         ArgumentCaptor<RecruitingStatusSummaryQuery> captor =
             ArgumentCaptor.forClass(RecruitingStatusSummaryQuery.class);

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
@@ -178,9 +178,10 @@ class RecruitingSeasonAdminGraphQlControllerTest {
             .willReturn(new RecruitingStatusSummaryInfo(
                 3L,
                 Map.of(RecruitingApplicationStatus.SUBMITTED, 3L),
+                List.of(),
                 List.of(new RecruitingSchoolStatusSummaryInfo(
                     22L, "테스트대학교", 3L, "중앙", 3L,
-                    Map.of(RecruitingApplicationStatus.SUBMITTED, 3L), List.of()
+                    Map.of(RecruitingApplicationStatus.SUBMITTED, 3L), List.of(), List.of()
                 ))
             ));
 

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
@@ -59,6 +59,7 @@ import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluat
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingChapterEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
@@ -297,9 +298,12 @@ class RecruitingAdminControllerTest {
     void 상태_요약_API는_status별_count를_반환한다() throws Exception {
         Map<RecruitingApplicationStatus, Long> counts = new EnumMap<>(RecruitingApplicationStatus.class);
         counts.put(RecruitingApplicationStatus.SUBMITTED, 3L);
+        List<RecruitingPartStatusSummaryInfo> parts = List.of(
+            new RecruitingPartStatusSummaryInfo(ChallengerTrack.PLAN, 3L, counts)
+        );
         given(getApplicationQueryUseCase.getStatusSummary(any()))
-            .willReturn(new RecruitingStatusSummaryInfo(3L, counts, List.of(
-                new RecruitingSchoolStatusSummaryInfo(22L, "테스트대학교", 7L, "중앙", 3L, counts, List.of())
+            .willReturn(new RecruitingStatusSummaryInfo(3L, counts, parts, List.of(
+                new RecruitingSchoolStatusSummaryInfo(22L, "테스트대학교", 7L, "중앙", 3L, counts, parts, List.of())
             )));
 
         mockMvc.perform(get("/api/v1/recruiting/admin/summary")
@@ -310,7 +314,11 @@ class RecruitingAdminControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.totalCount").value(3L))
             .andExpect(jsonPath("$.result.countByStatus.SUBMITTED").value(3L))
-            .andExpect(jsonPath("$.result.schools[0].schoolName").value("테스트대학교"));
+            .andExpect(jsonPath("$.result.parts[0].part").value("PLAN"))
+            .andExpect(jsonPath("$.result.parts[0].totalCount").value(3L))
+            .andExpect(jsonPath("$.result.parts[0].countByStatus.SUBMITTED").value(3L))
+            .andExpect(jsonPath("$.result.schools[0].schoolName").value("테스트대학교"))
+            .andExpect(jsonPath("$.result.schools[0].parts[0].part").value("PLAN"));
 
         ArgumentCaptor<RecruitingStatusSummaryQuery> captor =
             ArgumentCaptor.forClass(RecruitingStatusSummaryQuery.class);

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -71,13 +72,18 @@ class RecruitingQueryServiceTest {
     @InjectMocks
     RecruitingQueryService sut;
 
+    private static final Set<RecruitingApplicationStatus> SUMMARY_STATUSES = EnumSet.complementOf(EnumSet.of(
+        RecruitingApplicationStatus.DRAFT,
+        RecruitingApplicationStatus.CANCELLED
+    ));
+
     @Test
     @DisplayName("상태_요약은_summary_row의_지원서_상태를_집계한다")
     void summarizeApplicationStatuses() {
         // Given
         given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
         givenSummaryScope();
-        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, null)).willReturn(List.of(
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES)).willReturn(List.of(
             row("지원자1", RecruitingApplicationStatus.SUBMITTED),
             row("지원자2", RecruitingApplicationStatus.SUBMITTED),
             row("지원자3", RecruitingApplicationStatus.FINAL_PASSED)
@@ -97,6 +103,21 @@ class RecruitingQueryServiceTest {
                 assertThat(round.totalCount()).isEqualTo(3L);
             });
         });
+    }
+
+    @Test
+    @DisplayName("상태 요약은 DRAFT·CANCELLED를 제외한 상태만 집계 대상으로 조회한다")
+    void statusSummaryExcludesDraftAndCancelledFromQuery() {
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
+        givenSummaryScope();
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES))
+            .willReturn(List.of(row("지원자", RecruitingApplicationStatus.SUBMITTED)));
+
+        sut.getStatusSummary(summaryQuery(Set.of(10L), Set.of()));
+
+        then(loadApplicationPort).should().searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES);
+        assertThat(SUMMARY_STATUSES)
+            .doesNotContain(RecruitingApplicationStatus.DRAFT, RecruitingApplicationStatus.CANCELLED);
     }
 
     @Test
@@ -126,13 +147,13 @@ class RecruitingQueryServiceTest {
     void filterStatusSummaryByRound() {
         given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
         givenSummaryScope();
-        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), Set.of(20L), null))
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), Set.of(20L), SUMMARY_STATUSES))
             .willReturn(List.of(row("지원자", RecruitingApplicationStatus.SUBMITTED)));
 
         RecruitingStatusSummaryInfo result = sut.getStatusSummary(summaryQuery(Set.of(10L), Set.of(20L)));
 
         assertThat(result.totalCount()).isEqualTo(1L);
-        then(loadApplicationPort).should().searchSummaryRows(1L, Set.of(10L), Set.of(20L), null);
+        then(loadApplicationPort).should().searchSummaryRows(1L, Set.of(10L), Set.of(20L), SUMMARY_STATUSES);
     }
 
     @Test
@@ -149,7 +170,7 @@ class RecruitingQueryServiceTest {
         ));
         given(loadSeasonPort.listByGisuId(1L)).willReturn(List.of(season));
         given(loadRoundPort.listBySeasonIds(List.of(5L))).willReturn(List.of(firstRound, emptyRound));
-        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, null))
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES))
             .willReturn(List.of(row("지원자", RecruitingApplicationStatus.SUBMITTED)));
 
         RecruitingStatusSummaryInfo result = sut.getStatusSummary(RecruitingStatusSummaryQuery.builder()

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -133,9 +133,15 @@ class RecruitingQueryServiceTest {
 
         RecruitingStatusSummaryInfo result = sut.getStatusSummary(summaryQuery(Set.of(10L), Set.of()));
 
+        // 지원자가 없는 파트(DESIGN, MOBILE)도 0건 슬롯으로 포함되고 sortOrder 순으로 정렬된다.
         assertThat(result.parts())
             .extracting(part -> part.part())
-            .containsExactly(ChallengerTrack.PLAN, ChallengerTrack.WEB_PRODUCT_ENGINEER);
+            .containsExactly(
+                ChallengerTrack.PLAN,
+                ChallengerTrack.DESIGN,
+                ChallengerTrack.WEB_PRODUCT_ENGINEER,
+                ChallengerTrack.MOBILE_PRODUCT_ENGINEER
+            );
         assertThat(result.parts())
             .filteredOn(part -> part.part() == ChallengerTrack.WEB_PRODUCT_ENGINEER)
             .singleElement()
@@ -144,11 +150,18 @@ class RecruitingQueryServiceTest {
                 assertThat(part.countByStatus().get(RecruitingApplicationStatus.SUBMITTED)).isEqualTo(1L);
                 assertThat(part.countByStatus().get(RecruitingApplicationStatus.FINAL_PASSED)).isEqualTo(1L);
             });
+        assertThat(result.parts())
+            .filteredOn(part -> part.part() == ChallengerTrack.DESIGN)
+            .singleElement()
+            .satisfies(part -> {
+                assertThat(part.totalCount()).isZero();
+                assertThat(part.countByStatus()).isEmpty();
+            });
         assertThat(result.parts().stream().mapToLong(part -> part.totalCount()).sum())
             .isEqualTo(result.totalCount());
         assertThat(result.schools()).singleElement()
             .satisfies(school -> assertThat(school.rounds()).singleElement()
-                .satisfies(round -> assertThat(round.parts()).hasSize(2)));
+                .satisfies(round -> assertThat(round.parts()).hasSize(4)));
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -28,6 +28,8 @@ import com.umc.product.organization.application.port.in.query.dto.school.SchoolD
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQuestionScopeUseCase;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationQuestionScopeInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryQuery;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
@@ -197,6 +199,107 @@ class RecruitingQueryServiceTest {
             assertThat(part.totalCount()).isZero();
             assertThat(part.countByStatus()).isEmpty();
         });
+    }
+
+    @Test
+    @DisplayName("상태 요약은 학교·Round가 여러 개일 때도 각 계층의 parts를 해당 그룹 rows로만 집계한다")
+    void statusSummaryAggregatesPartsPerSchoolAndRound() {
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
+        RecruitingSeason season10 = RecruitingSeason.create(1L, 10L);
+        ReflectionTestUtils.setField(season10, "id", 5L);
+        RecruitingSeason season11 = RecruitingSeason.create(1L, 11L);
+        ReflectionTestUtils.setField(season11, "id", 6L);
+        RecruitingRound round20 = summaryRound(season10, 20L, "A대 1차");
+        RecruitingRound round22 = summaryRound(season10, 22L, "A대 2차");
+        RecruitingRound round21 = summaryRound(season11, 21L, "B대 1차");
+        given(getSchoolUseCase.getSchoolListByGisuId(1L))
+            .willReturn(List.of(school(10L, "A대학교"), school(11L, "B대학교")));
+        given(loadSeasonPort.listByGisuId(1L)).willReturn(List.of(season10, season11));
+        given(loadRoundPort.listBySeasonIds(List.of(5L, 6L))).willReturn(List.of(round20, round22, round21));
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L, 11L), null, SUMMARY_STATUSES)).willReturn(List.of(
+            row("A웹서류", RecruitingApplicationStatus.SUBMITTED, ChallengerTrack.WEB_PRODUCT_ENGINEER, 10L, 20L),
+            row("A기획서류", RecruitingApplicationStatus.SUBMITTED, ChallengerTrack.PLAN, 10L, 20L),
+            row("A웹최종", RecruitingApplicationStatus.FINAL_PASSED, ChallengerTrack.WEB_PRODUCT_ENGINEER, 10L, 22L),
+            row("B기획", RecruitingApplicationStatus.SUBMITTED, ChallengerTrack.PLAN, 11L, 21L),
+            row("B디자인", RecruitingApplicationStatus.DOCUMENT_FAILED, ChallengerTrack.DESIGN, 11L, 21L)
+        ));
+
+        RecruitingStatusSummaryInfo result = sut.getStatusSummary(summaryQuery(Set.of(10L, 11L), Set.of()));
+
+        // 전체: PLAN 2, DESIGN 1, WEB 2, MOBILE 0
+        assertThat(partTotal(result.parts(), ChallengerTrack.PLAN)).isEqualTo(2L);
+        assertThat(partTotal(result.parts(), ChallengerTrack.DESIGN)).isEqualTo(1L);
+        assertThat(partTotal(result.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER)).isEqualTo(2L);
+        assertThat(partTotal(result.parts(), ChallengerTrack.MOBILE_PRODUCT_ENGINEER)).isZero();
+        assertPartSumMatchesTotal(result.parts(), result.totalCount());
+
+        RecruitingSchoolStatusSummaryInfo schoolA = schoolOf(result, 10L);
+        assertThat(partTotal(schoolA.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER)).isEqualTo(2L);
+        assertThat(partStatus(schoolA.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER,
+            RecruitingApplicationStatus.SUBMITTED)).isEqualTo(1L);
+        assertThat(partStatus(schoolA.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER,
+            RecruitingApplicationStatus.FINAL_PASSED)).isEqualTo(1L);
+        assertThat(partTotal(schoolA.parts(), ChallengerTrack.PLAN)).isEqualTo(1L);
+        assertThat(partTotal(schoolA.parts(), ChallengerTrack.DESIGN)).isZero();
+        assertPartSumMatchesTotal(schoolA.parts(), schoolA.totalCount());
+
+        RecruitingSchoolStatusSummaryInfo schoolB = schoolOf(result, 11L);
+        assertThat(partTotal(schoolB.parts(), ChallengerTrack.PLAN)).isEqualTo(1L);
+        assertThat(partTotal(schoolB.parts(), ChallengerTrack.DESIGN)).isEqualTo(1L);
+        assertThat(partTotal(schoolB.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER)).isZero();
+        assertPartSumMatchesTotal(schoolB.parts(), schoolB.totalCount());
+
+        RecruitingRoundStatusSummaryInfo round20Info = roundOf(schoolA, 20L);
+        assertThat(partTotal(round20Info.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER)).isEqualTo(1L);
+        assertThat(partTotal(round20Info.parts(), ChallengerTrack.PLAN)).isEqualTo(1L);
+        RecruitingRoundStatusSummaryInfo round22Info = roundOf(schoolA, 22L);
+        assertThat(partTotal(round22Info.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER)).isEqualTo(1L);
+        assertThat(partStatus(round22Info.parts(), ChallengerTrack.WEB_PRODUCT_ENGINEER,
+            RecruitingApplicationStatus.FINAL_PASSED)).isEqualTo(1L);
+        assertThat(partTotal(round22Info.parts(), ChallengerTrack.PLAN)).isZero();
+        RecruitingRoundStatusSummaryInfo round21Info = roundOf(schoolB, 21L);
+        assertThat(partTotal(round21Info.parts(), ChallengerTrack.PLAN)).isEqualTo(1L);
+        assertThat(partStatus(round21Info.parts(), ChallengerTrack.DESIGN,
+            RecruitingApplicationStatus.DOCUMENT_FAILED)).isEqualTo(1L);
+    }
+
+    private RecruitingSchoolStatusSummaryInfo schoolOf(RecruitingStatusSummaryInfo result, Long schoolId) {
+        return result.schools().stream()
+            .filter(school -> school.schoolId().equals(schoolId))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private RecruitingRoundStatusSummaryInfo roundOf(RecruitingSchoolStatusSummaryInfo school, Long roundId) {
+        return school.rounds().stream()
+            .filter(round -> round.roundId().equals(roundId))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private long partTotal(List<RecruitingPartStatusSummaryInfo> parts, ChallengerTrack track) {
+        return parts.stream()
+            .filter(part -> part.part() == track)
+            .findFirst()
+            .orElseThrow()
+            .totalCount();
+    }
+
+    private long partStatus(
+        List<RecruitingPartStatusSummaryInfo> parts,
+        ChallengerTrack track,
+        RecruitingApplicationStatus status
+    ) {
+        return parts.stream()
+            .filter(part -> part.part() == track)
+            .findFirst()
+            .orElseThrow()
+            .countByStatus()
+            .getOrDefault(status, 0L);
+    }
+
+    private void assertPartSumMatchesTotal(List<RecruitingPartStatusSummaryInfo> parts, Long totalCount) {
+        assertThat(parts.stream().mapToLong(part -> part.totalCount()).sum()).isEqualTo(totalCount);
     }
 
     @Test
@@ -371,11 +474,21 @@ class RecruitingQueryServiceTest {
         RecruitingApplicationStatus status,
         ChallengerTrack firstChoice
     ) {
+        return row(applicantName, status, firstChoice, 10L, 20L);
+    }
+
+    private RecruitingApplicationSummaryRow row(
+        String applicantName,
+        RecruitingApplicationStatus status,
+        ChallengerTrack firstChoice,
+        Long schoolId,
+        Long roundId
+    ) {
         return new RecruitingApplicationSummaryRow(
             1L,
             1L,
-            10L,
-            20L,
+            schoolId,
+            roundId,
             "15기 본모집",
             RecruitingRoundType.REGULAR,
             1,

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -121,6 +121,37 @@ class RecruitingQueryServiceTest {
     }
 
     @Test
+    @DisplayName("상태 요약은 1지망 파트별로 상태를 교차집계하고 sortOrder 순으로 정렬한다")
+    void statusSummaryAggregatesByFirstChoicePart() {
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
+        givenSummaryScope();
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES)).willReturn(List.of(
+            row("웹1", RecruitingApplicationStatus.SUBMITTED, ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            row("웹2", RecruitingApplicationStatus.FINAL_PASSED, ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            row("기획1", RecruitingApplicationStatus.SUBMITTED, ChallengerTrack.PLAN)
+        ));
+
+        RecruitingStatusSummaryInfo result = sut.getStatusSummary(summaryQuery(Set.of(10L), Set.of()));
+
+        assertThat(result.parts())
+            .extracting(part -> part.part())
+            .containsExactly(ChallengerTrack.PLAN, ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(result.parts())
+            .filteredOn(part -> part.part() == ChallengerTrack.WEB_PRODUCT_ENGINEER)
+            .singleElement()
+            .satisfies(part -> {
+                assertThat(part.totalCount()).isEqualTo(2L);
+                assertThat(part.countByStatus().get(RecruitingApplicationStatus.SUBMITTED)).isEqualTo(1L);
+                assertThat(part.countByStatus().get(RecruitingApplicationStatus.FINAL_PASSED)).isEqualTo(1L);
+            });
+        assertThat(result.parts().stream().mapToLong(part -> part.totalCount()).sum())
+            .isEqualTo(result.totalCount());
+        assertThat(result.schools()).singleElement()
+            .satisfies(school -> assertThat(school.rounds()).singleElement()
+                .satisfies(round -> assertThat(round.parts()).hasSize(2)));
+    }
+
+    @Test
     @DisplayName("다른 기수의 중앙 총괄단은 상태 요약을 조회할 수 없다")
     void rejectStatusSummaryForCentralCoreFromDifferentGisu() {
         given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(false);
@@ -284,6 +315,14 @@ class RecruitingQueryServiceTest {
     }
 
     private RecruitingApplicationSummaryRow row(String applicantName, RecruitingApplicationStatus status) {
+        return row(applicantName, status, ChallengerTrack.WEB_PRODUCT_ENGINEER);
+    }
+
+    private RecruitingApplicationSummaryRow row(
+        String applicantName,
+        RecruitingApplicationStatus status,
+        ChallengerTrack firstChoice
+    ) {
         return new RecruitingApplicationSummaryRow(
             1L,
             1L,
@@ -297,7 +336,7 @@ class RecruitingQueryServiceTest {
             900L,
             applicantName,
             "masked-source@umc.test",
-            ChallengerTrack.WEB_PRODUCT_ENGINEER,
+            firstChoice,
             null,
             null,
             status,

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -27,6 +27,7 @@ import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQuestionScopeUseCase;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationQuestionScopeInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryQuery;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
@@ -162,6 +163,40 @@ class RecruitingQueryServiceTest {
         assertThat(result.schools()).singleElement()
             .satisfies(school -> assertThat(school.rounds()).singleElement()
                 .satisfies(round -> assertThat(round.parts()).hasSize(4)));
+    }
+
+    @Test
+    @DisplayName("상태 요약은 지원서가 전혀 없어도 전체·학교·Round 모두에서 4개 파트 슬롯을 0건으로 반환한다")
+    void statusSummaryReturnsAllPartSlotsWhenNoApplications() {
+        given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(true);
+        givenSummaryScope();
+        given(loadApplicationPort.searchSummaryRows(1L, Set.of(10L), null, SUMMARY_STATUSES))
+            .willReturn(List.of());
+
+        RecruitingStatusSummaryInfo result = sut.getStatusSummary(summaryQuery(Set.of(10L), Set.of()));
+
+        assertThat(result.totalCount()).isZero();
+        assertAllPartSlotsZero(result.parts());
+        assertThat(result.schools()).singleElement().satisfies(school -> {
+            assertAllPartSlotsZero(school.parts());
+            assertThat(school.rounds()).singleElement()
+                .satisfies(round -> assertAllPartSlotsZero(round.parts()));
+        });
+    }
+
+    private void assertAllPartSlotsZero(List<RecruitingPartStatusSummaryInfo> parts) {
+        assertThat(parts)
+            .extracting(part -> part.part())
+            .containsExactly(
+                ChallengerTrack.PLAN,
+                ChallengerTrack.DESIGN,
+                ChallengerTrack.WEB_PRODUCT_ENGINEER,
+                ChallengerTrack.MOBILE_PRODUCT_ENGINEER
+            );
+        assertThat(parts).allSatisfy(part -> {
+            assertThat(part.totalCount()).isZero();
+            assertThat(part.countByStatus()).isEmpty();
+        });
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용
지원현황 요약 API에 1지망 파트별 지원서 상태 집계를 추가했습니다.                                                                                                
기존 학교·Round·상태별 집계에 다음 정보를 추가로 제공합니다.                     
                                                                                   
  - 전체 지원서 기준 파트별 집계                                                   
  - 학교별 파트 집계                                                               
  - Round별 파트 집계                                                              
  - 파트별 전체 지원서 수                                                          
  - 파트별 상태별 지원서 수                                                        
                                                                                   
파트는 지원서의 firstChoice를 기준으로 집계합니다.       

### 집계 기준                                                                     
                                                                                   
  - DRAFT, CANCELLED 상태는 집계에서 제외                                          
  - PLAN, DESIGN, WEB_PRODUCT_ENGINEER, MOBILE_PRODUCT_ENGINEER를 항상 반환        
  - 지원서가 없는 파트도 totalCount = 0으로 반환                                   
  - INFRA_PLUS는 모집 대상이 아니므로 제외                                         
  - 파트 순서는 ChallengerTrack.sortOrder 기준                                     
  - 파트별 상태 집계의 합은 해당 계층의 전체 지원서 수와 일치


## 💬 리뷰 중점사항
