### PR TITLE
[Feat] 로그인 회원 본인 모집 지원 내역 조회 API 추가

### DIFF
--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -179,6 +179,9 @@ operation::recruiting-admin-controller-test/평가_현황_집계_api는_지부_�
 
 == Recruiting application
 
+=== get-my-applications-uses-authenticated-member
+operation::recruiting-application-controller-test/get-my-applications-uses-authenticated-member[snippets='http-request,http-response']
+
 === create-draft-uses-authenticated-actor
 operation::recruiting-application-controller-test/create-draft-uses-authenticated-actor[snippets='http-request,http-response']
 
@@ -348,4 +351,3 @@ operation::umc-product-squad-controller-documentation-test/umc_product_-squad를
 
 === 제거된_-squad_참여자_전체_교체_api는_404를_반환한다
 operation::umc-product-squad-controller-documentation-test/제거된_-squad_참여자_전체_교체_api는_404를_반환한다[snippets='http-request,http-response']
-

--- a/docs/onboarding/recruiting/README.md
+++ b/docs/onboarding/recruiting/README.md
@@ -91,6 +91,8 @@ OPEN Round에서 면접을 껐다 다시 켜면 승계할 값이 없으므로 �
 
 - 로그인 지원자는 CurrentMember로 초안 생성, 수정, 제출, 철회를 수행한다.
 - 익명 지원자는 생성 시 한 번 받은 `applicationKey`와 email로 조회, 수정, 제출, 철회를 수행한다.
+- 회원·익명 지원서 조회 응답은 `gisuId`와 `roundId`를 제공하며, 화면에 필요한 모집 정보는 공개 모집 목록 API의
+  `roundIds` 필터로 분리 조회한다.
 - credential은 URL에 넣지 않고 body 또는 GraphQL variables로 전달한다.
 - credential 조회·수정·제출·철회는 client IP 기준 동일한 분당 5회 bucket을 공유한다.
 - 제출 완료 지원서도 접수 종료 전에는 Form scope를 유지해 수정할 수 있다.

