### PR TITLE
[Fix] 지부장의 리크루팅 관련 권한 수정

### DIFF
--- a/src/main/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluator.java
@@ -1,14 +1,21 @@
 package com.umc.product.recruiting.application.service.evaluator;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Component;
 
 import com.umc.product.authorization.application.port.out.ResourcePermissionEvaluator;
+import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
+import com.umc.product.authorization.domain.RoleAttribute;
 import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.authorization.domain.exception.AuthorizationErrorCode;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.domain.RecruitingSeason;
 
@@ -19,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluator {
 
     private final LoadRecruitingSeasonPort loadRecruitingSeasonPort;
+    private final GetSchoolUseCase getSchoolUseCase;
 
     @Override
     public ResourceType supportedResourceType() {
@@ -47,8 +55,26 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
         }
 
         RecruitingSeason season = loadRecruitingSeason(resourcePermission);
-        return isCentralCoreInGisu(subjectAttributes, season.getGisuId())
-            || isSchoolCoreOf(subjectAttributes, season.getGisuId(), season.getSchoolId());
+        Long gisuId = season.getGisuId();
+
+        if (isCentralCoreInGisu(subjectAttributes, gisuId)) {
+            return true;
+        }
+
+        Long schoolId = season.getSchoolId();
+        Long chapterId = getChapterIdOfSchool(schoolId);
+
+        boolean isMyChapterPresident = isChapterPresidentInGisu(subjectAttributes, gisuId, chapterId);
+        boolean isAnyChapterPresident = isChapterPresidentInGisu(subjectAttributes, gisuId);
+
+        boolean isMySchoolCore = isSchoolCoreOf(subjectAttributes, gisuId, schoolId);
+        boolean isAnySchoolCore = isSchoolCoreInGisu(subjectAttributes, gisuId);
+
+        if (resourcePermission.permission() == PermissionType.READ) {
+            return isAnyChapterPresident || isAnySchoolCore;
+        }
+
+        return isMyChapterPresident || isMySchoolCore;
     }
 
     private boolean canManageAllRecruiting(
@@ -71,7 +97,8 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
         return subjectAttributes.toAuthoritySnapshot().isCentralCoreInAnyGisu()
             || subjectAttributes.roleAttributes().stream()
             .anyMatch(roleAttribute -> roleAttribute.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
-                || roleAttribute.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT);
+                || roleAttribute.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT
+                || roleAttribute.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT);
     }
 
     private boolean hasAnyCentralCoreRole(SubjectAttributes subjectAttributes) {
@@ -84,5 +111,45 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
 
     private boolean isSchoolCoreOf(SubjectAttributes subjectAttributes, Long gisuId, Long schoolId) {
         return subjectAttributes.toAuthoritySnapshot().isSchoolCoreInGisu(gisuId, schoolId);
+    }
+
+    private Long getChapterIdOfSchool(Long schoolId) {
+        SchoolDetailInfo schoolDetail = getSchoolUseCase.getSchoolDetail(schoolId);
+        if (schoolDetail == null) {
+            return null;
+        }
+        return schoolDetail.chapterId();
+    }
+
+    private boolean isChapterPresidentInGisu(
+        SubjectAttributes subjectAttributes,
+        Long gisuId,
+        Long chapterId
+    ) {
+        if (chapterId == null) {
+            return false;
+        }
+        return subjectAttributes.toAuthoritySnapshot().isChapterPresidentInGisu(gisuId, chapterId);
+    }
+
+    private boolean isChapterPresidentInGisu(
+        SubjectAttributes subjectAttributes,
+        Long gisuId
+    ) {
+        return subjectAttributes.toAuthoritySnapshot().challengerRoles().stream()
+            .filter(role -> Objects.equals(role.gisuId(), gisuId))
+            .filter(role -> role.organizationType() == OrganizationType.CHAPTER)
+            .anyMatch(role -> role.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT);
+    }
+
+    private boolean isSchoolCoreInGisu(
+        SubjectAttributes subjectAttributes,
+        Long gisuId
+    ) {
+        return subjectAttributes.toAuthoritySnapshot().challengerRoles().stream()
+            .filter(role -> Objects.equals(role.gisuId(), gisuId))
+            .filter(role -> role.organizationType() == OrganizationType.SCHOOL)
+            .map(RoleAttribute::roleType)
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolCore);
     }
 }

