### PR TITLE
[Fix] 내 일정 조회에서 여러 달에 걸친 일정이 시작 월에만 조회되는 문제

### DIFF
--- a/src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java
+++ b/src/main/java/com/umc/product/schedule/adapter/in/web/v2/ScheduleQueryV2Controller.java
@@ -67,7 +67,11 @@ public class ScheduleQueryV2Controller {
         message = "내 일정을 보려면 챌린저 활동 기록이 필요해요. 활동 기록을 확인해주세요."
     )
     @Operation(operationId = "SCHEDULE-Q002", summary = "내 일정 조회", description = """
-        로그인한 사용자가 참여하는 일정 중 Query Param의 `from`, `to` 사이에 시작일이 있는 일정을 모두 조회합니다.
+        로그인한 사용자가 참여하는 일정 중 Query Param의 `from` ~ `to` 기간과 일정 기간이 겹치는 일정을 모두 조회합니다.
+
+        시작일이 아닌 기간 겹침(`startsAt <= to AND endsAt >= from`) 기준이므로, 여러 달에 걸친 일정은
+        걸쳐 있는 모든 달의 조회 결과에 포함됩니다.
+        (ex. 6/30 ~ 8/2 일정은 6월, 7월, 8월 조회에 모두 포함)
 
         활동-출석 체크 UI에서 활용하기 위해서는 `isAttendanceRequired` 필드를 `true`로 해서 출석을 트래킹하는 API에 대해서만 조회하면 됩니다.
 

--- a/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleQueryRepository.java
+++ b/src/main/java/com/umc/product/schedule/adapter/out/persistence/ScheduleQueryRepository.java
@@ -3,17 +3,20 @@ package com.umc.product.schedule.adapter.out.persistence;
 import static com.umc.product.schedule.domain.QSchedule.schedule;
 import static com.umc.product.schedule.domain.QScheduleParticipant.scheduleParticipant;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.umc.product.schedule.domain.Schedule;
-import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
@@ -32,7 +35,7 @@ public class ScheduleQueryRepository {
             .leftJoin(schedule.tags).fetchJoin()
             .where(
                 scheduleParticipant.memberId.eq(memberId), // 내가 참여자인 일정
-                schedule.startsAt.between(from, to), // from ~ to 사이
+                overlapsPeriod(from, to), // from ~ to 와 기간이 겹치는 일정
                 isAttendanceRequiredEq(isAttendanceRequired) // 동적 쿼리
             )
             .orderBy(schedule.startsAt.asc())
@@ -86,6 +89,22 @@ public class ScheduleQueryRepository {
     }
 
     // ========================== 동적 조건 Helper Method ==========================
+
+    // 조회 기간(from ~ to)과 일정 기간(startsAt ~ endsAt)이 겹치는지 판별하는 메서드
+    // 시작 시각만 비교하면 여러 달에 걸친 일정이 시작한 달에서만 조회되므로, 기간 겹침으로 판별한다.
+    // ex) 6/30 ~ 8/2 일정은 6월/7월/8월 조회에 모두 포함된다.
+    private BooleanExpression overlapsPeriod(Instant from, Instant to) {
+        BooleanExpression startsBeforePeriodEnds = (to != null) ? schedule.startsAt.loe(to) : null;
+        BooleanExpression endsAfterPeriodStarts = (from != null) ? schedule.endsAt.goe(from) : null;
+
+        if (startsBeforePeriodEnds == null) {
+            return endsAfterPeriodStarts;
+        }
+        if (endsAfterPeriodStarts == null) {
+            return startsBeforePeriodEnds;
+        }
+        return startsBeforePeriodEnds.and(endsAfterPeriodStarts);
+    }
 
     // 동적 쿼리 처리 헬퍼 메서드
     private BooleanExpression isAttendanceRequiredEq(Boolean isAttendanceRequired) {

--- a/src/main/java/com/umc/product/schedule/application/port/out/LoadSchedulePort.java
+++ b/src/main/java/com/umc/product/schedule/application/port/out/LoadSchedulePort.java
@@ -1,11 +1,12 @@
 package com.umc.product.schedule.application.port.out;
 
-import com.umc.product.schedule.domain.Schedule;
-import com.umc.product.schedule.domain.enums.AttendanceStatus;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.enums.AttendanceStatus;
 
 public interface LoadSchedulePort {
 
@@ -14,6 +15,10 @@ public interface LoadSchedulePort {
     boolean existsById(Long id);
 
     /**
+     * 사용자가 참여하는 일정 중 (from ~ to) 기간과 일정 기간(startsAt ~ endsAt)이 겹치는 일정을 조회합니다.
+     * <p>
+     * 시작 시각 기준이 아닌 기간 겹침 기준이므로, 여러 달에 걸친 일정은 걸쳐 있는 모든 달의 조회에 포함됩니다.
+     *
      * @param memberId             사용자 memberId
      * @param from                 탐색을 시작할 날짜
      * @param to                   탐색을 끝낼 날짜

--- a/src/test/java/com/umc/product/schedule/adapter/out/persistence/ScheduleQueryRepositoryTest.java
+++ b/src/test/java/com/umc/product/schedule/adapter/out/persistence/ScheduleQueryRepositoryTest.java
@@ -1,0 +1,175 @@
+package com.umc.product.schedule.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import com.umc.product.schedule.domain.Schedule;
+import com.umc.product.schedule.domain.ScheduleParticipant;
+import com.umc.product.schedule.domain.enums.ScheduleTag;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@Import(ScheduleQueryRepository.class)
+@DisplayName("ScheduleQueryRepository")
+class ScheduleQueryRepositoryTest {
+
+    private static final Long MEMBER_ID = 100L;
+
+    @Autowired
+    ScheduleQueryRepository sut;
+
+    @Autowired
+    ScheduleJpaRepository scheduleJpaRepository;
+
+    @Autowired
+    ScheduleParticipantJpaRepository scheduleParticipantJpaRepository;
+
+    @ParameterizedTest(name = "{2} 조회")
+    @CsvSource({
+        "2026-06-01T00:00:00Z, 2026-06-30T23:59:59Z, 6월",
+        "2026-07-01T00:00:00Z, 2026-07-31T23:59:59Z, 7월",
+        "2026-08-01T00:00:00Z, 2026-08-31T23:59:59Z, 8월"
+    })
+    @DisplayName("여러 달에 걸친 일정은 걸쳐 있는 모든 달의 조회 결과에 포함된다")
+    void findMySchedules_여러_달에_걸친_일정을_모든_달에서_조회한다(String from, String to, String month) {
+        // given : 6/30 ~ 8/2 까지 진행되는 일정
+        Schedule schedule = saveScheduleWithParticipant(
+            "3개월에 걸친 일정",
+            Instant.parse("2026-06-30T00:00:00Z"),
+            Instant.parse("2026-08-02T00:00:00Z")
+        );
+
+        // when
+        List<Schedule> results = sut.findMySchedules(
+            MEMBER_ID, Instant.parse(from), Instant.parse(to), null
+        );
+
+        // then
+        assertThat(results)
+            .as("%s 조회 결과", month)
+            .extracting(Schedule::getId)
+            .containsExactly(schedule.getId());
+    }
+
+    @Test
+    @DisplayName("조회 기간이 끝난 뒤에 시작하는 일정은 조회되지 않는다")
+    void findMySchedules_조회_기간_이후에_시작하는_일정은_제외한다() {
+        // given
+        saveScheduleWithParticipant(
+            "9월 일정",
+            Instant.parse("2026-09-01T00:00:00Z"),
+            Instant.parse("2026-09-01T02:00:00Z")
+        );
+
+        // when : 7월 조회
+        List<Schedule> results = sut.findMySchedules(
+            MEMBER_ID,
+            Instant.parse("2026-07-01T00:00:00Z"),
+            Instant.parse("2026-07-31T23:59:59Z"),
+            null
+        );
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조회 기간이 시작하기 전에 끝난 일정은 조회되지 않는다")
+    void findMySchedules_조회_기간_이전에_종료된_일정은_제외한다() {
+        // given
+        saveScheduleWithParticipant(
+            "5월 일정",
+            Instant.parse("2026-05-01T00:00:00Z"),
+            Instant.parse("2026-05-01T02:00:00Z")
+        );
+
+        // when : 7월 조회
+        List<Schedule> results = sut.findMySchedules(
+            MEMBER_ID,
+            Instant.parse("2026-07-01T00:00:00Z"),
+            Instant.parse("2026-07-31T23:59:59Z"),
+            null
+        );
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("일정 종료 시각이 조회 시작 시각과 같으면 조회 결과에 포함된다")
+    void findMySchedules_경계값인_종료_시각도_포함한다() {
+        // given : 7월 조회 시작 시각에 정확히 끝나는 일정
+        Schedule schedule = saveScheduleWithParticipant(
+            "6월 말 ~ 7월 1일 0시 일정",
+            Instant.parse("2026-06-30T22:00:00Z"),
+            Instant.parse("2026-07-01T00:00:00Z")
+        );
+
+        // when
+        List<Schedule> results = sut.findMySchedules(
+            MEMBER_ID,
+            Instant.parse("2026-07-01T00:00:00Z"),
+            Instant.parse("2026-07-31T23:59:59Z"),
+            null
+        );
+
+        // then
+        assertThat(results)
+            .extracting(Schedule::getId)
+            .containsExactly(schedule.getId());
+    }
+
+    @Test
+    @DisplayName("참여자가 아닌 사용자의 일정은 기간이 겹쳐도 조회되지 않는다")
+    void findMySchedules_참여자가_아니면_제외한다() {
+        // given
+        saveScheduleWithParticipant(
+            "3개월에 걸친 일정",
+            Instant.parse("2026-06-30T00:00:00Z"),
+            Instant.parse("2026-08-02T00:00:00Z")
+        );
+
+        // when : 다른 사용자로 7월 조회
+        List<Schedule> results = sut.findMySchedules(
+            MEMBER_ID + 1,
+            Instant.parse("2026-07-01T00:00:00Z"),
+            Instant.parse("2026-07-31T23:59:59Z"),
+            null
+        );
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    private Schedule saveScheduleWithParticipant(String name, Instant startsAt, Instant endsAt) {
+        Schedule schedule = scheduleJpaRepository.save(
+            Schedule.builder()
+                .name(name)
+                .description("테스트 일정")
+                .tags(Set.of(ScheduleTag.GENERAL))
+                .authorMemberId(MEMBER_ID)
+                .startsAt(startsAt)
+                .endsAt(endsAt)
+                .build()
+        );
+
+        scheduleParticipantJpaRepository.save(
+            ScheduleParticipant.builder()
+                .memberId(MEMBER_ID)
+                .schedule(schedule)
+                .build()
+        );
+
+        return schedule;
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

-  resolves #1241

내 일정 조회(`SCHEDULE-Q002`)의 기간 필터를 **시작 시각 기준 -> 기간 겹침 기준**으로 변경했습니다.

### 문제
`ScheduleQueryRepository.findMySchedules()`가 `schedule.startsAt.between(from, to)`로 시작 시각만 비교하고 있어, 여러 달에 걸친 일정이 시작한 달에서만 조회됐습니다.
- 6/30 ~ 8/2 일정 -> 6월 조회 O / 7월 조회 X / 8월 조회 X

### 변경
- 기간 겹침 조건(`startsAt <= to AND endsAt >= from`)을 판별하는 `overlapsPeriod()` 추가 후 적용
- `from`/`to` 한쪽만 들어와도 동작하도록 null 처리 (현재 컨트롤러는 둘 다 필수)
- `LoadSchedulePort` Javadoc, `SCHEDULE-Q002` Swagger 설명을 기간 겹침 기준으로 갱신


## 💬 리뷰 중점사항