### PR TITLE
[Fix] 면접 일정 Form 생성 경로 부재로 면접 차수 OPEN 불가 문제 해결

### DIFF
--- a/docs/onboarding/recruiting/README.md
+++ b/docs/onboarding/recruiting/README.md
@@ -85,6 +85,7 @@ Recruiting은 학교별 모집 Season, Round, 지원서, 평가, 면접 일정, 
 `availabilityFormId`/`availabilityScheduleQuestionId`는 지원 Form이 아니라 비익명·SCHEDULE 필수 질문 하나짜리 전용 Form을 가리키며,
 매핑이 비어 있으면 Round OPEN 시 `RecruitingInterviewAvailabilityFormProvisioner`가 생성·게시한다.
 Round 수정 요청에 매핑이 없으면 기존 값을 승계한다. configuration을 통째로 교체하는 구조라 승계하지 않으면 매핑이 사라진다.
+OPEN Round에서 면접을 껐다 다시 켜면 승계할 값이 없으므로 수정 시점에 새로 생성한다.
 
 ## 지원과 재지원
 

--- a/docs/onboarding/recruiting/README.md
+++ b/docs/onboarding/recruiting/README.md
@@ -62,7 +62,7 @@ Recruiting은 학교별 모집 Season, Round, 지원서, 평가, 면접 일정, 
 
 | 요청 | 허용 조건 | 결과 |
 |---|---|---|
-| `DRAFT -> OPEN` | 지원 Form 구조가 유효하고, 면접 Round면 게시된 availability Form이 존재 | Round OPEN, RecruitingApplicationForm/실제 Form PUBLISHED |
+| `DRAFT -> OPEN` | 지원 Form 구조가 유효할 것. 면접 Round는 availability Form이 없으면 서버가 자동 생성·게시한 뒤 검증한다 | Round OPEN, RecruitingApplicationForm/실제 Form PUBLISHED, 면접 Round면 availability 매핑 확정 |
 | `OPEN -> DRAFT` | RecruitingApplication과 실제 FormResponse가 모두 0건 | Round/RecruitingApplicationForm/실제 Form DRAFT |
 | `OPEN -> CLOSED` | OPEN 상태 | Round/RecruitingApplicationForm/실제 Form CLOSED |
 | `CLOSED -> DRAFT/OPEN` | 허용하지 않음 | `409` |
@@ -79,6 +79,12 @@ Recruiting은 학교별 모집 Season, Round, 지원서, 평가, 면접 일정, 
 6. Round OPEN 시 모든 section 정책과 모집 트랙별 TRACK section을 검증하고 Form을 게시한다.
 
 별도 Form 게시·마감 및 section 정책 추가 API는 제공하지 않는다. Form 자체 접수 기간 동기화는 공개 UseCase가 제공될 때 연결할 TODO로 남아 있다.
+
+## 면접 일정 조율 Form
+
+`availabilityFormId`/`availabilityScheduleQuestionId`는 지원 Form이 아니라 비익명·SCHEDULE 필수 질문 하나짜리 전용 Form을 가리키며,
+매핑이 비어 있으면 Round OPEN 시 `RecruitingInterviewAvailabilityFormProvisioner`가 생성·게시한다.
+Round 수정 요청에 매핑이 없으면 기존 값을 승계한다. configuration을 통째로 교체하는 구조라 승계하지 않으면 매핑이 사라진다.
 
 ## 지원과 재지원
 

--- a/docs/onboarding/recruiting/test-cases.md
+++ b/docs/onboarding/recruiting/test-cases.md
@@ -23,7 +23,7 @@
 |---|---|
 | `RecruitingSeasonCommandServiceTest` | Season 생성 권한, 중복 Season, quota 교체, 사용량 미만 감소 거부, Round 트랙 보존 |
 | `RecruitingRoundCreateCommandServiceTest` | 본/추가모집 차수, 양수 TO 부분집합, 중복 차수와 0 TO, REST·GraphQL 공용 UseCase의 `INFRA_PLUS` 거부 |
-| `RecruitingRoundUpdateCommandServiceTest` | 제목·설정 수정, 대소문자 제목 중복, 지원서 존재 후 모집 정책 잠금, Form 제목 동기화, 게시된 availability Form의 OPEN 조건, 지원서/FormResponse 없는 OPEN의 DRAFT 복귀와 데이터 존재 시 충돌 |
+| `RecruitingRoundUpdateCommandServiceTest` | 제목·설정 수정, 대소문자 제목 중복, 지원서 존재 후 모집 정책 잠금, Form 제목 동기화, 게시된 availability Form의 OPEN 조건, 매핑이 없는 면접 Round OPEN 시 조율 Form 자동 생성과 이미 매핑·면접 미진행 시 생성 생략, 수정 요청에 매핑이 없을 때 기존 값 승계, 지원서/FormResponse 없는 OPEN의 DRAFT 복귀와 데이터 존재 시 충돌 |
 | `RecruitingRoundLifecycleCommandServiceTest` | DRAFT hard delete 조건과 명시적 삭제 순서, 원본/대상 권한, 복제 설정·Form 조건부 이동 재매핑, availability Form 초기화 |
 | `RecruitingApplicationFormStructureCommandServiceTest` | 전체 Form 생성, section client key를 실제 ID로 변환, TRACK 간 잘못된 이동 및 다른 Form ID 거부 |
 | `RecruitingApplicationFormCommandServiceTest` | Round OPEN/DRAFT/CLOSED에 사용되는 Recruiting Form과 실제 Form 게시·취소·마감 lock 및 호출 순서, Season scope, 게시 전 정책 검증 |
@@ -39,6 +39,7 @@
 | `RecruitingApplicationInterviewQuestionCommandServiceTest` | 개별 질문 관리 권한과 Application scope |
 | `RecruitingApplicationInterviewQuestionPreSubmissionCommandServiceTest` | 최초 면접 평가 전 개별 질문 변경 허용, 이후 동결 |
 | `RecruitingDecisionCommandServiceTest` | 서류 불합격, 면접 진행 시 일정 자동 생성, 면접 미진행 시 즉시 skip, 최종 판정 권한·acceptedTrack·중복 합격 |
