### PR TITLE
[Fix] 학교 목록 정렬이 가나다순으로 나오지 않는 문제

### DIFF
--- a/src/main/resources/db/migration/V2026.08.13.16.34__alter_school_name_collation.sql
+++ b/src/main/resources/db/migration/V2026.08.13.16.34__alter_school_name_collation.sql
@@ -1,0 +1,20 @@
+-- school.name 가나다 정렬 복구.
+--
+-- DB 기본 collation 이 en_US.utf8(libc) 인데, glibc 정렬 테이블에는 한글 음절(U+AC00~U+D7A3)의
+-- 가중치가 없다. 그래서 한글끼리는 1차 비교가 전부 무승부가 되고 길이 -> 코드포인트 라는
+-- 최후 수단으로 떨어진다. 그 결과 ORDER BY name 이
+--   가천대학교 ... 한성대학교(5글자 전부) -> 가톨릭대학교(6글자) -> 강릉원주대학교(7글자) ...
+-- 순서로 나온다.
+--
+-- 컬럼 collation 을 ICU ko-KR 로 지정하면 ORDER BY name 이 가나다순이 된다.
+-- ko-KR-x-icu 는 deterministic 이라 동등성 비교와 unique 제약 의미는 바뀌지 않고,
+-- 라틴 문자 정렬 순서도 기존 en_US.utf8 과 동일하다(ICU 가 라틴을 CLDR 공통 규칙으로 처리).
+--
+-- 근본 해결은 DB 를 LOCALE_PROVIDER icu ICU_LOCALE 'ko-KR' 로 생성하는 것이다.
+-- PostgreSQL 은 기존 DB 의 collation 을 제자리에서 바꿀 수 없어(덤프/복원 필요)
+-- k3s 이관 시 신규 DB 생성 단계에서 적용한다. 지금은 사용자에게 노출 중인 school.name 만 막는다.
+-- 같은 이유로 member/chapter/study_group/project 의 name 도 여전히 깨진 순서로 정렬된다.
+--
+-- collation 만 바꾸는 ALTER 는 힙을 재작성하지 않고 딸린 인덱스만 재생성한다.
+-- school.name 에는 인덱스가 없어 메타데이터 변경으로 끝난다.
+ALTER TABLE school ALTER COLUMN name TYPE varchar(255) COLLATE "ko-KR-x-icu";


### PR DESCRIPTION
## 🚀 작업 내용

`GET /api/v1/schools/all` 이 가나다순으로 정렬되지 않고 아래처럼 반환됩니다.

```
가천대학교, 경희대학교, 광운대학교 ... 한성대학교   ← 5글자 학교가 전부 먼저
가톨릭대학교                                      ← 6글자
강릉원주대학교, 경상국립대학교 ...                  ← 7글자
```

원인은 DB 기본 collation 입니다.

```
datcollate = en_US.utf8 (libc provider)
```

### 안전성

- 라틴 문자 정렬 순서는 기존 `en_US.utf8` 과 **동일**. ICU 가 라틴을 CLDR 공통 규칙으로 처리하고 `ko-KR` 은 그 위에 한글 규칙만 얹는 구조라, 영문 학교명이 섞여도 순서가 바뀌지 않습니다

## 💬 리뷰 중점사항

**이 PR 은 `school.name` 만 고칩니다.** 같은 이유로 아직 깨져 있는 곳:

| 컬럼 | 위치 |
|---|---|
| `member.name` | `MemberQueryRepository` 74·111·153·185, `ChallengerQueryRepository` 79·110·213·244 |
| `chapter.name` / `school.name` | `AdminOperationsAnalyticsQueryRepository` 194·268·342 |
| `studyGroup.name` | `StudyGroupQueryRepository` 251 |
| `project.name` | `ProjectQueryRepository` 222 |

근본 해결은 DB 자체를 ICU 로 만드는 것입니다.

PostgreSQL 은 기존 DB 의 collation 을 제자리에서 바꿀 수 없어(`ALTER DATABASE ... SET LC_COLLATE` → `ERROR: unrecognized configuration parameter`) 덤프/복원이 필요합니다. **k3s 이관 시 신규 DB 생성 단계에서 적용할 예정**이라, 이번에는 사용자에게 직접 노출 중인 `school.name` 만 막았습니다.

## 참고

https://dfdfg42.tistory.com/entry/PostgreSQL-%ED%95%9C%EA%B8%80%EC%A0%95%EB%A0%AC%EC%9D%B4-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EC%95%88%EB%90%98%EB%8A%94-%EB%AC%B8%EC%A0%9C