--- a/src/main/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluator.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluator.java
@@ -68,10 +68,10 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
         boolean isAnyChapterPresident = isChapterPresidentInGisu(subjectAttributes, gisuId);
 
         boolean isMySchoolCore = isSchoolCoreOf(subjectAttributes, gisuId, schoolId);
-        boolean isAnySchoolCore = isSchoolCoreInGisu(subjectAttributes, gisuId);
+        boolean isAnySchoolAdmin = isSchoolAdminInGisu(subjectAttributes, gisuId);
 
         if (resourcePermission.permission() == PermissionType.READ) {
-            return isAnyChapterPresident || isAnySchoolCore;
+            return isAnyChapterPresident || isAnySchoolAdmin;
         }
 
         return isMyChapterPresident || isMySchoolCore;
@@ -96,8 +96,7 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
     private boolean hasAnyRecruitingOperatorRole(SubjectAttributes subjectAttributes) {
         return subjectAttributes.toAuthoritySnapshot().isCentralCoreInAnyGisu()
             || subjectAttributes.roleAttributes().stream()
-            .anyMatch(roleAttribute -> roleAttribute.roleType() == ChallengerRoleType.SCHOOL_PRESIDENT
-                || roleAttribute.roleType() == ChallengerRoleType.SCHOOL_VICE_PRESIDENT
+            .anyMatch(roleAttribute -> roleAttribute.roleType().isAtLeastSchoolAdmin()
                 || roleAttribute.roleType() == ChallengerRoleType.CHAPTER_PRESIDENT);
     }
 
@@ -151,5 +150,16 @@ public class RecruitingPermissionEvaluator implements ResourcePermissionEvaluato
             .filter(role -> role.organizationType() == OrganizationType.SCHOOL)
             .map(RoleAttribute::roleType)
             .anyMatch(ChallengerRoleType::isAtLeastSchoolCore);
+    }
+
+    private boolean isSchoolAdminInGisu(
+        SubjectAttributes subjectAttributes,
+        Long gisuId
+    ) {
+        return subjectAttributes.toAuthoritySnapshot().challengerRoles().stream()
+            .filter(role -> Objects.equals(role.gisuId(), gisuId))
+            .filter(role -> role.organizationType() == OrganizationType.SCHOOL)
+            .map(RoleAttribute::roleType)
+            .anyMatch(ChallengerRoleType::isAtLeastSchoolAdmin);
     }
 }

--- a/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
@@ -24,6 +24,8 @@ import com.umc.product.authorization.domain.SystemRoleType;
 import com.umc.product.authorization.domain.exception.AuthorizationDomainException;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
+import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.domain.RecruitingSeason;
 