+| `RecruitingInterviewAvailabilityFormProvisionerTest` | 면접 일정 조율 Form을 비익명으로 만들고 SCHEDULE 필수 질문 하나를 넣어 게시하는지, 차수 제목 기반 Form 제목과 요청자 ID 전달 |
 | `RecruitingInterviewAvailabilityRequestCoordinatorTest` | 일정 row와 Outbox의 같은 transaction 생성, 멱등 재요청과 실패 재시도 |
 | `RecruitingInterviewCommandServiceTest` | 면접 생략 시 Application 전이와 기존 일정 `CANCELLED`, 일정 후보 overlap 위임 |
 | `RecruitingInterviewScheduleCommandServiceTest` | 로그인한 면접 대상 지원자 본인만 `AVAILABILITY_REQUESTED` 일정에 제출, published·기명 Form의 지정된 sole-required `SCHEDULE` 질문 검증, FormResponse 즉시 최종 제출·ID 저장·`AVAILABILITY_SUBMITTED` 전이, 비어 있지 않은 times/null·Form 검증 오류, 시작 포함·종료 제외 기간과 `RECRUITING-0413`, 실패 시 일정 상태·응답 ID 미변경 |

--- a/docs/onboarding/recruiting/test-cases.md
+++ b/docs/onboarding/recruiting/test-cases.md
@@ -40,6 +40,7 @@
 | `RecruitingApplicationInterviewQuestionPreSubmissionCommandServiceTest` | 최초 면접 평가 전 개별 질문 변경 허용, 이후 동결 |
 | `RecruitingDecisionCommandServiceTest` | 서류 불합격, 면접 진행 시 일정 자동 생성, 면접 미진행 시 즉시 skip, 최종 판정 권한·acceptedTrack·중복 합격 |
 | `RecruitingInterviewAvailabilityFormProvisionerTest` | 면접 일정 조율 Form을 비익명으로 만들고 SCHEDULE 필수 질문 하나를 넣어 게시하는지, 차수 제목 기반 Form 제목과 요청자 ID 전달 |
