### PR TITLE
[Fix] 스레드 검색 결과를 단일 목록으로 반환하고 total에 고정 스레드 포함

### DIFF
--- a/docs/guides/community-thread-client-contract.md
+++ b/docs/guides/community-thread-client-contract.md
@@ -59,6 +59,18 @@ Admin surface의 완전한 경로는 `/api/v1/community/admin/thread-message-rep
 메시지 history는 newest-first, exclusive `before` cursor, 기본 limit 30, 최대 100이다. broker가
 끊기거나 event가 누락되면 이 endpoint와 thread detail/member query로 상태를 backfill한다.
 
+`GET /threads`는 `q` 유무로 응답 구성이 달라진다.
+
+- `q` 없음: 목록 화면의 "고정"과 "전체" 두 섹션에 대응해 `pinned`와 `threads`를 나눠 반환한다.
+  `pinned`는 요청자가 고정한 참여 스레드 전부이고 페이징하지 않는다. `total`과 `nextOffset`은
+  `threads`만 센다.
+- `q` 있음: 검색 화면의 "검색 결과 N개" 단일 목록에 대응해 `pinned`는 항상 빈 배열이고 매칭된
+  스레드를 전부 `threads`에 담는다. 요청자가 고정한 스레드가 상단에 오고, `total`과 `nextOffset`은
+  고정 스레드를 포함한 전체 매칭 수를 기준으로 한다.
+
+두 경우 모두 참여하지 않은 스레드도 포함하며, 매칭은 thread `title`과 `description`의 대소문자 무시
+부분일치다. 메시지 본문은 검색 대상이 아니다. 참여 여부는 각 항목의 `isJoined`로 구분한다.
+
 ## 3. WebSocket 연결
 
 SockJS/STOMP endpoint는 `/ws`, native WebSocket transport endpoint는 `/ws/websocket`이다. 두

--- a/src/main/java/com/umc/product/community/adapter/out/persistence/CommunityThreadQueryRepository.java
+++ b/src/main/java/com/umc/product/community/adapter/out/persistence/CommunityThreadQueryRepository.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -42,7 +44,16 @@ public class CommunityThreadQueryRepository {
         return new CommunityThreadListRows(pinned, unpinned, unpinnedTotal);
     }
 
+    /**
+     * 목록 화면은 "고정"과 "전체"를 나눠 보여주므로 keyword가 없으면 두 목록으로 분리한다. 검색 화면은 단일 목록에 "검색 결과 N개"를 표시하므로 keyword가 있으면
+     * pinned를 비우고 매칭된 스레드 전체를 unpinned 하나에 담는다. 이때 unpinnedTotal은 고정 스레드를 포함한 전체 매칭 수다.
+     */
     public CommunityThreadListRows browseThreads(CommunityThreadListCondition condition) {
+        if (condition.keyword() != null) {
+            return new CommunityThreadListRows(
+                List.of(), fetchSearchRows(condition), countSearch(condition)
+            );
+        }
         List<CommunityThreadQueryRow> pinned = fetchThreadRows(condition, true);
         List<CommunityThreadQueryRow> unpinned = fetchBrowseRows(condition);
         long unpinnedTotal = countBrowse(condition);
@@ -173,6 +184,47 @@ public class CommunityThreadQueryRepository {
             .toList();
     }
 
+    private List<CommunityThreadQueryRow> fetchSearchRows(CommunityThreadListCondition condition) {
+        QCommunityThreadMember requesterMembership = new QCommunityThreadMember("searchRequesterMembership");
+        JPQLQuery<Long> memberCount = activeMemberCount("searchActiveMembership");
+
+        return queryFactory
+            .select(threadProjection(requesterMembership, memberCount))
+            .from(communityThread)
+            .leftJoin(requesterMembership).on(
+                requesterMembership.threadId.eq(communityThread.id),
+                requesterMembership.memberId.eq(condition.requesterMemberId()),
+                requesterMembership.state.eq(CommunityThreadMemberState.ACTIVE)
+            )
+            .where(listCondition(condition, requesterMembership))
+            .orderBy(
+                pinnedFirst(requesterMembership),
+                communityThread.lastActivityAt.desc(),
+                communityThread.id.desc()
+            )
+            .offset(condition.offset())
+            .limit(condition.limit())
+            .fetch()
+            .stream()
+            .map(row -> toThreadRow(row, requesterMembership, memberCount))
+            .toList();
+    }
+
+    private long countSearch(CommunityThreadListCondition condition) {
+        QCommunityThreadMember requesterMembership = new QCommunityThreadMember("countSearchMembership");
+        Long count = queryFactory
+            .select(communityThread.id.count())
+            .from(communityThread)
+            .leftJoin(requesterMembership).on(
+                requesterMembership.threadId.eq(communityThread.id),
+                requesterMembership.memberId.eq(condition.requesterMemberId()),
+                requesterMembership.state.eq(CommunityThreadMemberState.ACTIVE)
+            )
+            .where(listCondition(condition, requesterMembership))
+            .fetchOne();
+        return count == null ? 0L : count;
+    }
+
     private long countBrowse(CommunityThreadListCondition condition) {
         QCommunityThreadMember requesterMembership = new QCommunityThreadMember("countBrowseMembership");
         Long count = queryFactory
@@ -239,6 +291,16 @@ public class CommunityThreadQueryRepository {
             where.and(requesterMembership.unreadCount.gt(0L));
         }
         return where;
+    }
+
+    /**
+     * pinned는 left join 컬럼이라 비멤버 스레드에서 null이 된다. boolean 정렬은 DB마다 null 위치가 달라지므로 정렬 키를 0/1로 고정한다.
+     */
+    private OrderSpecifier<Integer> pinnedFirst(QCommunityThreadMember requesterMembership) {
+        return new CaseBuilder()
+            .when(requesterMembership.pinned.isTrue()).then(0)
+            .otherwise(1)
+            .asc();
     }
 
     private BooleanExpression keywordContains(String keyword) {

--- a/src/test/java/com/umc/product/community/adapter/out/persistence/CommunityThreadReadQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/community/adapter/out/persistence/CommunityThreadReadQueryRepositoryTest.java
@@ -220,15 +220,98 @@ class CommunityThreadReadQueryRepositoryTest {
         assertThat(result.unpinnedTotal()).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("browse 검색은 고정/전체 분리 없이 매칭 스레드를 한 목록에 담고 고정을 상단에 두며 제목·소개글을 함께 본다")
+    void browseThreads_검색은_단일_목록으로_고정을_상단에_둔다() {
+        // given
+        CommunityThread pinnedMatch = persistThread(2_201L, "축구 모임", CommunityThreadCategory.FREE);
+        CommunityThread joinedMatch = persistThread(2_202L, "축구 번개", CommunityThreadCategory.FREE);
+        CommunityThread descriptionMatch = persistThread(
+            2_203L, "주말 운동", "축구 하실 분 모집합니다", CommunityThreadCategory.FREE
+        );
+        CommunityThread noMatch = persistThread(2_204L, "야구 모임", CommunityThreadCategory.FREE);
+        persistRequesterMembership(pinnedMatch, true, 0L);
+        persistRequesterMembership(joinedMatch, false, 0L);
+        persistMembership(descriptionMatch, 999L);
+        persistRequesterMembership(noMatch, false, 0L);
+        flushAndClear();
+
+        // when
+        CommunityThreadListRows result = sut.browseThreads(new CommunityThreadListCondition(
+            REQUESTER_ID, null, false, "축구", 0, 20
+        ));
+
+        // then
+        assertThat(result.pinned()).isEmpty();
+        assertThat(result.unpinned()).extracting(row -> row.threadId())
+            .containsExactly(pinnedMatch.getId(), descriptionMatch.getId(), joinedMatch.getId());
+        assertThat(result.unpinnedTotal()).isEqualTo(3L);
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("browse 검색 결과가 고정 스레드뿐이어도 total이 고정 스레드를 센다")
+    void browseThreads_검색_total은_고정_스레드를_포함한다() {
+        // given
+        CommunityThread pinnedMatch = persistThread(2_211L, "축구 모임", CommunityThreadCategory.FREE);
+        CommunityThread noMatch = persistThread(2_212L, "야구 모임", CommunityThreadCategory.FREE);
+        persistRequesterMembership(pinnedMatch, true, 0L);
+        persistRequesterMembership(noMatch, false, 0L);
+        flushAndClear();
+
+        // when
+        CommunityThreadListRows result = sut.browseThreads(new CommunityThreadListCondition(
+            REQUESTER_ID, null, false, "축구", 0, 20
+        ));
+
+        // then
+        assertThat(result.pinned()).isEmpty();
+        assertThat(result.unpinned()).extracting(row -> row.threadId())
+            .containsExactly(pinnedMatch.getId());
+        assertThat(result.unpinnedTotal()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("browse 검색 페이징은 고정 스레드를 포함한 단일 목록 기준으로 offset을 센다")
+    void browseThreads_검색_페이징은_고정을_포함해_계산한다() {
+        // given
+        CommunityThread pinnedMatch = persistThread(2_221L, "축구 모임", CommunityThreadCategory.FREE);
+        CommunityThread olderMatch = persistThread(2_222L, "축구 번개", CommunityThreadCategory.FREE);
+        CommunityThread newerMatch = persistThread(2_223L, "축구 리그", CommunityThreadCategory.FREE);
+        persistRequesterMembership(pinnedMatch, true, 0L);
+        persistRequesterMembership(olderMatch, false, 0L);
+        persistRequesterMembership(newerMatch, false, 0L);
+        flushAndClear();
+
+        // when
+        CommunityThreadListRows result = sut.browseThreads(new CommunityThreadListCondition(
+            REQUESTER_ID, null, false, "축구", 1, 1
+        ));
+
+        // then
+        assertThat(result.unpinned()).extracting(row -> row.threadId())
+            .containsExactly(newerMatch.getId());
+        assertThat(result.unpinnedTotal()).isEqualTo(3L);
+    }
+
     private CommunityThread persistThread(
         Long chatRoomId,
         String title,
         CommunityThreadCategory category
     ) {
+        return persistThread(chatRoomId, title, null, category);
+    }
+
+    private CommunityThread persistThread(
+        Long chatRoomId,
+        String title,
+        String description,
+        CommunityThreadCategory category
+    ) {
         return threadRepository.save(CommunityThread.create(
             chatRoomId,
             title,
-            null,
+            description,
             category,
             "💬",
             REQUESTER_ID,


### PR DESCRIPTION
## 🚀 작업 내용

- resolves #1242 

1. 스레드 검색(`GET /api/v1/community/threads?q=`)에서 매칭된 고정 스레드가 `pinned` 배열로 빠지고 `total`에서 제외되던 문제를 고쳤어요.

2. `CommunityThreadQueryRepository.browseThreads`에 `q` 유무 분기를 넣었어요.

  - **`q` 없음** : 기존 그대로예요. 목록 화면의 "고정"/"전체" 2섹션에 맞춰 `pinned`와 `threads`를
    나눠 반환해요.
  - **`q` 있음** : 검색 화면이 "검색 결과 N개" 단일 목록이라 `pinned`를 비우고 매칭 스레드를 전부
    `threads`에 담아요. `total`과 `nextOffset`도 고정 포함 전체 매칭 수 기준이에요.


## 💬 리뷰 중점사항
