### PR TITLE
[Fix] 리크루팅 차수 목록 조회에서 빈 시즌 누락 수정

### DIFF
--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -160,18 +161,27 @@ public class RecruitingSeasonQueryService implements
                 LinkedHashMap::new,
                 Collectors.mapping(RecruitingRoundConfigurationInfo::from, Collectors.toList())
             ));
-        return roundsBySeason.entrySet().stream()
-            .map(entry -> {
-                VisibleSeason visible = seasonById.get(entry.getKey());
-                return RecruitingSeasonSummaryInfo.of(
-                    visible.season(),
-                    visible.school().chapterId(),
-                    visible.school().chapterName(),
-                    visible.school().schoolName(),
-                    entry.getValue()
-                );
-            })
+        List<RecruitingSeasonSummaryInfo> populatedSeasons = roundsBySeason.entrySet().stream()
+            .map(entry -> toSummary(seasonById.get(entry.getKey()), entry.getValue()))
             .toList();
+        List<RecruitingSeasonSummaryInfo> emptySeasons = visibleSeasons.stream()
+            .filter(visible -> !roundsBySeason.containsKey(visible.season().getId()))
+            .map(visible -> toSummary(visible, List.of()))
+            .toList();
+        return Stream.concat(populatedSeasons.stream(), emptySeasons.stream()).toList();
+    }
+
+    private RecruitingSeasonSummaryInfo toSummary(
+        VisibleSeason visible,
+        List<RecruitingRoundConfigurationInfo> rounds
+    ) {
+        return RecruitingSeasonSummaryInfo.of(
+            visible.season(),
+            visible.school().chapterId(),
+            visible.school().chapterName(),
+            visible.school().schoolName(),
+            rounds
+        );
     }
 
     @Override

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryServiceTest.java
@@ -24,9 +24,11 @@ import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicRoundSearchQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundGroupSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonConfigurationInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSearchQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
@@ -164,6 +166,44 @@ class RecruitingSeasonQueryServiceTest {
             assertThat(found.seasonId()).isEqualTo(100L);
             assertThat(found.round().id()).isEqualTo(200L);
         });
+    }
+
+    @Test
+    @DisplayName("차수 그룹 조회는 차수가 없는 시즌을 빈 차수 목록으로 포함하되, "
+        + "차수가 있는 시즌들의 기존 정렬(차수 등장 순서)은 그대로 유지하고 뒤에 덧붙인다")
+    void searchRoundGroupsIncludesEmptySeasonAfterPopulatedSeasonsInOriginalOrder() {
+        RecruitingSeason olderSeason = season(100L, 1L, 10L);
+        RecruitingSeason newerSeason = season(102L, 1L, 30L);
+        RecruitingSeason emptySeason = season(101L, 1L, 20L);
+        RecruitingRound olderRound = regularRound(olderSeason, 200L);
+        ReflectionTestUtils.setField(olderRound, "createdAt", Instant.parse("2026-07-01T00:00:00Z"));
+        RecruitingRound newerRound = regularRound(newerSeason, 201L);
+        ReflectionTestUtils.setField(newerRound, "createdAt", Instant.parse("2026-08-01T00:00:00Z"));
+        SubjectAttributes subject = SubjectAttributes.builder().memberId(99L).build();
+        given(getSchoolUseCase.getSchoolListByGisuId(1L)).willReturn(List.of(
+            school(7L, "A 지부", 10L, "A 학교"),
+            school(7L, "A 지부", 20L, "B 학교"),
+            school(7L, "A 지부", 30L, "C 학교")
+        ));
+        given(loadSeasonPort.listByGisuId(1L))
+            .willReturn(List.of(olderSeason, newerSeason, emptySeason));
+        given(checkPermissionUseCase.loadSubject(99L)).willReturn(subject);
+        given(checkPermissionUseCase.check(subject, readPermission(100L))).willReturn(true);
+        given(checkPermissionUseCase.check(subject, readPermission(101L))).willReturn(true);
+        given(checkPermissionUseCase.check(subject, readPermission(102L))).willReturn(true);
+        given(loadRoundPort.listBySeasonIds(List.of(100L, 102L, 101L)))
+            .willReturn(List.of(olderRound, newerRound));
+
+        var result = sut.searchRoundGroups(RecruitingRoundGroupSearchQuery.builder()
+            .gisuId(1L)
+            .requesterMemberId(99L)
+            .build());
+
+        assertThat(result).extracting(RecruitingSeasonSummaryInfo::seasonId)
+            .containsExactly(102L, 100L, 101L);
+        assertThat(result).filteredOn(found -> found.seasonId().equals(101L))
+            .singleElement()
+            .satisfies(found -> assertThat(found.rounds()).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용

Closes #1221

**무엇을**: `GET /api/v1/recruiting/admin/rounds` (모집 차수 목록 조회)가 차수(Round)를 하나도 만들지 않은 시즌을 응답에서 통째로 누락하던 버그를 수정했습니다.

**왜**: 운영진이 새 시즌을 생성한 직후에는 차수가 0개이므로 관리자 화면에 그 시즌이 뜨지 않고, 결과적으로 첫 차수를 생성하는 화면 진입점 자체에 도달할 수 없었습니다 (시즌 생성엔 차수가 필요 없는데, 차수 생성엔 화면에서 시즌 선택이 필요한 순환 문제).

**어떻게**: `RecruitingSeasonQueryService.searchRoundGroups()`가 차수를 시즌별로 그룹핑한 `Map`의 `entrySet()`만 순회해서 응답을 만들다 보니, 그룹핑 결과에 애초에 등장하지 않는(=차수 없는) 시즌이 빠지는 구조였습니다.
- 차수가 있는 시즌들은 기존 로직(차수 최신순으로 훑다가 시즌이 처음 등장하는 순서) 그대로 두어 기존 정렬을 그대로 유지했습니다.
- 차수가 없어서 그룹핑 결과에 없는 시즌들만 별도로 찾아서, 빈 `rounds` 목록과 함께 뒤에 이어 붙였습니다.

## 💬 리뷰 중점사항

- 차수 있는 시즌은 "기존 정렬 그대로 먼저", 차수 없는 시즌은 "뒤에 추가"하는 방식으로 두 리스트를 이어 붙였는데, 이 순서 규칙이 합리적인지 검토 부탁드립니다.