+| `RecruitingRoundOpenAvailabilityFormIntegrationTest` | 실제 Form 모듈과 DB로 OPEN 전이를 태워 자동 생성된 조율 Form이 곧바로 뒤따르는 검증을 통과하는지, OPEN 차수에서 면접을 껐다 켜면 Form을 새로 만들어 수정이 완료되는지 |
 | `RecruitingInterviewAvailabilityRequestCoordinatorTest` | 일정 row와 Outbox의 같은 transaction 생성, 멱등 재요청과 실패 재시도 |
 | `RecruitingInterviewCommandServiceTest` | 면접 생략 시 Application 전이와 기존 일정 `CANCELLED`, 일정 후보 overlap 위임 |
 | `RecruitingInterviewScheduleCommandServiceTest` | 로그인한 면접 대상 지원자 본인만 `AVAILABILITY_REQUESTED` 일정에 제출, published·기명 Form의 지정된 sole-required `SCHEDULE` 질문 검증, FormResponse 즉시 최종 제출·ID 저장·`AVAILABILITY_SUBMITTED` 전이, 비어 있지 않은 times/null·Form 검증 오류, 시작 포함·종료 제외 기간과 `RECRUITING-0413`, 실패 시 일정 상태·응답 ID 미변경 |

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingInterviewAvailabilityFormProvisioner.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingInterviewAvailabilityFormProvisioner.java
@@ -1,0 +1,70 @@
+package com.umc.product.recruiting.application.service.command;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.form.application.port.in.command.ManageFormSectionUseCase;
+import com.umc.product.form.application.port.in.command.ManageFormUseCase;
+import com.umc.product.form.application.port.in.command.ManageQuestionUseCase;
+import com.umc.product.form.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.form.application.port.in.command.dto.PublishFormCommand;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.domain.RecruitingRound;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 면접 일정 조율 Form을 생성하고 게시한다.
+ * <p>
+ * 지원서 Form과 달리 응답자를 식별해야 배정 보드에서 지원자별 가능 시간을 표시할 수 있으므로 비익명으로 만든다.
+ * 구조는 {@code validateAvailabilityFormForOpen}이 요구하는 형태(SCHEDULE 필수 질문 정확히 1개)로 고정한다.
+ * <p>
+ * 운영진이 문구를 편집하는 UI가 없어 제목과 질문 문구는 상수로 둔다.
+ * TODO: 문구 입력 UI가 제공되면 Round 설정에서 받아 넘기도록 확장한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class RecruitingInterviewAvailabilityFormProvisioner {
+
+    private static final String FORM_TITLE_SUFFIX = " 면접 일정 조율";
+    private static final String SECTION_TITLE = "면접 가능 시간";
+    private static final String QUESTION_TITLE = "면접 가능한 시간을 선택해주세요";
+
+    private final ManageFormUseCase manageFormUseCase;
+    private final ManageFormSectionUseCase manageFormSectionUseCase;
+    private final ManageQuestionUseCase manageQuestionUseCase;
+
+    public AvailabilityFormMapping provision(RecruitingRound round, Long requesterMemberId) {
+        Long formId = manageFormUseCase.createDraft(CreateDraftFormCommand.builder()
+            .createdMemberId(requesterMemberId)
+            .title(round.getTitle() + FORM_TITLE_SUFFIX)
+            .isAnonymous(false)
+            .allowDuplicateResponses(false)
+            .build());
+
+        Long sectionId = manageFormSectionUseCase.createSection(CreateFormSectionCommand.builder()
+            .formId(formId)
+            .requesterMemberId(requesterMemberId)
+            .title(SECTION_TITLE)
+            .build());
+
+        Long questionId = manageQuestionUseCase.createQuestion(CreateQuestionCommand.builder()
+            .sectionId(sectionId)
+            .requesterMemberId(requesterMemberId)
+            .type(QuestionType.SCHEDULE)
+            .title(QUESTION_TITLE)
+            .isRequired(true)
+            .build());
+
+        manageFormUseCase.publishForm(PublishFormCommand.builder()
+            .formId(formId)
+            .requesterMemberId(requesterMemberId)
+            .build());
+
+        return new AvailabilityFormMapping(formId, questionId);
+    }
+
+    public record AvailabilityFormMapping(Long formId, Long scheduleQuestionId) {
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
@@ -69,6 +69,7 @@ public class RecruitingRoundCommandService implements
     private final ManageFormUseCase manageFormUseCase;
     private final GetFormUseCase getFormUseCase;
     private final GetFormResponseUseCase getFormResponseUseCase;
+    private final RecruitingInterviewAvailabilityFormProvisioner availabilityFormProvisioner;
 
     @Override
     public Long createRound(CreateRecruitingRoundCommand command) {
@@ -115,6 +116,7 @@ public class RecruitingRoundCommandService implements
         RecruitingRound round = getRoundInSeasonForUpdate(command.roundId(), command.seasonId());
         RecruitingRoundStatus status = command.status();
         if (status == RecruitingRoundStatus.OPEN) {
+            provisionAvailabilityFormIfAbsent(round, command.requesterMemberId());
             validateAvailabilityFormForOpen(round);
             var applicationForm = loadApplicationFormPort.findByRoundId(round.getId())
                 .orElseThrow(() -> new RecruitingDomainException(
@@ -155,6 +157,18 @@ public class RecruitingRoundCommandService implements
             throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_INVALID_TRANSITION);
         }
         saveRoundPort.save(round);
+    }
+
+    /**
+     * 면접 Round인데 조율 Form이 없으면 게시된 Form을 만들어 매핑한다.
+     * 관리자가 외부 Form을 이미 지정했다면 그대로 두고 아래 검증에 맡긴다.
+     */
+    private void provisionAvailabilityFormIfAbsent(RecruitingRound round, Long requesterMemberId) {
+        if (!round.isInterviewRequired() || round.getAvailabilityFormId() != null) {
+            return;
+        }
+        var mapping = availabilityFormProvisioner.provision(round, requesterMemberId);
+        round.assignAvailabilityForm(mapping.formId(), mapping.scheduleQuestionId());
     }
 
     private void validateAvailabilityFormForOpen(RecruitingRound round) {

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
@@ -93,7 +93,10 @@ public class RecruitingRoundCommandService implements
     public void updateRound(UpdateRecruitingRoundCommand command) {
         RecruitingRound round = getRoundInSeasonForUpdate(command.roundId(), command.seasonId());
         validateTitleAvailable(command.seasonId(), command.title(), command.roundId());
-        RecruitingRoundConfiguration configuration = command.configuration().toDomain();
+        RecruitingRoundConfiguration configuration = inheritAvailabilityForm(
+            round,
+            command.configuration().toDomain()
+        );
         validateRecruitableTrackSubset(command.seasonId(), configuration.recruitableTracks());
         validateInterviewSessions(round, configuration);
         if (round.getStatus() == RecruitingRoundStatus.OPEN && configuration.interviewRequired()) {
@@ -157,6 +160,37 @@ public class RecruitingRoundCommandService implements
             throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_INVALID_TRANSITION);
         }
         saveRoundPort.save(round);
+    }
+
+    /**
+     * 자동 생성한 조율 Form 매핑은 요청에 없어도 유지한다.
+     * configuration을 통째로 교체하는 구조라 승계하지 않으면 수정 한 번에 매핑이 사라진다.
+     */
+    private RecruitingRoundConfiguration inheritAvailabilityForm(
+        RecruitingRound round,
+        RecruitingRoundConfiguration configuration
+    ) {
+        boolean nothingToInherit = !configuration.interviewRequired()
+            || configuration.availabilityFormId() != null
+            || round.getAvailabilityFormId() == null;
+        if (nothingToInherit) {
+            return configuration;
+        }
+        return RecruitingRoundConfiguration.of(
+            configuration.recruitableTracks(),
+            configuration.secondChoiceEnabled(),
+            configuration.documentStartAt(),
+            configuration.documentEndAt(),
+            configuration.documentResultPublishedAt(),
+            configuration.interviewRequired(),
+            configuration.interviewStartAt(),
+            configuration.interviewEndAt(),
+            configuration.finalResultPublishedAt(),
+            round.getAvailabilityFormId(),
+            round.getAvailabilityScheduleQuestionId(),
+            configuration.announcement(),
+            configuration.contactText()
+        );
     }
 
     /**

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
@@ -100,6 +100,7 @@ public class RecruitingRoundCommandService implements
         validateRecruitableTrackSubset(command.seasonId(), configuration.recruitableTracks());
         validateInterviewSessions(round, configuration);
         if (round.getStatus() == RecruitingRoundStatus.OPEN && configuration.interviewRequired()) {
+            configuration = withProvisionedAvailabilityForm(round, configuration, command.requesterMemberId());
             validateAvailabilityFormForOpen(
                 configuration.availabilityFormId(),
                 configuration.availabilityScheduleQuestionId()
@@ -176,6 +177,36 @@ public class RecruitingRoundCommandService implements
         if (nothingToInherit) {
             return configuration;
         }
+        return withAvailabilityMapping(
+            configuration,
+            round.getAvailabilityFormId(),
+            round.getAvailabilityScheduleQuestionId()
+        );
+    }
+
+    /**
+     * OPEN Round를 수정하면서 면접을 다시 켰다면 승계할 매핑이 없으므로 이 시점에 새로 만든다.
+     * <p>
+     * Round의 {@code interviewRequired}는 아직 이번 요청을 반영하기 전이라
+     * {@code assignAvailabilityForm} 대신 configuration에 담아 {@code round.update}에서 함께 반영한다.
+     */
+    private RecruitingRoundConfiguration withProvisionedAvailabilityForm(
+        RecruitingRound round,
+        RecruitingRoundConfiguration configuration,
+        Long requesterMemberId
+    ) {
+        if (configuration.availabilityFormId() != null) {
+            return configuration;
+        }
+        var mapping = availabilityFormProvisioner.provision(round, requesterMemberId);
+        return withAvailabilityMapping(configuration, mapping.formId(), mapping.scheduleQuestionId());
+    }
+
+    private RecruitingRoundConfiguration withAvailabilityMapping(
+        RecruitingRoundConfiguration configuration,
+        Long availabilityFormId,
+        Long availabilityScheduleQuestionId
+    ) {
         return RecruitingRoundConfiguration.of(
             configuration.recruitableTracks(),
             configuration.secondChoiceEnabled(),
@@ -186,8 +217,8 @@ public class RecruitingRoundCommandService implements
             configuration.interviewStartAt(),
             configuration.interviewEndAt(),
             configuration.finalResultPublishedAt(),
-            round.getAvailabilityFormId(),
-            round.getAvailabilityScheduleQuestionId(),
+            availabilityFormId,
+            availabilityScheduleQuestionId,
             configuration.announcement(),
             configuration.contactText()
         );

--- a/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
+++ b/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
@@ -245,6 +245,20 @@ public class RecruitingRound extends BaseEntity {
             && recruitableTracks.contains(track);
     }
 
+    /**
+     * 자동 생성한 면접 일정 조율 Form의 매핑만 반영한다.
+     * 면접을 진행하는 Round에서만 호출하며, 두 ID는 항상 함께 설정해 configuration의 XOR 불변식을 유지한다.
+     */
+    public void assignAvailabilityForm(Long formId, Long questionId) {
+        boolean invalidMapping = formId == null || formId <= 0
+            || questionId == null || questionId <= 0;
+        if (!interviewRequired || invalidMapping) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_INVALID_SCHEDULE);
+        }
+        this.availabilityFormId = formId;
+        this.availabilityScheduleQuestionId = questionId;
+    }
+
     public void open() {
         validateStatus(RecruitingRoundStatus.DRAFT);
         this.status = RecruitingRoundStatus.OPEN;

--- a/src/test/java/com/umc/product/integration/recruiting/RecruitingRoundOpenAvailabilityFormIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/recruiting/RecruitingRoundOpenAvailabilityFormIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.umc.product.integration.recruiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.application.port.in.query.GetFormUseCase;
+import com.umc.product.form.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.form.domain.enums.FormStatus;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
+import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingApplicationFormUseCase;
+import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruitingRoundStatusCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
+import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundPort;
+import com.umc.product.recruiting.application.port.out.SaveRecruitingSeasonPort;
+import com.umc.product.recruiting.domain.RecruitingRound;
+import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
+import com.umc.product.recruiting.domain.RecruitingSeason;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+import com.umc.product.recruiting.domain.enums.RecruitingRoundStatus;
+import com.umc.product.support.IntegrationTestSupport;
+
+/**
+ * 면접 차수 OPEN 전이에서 프로비저너가 만든 Form이 곧바로 뒤따르는 검증을 통과하는지 확인한다.
+ * <p>
+ * 서비스 단위 테스트는 provisioner와 GetFormUseCase를 각각 stub 하므로 두 축의 결합을 증명하지 못한다.
+ * 실제 Form 모듈과 DB를 함께 태워야 게시 누락, 익명 설정, 질문 구조, 같은 트랜잭션 내 가시성을 잡을 수 있다.
+ */
+class RecruitingRoundOpenAvailabilityFormIntegrationTest extends IntegrationTestSupport {
+
+    private static final Long REQUESTER_MEMBER_ID = 9001L;
+    private static final ChallengerTrack RECRUITABLE_TRACK = ChallengerTrack.WEB_PRODUCT_ENGINEER;
+
+    @Autowired
+    UpdateRecruitingRoundStatusUseCase updateRoundStatusUseCase;
+
+    @Autowired
+    UpsertRecruitingApplicationFormUseCase upsertApplicationFormUseCase;
+
+    @Autowired
+    SaveRecruitingSeasonPort saveSeasonPort;
+
+    @Autowired
+    SaveRecruitingRoundPort saveRoundPort;
+
+    @Autowired
+    LoadRecruitingRoundPort loadRoundPort;
+
+    @Autowired
+    GetFormUseCase getFormUseCase;
+
+    @Test
+    @DisplayName("면접 차수를 OPEN하면 자동 생성된 조율 Form이 OPEN 검증을 그대로 통과한다")
+    void openInterviewRoundProvisionsAvailabilityFormThatPassesValidation() {
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 101L));
+        RecruitingRound round = saveRoundPort.save(RecruitingRound.createRegular(
+            season,
+            "본모집",
+            interviewConfigurationWithoutMapping()
+        ));
+        upsertApplicationForm(season.getId(), round.getId());
+
+        updateRoundStatusUseCase.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(season.getId())
+            .roundId(round.getId())
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .build());
+
+        RecruitingRound opened = loadRoundPort.getById(round.getId());
+        assertThat(opened.getStatus()).isEqualTo(RecruitingRoundStatus.OPEN);
+        assertThat(opened.getAvailabilityFormId()).isNotNull();
+        assertThat(opened.getAvailabilityScheduleQuestionId()).isNotNull();
+
+        FormWithStructureInfo availabilityForm =
+            getFormUseCase.getFormWithStructure(opened.getAvailabilityFormId());
+        assertThat(availabilityForm.status()).isEqualTo(FormStatus.PUBLISHED);
+        assertThat(availabilityForm.isAnonymous()).isFalse();
+
+        List<FormWithStructureInfo.QuestionWithOptions> questions = availabilityForm.sections().stream()
+            .flatMap(section -> section.questions().stream())
+            .toList();
+        assertThat(questions.stream().filter(FormWithStructureInfo.QuestionWithOptions::isRequired))
+            .singleElement()
+            .satisfies(question -> {
+                assertThat(question.questionId()).isEqualTo(opened.getAvailabilityScheduleQuestionId());
+                assertThat(question.type()).isEqualTo(QuestionType.SCHEDULE);
+            });
+    }
+
+    private void upsertApplicationForm(Long seasonId, Long roundId) {
+        upsertApplicationFormUseCase.upsert(UpsertRecruitingApplicationFormCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .description("지원서")
+            .sections(List.of(
+                UpsertRecruitingApplicationFormCommand.SectionEntry.builder()
+                    .clientKey("common")
+                    .title("공통")
+                    .type(RecruitingFormSectionType.COMMON)
+                    .questions(List.of(UpsertRecruitingApplicationFormCommand.QuestionEntry.builder()
+                        .type(QuestionType.SHORT_TEXT)
+                        .title("지원 동기")
+                        .required(true)
+                        .build()))
+                    .build(),
+                UpsertRecruitingApplicationFormCommand.SectionEntry.builder()
+                    .clientKey("track")
+                    .title("파트 문항")
+                    .type(RecruitingFormSectionType.TRACK)
+                    .track(RECRUITABLE_TRACK)
+                    .questions(List.of(UpsertRecruitingApplicationFormCommand.QuestionEntry.builder()
+                        .type(QuestionType.SHORT_TEXT)
+                        .title("사용 기술")
+                        .required(true)
+                        .build()))
+                    .build()
+            ))
+            .build());
+    }
+
+    private RecruitingRoundConfiguration interviewConfigurationWithoutMapping() {
+        return RecruitingRoundConfiguration.of(
+            List.of(RECRUITABLE_TRACK),
+            false,
+            Instant.parse("2026-08-01T00:00:00Z"),
+            Instant.parse("2026-08-08T00:00:00Z"),
+            Instant.parse("2026-08-10T00:00:00Z"),
+            true,
+            Instant.parse("2026-08-11T00:00:00Z"),
+            Instant.parse("2026-08-15T00:00:00Z"),
+            Instant.parse("2026-08-16T00:00:00Z"),
+            null,
+            null,
+            null,
+            "문의 채널"
+        );
+    }
+}