@@ -40,11 +42,14 @@ class RecruitingPermissionEvaluatorTest {
     @Mock
     LoadRecruitingSeasonPort loadRecruitingSeasonPort;
 
+    @Mock
+    GetSchoolUseCase getSchoolUseCase;
+
     RecruitingPermissionEvaluator sut;
 
     @BeforeEach
     void setUp() {
-        sut = new RecruitingPermissionEvaluator(loadRecruitingSeasonPort);
+        sut = new RecruitingPermissionEvaluator(loadRecruitingSeasonPort, getSchoolUseCase);
     }
 
     @Test
@@ -57,6 +62,7 @@ class RecruitingPermissionEvaluatorTest {
     @DisplayName("학교 회장단은 자기 학교 모집 WRITE 권한을 통과한다")
     void 학교_회장단은_자기_학교_모집_WRITE_권한을_통과한다() {
         givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
         SubjectAttributes subject = subjectWithRoles(schoolPresidentRole(SCHOOL_ID));
 
         assertThat(sut.evaluate(subject, seasonPermission(PermissionType.WRITE))).isTrue();
@@ -66,9 +72,61 @@ class RecruitingPermissionEvaluatorTest {
     @DisplayName("학교 회장단은 다른 학교 모집 WRITE 권한을 거부한다")
     void 학교_회장단은_다른_학교_모집_WRITE_권한을_거부한다() {
         givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
         SubjectAttributes subject = subjectWithRoles(schoolPresidentRole(OTHER_SCHOOL_ID));
 
         assertThat(sut.evaluate(subject, seasonPermission(PermissionType.WRITE))).isFalse();
+    }
+
+    @Test
+    @DisplayName("학교 회장단은 다른 학교 모집 READ 권한을 통과한다")
+    void 학교_회장단은_다른_학교_모집_READ_권한을_통과한다() {
+        givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
+        SubjectAttributes subject = subjectWithRoles(schoolPresidentRole(OTHER_SCHOOL_ID));
+
+        assertThat(sut.evaluate(subject, seasonPermission(PermissionType.READ))).isTrue();
+    }
+
+    @Test
+    @DisplayName("지부장은 리소스 ID가 없는 경우 모집 READ 권한을 통과한다")
+    void 지부장은_리소스_ID가_없는_경우_모집_READ_권한을_통과한다() {
+        SubjectAttributes subject = subjectWithRoles(chapterPresidentRole(100L));
+
+        assertThat(sut.evaluate(
+            subject,
+            ResourcePermission.ofType(ResourceType.RECRUITMENT, PermissionType.READ)
+        )).isTrue();
+    }
+
+    @Test
+    @DisplayName("지부장은 자기 지부 소속 학교 모집 WRITE 권한을 통과한다")
+    void 지부장은_자기_지부_소속_학교_모집_WRITE_권한을_통과한다() {
+        givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
+        SubjectAttributes subject = subjectWithRoles(chapterPresidentRole(100L));
+
+        assertThat(sut.evaluate(subject, seasonPermission(PermissionType.WRITE))).isTrue();
+    }
+
+    @Test
+    @DisplayName("지부장은 다른 지부 소속 학교 모집 WRITE 권한을 거부한다")
+    void 지부장은_다른_지부_소속_학교_모집_WRITE_권한을_거부한다() {
+        givenSeason();
+        givenSchool(SCHOOL_ID, 200L);
+        SubjectAttributes subject = subjectWithRoles(chapterPresidentRole(100L));
+
+        assertThat(sut.evaluate(subject, seasonPermission(PermissionType.WRITE))).isFalse();
+    }
+
+    @Test
+    @DisplayName("지부장은 다른 지부 소속 학교 모집 READ 권한을 통과한다")
+    void 지부장은_다른_지부_소속_학교_모집_READ_권한을_통과한다() {
+        givenSeason();
+        givenSchool(SCHOOL_ID, 200L);
+        SubjectAttributes subject = subjectWithRoles(chapterPresidentRole(100L));
+
+        assertThat(sut.evaluate(subject, seasonPermission(PermissionType.READ))).isTrue();
     }
 
     @Test
@@ -113,6 +171,7 @@ class RecruitingPermissionEvaluatorTest {
     @DisplayName("학교 회장단은 자기 학교라도 MANAGE 권한을 거부한다")
     void 학교_회장단은_자기_학교라도_MANAGE_권한을_거부한다() {
         givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
         SubjectAttributes subject = subjectWithRoles(schoolPresidentRole(SCHOOL_ID));
 
         assertThat(sut.evaluate(subject, seasonPermission(PermissionType.MANAGE))).isFalse();
@@ -122,6 +181,7 @@ class RecruitingPermissionEvaluatorTest {
     @DisplayName("교내 파트장은 모집 WRITE 권한을 거부한다")
     void 교내_파트장은_모집_WRITE_권한을_거부한다() {
         givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
         SubjectAttributes subject = subjectWithRoles(schoolPartLeaderRole(SCHOOL_ID));
 
         assertThat(sut.evaluate(subject, seasonPermission(PermissionType.WRITE))).isFalse();
@@ -139,6 +199,27 @@ class RecruitingPermissionEvaluatorTest {
     private void givenSeason() {
         given(loadRecruitingSeasonPort.getById(SEASON_ID))
             .willReturn(season());
+    }
+
+    private void givenSchool(Long schoolId, Long chapterId) {
+        given(getSchoolUseCase.getSchoolDetail(schoolId))
+            .willReturn(schoolDetail(schoolId, chapterId));
+    }
+
+    private SchoolDetailInfo schoolDetail(Long schoolId, Long chapterId) {
+        return new SchoolDetailInfo(
+            chapterId,
+            "테스트지부",
+            "테스트학교",
+            "테스트대",
+            schoolId,
+            null,
+            null,
+            List.of(),
+            true,
+            null,
+            null
+        );
     }
 
     private RecruitingSeason season() {
@@ -193,6 +274,16 @@ class RecruitingPermissionEvaluatorTest {
             ChallengerRoleType.SCHOOL_PART_LEADER,
             OrganizationType.SCHOOL,
             schoolId,
+            null,
+            GISU_ID
+        );
+    }
+
+    private RoleAttribute chapterPresidentRole(Long chapterId) {
+        return new RoleAttribute(
+            ChallengerRoleType.CHAPTER_PRESIDENT,
+            OrganizationType.CHAPTER,
+            chapterId,
             null,
             GISU_ID
         );

--- a/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
@@ -187,6 +187,27 @@ class RecruitingPermissionEvaluatorTest {
     }
 
     @Test
+    @DisplayName("교내 파트장은 다른 학교 모집 READ 권한을 통과한다")
+    void 교내_파트장은_다른_학교_모집_READ_권한을_통과한다() {
+        givenSeason();
+        givenSchool(SCHOOL_ID, 100L);
+        SubjectAttributes subject = subjectWithRoles(schoolPartLeaderRole(OTHER_SCHOOL_ID));
+
+        assertThat(sut.evaluate(subject, seasonPermission(PermissionType.READ))).isTrue();
+    }
+
+    @Test
+    @DisplayName("교내 파트장은 리소스 ID가 없는 경우 모집 READ 권한을 통과한다")
+    void 교내_파트장은_리소스_ID가_없는_경우_모집_READ_권한을_통과한다() {
+        SubjectAttributes subject = subjectWithRoles(schoolPartLeaderRole(SCHOOL_ID));
+
+        assertThat(sut.evaluate(
+            subject,
+            ResourcePermission.ofType(ResourceType.RECRUITMENT, PermissionType.READ)
+        )).isTrue();
+    }
+
+    @Test
     @DisplayName("DELETE 권한은 evaluator에서 구현하지 않아 예외가 발생한다")
     void DELETE_권한은_evaluator에서_구현하지_않아_예외가_발생한다() {
         SubjectAttributes subject = subjectWithRoles(centralPresidentRole());

--- a/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluatorTest.java
@@ -171,7 +171,6 @@ class RecruitingPermissionEvaluatorTest {
     @DisplayName("학교 회장단은 자기 학교라도 MANAGE 권한을 거부한다")
     void 학교_회장단은_자기_학교라도_MANAGE_권한을_거부한다() {
         givenSeason();
-        givenSchool(SCHOOL_ID, 100L);
         SubjectAttributes subject = subjectWithRoles(schoolPresidentRole(SCHOOL_ID));
 
         assertThat(sut.evaluate(subject, seasonPermission(PermissionType.MANAGE))).isFalse();


### PR DESCRIPTION
## 🚀 작업 내용
리쿠르팅 어드민 권한 정책 변경 및 지부장 접근 오류를 해결했습니다. 
- resolves #1229

- 지부장 권한 추가 (`403 Forbidden` 해결)
  - 초기 리소스 권한 검사(`hasAnyRecruitingOperatorRole`)에 `CHAPTER_PRESIDENT`를 추가하여 리쿠르팅 어드민(`/rounds` 등)에 정상적으로 접근할 수 있도록 수정했습니다.
  
- 본인/타 조직 권한 분리 (Read-Only 정책 적용)
  - `READ` 권한: 소속에 상관없이 해당 기수의 지부장 또는 학교 회장단이면 조회(Read-Only)가 가능하도록 개방했습니다.
  - `WRITE, EDIT, APPROVE` 권한: 본인 소속 지부(지부장) 또는 본인 소속 학교(회장단) 리소스인 경우에만 생성/수정/승인할 수 있도록 제한했
습니다.

- 주요 변경 사항
  - `RecruitingPermissionEvaluator` 권한 분리 로직 적용
  - 타 지부 확인을 위해 `GetSchoolUseCase` 의존성 주입 추가
  - 본인/타 지부 및 학교에 대한 5가지 권한 분리 검증 단위 테스트 추가 (`RecruitingPermissionEvaluatorTest`)


## 💬 리뷰 중점사항
