### PR TITLE
 [Fix] 스레드 비참여자의 메시지 조회 허용과 강퇴 회원 조회 차단

### DIFF
--- a/docs/adr/026-separate-chat-engine-consumer-realtime-responsibilities.md
+++ b/docs/adr/026-separate-chat-engine-consumer-realtime-responsibilities.md
@@ -145,8 +145,10 @@ Registry는 destination을 지원하는 authorizer가 **정확히 하나이고**
 1. 외부 요청은 consumer resource ID만 받는다. Engine `roomId`를 client 입력으로 직접 받지 않는다.
 2. 하나의 Chat room은 하나의 consumer resource가 소유한다. Consumer의 `chatRoomId`에는 unique
    constraint 또는 동등한 애플리케이션 불변식을 둔다.
-3. Consumer 권한과 Chat membership을 모두 만족해야 한다. Subscription authorizer 승인은 Chat
-   membership 생성이나 변경을 대신하지 않는다.
+3. Consumer 권한과 Chat 방 접근 권한을 모두 만족해야 한다. 변경은 Chat membership을 요구하고,
+   조회는 방의 `ChatRoomReadScope`가 정한다(`MEMBER_ONLY` 기본, `PUBLIC`이면 비멤버 조회 허용).
+   Subscription authorizer 승인은 Chat membership 생성이나 변경을 대신하지 않는다.
+   자세한 내용은 아래 `Amendment: room read scope`를 참고한다.
 4. Consumer가 engine 방을 생성한 뒤 resource에 `chatRoomId`를 저장하는 과정은 하나의 application
    transaction에서 수행한다.
 5. `StompSubscriptionAuthorizer.supports`는 자신이 소유한 exact destination namespace만 선택한다.
@@ -564,3 +566,35 @@ FCM/APNs, token, deeplink, title/name, mute/offline/DND 결정과 notification d
   `EventOutboxRelayMetrics` retry/failed도 low-cardinality를 유지한다. 이름은
   `community.thread.realtime.send.commands`, `.reject.commands`, `.rate.limit.rejections`,
   `.fanout.events`, `.fanout.recipients`, `.broadcast.failures`, `.backfill.requests`로 고정한다.
+
+## Amendment: room read scope
+
+Status: Accepted - 이슈 #1244 (2026-08-11)
+
+원 결정은 Chat 방 접근을 membership 단일 규칙으로 두었다. 그러나 Community thread는 상세 조회가
+비참여자에게도 공개인 반면 메시지 조회만 membership을 요구해, 스레드에 진입한 비참여자가 대화를
+읽을 수 없는 모순이 있었다. 조회 경로의 차단 지점이 Community와 Chat 두 곳이라 소비 도메인만
+고쳐서는 해결되지 않는다.
+
+Chat engine에 consumer 분기를 넣는 대신 방 속성으로 조회 범위를 표현하기로 한다.
+
+- `ChatRoomReadScope`는 `MEMBER_ONLY`(기본)와 `PUBLIC`을 갖고 `chat_room.read_scope`에 저장한다.
+  값은 방을 만든 소비 도메인이 `CreateChatRoomCommand`로 정하며, engine은 소비 도메인을 알지 않는다.
+- `ChatRoomAccessPolicy.verifyMember`는 모든 변경 경로가 그대로 사용한다. 조회 경로만
+  `verifyReadable`을 사용하며, 참여자이거나 방이 `PUBLIC`이어야 한다. 참여자 여부를 먼저 확인하므로
+  `MEMBER_ONLY` 방의 조회 비용은 기존과 같다.
+- 방을 찾지 못하면 존재 여부를 노출하지 않도록 `CHAT_ROOM_ACCESS_DENIED`로 막는다.
+
+따라서 보안 불변식 3번은 "조회는 방의 read scope, 변경은 membership"으로 나뉜다. `PUBLIC`을 선택한
+소비 도메인은 resource 단위 조회 권한 검증을 자신이 계속 소유한다. Chat은 방이 공개인지만 알고
+어떤 사용자가 그 resource를 볼 수 있는지는 판단하지 않는다.
+
+Community thread 방만 `PUBLIC`으로 만든다. 기존 방은 마이그레이션에서 소유 관계를 따라 backfill하며,
+그 밖의 모든 방과 앞으로 추가될 소비 도메인은 명시하지 않는 한 `MEMBER_ONLY`로 남는다.
+
+`PUBLIC`이 "누구나"를 뜻하지 않는다는 점을 Community가 보여준다. 방은 `PUBLIC`이지만 Community는
+KICKED 요청자의 목록/상세/메시지 조회를 자신의 계층에서 차단한다. Chat은 방이 공개인지만 알고
+강퇴 같은 resource 상태는 모른다.
+
+실시간 fan-out 수신자는 여전히 ACTIVE 멤버로 한정한다. 비참여자는 history query로만 대화를 읽고
+push event를 받지 않는다.

--- a/docs/guides/community-thread-client-contract.md
+++ b/docs/guides/community-thread-client-contract.md
@@ -173,9 +173,20 @@ failure와 rate-limit(typed 429)을 포함한다. rate-limit은 해당 command�
 
 ## 7. Lifecycle와 recovery
 
-ACTIVE OWNER/ADMIN/MEMBER만 send/reply/mention/react/read/report를 수행한다. author만 edit할 수 있고,
-author 또는 OWNER/ADMIN만 tombstone할 수 있다. OWNER가 leave/kick/demote하려면 먼저 atomic ownership
-transfer가 필요하다. LEFT는 재초대할 수 있지만 KICKED는 재초대할 수 없다.
+조회와 변경의 권한 경계가 다르다. thread detail, member query와 message history query는 참여 여부와
+무관하게 로그인 회원 모두에게 열려 있다. 클라이언트는 비참여자가 스레드에 진입해 대화를 읽는 흐름을
+가정해야 한다. LEFT도 비참여자와 동일하게 조회할 수 있다.
+
+KICKED만 예외다. 강퇴된 회원에게는 thread list에서 해당 스레드가 아예 노출되지 않고, detail/member/
+message query는 `THREAD_ACCESS_DENIED`로 거부된다.
+
+반면 ACTIVE OWNER/ADMIN/MEMBER만 send/reply/mention/react/read/report를 수행한다. author만 edit할 수
+있고, author 또는 OWNER/ADMIN만 tombstone할 수 있다. OWNER가 leave/kick/demote하려면 먼저 atomic
+ownership transfer가 필요하다. LEFT는 재초대할 수 있지만 KICKED는 재초대할 수 없다.
+
+실시간 fan-out 수신자도 ACTIVE 멤버로 한정한다. 따라서 비참여자는 진입 시점의 history만 보고 이후
+새 message/reaction/read event를 push로 받지 않는다. 최신 상태가 필요하면 history query로 다시
+조회한다.
 
 thread soft delete 뒤에는 모든 REST/STOMP access가 거부되지만 Chat row와 history는 보존된다.
 message/reaction/read gap은 history/latest query로, metadata/member/settings gap은 thread detail/list/