--- a/src/test/java/com/umc/product/integration/recruiting/RecruitingRoundOpenAvailabilityFormIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/recruiting/RecruitingRoundOpenAvailabilityFormIntegrationTest.java
@@ -15,15 +15,20 @@ import com.umc.product.form.application.port.in.query.dto.FormWithStructureInfo;
 import com.umc.product.form.domain.enums.FormStatus;
 import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
+import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingApplicationFormUseCase;
+import com.umc.product.recruiting.application.port.in.command.dto.RecruitingRoundConfigurationCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruitingRoundStatusCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingSeasonPort;
+import com.umc.product.recruiting.application.port.out.SaveRecruitingSeasonTrackQuotaPort;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
 import com.umc.product.recruiting.domain.RecruitingSeason;
+import com.umc.product.recruiting.domain.RecruitingSeasonTrackQuota;
 import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
 import com.umc.product.recruiting.domain.enums.RecruitingRoundStatus;
 import com.umc.product.support.IntegrationTestSupport;
@@ -43,10 +48,16 @@ class RecruitingRoundOpenAvailabilityFormIntegrationTest extends IntegrationTest
     UpdateRecruitingRoundStatusUseCase updateRoundStatusUseCase;
 
     @Autowired
+    UpdateRecruitingRoundUseCase updateRoundUseCase;
+
+    @Autowired
     UpsertRecruitingApplicationFormUseCase upsertApplicationFormUseCase;
 
     @Autowired
     SaveRecruitingSeasonPort saveSeasonPort;
