### PR TITLE
[Feat] 모집 차수 지원 Form 구조 조회 API 추가

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
@@ -14,6 +14,7 @@ import com.umc.product.global.security.annotation.CurrentMember;
 import com.umc.product.recruiting.adapter.in.graphql.dto.CloneRecruitingRoundGraphQlRequest;
 import com.umc.product.recruiting.adapter.in.graphql.dto.CreateRecruitingRoundGraphQlRequest;
 import com.umc.product.recruiting.adapter.in.graphql.dto.CreateRecruitingSeasonGraphQlRequest;
+import com.umc.product.recruiting.adapter.in.graphql.dto.RecruitingAdminFormStructureGraphQlResponse;
 import com.umc.product.recruiting.adapter.in.graphql.dto.RecruitingDecisionHistoryPageGraphQlResponse;
 import com.umc.product.recruiting.adapter.in.graphql.dto.RecruitingDecisionHistorySearchGraphQlRequest;
 import com.umc.product.recruiting.adapter.in.graphql.dto.RecruitingEvaluationStatisticsGraphQlRequest;
@@ -40,6 +41,7 @@ import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruiti
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonConfigurationUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingDecisionHistoryUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
@@ -64,7 +66,21 @@ public class RecruitingAdminGraphQlController {
     private final UpdateRecruitingRoundUseCase updateRoundUseCase;
     private final CloneRecruitingRoundUseCase cloneRoundUseCase;
     private final DeleteRecruitingRoundUseCase deleteRoundUseCase;
+    private final GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
     private final RecruitingGraphQlPermissionSupport permissionSupport;
+
+    @QueryMapping
+    public RecruitingAdminFormStructureGraphQlResponse recruitingAdminFormStructure(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
+        @Argument Long seasonId,
+        @Argument Long roundId
+    ) {
+        Long requesterMemberId = permissionSupport.currentMemberId(memberPrincipal);
+        permissionSupport.assertRecruitmentPermission(requesterMemberId, seasonId, PermissionType.READ);
+        return RecruitingAdminFormStructureGraphQlResponse.from(
+            getRecruitingFormQueryUseCase.getAdminFormStructure(seasonId, roundId)
+        );
+    }
 
     @QueryMapping
     public List<RecruitingSeasonSummaryGraphQlResponse> recruitingRoundGroups(

--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingAdminFormStructureGraphQlResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingAdminFormStructureGraphQlResponse.java
@@ -1,0 +1,97 @@
+package com.umc.product.recruiting.adapter.in.graphql.dto;
+
+import java.util.List;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+
+public record RecruitingAdminFormStructureGraphQlResponse(
+    boolean exists,
+    Long applicationFormId,
+    Long formId,
+    String title,
+    String description,
+    RecruitingApplicationFormStatus status,
+    List<SectionGraphQlResponse> sections
+) {
+
+    public static RecruitingAdminFormStructureGraphQlResponse from(RecruitingAdminFormStructureInfo info) {
+        return new RecruitingAdminFormStructureGraphQlResponse(
+            info.exists(),
+            info.applicationFormId(),
+            info.formId(),
+            info.title(),
+            info.description(),
+            info.status(),
+            info.sections().stream().map(SectionGraphQlResponse::from).toList()
+        );
+    }
+
+    public record SectionGraphQlResponse(
+        Long sectionId,
+        String title,
+        String description,
+        Long orderNo,
+        RecruitingFormSectionType type,
+        ChallengerTrack track,
+        List<QuestionGraphQlResponse> questions
+    ) {
+
+        private static SectionGraphQlResponse from(RecruitingAdminFormStructureInfo.SectionInfo section) {
+            return new SectionGraphQlResponse(
+                section.sectionId(),
+                section.title(),
+                section.description(),
+                section.orderNo(),
+                section.type(),
+                section.track(),
+                section.questions().stream().map(QuestionGraphQlResponse::from).toList()
+            );
+        }
+    }
+
+    public record QuestionGraphQlResponse(
+        Long questionId,
+        String title,
+        String description,
+        QuestionType type,
+        boolean required,
+        Long orderNo,
+        List<OptionGraphQlResponse> options
+    ) {
+
+        private static QuestionGraphQlResponse from(RecruitingAdminFormStructureInfo.QuestionInfo question) {
+            return new QuestionGraphQlResponse(
+                question.questionId(),
+                question.title(),
+                question.description(),
+                question.type(),
+                question.required(),
+                question.orderNo(),
+                question.options().stream().map(OptionGraphQlResponse::from).toList()
+            );
+        }
+    }
+
+    public record OptionGraphQlResponse(
+        Long optionId,
+        String content,
+        Long orderNo,
+        boolean other,
+        Long nextSectionId
+    ) {
+
+        private static OptionGraphQlResponse from(RecruitingAdminFormStructureInfo.OptionInfo option) {
+            return new OptionGraphQlResponse(
+                option.optionId(),
+                option.content(),
+                option.orderNo(),
+                option.other(),
+                option.nextSectionId()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingAdminFormStructureGraphQlResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingAdminFormStructureGraphQlResponse.java
@@ -32,6 +32,7 @@ public record RecruitingAdminFormStructureGraphQlResponse(
 
     public record SectionGraphQlResponse(
         Long sectionId,
+        String clientKey,
         String title,
         String description,
         Long orderNo,
@@ -43,6 +44,7 @@ public record RecruitingAdminFormStructureGraphQlResponse(
         private static SectionGraphQlResponse from(RecruitingAdminFormStructureInfo.SectionInfo section) {
             return new SectionGraphQlResponse(
                 section.sectionId(),
+                section.clientKey(),
                 section.title(),
                 section.description(),
                 section.orderNo(),
@@ -81,7 +83,8 @@ public record RecruitingAdminFormStructureGraphQlResponse(
         String content,
         Long orderNo,
         boolean other,
-        Long nextSectionId
+        Long nextSectionId,
+        String nextSectionKey
     ) {
 
         private static OptionGraphQlResponse from(RecruitingAdminFormStructureInfo.OptionInfo option) {
@@ -90,7 +93,8 @@ public record RecruitingAdminFormStructureGraphQlResponse(
                 option.content(),
                 option.orderNo(),
                 option.other(),
-                option.nextSectionId()
+                option.nextSectionId(),
+                option.nextSectionKey()
             );
         }
     }

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminController.java
@@ -33,6 +33,7 @@ import com.umc.product.recruiting.adapter.in.web.dto.request.RecruitingDecisionR
 import com.umc.product.recruiting.adapter.in.web.dto.request.RecruitingDocumentDecisionRequest;
 import com.umc.product.recruiting.adapter.in.web.dto.request.SkipRecruitingInterviewRequest;
 import com.umc.product.recruiting.adapter.in.web.dto.request.UpsertRecruitingApplicationFormRequest;
+import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingAdminFormStructureResponse;
 import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingDecisionHistoryPageResponse;
 import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingEvaluationStatisticsResponse;
 import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingIdResponse;
@@ -51,6 +52,7 @@ import com.umc.product.recruiting.application.port.in.query.ExportRecruitingCsvU
 import com.umc.product.recruiting.application.port.in.query.ExportRecruitingDecisionHistoryCsvUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingDecisionHistoryUseCase;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingDecisionHistorySearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsQuery;
@@ -85,6 +87,25 @@ public class RecruitingAdminController {
     private final SearchRecruitingDecisionHistoryUseCase searchDecisionHistoryUseCase;
     private final ExportRecruitingDecisionHistoryCsvUseCase exportDecisionHistoryCsvUseCase;
     private final GetRecruitingEvaluationStatisticsUseCase getEvaluationStatisticsUseCase;
+    private final GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
+
+    @GetMapping("/seasons/{seasonId}/rounds/{roundId}/form")
+    @CheckAccess(resourceType = ResourceType.RECRUITMENT, resourceId = "#seasonId", permission = PermissionType.READ)
+    @Operation(
+        operationId = "RECRUITING-ADMIN-022",
+        summary = "지원 Form 전체 구조 조회",
+        description = "편집 화면에서 저장된 section, question, option과 COMMON/TRACK 정책을 한 번에 불러옵니다. "
+            + "공개 조회와 달리 Form 상태와 지망 트랙에 관계없이 전체 구조를 반환하며, "
+            + "Form을 아직 만들지 않은 차수는 exists=false인 빈 구조를 반환합니다."
+    )
+    public RecruitingAdminFormStructureResponse getForm(
+        @PathVariable @Positive Long seasonId,
+        @PathVariable @Positive Long roundId
+    ) {
+        return RecruitingAdminFormStructureResponse.from(
+            getRecruitingFormQueryUseCase.getAdminFormStructure(seasonId, roundId)
+        );
+    }
 
     @PutMapping("/seasons/{seasonId}/rounds/{roundId}/form")
     @CheckAccess(resourceType = ResourceType.RECRUITMENT, resourceId = "#seasonId", permission = PermissionType.WRITE)

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingAdminFormStructureResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingAdminFormStructureResponse.java
@@ -37,6 +37,7 @@ public record RecruitingAdminFormStructureResponse(
     @Schema(description = "지원 Form section")
     public record SectionResponse(
         @Schema(description = "section ID", example = "300") Long sectionId,
+        @Schema(description = "저장된 section을 가리키는 편집기 key", example = "section-300") String clientKey,
         @Schema(description = "section 제목") String title,
         @Schema(description = "section 설명") String description,
         @Schema(description = "section 순서", example = "1") Long orderNo,
@@ -48,6 +49,7 @@ public record RecruitingAdminFormStructureResponse(
         private static SectionResponse from(RecruitingAdminFormStructureInfo.SectionInfo section) {
             return new SectionResponse(
                 section.sectionId(),
+                section.clientKey(),
                 section.title(),
                 section.description(),
                 section.orderNo(),
@@ -88,7 +90,8 @@ public record RecruitingAdminFormStructureResponse(
         @Schema(description = "option 내용") String content,
         @Schema(description = "option 순서", example = "1") Long orderNo,
         @Schema(description = "기타 option 여부", example = "false") boolean other,
-        @Schema(description = "조건부 이동 대상 section ID") Long nextSectionId
+        @Schema(description = "조건부 이동 대상 section ID") Long nextSectionId,
+        @Schema(description = "조건부 이동 대상 section의 편집기 key", example = "section-300") String nextSectionKey
     ) {
 
         private static OptionResponse from(RecruitingAdminFormStructureInfo.OptionInfo option) {
@@ -97,7 +100,8 @@ public record RecruitingAdminFormStructureResponse(
                 option.content(),
                 option.orderNo(),
                 option.other(),
-                option.nextSectionId()
+                option.nextSectionId(),
+                option.nextSectionKey()
             );
         }
     }

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingAdminFormStructureResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingAdminFormStructureResponse.java
@@ -1,0 +1,104 @@
+package com.umc.product.recruiting.adapter.in.web.dto.response;
+
+import java.util.List;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "운영진 편집기용 지원 Form 전체 구조 응답")
+public record RecruitingAdminFormStructureResponse(
+    @Schema(description = "지원 Form 생성 여부. false면 나머지 값은 비어 있습니다.", example = "true")
+    boolean exists,
+    @Schema(description = "리크루팅 지원 Form ID", example = "50") Long applicationFormId,
+    @Schema(description = "Form 모듈 Form ID", example = "100") Long formId,
+    @Schema(description = "Form 제목") String title,
+    @Schema(description = "Form 설명") String description,
+    @Schema(description = "지원 Form 상태", example = "DRAFT") RecruitingApplicationFormStatus status,
+    @Schema(description = "section 목록") List<SectionResponse> sections
+) {
+
+    public static RecruitingAdminFormStructureResponse from(RecruitingAdminFormStructureInfo info) {
+        return new RecruitingAdminFormStructureResponse(
+            info.exists(),
+            info.applicationFormId(),
+            info.formId(),
+            info.title(),
+            info.description(),
+            info.status(),
+            info.sections().stream().map(SectionResponse::from).toList()
+        );
+    }
+
+    @Schema(description = "지원 Form section")
+    public record SectionResponse(
+        @Schema(description = "section ID", example = "300") Long sectionId,
+        @Schema(description = "section 제목") String title,
+        @Schema(description = "section 설명") String description,
+        @Schema(description = "section 순서", example = "1") Long orderNo,
+        @Schema(description = "section 유형", example = "COMMON") RecruitingFormSectionType type,
+        @Schema(description = "TRACK section의 모집 트랙. COMMON이면 null입니다.") ChallengerTrack track,
+        @Schema(description = "question 목록") List<QuestionResponse> questions
+    ) {
+
+        private static SectionResponse from(RecruitingAdminFormStructureInfo.SectionInfo section) {
+            return new SectionResponse(
+                section.sectionId(),
+                section.title(),
+                section.description(),
+                section.orderNo(),
+                section.type(),
+                section.track(),
+                section.questions().stream().map(QuestionResponse::from).toList()
+            );
+        }
+    }
+
+    @Schema(description = "지원 Form question")
+    public record QuestionResponse(
+        @Schema(description = "question ID", example = "400") Long questionId,
+        @Schema(description = "question 제목") String title,
+        @Schema(description = "question 설명") String description,
+        @Schema(description = "question 유형", example = "SHORT_ANSWER") QuestionType type,
+        @Schema(description = "필수 응답 여부", example = "true") boolean required,
+        @Schema(description = "question 순서", example = "1") Long orderNo,
+        @Schema(description = "option 목록") List<OptionResponse> options
+    ) {
+
+        private static QuestionResponse from(RecruitingAdminFormStructureInfo.QuestionInfo question) {
+            return new QuestionResponse(
+                question.questionId(),
+                question.title(),
+                question.description(),
+                question.type(),
+                question.required(),
+                question.orderNo(),
+                question.options().stream().map(OptionResponse::from).toList()
+            );
+        }
+    }
+
+    @Schema(description = "지원 Form question option")
+    public record OptionResponse(
+        @Schema(description = "option ID", example = "500") Long optionId,
+        @Schema(description = "option 내용") String content,
+        @Schema(description = "option 순서", example = "1") Long orderNo,
+        @Schema(description = "기타 option 여부", example = "false") boolean other,
+        @Schema(description = "조건부 이동 대상 section ID") Long nextSectionId
+    ) {
+
+        private static OptionResponse from(RecruitingAdminFormStructureInfo.OptionInfo option) {
+            return new OptionResponse(
+                option.optionId(),
+                option.content(),
+                option.orderNo(),
+                option.other(),
+                option.nextSectionId()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/GetRecruitingFormQueryUseCase.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/GetRecruitingFormQueryUseCase.java
@@ -2,6 +2,7 @@ package com.umc.product.recruiting.application.port.in.query;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.form.application.port.in.query.dto.FormWithStructureInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
 
 public interface GetRecruitingFormQueryUseCase {
 
@@ -10,6 +11,12 @@ public interface GetRecruitingFormQueryUseCase {
         ChallengerTrack firstChoice,
         ChallengerTrack secondChoice
     );
+
+    /**
+     * 운영진 편집기용 지원 Form 전체 구조를 조회한다.
+     * 공개 조회와 달리 Form 상태와 지망 트랙에 관계없이 모든 section을 반환한다.
+     */
+    RecruitingAdminFormStructureInfo getAdminFormStructure(Long seasonId, Long roundId);
 
     boolean isApplicationFormBelongsToSeason(Long applicationFormId, Long seasonId);
 

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingAdminFormStructureInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingAdminFormStructureInfo.java
@@ -40,6 +40,7 @@ public record RecruitingAdminFormStructureInfo(
     @Builder
     public record SectionInfo(
         Long sectionId,
+        String clientKey,
         String title,
         String description,
         Long orderNo,
@@ -67,7 +68,8 @@ public record RecruitingAdminFormStructureInfo(
         String content,
         Long orderNo,
         boolean other,
-        Long nextSectionId
+        Long nextSectionId,
+        String nextSectionKey
     ) {
     }
 }

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingAdminFormStructureInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingAdminFormStructureInfo.java
@@ -1,0 +1,73 @@
+package com.umc.product.recruiting.application.port.in.query.dto;
+
+import java.util.List;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+
+import lombok.Builder;
+
+/**
+ * 운영진 편집기에서 사용하는 지원 Form 전체 구조.
+ *
+ * <p>공개 조회와 달리 트랙 필터링 없이 모든 section을 담고, Form 모듈이 알지 못하는
+ * COMMON/TRACK 정책({@code type}, {@code track})을 section마다 병합해 노출한다.
+ * Upsert 요청과 대칭 구조라 편집 화면에서 그대로 되돌려 보낼 수 있다.
+ *
+ * <p>Form을 아직 만들지 않은 차수는 {@link #empty()}로 표현한다. 차수 자체가 없거나
+ * 다른 시즌 소속이면 이 값이 아니라 예외로 처리한다.
+ */
+@Builder
+public record RecruitingAdminFormStructureInfo(
+    boolean exists,
+    Long applicationFormId,
+    Long formId,
+    String title,
+    String description,
+    RecruitingApplicationFormStatus status,
+    List<SectionInfo> sections
+) {
+
+    public static RecruitingAdminFormStructureInfo empty() {
+        return RecruitingAdminFormStructureInfo.builder()
+            .exists(false)
+            .sections(List.of())
+            .build();
+    }
+
+    @Builder
+    public record SectionInfo(
+        Long sectionId,
+        String title,
+        String description,
+        Long orderNo,
+        RecruitingFormSectionType type,
+        ChallengerTrack track,
+        List<QuestionInfo> questions
+    ) {
+    }
+
+    @Builder
+    public record QuestionInfo(
+        Long questionId,
+        String title,
+        String description,
+        QuestionType type,
+        boolean required,
+        Long orderNo,
+        List<OptionInfo> options
+    ) {
+    }
+
+    @Builder
+    public record OptionInfo(
+        Long optionId,
+        String content,
+        Long orderNo,
+        boolean other,
+        Long nextSectionId
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -61,6 +61,8 @@ public class RecruitingQueryService implements
     ValidateRecruitingApplicationScopeUseCase,
     ValidateRecruitingFormScopeUseCase {
 
+    private static final String SECTION_CLIENT_KEY_PREFIX = "section-";
+
     /** 지원 현황 집계 대상 상태. 작성 중(DRAFT)·지원 취소(CANCELLED)는 제외한다. */
     private static final Set<RecruitingApplicationStatus> SUMMARY_STATUSES = EnumSet.complementOf(EnumSet.of(
         RecruitingApplicationStatus.DRAFT,
@@ -199,6 +201,7 @@ public class RecruitingQueryService implements
         }
         return RecruitingAdminFormStructureInfo.SectionInfo.builder()
             .sectionId(section.sectionId())
+            .clientKey(sectionClientKey(section.sectionId()))
             .title(section.title())
             .description(section.description())
             .orderNo(section.orderNo())
@@ -219,11 +222,18 @@ public class RecruitingQueryService implements
                             .orderNo(option.orderNo())
                             .other(option.isOther())
                             .nextSectionId(option.nextSectionId())
+                            .nextSectionKey(option.nextSectionId() == null
+                                ? null
+                                : sectionClientKey(option.nextSectionId()))
                             .build())
                         .toList())
                     .build())
                 .toList())
             .build();
+    }
+
+    private static String sectionClientKey(Long sectionId) {
+        return SECTION_CLIENT_KEY_PREFIX + sectionId;
     }
 
     @Override

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -9,6 +9,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -167,9 +169,9 @@ public class RecruitingQueryService implements
         FormWithStructureInfo structure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
         Map<Long, RecruitingFormSectionPolicy> policyBySectionId = loadFormSectionPolicyPort
             .listByApplicationFormId(applicationForm.getId()).stream()
-            .collect(java.util.stream.Collectors.toMap(
+            .collect(Collectors.toMap(
                 RecruitingFormSectionPolicy::getFormSectionId,
-                java.util.function.Function.identity()
+                Function.identity()
             ));
         return RecruitingAdminFormStructureInfo.builder()
             .exists(true)

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingQueryService.java
@@ -25,6 +25,7 @@ import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplica
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.ValidateRecruitingApplicationScopeUseCase;
 import com.umc.product.recruiting.application.port.in.query.ValidateRecruitingFormScopeUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
@@ -33,12 +34,14 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatus
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryQuery;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingFormSectionPolicyPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.application.port.out.dto.RecruitingApplicationSummaryRow;
 import com.umc.product.recruiting.domain.RecruitingApplicantProfile;
 import com.umc.product.recruiting.domain.RecruitingApplication;
 import com.umc.product.recruiting.domain.RecruitingApplicationForm;
+import com.umc.product.recruiting.domain.RecruitingFormSectionPolicy;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
 import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
@@ -72,6 +75,7 @@ public class RecruitingQueryService implements
     private final LoadRecruitingRoundPort loadRoundPort;
     private final LoadRecruitingSeasonPort loadSeasonPort;
     private final LoadRecruitingApplicationFormPort loadApplicationFormPort;
+    private final LoadRecruitingFormSectionPolicyPort loadFormSectionPolicyPort;
     private final GetSchoolUseCase getSchoolUseCase;
     private final GetGisuAuthorityScopeUseCase getGisuAuthorityScopeUseCase;
     private final GetFormUseCase getFormUseCase;
@@ -142,6 +146,78 @@ public class RecruitingQueryService implements
                     .options(question.options().stream()
                         .filter(option -> option.nextSectionId() == null
                             || visibleSectionIds.contains(option.nextSectionId()))
+                        .toList())
+                    .build())
+                .toList())
+            .build();
+    }
+
+    @Override
+    public RecruitingAdminFormStructureInfo getAdminFormStructure(Long seasonId, Long roundId) {
+        RecruitingRound round = loadRoundPort.getById(roundId);
+        if (!Objects.equals(round.getSeason().getId(), seasonId)) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_NOT_FOUND);
+        }
+        return loadApplicationFormPort.findByRoundId(roundId)
+            .map(this::toAdminFormStructure)
+            .orElseGet(RecruitingAdminFormStructureInfo::empty);
+    }
+
+    private RecruitingAdminFormStructureInfo toAdminFormStructure(RecruitingApplicationForm applicationForm) {
+        FormWithStructureInfo structure = getFormUseCase.getFormWithStructure(applicationForm.getFormId());
+        Map<Long, RecruitingFormSectionPolicy> policyBySectionId = loadFormSectionPolicyPort
+            .listByApplicationFormId(applicationForm.getId()).stream()
+            .collect(java.util.stream.Collectors.toMap(
+                RecruitingFormSectionPolicy::getFormSectionId,
+                java.util.function.Function.identity()
+            ));
+        return RecruitingAdminFormStructureInfo.builder()
+            .exists(true)
+            .applicationFormId(applicationForm.getId())
+            .formId(applicationForm.getFormId())
+            .title(structure.title())
+            .description(structure.description())
+            .status(applicationForm.getStatus())
+            .sections(structure.sections().stream()
+                .map(section -> toAdminSection(section, policyBySectionId.get(section.sectionId())))
+                .toList())
+            .build();
+    }
+
+    /**
+     * COMMON/TRACK 정책은 Form 모듈이 아닌 recruiting 쪽에 저장되므로 section마다 병합한다.
+     * 정책이 없는 section은 Upsert 경로가 만들 수 없는 상태라 데이터 정합성 문제로 본다.
+     */
+    private RecruitingAdminFormStructureInfo.SectionInfo toAdminSection(
+        FormWithStructureInfo.SectionWithQuestions section,
+        RecruitingFormSectionPolicy policy
+    ) {
+        if (policy == null) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_FORM_SECTION_POLICY_INVALID);
+        }
+        return RecruitingAdminFormStructureInfo.SectionInfo.builder()
+            .sectionId(section.sectionId())
+            .title(section.title())
+            .description(section.description())
+            .orderNo(section.orderNo())
+            .type(policy.getType())
+            .track(policy.getTrack())
+            .questions(section.questions().stream()
+                .map(question -> RecruitingAdminFormStructureInfo.QuestionInfo.builder()
+                    .questionId(question.questionId())
+                    .title(question.title())
+                    .description(question.description())
+                    .type(question.type())
+                    .required(question.isRequired())
+                    .orderNo(question.orderNo())
+                    .options(question.options().stream()
+                        .map(option -> RecruitingAdminFormStructureInfo.OptionInfo.builder()
+                            .optionId(option.optionId())
+                            .content(option.content())
+                            .orderNo(option.orderNo())
+                            .other(option.isOther())
+                            .nextSectionId(option.nextSectionId())
+                            .build())
                         .toList())
                     .build())
                 .toList())

--- a/src/main/resources/graphql/recruiting.graphqls
+++ b/src/main/resources/graphql/recruiting.graphqls
@@ -503,6 +503,7 @@ type RecruitingAdminFormStructure {
 
 type RecruitingAdminFormSection {
   sectionId: ID!
+  clientKey: String!
   title: String!
   description: String
   orderNo: Long!
@@ -527,6 +528,7 @@ type RecruitingAdminFormQuestionOption {
   orderNo: Long!
   other: Boolean!
   nextSectionId: ID
+  nextSectionKey: String
 }
 
 type RecruitingApplicationCreated {

--- a/src/main/resources/graphql/recruiting.graphqls
+++ b/src/main/resources/graphql/recruiting.graphqls
@@ -10,6 +10,7 @@ extend type Query {
     input: RecruitingApplicationCredentialInput!
   ): RecruitingPublicApplication!
   recruitingApplication(applicationId: ID!): RecruitingApplication!
+  recruitingAdminFormStructure(seasonId: ID!, roundId: ID!): RecruitingAdminFormStructure!
   recruitingRoundGroups(input: RecruitingRoundSearchInput!): [RecruitingSeasonSummary!]!
   recruitingRoundTitleAvailable(seasonId: ID!, title: String!, excludedRoundId: ID): Boolean!
   recruitingSeasonConfiguration(seasonId: ID!): RecruitingSeasonConfiguration!
@@ -482,6 +483,45 @@ type RecruitingFormQuestion {
 }
 
 type RecruitingFormQuestionOption {
+  optionId: ID!
+  content: String!
+  orderNo: Long!
+  other: Boolean!
+  nextSectionId: ID
+}
+
+"운영진 편집기용 지원 Form 전체 구조. Form 미생성 차수는 exists=false이고 나머지는 비어 있다."
+type RecruitingAdminFormStructure {
+  exists: Boolean!
+  applicationFormId: ID
+  formId: ID
+  title: String
+  description: String
+  status: RecruitingApplicationFormStatus
+  sections: [RecruitingAdminFormSection!]!
+}
+
+type RecruitingAdminFormSection {
+  sectionId: ID!
+  title: String!
+  description: String
+  orderNo: Long!
+  type: RecruitingFormSectionType!
+  track: ChallengerTrack
+  questions: [RecruitingAdminFormQuestion!]!
+}
+
+type RecruitingAdminFormQuestion {
+  questionId: ID!
+  title: String!
+  description: String
+  type: QuestionType!
+  required: Boolean!
+  orderNo: Long!
+  options: [RecruitingAdminFormQuestionOption!]!
+}
+
+type RecruitingAdminFormQuestionOption {
   optionId: ID!
   content: String!
   orderNo: Long!

--- a/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
@@ -12,7 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingApplicationFormUseCase;
+import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruitingRoundStatusCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
@@ -21,7 +23,9 @@ import com.umc.product.recruiting.application.port.out.SaveRecruitingSeasonPort;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
 import com.umc.product.recruiting.domain.RecruitingSeason;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
 import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+import com.umc.product.recruiting.domain.enums.RecruitingRoundStatus;
 import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
 import com.umc.product.support.IntegrationTestSupport;
 
@@ -39,6 +43,9 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
 
     @Autowired
     UpsertRecruitingApplicationFormUseCase upsertApplicationFormUseCase;
+
+    @Autowired
+    UpdateRecruitingRoundStatusUseCase updateRoundStatusUseCase;
 
     @Autowired
     GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
@@ -72,11 +79,16 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
         RecruitingAdminFormStructureInfo.SectionInfo common = structure.sections().get(0);
         assertThat(common.type()).isEqualTo(RecruitingFormSectionType.COMMON);
         assertThat(common.track()).isNull();
+        assertThat(common.orderNo()).isNotNull();
         assertThat(common.questions()).singleElement().satisfies(question -> {
             assertThat(question.title()).isEqualTo("지원 동기");
             assertThat(question.type()).isEqualTo(QuestionType.RADIO);
             assertThat(question.required()).isTrue();
+            assertThat(question.orderNo()).isNotNull();
             assertThat(question.options()).hasSize(2);
+            assertThat(question.options()).allSatisfy(option ->
+                assertThat(option.orderNo()).isNotNull()
+            );
         });
 
         RecruitingAdminFormStructureInfo.SectionInfo track = structure.sections().get(1);
@@ -85,7 +97,14 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
         assertThat(track.questions()).singleElement().satisfies(question -> {
             assertThat(question.title()).isEqualTo("사용 기술");
             assertThat(question.required()).isFalse();
+            assertThat(question.orderNo()).isNotNull();
         });
+
+        // section은 요청 순서대로 복원되어야 편집 화면이 저장 당시 배치를 재현할 수 있다.
+        assertThat(common.orderNo()).isLessThan(track.orderNo());
+        assertThat(common.questions().get(0).options())
+            .extracting(RecruitingAdminFormStructureInfo.OptionInfo::orderNo)
+            .isSorted();
 
         // 조건부 이동은 clientKey가 아니라 저장된 sectionId로 복원된다.
         assertThat(common.questions().get(0).options().get(0).nextSectionId())
@@ -111,6 +130,38 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
         assertThat(structure.applicationFormId()).isNull();
         assertThat(structure.formId()).isNull();
         assertThat(structure.sections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("OPEN 차수의 게시된 Form도 상태와 무관하게 전체 구조를 반환한다")
+    void publishedFormIsStillReadableForEditing() {
+        // Given
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 205L));
+        RecruitingRound round = saveRoundPort.save(
+            RecruitingRound.createRegular(season, "본모집", configuration())
+        );
+        // 게시 검증이 COMMON -> TRACK 조건부 이동을 금지하므로 이동 없는 Form으로 구성한다.
+        upsertApplicationForm(season.getId(), round.getId(), false);
+        updateRoundStatusUseCase.updateRoundStatus(UpdateRecruitingRoundStatusCommand.builder()
+            .seasonId(season.getId())
+            .roundId(round.getId())
+            .status(RecruitingRoundStatus.OPEN)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .build());
+
+        // When
+        RecruitingAdminFormStructureInfo structure =
+            getRecruitingFormQueryUseCase.getAdminFormStructure(season.getId(), round.getId());
+
+        // Then
+        // 공개 조회는 PUBLISHED만 허용하고 지망 트랙으로 section을 걸러내지만,
+        // 편집기 조회는 상태 검증도 트랙 필터링도 하지 않는다.
+        assertThat(structure.exists()).isTrue();
+        assertThat(structure.status()).isEqualTo(RecruitingApplicationFormStatus.PUBLISHED);
+        assertThat(structure.sections()).hasSize(2);
+        assertThat(structure.sections())
+            .extracting(RecruitingAdminFormStructureInfo.SectionInfo::type)
+            .containsExactly(RecruitingFormSectionType.COMMON, RecruitingFormSectionType.TRACK);
     }
 
     @Test
@@ -149,6 +200,10 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
     }
 
     private void upsertApplicationForm(Long seasonId, Long roundId) {
+        upsertApplicationForm(seasonId, roundId, true);
+    }
+
+    private void upsertApplicationForm(Long seasonId, Long roundId, boolean withConditionalTransition) {
         upsertApplicationFormUseCase.upsert(UpsertRecruitingApplicationFormCommand.builder()
             .seasonId(seasonId)
             .roundId(roundId)
@@ -166,7 +221,7 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
                         .options(List.of(
                             UpsertRecruitingApplicationFormCommand.OptionEntry.builder()
                                 .content("파트 문항으로")
-                                .nextSectionKey("track")
+                                .nextSectionKey(withConditionalTransition ? "track" : null)
                                 .build(),
                             UpsertRecruitingApplicationFormCommand.OptionEntry.builder()
                                 .content("이동 없음")

--- a/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.umc.product.integration.recruiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
+import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingApplicationFormUseCase;
+import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
+import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundPort;
+import com.umc.product.recruiting.application.port.out.SaveRecruitingSeasonPort;
+import com.umc.product.recruiting.domain.RecruitingRound;
+import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
+import com.umc.product.recruiting.domain.RecruitingSeason;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
+import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
+import com.umc.product.support.IntegrationTestSupport;
+
+/**
+ * 편집기 왕복(Upsert 저장 -> 조회)이 구조를 그대로 복원하는지 확인한다.
+ * <p>
+ * COMMON/TRACK 정책은 Form 모듈이 아닌 recruiting 쪽에 저장되므로, 서비스 단위 stub으로는
+ * 병합 누락을 잡을 수 없다. 실제 Form 모듈과 DB를 함께 태워야 section 정책, orderNo, 필수 여부,
+ * 조건부 이동 대상이 저장된 그대로 돌아오는지 증명할 수 있다.
+ */
+class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSupport {
+
+    private static final Long REQUESTER_MEMBER_ID = 9101L;
+    private static final ChallengerTrack RECRUITABLE_TRACK = ChallengerTrack.WEB_PRODUCT_ENGINEER;
+
+    @Autowired
+    UpsertRecruitingApplicationFormUseCase upsertApplicationFormUseCase;
+
+    @Autowired
+    GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
+
+    @Autowired
+    SaveRecruitingSeasonPort saveSeasonPort;
+
+    @Autowired
+    SaveRecruitingRoundPort saveRoundPort;
+
+    @Test
+    @DisplayName("Upsert로 저장한 지원 Form 구조는 조회에서 section 정책까지 그대로 복원된다")
+    void upsertThenGetRestoresWholeStructure() {
+        // Given
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 201L));
+        RecruitingRound round = saveRoundPort.save(
+            RecruitingRound.createRegular(season, "본모집", configuration())
+        );
+        upsertApplicationForm(season.getId(), round.getId());
+
+        // When
+        RecruitingAdminFormStructureInfo structure =
+            getRecruitingFormQueryUseCase.getAdminFormStructure(season.getId(), round.getId());
+
+        // Then
+        assertThat(structure.exists()).isTrue();
+        assertThat(structure.applicationFormId()).isNotNull();
+        assertThat(structure.formId()).isNotNull();
+        assertThat(structure.sections()).hasSize(2);
+
+        RecruitingAdminFormStructureInfo.SectionInfo common = structure.sections().get(0);
+        assertThat(common.type()).isEqualTo(RecruitingFormSectionType.COMMON);
+        assertThat(common.track()).isNull();
+        assertThat(common.questions()).singleElement().satisfies(question -> {
+            assertThat(question.title()).isEqualTo("지원 동기");
+            assertThat(question.type()).isEqualTo(QuestionType.RADIO);
+            assertThat(question.required()).isTrue();
+            assertThat(question.options()).hasSize(2);
+        });
+
+        RecruitingAdminFormStructureInfo.SectionInfo track = structure.sections().get(1);
+        assertThat(track.type()).isEqualTo(RecruitingFormSectionType.TRACK);
+        assertThat(track.track()).isEqualTo(RECRUITABLE_TRACK);
+        assertThat(track.questions()).singleElement().satisfies(question -> {
+            assertThat(question.title()).isEqualTo("사용 기술");
+            assertThat(question.required()).isFalse();
+        });
+
+        // 조건부 이동은 clientKey가 아니라 저장된 sectionId로 복원된다.
+        assertThat(common.questions().get(0).options().get(0).nextSectionId())
+            .isEqualTo(track.sectionId());
+        assertThat(common.questions().get(0).options().get(1).nextSectionId()).isNull();
+    }
+
+    @Test
+    @DisplayName("지원 Form을 만들지 않은 차수는 빈 구조를 반환한다")
+    void roundWithoutFormReturnsEmptyStructure() {
+        // Given
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 202L));
+        RecruitingRound round = saveRoundPort.save(
+            RecruitingRound.createRegular(season, "본모집", configuration())
+        );
+
+        // When
+        RecruitingAdminFormStructureInfo structure =
+            getRecruitingFormQueryUseCase.getAdminFormStructure(season.getId(), round.getId());
+
+        // Then
+        assertThat(structure.exists()).isFalse();
+        assertThat(structure.applicationFormId()).isNull();
+        assertThat(structure.formId()).isNull();
+        assertThat(structure.sections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 시즌의 차수 ID로는 지원 Form 구조를 조회할 수 없다")
+    void roundOfAnotherSeasonIsRejected() {
+        // Given
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 203L));
+        RecruitingSeason otherSeason = saveSeasonPort.save(RecruitingSeason.create(9L, 204L));
+        RecruitingRound round = saveRoundPort.save(
+            RecruitingRound.createRegular(season, "본모집", configuration())
+        );
+        upsertApplicationForm(season.getId(), round.getId());
+
+        // When & Then
+        assertThatThrownBy(() ->
+            getRecruitingFormQueryUseCase.getAdminFormStructure(otherSeason.getId(), round.getId())
+        ).isInstanceOf(RecruitingDomainException.class);
+    }
+
+    private RecruitingRoundConfiguration configuration() {
+        return RecruitingRoundConfiguration.of(
+            List.of(RECRUITABLE_TRACK),
+            false,
+            Instant.parse("2026-08-01T00:00:00Z"),
+            Instant.parse("2026-08-08T00:00:00Z"),
+            Instant.parse("2026-08-10T00:00:00Z"),
+            false,
+            null,
+            null,
+            Instant.parse("2026-08-16T00:00:00Z"),
+            null,
+            null,
+            "안내",
+            "연락처"
+        );
+    }
+
+    private void upsertApplicationForm(Long seasonId, Long roundId) {
+        upsertApplicationFormUseCase.upsert(UpsertRecruitingApplicationFormCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .description("지원서")
+            .sections(List.of(
+                UpsertRecruitingApplicationFormCommand.SectionEntry.builder()
+                    .clientKey("common")
+                    .title("공통")
+                    .type(RecruitingFormSectionType.COMMON)
+                    .questions(List.of(UpsertRecruitingApplicationFormCommand.QuestionEntry.builder()
+                        .type(QuestionType.RADIO)
+                        .title("지원 동기")
+                        .required(true)
+                        .options(List.of(
+                            UpsertRecruitingApplicationFormCommand.OptionEntry.builder()
+                                .content("파트 문항으로")
+                                .nextSectionKey("track")
+                                .build(),
+                            UpsertRecruitingApplicationFormCommand.OptionEntry.builder()
+                                .content("이동 없음")
+                                .build()
+                        ))
+                        .build()))
+                    .build(),
+                UpsertRecruitingApplicationFormCommand.SectionEntry.builder()
+                    .clientKey("track")
+                    .title("파트 문항")
+                    .type(RecruitingFormSectionType.TRACK)
+                    .track(RECRUITABLE_TRACK)
+                    .questions(List.of(UpsertRecruitingApplicationFormCommand.QuestionEntry.builder()
+                        .type(QuestionType.SHORT_TEXT)
+                        .title("사용 기술")
+                        .required(false)
+                        .build()))
+                    .build()
+            ))
+            .build());
+    }
+}

--- a/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/recruiting/RecruitingAdminFormStructureQueryIntegrationTest.java
@@ -30,7 +30,7 @@ import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
 import com.umc.product.support.IntegrationTestSupport;
 
 /**
- * 편집기 왕복(Upsert 저장 -> 조회)이 구조를 그대로 복원하는지 확인한다.
+ * 편집기 왕복(Upsert 저장 -> 조회 -> Upsert)이 구조를 그대로 유지하는지 확인한다.
  * <p>
  * COMMON/TRACK 정책은 Form 모듈이 아닌 recruiting 쪽에 저장되므로, 서비스 단위 stub으로는
  * 병합 누락을 잡을 수 없다. 실제 Form 모듈과 DB를 함께 태워야 section 정책, orderNo, 필수 여부,
@@ -106,10 +106,54 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
             .extracting(RecruitingAdminFormStructureInfo.OptionInfo::orderNo)
             .isSorted();
 
-        // 조건부 이동은 clientKey가 아니라 저장된 sectionId로 복원된다.
-        assertThat(common.questions().get(0).options().get(0).nextSectionId())
-            .isEqualTo(track.sectionId());
-        assertThat(common.questions().get(0).options().get(1).nextSectionId()).isNull();
+        // 조건부 이동은 저장된 ID와 PUT에 바로 사용할 수 있는 결정적 key를 함께 반환한다.
+        assertThat(common.clientKey()).isEqualTo("section-" + common.sectionId());
+        assertThat(track.clientKey()).isEqualTo("section-" + track.sectionId());
+        assertThat(common.questions().get(0).options().get(0))
+            .satisfies(option -> {
+                assertThat(option.nextSectionId()).isEqualTo(track.sectionId());
+                assertThat(option.nextSectionKey()).isEqualTo(track.clientKey());
+            });
+        assertThat(common.questions().get(0).options().get(1))
+            .satisfies(option -> {
+                assertThat(option.nextSectionId()).isNull();
+                assertThat(option.nextSectionKey()).isNull();
+            });
+    }
+
+    @Test
+    @DisplayName("조회한 지원 Form 구조를 다시 Upsert해도 section과 조건부 이동이 유지된다")
+    void getThenUpsertPreservesStructureAndConditionalTransition() {
+        // Given
+        RecruitingSeason season = saveSeasonPort.save(RecruitingSeason.create(9L, 206L));
+        RecruitingRound round = saveRoundPort.save(
+            RecruitingRound.createRegular(season, "본모집", configuration())
+        );
+        upsertApplicationForm(season.getId(), round.getId());
+
+        // When
+        RecruitingAdminFormStructureInfo loaded =
+            getRecruitingFormQueryUseCase.getAdminFormStructure(season.getId(), round.getId());
+        upsertApplicationFormUseCase.upsert(commandFrom(season.getId(), round.getId(), loaded));
+        RecruitingAdminFormStructureInfo reloaded =
+            getRecruitingFormQueryUseCase.getAdminFormStructure(season.getId(), round.getId());
+
+        // Then
+        assertThat(reloaded.sections())
+            .extracting(
+                RecruitingAdminFormStructureInfo.SectionInfo::sectionId,
+                RecruitingAdminFormStructureInfo.SectionInfo::clientKey
+            )
+            .containsExactlyElementsOf(loaded.sections().stream()
+                .map(section -> org.assertj.core.groups.Tuple.tuple(section.sectionId(), section.clientKey()))
+                .toList());
+        RecruitingAdminFormStructureInfo.SectionInfo common = reloaded.sections().getFirst();
+        RecruitingAdminFormStructureInfo.SectionInfo track = reloaded.sections().get(1);
+        assertThat(common.questions().getFirst().options().getFirst())
+            .satisfies(option -> {
+                assertThat(option.nextSectionId()).isEqualTo(track.sectionId());
+                assertThat(option.nextSectionKey()).isEqualTo(track.clientKey());
+            });
     }
 
     @Test
@@ -242,5 +286,59 @@ class RecruitingAdminFormStructureQueryIntegrationTest extends IntegrationTestSu
                     .build()
             ))
             .build());
+    }
+
+    private UpsertRecruitingApplicationFormCommand commandFrom(
+        Long seasonId,
+        Long roundId,
+        RecruitingAdminFormStructureInfo structure
+    ) {
+        return UpsertRecruitingApplicationFormCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .requesterMemberId(REQUESTER_MEMBER_ID)
+            .description(structure.description())
+            .sections(structure.sections().stream()
+                .map(this::toSectionEntry)
+                .toList())
+            .build();
+    }
+
+    private UpsertRecruitingApplicationFormCommand.SectionEntry toSectionEntry(
+        RecruitingAdminFormStructureInfo.SectionInfo section
+    ) {
+        return UpsertRecruitingApplicationFormCommand.SectionEntry.builder()
+            .sectionId(section.sectionId())
+            .clientKey(section.clientKey())
+            .title(section.title())
+            .description(section.description())
+            .type(section.type())
+            .track(section.track())
+            .questions(section.questions().stream().map(this::toQuestionEntry).toList())
+            .build();
+    }
+
+    private UpsertRecruitingApplicationFormCommand.QuestionEntry toQuestionEntry(
+        RecruitingAdminFormStructureInfo.QuestionInfo question
+    ) {
+        return UpsertRecruitingApplicationFormCommand.QuestionEntry.builder()
+            .questionId(question.questionId())
+            .type(question.type())
+            .title(question.title())
+            .description(question.description())
+            .required(question.required())
+            .options(question.options().stream().map(this::toOptionEntry).toList())
+            .build();
+    }
+
+    private UpsertRecruitingApplicationFormCommand.OptionEntry toOptionEntry(
+        RecruitingAdminFormStructureInfo.OptionInfo option
+    ) {
+        return UpsertRecruitingApplicationFormCommand.OptionEntry.builder()
+            .optionId(option.optionId())
+            .content(option.content())
+            .other(option.other())
+            .nextSectionKey(option.nextSectionKey())
+            .build();
     }
 }

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
 import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.global.config.GraphQlRuntimeWiringConfig;
 import com.umc.product.global.exception.GraphQlExceptionAdvice;
 import com.umc.product.global.security.CurrentMemberProvider;
@@ -123,11 +124,25 @@ class RecruitingRoundAdminGraphQlControllerTest {
                 .status(RecruitingApplicationFormStatus.DRAFT)
                 .sections(List.of(RecruitingAdminFormStructureInfo.SectionInfo.builder()
                     .sectionId(300L)
+                    .clientKey("section-300")
                     .title("PLAN 파트")
                     .orderNo(1L)
                     .type(RecruitingFormSectionType.TRACK)
                     .track(ChallengerTrack.PLAN)
-                    .questions(List.of())
+                    .questions(List.of(RecruitingAdminFormStructureInfo.QuestionInfo.builder()
+                        .questionId(400L)
+                        .title("지원 동기")
+                        .type(QuestionType.LONG_TEXT)
+                        .required(true)
+                        .orderNo(1L)
+                        .options(List.of(RecruitingAdminFormStructureInfo.OptionInfo.builder()
+                            .optionId(500L)
+                            .content("다음")
+                            .orderNo(1L)
+                            .nextSectionId(300L)
+                            .nextSectionKey("section-300")
+                            .build()))
+                        .build()))
                     .build()))
                 .build());
 
@@ -137,15 +152,26 @@ class RecruitingRoundAdminGraphQlControllerTest {
                     exists
                     applicationFormId
                     status
-                    sections { sectionId type track }
+                    sections {
+                      sectionId
+                      clientKey
+                      type
+                      track
+                      questions { options { nextSectionId nextSectionKey } }
+                    }
                   }
                 }
                 """)
             .execute()
             .path("recruitingAdminFormStructure.exists").entity(Boolean.class).isEqualTo(true)
             .path("recruitingAdminFormStructure.applicationFormId").entity(String.class).isEqualTo("30")
+            .path("recruitingAdminFormStructure.sections[0].clientKey").entity(String.class).isEqualTo("section-300")
             .path("recruitingAdminFormStructure.sections[0].type").entity(String.class).isEqualTo("TRACK")
-            .path("recruitingAdminFormStructure.sections[0].track").entity(String.class).isEqualTo("PLAN");
+            .path("recruitingAdminFormStructure.sections[0].track").entity(String.class).isEqualTo("PLAN")
+            .path("recruitingAdminFormStructure.sections[0].questions[0].options[0].nextSectionId")
+            .entity(String.class).isEqualTo("300")
+            .path("recruitingAdminFormStructure.sections[0].questions[0].options[0].nextSectionKey")
+            .entity(String.class).isEqualTo("section-300");
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
+import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.global.config.GraphQlRuntimeWiringConfig;
 import com.umc.product.global.exception.GraphQlExceptionAdvice;
 import com.umc.product.global.security.CurrentMemberProvider;
@@ -39,11 +40,15 @@ import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruiti
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonConfigurationUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingDecisionHistoryUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingSeasonUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
 
 @GraphQlTest(RecruitingAdminGraphQlController.class)
 @Import({
@@ -88,6 +93,8 @@ class RecruitingRoundAdminGraphQlControllerTest {
     @MockitoBean
     UpdateRecruitingRoundUseCase updateRoundUseCase;
     @MockitoBean
+    GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
+    @MockitoBean
     CheckPermissionUseCase checkPermissionUseCase;
     @MockitoBean
     CurrentMemberProvider currentMemberProvider;
@@ -102,6 +109,64 @@ class RecruitingRoundAdminGraphQlControllerTest {
     @AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("GraphQL 지원 Form 구조 조회는 section 정책을 함께 반환한다")
+    void recruitingAdminFormStructure() {
+        given(getRecruitingFormQueryUseCase.getAdminFormStructure(10L, 20L))
+            .willReturn(RecruitingAdminFormStructureInfo.builder()
+                .exists(true)
+                .applicationFormId(30L)
+                .formId(100L)
+                .title("15기 본모집")
+                .status(RecruitingApplicationFormStatus.DRAFT)
+                .sections(List.of(RecruitingAdminFormStructureInfo.SectionInfo.builder()
+                    .sectionId(300L)
+                    .title("PLAN 파트")
+                    .orderNo(1L)
+                    .type(RecruitingFormSectionType.TRACK)
+                    .track(ChallengerTrack.PLAN)
+                    .questions(List.of())
+                    .build()))
+                .build());
+
+        graphQlTester.document("""
+                query {
+                  recruitingAdminFormStructure(seasonId: 10, roundId: 20) {
+                    exists
+                    applicationFormId
+                    status
+                    sections { sectionId type track }
+                  }
+                }
+                """)
+            .execute()
+            .path("recruitingAdminFormStructure.exists").entity(Boolean.class).isEqualTo(true)
+            .path("recruitingAdminFormStructure.applicationFormId").entity(String.class).isEqualTo("30")
+            .path("recruitingAdminFormStructure.sections[0].type").entity(String.class).isEqualTo("TRACK")
+            .path("recruitingAdminFormStructure.sections[0].track").entity(String.class).isEqualTo("PLAN");
+    }
+
+    @Test
+    @DisplayName("GraphQL 지원 Form 구조 조회는 Form 미생성 차수에 빈 구조를 반환한다")
+    void recruitingAdminFormStructureEmpty() {
+        given(getRecruitingFormQueryUseCase.getAdminFormStructure(10L, 20L))
+            .willReturn(RecruitingAdminFormStructureInfo.empty());
+
+        graphQlTester.document("""
+                query {
+                  recruitingAdminFormStructure(seasonId: 10, roundId: 20) {
+                    exists
+                    applicationFormId
+                    sections { sectionId }
+                  }
+                }
+                """)
+            .execute()
+            .path("recruitingAdminFormStructure.exists").entity(Boolean.class).isEqualTo(false)
+            .path("recruitingAdminFormStructure.applicationFormId").valueIsNull()
+            .path("recruitingAdminFormStructure.sections").entityList(Object.class).hasSize(0);
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
@@ -45,6 +45,7 @@ import com.umc.product.recruiting.application.port.in.command.dto.ReplaceRecruit
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonConfigurationUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingDecisionHistoryUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
@@ -116,6 +117,8 @@ class RecruitingSeasonAdminGraphQlControllerTest {
     UpdateRecruitingRoundStatusUseCase updateRoundStatusUseCase;
     @MockitoBean
     UpdateRecruitingRoundUseCase updateRoundUseCase;
+    @MockitoBean
+    GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
     @MockitoBean
     CheckPermissionUseCase checkPermissionUseCase;
     @MockitoBean

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
@@ -197,6 +197,7 @@ class RecruitingAdminControllerTest {
                 .status(RecruitingApplicationFormStatus.DRAFT)
                 .sections(List.of(RecruitingAdminFormStructureInfo.SectionInfo.builder()
                     .sectionId(300L)
+                    .clientKey("section-300")
                     .title("PLAN 파트")
                     .orderNo(1L)
                     .type(RecruitingFormSectionType.TRACK)
@@ -207,7 +208,13 @@ class RecruitingAdminControllerTest {
                         .type(QuestionType.LONG_TEXT)
                         .required(true)
                         .orderNo(1L)
-                        .options(List.of())
+                        .options(List.of(RecruitingAdminFormStructureInfo.OptionInfo.builder()
+                            .optionId(500L)
+                            .content("다음")
+                            .orderNo(1L)
+                            .nextSectionId(300L)
+                            .nextSectionKey("section-300")
+                            .build()))
                         .build()))
                     .build()))
                 .build());
@@ -219,8 +226,11 @@ class RecruitingAdminControllerTest {
             .andExpect(jsonPath("$.result.status").value("DRAFT"))
             .andExpect(jsonPath("$.result.sections[0].type").value("TRACK"))
             .andExpect(jsonPath("$.result.sections[0].track").value("PLAN"))
+            .andExpect(jsonPath("$.result.sections[0].clientKey").value("section-300"))
             .andExpect(jsonPath("$.result.sections[0].questions[0].required").value(true))
-            .andExpect(jsonPath("$.result.sections[0].questions[0].orderNo").value(1));
+            .andExpect(jsonPath("$.result.sections[0].questions[0].orderNo").value(1))
+            .andExpect(jsonPath("$.result.sections[0].questions[0].options[0].nextSectionId").value(300))
+            .andExpect(jsonPath("$.result.sections[0].questions[0].options[0].nextSectionKey").value("section-300"));
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingAdminControllerTest.java
@@ -37,6 +37,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
 import com.umc.product.global.security.MemberPrincipal;
@@ -61,9 +62,11 @@ import com.umc.product.recruiting.application.port.in.query.ExportRecruitingCsvU
 import com.umc.product.recruiting.application.port.in.query.ExportRecruitingDecisionHistoryCsvUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
+import com.umc.product.recruiting.application.port.in.query.GetRecruitingFormQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingInterviewScheduleBoardUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingInterviewSessionUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingDecisionHistoryUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingChapterEvaluationStatisticsInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingDecisionHistoryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingDecisionHistoryPageInfo;
@@ -76,10 +79,12 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchool
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingTrackEvaluationCountInfo;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationFormStatus;
 import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
 import com.umc.product.recruiting.domain.enums.RecruitingDecisionHistorySortOrder;
 import com.umc.product.recruiting.domain.enums.RecruitingDecisionResult;
 import com.umc.product.recruiting.domain.enums.RecruitingEvaluationProgressStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingFormSectionType;
 import com.umc.product.support.RestDocsConfig;
 
 @WebMvcTest(controllers = {RecruitingAdminController.class, RecruitingAdminInterviewController.class})
@@ -139,6 +144,8 @@ class RecruitingAdminControllerTest {
     ExportRecruitingDecisionHistoryCsvUseCase exportDecisionHistoryCsvUseCase;
     @MockitoBean
     UpsertRecruitingApplicationFormUseCase upsertFormUseCase;
+    @MockitoBean
+    GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
 
     @BeforeEach
     void setUpSecurityContext() {
@@ -175,6 +182,58 @@ class RecruitingAdminControllerTest {
         assertThat(captor.getValue().seasonId()).isEqualTo(SEASON_ID);
         assertThat(captor.getValue().roundId()).isEqualTo(ROUND_ID);
         assertThat(captor.getValue().requesterMemberId()).isEqualTo(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("모집 폼 조회 API는 section 정책과 question 구조를 함께 반환한다")
+    void 모집_폼_조회_API는_section_정책과_question_구조를_함께_반환한다() throws Exception {
+        given(getRecruitingFormQueryUseCase.getAdminFormStructure(SEASON_ID, ROUND_ID))
+            .willReturn(RecruitingAdminFormStructureInfo.builder()
+                .exists(true)
+                .applicationFormId(APPLICATION_FORM_ID)
+                .formId(100L)
+                .title("15기 본모집")
+                .description("지원서")
+                .status(RecruitingApplicationFormStatus.DRAFT)
+                .sections(List.of(RecruitingAdminFormStructureInfo.SectionInfo.builder()
+                    .sectionId(300L)
+                    .title("PLAN 파트")
+                    .orderNo(1L)
+                    .type(RecruitingFormSectionType.TRACK)
+                    .track(ChallengerTrack.PLAN)
+                    .questions(List.of(RecruitingAdminFormStructureInfo.QuestionInfo.builder()
+                        .questionId(400L)
+                        .title("지원 동기")
+                        .type(QuestionType.LONG_TEXT)
+                        .required(true)
+                        .orderNo(1L)
+                        .options(List.of())
+                        .build()))
+                    .build()))
+                .build());
+
+        mockMvc.perform(get("/api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/form", SEASON_ID, ROUND_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.exists").value(true))
+            .andExpect(jsonPath("$.result.applicationFormId").value(APPLICATION_FORM_ID))
+            .andExpect(jsonPath("$.result.status").value("DRAFT"))
+            .andExpect(jsonPath("$.result.sections[0].type").value("TRACK"))
+            .andExpect(jsonPath("$.result.sections[0].track").value("PLAN"))
+            .andExpect(jsonPath("$.result.sections[0].questions[0].required").value(true))
+            .andExpect(jsonPath("$.result.sections[0].questions[0].orderNo").value(1));
+    }
+
+    @Test
+    @DisplayName("모집 폼 조회 API는 Form을 만들지 않은 차수에 빈 구조를 반환한다")
+    void 모집_폼_조회_API는_Form을_만들지_않은_차수에_빈_구조를_반환한다() throws Exception {
+        given(getRecruitingFormQueryUseCase.getAdminFormStructure(SEASON_ID, ROUND_ID))
+            .willReturn(RecruitingAdminFormStructureInfo.empty());
+
+        mockMvc.perform(get("/api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/form", SEASON_ID, ROUND_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.exists").value(false))
+            .andExpect(jsonPath("$.result.applicationFormId").doesNotExist())
+            .andExpect(jsonPath("$.result.sections").isEmpty());
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRestContractTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRestContractTest.java
@@ -86,6 +86,7 @@ class RecruitingRestContractTest {
                 "RECRUITING-ADMIN-016",
                 "RECRUITING-ADMIN-017",
                 "RECRUITING-ADMIN-021",
+                "RECRUITING-ADMIN-022",
                 "RECRUITING-ADMIN-031",
                 "RECRUITING-ADMIN-032",
                 "RECRUITING-ADMIN-033",

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingQueryServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +29,7 @@ import com.umc.product.form.domain.enums.QuestionType;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQuestionScopeUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingAdminFormStructureInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationQuestionScopeInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
@@ -36,10 +38,12 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatus
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingStatusSummaryQuery;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingFormSectionPolicyPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.application.port.out.dto.RecruitingApplicationSummaryRow;
 import com.umc.product.recruiting.domain.RecruitingApplicationForm;
+import com.umc.product.recruiting.domain.RecruitingFormSectionPolicy;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
 import com.umc.product.recruiting.domain.RecruitingSeason;
@@ -58,6 +62,9 @@ class RecruitingQueryServiceTest {
 
     @Mock
     LoadRecruitingApplicationFormPort loadApplicationFormPort;
+
+    @Mock
+    LoadRecruitingFormSectionPolicyPort loadFormSectionPolicyPort;
 
     @Mock
     LoadRecruitingRoundPort loadRoundPort;
@@ -498,6 +505,57 @@ class RecruitingQueryServiceTest {
                 .extracting(FormWithStructureInfo.Option::optionId)
                 .containsExactly(101L)
         );
+    }
+
+    @Test
+    @DisplayName("운영진 지원 Form 구조는 PUT 요청에 필요한 결정적 section key를 반환한다")
+    void adminFormStructureProvidesRoundTripKeys() {
+        // Given
+        RecruitingSeason season = RecruitingSeason.create(1L, 10L);
+        ReflectionTestUtils.setField(season, "id", 1L);
+        RecruitingRound round = RecruitingRound.createRegular(season, RecruitingRoundConfiguration.of(
+            List.of(ChallengerTrack.PLAN),
+            true,
+            Instant.parse("2026-08-01T00:00:00Z"),
+            Instant.parse("2026-08-08T00:00:00Z"),
+            Instant.parse("2026-08-10T00:00:00Z"),
+            false,
+            null,
+            null,
+            Instant.parse("2026-08-16T00:00:00Z"),
+            null,
+            null,
+            null
+        ));
+        RecruitingApplicationForm applicationForm = RecruitingApplicationForm.create(round, 500L);
+        ReflectionTestUtils.setField(applicationForm, "id", 100L);
+        given(loadRoundPort.getById(20L)).willReturn(round);
+        given(loadApplicationFormPort.findByRoundId(20L)).willReturn(Optional.of(applicationForm));
+        given(getFormUseCase.getFormWithStructure(500L)).willReturn(FormWithStructureInfo.builder()
+            .formId(500L)
+            .sections(List.of(
+                section(11L, 101L, List.of(option(1001L, "다음", 12L))),
+                section(12L, 22L, List.of())
+            ))
+            .build());
+        given(loadFormSectionPolicyPort.listByApplicationFormId(100L)).willReturn(List.of(
+            RecruitingFormSectionPolicy.createCommon(applicationForm, 11L),
+            RecruitingFormSectionPolicy.createCommon(applicationForm, 12L)
+        ));
+
+        // When
+        var result = sut.getAdminFormStructure(1L, 20L);
+
+        // Then
+        assertThat(result.sections())
+            .extracting(RecruitingAdminFormStructureInfo.SectionInfo::clientKey)
+            .containsExactly("section-11", "section-12");
+        assertThat(result.sections().getFirst().questions().getFirst().options().getFirst())
+            .extracting(
+                RecruitingAdminFormStructureInfo.OptionInfo::nextSectionId,
+                RecruitingAdminFormStructureInfo.OptionInfo::nextSectionKey
+            )
+            .containsExactly(12L, "section-12");
     }
 
     private FormWithStructureInfo.SectionWithQuestions section(


### PR DESCRIPTION

## 🚀 작업 내용

closes #1231

DRAFT 공고를 편집 화면에서 다시 불러오려면 저장된 Form이 필요한데 해당 경로에 PUT만 있습니다. 해당 API를 추가했습니다.

- REST: `GET /api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/form` 
- GraphQL: `recruitingAdminFormStructure(seasonId, roundId)` 
- 권한: `@CheckAccess(RECRUITMENT, #seasonId, READ)` 

### 변경 사항

- **조회 UseCase 추가**: `GetRecruitingFormQueryUseCase#getAdminFormStructure`, `RecruitingQueryService`에 구현
- **section 정책 병합**:  `type`(COMMON/TRACK) · `track`은 `RecruitingFormSectionPolicy`에 따로 저장돼 있어 `formSectionId` 기준으로 합침 (`cloneForm`과 동일 방식)
- **응답 DTO**: REST · GraphQL 각각 추가, Upsert 요청과 대칭 구조 (`orderNo` · 필수 여부 · 조건부 이동 포함)

### 참고

- 공개용 `GET /forms/{applicationFormId}/structure`는 `PUBLISHED`가 아니면 예외를 던지고 지망 트랙으로 section을 걸러내 대체 불가입니다.
- `@CheckAccess`가 `seasonId`만 보므로 round의 시즌 소속을 별도 검증해 권한 우회를 막았습니다.
