### PR TITLE
[Feat] 모집 차수 목록에 작성자 및 지원서 존재 여부 추가

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
@@ -194,7 +194,9 @@ public class RecruitingAdminGraphQlController {
     ) {
         Long requesterMemberId = permissionSupport.currentMemberId(memberPrincipal);
         permissionSupport.assertRecruitmentPermission(requesterMemberId, seasonId, PermissionType.WRITE);
-        return RecruitingIdGraphQlResponse.from(createRoundUseCase.createRound(input.toCommand(seasonId)));
+        return RecruitingIdGraphQlResponse.from(
+            createRoundUseCase.createRound(input.toCommand(seasonId, requesterMemberId))
+        );
     }
 
     @MutationMapping

--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/CreateRecruitingRoundGraphQlRequest.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/CreateRecruitingRoundGraphQlRequest.java
@@ -27,7 +27,7 @@ public record CreateRecruitingRoundGraphQlRequest(
     String contactText
 ) {
 
-    public CreateRecruitingRoundCommand toCommand(Long seasonId) {
+    public CreateRecruitingRoundCommand toCommand(Long seasonId, Long requesterMemberId) {
         return CreateRecruitingRoundCommand.builder()
             .seasonId(seasonId)
             .type(type)
@@ -48,6 +48,7 @@ public record CreateRecruitingRoundGraphQlRequest(
                 announcement,
                 contactText
             ))
+            .requesterMemberId(requesterMemberId)
             .build();
     }
 }