+
+    @Autowired
+    SaveRecruitingSeasonTrackQuotaPort saveQuotaPort;
 
     @Autowired
     SaveRecruitingRoundPort saveRoundPort;
@@ -94,6 +105,72 @@ class RecruitingRoundOpenAvailabilityFormIntegrationTest extends IntegrationTest
                 assertThat(question.questionId()).isEqualTo(opened.getAvailabilityScheduleQuestionId());
                 assertThat(question.type()).isEqualTo(QuestionType.SCHEDULE);
             });
+    }
+
+    @Test
+    @DisplayName("OPEN 차수에서 면접을 껐다 다시 켜도 조율 Form이 새로 생성되어 수정이 완료된다")
+    void reenablingInterviewWhileOpenProvisionsNewAvailabilityForm() {
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 102L));
+        saveQuotaPort.saveAll(List.of(
+            RecruitingSeasonTrackQuota.create(season, RECRUITABLE_TRACK, 5)
+        ));
+        RecruitingRound round = saveRoundPort.save(RecruitingRound.createRegular(
+            season,
+            "본모집",
+            interviewConfigurationWithoutMapping()
+        ));
+        upsertApplicationForm(season.getId(), round.getId());
+        openRound(season.getId(), round.getId());
+        Long firstFormId = loadRoundPort.getById(round.getId()).getAvailabilityFormId();
+
+        updateInterviewRequired(season.getId(), round.getId(), false);
+        assertThat(loadRoundPort.getById(round.getId()).getAvailabilityFormId()).isNull();
+
+        updateInterviewRequired(season.getId(), round.getId(), true);
+
+        RecruitingRound reenabled = loadRoundPort.getById(round.getId());
+        assertThat(reenabled.isInterviewRequired()).isTrue();
+        assertThat(reenabled.getAvailabilityFormId())
+            .isNotNull()
+            .isNotEqualTo(firstFormId);
+
+        FormWithStructureInfo availabilityForm =
+            getFormUseCase.getFormWithStructure(reenabled.getAvailabilityFormId());
+        assertThat(availabilityForm.status()).isEqualTo(FormStatus.PUBLISHED);
+        assertThat(availabilityForm.isAnonymous()).isFalse();
+    }
+
+    private void openRound(Long seasonId, Long roundId) {
+        updateRoundStatusUseCase.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .build());
+    }
+
+    private void updateInterviewRequired(Long seasonId, Long roundId, boolean interviewRequired) {
+        updateRoundUseCase.updateRound(UpdateRecruitingRoundCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .title("본모집")
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .configuration(RecruitingRoundConfigurationCommand.of(
+                List.of(RECRUITABLE_TRACK),
+                false,
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-08-08T00:00:00Z"),
+                Instant.parse("2026-08-10T00:00:00Z"),
+                interviewRequired,
+                interviewRequired ? Instant.parse("2026-08-11T00:00:00Z") : null,
+                interviewRequired ? Instant.parse("2026-08-15T00:00:00Z") : null,
+                Instant.parse("2026-08-16T00:00:00Z"),
+                null,
+                null,
+                null,
+                "문의 채널"
+            ))
+            .build());
     }
 
     private void upsertApplicationForm(Long seasonId, Long roundId) {

--- a/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundCreationConcurrencyTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundCreationConcurrencyTest.java
@@ -30,6 +30,7 @@ import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruiti
 import com.umc.product.recruiting.application.port.in.command.dto.RecruitingRoundConfigurationCommand;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
+import com.umc.product.recruiting.application.service.command.RecruitingInterviewAvailabilityFormProvisioner;
 import com.umc.product.recruiting.application.service.command.RecruitingRoundCommandService;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.RecruitingSeason;
@@ -77,6 +78,8 @@ class RecruitingRoundCreationConcurrencyTest {
     GetFormUseCase getFormUseCase;
     @MockitoBean
     GetFormResponseUseCase getFormResponseUseCase;
+    @MockitoBean
+    RecruitingInterviewAvailabilityFormProvisioner availabilityFormProvisioner;
 
     @Test
     @DisplayName("동시 추가모집 생성은 Season lock으로 차수를 1부터 순차 배정한다")

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingInterviewAvailabilityFormProvisionerTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingInterviewAvailabilityFormProvisionerTest.java
@@ -1,0 +1,98 @@
+package com.umc.product.recruiting.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.application.port.in.command.ManageFormSectionUseCase;
+import com.umc.product.form.application.port.in.command.ManageFormUseCase;
+import com.umc.product.form.application.port.in.command.ManageQuestionUseCase;
+import com.umc.product.form.application.port.in.command.dto.CreateDraftFormCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateFormSectionCommand;
+import com.umc.product.form.application.port.in.command.dto.CreateQuestionCommand;
+import com.umc.product.form.application.port.in.command.dto.PublishFormCommand;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.command.dto.RecruitingRoundConfigurationCommand;
+import com.umc.product.recruiting.domain.RecruitingRound;
+import com.umc.product.recruiting.domain.RecruitingSeason;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitingInterviewAvailabilityFormProvisionerTest {
+
+    @Mock
+    ManageFormUseCase manageFormUseCase;
+    @Mock
+    ManageFormSectionUseCase manageFormSectionUseCase;
+    @Mock
+    ManageQuestionUseCase manageQuestionUseCase;
+    @InjectMocks
+    RecruitingInterviewAvailabilityFormProvisioner sut;
+
+    @Test
+    @DisplayName("OPEN 검증이 요구하는 비익명·SCHEDULE 필수 질문 1개 구조로 Form을 만들고 게시한다")
+    void provisionPublishedAvailabilityForm() {
+        given(manageFormUseCase.createDraft(any(CreateDraftFormCommand.class))).willReturn(500L);
+        given(manageFormSectionUseCase.createSection(any(CreateFormSectionCommand.class))).willReturn(700L);
+        given(manageQuestionUseCase.createQuestion(any(CreateQuestionCommand.class))).willReturn(600L);
+
+        var mapping = sut.provision(interviewRound("본모집"), 99L);
+
+        assertThat(mapping.formId()).isEqualTo(500L);
+        assertThat(mapping.scheduleQuestionId()).isEqualTo(600L);
+
+        ArgumentCaptor<CreateDraftFormCommand> formCaptor =
+            ArgumentCaptor.forClass(CreateDraftFormCommand.class);
+        then(manageFormUseCase).should().createDraft(formCaptor.capture());
+        assertThat(formCaptor.getValue().isAnonymous()).isFalse();
+        assertThat(formCaptor.getValue().title()).isEqualTo("본모집 면접 일정 조율");
+        assertThat(formCaptor.getValue().createdMemberId()).isEqualTo(99L);
+
+        ArgumentCaptor<CreateQuestionCommand> questionCaptor =
+            ArgumentCaptor.forClass(CreateQuestionCommand.class);
+        then(manageQuestionUseCase).should().createQuestion(questionCaptor.capture());
+        assertThat(questionCaptor.getValue().sectionId()).isEqualTo(700L);
+        assertThat(questionCaptor.getValue().type()).isEqualTo(QuestionType.SCHEDULE);
+        assertThat(questionCaptor.getValue().isRequired()).isTrue();
+        assertThat(questionCaptor.getValue().title()).isEqualTo("면접 가능한 시간을 선택해주세요");
+
+        ArgumentCaptor<PublishFormCommand> publishCaptor =
+            ArgumentCaptor.forClass(PublishFormCommand.class);
+        then(manageFormUseCase).should().publishForm(publishCaptor.capture());
+        assertThat(publishCaptor.getValue().formId()).isEqualTo(500L);
+    }
+
+    private RecruitingRound interviewRound(String title) {
+        return RecruitingRound.createRegular(
+            RecruitingSeason.create(1L, 2L),
+            title,
+            RecruitingRoundConfigurationCommand.of(
+                List.of(ChallengerTrack.PLAN),
+                false,
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-08-08T00:00:00Z"),
+                Instant.parse("2026-08-10T00:00:00Z"),
+                true,
+                Instant.parse("2026-08-11T00:00:00Z"),
+                Instant.parse("2026-08-14T00:00:00Z"),
+                Instant.parse("2026-08-16T00:00:00Z"),
+                null,
+                null,
+                null,
+                null
+            ).toDomain()
+        );
+    }
+}

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
@@ -276,8 +276,8 @@ class RecruitingRoundUpdateCommandServiceTest {
     }
 
     @Test
-    @DisplayName("OPEN 면접 차수는 availability 매핑을 제거할 수 없다")
-    void rejectRemovingAvailabilityMappingWhileOpen() {
+    @DisplayName("OPEN 면접 차수는 요청에 availability 매핑이 없어도 기존 매핑을 유지한다")
+    void inheritAvailabilityMappingWhenOmittedWhileOpen() {
         RecruitingSeason season = season(10L);
         RecruitingRound round = interviewRound(20L, season, 500L, 600L);
         round.open();
@@ -285,18 +285,21 @@ class RecruitingRoundUpdateCommandServiceTest {
         given(loadQuotaPort.listBySeasonId(10L)).willReturn(List.of(
             RecruitingSeasonTrackQuota.create(season, ChallengerTrack.PLAN, 4)
         ));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(availabilityForm(
+            FormStatus.PUBLISHED,
+            question(600L, QuestionType.SCHEDULE, true)
+        ));
 
-        assertThatThrownBy(() -> sut.updateRound(UpdateRecruitingRoundCommand.builder()
+        sut.updateRound(UpdateRecruitingRoundCommand.builder()
             .seasonId(10L)
             .roundId(20L)
             .title("본모집")
             .configuration(interviewConfiguration(null, null))
-            .build()))
-            .isInstanceOf(RecruitingDomainException.class)
-            .extracting("baseCode")
-            .isEqualTo(RecruitingErrorCode.RECRUITING_ROUND_INVALID_SCHEDULE);
+            .build());
 
-        then(saveRoundPort).should(never()).save(any());
+        assertThat(round.getAvailabilityFormId()).isEqualTo(500L);
+        assertThat(round.getAvailabilityScheduleQuestionId()).isEqualTo(600L);
+        then(saveRoundPort).should().save(round);
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
@@ -80,6 +80,8 @@ class RecruitingRoundUpdateCommandServiceTest {
     GetFormUseCase getFormUseCase;
     @Mock
     GetFormResponseUseCase getFormResponseUseCase;
+    @Mock
+    RecruitingInterviewAvailabilityFormProvisioner availabilityFormProvisioner;
     @InjectMocks
     RecruitingRoundCommandService sut;
 
@@ -463,6 +465,78 @@ class RecruitingRoundUpdateCommandServiceTest {
 
         assertThat(round.getStatus()).isEqualTo(RecruitingRoundStatus.OPEN);
         then(publishApplicationFormUseCase).should().publish(any());
+    }
+
+    @Test
+    @DisplayName("availability 매핑이 없는 면접 차수는 OPEN 시 조율 Form을 자동 생성해 매핑한다")
+    void provisionAvailabilityFormWhenOpeningInterviewRoundWithoutMapping() {
+        RecruitingRound round = interviewRound(20L, season(10L), null, null);
+        RecruitingApplicationForm applicationForm = RecruitingApplicationForm.create(round, 100L);
+        ReflectionTestUtils.setField(applicationForm, "id", 30L);
+        given(loadRoundPort.getByIdForUpdate(20L)).willReturn(round);
+        given(availabilityFormProvisioner.provision(round, 99L)).willReturn(
+            new RecruitingInterviewAvailabilityFormProvisioner.AvailabilityFormMapping(500L, 600L)
+        );
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(availabilityForm(
+            FormStatus.PUBLISHED,
+            question(600L, QuestionType.SCHEDULE, true)
+        ));
+        given(loadApplicationFormPort.findByRoundId(20L)).willReturn(Optional.of(applicationForm));
+
+        sut.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(10L)
+            .roundId(20L)
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(99L)
+            .build());
+
+        assertThat(round.getStatus()).isEqualTo(RecruitingRoundStatus.OPEN);
+        assertThat(round.getAvailabilityFormId()).isEqualTo(500L);
+        assertThat(round.getAvailabilityScheduleQuestionId()).isEqualTo(600L);
+        then(publishApplicationFormUseCase).should().publish(any());
+    }
+
+    @Test
+    @DisplayName("이미 availability 매핑이 있으면 OPEN 시 조율 Form을 새로 만들지 않는다")
+    void skipProvisioningWhenAvailabilityMappingExists() {
+        RecruitingRound round = interviewRound(20L, season(10L), 500L, 600L);
+        RecruitingApplicationForm applicationForm = RecruitingApplicationForm.create(round, 100L);
+        ReflectionTestUtils.setField(applicationForm, "id", 30L);
+        given(loadRoundPort.getByIdForUpdate(20L)).willReturn(round);
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(availabilityForm(
+            FormStatus.PUBLISHED,
+            question(600L, QuestionType.SCHEDULE, true)
+        ));
+        given(loadApplicationFormPort.findByRoundId(20L)).willReturn(Optional.of(applicationForm));
+
+        sut.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(10L)
+            .roundId(20L)
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(99L)
+            .build());
+
+        then(availabilityFormProvisioner).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("면접 없는 차수는 OPEN 시 조율 Form을 만들지 않는다")
+    void skipProvisioningWhenInterviewNotRequired() {
+        RecruitingRound round = round(20L, season(10L));
+        RecruitingApplicationForm applicationForm = RecruitingApplicationForm.create(round, 100L);
+        ReflectionTestUtils.setField(applicationForm, "id", 30L);
+        given(loadRoundPort.getByIdForUpdate(20L)).willReturn(round);
+        given(loadApplicationFormPort.findByRoundId(20L)).willReturn(Optional.of(applicationForm));
+
+        sut.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(10L)
+            .roundId(20L)
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(99L)
+            .build());
+
+        assertThat(round.getAvailabilityFormId()).isNull();
+        then(availabilityFormProvisioner).shouldHaveNoInteractions();
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundUpdateCommandServiceTest.java
@@ -299,6 +299,39 @@ class RecruitingRoundUpdateCommandServiceTest {
 
         assertThat(round.getAvailabilityFormId()).isEqualTo(500L);
         assertThat(round.getAvailabilityScheduleQuestionId()).isEqualTo(600L);
+        then(availabilityFormProvisioner).shouldHaveNoInteractions();
+        then(saveRoundPort).should().save(round);
+    }
+
+    @Test
+    @DisplayName("OPEN 차수에서 면접을 다시 켜면 승계할 매핑이 없으므로 조율 Form을 새로 만든다")
+    void provisionAvailabilityFormWhenInterviewReenabledWhileOpen() {
+        RecruitingSeason season = season(10L);
+        RecruitingRound round = configuredRound(20L, season, ChallengerTrack.PLAN, false);
+        round.open();
+        given(loadRoundPort.getByIdForUpdate(20L)).willReturn(round);
+        given(loadQuotaPort.listBySeasonId(10L)).willReturn(List.of(
+            RecruitingSeasonTrackQuota.create(season, ChallengerTrack.PLAN, 4)
+        ));
+        given(availabilityFormProvisioner.provision(round, 99L)).willReturn(
+            new RecruitingInterviewAvailabilityFormProvisioner.AvailabilityFormMapping(500L, 600L)
+        );
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(availabilityForm(
+            FormStatus.PUBLISHED,
+            question(600L, QuestionType.SCHEDULE, true)
+        ));
+
+        sut.updateRound(UpdateRecruitingRoundCommand.builder()
+            .seasonId(10L)
+            .roundId(20L)
+            .title("본모집")
+            .requesterMemberId(99L)
+            .configuration(interviewConfiguration(null, null))
+            .build());
+
+        assertThat(round.isInterviewRequired()).isTrue();
+        assertThat(round.getAvailabilityFormId()).isEqualTo(500L);
+        assertThat(round.getAvailabilityScheduleQuestionId()).isEqualTo(600L);
         then(saveRoundPort).should().save(round);
     }
 

--- a/src/test/java/com/umc/product/recruiting/domain/RecruitingRoundConfigurationTest.java
+++ b/src/test/java/com/umc/product/recruiting/domain/RecruitingRoundConfigurationTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
@@ -101,6 +103,51 @@ class RecruitingRoundConfigurationTest {
     }
 
     @Test
+    @DisplayName("면접 차수에 유효한 매핑을 지정하면 Form과 SCHEDULE question이 함께 설정된다")
+    void assignAvailabilityFormSetsBothIds() {
+        RecruitingRound round = draftInterviewRoundWithoutMapping();
+
+        round.assignAvailabilityForm(500L, 600L);
+
+        assertThat(round.getAvailabilityFormId()).isEqualTo(500L);
+        assertThat(round.getAvailabilityScheduleQuestionId()).isEqualTo(600L);
+    }
+
+    @ParameterizedTest
+    @CsvSource(nullValues = "null", value = {
+        "null, 600",
+        "500, null",
+        "null, null"
+    })
+    @DisplayName("면접 가능 시간 매핑에 null ID를 지정할 수 없다")
+    void assignAvailabilityFormRejectsNullIds(Long formId, Long questionId) {
+        assertAssignmentRejected(draftInterviewRoundWithoutMapping(), formId, questionId);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0, 600",
+        "-1, 600",
+        "500, 0",
+        "500, -1"
+    })
+    @DisplayName("면접 가능 시간 매핑에 양수가 아닌 ID를 지정할 수 없다")
+    void assignAvailabilityFormRejectsNonPositiveIds(Long formId, Long questionId) {
+        assertAssignmentRejected(draftInterviewRoundWithoutMapping(), formId, questionId);
+    }
+
+    @Test
+    @DisplayName("면접을 진행하지 않는 차수에는 면접 가능 시간 매핑을 지정할 수 없다")
+    void assignAvailabilityFormRejectsNonInterviewRound() {
+        RecruitingRound round = RecruitingRound.createRegular(
+            RecruitingSeason.create(1L, 10L),
+            noInterviewConfiguration(null)
+        );
+
+        assertAssignmentRejected(round, 500L, 600L);
+    }
+
+    @Test
     @DisplayName("모집 트랙은 비어 있을 수 없다")
     void configuredRoundRejectsEmptyTracks() {
         assertInvalidTracks(List.of());
@@ -122,6 +169,21 @@ class RecruitingRoundConfigurationTest {
     @DisplayName("모집 트랙에는 INFRA_PLUS를 설정할 수 없다")
     void configuredRoundRejectsInfraPlusTrack() {
         assertInvalidTracks(List.of(ChallengerTrack.INFRA_PLUS));
+    }
+
+    private RecruitingRound draftInterviewRoundWithoutMapping() {
+        return RecruitingRound.createRegular(
+            RecruitingSeason.create(1L, 10L),
+            interviewConfiguration(null, null)
+        );
+    }
+
+    /** 방어 코드는 예외를 던질 뿐 아니라 매핑을 남기지 않아야 한다. */
+    private void assertAssignmentRejected(RecruitingRound round, Long formId, Long questionId) {
+        assertInvalidSchedule(() -> round.assignAvailabilityForm(formId, questionId));
+
+        assertThat(round.getAvailabilityFormId()).isNull();
+        assertThat(round.getAvailabilityScheduleQuestionId()).isNull();
     }
 
     private void assertInvalidTracks(List<ChallengerTrack> tracks) {


### PR DESCRIPTION
## 🚀 작업 내용

resolves #1223

**무엇을** : 면접 일정 조율을 사용하는(`interviewRequired=true`) 모집 차수가 `DRAFT -> OPEN` 전환에 항상 실패하던 문제를 해결했습니다.

**왜**: `availabilityFormId`/`availabilityScheduleQuestionId`는 지원서 Form이 아니라 면접 일정 조율 전용 Form을 가리킵니다. OPEN 검증은 ① PUBLISHED ② 비익명 ③ 필수 질문 정확히 1개 ④ SCHEDULE 타입을 요구하는데, 이를 만족하는 Form을 만들 경로가 서버에 없었습니다. (`form` 모듈에 외부 노출 API 없음, 지원서 Form은 `isAnonymous(true)` 고정이라 ②에서 탈락, Vote Form은 ④에서 탈락) 사용하는 쪽만 구현되고 Form을 만드는 쪽이 비어 있던 상태입니다.

**어떻게**: 면접 일정 조율 Form을 서버가 자동 생성하도록 했습니다.

1. `RecruitingInterviewAvailabilityFormProvisioner`(신규)가 비익명 Form + SCHEDULE 필수 질문 1개를 만들어 게시합니다. 면접 Round OPEN 시 매핑이 비어 있으면 검증 직전에 호출하고, 관리자가 외부 Form을 이미 지정한 경우는 건드리지 않습니다. 문구는 `"면접 가능한 시간을 선택해주세요"` 상수이며, 문구 입력 UI가 생기면 별도 API로 확장할 예정입니다.
2. configuration을 통째로 교체하는 구조라 프론트가 매핑을 echo하지 않으면 수정 한 번에 사라지므로, 요청에 매핑이 없으면 기존 값을 승계합니다.

결론적으로 프론트는 이제 두 필드를 보내지 않아도 됩니다.

## 💬 리뷰 중점사항

- 차수 수정 요청에 availability 매핑이 없을 때, 예전에는 에러를 냈지만 이제는 기존 값을 유지합니다(기존 테스트 기대 변경)
- 자동 생성 Form 제목 규칙(`"{차수 제목} 면접 일정 조율"`)과 `OPEN -> DRAFT` 시 Form 유지(응답 보존) 판단도 확인 부탁드립니다