### PR TITLE
[Fix] 익명 지원 경로 500 에러 수정

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicantLockPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicantLockPersistenceAdapter.java
@@ -1,12 +1,15 @@
 package com.umc.product.recruiting.adapter.out.persistence;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.springframework.stereotype.Component;
 
 import com.umc.product.recruiting.application.port.out.LockRecruitingApplicantPort;
+import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
+import com.umc.product.recruiting.domain.exception.RecruitingErrorCode;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -39,18 +42,21 @@ public class RecruitingApplicantLockPersistenceAdapter implements LockRecruiting
         Long applicantMemberId,
         Collection<String> normalizedEmails
     ) {
-        if (gisuId == null || applicantMemberId == null) {
-            throw new IllegalArgumentException("Recruiting applicant lock requires gisuId and memberId");
+        if (gisuId == null) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICANT_IDENTITY_REQUIRED);
         }
-        Stream<String> memberKey = Stream.of("recruiting:gisu:%d:member:%d".formatted(
-            gisuId,
-            applicantMemberId
-        ));
+        Stream<String> memberKey = applicantMemberId == null
+            ? Stream.empty()
+            : Stream.of("recruiting:gisu:%d:member:%d".formatted(gisuId, applicantMemberId));
         Stream<String> emailKeys = normalizedEmails.stream()
             .filter(email -> email != null && !email.isBlank())
             .map(email -> email.strip().toLowerCase(Locale.ROOT))
             .map(email -> "recruiting:gisu:%d:email:%s".formatted(gisuId, email));
-        return Stream.concat(memberKey, emailKeys).distinct().sorted();
+        List<String> keys = Stream.concat(memberKey, emailKeys).distinct().sorted().toList();
+        if (keys.isEmpty()) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICANT_IDENTITY_REQUIRED);
+        }
+        return keys.stream();
     }
 
     private void acquireTransactionLock(String lockKey) {

--- a/src/main/java/com/umc/product/recruiting/application/port/out/LockRecruitingApplicantPort.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/out/LockRecruitingApplicantPort.java
@@ -4,5 +4,12 @@ import java.util.Collection;
 
 public interface LockRecruitingApplicantPort {
 
+    /**
+     * 기수 단위로 지원자 slot에 advisory lock을 건다.
+     *
+     * @param gisuId 필수
+     * @param applicantMemberId 회원 지원 시 필수, 익명 지원이면 {@code null}
+     * @param normalizedEmails 잠글 이메일 목록. memberId가 {@code null}이면 최소 1건 필요.
+     */
     void lockByGisuAndApplicant(Long gisuId, Long applicantMemberId, Collection<String> normalizedEmails);
 }

--- a/src/main/java/com/umc/product/recruiting/domain/exception/RecruitingErrorCode.java
+++ b/src/main/java/com/umc/product/recruiting/domain/exception/RecruitingErrorCode.java
@@ -105,6 +105,7 @@ public enum RecruitingErrorCode implements BaseCode {
     RECRUITING_INTERVIEW_QUESTION_IMMUTABLE(HttpStatus.CONFLICT, "RECRUITING-0505", "면접 평가 제출 후에는 질문을 변경할 수 없어요."),
     RECRUITING_INTERVIEW_QUESTION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "RECRUITING-0506", "면접 질문을 변경할 권한이 없어요."),
     RECRUITING_INTERVIEW_QUESTION_INVALID_ACTOR(HttpStatus.BAD_REQUEST, "RECRUITING-0507", "면접 질문 변경자 정보가 올바르지 않아요."),
+    RECRUITING_APPLICANT_IDENTITY_REQUIRED(HttpStatus.INTERNAL_SERVER_ERROR, "RECRUITING-0508", "지원자를 식별하려면 기수와 회원 또는 이메일이 필요해요."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 작업 내용
버그
- POST `/api/v1/recruiting/public/applications` (익명 지원서 초안 생성) 호출 시 500 발생
- 응답: `IllegalArgumentException: Recruiting applicant lock requires gisuId and memberId`
- 원인: `RecruitingApplicantLockPersistenceAdapter.lockKeys`가 `memberId` 필수 조건을 강제하는데, 익명 경로는 `memberId=null`을 전달함

수정
- `lockKeys` 전제조건 완화
  - `gisuId`는 계속 필수
  - `memberId`는 `nullable`로 허용 (익명 지원 케이스)
  - `memberId`가 `null`이면 `email`을 최소 1건 요구 → 잠금 키가 반드시 최소 1개는 생성되도록 안전장치 유지
- IllegalArgumentException → 도메인 예외 RecruitingDomainException으로 전환
  - 신규 에러코드 `RECRUITING-0508` `RECRUITING_APPLICANT_IDENTITY_REQUIRED` (`INTERNAL_SERVER_ERROR`)

익명 지원 경로 전체가 같은 어댑터를 공유하므로 아래 API들이 함께 정상화됩니다.
- POST /applications (익명 초안 생성) — 리포트된 500 원인
- POST /applications/submit (익명 제출)
- PUT /applications (익명 수정)
- POST /applications/cancel (익명 철회)

회원(로그인) 지원 경로는 `memberId`가 존재하므로 기존 `memberKey` + `emailKey` 조합 그대로 유지됩니다.

## 💬 리뷰 중점사항
- 잠금 키 축소 안전성: `memberId=null` 익명 경로에서는 `memberKey`를 생략하고 `gisu:%d:email:%s` 키만 사용합니다. 동일 이메일로 같은 기수에 동시 요청이 들어와도 email 키 하나만으로 advisory lock이 걸리므로 중복 지원 차단은 유지된다고 봤는데, 이 부분 검토 부탁드립니다.
- 에러코드 위상: `RECRUITING-0508`을 `INTERNAL_SERVER_ERROR`로 잡았습니다. 이 조건이 트리거되면 실질적으로 호출자 프로그래밍 오류(요구 필드 미전달)이기 때문에 400보다는 500이 더 명확하다고 판단했습니다.