--- a/docs/onboarding/recruiting/README.md
+++ b/docs/onboarding/recruiting/README.md
@@ -130,6 +130,7 @@ Form `021`, evaluator `031~033`, 질문 `041~048`, 일정 `051~052`, 판정 `061
 | PUT | `/api/v1/recruiting/public/applications` | 익명 지원서 수정 |
 | POST | `/api/v1/recruiting/public/applications/submit` | 익명 지원서 제출 |
 | POST | `/api/v1/recruiting/public/applications/cancel` | 익명 지원서 철회 |
+| GET | `/api/v1/recruiting/applications` | 로그인 회원 본인 지원 내역 조회. 비회원 조회와 동일한 결과 공개 정책 적용 |
 | POST | `/api/v1/recruiting/applications` | 로그인 지원서 초안 생성 |
 | PUT | `/api/v1/recruiting/applications/{applicationId}` | 로그인 지원서 수정 |
 | POST | `/api/v1/recruiting/applications/{applicationId}/submit` | 로그인 지원서 제출 |

--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingPublicApplicationGraphQlResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingPublicApplicationGraphQlResponse.java
@@ -10,6 +10,8 @@ import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
 
 public record RecruitingPublicApplicationGraphQlResponse(
     Long applicationId,
+    Long gisuId,
+    Long roundId,
     String applicantName,
     String applicantEmail,
     ChallengerTrack firstChoice,
@@ -26,6 +28,8 @@ public record RecruitingPublicApplicationGraphQlResponse(
     public static RecruitingPublicApplicationGraphQlResponse from(RecruitingPublicApplicationInfo info) {
         return new RecruitingPublicApplicationGraphQlResponse(
             info.applicationId(),
+            info.gisuId(),
+            info.roundId(),
             info.applicantName(),
             info.applicantEmail(),
             info.firstChoice(),

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationController.java
@@ -1,6 +1,9 @@
 package com.umc.product.recruiting.adapter.in.web;
 
+import java.util.List;
+
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,10 +20,12 @@ import com.umc.product.recruiting.adapter.in.web.dto.request.SubmitRecruitingApp
 import com.umc.product.recruiting.adapter.in.web.dto.request.UpdateRecruitingApplicationDraftRequest;
 import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingApplicationCreatedResponse;
 import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingApplicationResponse;
+import com.umc.product.recruiting.adapter.in.web.dto.response.RecruitingPublicApplicationResponse;
 import com.umc.product.recruiting.application.port.in.command.CancelRecruitingApplicationUseCase;
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingApplicationDraftUseCase;
 import com.umc.product.recruiting.application.port.in.command.SubmitRecruitingApplicationUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingApplicationDraftUseCase;
+import com.umc.product.recruiting.application.port.in.query.ListMyRecruitingApplicationsUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,6 +46,22 @@ public class RecruitingApplicationController {
     private final UpdateRecruitingApplicationDraftUseCase updateDraftUseCase;
     private final SubmitRecruitingApplicationUseCase submitUseCase;
     private final CancelRecruitingApplicationUseCase cancelUseCase;
+    private final ListMyRecruitingApplicationsUseCase listMyApplicationsUseCase;
+
+    @GetMapping
+    @Operation(
+        operationId = "RECRUITING-APPLICATION-005",
+        summary = "본인 지원 내역 조회",
+        description = "로그인 회원의 전체 모집 지원 내역을 조회합니다. 응답과 결과 공개 시점은 비회원 지원서 조회와 동일합니다."
+    )
+    public List<RecruitingPublicApplicationResponse> getMyApplications(
+        @Parameter(hidden = true)
+        @CurrentMember MemberPrincipal memberPrincipal
+    ) {
+        return listMyApplicationsUseCase.listMyApplications(resolveMemberId(memberPrincipal)).stream()
+            .map(RecruitingPublicApplicationResponse::from)
+            .toList();
+    }
 
     @PostMapping
     @Operation(

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingPublicApplicationResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingPublicApplicationResponse.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "지원자가 본인 인증 후 조회한 지원서")
 public record RecruitingPublicApplicationResponse(
     @Schema(description = "지원서 ID", example = "100") Long applicationId,
+    @Schema(description = "지원 모집 기수 ID", example = "11") Long gisuId,
+    @Schema(description = "지원 모집 차수 ID", example = "20") Long roundId,
     @Schema(description = "지원자 이름", example = "홍길동") String applicantName,
     @Schema(description = "정규화된 지원자 이메일", example = "applicant@example.org") String applicantEmail,
     @Schema(description = "1지망 모집 트랙", example = "PLAN") ChallengerTrack firstChoice,
@@ -29,6 +31,8 @@ public record RecruitingPublicApplicationResponse(
     public static RecruitingPublicApplicationResponse from(RecruitingPublicApplicationInfo info) {
         return new RecruitingPublicApplicationResponse(
             info.applicationId(),
+            info.gisuId(),
+            info.roundId(),
             info.applicantName(),
             info.applicantEmail(),
             info.firstChoice(),

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingPublicApplicationResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingPublicApplicationResponse.java
@@ -10,7 +10,7 @@ import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "익명 지원자가 자격 증명으로 조회한 지원서")
+@Schema(description = "지원자가 본인 인증 후 조회한 지원서")
 public record RecruitingPublicApplicationResponse(
     @Schema(description = "지원서 ID", example = "100") Long applicationId,
     @Schema(description = "지원자 이름", example = "홍길동") String applicantName,

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationPersistenceAdapter.java
@@ -74,6 +74,11 @@ public class RecruitingApplicationPersistenceAdapter
     }
 
     @Override
+    public List<RecruitingApplication> listByApplicantMemberId(Long applicantMemberId) {
+        return recruitingApplicationQueryRepository.listByApplicantMemberId(applicantMemberId);
+    }
+
+    @Override
     public RecruitingApplicantLockTarget getApplicantLockTarget(Long id) {
         return recruitingApplicationQueryRepository.findApplicantLockTarget(id)
             .orElseThrow(() -> new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND));

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationQueryRepository.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationQueryRepository.java
@@ -54,6 +54,17 @@ public class RecruitingApplicationQueryRepository {
         return Optional.ofNullable(result);
     }
 
+    public List<RecruitingApplication> listByApplicantMemberId(Long applicantMemberId) {
+        return queryFactory
+            .selectFrom(recruitingApplication)
+            .innerJoin(recruitingApplication.applicationForm, recruitingApplicationForm).fetchJoin()
+            .innerJoin(recruitingApplicationForm.round, recruitingRound).fetchJoin()
+            .innerJoin(recruitingRound.season, recruitingSeason).fetchJoin()
+            .where(recruitingApplication.applicantMemberId.eq(applicantMemberId))
+            .orderBy(recruitingApplication.id.desc())
+            .fetch();
+    }
+
     public Optional<RecruitingApplication> findByIdForUpdate(Long id) {
         RecruitingApplication result = queryFactory
             .selectFrom(recruitingApplication)

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/ListMyRecruitingApplicationsUseCase.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/ListMyRecruitingApplicationsUseCase.java
@@ -1,0 +1,10 @@
+package com.umc.product.recruiting.application.port.in.query;
+
+import java.util.List;
+
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicApplicationInfo;
+
+public interface ListMyRecruitingApplicationsUseCase {
+
+    List<RecruitingPublicApplicationInfo> listMyApplications(Long requesterMemberId);
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingPublicApplicationInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingPublicApplicationInfo.java
@@ -13,6 +13,8 @@ import lombok.Builder;
 @Builder
 public record RecruitingPublicApplicationInfo(
     Long applicationId,
+    Long gisuId,
+    Long roundId,
     String applicantName,
     String applicantEmail,
     ChallengerTrack firstChoice,

--- a/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingApplicationPort.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingApplicationPort.java
@@ -30,6 +30,8 @@ public interface LoadRecruitingApplicationPort {
 
     RecruitingApplication getByIdWithDetailsForUpdate(Long id);
 
+    List<RecruitingApplication> listByApplicantMemberId(Long applicantMemberId);
+
     RecruitingApplicantLockTarget getApplicantLockTarget(Long id);
 
     Long getRoundIdByApplicationId(Long id);

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingApplicationViewFactory.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingApplicationViewFactory.java
@@ -34,6 +34,8 @@ final class RecruitingApplicationViewFactory {
         RecruitingPublicResultStatus finalResult = resolveFinalResult(application.getStatus(), round, now);
         return RecruitingPublicApplicationInfo.builder()
             .applicationId(application.getId())
+            .gisuId(round.getSeason().getGisuId())
+            .roundId(round.getId())
             .applicantName(application.getApplicantName())
             .applicantEmail(application.getApplicantEmail())
             .firstChoice(application.getFirstChoice())

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingApplicationViewFactory.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingApplicationViewFactory.java
@@ -1,0 +1,99 @@
+package com.umc.product.recruiting.application.service.query;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import com.umc.product.form.application.port.in.query.dto.FormResponseWithAnswersInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicApplicationInfo;
+import com.umc.product.recruiting.domain.RecruitingApplication;
+import com.umc.product.recruiting.domain.RecruitingRound;
+import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
+import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
+import com.umc.product.recruiting.domain.exception.RecruitingErrorCode;
+
+/**
+ * 지원자에게 공개하는 지원서 조회 정보를 생성한다.
+ * <p>
+ * 회원/비회원 조회 경로가 동일한 결과 공개 시각과 응답 표현을 사용하도록 공개 정책을 한곳에서 관리한다.
+ */
+final class RecruitingApplicationViewFactory {
+
+    private RecruitingApplicationViewFactory() {
+    }
+
+    static RecruitingPublicApplicationInfo create(
+        RecruitingApplication application,
+        FormResponseWithAnswersInfo formResponse,
+        Instant now
+    ) {
+        validateLinkedFormResponse(application, formResponse);
+
+        RecruitingRound round = application.getRound();
+        RecruitingPublicResultStatus documentResult = resolveDocumentResult(application.getStatus(), round, now);
+        RecruitingPublicResultStatus finalResult = resolveFinalResult(application.getStatus(), round, now);
+        return RecruitingPublicApplicationInfo.builder()
+            .applicationId(application.getId())
+            .applicantName(application.getApplicantName())
+            .applicantEmail(application.getApplicantEmail())
+            .firstChoice(application.getFirstChoice())
+            .secondChoice(application.getSecondChoice())
+            .submitted(application.getSubmittedAt() != null)
+            .cancelled(application.getStatus() == RecruitingApplicationStatus.CANCELLED)
+            .editable(application.isEditable() && round.isLocalApplicationPeriodOpenAt(
+                now,
+                application.getApplicationForm().getStatus()
+            ))
+            .documentResult(documentResult)
+            .finalResult(finalResult)
+            .acceptedTrack(finalResult == RecruitingPublicResultStatus.APPROVED
+                ? application.getAcceptedTrack()
+                : null)
+            .answers(formResponse.answers().stream().map(RecruitingPublicApplicationInfo.Answer::from).toList())
+            .build();
+    }
+
+    private static void validateLinkedFormResponse(
+        RecruitingApplication application,
+        FormResponseWithAnswersInfo formResponse
+    ) {
+        if (!Objects.equals(formResponse.id(), application.getFormResponseId())
+            || !Objects.equals(formResponse.formId(), application.getApplicationForm().getFormId())
+            || !Objects.equals(formResponse.respondentMemberId(), application.getApplicantMemberId())) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
+        }
+    }
+
+    private static RecruitingPublicResultStatus resolveDocumentResult(
+        RecruitingApplicationStatus status,
+        RecruitingRound round,
+        Instant now
+    ) {
+        if (now.isBefore(round.getDocumentResultPublishedAt())) {
+            return RecruitingPublicResultStatus.PENDING;
+        }
+        if (status == RecruitingApplicationStatus.DOCUMENT_FAILED) {
+            return RecruitingPublicResultStatus.REJECTED;
+        }
+        return switch (status) {
+            case INTERVIEW_ASSIGNED, INTERVIEW_SKIPPED, FINAL_PASSED, FINAL_FAILED ->
+                RecruitingPublicResultStatus.APPROVED;
+            default -> RecruitingPublicResultStatus.PENDING;
+        };
+    }
+
+    private static RecruitingPublicResultStatus resolveFinalResult(
+        RecruitingApplicationStatus status,
+        RecruitingRound round,
+        Instant now
+    ) {
+        if (now.isBefore(round.getFinalResultPublishedAt())) {
+            return RecruitingPublicResultStatus.PENDING;
+        }
+        return switch (status) {
+            case FINAL_PASSED -> RecruitingPublicResultStatus.APPROVED;
+            case FINAL_FAILED -> RecruitingPublicResultStatus.REJECTED;
+            default -> RecruitingPublicResultStatus.PENDING;
+        };
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryService.java
@@ -1,0 +1,66 @@
+package com.umc.product.recruiting.application.service.query;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.form.application.port.in.query.GetFormResponseUseCase;
+import com.umc.product.form.application.port.in.query.dto.FormResponseWithAnswersInfo;
+import com.umc.product.recruiting.application.port.in.query.ListMyRecruitingApplicationsUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicApplicationInfo;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
+import com.umc.product.recruiting.domain.RecruitingApplication;
+import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
+import com.umc.product.recruiting.domain.exception.RecruitingErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecruitingMyApplicationQueryService implements ListMyRecruitingApplicationsUseCase {
+
+    private final LoadRecruitingApplicationPort loadApplicationPort;
+    private final GetFormResponseUseCase getFormResponseUseCase;
+    private final Clock clock;
+
+    @Override
+    public List<RecruitingPublicApplicationInfo> listMyApplications(Long requesterMemberId) {
+        List<RecruitingApplication> applications = loadApplicationPort.listByApplicantMemberId(requesterMemberId);
+        if (applications.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> formResponseIds = applications.stream()
+            .map(RecruitingApplication::getFormResponseId)
+            .collect(Collectors.toSet());
+        Map<Long, FormResponseWithAnswersInfo> formResponses =
+            getFormResponseUseCase.findResponsesWithAnswers(formResponseIds);
+        Instant now = clock.instant();
+
+        return applications.stream()
+            .map(application -> RecruitingApplicationViewFactory.create(
+                application,
+                getFormResponse(application, formResponses),
+                now
+            ))
+            .toList();
+    }
+
+    private FormResponseWithAnswersInfo getFormResponse(
+        RecruitingApplication application,
+        Map<Long, FormResponseWithAnswersInfo> formResponses
+    ) {
+        FormResponseWithAnswersInfo formResponse = formResponses.get(application.getFormResponseId());
+        if (formResponse == null) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
+        }
+        return formResponse;
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryService.java
@@ -1,8 +1,6 @@
 package com.umc.product.recruiting.application.service.query;
 
 import java.time.Clock;
-import java.time.Instant;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +12,6 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublic
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
 import com.umc.product.recruiting.domain.RecruitingApplicantEmail;
 import com.umc.product.recruiting.domain.RecruitingApplication;
-import com.umc.product.recruiting.domain.RecruitingRound;
-import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
-import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
 import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
 import com.umc.product.recruiting.domain.exception.RecruitingErrorCode;
 
@@ -43,75 +38,8 @@ public class RecruitingPublicApplicationQueryService implements GetAnonymousRecr
         FormResponseWithAnswersInfo formResponse = getFormResponseUseCase.getResponseWithAnswersByAccessKey(
             application.getFormResponseAccessKey()
         );
-        validateLinkedFormResponse(application, formResponse);
 
-        Instant now = clock.instant();
-        RecruitingRound round = application.getRound();
-        RecruitingPublicResultStatus documentResult = resolveDocumentResult(application.getStatus(), round, now);
-        RecruitingPublicResultStatus finalResult = resolveFinalResult(application.getStatus(), round, now);
-        return RecruitingPublicApplicationInfo.builder()
-            .applicationId(application.getId())
-            .applicantName(application.getApplicantName())
-            .applicantEmail(application.getApplicantEmail())
-            .firstChoice(application.getFirstChoice())
-            .secondChoice(application.getSecondChoice())
-            .submitted(application.getSubmittedAt() != null)
-            .cancelled(application.getStatus() == RecruitingApplicationStatus.CANCELLED)
-            .editable(application.isEditable() && round.isLocalApplicationPeriodOpenAt(
-                now,
-                application.getApplicationForm().getStatus()
-            ))
-            .documentResult(documentResult)
-            .finalResult(finalResult)
-            .acceptedTrack(finalResult == RecruitingPublicResultStatus.APPROVED
-                ? application.getAcceptedTrack()
-                : null)
-            .answers(formResponse.answers().stream().map(RecruitingPublicApplicationInfo.Answer::from).toList())
-            .build();
-    }
-
-    private void validateLinkedFormResponse(
-        RecruitingApplication application,
-        FormResponseWithAnswersInfo formResponse
-    ) {
-        if (!Objects.equals(formResponse.id(), application.getFormResponseId())
-            || !Objects.equals(formResponse.formId(), application.getApplicationForm().getFormId())
-            || formResponse.respondentMemberId() != null) {
-            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
-        }
-    }
-
-    private RecruitingPublicResultStatus resolveDocumentResult(
-        RecruitingApplicationStatus status,
-        RecruitingRound round,
-        Instant now
-    ) {
-        if (now.isBefore(round.getDocumentResultPublishedAt())) {
-            return RecruitingPublicResultStatus.PENDING;
-        }
-        if (status == RecruitingApplicationStatus.DOCUMENT_FAILED) {
-            return RecruitingPublicResultStatus.REJECTED;
-        }
-        return switch (status) {
-            case INTERVIEW_ASSIGNED, INTERVIEW_SKIPPED, FINAL_PASSED, FINAL_FAILED ->
-                RecruitingPublicResultStatus.APPROVED;
-            default -> RecruitingPublicResultStatus.PENDING;
-        };
-    }
-
-    private RecruitingPublicResultStatus resolveFinalResult(
-        RecruitingApplicationStatus status,
-        RecruitingRound round,
-        Instant now
-    ) {
-        if (now.isBefore(round.getFinalResultPublishedAt())) {
-            return RecruitingPublicResultStatus.PENDING;
-        }
-        return switch (status) {
-            case FINAL_PASSED -> RecruitingPublicResultStatus.APPROVED;
-            case FINAL_FAILED -> RecruitingPublicResultStatus.REJECTED;
-            default -> RecruitingPublicResultStatus.PENDING;
-        };
+        return RecruitingApplicationViewFactory.create(application, formResponse, clock.instant());
     }
 
     private void validateApplicationKey(String applicationKey) {

--- a/src/main/resources/graphql/recruiting.graphqls
+++ b/src/main/resources/graphql/recruiting.graphqls
@@ -506,6 +506,8 @@ type RecruitingApplication {
 
 type RecruitingPublicApplication {
   applicationId: ID!
+  gisuId: ID!
+  roundId: ID!
   applicantName: String!
   applicantEmail: String!
   firstChoice: ChallengerTrack!

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingGraphQlSecurityTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingGraphQlSecurityTest.java
@@ -209,6 +209,8 @@ class RecruitingGraphQlSecurityTest {
         given(getAnonymousApplicationUseCase.getByCredential("applicant@example.invalid", "A1B2C3"))
             .willReturn(RecruitingPublicApplicationInfo.builder()
                 .applicationId(30L)
+                .gisuId(11L)
+                .roundId(20L)
                 .applicantName("지원자")
                 .applicantEmail("applicant@example.invalid")
                 .firstChoice(ChallengerTrack.PLAN)

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingGraphQlSurfaceTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingGraphQlSurfaceTest.java
@@ -126,6 +126,8 @@ class RecruitingGraphQlSurfaceTest {
                 .isEqualTo("RecruitingApplicationRegistrationStatus!");
             assertThat(fieldType(data, "RecruitingApplication", "acceptedTrack"))
                 .isEqualTo("ChallengerTrack");
+            assertThat(fieldType(data, "RecruitingPublicApplication", "gisuId")).isEqualTo("ID!");
+            assertThat(fieldType(data, "RecruitingPublicApplication", "roundId")).isEqualTo("ID!");
             assertThat(fieldType(data, "Mutation", "submitRecruitingInterviewAvailability")).isEqualTo("Boolean!");
             assertThat(inputFieldType(data, "SubmitRecruitingInterviewAvailabilityInput", "times")).isEqualTo("[Instant!]!");
             assertThat(inputFieldType(data, "ConfirmRecruitingInterviewScheduleInput", "sessionId")).isEqualTo("ID!");

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTest.java
@@ -32,6 +32,8 @@ class RecruitingApplicationControllerTest extends RecruitingApplicationControlle
         given(listMyApplicationsUseCase.listMyApplications(200L)).willReturn(List.of(
             RecruitingPublicApplicationInfo.builder()
                 .applicationId(100L)
+                .gisuId(11L)
+                .roundId(20L)
                 .applicantName("홍길동")
                 .applicantEmail("applicant@example.com")
                 .firstChoice(ChallengerTrack.PLAN)
@@ -45,6 +47,8 @@ class RecruitingApplicationControllerTest extends RecruitingApplicationControlle
         mockMvc.perform(get("/api/v1/recruiting/applications").session(authenticatedSession))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result[0].applicationId").value(100L))
+            .andExpect(jsonPath("$.result[0].gisuId").value(11L))
+            .andExpect(jsonPath("$.result[0].roundId").value(20L))
             .andExpect(jsonPath("$.result[0].applicantName").value("홍길동"))
             .andExpect(jsonPath("$.result[0].submitted").value(true))
             .andExpect(jsonPath("$.result[0].documentResult").value("PENDING"))

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +19,48 @@ import org.springframework.http.MediaType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingApplicationDraftCommand;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingApplicationCreatedInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicApplicationInfo;
 import com.umc.product.recruiting.domain.enums.RecruitingApplicationStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
 
 @DisplayName("RecruitingApplicationController 생성/인증")
 class RecruitingApplicationControllerTest extends RecruitingApplicationControllerTestSupport {
+
+    @Test
+    @DisplayName("본인 지원 내역 조회 API는 인증 회원의 지원서를 비회원 조회와 같은 응답으로 반환한다")
+    void getMyApplicationsUsesAuthenticatedMember() throws Exception {
+        given(listMyApplicationsUseCase.listMyApplications(200L)).willReturn(List.of(
+            RecruitingPublicApplicationInfo.builder()
+                .applicationId(100L)
+                .applicantName("홍길동")
+                .applicantEmail("applicant@example.com")
+                .firstChoice(ChallengerTrack.PLAN)
+                .submitted(true)
+                .documentResult(RecruitingPublicResultStatus.PENDING)
+                .finalResult(RecruitingPublicResultStatus.PENDING)
+                .answers(List.of())
+                .build()
+        ));
+
+        mockMvc.perform(get("/api/v1/recruiting/applications").session(authenticatedSession))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result[0].applicationId").value(100L))
+            .andExpect(jsonPath("$.result[0].applicantName").value("홍길동"))
+            .andExpect(jsonPath("$.result[0].submitted").value(true))
+            .andExpect(jsonPath("$.result[0].documentResult").value("PENDING"))
+            .andExpect(jsonPath("$.result[0].answers").isArray());
+
+        then(listMyApplicationsUseCase).should().listMyApplications(200L);
+    }
+
+    @Test
+    @DisplayName("비로그인 회원의 본인 지원 내역 조회 요청은 거부한다")
+    void rejectUnauthenticatedGetMyApplications() throws Exception {
+        mockMvc.perform(get("/api/v1/recruiting/applications"))
+            .andExpect(status().isUnauthorized());
+
+        then(listMyApplicationsUseCase).shouldHaveNoInteractions();
+    }
 
     @Test
     @DisplayName("지원서 draft 생성 API는 인증 actor와 지원 기본 정보를 command로 전달한다")

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTestSupport.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationControllerTestSupport.java
@@ -29,6 +29,7 @@ import com.umc.product.recruiting.application.port.in.command.CancelRecruitingAp
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingApplicationDraftUseCase;
 import com.umc.product.recruiting.application.port.in.command.SubmitRecruitingApplicationUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingApplicationDraftUseCase;
+import com.umc.product.recruiting.application.port.in.query.ListMyRecruitingApplicationsUseCase;
 import com.umc.product.support.RestDocsConfig;
 
 @WebMvcTest(controllers = RecruitingApplicationController.class)
@@ -58,6 +59,9 @@ abstract class RecruitingApplicationControllerTestSupport {
 
     @MockitoBean
     CancelRecruitingApplicationUseCase cancelUseCase;
+
+    @MockitoBean
+    ListMyRecruitingApplicationsUseCase listMyApplicationsUseCase;
 
     MockHttpSession authenticatedSession;
 

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationRandomPortIntegrationTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingApplicationRandomPortIntegrationTest.java
@@ -431,6 +431,8 @@ class RecruitingApplicationRandomPortIntegrationTest {
     private static RecruitingPublicApplicationInfo publicApplicationInfo() {
         return RecruitingPublicApplicationInfo.builder()
             .applicationId(900L)
+            .gisuId(1L)
+            .roundId(10L)
             .applicantName("지원자")
             .applicantEmail(PROBE_EMAIL)
             .firstChoice(ChallengerTrack.PLAN)

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingPublicControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingPublicControllerTest.java
@@ -125,6 +125,8 @@ class RecruitingPublicControllerTest {
         given(getAnonymousApplicationUseCase.getByCredential("applicant@example.com", "A1B2C3"))
             .willReturn(RecruitingPublicApplicationInfo.builder()
                 .applicationId(100L)
+                .gisuId(11L)
+                .roundId(20L)
                 .applicantName("홍길동")
                 .applicantEmail("applicant@example.com")
                 .firstChoice(com.umc.product.common.domain.enums.ChallengerTrack.PLAN)
@@ -145,6 +147,8 @@ class RecruitingPublicControllerTest {
                     """))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.applicationId").value(100L))
+            .andExpect(jsonPath("$.result.gisuId").value(11L))
+            .andExpect(jsonPath("$.result.roundId").value(20L))
             .andExpect(jsonPath("$.result.documentResult").value("PENDING"))
             .andExpect(jsonPath("$.result.applicationKey").doesNotExist())
             .andExpect(jsonPath("$.result.formResponseAccessKey").doesNotExist());

--- a/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingPersistenceAdapterTest.java
@@ -36,6 +36,25 @@ import ch.qos.logback.core.read.ListAppender;
 class RecruitingPersistenceAdapterTest extends RecruitingPersistenceAdapterTestSupport {
 
     @Test
+    @DisplayName("회원 ID로 본인 지원서를 최신순 조회하고 다른 회원 지원서는 제외한다")
+    void listApplicationsByApplicantMemberId() {
+        RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(1L, 10L));
+        RecruitingApplication first = saveMemberApplication(season, 1, 200L, 1_001L, "A1B2C3");
+        RecruitingApplication second = saveMemberApplication(season, 2, 200L, 1_002L, "D4E5F6");
+        saveMemberApplication(season, 3, 201L, 1_003L, "G7H8I9");
+        em.flush();
+        em.clear();
+
+        List<RecruitingApplication> result = applicationAdapter.listByApplicantMemberId(200L);
+
+        assertThat(result)
+            .extracting(RecruitingApplication::getId)
+            .containsExactly(second.getId(), first.getId());
+        assertThat(result)
+            .allMatch(application -> application.getApplicationForm().getRound().getSeason().getId() != null);
+    }
+
+    @Test
     @DisplayName("모집_시즌_차수_폼_지원서를_저장하고_embedded_email_경로로_조회한다")
     void saveAndLoadRecruitingCoreGraphWithDetails() {
         RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(1L, 10L));
@@ -267,5 +286,36 @@ class RecruitingPersistenceAdapterTest extends RecruitingPersistenceAdapterTestS
         assertThat(row.schoolId()).isEqualTo(20L);
         assertThat(row.firstChoice()).isEqualTo(ChallengerTrack.WEB_PRODUCT_ENGINEER);
         assertThat(row.applicationStatus()).isEqualTo(RecruitingApplicationStatus.SUBMITTED);
+    }
+
+    private RecruitingApplication saveMemberApplication(
+        RecruitingSeason season,
+        int roundNo,
+        Long memberId,
+        Long formResponseId,
+        String applicationKey
+    ) {
+        RecruitingRound round = roundAdapter.save(RecruitingRound.createAdditional(
+            season,
+            roundNo,
+            applicationConfiguration()
+        ));
+        RecruitingApplicationForm form = formAdapter.save(RecruitingApplicationForm.create(
+            round,
+            10_000L + roundNo
+        ));
+        return applicationAdapter.save(RecruitingApplication.createMemberDraft(
+            form,
+            formResponseId,
+            memberId,
+            RecruitingApplicantProfile.create(
+                round,
+                "지원자" + memberId,
+                RecruitingApplicantEmail.from("applicant" + memberId + "@example.com"),
+                ChallengerTrack.WEB_PRODUCT_ENGINEER,
+                null
+            ),
+            applicationKey
+        ));
     }
 }

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
@@ -66,6 +66,8 @@ class RecruitingMyApplicationQueryServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).applicationId()).isEqualTo(900L);
+        assertThat(result.get(0).gisuId()).isEqualTo(1L);
+        assertThat(result.get(0).roundId()).isEqualTo(10L);
         assertThat(result.get(0).documentResult()).isEqualTo(RecruitingPublicResultStatus.APPROVED);
         assertThat(result.get(0).finalResult()).isEqualTo(RecruitingPublicResultStatus.PENDING);
         assertThat(result.get(0).acceptedTrack()).isNull();

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
@@ -100,6 +100,21 @@ class RecruitingMyApplicationQueryServiceTest {
             .isEqualTo(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("다른 회원의 Form 응답이 연결되면 본인 지원 내역을 공개하지 않는다")
+    void rejectFormResponseOwnedByAnotherMember() {
+        RecruitingApplication application = finalPassedApplication();
+        given(loadApplicationPort.listByApplicantMemberId(MEMBER_ID)).willReturn(List.of(application));
+        given(getFormResponseUseCase.findResponsesWithAnswers(Set.of(700L)))
+            .willReturn(Map.of(700L, formResponse(700L, 201L)));
+        given(clock.instant()).willReturn(Instant.parse("2026-08-16T00:00:00Z"));
+
+        assertThatThrownBy(() -> sut.listMyApplications(MEMBER_ID))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
+    }
+
     private RecruitingApplication finalPassedApplication() {
         RecruitingApplicationForm form = publishedForm();
         RecruitingApplication application = RecruitingApplication.createMemberDraft(

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingMyApplicationQueryServiceTest.java
@@ -1,0 +1,156 @@
+package com.umc.product.recruiting.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.form.application.port.in.query.GetFormResponseUseCase;
+import com.umc.product.form.application.port.in.query.dto.FormResponseWithAnswersInfo;
+import com.umc.product.form.domain.enums.FormResponseStatus;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicApplicationInfo;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
+import com.umc.product.recruiting.domain.RecruitingApplicantEmail;
+import com.umc.product.recruiting.domain.RecruitingApplicantProfile;
+import com.umc.product.recruiting.domain.RecruitingApplication;
+import com.umc.product.recruiting.domain.RecruitingApplicationForm;
+import com.umc.product.recruiting.domain.RecruitingRound;
+import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
+import com.umc.product.recruiting.domain.RecruitingSeason;
+import com.umc.product.recruiting.domain.enums.RecruitingPublicResultStatus;
+import com.umc.product.recruiting.domain.exception.RecruitingDomainException;
+import com.umc.product.recruiting.domain.exception.RecruitingErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitingMyApplicationQueryServiceTest {
+
+    private static final Long MEMBER_ID = 200L;
+
+    @Mock
+    LoadRecruitingApplicationPort loadApplicationPort;
+
+    @Mock
+    GetFormResponseUseCase getFormResponseUseCase;
+
+    @Mock
+    Clock clock;
+
+    @InjectMocks
+    RecruitingMyApplicationQueryService sut;
+
+    @Test
+    @DisplayName("회원 본인 지원 내역은 Form 응답을 일괄 조회하고 비회원과 같은 공개 정책을 적용한다")
+    void listMyApplicationsUsesBatchFormResponsesAndSharedVisibilityPolicy() {
+        RecruitingApplication application = finalPassedApplication();
+        given(loadApplicationPort.listByApplicantMemberId(MEMBER_ID)).willReturn(List.of(application));
+        given(getFormResponseUseCase.findResponsesWithAnswers(Set.of(700L)))
+            .willReturn(Map.of(700L, formResponse(700L, MEMBER_ID)));
+        given(clock.instant()).willReturn(Instant.parse("2026-08-15T23:59:59Z"));
+
+        List<RecruitingPublicApplicationInfo> result = sut.listMyApplications(MEMBER_ID);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).applicationId()).isEqualTo(900L);
+        assertThat(result.get(0).documentResult()).isEqualTo(RecruitingPublicResultStatus.APPROVED);
+        assertThat(result.get(0).finalResult()).isEqualTo(RecruitingPublicResultStatus.PENDING);
+        assertThat(result.get(0).acceptedTrack()).isNull();
+        then(getFormResponseUseCase).should().findResponsesWithAnswers(Set.of(700L));
+    }
+
+    @Test
+    @DisplayName("회원 본인 지원 내역이 없으면 Form 응답을 조회하지 않고 빈 목록을 반환한다")
+    void returnEmptyListWithoutLoadingFormResponses() {
+        given(loadApplicationPort.listByApplicantMemberId(MEMBER_ID)).willReturn(List.of());
+
+        List<RecruitingPublicApplicationInfo> result = sut.listMyApplications(MEMBER_ID);
+
+        assertThat(result).isEmpty();
+        then(getFormResponseUseCase).shouldHaveNoInteractions();
+        then(clock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("지원서와 연결된 기명 Form 응답이 없으면 지원서 미존재 오류로 실패한다")
+    void failWhenLinkedFormResponseIsMissing() {
+        RecruitingApplication application = finalPassedApplication();
+        given(loadApplicationPort.listByApplicantMemberId(MEMBER_ID)).willReturn(List.of(application));
+        given(getFormResponseUseCase.findResponsesWithAnswers(Set.of(700L))).willReturn(Map.of());
+        given(clock.instant()).willReturn(Instant.parse("2026-08-16T00:00:00Z"));
+
+        assertThatThrownBy(() -> sut.listMyApplications(MEMBER_ID))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
+    }
+
+    private RecruitingApplication finalPassedApplication() {
+        RecruitingApplicationForm form = publishedForm();
+        RecruitingApplication application = RecruitingApplication.createMemberDraft(
+            form,
+            700L,
+            MEMBER_ID,
+            RecruitingApplicantProfile.create(
+                form.getRound(),
+                "홍길동",
+                RecruitingApplicantEmail.from("applicant@example.com"),
+                ChallengerTrack.PLAN,
+                ChallengerTrack.DESIGN
+            ),
+            "A1B2C3"
+        );
+        ReflectionTestUtils.setField(application, "id", 900L);
+        application.submit(MEMBER_ID);
+        application.skipInterview(10L, "면접 미진행");
+        application.passFinal(10L, "최종 합격", ChallengerTrack.PLAN);
+        return application;
+    }
+
+    private RecruitingApplicationForm publishedForm() {
+        RecruitingSeason season = RecruitingSeason.create(1L, 10L);
+        ReflectionTestUtils.setField(season, "id", 1L);
+        RecruitingRound round = RecruitingRound.createRegular(season, RecruitingRoundConfiguration.of(
+            List.of(ChallengerTrack.PLAN, ChallengerTrack.DESIGN),
+            true,
+            Instant.parse("2026-08-01T00:00:00Z"),
+            Instant.parse("2026-08-08T00:00:00Z"),
+            Instant.parse("2026-08-10T00:00:00Z"),
+            false,
+            null,
+            null,
+            Instant.parse("2026-08-16T00:00:00Z"),
+            null,
+            null,
+            null
+        ));
+        ReflectionTestUtils.setField(round, "id", 10L);
+        RecruitingApplicationForm form = RecruitingApplicationForm.create(round, 500L);
+        ReflectionTestUtils.setField(form, "id", 100L);
+        form.publish(form.getRound().getRecruitableTracks());
+        return form;
+    }
+
+    private FormResponseWithAnswersInfo formResponse(Long id, Long respondentMemberId) {
+        return FormResponseWithAnswersInfo.builder()
+            .id(id)
+            .formId(500L)
+            .respondentMemberId(respondentMemberId)
+            .status(FormResponseStatus.SUBMITTED)
+            .answers(List.of())
+            .build();
+    }
+}

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.umc.product.recruiting.application.service.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -93,6 +94,21 @@ class RecruitingPublicApplicationQueryServiceTest {
             .isEqualTo(RecruitingErrorCode.RECRUITING_APPLICATION_INVALID_KEY);
     }
 
+    @Test
+    @DisplayName("회원 지원서는 email과 application key가 일치해도 비회원 방식으로 조회할 수 없다")
+    void rejectMemberApplicationByAnonymousCredential() {
+        RecruitingApplication application = memberApplication();
+        given(loadApplicationPort.findByApplicantEmailAndApplicationKey("applicant@example.com", "A1B2C3"))
+            .willReturn(Optional.of(application));
+
+        assertThatThrownBy(() -> sut.getByCredential("applicant@example.com", "A1B2C3"))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_APPLICATION_NOT_FOUND);
+        then(getFormResponseUseCase).shouldHaveNoInteractions();
+        then(clock).shouldHaveNoInteractions();
+    }
+
     private RecruitingApplication finalPassedApplication() {
         RecruitingApplicationForm form = publishedForm();
         RecruitingApplication application = RecruitingApplication.createAnonymousDraft(
@@ -114,6 +130,25 @@ class RecruitingPublicApplicationQueryServiceTest {
         application.submitAnonymous("applicant@example.com");
         application.skipInterview(10L, "면접 미진행");
         application.passFinal(10L, "최종 합격", ChallengerTrack.PLAN);
+        return application;
+    }
+
+    private RecruitingApplication memberApplication() {
+        RecruitingApplicationForm form = publishedForm();
+        RecruitingApplication application = RecruitingApplication.createMemberDraft(
+            form,
+            700L,
+            200L,
+            RecruitingApplicantProfile.create(
+                form.getRound(),
+                "홍길동",
+                RecruitingApplicantEmail.from("applicant@example.com"),
+                ChallengerTrack.PLAN,
+                ChallengerTrack.DESIGN
+            ),
+            "A1B2C3"
+        );
+        ReflectionTestUtils.setField(application, "id", 900L);
         return application;
     }
 

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingPublicApplicationQueryServiceTest.java
@@ -61,6 +61,8 @@ class RecruitingPublicApplicationQueryServiceTest {
 
         RecruitingPublicApplicationInfo result = sut.getByCredential(" Applicant@Example.COM ", "A1B2C3");
 
+        assertThat(result.gisuId()).isEqualTo(1L);
+        assertThat(result.roundId()).isEqualTo(10L);
         assertThat(result.documentResult()).isEqualTo(RecruitingPublicResultStatus.APPROVED);
         assertThat(result.finalResult()).isEqualTo(RecruitingPublicResultStatus.PENDING);
         assertThat(result.acceptedTrack()).isNull();


### PR DESCRIPTION
## 🚀 작업 내용                                                                                                                                                                                          
                                                                                                                                                                                                           
  closes #1232                                                                                                                                                                                        
                                                                                                                                                                                                           
로그인 회원이 이메일과 지원키를 입력하지 않고, 인증 정보로 본인의 모집 지원 내역을 조회할 수 있는 API를 추가했습니다.                                                                                    
                                                                                                                                                                                                           
  기존 비회원 지원서 조회와 동일한 응답 구조 및 결과 공개 정책을 사용하며, 회원과 비회원은 지원서 소유자를 확인하는 방식만 구분합니다.                                                                     
                                                                                                                                                                                                           
  ## 변경 사항                                                                                                                                                                                             
                                                                                                                                                                                                           
  ### 본인 지원 내역 조회 API 추가
                                                                                                                                                                                                           
  - `GET /api/v1/recruiting/applications`
  - `@CurrentMember`의 `memberId`를 기준으로 본인 지원서만 조회                                                                                                                                            
  - 지원 내역이 없으면 빈 목록 반환
  - 최신 지원서 순으로 정렬                                                                                                                                                                                
  - 비로그인 요청은 `401` 반환                                                                                                                                                                             
                                                                                                                                                                                                           
  ### 회원·비회원 조회 응답 통일
                                                                                                                                                                                                           
  기존 비회원 지원서 조회와 동일하게 다음 정보를 반환합니다.
                                                                                                                                                                                                           
  - 지원자 및 지망 트랙                                                                                                                                                                                    
  - 제출·취소·수정 가능 여부                                                                                                                                                                               
  - 서류 및 최종 결과                                                                                                                                                                                      
  - 최종 합격 트랙
  - Form 답변                                                                                                                                                                                              
                                                                                                                                                                                                           
  서류·최종 결과와 합격 트랙은 기존 비회원 조회와 동일한 발표 시각 정책을 적용합니다.                                                                                                                      
                                                                                                                                                                                                           
  ### 지원서와 모집 차수 연결 정보 추가                                                                                                                                                                    
                                                                                                                                                                                                           
  지원서 응답에 다음 식별자를 추가했습니다.                                                                                                                                                                
                                                                                                                                                                                                           
  - `gisuId`                                                                                                                                                                                               
  - `roundId`                                                                                                                                                                                              
                                                                                                                                                                                                           
  라운드 상세 정보는 지원서 응답에 중복 포함하지 않습니다. 프론트에서는 식별자를 이용해 기존 공개 모집 목록 API를 호출하여 조합할 수 있습니다.                                                                                                                                                                                                                                            

  ### 공개 응답 생성 로직 공통화                                                                                                                                                                           
                                                                                                                                                                                                           
  회원·비회원 조회 간 결과 노출 정책이 달라지지 않도록 다음 로직을 공통 Factory로 분리했습니다.                                                                                                            
                                                                                                                                                                                                           
  - 지원서와 FormResponse 연결 검증                                                                                                                                                                        
  - 제출·취소·수정 가능 여부 계산
  - 서류 및 최종 결과 공개 시각 판정                                                                                                                                                                       
  - 발표 전 합격 트랙 비공개 처리                                                                                                                                                                          
  - 응답 DTO 조립                                                                                                                                                                                          

  ### 조회 성능 보완                                                                                                                                                                                       

  - 회원 지원서는 memberId 기준으로 한 번에 조회                                                                                                                                                           
  - 지원서에 연결된 FormResponse와 답변은 batch 조회                                                                                                                                                       
  - 지원서별 FormResponse 개별 조회로 인한 N+1 방지
  - ApplicationForm, Round, Season은 fetch join으로 조회                                                                                                                                                   
                                                                                                                                                                                                     
                                                                                                                                                                                                           
  ## 🧪 테스트                                                                                                                                                                                             
                                                                                                                                                                                                           
  다음 동작을 검증하는 테스트를 추가했습니다.                                                                                                                                                              
                                                                                                                                                                                                           
  - 인증 회원 ID를 기준으로 본인 지원 내역 조회                                                                                                                                                            
  - 다른 회원의 지원서 제외                                                                                                                                                                                
  - 최신 지원서 순 정렬                                                                                                                                                                                    
  - 비로그인 요청 401                                                                                                                                                                                      
  - 지원 내역이 없는 경우 빈 목록 반환
  - FormResponse 및 답변 batch 조회
  - 회원·비회원의 동일한 결과 공개 정책
  - 발표 전 결과 및 합격 트랙 비공개                                                                                                                                                                       
  - gisuId, roundId 응답 매핑
  - REST·GraphQL 계약 일치