--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingSeasonSummaryGraphQlResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/dto/RecruitingSeasonSummaryGraphQlResponse.java
@@ -25,7 +25,7 @@ public record RecruitingSeasonSummaryGraphQlResponse(
             info.schoolName(),
             info.memo(),
             info.rounds().stream()
-                .map(RecruitingSeasonConfigurationGraphQlResponse.Round::from)
+                .map(detail -> RecruitingSeasonConfigurationGraphQlResponse.Round.from(detail.configuration()))
                 .toList()
         );
     }

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminController.java
@@ -191,10 +191,13 @@ public class RecruitingSeasonAdminController {
             + "INFRA_PLUS는 모집할 수 없으며 면접 Round의 availability Form은 OPEN 전까지 설정·게시해야 합니다."
     )
     public RecruitingIdResponse createRound(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
         @PathVariable @Positive Long seasonId,
         @Valid @RequestBody CreateRecruitingRoundRequest request
     ) {
-        return RecruitingIdResponse.from(createRoundUseCase.createRound(request.toCommand(seasonId)));
+        return RecruitingIdResponse.from(
+            createRoundUseCase.createRound(request.toCommand(seasonId, memberPrincipal.getMemberId()))
+        );
     }
 
     @PatchMapping("/seasons/{seasonId}/rounds/{roundId}/status")

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/request/CreateRecruitingRoundRequest.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/request/CreateRecruitingRoundRequest.java
@@ -39,13 +39,14 @@ public record CreateRecruitingRoundRequest(
     @Schema(description = "문의 연락처") String contactText
 ) {
 
-    public CreateRecruitingRoundCommand toCommand(Long seasonId) {
+    public CreateRecruitingRoundCommand toCommand(Long seasonId, Long requesterMemberId) {
         return CreateRecruitingRoundCommand.builder()
             .seasonId(seasonId)
             .type(type)
             .roundNo(roundNo)
             .title(title)
             .configuration(toConfigurationCommand())
+            .requesterMemberId(requesterMemberId)
             .build();
     }
 

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingSeasonSummaryResponse.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/dto/response/RecruitingSeasonSummaryResponse.java
@@ -1,8 +1,15 @@
 package com.umc.product.recruiting.adapter.in.web.dto.response;
 
+import java.time.Instant;
 import java.util.List;
 
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundAuthorInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundConfigurationInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
+import com.umc.product.recruiting.domain.enums.RecruitingRoundStatus;
+import com.umc.product.recruiting.domain.enums.RecruitingRoundType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -16,7 +23,7 @@ public record RecruitingSeasonSummaryResponse(
     @Schema(description = "학교명", example = "한국대학교") String schoolName,
     @Schema(description = "시즌 운영진 공유 메모") String memo,
     @Schema(description = "시즌에 속한 모집 차수")
-    List<RecruitingSeasonConfigurationResponse.RoundResponse> rounds
+    List<RoundResponse> rounds
 ) {
 
     public static RecruitingSeasonSummaryResponse from(RecruitingSeasonSummaryInfo info) {
@@ -29,8 +36,74 @@ public record RecruitingSeasonSummaryResponse(
             info.schoolName(),
             info.memo(),
             info.rounds().stream()
-                .map(RecruitingSeasonConfigurationResponse.RoundResponse::from)
+                .map(RoundResponse::from)
                 .toList()
         );
+    }
+
+    @Schema(description = "목록용 모집 차수 상세")
+    public record RoundResponse(
+        Long id,
+        String title,
+        RecruitingRoundType type,
+        Integer roundNo,
+        RecruitingRoundStatus status,
+        List<ChallengerTrack> recruitableTracks,
+        boolean secondChoiceEnabled,
+        Instant documentStartAt,
+        Instant documentEndAt,
+        Instant documentResultPublishedAt,
+        boolean interviewRequired,
+        Instant interviewStartAt,
+        Instant interviewEndAt,
+        Instant finalResultPublishedAt,
+        Long availabilityFormId,
+        Long availabilityScheduleQuestionId,
+        String announcement,
+        String contactText,
+        Instant createdAt,
+        AuthorResponse author,
+        boolean hasApplicants
+    ) {
+
+        private static RoundResponse from(RecruitingRoundDetailInfo detail) {
+            RecruitingRoundConfigurationInfo info = detail.configuration();
+            return new RoundResponse(
+                info.id(),
+                info.title(),
+                info.type(),
+                info.roundNo(),
+                info.status(),
+                info.recruitableTracks(),
+                info.secondChoiceEnabled(),
+                info.documentStartAt(),
+                info.documentEndAt(),
+                info.documentResultPublishedAt(),
+                info.interviewRequired(),
+                info.interviewStartAt(),
+                info.interviewEndAt(),
+                info.finalResultPublishedAt(),
+                info.availabilityFormId(),
+                info.availabilityScheduleQuestionId(),
+                info.announcement(),
+                info.contactText(),
+                detail.createdAt(),
+                AuthorResponse.from(detail.author()),
+                detail.hasApplicants()
+            );
+        }
+    }
+
+    @Schema(description = "모집 차수 작성자")
+    public record AuthorResponse(Long memberId, String name, String nickname, String schoolName) {
+
+        private static AuthorResponse from(RecruitingRoundAuthorInfo info) {
+            return info == null ? null : new AuthorResponse(
+                info.memberId(),
+                info.name(),
+                info.nickname(),
+                info.schoolName()
+            );
+        }
     }
 }

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationJpaRepository.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationJpaRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.recruiting.domain.RecruitingApplication;
@@ -33,6 +35,9 @@ public interface RecruitingApplicationJpaRepository extends JpaRepository<Recrui
     );
 
     boolean existsByRound_Id(Long roundId);
+
+    @Query("SELECT DISTINCT a.round.id FROM RecruitingApplication a WHERE a.round.id IN :roundIds")
+    List<Long> findRoundIdsHavingApplication(@Param("roundIds") Collection<Long> roundIds);
 
     long countByRound_Season_IdAndAcceptedTrackAndRegistrationStatusIn(
         Long seasonId,

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.umc.product.recruiting.adapter.out.persistence;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -140,6 +141,14 @@ public class RecruitingApplicationPersistenceAdapter
     @Override
     public boolean existsByRoundId(Long roundId) {
         return recruitingApplicationJpaRepository.existsByRound_Id(roundId);
+    }
+
+    @Override
+    public Set<Long> filterRoundIdsHavingApplication(Collection<Long> roundIds) {
+        if (roundIds == null || roundIds.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(recruitingApplicationJpaRepository.findRoundIdsHavingApplication(roundIds));
     }
 
     @Override

--- a/src/main/java/com/umc/product/recruiting/application/port/in/command/dto/CreateRecruitingRoundCommand.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/command/dto/CreateRecruitingRoundCommand.java
@@ -12,7 +12,8 @@ public record CreateRecruitingRoundCommand(
     RecruitingRoundType type,
     Integer roundNo,
     String title,
-    RecruitingRoundConfigurationCommand configuration
+    RecruitingRoundConfigurationCommand configuration,
+    Long requesterMemberId
 ) {
 
     public CreateRecruitingRoundCommand {

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundAuthorInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundAuthorInfo.java
@@ -1,0 +1,23 @@
+package com.umc.product.recruiting.application.port.in.query.dto;
+
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+
+/**
+ * 모집 공고 작성자 표시용 정보
+ */
+public record RecruitingRoundAuthorInfo(
+    Long memberId,
+    String name,
+    String nickname,
+    String schoolName
+) {
+
+    public static RecruitingRoundAuthorInfo from(MemberInfo member) {
+        return new RecruitingRoundAuthorInfo(
+            member.id(),
+            member.name(),
+            member.nickname(),
+            member.schoolName()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundDetailInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingRoundDetailInfo.java
@@ -1,0 +1,26 @@
+package com.umc.product.recruiting.application.port.in.query.dto;
+
+import java.time.Instant;
+
+/**
+ * 차수 설정에 조회 시점 부가 정보를 얹은 값.
+ *
+ * <p>작성자와 지원자 유무는 차수의 설정이 아니라 목록 화면이 필요로 하는 조회 결과라
+ * {@link RecruitingRoundConfigurationInfo}를 오염시키지 않고 여기서 합친다.
+ */
+public record RecruitingRoundDetailInfo(
+    RecruitingRoundConfigurationInfo configuration,
+    Instant createdAt,
+    RecruitingRoundAuthorInfo author,
+    boolean hasApplicants
+) {
+
+    public static RecruitingRoundDetailInfo of(
+        RecruitingRoundConfigurationInfo configuration,
+        Instant createdAt,
+        RecruitingRoundAuthorInfo author,
+        boolean hasApplicants
+    ) {
+        return new RecruitingRoundDetailInfo(configuration, createdAt, author, hasApplicants);
+    }
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingSeasonSummaryInfo.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/query/dto/RecruitingSeasonSummaryInfo.java
@@ -12,7 +12,7 @@ public record RecruitingSeasonSummaryInfo(
     Long schoolId,
     String schoolName,
     String memo,
-    List<RecruitingRoundConfigurationInfo> rounds
+    List<RecruitingRoundDetailInfo> rounds
 ) {
 
     public static RecruitingSeasonSummaryInfo of(
@@ -20,7 +20,7 @@ public record RecruitingSeasonSummaryInfo(
         Long chapterId,
         String chapterName,
         String schoolName,
-        List<RecruitingRoundConfigurationInfo> rounds
+        List<RecruitingRoundDetailInfo> rounds
     ) {
         return new RecruitingSeasonSummaryInfo(
             season.getId(),

--- a/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingApplicationPort.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingApplicationPort.java
@@ -3,6 +3,7 @@ package com.umc.product.recruiting.application.port.out;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -71,6 +72,8 @@ public interface LoadRecruitingApplicationPort {
     );
 
     long countReservedOrRegisteredBySeasonIdAndTrack(Long seasonId, ChallengerTrack track);
+
+    Set<Long> filterRoundIdsHavingApplication(Collection<Long> roundIds);
 
     List<RecruitingApplication> listByRoundId(Long roundId);
 

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCommandService.java
@@ -84,8 +84,10 @@ public class RecruitingRoundCommandService implements
         RecruitingRoundConfiguration configuration = command.configuration().toDomain();
         validateRecruitableTrackSubset(command.seasonId(), configuration.recruitableTracks());
         RecruitingRound round = type == RecruitingRoundType.REGULAR
-            ? RecruitingRound.createRegular(season, command.title(), configuration)
-            : RecruitingRound.createAdditional(season, roundNo, command.title(), configuration);
+            ? RecruitingRound.createRegular(season, command.title(), configuration, command.requesterMemberId())
+            : RecruitingRound.createAdditional(
+                season, roundNo, command.title(), configuration, command.requesterMemberId()
+            );
         return saveRoundPort.save(round).getId();
     }
 

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
@@ -122,6 +122,7 @@ public class RecruitingRoundLifecycleCommandService implements
             .roundNo(command.roundNo())
             .title(command.title())
             .configuration(copyConfiguration(source))
+            .requesterMemberId(command.requesterMemberId())
             .build());
         RecruitingRound clonedRound = loadRoundPort.getById(clonedRoundId);
 

--- a/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryService.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -20,6 +21,8 @@ import com.umc.product.authorization.domain.PermissionType;
 import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
@@ -31,7 +34,9 @@ import com.umc.product.recruiting.application.port.in.query.SearchRecruitingSeas
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicRoundGroupInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicRoundInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicRoundSearchQuery;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundAuthorInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundConfigurationInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundGroupSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundSummaryInfo;
@@ -40,6 +45,7 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeason
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonTrackQuotaInfo;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonTrackQuotaPort;
@@ -76,7 +82,9 @@ public class RecruitingSeasonQueryService implements
     private final LoadRecruitingSeasonTrackQuotaPort loadQuotaPort;
     private final LoadRecruitingRoundPort loadRoundPort;
     private final LoadRecruitingApplicationFormPort loadApplicationFormPort;
+    private final LoadRecruitingApplicationPort loadApplicationPort;
     private final GetSchoolUseCase getSchoolUseCase;
+    private final GetMemberUseCase getMemberUseCase;
     private final CheckPermissionUseCase checkPermissionUseCase;
     private final Clock clock;
 
@@ -103,10 +111,12 @@ public class RecruitingSeasonQueryService implements
             null,
             query.requesterMemberId()
         );
-        Map<Long, List<RecruitingRoundConfigurationInfo>> roundsBySeasonId = listRounds(visibleSeasons).stream()
+        List<RecruitingRound> rounds = listRounds(visibleSeasons);
+        Map<Long, RecruitingRoundDetailInfo> detailByRoundId = detailByRoundId(rounds);
+        Map<Long, List<RecruitingRoundDetailInfo>> roundsBySeasonId = rounds.stream()
             .collect(Collectors.groupingBy(
                 round -> round.getSeason().getId(),
-                Collectors.mapping(RecruitingRoundConfigurationInfo::from, Collectors.toList())
+                Collectors.mapping(round -> detailByRoundId.get(round.getId()), Collectors.toList())
             ));
         return visibleSeasons.stream()
             .map(visible -> RecruitingSeasonSummaryInfo.of(
@@ -155,11 +165,12 @@ public class RecruitingSeasonQueryService implements
         List<RecruitingRound> rounds = sortRounds(filterRounds(listRounds(visibleSeasons), query.track()), query.effectiveSort());
         Map<Long, VisibleSeason> seasonById = visibleSeasons.stream()
             .collect(Collectors.toMap(visible -> visible.season().getId(), Function.identity()));
-        Map<Long, List<RecruitingRoundConfigurationInfo>> roundsBySeason = rounds.stream()
+        Map<Long, RecruitingRoundDetailInfo> detailByRoundId = detailByRoundId(rounds);
+        Map<Long, List<RecruitingRoundDetailInfo>> roundsBySeason = rounds.stream()
             .collect(Collectors.groupingBy(
                 round -> round.getSeason().getId(),
                 LinkedHashMap::new,
-                Collectors.mapping(RecruitingRoundConfigurationInfo::from, Collectors.toList())
+                Collectors.mapping(round -> detailByRoundId.get(round.getId()), Collectors.toList())
             ));
         List<RecruitingSeasonSummaryInfo> populatedSeasons = roundsBySeason.entrySet().stream()
             .map(entry -> toSummary(seasonById.get(entry.getKey()), entry.getValue()))
@@ -173,7 +184,7 @@ public class RecruitingSeasonQueryService implements
 
     private RecruitingSeasonSummaryInfo toSummary(
         VisibleSeason visible,
-        List<RecruitingRoundConfigurationInfo> rounds
+        List<RecruitingRoundDetailInfo> rounds
     ) {
         return RecruitingSeasonSummaryInfo.of(
             visible.season(),
@@ -244,6 +255,45 @@ public class RecruitingSeasonQueryService implements
         return excludedRoundId == null
             ? !loadRoundPort.existsBySeasonIdAndTitleIgnoreCase(seasonId, normalizedTitle)
             : !loadRoundPort.existsBySeasonIdAndTitleIgnoreCaseAndIdNot(seasonId, normalizedTitle, excludedRoundId);
+    }
+
+    /**
+     * 차수 설정에 작성자와 지원자 유무를 얹는다.
+     */
+    private Map<Long, RecruitingRoundDetailInfo> detailByRoundId(List<RecruitingRound> rounds) {
+        if (rounds.isEmpty()) {
+            return Map.of();
+        }
+        Set<Long> roundIdsHavingApplication = loadApplicationPort.filterRoundIdsHavingApplication(
+            rounds.stream().map(RecruitingRound::getId).toList()
+        );
+        Set<Long> authorMemberIds = rounds.stream()
+            .map(RecruitingRound::getCreatedByMemberId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        Map<Long, MemberInfo> memberById = authorMemberIds.isEmpty()
+            ? Map.of()
+            : getMemberUseCase.findAllByIds(authorMemberIds);
+        return rounds.stream().collect(Collectors.toMap(
+            RecruitingRound::getId,
+            round -> RecruitingRoundDetailInfo.of(
+                RecruitingRoundConfigurationInfo.from(round),
+                round.getCreatedAt(),
+                resolveAuthor(round, memberById),
+                roundIdsHavingApplication.contains(round.getId())
+            ),
+            (left, right) -> left,
+            LinkedHashMap::new
+        ));
+    }
+
+    /** 컬럼 추가 이전 차수이거나 탈퇴 등으로 회원을 찾지 못하면 작성자를 비운다. */
+    private RecruitingRoundAuthorInfo resolveAuthor(RecruitingRound round, Map<Long, MemberInfo> memberById) {
+        if (round.getCreatedByMemberId() == null) {
+            return null;
+        }
+        MemberInfo member = memberById.get(round.getCreatedByMemberId());
+        return member == null ? null : RecruitingRoundAuthorInfo.from(member);
     }
 
     private List<VisibleSeason> listVisibleSeasons(

--- a/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
+++ b/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
@@ -110,14 +110,24 @@ public class RecruitingRound extends BaseEntity {
     @Column(name = "contact_text", columnDefinition = "TEXT")
     private String contactText;
 
+    @Column(name = "created_by_member_id")
+    private Long createdByMemberId;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private RecruitingRound(RecruitingSeason season, RecruitingRoundType type, Integer roundNo, String title) {
+    private RecruitingRound(
+        RecruitingSeason season,
+        RecruitingRoundType type,
+        Integer roundNo,
+        String title,
+        Long createdByMemberId
+    ) {
         validateRoundNo(roundNo);
         this.season = season;
         this.type = type;
         this.roundNo = roundNo;
         this.title = normalizeTitle(title);
         this.status = RecruitingRoundStatus.DRAFT;
+        this.createdByMemberId = createdByMemberId;
     }
 
     public static RecruitingRound createRegular(RecruitingSeason season) {
@@ -125,11 +135,16 @@ public class RecruitingRound extends BaseEntity {
     }
 
     public static RecruitingRound createRegular(RecruitingSeason season, String title) {
+        return createRegular(season, title, (Long) null);
+    }
+
+    public static RecruitingRound createRegular(RecruitingSeason season, String title, Long createdByMemberId) {
         return RecruitingRound.builder()
             .season(season)
             .type(RecruitingRoundType.REGULAR)
             .roundNo(1)
             .title(title)
+            .createdByMemberId(createdByMemberId)
             .build();
     }
 
@@ -145,7 +160,16 @@ public class RecruitingRound extends BaseEntity {
         String title,
         RecruitingRoundConfiguration configuration
     ) {
-        RecruitingRound round = createRegular(season, title);
+        return createRegular(season, title, configuration, null);
+    }
+
+    public static RecruitingRound createRegular(
+        RecruitingSeason season,
+        String title,
+        RecruitingRoundConfiguration configuration,
+        Long createdByMemberId
+    ) {
+        RecruitingRound round = createRegular(season, title, createdByMemberId);
         round.applyConfiguration(configuration);
         return round;
     }
@@ -155,11 +179,21 @@ public class RecruitingRound extends BaseEntity {
     }
 
     public static RecruitingRound createAdditional(RecruitingSeason season, Integer roundNo, String title) {
+        return createAdditional(season, roundNo, title, (Long) null);
+    }
+
+    public static RecruitingRound createAdditional(
+        RecruitingSeason season,
+        Integer roundNo,
+        String title,
+        Long createdByMemberId
+    ) {
         return RecruitingRound.builder()
             .season(season)
             .type(RecruitingRoundType.ADDITIONAL)
             .roundNo(roundNo)
             .title(title)
+            .createdByMemberId(createdByMemberId)
             .build();
     }
 
@@ -177,7 +211,17 @@ public class RecruitingRound extends BaseEntity {
         String title,
         RecruitingRoundConfiguration configuration
     ) {
-        RecruitingRound round = createAdditional(season, roundNo, title);
+        return createAdditional(season, roundNo, title, configuration, null);
+    }
+
+    public static RecruitingRound createAdditional(
+        RecruitingSeason season,
+        Integer roundNo,
+        String title,
+        RecruitingRoundConfiguration configuration,
+        Long createdByMemberId
+    ) {
+        RecruitingRound round = createAdditional(season, roundNo, title, createdByMemberId);
         round.applyConfiguration(configuration);
         return round;
     }

--- a/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
+++ b/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
@@ -135,17 +135,11 @@ public class RecruitingRound extends BaseEntity {
     }
 
     public static RecruitingRound createRegular(RecruitingSeason season, String title) {
-        return createRegular(season, title, (Long) null);
+        return createRound(season, RecruitingRoundType.REGULAR, 1, title, null);
     }
 
     public static RecruitingRound createRegular(RecruitingSeason season, String title, Long createdByMemberId) {
-        return RecruitingRound.builder()
-            .season(season)
-            .type(RecruitingRoundType.REGULAR)
-            .roundNo(1)
-            .title(title)
-            .createdByMemberId(createdByMemberId)
-            .build();
+        return createRound(season, RecruitingRoundType.REGULAR, 1, title, createdByMemberId);
     }
 
     public static RecruitingRound createRegular(
@@ -179,7 +173,7 @@ public class RecruitingRound extends BaseEntity {
     }
 
     public static RecruitingRound createAdditional(RecruitingSeason season, Integer roundNo, String title) {
-        return createAdditional(season, roundNo, title, (Long) null);
+        return createRound(season, RecruitingRoundType.ADDITIONAL, roundNo, title, null);
     }
 
     public static RecruitingRound createAdditional(
@@ -188,9 +182,19 @@ public class RecruitingRound extends BaseEntity {
         String title,
         Long createdByMemberId
     ) {
+        return createRound(season, RecruitingRoundType.ADDITIONAL, roundNo, title, createdByMemberId);
+    }
+
+    private static RecruitingRound createRound(
+        RecruitingSeason season,
+        RecruitingRoundType type,
+        Integer roundNo,
+        String title,
+        Long createdByMemberId
+    ) {
         return RecruitingRound.builder()
             .season(season)
-            .type(RecruitingRoundType.ADDITIONAL)
+            .type(type)
             .roundNo(roundNo)
             .title(title)
             .createdByMemberId(createdByMemberId)

--- a/src/main/resources/db/migration/V2026.08.08.16.30__add_created_by_member_id_to_recruiting_round.sql
+++ b/src/main/resources/db/migration/V2026.08.08.16.30__add_created_by_member_id_to_recruiting_round.sql
@@ -1,0 +1,6 @@
+-- 모집 목록/공유 보관함에서 공고 작성자를 노출하기 위해 차수에 작성자를 기록한다.
+ALTER TABLE public.recruiting_round
+    ADD COLUMN created_by_member_id BIGINT;
+
+COMMENT ON COLUMN public.recruiting_round.created_by_member_id
+    IS '차수를 생성한 운영진 member ID. 컬럼 추가 이전 차수는 NULL.';

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
@@ -59,6 +59,7 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvalua
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingEvaluationStatisticsQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPartStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundConfigurationInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundGroupSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundStatusSummaryInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSchoolEvaluationStatisticsInfo;
@@ -403,7 +404,12 @@ class RecruitingSeasonAdminGraphQlControllerTest {
                 22L,
                 "A 학교",
                 "운영진 메모",
-                List.of(roundConfiguration())
+                List.of(new RecruitingRoundDetailInfo(
+                    roundConfiguration(),
+                    Instant.parse("2026-07-31T12:00:00Z"),
+                    null,
+                    true
+                ))
             )
         ));
 

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
@@ -40,6 +40,7 @@ import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingS
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
+import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingSeasonCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.ReplaceRecruitingSeasonTrackQuotasCommand;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
@@ -47,7 +48,9 @@ import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonC
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingSeasonUseCase;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundAuthorInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundConfigurationInfo;
+import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingRoundGroupSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonConfigurationInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
@@ -133,6 +136,36 @@ class RecruitingSeasonAdminControllerTest {
     }
 
     @Test
+    @DisplayName("차수 생성 요청은 현재 회원을 작성자로 command에 전달한다")
+    void createRoundPassesCurrentMemberAsAuthor() throws Exception {
+        given(createRoundUseCase.createRound(any())).willReturn(20L);
+
+        mockMvc.perform(post("/api/v1/recruiting/admin/seasons/{seasonId}/rounds", 10L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "15기 본모집",
+                      "type": "REGULAR",
+                      "recruitableTracks": ["PLAN"],
+                      "secondChoiceEnabled": false,
+                      "documentStartAt": "2026-08-01T00:00:00Z",
+                      "documentEndAt": "2026-08-08T00:00:00Z",
+                      "documentResultPublishedAt": "2026-08-10T00:00:00Z",
+                      "interviewRequired": false,
+                      "finalResultPublishedAt": "2026-08-16T00:00:00Z"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.id").value(20L));
+
+        ArgumentCaptor<CreateRecruitingRoundCommand> captor =
+            ArgumentCaptor.forClass(CreateRecruitingRoundCommand.class);
+        then(createRoundUseCase).should().createRound(captor.capture());
+        assertThat(captor.getValue().seasonId()).isEqualTo(10L);
+        assertThat(captor.getValue().requesterMemberId()).isEqualTo(MEMBER_ID);
+    }
+
+    @Test
     @DisplayName("시즌 설정 조회는 availability Form과 SCHEDULE 질문 ID를 함께 반환한다")
     void getSeasonConfigurationIncludesAvailabilityQuestionId() throws Exception {
         given(getSeasonConfigurationUseCase.getBySeasonId(10L)).willReturn(
@@ -192,7 +225,12 @@ class RecruitingSeasonAdminControllerTest {
                 22L,
                 "A 학교",
                 "운영진 메모",
-                List.of(roundConfiguration())
+                List.of(new RecruitingRoundDetailInfo(
+                    roundConfiguration(),
+                    java.time.Instant.parse("2026-07-31T12:00:00Z"),
+                    new RecruitingRoundAuthorInfo(99L, "홍길동", "길동", "A 학교"),
+                    true
+                ))
             )
         ));
 
@@ -206,7 +244,11 @@ class RecruitingSeasonAdminControllerTest {
             .andExpect(jsonPath("$.result[0].schoolName").value("A 학교"))
             .andExpect(jsonPath("$.result[0].rounds[0].id").value(20L))
             .andExpect(jsonPath("$.result[0].rounds[0].availabilityFormId").value(100L))
-            .andExpect(jsonPath("$.result[0].rounds[0].availabilityScheduleQuestionId").value(200L));
+            .andExpect(jsonPath("$.result[0].rounds[0].availabilityScheduleQuestionId").value(200L))
+            .andExpect(jsonPath("$.result[0].rounds[0].createdAt").value("2026-07-31T12:00:00Z"))
+            .andExpect(jsonPath("$.result[0].rounds[0].author.memberId").value(99L))
+            .andExpect(jsonPath("$.result[0].rounds[0].author.name").value("홍길동"))
+            .andExpect(jsonPath("$.result[0].rounds[0].hasApplicants").value(true));
 
         ArgumentCaptor<RecruitingRoundGroupSearchQuery> captor =
             ArgumentCaptor.forClass(RecruitingRoundGroupSearchQuery.class);

--- a/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingPersistenceAdapterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,40 @@ class RecruitingPersistenceAdapterTest extends RecruitingPersistenceAdapterTestS
             .containsExactly(second.getId(), first.getId());
         assertThat(result)
             .allMatch(application -> application.getApplicationForm().getRound().getSeason().getId() != null);
+    }
+
+    @Test
+    @DisplayName("지원서가 있는 차수 ID는 지원서 상태와 무관하게 한 번에 조회한다")
+    void filterRoundIdsHavingApplicationIgnoresApplicationStatus() {
+        RecruitingGraph draft = persistApplicationGraph(
+            9L,
+            90L,
+            1,
+            "identity:draft",
+            RecruitingApplicationStatus.DRAFT
+        );
+        RecruitingGraph failed = persistApplicationGraph(
+            9L,
+            90L,
+            2,
+            "identity:failed",
+            RecruitingApplicationStatus.DOCUMENT_FAILED
+        );
+        RecruitingRound emptyRound = roundAdapter.save(RecruitingRound.createAdditional(
+            draft.season(),
+            3,
+            applicationConfiguration()
+        ));
+        em.flush();
+        em.clear();
+
+        Set<Long> result = applicationAdapter.filterRoundIdsHavingApplication(List.of(
+            draft.round().getId(),
+            failed.round().getId(),
+            emptyRound.getId()
+        ));
+
+        assertThat(result).containsExactlyInAnyOrder(draft.round().getId(), failed.round().getId());
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCreateCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundCreateCommandServiceTest.java
@@ -59,6 +59,7 @@ class RecruitingRoundCreateCommandServiceTest {
         given(loadQuotaPort.listBySeasonId(10L)).willReturn(List.of(quota(season, ChallengerTrack.PLAN, 3)));
         given(saveRoundPort.save(any())).willAnswer(invocation -> {
             RecruitingRound round = invocation.getArgument(0);
+            assertThat(round.getCreatedByMemberId()).isEqualTo(99L);
             ReflectionTestUtils.setField(round, "id", 200L);
             return round;
         });
@@ -157,6 +158,7 @@ class RecruitingRoundCreateCommandServiceTest {
             .roundNo(roundNo)
             .title(type == RecruitingRoundType.REGULAR ? "본모집" : "추가모집 " + roundNo + "차")
             .configuration(configuration(track))
+            .requesterMemberId(99L)
             .build();
     }
 

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
@@ -186,6 +186,7 @@ class RecruitingRoundLifecycleCommandServiceTest {
         assertThat(captor.getValue().configuration().availabilityFormId()).isNull();
         assertThat(captor.getValue().configuration().availabilityScheduleQuestionId()).isNull();
         assertThat(captor.getValue().configuration().announcement()).isEqualTo("공고");
+        assertThat(captor.getValue().requesterMemberId()).isEqualTo(99L);
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/query/RecruitingSeasonQueryServiceTest.java
@@ -2,10 +2,12 @@ package com.umc.product.recruiting.application.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +23,8 @@ import com.umc.product.authorization.domain.ResourcePermission;
 import com.umc.product.authorization.domain.ResourceType;
 import com.umc.product.authorization.domain.SubjectAttributes;
 import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.school.SchoolDetailInfo;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingPublicRoundSearchQuery;
@@ -30,6 +34,7 @@ import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeason
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSearchQuery;
 import com.umc.product.recruiting.application.port.in.query.dto.RecruitingSeasonSummaryInfo;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
+import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingSeasonTrackQuotaPort;
@@ -56,7 +61,13 @@ class RecruitingSeasonQueryServiceTest {
     LoadRecruitingApplicationFormPort loadApplicationFormPort;
 
     @Mock
+    LoadRecruitingApplicationPort loadApplicationPort;
+
+    @Mock
     GetSchoolUseCase getSchoolUseCase;
+
+    @Mock
+    GetMemberUseCase getMemberUseCase;
 
     @Mock
     CheckPermissionUseCase checkPermissionUseCase;
@@ -136,8 +147,67 @@ class RecruitingSeasonQueryServiceTest {
             assertThat(found.chapterId()).isEqualTo(7L);
             assertThat(found.schoolName()).isEqualTo("A 학교");
             assertThat(found.rounds()).singleElement()
-                .satisfies(foundRound -> assertThat(foundRound.id()).isEqualTo(200L));
+                .satisfies(foundRound -> assertThat(foundRound.configuration().id()).isEqualTo(200L));
         });
+    }
+
+    @Test
+    @DisplayName("차수 그룹 목록은 작성자와 지원자 유무를 일괄 조회하고 기존 차수의 작성자는 비운다")
+    void searchRoundGroupsEnrichesRoundsInBatchAndKeepsLegacyAuthorNull() {
+        RecruitingSeason season = season(100L, 1L, 10L);
+        RecruitingRound authoredRound = RecruitingRound.createRegular(
+            season,
+            "본모집",
+            regularRoundConfiguration(),
+            500L
+        );
+        ReflectionTestUtils.setField(authoredRound, "id", 200L);
+        ReflectionTestUtils.setField(authoredRound, "createdAt", Instant.parse("2026-07-01T00:00:00Z"));
+        RecruitingRound legacyRound = RecruitingRound.createAdditional(
+            season,
+            2,
+            "추가모집",
+            regularRoundConfiguration(),
+            null
+        );
+        ReflectionTestUtils.setField(legacyRound, "id", 201L);
+        ReflectionTestUtils.setField(legacyRound, "createdAt", Instant.parse("2026-07-02T00:00:00Z"));
+        SubjectAttributes subject = SubjectAttributes.builder().memberId(99L).build();
+        MemberInfo author = MemberInfo.builder()
+            .id(500L)
+            .name("홍길동")
+            .nickname("길동")
+            .schoolName("A 학교")
+            .build();
+        given(getSchoolUseCase.getSchoolListByGisuId(1L))
+            .willReturn(List.of(school(7L, "A 지부", 10L, "A 학교")));
+        given(loadSeasonPort.listByGisuId(1L)).willReturn(List.of(season));
+        given(checkPermissionUseCase.loadSubject(99L)).willReturn(subject);
+        given(checkPermissionUseCase.check(subject, readPermission(100L))).willReturn(true);
+        given(loadRoundPort.listBySeasonIds(List.of(100L))).willReturn(List.of(authoredRound, legacyRound));
+        given(loadApplicationPort.filterRoundIdsHavingApplication(List.of(201L, 200L)))
+            .willReturn(Set.of(201L));
+        given(getMemberUseCase.findAllByIds(Set.of(500L))).willReturn(Map.of(500L, author));
+
+        var result = sut.searchRoundGroups(RecruitingRoundGroupSearchQuery.builder()
+            .gisuId(1L)
+            .requesterMemberId(99L)
+            .build());
+
+        assertThat(result).singleElement().satisfies(group -> {
+            assertThat(group.rounds()).hasSize(2);
+            assertThat(group.rounds().get(0).createdAt()).isEqualTo(Instant.parse("2026-07-02T00:00:00Z"));
+            assertThat(group.rounds().get(0).author()).isNull();
+            assertThat(group.rounds().get(0).hasApplicants()).isTrue();
+            assertThat(group.rounds().get(1).author()).satisfies(found -> {
+                assertThat(found.memberId()).isEqualTo(500L);
+                assertThat(found.name()).isEqualTo("홍길동");
+                assertThat(found.schoolName()).isEqualTo("A 학교");
+            });
+            assertThat(group.rounds().get(1).hasApplicants()).isFalse();
+        });
+        then(loadApplicationPort).should().filterRoundIdsHavingApplication(List.of(201L, 200L));
+        then(getMemberUseCase).should().findAllByIds(Set.of(500L));
     }
 
     @Test
@@ -314,7 +384,13 @@ class RecruitingSeasonQueryServiceTest {
     }
 
     private RecruitingRound regularRound(RecruitingSeason season, Long id) {
-        RecruitingRound round = RecruitingRound.createRegular(season, RecruitingRoundConfiguration.of(
+        RecruitingRound round = RecruitingRound.createRegular(season, regularRoundConfiguration());
+        ReflectionTestUtils.setField(round, "id", id);
+        return round;
+    }
+
+    private RecruitingRoundConfiguration regularRoundConfiguration() {
+        return RecruitingRoundConfiguration.of(
             List.of(ChallengerTrack.PLAN),
             false,
             Instant.parse("2026-08-01T00:00:00Z"),
@@ -327,9 +403,7 @@ class RecruitingSeasonQueryServiceTest {
             null,
             "안내",
             "contact"
-        ));
-        ReflectionTestUtils.setField(round, "id", id);
-        return round;
+        );
     }
 
     private RecruitingApplicationForm publishedApplicationForm(RecruitingRound round) {


### PR DESCRIPTION
## 🚀 작업 내용

closes #1233

모집 관리 목록에서 작성자·작성일을 보여주고, 지원자가 있는 공고의 수정을 막을 수 있도록 목록 응답을 확장했습니다.

- 차수 생성·복제 시 요청자 ID를 `recruiting_round.created_by_member_id`에 저장합니다.
  - 기존 차수는 작성자 정보가 없어 `author: null`로 반환합니다.
- `GET /api/v1/recruiting/admin/rounds`의 차수 응답에 `createdAt`, `author`, `hasApplicants`를 추가합니다.
- 작성자와 지원서 존재 여부를 차수 단위로 반복 조회하지 않고 일괄 조회합니다.
- `hasApplicants`는 지원서 상태와 관계없이 하나라도 존재하면 `true`입니다.
  - 서버의 기존 수정 잠금 정책과 동일한 기준을 사용합니다.
- `/admin/summary`, 시즌 설정 조회, GraphQL 외부 응답 계약은 변경하지 않습니다.

## 💬 리뷰 중점사항

- `hasApplicants`가 모든 지원서 상태를 포함해 기존 수정 잠금 정책과 동일하게 동작하는지 확인 부탁드립니다.