### PR TITLE
[Fix] Community Thread 메시지 응답에 첨부 파일 접근 URL 포함

### DIFF
--- a/src/main/java/com/umc/product/community/adapter/in/web/dto/response/CommunityThreadMessageResponse.java
+++ b/src/main/java/com/umc/product/community/adapter/in/web/dto/response/CommunityThreadMessageResponse.java
@@ -5,6 +5,7 @@ import static com.umc.product.community.adapter.in.web.CommunityWebNumbers.text;
 import java.time.Instant;
 import java.util.List;
 
+import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageFileInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageMentionInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageReplyInfo;
@@ -20,7 +21,7 @@ public record CommunityThreadMessageResponse(
     String content,
     CommunityThreadMessageType type,
     CommunityThreadMessageStatus status,
-    List<String> fileMetadataIds,
+    List<File> files,
     List<Mention> mentions,
     ReplyTo replyTo,
     List<Reaction> reactions,
@@ -38,7 +39,7 @@ public record CommunityThreadMessageResponse(
             info.content(),
             info.type(),
             info.status(),
-            info.fileMetadataIds(),
+            info.files().stream().map(File::from).toList(),
             info.mentions().stream().map(Mention::from).toList(),
             ReplyTo.from(info.replyTo()),
             info.reactions().stream().map(Reaction::from).toList(),
@@ -46,6 +47,16 @@ public record CommunityThreadMessageResponse(
             info.editedAt(),
             info.deletedAt()
         );
+    }
+
+    /**
+     * 첨부 파일. {@code fileUrl} 은 유효기간이 있는 서명 URL 이며 조회할 때마다 새로 발급된다.
+     */
+    public record File(String fileId, String fileName, String fileSize, String fileUrl) {
+
+        private static File from(CommunityThreadMessageFileInfo info) {
+            return new File(info.fileId(), info.fileName(), text(info.fileSize()), info.fileUrl());
+        }
     }
 
     public record Mention(String memberId, String name) {

--- a/src/main/java/com/umc/product/community/application/port/in/query/thread/message/dto/CommunityThreadMessageFileInfo.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/thread/message/dto/CommunityThreadMessageFileInfo.java
@@ -1,0 +1,34 @@
+package com.umc.product.community.application.port.in.query.thread.message.dto;
+
+import com.umc.product.storage.application.port.in.query.dto.FileInfo;
+
+/**
+ * 스레드 메시지에 첨부된 파일 하나의 조회 모델.
+ *
+ * <p>파일 ID와 접근 URL을 한 객체로 묶어, 클라이언트가 두 목록을 인덱스로 짝지을 필요를 없앤다.
+ * storage 메타에서 누락된 파일은 목록에서 제외되므로 인덱스 기반 매칭은 어긋날 수 있다.</p>
+ *
+ * <p>{@code fileUrl} 은 유효기간이 있는 서명 URL 이며, 조회할 때마다 새로 발급된다.</p>
+ */
+public record CommunityThreadMessageFileInfo(
+    String fileId,
+    String fileName,
+    Long fileSize,
+    String fileUrl
+) {
+
+    public CommunityThreadMessageFileInfo {
+        if (fileId == null || fileId.isBlank()) {
+            throw new IllegalArgumentException("fileId must not be blank");
+        }
+    }
+
+    public static CommunityThreadMessageFileInfo from(FileInfo file) {
+        return new CommunityThreadMessageFileInfo(
+            file.fileId(),
+            file.originalFileName(),
+            file.fileSize(),
+            file.fileLink()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/community/application/port/in/query/thread/message/dto/CommunityThreadMessageInfo.java
+++ b/src/main/java/com/umc/product/community/application/port/in/query/thread/message/dto/CommunityThreadMessageInfo.java
@@ -12,7 +12,7 @@ public record CommunityThreadMessageInfo(
     String content,
     CommunityThreadMessageType type,
     CommunityThreadMessageStatus status,
-    List<String> fileMetadataIds,
+    List<CommunityThreadMessageFileInfo> files,
     List<CommunityThreadMessageMentionInfo> mentions,
     CommunityThreadMessageReplyInfo replyTo,
     List<CommunityThreadReactionInfo> reactions,
@@ -26,7 +26,7 @@ public record CommunityThreadMessageInfo(
         messageId = requirePositive(messageId, "messageId");
         threadId = requirePositive(threadId, "threadId");
         senderId = requirePositive(senderId, "senderId");
-        fileMetadataIds = fileMetadataIds == null ? List.of() : List.copyOf(fileMetadataIds);
+        files = files == null ? List.of() : List.copyOf(files);
         mentions = mentions == null ? List.of() : List.copyOf(mentions);
         reactions = reactions == null ? List.of() : List.copyOf(reactions);
     }

--- a/src/main/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssembler.java
+++ b/src/main/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssembler.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import com.umc.product.chat.application.port.in.query.dto.ChatMessageInfo;
 import com.umc.product.chat.application.port.in.query.dto.ChatMessageReplyInfo;
 import com.umc.product.chat.application.port.in.query.dto.ChatReactionInfo;
 import com.umc.product.chat.domain.MessageContentType;
+import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageFileInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageMentionInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageReplyInfo;
@@ -21,14 +23,19 @@ import com.umc.product.community.application.port.in.query.thread.message.dto.Co
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadReactionInfo;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.storage.application.port.in.query.dto.FileInfo;
 
 import lombok.RequiredArgsConstructor;
 
 /**
  * Chat 엔진의 조회 모델을 Community thread 공개 모델로 변환한다.
  *
- * <p>Chat room id는 Community 외부 계약에 포함하지 않고, 이름이 필요한 멤버를 한 번의
- * batch query로 조립한다.</p>
+ * <p>Chat room id는 Community 외부 계약에 포함하지 않고, 이름이 필요한 멤버와 첨부 파일을
+ * 각각 한 번의 batch query로 조립한다.</p>
+ *
+ * <p>첨부 파일은 fileId 만으로는 렌더링할 수 없으므로 storage 도메인에서 접근 URL 을 조회해
+ * 함께 내려준다. REST 응답과 STOMP 브로드캐스트가 이 조립 결과를 공유한다.</p>
  */
 @Component
 @RequiredArgsConstructor
@@ -37,6 +44,7 @@ public class CommunityThreadMessageInfoAssembler {
     private static final String UNKNOWN_MEMBER_NAME = "알 수 없음";
 
     private final GetMemberUseCase getMemberUseCase;
+    private final GetFileUseCase getFileUseCase;
 
     public CommunityThreadMessageInfo assemble(Long threadId, ChatMessageInfo message) {
         return assemble(threadId, List.of(message)).get(0);
@@ -48,8 +56,9 @@ public class CommunityThreadMessageInfoAssembler {
         }
 
         Map<Long, MemberInfo> members = loadMembers(messages);
+        Map<String, FileInfo> files = loadFiles(messages);
         return messages.stream()
-            .map(message -> toInfo(threadId, message, members))
+            .map(message -> toInfo(threadId, message, members, files))
             .toList();
     }
 
@@ -61,10 +70,12 @@ public class CommunityThreadMessageInfoAssembler {
             return Map.of();
         }
 
-        Map<Long, MemberInfo> members = loadMembers(List.copyOf(messagesByRecipient.values()));
+        List<ChatMessageInfo> messages = List.copyOf(messagesByRecipient.values());
+        Map<Long, MemberInfo> members = loadMembers(messages);
+        Map<String, FileInfo> files = loadFiles(messages);
         Map<Long, CommunityThreadMessageInfo> result = new LinkedHashMap<>();
         messagesByRecipient.forEach((recipientMemberId, message) ->
-            result.put(recipientMemberId, toInfo(threadId, message, members)));
+            result.put(recipientMemberId, toInfo(threadId, message, members, files)));
         return Collections.unmodifiableMap(result);
     }
 
@@ -85,10 +96,26 @@ public class CommunityThreadMessageInfoAssembler {
         return memberIds.isEmpty() ? Map.of() : getMemberUseCase.findAllByIds(memberIds);
     }
 
+    /**
+     * 조립 대상 메시지 전체의 fileId 를 모아 storage 도메인에서 IN 쿼리 1회로 batch 조회한다.
+     *
+     * <p>storage 에서 누락된 fileId 는 결과 Map 에서 빠지므로, 호출부는 누락 가능성을 가정해야 한다.</p>
+     */
+    private Map<String, FileInfo> loadFiles(List<ChatMessageInfo> messages) {
+        Set<String> fileIds = new LinkedHashSet<>();
+        messages.forEach(message -> {
+            if (message.fileMetadataIds() != null) {
+                fileIds.addAll(message.fileMetadataIds());
+            }
+        });
+        return fileIds.isEmpty() ? Map.of() : getFileUseCase.findAllByIds(List.copyOf(fileIds));
+    }
+
     private CommunityThreadMessageInfo toInfo(
         Long threadId,
         ChatMessageInfo message,
-        Map<Long, MemberInfo> members
+        Map<Long, MemberInfo> members,
+        Map<String, FileInfo> files
     ) {
         List<CommunityThreadMessageMentionInfo> mentions = message.mentionedMemberIds().stream()
             .map(memberId -> new CommunityThreadMessageMentionInfo(memberId, memberName(members, memberId)))
@@ -107,7 +134,7 @@ public class CommunityThreadMessageInfoAssembler {
             message.content(),
             toCommunityType(message.contentType()),
             CommunityThreadMessageStatus.SENT,
-            message.fileMetadataIds(),
+            toFileInfos(message.fileMetadataIds(), files),
             mentions,
             replyTo,
             reactions,
@@ -116,6 +143,26 @@ public class CommunityThreadMessageInfoAssembler {
             message.editedAt(),
             message.deletedAt()
         );
+    }
+
+    /**
+     * 메시지가 참조하는 fileId 순서를 그대로 유지하며 조회 결과를 채운다.
+     *
+     * <p>storage 에서 누락된 fileId 는 건너뛴다. 원본 순서를 순회하므로 누락이 있어도 남은 파일의
+     * 표시 순서는 어긋나지 않는다.</p>
+     */
+    private List<CommunityThreadMessageFileInfo> toFileInfos(
+        List<String> fileMetadataIds,
+        Map<String, FileInfo> files
+    ) {
+        if (fileMetadataIds == null || fileMetadataIds.isEmpty()) {
+            return List.of();
+        }
+        return fileMetadataIds.stream()
+            .map(files::get)
+            .filter(Objects::nonNull)
+            .map(CommunityThreadMessageFileInfo::from)
+            .toList();
     }
 
     private CommunityThreadMessageReplyInfo toReplyInfo(

--- a/src/main/resources/static/docs/asyncapi.yaml
+++ b/src/main/resources/static/docs/asyncapi.yaml
@@ -868,7 +868,7 @@ components:
         - content
         - type
         - status
-        - fileMetadataIds
+        - files
         - mentions
         - replyTo
         - reactions
@@ -893,10 +893,13 @@ components:
         status:
           type: string
           enum: [SENT]
-        fileMetadataIds:
+        files:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/MessageFile"
+          description: >-
+            첨부 파일. fileId 와 접근 URL 을 한 객체로 묶어 내려주므로 인덱스 매칭이 필요 없습니다.
+            storage 에서 누락된 파일은 목록에서 제외되며, 남은 파일의 순서는 전송 시점 순서를 유지합니다.
         mentions:
           type: array
           items:
@@ -918,6 +921,21 @@ components:
           $ref: "#/components/schemas/NullableDateTime"
         deletedAt:
           $ref: "#/components/schemas/NullableDateTime"
+
+    MessageFile:
+      type: object
+      additionalProperties: false
+      required: [fileId, fileName, fileSize, fileUrl]
+      properties:
+        fileId:
+          type: string
+        fileName:
+          $ref: "#/components/schemas/NullableString"
+        fileSize:
+          $ref: "#/components/schemas/NullableString"
+        fileUrl:
+          $ref: "#/components/schemas/NullableString"
+          description: 유효기간 60분의 서명 URL 입니다. 조회할 때마다 새로 발급되므로 장기 캐싱하면 만료됩니다.
 
     MessageMention:
       type: object

--- a/src/test/java/com/umc/product/community/adapter/in/web/CommunityThreadQueryControllerTest.java
+++ b/src/test/java/com/umc/product/community/adapter/in/web/CommunityThreadQueryControllerTest.java
@@ -43,6 +43,7 @@ import com.umc.product.community.application.port.in.query.thread.dto.ThreadMemb
 import com.umc.product.community.application.port.in.query.thread.dto.ThreadMemberPageInfo;
 import com.umc.product.community.application.port.in.query.thread.dto.ThreadSummaryInfo;
 import com.umc.product.community.application.port.in.query.thread.message.GetCommunityThreadMessageHistoryUseCase;
+import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageFileInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageHistoryQuery;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageInfo;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageMentionInfo;
@@ -217,7 +218,8 @@ class CommunityThreadQueryControllerTest {
     void getMessageHistory_mapsCursorAndNestedNumericValues() throws Exception {
         CommunityThreadMessageInfo message = new CommunityThreadMessageInfo(
             500L, 42L, 7L, "하늘", "안녕하세요", CommunityThreadMessageType.TEXT,
-            CommunityThreadMessageStatus.SENT, List.of("file-key"),
+            CommunityThreadMessageStatus.SENT,
+            List.of(new CommunityThreadMessageFileInfo("file-key", "shot.png", 2_048L, "https://cdn/file-key")),
             List.of(new CommunityThreadMessageMentionInfo(8L, "구름")),
             new CommunityThreadMessageReplyInfo(499L, "구름", "이전 메시지"),
             List.of(new CommunityThreadReactionInfo("👍", 2L, true)), null,

--- a/src/test/java/com/umc/product/community/adapter/in/web/CommunityThreadQueryControllerTest.java
+++ b/src/test/java/com/umc/product/community/adapter/in/web/CommunityThreadQueryControllerTest.java
@@ -237,6 +237,10 @@ class CommunityThreadQueryControllerTest {
             .andExpect(jsonPath("$.result.messages[0].mentions[0].memberId").value("8"))
             .andExpect(jsonPath("$.result.messages[0].replyTo.messageId").value("499"))
             .andExpect(jsonPath("$.result.messages[0].reactions[0].count").value("2"))
+            .andExpect(jsonPath("$.result.messages[0].files[0].fileId").value("file-key"))
+            .andExpect(jsonPath("$.result.messages[0].files[0].fileName").value("shot.png"))
+            .andExpect(jsonPath("$.result.messages[0].files[0].fileSize").value("2048"))
+            .andExpect(jsonPath("$.result.messages[0].files[0].fileUrl").value("https://cdn/file-key"))
             .andExpect(jsonPath("$.result.hasMore").value(true))
             .andExpect(jsonPath("$.result.nextBefore").value("499"));
 

--- a/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssemblerTest.java
+++ b/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssemblerTest.java
@@ -27,6 +27,9 @@ import com.umc.product.community.application.port.in.query.thread.message.dto.Co
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageType;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
+import com.umc.product.storage.application.port.in.query.dto.FileInfo;
+import com.umc.product.storage.domain.enums.FileCategory;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommunityThreadMessageInfoAssembler")
@@ -39,13 +42,17 @@ class CommunityThreadMessageInfoAssemblerTest {
     @Mock
     GetMemberUseCase getMemberUseCase;
 
+    @Mock
+    GetFileUseCase getFileUseCase;
+
     @Test
     @DisplayName(
         "한 페이지의 sender·mention·reply 이름은 단 한 번의 Member batch 조회로 매핑되고 "
             + "roomId는 노출하지 않는다"
     )
     void assembleBatchNamesOnceWithoutRawRoomId() {
-        CommunityThreadMessageInfoAssembler sut = new CommunityThreadMessageInfoAssembler(getMemberUseCase);
+        CommunityThreadMessageInfoAssembler sut =
+            new CommunityThreadMessageInfoAssembler(getMemberUseCase, getFileUseCase);
         ChatMessageInfo first = chatMessage(
             900L,
             10L,
@@ -88,7 +95,8 @@ class CommunityThreadMessageInfoAssemblerTest {
     @Test
     @DisplayName("IMAGE와 SYSTEM도 Community type으로 변환하고 서버 status는 항상 SENT로 고정한다")
     void assembleMapsImageAndSystemToSent() {
-        CommunityThreadMessageInfoAssembler sut = new CommunityThreadMessageInfoAssembler(getMemberUseCase);
+        CommunityThreadMessageInfoAssembler sut =
+            new CommunityThreadMessageInfoAssembler(getMemberUseCase, getFileUseCase);
         ChatMessageInfo image = new ChatMessageInfo(
             900L,
             ROOM_ID,
@@ -107,6 +115,8 @@ class CommunityThreadMessageInfoAssemblerTest {
         );
         MemberInfo sender = mockMember(10L, "보낸이");
         given(getMemberUseCase.findAllByIds(Set.of(10L))).willReturn(Map.of(10L, sender));
+        given(getFileUseCase.findAllByIds(List.of("file-1")))
+            .willReturn(Map.of("file-1", fileInfo("file-1", "screenshot.png", 1_024L)));
 
         ChatMessageInfo system = new ChatMessageInfo(
             901L,
@@ -130,7 +140,10 @@ class CommunityThreadMessageInfoAssemblerTest {
 
         assertThat(imageInfo.type()).isEqualTo(CommunityThreadMessageType.IMAGE);
         assertThat(imageInfo.status()).isEqualTo(CommunityThreadMessageStatus.SENT);
-        assertThat(imageInfo.fileMetadataIds()).containsExactly("file-1");
+        assertThat(imageInfo.files()).extracting("fileId", "fileName", "fileSize", "fileUrl")
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple("file-1", "screenshot.png", 1_024L, "https://cdn/file-1")
+        );
         assertThat(systemInfo.type()).isEqualTo(CommunityThreadMessageType.SYSTEM);
         assertThat(systemInfo.status()).isEqualTo(CommunityThreadMessageStatus.SENT);
         then(getMemberUseCase).should(times(2)).findAllByIds(Set.of(10L));
@@ -158,6 +171,20 @@ class CommunityThreadMessageInfoAssemblerTest {
             mentions,
             reply,
             List.of(new ChatReactionInfo("👍", 2L, true))
+        );
+    }
+
+    private FileInfo fileInfo(String fileId, String fileName, Long fileSize) {
+        return new FileInfo(
+            fileId,
+            fileName,
+            FileCategory.POST_IMAGE,
+            "image/png",
+            fileSize,
+            "https://cdn/" + fileId,
+            true,
+            10L,
+            CREATED_AT
         );
     }
 

--- a/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssemblerTest.java
+++ b/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageInfoAssemblerTest.java
@@ -149,6 +149,53 @@ class CommunityThreadMessageInfoAssemblerTest {
         then(getMemberUseCase).should(times(2)).findAllByIds(Set.of(10L));
     }
 
+    @Test
+    @DisplayName("첨부 파일은 한 번의 batch 조회로 URL을 채우고, storage에서 누락된 파일은 건너뛰되 원본 순서를 유지한다")
+    void assembleResolvesFileUrlsInOneBatchAndKeepsOrderWhenSomeAreMissing() {
+        CommunityThreadMessageInfoAssembler sut =
+            new CommunityThreadMessageInfoAssembler(getMemberUseCase, getFileUseCase);
+        ChatMessageInfo first = imageMessage(900L, List.of("file-a", "file-b", "file-c"));
+        ChatMessageInfo second = imageMessage(901L, List.of("file-d"));
+        given(getMemberUseCase.findAllByIds(Set.of(10L))).willReturn(Map.of(10L, mockMember(10L, "보낸이")));
+        // file-b 는 삭제되어 storage 조회 결과에서 빠진다.
+        given(getFileUseCase.findAllByIds(List.of("file-a", "file-b", "file-c", "file-d")))
+            .willReturn(Map.of(
+                "file-a", fileInfo("file-a", "a.png", 1L),
+                "file-c", fileInfo("file-c", "c.png", 3L),
+                "file-d", fileInfo("file-d", "d.png", 4L)
+            ));
+
+        List<CommunityThreadMessageInfo> result = sut.assemble(THREAD_ID, List.of(first, second));
+
+        assertThat(result.get(0).files()).extracting("fileId", "fileUrl")
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple("file-a", "https://cdn/file-a"),
+                org.assertj.core.groups.Tuple.tuple("file-c", "https://cdn/file-c")
+        );
+        assertThat(result.get(1).files()).extracting("fileId")
+            .containsExactly("file-d");
+        then(getFileUseCase).should(times(1)).findAllByIds(List.of("file-a", "file-b", "file-c", "file-d"));
+    }
+
+    private ChatMessageInfo imageMessage(Long messageId, List<String> fileIds) {
+        return new ChatMessageInfo(
+            messageId,
+            ROOM_ID,
+            10L,
+            MessageContentType.IMAGE,
+            "캡션",
+            fileIds,
+            CREATED_AT,
+            null,
+            UUID.fromString("00000000-0000-0000-0000-00000000000" + (messageId - 899L)),
+            null,
+            null,
+            List.of(),
+            null,
+            List.of()
+        );
+    }
+
     private ChatMessageInfo chatMessage(
         Long messageId,
         Long senderId,

--- a/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageRecipientAssemblerTest.java
+++ b/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageRecipientAssemblerTest.java
@@ -22,6 +22,7 @@ import com.umc.product.chat.domain.MessageContentType;
 import com.umc.product.community.application.port.in.query.thread.message.dto.CommunityThreadMessageInfo;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.storage.application.port.in.query.GetFileUseCase;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Community thread recipient message assembler")
@@ -30,10 +31,14 @@ class CommunityThreadMessageRecipientAssemblerTest {
     @Mock
     GetMemberUseCase getMemberUseCase;
 
+    @Mock
+    GetFileUseCase getFileUseCase;
+
     @Test
     @DisplayName("수신자별 reaction을 유지하면서 sender 이름은 한 번의 Member batch로 조립한다")
     void assembleForRecipients_loadsMemberNamesOnce() {
-        CommunityThreadMessageInfoAssembler sut = new CommunityThreadMessageInfoAssembler(getMemberUseCase);
+        CommunityThreadMessageInfoAssembler sut =
+            new CommunityThreadMessageInfoAssembler(getMemberUseCase, getFileUseCase);
         Map<Long, ChatMessageInfo> messagesByRecipient = new LinkedHashMap<>();
         messagesByRecipient.put(10L, message(true));
         messagesByRecipient.put(20L, message(false));


### PR DESCRIPTION
## 🚀 작업 내용

- resolves #1217

스레드 `IMAGE` 메시지 조회 시 응답에 `fileMetadataIds`만 내려가 클라이언트가 이미지를 렌더링할 수 없었어요.

### 원인
`CommunityThreadMessageInfoAssembler`가 발신자 ID는 배치 조회해 이름으로 치환하면서, 파일에 대응하는 변환은 없었어요.
`GetFileUseCase` 의존성 자체가 없어 `fileMetadataIds`가 그대로 응답까지 흘러갔어요.

### 수정
  - `CommunityThreadMessageFileInfo` 추가 (`fileId` / `fileName` / `fileSize` / `fileUrl`)
  - assembler에 `GetFileUseCase` 주입, 페이지 단위 fileId를 모아 **IN 쿼리 1회**로 배치 조회
  - 원본 `fileMetadataIds` 순서를 순회하며 URL을 채우고, storage에서 누락된 파일은 건너뜀
  - `asyncapi.yaml`의 `CommunityThreadMessage` 스키마 동기화 (`MessageFile` 신설)

REST와 STOMP가 같은 조립 결과를 공유해서, assembler 한 곳에서 두 경로가 함께 해결돼요.

### 변동 사항
응답의 `fileMetadataIds`를 **제거**하고 `files`로 교체했어요. `files[].fileId`로 동일 정보를 얻을 수 있어요.

  | 경로 | 영향 |
  | --- | --- |
  | `COMMUNITY-THREAD-105` (message history) | `fileMetadataIds` -> `files` |
  | STOMP `message.created` / `updated` / `deleted` | 동일 |

메시지 **전송** 요청(`CreateCommunityThreadMessageRequest`)의 `fileMetadataIds`는 그대로예요.

#### 기타 참고 사항
- **URL 유효기간 60분** : CloudFront 서명 URL이라 만료되면 403이 떠요. 조회 시마다 새로 발급되므로 재조회로 복구할 수 있어요. 403은 앱을 1시간 이상 켜둔 채 미로딩 과거 메시지까지 스크롤하는 경우에만 발생하므로, 클라이언트에서 로드 실패 시 재조회로 대응해야 해요. 해당 케이스 빈도 확인 후 필요하다고 판단 시, 갱신 전용 API를 별도로 구현할 생각이에요.

## 💬 리뷰 중점사항