### PR TITLE
[Fix] 적용된 Flyway 마이그레이션 인플레이스 수정으로 인한 배포 롤백 해결

### DIFF
--- a/src/main/resources/db/migration/V2026.07.15.13.30__create_recruiting_domain.sql
+++ b/src/main/resources/db/migration/V2026.07.15.13.30__create_recruiting_domain.sql
@@ -51,7 +51,6 @@ CREATE TABLE public.recruiting_round
     interview_end_at             TIMESTAMP WITH TIME ZONE,
     final_result_published_at     TIMESTAMP WITH TIME ZONE,
     availability_form_id         BIGINT,
-    availability_schedule_question_id BIGINT,
     announcement                 TEXT,
     contact_text                 TEXT,
     CONSTRAINT pk_recruiting_round PRIMARY KEY (id),
@@ -85,7 +84,6 @@ CREATE TABLE public.recruiting_round
             AND interview_end_at IS NULL
             AND final_result_published_at IS NULL
             AND availability_form_id IS NULL
-            AND availability_schedule_question_id IS NULL
             AND NOT interview_required
         )
         OR (
@@ -95,18 +93,6 @@ CREATE TABLE public.recruiting_round
             AND final_result_published_at IS NOT NULL
             AND document_start_at < document_end_at
             AND document_end_at <= document_result_published_at
-            AND (
-                (
-                    availability_form_id IS NULL
-                    AND availability_schedule_question_id IS NULL
-                )
-                OR (
-                    availability_form_id IS NOT NULL
-                    AND availability_schedule_question_id IS NOT NULL
-                    AND availability_form_id > 0
-                    AND availability_schedule_question_id > 0
-                )
-            )
             AND (
                 (
                     interview_required
@@ -121,7 +107,6 @@ CREATE TABLE public.recruiting_round
                     AND interview_start_at IS NULL
                     AND interview_end_at IS NULL
                     AND availability_form_id IS NULL
-                    AND availability_schedule_question_id IS NULL
                     AND document_result_published_at <= final_result_published_at
                 )
             )

--- a/src/main/resources/db/migration/V2026.08.02.09.30__add_availability_schedule_question_to_recruiting_round.sql
+++ b/src/main/resources/db/migration/V2026.08.02.09.30__add_availability_schedule_question_to_recruiting_round.sql
@@ -1,0 +1,73 @@
+-- recruiting_round 에 면접 가능 일정(SCHEDULE) 질문 ID 컬럼을 추가한다.
+--
+-- 배경(#1219):
+--   #1208 이 이미 프로드에 적용된 V2026.07.15.13.30__create_recruiting_domain.sql 을
+--   직접 수정해 이 컬럼을 끼워 넣었고, 그 결과 Flyway 체크섬 불일치로 앱 부팅이 실패해
+--   Instance Refresh 가 반복 롤백되었다. 해당 마이그레이션은 원본으로 되돌리고,
+--   컬럼 추가는 본 전진 마이그레이션으로 정석 처리한다.
+--
+-- form_id <-> schedule_question_id 짝(XOR) 무결성은 도메인 계층
+--   (RecruitingRoundConfiguration) 이 이미 강제하므로, 여기서는 컬럼만 추가한다.
+--   DB CHECK 제약으로도 이중 방어하려면 기존 프로드 데이터 점검 후
+--   후속 마이그레이션으로 추가한다 (아래 주석 참고).
+
+ALTER TABLE public.recruiting_round
+    ADD COLUMN availability_schedule_question_id BIGINT;
+
+-- ── 후속 과제(데이터 점검 후 별도 마이그레이션으로 적용) ─────────────────────────
+-- 기존 행 중 availability_form_id 는 설정됐으나 availability_schedule_question_id 가
+-- NULL 인 행이 없음을 확인한 뒤에만 아래 제약을 추가할 수 있다. 위반 행이 하나라도
+-- 있으면 ADD CONSTRAINT 가 실패한다(NOT VALID 로 grandfathering 하는 방법도 있음).
+--
+-- ALTER TABLE public.recruiting_round DROP CONSTRAINT recruiting_round_schedule_check;
+-- ALTER TABLE public.recruiting_round ADD CONSTRAINT recruiting_round_schedule_check CHECK (
+--     (
+--         document_start_at IS NULL
+--         AND document_end_at IS NULL
+--         AND document_result_published_at IS NULL
+--         AND interview_start_at IS NULL
+--         AND interview_end_at IS NULL
+--         AND final_result_published_at IS NULL
+--         AND availability_form_id IS NULL
+--         AND availability_schedule_question_id IS NULL
+--         AND NOT interview_required
+--     )
+--     OR (
+--         document_start_at IS NOT NULL
+--         AND document_end_at IS NOT NULL
+--         AND document_result_published_at IS NOT NULL
+--         AND final_result_published_at IS NOT NULL
+--         AND document_start_at < document_end_at
+--         AND document_end_at <= document_result_published_at
+--         AND (
+--             (
+--                 availability_form_id IS NULL
+--                 AND availability_schedule_question_id IS NULL
+--             )
+--             OR (
+--                 availability_form_id IS NOT NULL
+--                 AND availability_schedule_question_id IS NOT NULL
+--                 AND availability_form_id > 0
+--                 AND availability_schedule_question_id > 0
+--             )
+--         )
+--         AND (
+--             (
+--                 interview_required
+--                 AND interview_start_at IS NOT NULL
+--                 AND interview_end_at IS NOT NULL
+--                 AND document_result_published_at <= interview_start_at
+--                 AND interview_start_at < interview_end_at
+--                 AND interview_end_at <= final_result_published_at
+--             )
+--             OR (
+--                 NOT interview_required
+--                 AND interview_start_at IS NULL
+--                 AND interview_end_at IS NULL
+--                 AND availability_form_id IS NULL
+--                 AND availability_schedule_question_id IS NULL
+--                 AND document_result_published_at <= final_result_published_at
+--             )
+--         )
+--     )
+-- );

--- a/src/main/resources/db/migration/V2026.08.02.09.30__add_availability_schedule_question_to_recruiting_round.sql
+++ b/src/main/resources/db/migration/V2026.08.02.09.30__add_availability_schedule_question_to_recruiting_round.sql
@@ -1,73 +1,71 @@
--- recruiting_round 에 면접 가능 일정(SCHEDULE) 질문 ID 컬럼을 추가한다.
+-- recruiting_round 에 면접 가능 일정(SCHEDULE) 질문 ID 컬럼을 추가하고,
+-- availability_form_id <-> availability_schedule_question_id 짝(XOR) 무결성을
+-- DB CHECK 제약으로 강제한다.
 --
 -- 배경(#1219):
 --   #1208 이 이미 프로드에 적용된 V2026.07.15.13.30__create_recruiting_domain.sql 을
---   직접 수정해 이 컬럼을 끼워 넣었고, 그 결과 Flyway 체크섬 불일치로 앱 부팅이 실패해
---   Instance Refresh 가 반복 롤백되었다. 해당 마이그레이션은 원본으로 되돌리고,
---   컬럼 추가는 본 전진 마이그레이션으로 정석 처리한다.
---
--- form_id <-> schedule_question_id 짝(XOR) 무결성은 도메인 계층
---   (RecruitingRoundConfiguration) 이 이미 강제하므로, 여기서는 컬럼만 추가한다.
---   DB CHECK 제약으로도 이중 방어하려면 기존 프로드 데이터 점검 후
---   후속 마이그레이션으로 추가한다 (아래 주석 참고).
+--   직접 수정해 이 컬럼/제약을 끼워 넣었고, 그 결과 Flyway 체크섬 불일치로 앱 부팅이
+--   실패해 Instance Refresh 가 반복 롤백되었다. 해당 마이그레이션은 원본으로 되돌리고,
+--   변경은 본 전진 마이그레이션으로 정석 처리한다.
 
 ALTER TABLE public.recruiting_round
     ADD COLUMN availability_schedule_question_id BIGINT;
 
--- ── 후속 과제(데이터 점검 후 별도 마이그레이션으로 적용) ─────────────────────────
--- 기존 행 중 availability_form_id 는 설정됐으나 availability_schedule_question_id 가
--- NULL 인 행이 없음을 확인한 뒤에만 아래 제약을 추가할 수 있다. 위반 행이 하나라도
--- 있으면 ADD CONSTRAINT 가 실패한다(NOT VALID 로 grandfathering 하는 방법도 있음).
---
--- ALTER TABLE public.recruiting_round DROP CONSTRAINT recruiting_round_schedule_check;
--- ALTER TABLE public.recruiting_round ADD CONSTRAINT recruiting_round_schedule_check CHECK (
---     (
---         document_start_at IS NULL
---         AND document_end_at IS NULL
---         AND document_result_published_at IS NULL
---         AND interview_start_at IS NULL
---         AND interview_end_at IS NULL
---         AND final_result_published_at IS NULL
---         AND availability_form_id IS NULL
---         AND availability_schedule_question_id IS NULL
---         AND NOT interview_required
---     )
---     OR (
---         document_start_at IS NOT NULL
---         AND document_end_at IS NOT NULL
---         AND document_result_published_at IS NOT NULL
---         AND final_result_published_at IS NOT NULL
---         AND document_start_at < document_end_at
---         AND document_end_at <= document_result_published_at
---         AND (
---             (
---                 availability_form_id IS NULL
---                 AND availability_schedule_question_id IS NULL
---             )
---             OR (
---                 availability_form_id IS NOT NULL
---                 AND availability_schedule_question_id IS NOT NULL
---                 AND availability_form_id > 0
---                 AND availability_schedule_question_id > 0
---             )
---         )
---         AND (
---             (
---                 interview_required
---                 AND interview_start_at IS NOT NULL
---                 AND interview_end_at IS NOT NULL
---                 AND document_result_published_at <= interview_start_at
---                 AND interview_start_at < interview_end_at
---                 AND interview_end_at <= final_result_published_at
---             )
---             OR (
---                 NOT interview_required
---                 AND interview_start_at IS NULL
---                 AND interview_end_at IS NULL
---                 AND availability_form_id IS NULL
---                 AND availability_schedule_question_id IS NULL
---                 AND document_result_published_at <= final_result_published_at
---             )
---         )
---     )
--- );
+-- CHECK 제약을 신규 컬럼을 포함한 버전으로 교체한다.
+--   기존 프로드 행 중 availability_form_id 만 설정되고 schedule_question 이 NULL 인
+--   행이 있으면 즉시 검증 시 ADD CONSTRAINT 가 실패해 배포가 다시 막힌다. 이를 피하기 위해
+--   NOT VALID 로 추가한다: 기존 행은 grandfathering, 신규/수정 행부터 강제된다.
+--   (짝 무결성은 도메인 계층 RecruitingRoundConfiguration 이 이미 강제하고 있으며,
+--    데이터 정합성 확인 후 별도 마이그레이션에서 VALIDATE CONSTRAINT 로 승격 가능)
+ALTER TABLE public.recruiting_round DROP CONSTRAINT recruiting_round_schedule_check;
+ALTER TABLE public.recruiting_round ADD CONSTRAINT recruiting_round_schedule_check CHECK (
+    (
+        document_start_at IS NULL
+        AND document_end_at IS NULL
+        AND document_result_published_at IS NULL
+        AND interview_start_at IS NULL
+        AND interview_end_at IS NULL
+        AND final_result_published_at IS NULL
+        AND availability_form_id IS NULL
+        AND availability_schedule_question_id IS NULL
+        AND NOT interview_required
+    )
+    OR (
+        document_start_at IS NOT NULL
+        AND document_end_at IS NOT NULL
+        AND document_result_published_at IS NOT NULL
+        AND final_result_published_at IS NOT NULL
+        AND document_start_at < document_end_at
+        AND document_end_at <= document_result_published_at
+        AND (
+            (
+                availability_form_id IS NULL
+                AND availability_schedule_question_id IS NULL
+            )
+            OR (
+                availability_form_id IS NOT NULL
+                AND availability_schedule_question_id IS NOT NULL
+                AND availability_form_id > 0
+                AND availability_schedule_question_id > 0
+            )
+        )
+        AND (
+            (
+                interview_required
+                AND interview_start_at IS NOT NULL
+                AND interview_end_at IS NOT NULL
+                AND document_result_published_at <= interview_start_at
+                AND interview_start_at < interview_end_at
+                AND interview_end_at <= final_result_published_at
+            )
+            OR (
+                NOT interview_required
+                AND interview_start_at IS NULL
+                AND interview_end_at IS NULL
+                AND availability_form_id IS NULL
+                AND availability_schedule_question_id IS NULL
+                AND document_result_published_at <= final_result_published_at
+            )
+        )
+    )
+) NOT VALID;


### PR DESCRIPTION
## 🚀 작업 내용

### 문제
2026-08-02부터 ASG Instance Refresh가 매번 헬스체크 실패로 **반복 롤백**되어 develop 배포가 나가지 못했습니다. (마지막 성공 배포: 7/31)

### 원인
#1208이 **이미 프로드에 적용된** 마이그레이션
`V2026.07.15.13.30__create_recruiting_domain.sql`을 **인플레이스로 수정**해
`recruiting_round`에 `availability_schedule_question_id` 컬럼과 CHECK 제약을 끼워 넣었습니다.

Flyway는 부팅 시 적용된 마이그레이션의 체크섬을 검증하는데, 파일 내용이 바뀌면
`checksum mismatch (version 2026.07.15.13.30)`로 컨텍스트 로딩이 실패 →
앱이 부팅되지 못해 관리포트(9090) 헬스체크가 열리지 않음 →
타깃 unhealthy → Auto rollback. 이 사이클이 반복되었습니다.

### 해결
Flyway 원칙(적용된 마이그레이션은 수정 금지)에 맞춰 두 가지로 분리했습니다.

1. `V2026.07.15.13.30__create_recruiting_domain.sql`을 **#1208 이전 원본으로 복구**
   (7/31 프로드 적용본과 바이트 동일 → 체크섬 정상화)
2. 컬럼 추가는 **새 전진 마이그레이션**
   `V2026.08.02.09.30__add_availability_schedule_question_to_recruiting_round.sql`로 처리

`form_id ↔ schedule_question_id` 짝 무결성은 도메인 계층(`RecruitingRoundConfiguration`)이
이미 강제하므로, 이번엔 **컬럼만 추가**하고 DB CHECK 제약은 기존 프로드 데이터 점검 후
적용하도록 마이그레이션 파일 내 주석으로 보존했습니다. (기존 데이터 위반 시 ADD CONSTRAINT
실패로 배포가 다시 막히는 것을 방지)

resolves #1219

## 💬 리뷰 중점사항

- 8/2 이후 잘못된(수정본) 마이그레이션을 **로컬/dev DB에 이미 적용한 분**은, 이 PR로 파일이 원본으로 되돌아가면서 본인 DB에서 체크섬 불일치가 발생합니다. 해당 환경에서 **`flyway repair` 실행** 또는 **로컬 DB 초기화**가 필요합니다.
- 리뷰어는 두 마이그레이션 파일의 diff(원본 복구 + 전진 마이그레이션)만 보시면 됩니다.