--- a/src/main/java/com/umc/product/chat/adapter/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/chat/adapter/out/persistence/ChatRoomPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.umc.product.chat.adapter.out.persistence;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -40,8 +41,13 @@ public class ChatRoomPersistenceAdapter implements
 
     @Override
     public ChatRoom getById(Long roomId) {
-        return chatRoomJpaRepository.findById(roomId)
+        return findById(roomId)
             .orElseThrow(() -> new ChatDomainException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<ChatRoom> findById(Long roomId) {
+        return chatRoomJpaRepository.findById(roomId);
     }
 
     @Override

--- a/src/main/java/com/umc/product/chat/application/policy/ChatRoomAccessPolicy.java
+++ b/src/main/java/com/umc/product/chat/application/policy/ChatRoomAccessPolicy.java
@@ -3,6 +3,8 @@ package com.umc.product.chat.application.policy;
 import org.springframework.stereotype.Component;
 
 import com.umc.product.chat.application.port.out.LoadChatMemberPort;
+import com.umc.product.chat.application.port.out.LoadChatRoomPort;
+import com.umc.product.chat.domain.ChatRoom;
 import com.umc.product.chat.domain.exception.ChatDomainException;
 import com.umc.product.chat.domain.exception.ChatErrorCode;
 
@@ -19,12 +21,33 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomAccessPolicy {
 
     private final LoadChatMemberPort loadChatMemberPort;
+    private final LoadChatRoomPort loadChatRoomPort;
 
     /**
      * 멤버가 해당 방의 참여자인지 검증한다. 참여자가 아니면 {@link ChatErrorCode#CHAT_ROOM_ACCESS_DENIED} 예외를 던진다.
+     * <p>
+     * 메시지 생성/수정/삭제, 리액션, 읽음 갱신 등 모든 변경은 방의 조회 범위와 무관하게 이 검증을 사용한다.
      */
     public void verifyMember(Long roomId, Long memberId) {
         if (!loadChatMemberPort.existsByRoomIdAndMemberId(roomId, memberId)) {
+            throw new ChatDomainException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+
+    /**
+     * 멤버가 해당 방의 메시지를 조회할 수 있는지 검증한다. 참여자이거나 방이 공개 조회 범위여야 한다.
+     * <p>
+     * 참여자 여부를 먼저 확인해 {@code MEMBER_ONLY} 방의 조회는 기존과 같이 쿼리 한 번으로 끝낸다.
+     * 방을 찾지 못하면 존재 여부를 노출하지 않도록 {@link ChatErrorCode#CHAT_ROOM_ACCESS_DENIED}로 막는다.
+     */
+    public void verifyReadable(Long roomId, Long memberId) {
+        if (loadChatMemberPort.existsByRoomIdAndMemberId(roomId, memberId)) {
+            return;
+        }
+        boolean publiclyReadable = loadChatRoomPort.findById(roomId)
+            .map(ChatRoom::isPubliclyReadable)
+            .orElse(false);
+        if (!publiclyReadable) {
             throw new ChatDomainException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
         }
     }

--- a/src/main/java/com/umc/product/chat/application/port/in/command/dto/CreateChatRoomCommand.java
+++ b/src/main/java/com/umc/product/chat/application/port/in/command/dto/CreateChatRoomCommand.java
@@ -1,9 +1,19 @@
 package com.umc.product.chat.application.port.in.command.dto;
 
+import com.umc.product.chat.domain.ChatRoomReadScope;
+
 public record CreateChatRoomCommand(
-    Long creatorMemberId
+    Long creatorMemberId,
+    ChatRoomReadScope readScope
 ) {
+    /**
+     * 멤버만 조회할 수 있는 방을 만든다. 조회 범위를 명시하지 않는 소비 도메인의 기본 진입점이다.
+     */
     public static CreateChatRoomCommand from(Long memberId) {
-        return new CreateChatRoomCommand(memberId);
+        return new CreateChatRoomCommand(memberId, ChatRoomReadScope.MEMBER_ONLY);
+    }
+
+    public static CreateChatRoomCommand of(Long memberId, ChatRoomReadScope readScope) {
+        return new CreateChatRoomCommand(memberId, readScope);
     }
 }

--- a/src/main/java/com/umc/product/chat/application/port/out/LoadChatRoomPort.java
+++ b/src/main/java/com/umc/product/chat/application/port/out/LoadChatRoomPort.java
@@ -1,10 +1,14 @@
 package com.umc.product.chat.application.port.out;
 
+import java.util.Optional;
+
 import com.umc.product.chat.domain.ChatRoom;
 
 public interface LoadChatRoomPort {
 
     ChatRoom getById(Long roomId);
+
+    Optional<ChatRoom> findById(Long roomId);
 
     /**
      * 방을 PESSIMISTIC_WRITE 락과 함께 조회한다(없으면 예외). 같은 방의 메시지 전송을 직렬화하기 위한 락 획득용.

--- a/src/main/java/com/umc/product/chat/application/service/command/ChatRoomCommandService.java
+++ b/src/main/java/com/umc/product/chat/application/service/command/ChatRoomCommandService.java
@@ -38,7 +38,7 @@ public class ChatRoomCommandService implements
 
     @Override
     public ChatRoomInfo create(CreateChatRoomCommand command) {
-        ChatRoom chatRoom = saveChatRoomPort.save(ChatRoom.create());
+        ChatRoom chatRoom = saveChatRoomPort.save(ChatRoom.create(command.readScope()));
         saveChatMemberPort.save(ChatMember.of(chatRoom.getId(), command.creatorMemberId()));
         return new ChatRoomInfo(
             chatRoom.getId(),

--- a/src/main/java/com/umc/product/chat/application/service/query/ChatMessageQueryService.java
+++ b/src/main/java/com/umc/product/chat/application/service/query/ChatMessageQueryService.java
@@ -55,11 +55,12 @@ public class ChatMessageQueryService implements
     /**
      * 방 메시지 내역을 최신순 커서 페이지네이션으로 조회한다. (size + 1 조회 후 hasNext 판별)
      * <p>
-     * 조회 전 요청자가 해당 방의 멤버인지 검증한다(비멤버는 접근 불가).
+     * 조회 전 요청자가 해당 방을 읽을 수 있는지 검증한다. 방 멤버이거나 방의 조회 범위가 공개여야 하며,
+     * 공개 방의 resource 단위 접근 권한은 방을 소유한 소비 도메인이 판단한다.
      */
     @Override
     public ChatMessageCursorResult getMessages(GetChatMessagesQuery query) {
-        chatRoomAccessPolicy.verifyMember(query.roomId(), query.memberId());
+        chatRoomAccessPolicy.verifyReadable(query.roomId(), query.memberId());
 
         List<ChatMessage> rows = loadChatMessagePort.listByRoomId(query.roomId(), query.cursorId(), query.size() + 1);
 
@@ -74,7 +75,7 @@ public class ChatMessageQueryService implements
 
     @Override
     public ChatMessageInfo getMessage(GetChatMessageQuery query) {
-        chatRoomAccessPolicy.verifyMember(query.roomId(), query.memberId());
+        chatRoomAccessPolicy.verifyReadable(query.roomId(), query.memberId());
         ChatMessage message = loadChatMessagePort.getByIdAndRoomId(query.messageId(), query.roomId());
         return chatMessageInfoAssembler.assemble(message, query.memberId());
     }

--- a/src/main/java/com/umc/product/chat/domain/ChatRoom.java
+++ b/src/main/java/com/umc/product/chat/domain/ChatRoom.java
@@ -4,6 +4,8 @@ import com.umc.product.common.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,8 +31,31 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "pinned_message_id")
     private Long pinnedMessageId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "read_scope", nullable = false, length = 20)
+    private ChatRoomReadScope readScope;
+
+    /**
+     * 멤버만 조회할 수 있는 방을 만든다. 조회 범위를 명시하지 않은 소비 도메인은 fail-closed 기본값을 갖는다.
+     */
     public static ChatRoom create() {
-        return ChatRoom.builder().build();
+        return create(ChatRoomReadScope.MEMBER_ONLY);
+    }
+
+    public static ChatRoom create(ChatRoomReadScope readScope) {
+        return ChatRoom.builder()
+            .readScope(readScope == null ? ChatRoomReadScope.MEMBER_ONLY : readScope)
+            .build();
+    }
+
+    /**
+     * 비멤버도 메시지를 조회할 수 있는 방인지 판단한다.
+     *
+     * <p>조회 인가에만 사용한다. 메시지 생성/수정/삭제, 리액션, 읽음 갱신은 이 값과 무관하게
+     * 방 멤버만 수행할 수 있다.</p>
+     */
+    public boolean isPubliclyReadable() {
+        return readScope == ChatRoomReadScope.PUBLIC;
     }
 
     public void pinMessage(Long messageId) {

--- a/src/main/java/com/umc/product/chat/domain/ChatRoomReadScope.java
+++ b/src/main/java/com/umc/product/chat/domain/ChatRoomReadScope.java
@@ -1,0 +1,19 @@
+package com.umc.product.chat.domain;
+
+/**
+ * 채팅방 메시지 조회의 공개 범위.
+ * <p>
+ * 방을 만든 소비 도메인이 생성 시점에 정하며, Chat engine은 소비 도메인을 알지 않고 이 값만 본다.
+ * 조회에만 적용되고 메시지 생성/수정/삭제, 리액션, 읽음 갱신 같은 모든 변경은 범위와 무관하게
+ * 방 멤버만 수행할 수 있다.
+ * <ul>
+ *     <li>{@code MEMBER_ONLY} - 방 멤버만 메시지를 조회할 수 있다. 기본값이며 fail-closed 기준선이다.</li>
+ *     <li>{@code PUBLIC} - 소비 도메인이 resource 접근을 허용한 사용자라면 비멤버도 조회할 수 있다.
+ *     resource 단위 공개 여부는 소비 도메인이 판단하므로, 이 값을 쓰는 소비 도메인은 자신의 조회
+ *     권한 검증을 반드시 유지해야 한다.</li>
+ * </ul>
+ */
+public enum ChatRoomReadScope {
+    MEMBER_ONLY,
+    PUBLIC
+}

--- a/src/main/java/com/umc/product/community/adapter/out/persistence/CommunityThreadQueryRepository.java
+++ b/src/main/java/com/umc/product/community/adapter/out/persistence/CommunityThreadQueryRepository.java
@@ -260,7 +260,8 @@ public class CommunityThreadQueryRepository {
 
     private BooleanBuilder baseCondition(CommunityThreadListCondition condition) {
         BooleanBuilder where = new BooleanBuilder()
-            .and(communityThread.deletedAt.isNull());
+            .and(communityThread.deletedAt.isNull())
+            .and(notKicked(condition.requesterMemberId()));
         if (condition.category() != null) {
             where.and(communityThread.category.eq(condition.category()));
         }
@@ -268,6 +269,24 @@ public class CommunityThreadQueryRepository {
             where.and(keywordContains(condition.keyword()));
         }
         return where;
+    }
+
+    /**
+     * 강퇴된 스레드를 목록에서 제외한다.
+     *
+     * <p>requester 멤버십 join은 ACTIVE만 매칭하므로 KICKED는 join 결과가 비어 "미참여 스레드"와
+     * 구분되지 않는다. 따라서 KICKED 행의 존재 여부를 별도 subquery로 확인한다.</p>
+     */
+    private BooleanExpression notKicked(Long requesterMemberId) {
+        QCommunityThreadMember kickedMembership = new QCommunityThreadMember("kickedMembership");
+        return JPAExpressions.selectOne()
+            .from(kickedMembership)
+            .where(
+                kickedMembership.threadId.eq(communityThread.id),
+                kickedMembership.memberId.eq(requesterMemberId),
+                kickedMembership.state.eq(CommunityThreadMemberState.KICKED)
+            )
+            .notExists();
     }
 
     private BooleanBuilder listCondition(

--- a/src/main/java/com/umc/product/community/application/service/command/CommunityThreadLifecycleCommandService.java
+++ b/src/main/java/com/umc/product/community/application/service/command/CommunityThreadLifecycleCommandService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.umc.product.chat.application.port.in.command.CreateChatRoomUseCase;
 import com.umc.product.chat.application.port.in.command.dto.CreateChatRoomCommand;
 import com.umc.product.chat.application.port.in.query.dto.ChatRoomInfo;
+import com.umc.product.chat.domain.ChatRoomReadScope;
 import com.umc.product.community.application.port.in.command.thread.CreateCommunityThreadUseCase;
 import com.umc.product.community.application.port.in.command.thread.DeleteCommunityThreadUseCase;
 import com.umc.product.community.application.port.in.command.thread.UpdateCommunityThreadUseCase;
@@ -58,8 +59,10 @@ public class CommunityThreadLifecycleCommandService implements
             throw new CommunityDomainException(CommunityErrorCode.THREAD_CAPACITY_EXCEEDED);
         }
 
+        // 스레드 메시지 조회는 상세 조회와 같이 비참여자에게도 열려 있으므로 방을 공개 조회 범위로 만든다.
+        // 메시지 변경과 실시간 수신은 ACTIVE 멤버 전용이며 Community가 별도로 검증한다.
         ChatRoomInfo chatRoom = createChatRoomUseCase.create(
-            CreateChatRoomCommand.from(command.actorMemberId())
+            CreateChatRoomCommand.of(command.actorMemberId(), ChatRoomReadScope.PUBLIC)
         );
         Instant occurredAt = clock.instant();
         CommunityThread thread = saveThreadPort.save(CommunityThread.create(

--- a/src/main/java/com/umc/product/community/application/service/message/CommunityThreadMessageQueryService.java
+++ b/src/main/java/com/umc/product/community/application/service/message/CommunityThreadMessageQueryService.java
@@ -38,6 +38,17 @@ import com.umc.product.community.domain.exception.CommunityErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Community thread 메시지 조회.
+ *
+ * <p>사용자 조회 경로({@code getHistory}, {@code recover}, {@code getMessage})는 스레드 상세와 같은
+ * 공개 범위를 따른다. 삭제되지 않은 스레드면 비참여자도 읽을 수 있고, 강퇴된 요청자만 차단한다.
+ * Chat engine은 방의 조회 범위로 이를 다시 확인한다. 메시지 생성/수정/삭제, 리액션, 읽음, 신고와
+ * 실시간 수신은 ACTIVE 멤버 전용이며 각 command 경로가 검증한다.</p>
+ *
+ * <p>반면 실시간 fan-out용 {@code getMessageForRecipients}는 수신자가 모두 ACTIVE 멤버인지 검증한다.
+ * 공개 조회와 달리 이 경로는 전달 대상 자체가 멤버로 한정되기 때문이다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -67,7 +78,7 @@ public class CommunityThreadMessageQueryService implements
 
     @Override
     public CommunityThreadMessageInfo getMessage(CommunityThreadMessageQuery query) {
-        CommunityThread thread = loadReadableThread(query.threadId(), query.requesterMemberId());
+        CommunityThread thread = loadPubliclyReadableThread(query.threadId(), query.requesterMemberId());
         ChatMessageInfo message = getChatMessageUseCase.getMessage(
             new GetChatMessageQuery(thread.getChatRoomId(), query.requesterMemberId(), query.messageId())
         );
@@ -131,7 +142,7 @@ public class CommunityThreadMessageQueryService implements
         Long beforeMessageId,
         int limit
     ) {
-        CommunityThread thread = loadReadableThread(threadId, requesterMemberId);
+        CommunityThread thread = loadPubliclyReadableThread(threadId, requesterMemberId);
         ChatMessageCursorResult chatPage = getChatMessagesUseCase.getMessages(
             new GetChatMessagesQuery(thread.getChatRoomId(), requesterMemberId, beforeMessageId, limit)
         );
@@ -142,14 +153,23 @@ public class CommunityThreadMessageQueryService implements
         );
     }
 
-    private CommunityThread loadReadableThread(Long threadId, Long requesterMemberId) {
+    /**
+     * 참여 여부와 무관하게 읽을 수 있는 스레드를 반환한다. 강퇴된 요청자만 차단한다.
+     */
+    private CommunityThread loadPubliclyReadableThread(Long threadId, Long requesterMemberId) {
         CommunityThread thread = loadActiveThread(threadId);
-        loadThreadMemberPort.findByThreadIdAndMemberId(threadId, requesterMemberId)
-            .filter(member -> member.isActive())
-            .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.THREAD_ACCESS_DENIED));
+        boolean kicked = loadThreadMemberPort.findByThreadIdAndMemberId(threadId, requesterMemberId)
+            .filter(CommunityThreadMember::isKicked)
+            .isPresent();
+        if (kicked) {
+            throw new CommunityDomainException(CommunityErrorCode.THREAD_ACCESS_DENIED);
+        }
         return thread;
     }
 
+    /**
+     * 삭제되지 않은 스레드를 조회한다. 멤버십은 검증하지 않으므로 호출부가 필요한 권한을 직접 확인한다.
+     */
     private CommunityThread loadActiveThread(Long threadId) {
         CommunityThread thread = loadThreadPort.findById(threadId)
             .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.THREAD_NOT_FOUND));

--- a/src/main/java/com/umc/product/community/application/service/query/CommunityThreadQueryService.java
+++ b/src/main/java/com/umc/product/community/application/service/query/CommunityThreadQueryService.java
@@ -256,11 +256,17 @@ public class CommunityThreadQueryService implements
         return row;
     }
 
+    /**
+     * 참여 여부와 무관하게 조회할 수 있는 스레드를 반환한다. 강퇴된 요청자만 차단한다.
+     */
     private CommunityThreadQueryRow getPublicReadableThread(Long threadId, Long requesterMemberId) {
         CommunityThreadQueryRow row = threadQueryPort.findThread(threadId, requesterMemberId)
             .orElseThrow(() -> new CommunityDomainException(CommunityErrorCode.THREAD_NOT_FOUND));
         if (row.deletedAt() != null) {
             throw new CommunityDomainException(CommunityErrorCode.THREAD_DELETED);
+        }
+        if (row.requesterState() == CommunityThreadMemberState.KICKED) {
+            throw new CommunityDomainException(CommunityErrorCode.THREAD_ACCESS_DENIED);
         }
         return row;
     }

--- a/src/main/java/com/umc/product/community/domain/CommunityThreadMember.java
+++ b/src/main/java/com/umc/product/community/domain/CommunityThreadMember.java
@@ -177,6 +177,15 @@ public class CommunityThreadMember extends BaseEntity {
         return state == CommunityThreadMemberState.ACTIVE;
     }
 
+    /**
+     * 강퇴된 멤버인지 판단한다.
+     *
+     * <p>LEFT와 달리 재초대할 수 없고, 스레드 목록/상세/메시지 조회가 모두 차단된다.</p>
+     */
+    public boolean isKicked() {
+        return state == CommunityThreadMemberState.KICKED;
+    }
+
     private void requireActive() {
         if (!isActive()) {
             throw new IllegalStateException("member must be ACTIVE");

--- a/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
+++ b/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
@@ -1,15 +1,17 @@
+-- DEFAULT는 제거하지 않는다.
+-- ASG instance refresh는 구/신 인스턴스가 함께 도는 구간이 있고, 그동안 구버전은 read_scope를
+-- 포함하지 않은 INSERT를 계속 보낸다. DEFAULT가 없으면 그 INSERT가 NOT NULL 위반으로 전부 실패한다.
+-- 또한 MEMBER_ONLY는 가장 닫힌 값이라, 값을 채우지 않는 코드가 생겨도 안전한 쪽으로 떨어진다.
 ALTER TABLE chat_room
     ADD COLUMN read_scope VARCHAR(20) DEFAULT 'MEMBER_ONLY' NOT NULL;
 
 -- Community thread 방은 스레드 상세와 동일하게 메시지 조회를 공개한다.
 -- 기존 스레드도 같은 규칙을 따라야 하므로 소유 관계를 따라 backfill 한다.
+-- 오버랩 구간에 구버전이 만든 스레드 방은 MEMBER_ONLY로 남으므로, 이번 릴리스가 완전히
+-- 롤아웃된 뒤 후속 migration에서 같은 backfill을 한 번 더 수행한다.
 UPDATE chat_room
 SET read_scope = 'PUBLIC'
 WHERE id IN (SELECT chat_room_id FROM community_thread);
-
--- 이후 생성되는 방은 엔티티가 항상 값을 채우므로 기본값에 기대지 않는다.
-ALTER TABLE chat_room
-    ALTER COLUMN read_scope DROP DEFAULT;
 
 ALTER TABLE chat_room
     ADD CONSTRAINT ck_chat_room_read_scope

--- a/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
+++ b/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
@@ -1,0 +1,16 @@
+ALTER TABLE chat_room
+    ADD COLUMN read_scope VARCHAR(20) DEFAULT 'MEMBER_ONLY' NOT NULL;
+
+-- Community thread 방은 스레드 상세와 동일하게 메시지 조회를 공개한다.
+-- 기존 스레드도 같은 규칙을 따라야 하므로 소유 관계를 따라 backfill 한다.
+UPDATE chat_room
+SET read_scope = 'PUBLIC'
+WHERE id IN (SELECT chat_room_id FROM community_thread);
+
+-- 이후 생성되는 방은 엔티티가 항상 값을 채우므로 기본값에 기대지 않는다.
+ALTER TABLE chat_room
+    ALTER COLUMN read_scope DROP DEFAULT;
+
+ALTER TABLE chat_room
+    ADD CONSTRAINT ck_chat_room_read_scope
+        CHECK (read_scope IN ('MEMBER_ONLY', 'PUBLIC'));

--- a/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
+++ b/src/main/resources/db/migration/V2026.08.11.03.00__add_read_scope_to_chat_room.sql
@@ -7,8 +7,8 @@ ALTER TABLE chat_room
 
 -- Community thread 방은 스레드 상세와 동일하게 메시지 조회를 공개한다.
 -- 기존 스레드도 같은 규칙을 따라야 하므로 소유 관계를 따라 backfill 한다.
--- 오버랩 구간에 구버전이 만든 스레드 방은 MEMBER_ONLY로 남으므로, 이번 릴리스가 완전히
--- 롤아웃된 뒤 후속 migration에서 같은 backfill을 한 번 더 수행한다.
+-- 롤링 배포 오버랩 구간에 구버전이 만든 방은 MEMBER_ONLY로 남을 수 있다.
+-- 같은 조건으로 이 UPDATE를 다시 실행하면 치유되며, 멱등이라 몇 번 돌려도 안전하다.
 UPDATE chat_room
 SET read_scope = 'PUBLIC'
 WHERE id IN (SELECT chat_room_id FROM community_thread);

--- a/src/test/java/com/umc/product/chat/application/policy/ChatRoomAccessPolicyTest.java
+++ b/src/test/java/com/umc/product/chat/application/policy/ChatRoomAccessPolicyTest.java
@@ -1,0 +1,93 @@
+package com.umc.product.chat.application.policy;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.chat.application.port.out.LoadChatMemberPort;
+import com.umc.product.chat.application.port.out.LoadChatRoomPort;
+import com.umc.product.chat.domain.ChatRoom;
+import com.umc.product.chat.domain.ChatRoomReadScope;
+import com.umc.product.chat.domain.exception.ChatDomainException;
+import com.umc.product.chat.domain.exception.ChatErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatRoomAccessPolicy")
+class ChatRoomAccessPolicyTest {
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    @Mock
+    LoadChatMemberPort loadChatMemberPort;
+    @Mock
+    LoadChatRoomPort loadChatRoomPort;
+
+    @InjectMocks
+    ChatRoomAccessPolicy sut;
+
+    @Test
+    @DisplayName("멤버는 방을 조회할 수 있고 조회 범위를 확인하지 않는다")
+    void verifyReadable_memberSkipsRoomLookup() {
+        given(loadChatMemberPort.existsByRoomIdAndMemberId(ROOM_ID, MEMBER_ID)).willReturn(true);
+
+        assertThatCode(() -> sut.verifyReadable(ROOM_ID, MEMBER_ID)).doesNotThrowAnyException();
+
+        then(loadChatRoomPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("PUBLIC 방은 비멤버도 조회할 수 있다")
+    void verifyReadable_nonMemberOnPublicRoom() {
+        given(loadChatMemberPort.existsByRoomIdAndMemberId(ROOM_ID, MEMBER_ID)).willReturn(false);
+        given(loadChatRoomPort.findById(ROOM_ID))
+            .willReturn(Optional.of(ChatRoom.create(ChatRoomReadScope.PUBLIC)));
+
+        assertThatCode(() -> sut.verifyReadable(ROOM_ID, MEMBER_ID)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("MEMBER_ONLY 방은 비멤버 조회를 거부한다")
+    void verifyReadable_nonMemberOnMemberOnlyRoom() {
+        given(loadChatMemberPort.existsByRoomIdAndMemberId(ROOM_ID, MEMBER_ID)).willReturn(false);
+        given(loadChatRoomPort.findById(ROOM_ID))
+            .willReturn(Optional.of(ChatRoom.create(ChatRoomReadScope.MEMBER_ONLY)));
+
+        assertAccessDenied(() -> sut.verifyReadable(ROOM_ID, MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방은 존재 여부를 노출하지 않고 접근 거부로 막는다")
+    void verifyReadable_missingRoomFailsClosed() {
+        given(loadChatMemberPort.existsByRoomIdAndMemberId(ROOM_ID, MEMBER_ID)).willReturn(false);
+        given(loadChatRoomPort.findById(ROOM_ID)).willReturn(Optional.empty());
+
+        assertAccessDenied(() -> sut.verifyReadable(ROOM_ID, MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("변경 검증은 조회 범위와 무관하게 비멤버를 거부한다")
+    void verifyMember_rejectsNonMemberRegardlessOfReadScope() {
+        given(loadChatMemberPort.existsByRoomIdAndMemberId(ROOM_ID, MEMBER_ID)).willReturn(false);
+
+        assertAccessDenied(() -> sut.verifyMember(ROOM_ID, MEMBER_ID));
+        then(loadChatRoomPort).shouldHaveNoInteractions();
+    }
+
+    private void assertAccessDenied(Runnable action) {
+        assertThatThrownBy(action::run)
+            .isInstanceOf(ChatDomainException.class)
+            .extracting(error -> ((ChatDomainException) error).getBaseCode())
+            .isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+    }
+}

--- a/src/test/java/com/umc/product/chat/application/service/command/ChatRoomCommandServiceTest.java
+++ b/src/test/java/com/umc/product/chat/application/service/command/ChatRoomCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.umc.product.chat.application.service.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.umc.product.chat.application.port.in.command.dto.CreateChatRoomCommand;
 import com.umc.product.chat.application.port.in.command.dto.PinChatRoomMessageCommand;
 import com.umc.product.chat.application.port.out.LoadChatMessagePort;
 import com.umc.product.chat.application.port.out.LoadChatRoomPort;
@@ -22,6 +24,7 @@ import com.umc.product.chat.application.port.out.SaveChatMemberPort;
 import com.umc.product.chat.application.port.out.SaveChatRoomPort;
 import com.umc.product.chat.domain.ChatMessage;
 import com.umc.product.chat.domain.ChatRoom;
+import com.umc.product.chat.domain.ChatRoomReadScope;
 import com.umc.product.chat.domain.MessageContentType;
 import com.umc.product.chat.domain.event.ChatRoomPinnedMessageChangedEvent;
 import com.umc.product.chat.domain.exception.ChatDomainException;
@@ -99,6 +102,40 @@ class ChatRoomCommandServiceTest {
         then(domainEventPublisher).should().publish(eventCaptor.capture());
         assertThat(eventCaptor.getValue().roomId()).isEqualTo(1L);
         assertThat(eventCaptor.getValue().pinnedMessageId()).isNull();
+    }
+
+    @Test
+    @DisplayName("조회 범위를 명시하지 않으면 멤버 전용 방으로 만든다")
+    void create_defaultsToMemberOnly() {
+        given(saveChatRoomPort.save(any(ChatRoom.class))).willAnswer(invocation -> {
+            ChatRoom saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 1L);
+            return saved;
+        });
+
+        sut.create(CreateChatRoomCommand.from(10L));
+
+        assertThat(capturedRoom().getReadScope()).isEqualTo(ChatRoomReadScope.MEMBER_ONLY);
+    }
+
+    @Test
+    @DisplayName("소비 도메인이 요청한 조회 범위를 방에 그대로 저장한다")
+    void create_appliesRequestedReadScope() {
+        given(saveChatRoomPort.save(any(ChatRoom.class))).willAnswer(invocation -> {
+            ChatRoom saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 1L);
+            return saved;
+        });
+
+        sut.create(CreateChatRoomCommand.of(10L, ChatRoomReadScope.PUBLIC));
+
+        assertThat(capturedRoom().getReadScope()).isEqualTo(ChatRoomReadScope.PUBLIC);
+    }
+
+    private ChatRoom capturedRoom() {
+        ArgumentCaptor<ChatRoom> captor = ArgumentCaptor.forClass(ChatRoom.class);
+        then(saveChatRoomPort).should().save(captor.capture());
+        return captor.getValue();
     }
 
     private ChatRoom room(Long id) {

--- a/src/test/java/com/umc/product/chat/application/service/command/ChatRoomLockRevalidationTest.java
+++ b/src/test/java/com/umc/product/chat/application/service/command/ChatRoomLockRevalidationTest.java
@@ -86,7 +86,7 @@ class ChatRoomLockRevalidationTest {
     @BeforeEach
     void setUp() {
         executor = Executors.newFixedThreadPool(2);
-        ChatRoomAccessPolicy accessPolicy = new ChatRoomAccessPolicy(loadChatMemberPort);
+        ChatRoomAccessPolicy accessPolicy = new ChatRoomAccessPolicy(loadChatMemberPort, loadChatRoomPort);
         sendService = new ChatMessageCommandService(
             saveChatMessagePort,
             loadChatMessagePort,

--- a/src/test/java/com/umc/product/chat/application/service/query/ChatMessageQueryServiceTest.java
+++ b/src/test/java/com/umc/product/chat/application/service/query/ChatMessageQueryServiceTest.java
@@ -80,10 +80,10 @@ class ChatMessageQueryServiceTest {
     }
 
     @Test
-    @DisplayName("요청자가 방 멤버가 아니면 메시지를 조회하지 않고 접근 거부 예외를 던진다")
+    @DisplayName("요청자가 방을 읽을 수 없으면 메시지를 조회하지 않고 접근 거부 예외를 던진다")
     void getMessages_accessDenied() {
         willThrow(new ChatDomainException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED))
-            .given(chatRoomAccessPolicy).verifyMember(1L, 10L);
+            .given(chatRoomAccessPolicy).verifyReadable(1L, 10L);
 
         assertThatThrownBy(() -> sut.getMessages(new GetChatMessagesQuery(1L, 10L, null, 2)))
             .isInstanceOf(ChatDomainException.class)
@@ -107,7 +107,7 @@ class ChatMessageQueryServiceTest {
     }
 
     @Test
-    @DisplayName("단건 조회도 방 멤버 접근 검증 뒤 enriched 메시지를 반환한다")
+    @DisplayName("단건 조회도 방 읽기 권한 검증 뒤 enriched 메시지를 반환한다")
     void getMessage_success() {
         ChatMessage message = message(30L, 1L, 20L);
         ChatMessageInfo info = ChatMessageInfo.from(message);
@@ -117,7 +117,7 @@ class ChatMessageQueryServiceTest {
         ChatMessageInfo result = sut.getMessage(new GetChatMessageQuery(1L, 10L, 30L));
 
         assertThat(result).isSameAs(info);
-        then(chatRoomAccessPolicy).should().verifyMember(1L, 10L);
+        then(chatRoomAccessPolicy).should().verifyReadable(1L, 10L);
     }
 
     @Test

--- a/src/test/java/com/umc/product/community/adapter/out/persistence/CommunityThreadReadQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/community/adapter/out/persistence/CommunityThreadReadQueryRepositoryTest.java
@@ -192,6 +192,50 @@ class CommunityThreadReadQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("browse는 강퇴된 스레드를 목록과 total에서 제외하고 탈퇴한 스레드는 남긴다")
+    void browseThreads_강퇴된_스레드를_제외한다() {
+        // given
+        CommunityThread open = persistThread(2_401L, "공개 스레드", CommunityThreadCategory.FREE);
+        CommunityThread kicked = persistThread(2_402L, "강퇴된 스레드", CommunityThreadCategory.FREE);
+        CommunityThread left = persistThread(2_403L, "탈퇴한 스레드", CommunityThreadCategory.FREE);
+        persistMembership(open, 999L);
+        persistKickedMembership(kicked);
+        persistLeftMembership(left);
+        flushAndClear();
+
+        // when
+        CommunityThreadListRows result = sut.browseThreads(new CommunityThreadListCondition(
+            REQUESTER_ID, CommunityThreadCategory.FREE, false, null, 0, 20
+        ));
+
+        // then
+        assertThat(result.unpinned()).extracting(row -> row.threadId())
+            .containsExactlyInAnyOrder(open.getId(), left.getId());
+        assertThat(result.unpinnedTotal()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("browse 검색도 강퇴된 스레드를 제외한다")
+    void browseThreads_검색에서도_강퇴된_스레드를_제외한다() {
+        // given
+        CommunityThread open = persistThread(2_501L, "스터디 모집", CommunityThreadCategory.PROJECT);
+        CommunityThread kicked = persistThread(2_502L, "스터디 마감", CommunityThreadCategory.PROJECT);
+        persistMembership(open, 999L);
+        persistKickedMembership(kicked);
+        flushAndClear();
+
+        // when
+        CommunityThreadListRows result = sut.browseThreads(new CommunityThreadListCondition(
+            REQUESTER_ID, null, false, "스터디", 0, 20
+        ));
+
+        // then
+        assertThat(result.unpinned()).extracting(row -> row.threadId())
+            .containsExactly(open.getId());
+        assertThat(result.unpinnedTotal()).isEqualTo(1L);
+    }
+
+    @Test
     @DisplayName("browse 안읽음 필터는 가입해 안 읽은 스레드만 고정/전체에 남기고 비멤버 스레드는 제외한다")
     void browseThreads_안읽음_필터를_적용한다() {
         // given
@@ -334,6 +378,18 @@ class CommunityThreadReadQueryRepositoryTest {
 
     private CommunityThreadMember persistMembership(CommunityThread thread, Long memberId) {
         return memberRepository.save(CommunityThreadMember.createMember(thread.getId(), memberId, NOW));
+    }
+
+    private CommunityThreadMember persistKickedMembership(CommunityThread thread) {
+        CommunityThreadMember member = CommunityThreadMember.createMember(thread.getId(), REQUESTER_ID, NOW);
+        member.kick(NOW.plusSeconds(1));
+        return memberRepository.save(member);
+    }
+
+    private CommunityThreadMember persistLeftMembership(CommunityThread thread) {
+        CommunityThreadMember member = CommunityThreadMember.createMember(thread.getId(), REQUESTER_ID, NOW);
+        member.leave(NOW.plusSeconds(1));
+        return memberRepository.save(member);
     }
 
     private void flushAndClear() {

--- a/src/test/java/com/umc/product/community/application/service/command/CommunityThreadLifecycleCommandServiceTest.java
+++ b/src/test/java/com/umc/product/community/application/service/command/CommunityThreadLifecycleCommandServiceTest.java
@@ -30,7 +30,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.chat.application.port.in.command.CreateChatRoomUseCase;
 import com.umc.product.chat.application.port.in.command.DeleteChatRoomUseCase;
+import com.umc.product.chat.application.port.in.command.dto.CreateChatRoomCommand;
 import com.umc.product.chat.application.port.in.query.dto.ChatRoomInfo;
+import com.umc.product.chat.domain.ChatRoomReadScope;
 import com.umc.product.community.application.port.in.command.thread.dto.CommunityThreadLifecycleInfo;
 import com.umc.product.community.application.port.in.command.thread.dto.CreateCommunityThreadCommand;
 import com.umc.product.community.application.port.in.command.thread.dto.ThreadActorCommand;
@@ -136,6 +138,11 @@ class CommunityThreadLifecycleCommandServiceTest {
         order.verify(saveMemberPort).save(any());
         order.verify(inviteManager).invite(any(), Mockito.eq(List.of(30L, 20L)), Mockito.eq(NOW));
         order.verify(eventPublisher).publish(any(CommunityThreadInvitedEvent.class));
+
+        ArgumentCaptor<CreateChatRoomCommand> chatRoomCommand =
+            ArgumentCaptor.forClass(CreateChatRoomCommand.class);
+        then(createChatRoomUseCase).should().create(chatRoomCommand.capture());
+        assertThat(chatRoomCommand.getValue().readScope()).isEqualTo(ChatRoomReadScope.PUBLIC);
     }
 
     @Test

--- a/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageQueryServiceTest.java
+++ b/src/test/java/com/umc/product/community/application/service/message/CommunityThreadMessageQueryServiceTest.java
@@ -52,6 +52,7 @@ class CommunityThreadMessageQueryServiceTest {
     private static final Long THREAD_ID = 11L;
     private static final Long ROOM_ID = 101L;
     private static final Long MEMBER_ID = 30L;
+    private static final Long NON_MEMBER_ID = 77L;
     private static final Instant NOW = Instant.parse("2026-07-18T00:00:00Z");
 
     @Mock
@@ -71,16 +72,13 @@ class CommunityThreadMessageQueryServiceTest {
     CommunityThreadMessageQueryService sut;
 
     @Test
-    @DisplayName("history는 Community ACTIVE 멤버 검증 뒤 Chat history를 호출하고 threadId만 포함한 page를 반환한다")
-    void historyValidatesCommunityBeforeChat() {
+    @DisplayName("history는 thread 조회 뒤 Chat history를 호출하고 threadId만 포함한 page를 반환한다")
+    void historyValidatesThreadBeforeChat() {
         CommunityThread thread = thread();
-        CommunityThreadMember member = activeMember(MEMBER_ID);
         ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "본문");
         ChatMessageCursorResult chatPage = new ChatMessageCursorResult(List.of(chatMessage), 899L, true);
         CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread));
-        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
-            .willReturn(Optional.of(member));
         given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willReturn(chatPage);
         given(infoAssembler.assemble(THREAD_ID, List.of(chatMessage))).willReturn(List.of(communityInfo));
 
@@ -95,21 +93,17 @@ class CommunityThreadMessageQueryServiceTest {
             new GetChatMessagesQuery(ROOM_ID, MEMBER_ID, 1_000L, 30)
         );
         then(realtimeMetrics).should().recordBackfill(Operation.MESSAGE_HISTORY, Outcome.SUCCESS);
-        InOrder order = inOrder(loadThreadPort, loadThreadMemberPort, getChatMessagesUseCase);
+        InOrder order = inOrder(loadThreadPort, getChatMessagesUseCase);
         order.verify(loadThreadPort).findById(THREAD_ID);
-        order.verify(loadThreadMemberPort).findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID);
         order.verify(getChatMessagesUseCase).getMessages(any(GetChatMessagesQuery.class));
     }
 
     @Test
-    @DisplayName("single은 Community ACTIVE 멤버 검증 뒤 Chat 단건 query를 호출한다")
-    void singleValidatesCommunityBeforeChat() {
-        CommunityThreadMember member = activeMember(MEMBER_ID);
+    @DisplayName("single은 thread 조회 뒤 Chat 단건 query를 호출한다")
+    void singleValidatesThreadBeforeChat() {
         ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "본문");
         CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
-        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
-            .willReturn(Optional.of(member));
         given(getChatMessageUseCase.getMessage(any(GetChatMessageQuery.class))).willReturn(chatMessage);
         given(infoAssembler.assemble(THREAD_ID, chatMessage)).willReturn(communityInfo);
 
@@ -120,22 +114,18 @@ class CommunityThreadMessageQueryServiceTest {
         assertThat(result).isSameAs(communityInfo);
         then(getChatMessageUseCase).should().getMessage(new GetChatMessageQuery(ROOM_ID, MEMBER_ID, 900L));
         then(realtimeMetrics).shouldHaveNoInteractions();
-        InOrder order = inOrder(loadThreadPort, loadThreadMemberPort, getChatMessageUseCase);
+        InOrder order = inOrder(loadThreadPort, getChatMessageUseCase);
         order.verify(loadThreadPort).findById(THREAD_ID);
-        order.verify(loadThreadMemberPort).findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID);
         order.verify(getChatMessageUseCase).getMessage(any(GetChatMessageQuery.class));
     }
 
     @Test
-    @DisplayName("recovery도 Community ACTIVE 멤버 검증 뒤 Chat public history query만 호출한다")
-    void recoveryValidatesCommunityBeforeChat() {
-        CommunityThreadMember member = activeMember(MEMBER_ID);
+    @DisplayName("recovery도 thread 조회 뒤 Chat public history query만 호출한다")
+    void recoveryValidatesThreadBeforeChat() {
         ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "복구");
         ChatMessageCursorResult chatPage = new ChatMessageCursorResult(List.of(chatMessage), null, false);
         CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
-        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
-            .willReturn(Optional.of(member));
         given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willReturn(chatPage);
         given(infoAssembler.assemble(THREAD_ID, List.of(chatMessage))).willReturn(List.of(communityInfo));
 
@@ -173,8 +163,6 @@ class CommunityThreadMessageQueryServiceTest {
     void historyFailureRecordsMetricAndPropagates() {
         RuntimeException failure = new IllegalStateException("chat query failed");
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
-        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
-            .willReturn(Optional.of(activeMember(MEMBER_ID)));
         given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willThrow(failure);
 
         assertThatThrownBy(() -> sut.getHistory(new CommunityThreadMessageHistoryQuery(
@@ -189,8 +177,6 @@ class CommunityThreadMessageQueryServiceTest {
     void recoveryFailureRecordsMetricAndPropagates() {
         RuntimeException failure = new IllegalStateException("chat recovery failed");
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
-        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
-            .willReturn(Optional.of(activeMember(MEMBER_ID)));
         given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willThrow(failure);
 
         assertThatThrownBy(() -> sut.recover(new CommunityThreadMessageRecoveryQuery(
@@ -201,19 +187,112 @@ class CommunityThreadMessageQueryServiceTest {
     }
 
     @Test
-    @DisplayName("LEFT 멤버는 single Chat query 전에 THREAD_ACCESS_DENIED로 거절한다")
-    void inactiveMemberIsRejectedBeforeSingle() {
-        CommunityThreadMember left = activeMember(MEMBER_ID);
-        left.leave(NOW.minusSeconds(60));
+    @DisplayName("스레드 비참여자도 history를 볼 수 있다")
+    void nonMemberReadsHistory() {
+        ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "본문");
+        ChatMessageCursorResult chatPage = new ChatMessageCursorResult(List.of(chatMessage), null, false);
+        CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
+        given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
+        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, NON_MEMBER_ID))
+            .willReturn(Optional.empty());
+        given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willReturn(chatPage);
+        given(infoAssembler.assemble(THREAD_ID, List.of(chatMessage))).willReturn(List.of(communityInfo));
+
+        CommunityThreadMessagePageInfo result = sut.getHistory(
+            new CommunityThreadMessageHistoryQuery(THREAD_ID, NON_MEMBER_ID, null, 30)
+        );
+
+        assertThat(result.messages()).containsExactly(communityInfo);
+        then(getChatMessagesUseCase).should().getMessages(
+            new GetChatMessagesQuery(ROOM_ID, NON_MEMBER_ID, null, 30)
+        );
+    }
+
+    @Test
+    @DisplayName("스레드 비참여자도 단건 메시지를 볼 수 있다")
+    void nonMemberReadsSingle() {
+        ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "본문");
+        CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
+        given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
+        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, NON_MEMBER_ID))
+            .willReturn(Optional.empty());
+        given(getChatMessageUseCase.getMessage(any(GetChatMessageQuery.class))).willReturn(chatMessage);
+        given(infoAssembler.assemble(THREAD_ID, chatMessage)).willReturn(communityInfo);
+
+        CommunityThreadMessageInfo result = sut.getMessage(
+            new CommunityThreadMessageQuery(THREAD_ID, NON_MEMBER_ID, 900L)
+        );
+
+        assertThat(result).isSameAs(communityInfo);
+        then(getChatMessageUseCase).should().getMessage(new GetChatMessageQuery(ROOM_ID, NON_MEMBER_ID, 900L));
+    }
+
+    @Test
+    @DisplayName("LEFT 멤버는 비참여자와 동일하게 history를 볼 수 있다")
+    void leftMemberReadsHistory() {
+        CommunityThreadMember left = CommunityThreadMember.createMember(THREAD_ID, MEMBER_ID, NOW);
+        left.leave(NOW.plusSeconds(60));
+        ChatMessageInfo chatMessage = chatMessage(900L, MEMBER_ID, "본문");
+        ChatMessageCursorResult chatPage = new ChatMessageCursorResult(List.of(chatMessage), null, false);
+        CommunityThreadMessageInfo communityInfo = org.mockito.Mockito.mock(CommunityThreadMessageInfo.class);
         given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
         given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
             .willReturn(Optional.of(left));
+        given(getChatMessagesUseCase.getMessages(any(GetChatMessagesQuery.class))).willReturn(chatPage);
+        given(infoAssembler.assemble(THREAD_ID, List.of(chatMessage))).willReturn(List.of(communityInfo));
+
+        CommunityThreadMessagePageInfo result = sut.getHistory(
+            new CommunityThreadMessageHistoryQuery(THREAD_ID, MEMBER_ID, null, 30)
+        );
+
+        assertThat(result.messages()).containsExactly(communityInfo);
+    }
+
+    @Test
+    @DisplayName("KICKED 멤버는 history Chat query 전에 THREAD_ACCESS_DENIED로 거절한다")
+    void kickedMemberIsRejectedBeforeHistory() {
+        given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
+        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
+            .willReturn(Optional.of(kickedMember(MEMBER_ID)));
+
+        assertThatThrownBy(() -> sut.getHistory(new CommunityThreadMessageHistoryQuery(
+            THREAD_ID, MEMBER_ID, null, 30
+        )))
+            .isInstanceOf(CommunityDomainException.class)
+            .extracting(error -> ((CommunityDomainException) error).getBaseCode())
+            .isEqualTo(CommunityErrorCode.THREAD_ACCESS_DENIED);
+        then(getChatMessagesUseCase).shouldHaveNoInteractions();
+        then(realtimeMetrics).should().recordBackfill(Operation.MESSAGE_HISTORY, Outcome.FAILURE);
+    }
+
+    @Test
+    @DisplayName("KICKED 멤버는 단건 Chat query 전에 THREAD_ACCESS_DENIED로 거절한다")
+    void kickedMemberIsRejectedBeforeSingle() {
+        given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
+        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
+            .willReturn(Optional.of(kickedMember(MEMBER_ID)));
 
         assertThatThrownBy(() -> sut.getMessage(new CommunityThreadMessageQuery(THREAD_ID, MEMBER_ID, 900L)))
             .isInstanceOf(CommunityDomainException.class)
             .extracting(error -> ((CommunityDomainException) error).getBaseCode())
             .isEqualTo(CommunityErrorCode.THREAD_ACCESS_DENIED);
         then(getChatMessageUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("KICKED 멤버는 recovery도 THREAD_ACCESS_DENIED로 거절한다")
+    void kickedMemberIsRejectedBeforeRecovery() {
+        given(loadThreadPort.findById(THREAD_ID)).willReturn(Optional.of(thread()));
+        given(loadThreadMemberPort.findByThreadIdAndMemberId(THREAD_ID, MEMBER_ID))
+            .willReturn(Optional.of(kickedMember(MEMBER_ID)));
+
+        assertThatThrownBy(() -> sut.recover(new CommunityThreadMessageRecoveryQuery(
+            THREAD_ID, MEMBER_ID, null, 30
+        )))
+            .isInstanceOf(CommunityDomainException.class)
+            .extracting(error -> ((CommunityDomainException) error).getBaseCode())
+            .isEqualTo(CommunityErrorCode.THREAD_ACCESS_DENIED);
+        then(getChatMessagesUseCase).shouldHaveNoInteractions();
     }
 
     private CommunityThread thread() {
@@ -230,8 +309,10 @@ class CommunityThreadMessageQueryServiceTest {
         return thread;
     }
 
-    private CommunityThreadMember activeMember(Long memberId) {
-        return CommunityThreadMember.createMember(THREAD_ID, memberId, NOW);
+    private CommunityThreadMember kickedMember(Long memberId) {
+        CommunityThreadMember member = CommunityThreadMember.createMember(THREAD_ID, memberId, NOW);
+        member.kick(NOW.plusSeconds(60));
+        return member;
     }
 
     private ChatMessageInfo chatMessage(Long messageId, Long senderId, String content) {

--- a/src/test/java/com/umc/product/community/application/service/query/CommunityThreadListDetailQueryServiceTest.java
+++ b/src/test/java/com/umc/product/community/application/service/query/CommunityThreadListDetailQueryServiceTest.java
@@ -275,6 +275,36 @@ class CommunityThreadListDetailQueryServiceTest {
     }
 
     @Test
+    @DisplayName("getPublicThread는 KICKED 요청자를 THREAD_ACCESS_DENIED로 거절한다")
+    void getPublicThread_강퇴된_요청자를_거절한다() {
+        // given
+        CommunityThreadQueryRow kicked = restrictedRow(CommunityThreadMemberState.KICKED, null);
+        given(threadQueryPort.findThread(1L, 10L)).willReturn(Optional.of(kicked));
+
+        // when & then
+        assertThatThrownBy(() -> sut.getPublicThread(new GetThreadDetailQuery(1L, 10L)))
+            .isInstanceOf(CommunityDomainException.class)
+            .extracting(exception -> ((CommunityDomainException) exception).getBaseCode())
+            .isEqualTo(CommunityErrorCode.THREAD_ACCESS_DENIED);
+        verifyNoInteractions(getMemberUseCase);
+    }
+
+    @Test
+    @DisplayName("getPublicThread는 LEFT 요청자에게는 상세를 반환한다")
+    void getPublicThread_탈퇴한_요청자를_허용한다() {
+        // given
+        CommunityThreadQueryRow left = restrictedRow(CommunityThreadMemberState.LEFT, null);
+        given(threadQueryPort.findThread(1L, 10L)).willReturn(Optional.of(left));
+
+        // when
+        var result = sut.getPublicThread(new GetThreadDetailQuery(1L, 10L));
+
+        // then
+        assertThat(result.threadId()).isEqualTo(1L);
+        assertThat(result.isJoined()).isFalse();
+    }
+
+    @Test
     @DisplayName("getPublicThread는 삭제된 스레드를 THREAD_DELETED로 거절한다")
     void getPublicThread_삭제된_스레드를_거절한다() {
         // given

--- a/src/test/java/com/umc/product/community/architecture/CommunityThreadArchitectureTest.java
+++ b/src/test/java/com/umc/product/community/architecture/CommunityThreadArchitectureTest.java
@@ -36,6 +36,15 @@ class CommunityThreadArchitectureTest {
         "com.umc.product.chat.domain.event.ChatReadUpdatedEvent"
     );
 
+    /**
+     * Community가 Chat command/query 계약을 채우기 위해 값으로만 쓰는 Chat domain enum. entity/repository 참조가 아니므로
+     * 경계 위반이 아니며, 소문자 import 문 전체를 정확히 일치시킨다.
+     */
+    private static final Set<String> ALLOWED_CHAT_DOMAIN_VALUE_IMPORTS = Set.of(
+        "import com.umc.product.chat.domain.messagecontenttype;",
+        "import com.umc.product.chat.domain.chatroomreadscope;"
+    );
+
     private static final Set<String> ALLOWED_DOMAIN_ROOTS = Set.of(
         "community",
         "common",
@@ -217,7 +226,7 @@ class CommunityThreadArchitectureTest {
         if (importLine.contains(".adapter.out.persistence.")) {
             return true;
         }
-        if (importLine.equals("import com.umc.product.chat.domain.messagecontenttype;")) {
+        if (ALLOWED_CHAT_DOMAIN_VALUE_IMPORTS.contains(importLine)) {
             return false;
         }
         if (importLine.contains(".chat.domain.")) {


### PR DESCRIPTION
## 🚀 작업 내용

- resolves #1244

스레드 상세는 비참여자에게 공개인데 메시지 조회만 참여자 전용이라, 스레드에 들어가도 대화가 안 보이는 문제를 해결했어요.

차단 지점이 **Community**와 **Chat** 두 곳이라 양쪽을 모두 수정했어요. Chat은 다른 도메인도 쓸 엔진이라 community 전용 분기를 넣지 않고, `ChatRoom`에 조회 범위(`MEMBER_ONLY` 기본 /`PUBLIC`)를 두어 스레드 방만 opt-in 하도록 했어요.

- **조회** : 메시지 조회를 상세와 같은 공개 범위로 맞췄어요
- **변경** : 생성·수정·삭제·리액션·읽음·신고와 실시간 수신은 그대로 ACTIVE 멤버 전용이에요
- **강퇴** : KICKED는 목록·상세·메시지 조회를 모두 차단했어요 (LEFT는 조회 가능)

`ADR-026`의 보안 불변식 3번이 "조회는 방의 read scope, 변경은 membership"으로 나뉘어서 개정안을 추가했어요.



## 💬 리뷰 중점사항

- **`CommunityThreadQueryRepository.notKicked()`** : requester join이 ACTIVE만 매칭해서 KICKED가 "미참여"와 구분되지 않아요. NOT EXISTS 서브쿼리를 `baseCondition`에 넣어 browse/search/count를 한 번에 덮었어요. pinned 쿼리엔 중복이지만 누락 방지를 우선했어요.
- **마이그레이션** : 기존 스레드 방을 소유 관계 따라 `PUBLIC`으로 backfill 해요.
