### PR TITLE
[Docs] 데모데이 투표 FE API 계약 초안 배포

### DIFF
--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -1,0 +1,1661 @@
+openapi: 3.1.0
+
+# ====================================================================
+# 데모데이 현장 투표 API — 구현 전 손으로 쓴 계약 초안
+#
+# 이 파일은 springdoc 자동 생성본(/docs-json)이 아니다.
+# 컨트롤러가 아직 없어서 리플렉션으로는 아무것도 생성되지 않는 기간 동안
+# FE가 먼저 착수할 수 있도록 사람이 직접 작성한 정적 문서다.
+#
+# servers·securityScheme 이름·응답 envelope는
+# global/config/OpenApiConfig.java 및 global/response/ApiResponse.java와
+# 의도적으로 동일하게 맞췄다. 자동 생성본으로 갈아탈 때 diff를 줄이기 위해서다.
+#
+# 삭제 트리거는 info.description 하단 참조.
+# ====================================================================
+
+info:
+  title: UMC PRODUCT API(데모데이 현장 투표)
+  version: draft-2026-08-13
+  description: |
+    ## 이 문서의 성격
+
+    데모데이 현장 투표 API의 **구현 전 계약 초안**입니다. 서버 컨트롤러가 아직 없어
+    자동 생성 문서(`UMC PRODUCT API`)에는 이 경로들이 나타나지 않습니다.
+    데모데이는 날짜가 고정된 현장 행사라 FE와 서버가 순차로 진행하면 일정을 맞출 수 없어,
+    영속성 작업 기간에 계약을 먼저 확정해 배포합니다.
+
+    구현이 끝난 경로는 자동 생성본으로 옮겨가며 이 문서에서 삭제됩니다.
+    **같은 경로가 양쪽에 다 보이면 자동 생성본이 정답입니다.**
+
+    ### 여기에 없는 것
+
+    - **로그인 API** (`/api/v1/auth/**`) — 이미 구현되어 있으므로 자동 생성본을 보세요.
+      UMC 회원은 이메일·Google·Kakao 로그인으로 AT를 발급받은 뒤
+      `GET /demoday/polls/{pollId}/participations/me`로 참여 흐름에 진입합니다.
+    - 부스 등록 API — 이번 기수에는 관리자 화면 없이 운영자가 직접 호출하며 계약이 아직 없습니다.
+    - 이상 패턴 조회, Poll 구성 관리(생성·수정·상태 변경) — 아직 설계 전입니다.
+    - QR 이미지 렌더링 — `qrValue` 문자열을 FE가 그대로 렌더링합니다.
+
+    ## 바뀌지 않는 것 — 이 계약에 맞춰 구현해도 됩니다
+
+    - 경로, HTTP method, 성공 status
+    - 요청·응답 본문의 필드 이름과 타입, nullable 여부
+    - 공통 응답 envelope 구조 (`success` / `code` / `message` / `result`)
+    - 각 경로의 인증 주체 (공개 / 참여자 / `SUPER_ADMIN`)
+    - 도메인 규칙 — 스탬프 6개 수집, 스탬프 간 5분 쿨다운, 투표 권한 5분 유효,
+      Poll당 1인 1표, Poll 간 완전 독립
+    - 이미 번호가 붙은 오류 코드 (`DEMODAY-0300`, `0400`~`0404`, `0501`, `0503`)
+
+    ## 바뀔 수 있는 것 — 여기에 의존하지 마세요
+
+    - **`code` 문자열이 `DEMODAY-XXXX`로 표기된 오류** — 서버 구현 시 확정해 별도 공유합니다.
+      해당 상황의 HTTP status와 도메인 규칙은 확정이므로, 화면 분기는 status 기준으로 먼저 만드세요.
+    - **외부 방문자 HttpOnly Cookie의 이름과 세부 속성** (`SameSite`·만료·CSRF 방어).
+      HttpOnly라 FE가 읽지 않고 `withCredentials`로 자동 첨부되므로 FE 코드에는 영향이 없습니다.
+    - **`qrValue`의 호스트와 경로** — 배포 환경에 따라 달라집니다.
+      FE는 조립하지 않고 받은 문자열을 그대로 렌더링합니다.
+    - `requiredStampCount`의 값 (현재 6). 서버가 내려주는 값을 쓰고 6을 상수로 박지 마세요.
+    - 관리자 대시보드에 향후 추가될 수 있는 통계 필드.
+
+    ## 공통 응답 envelope
+
+    모든 JSON 응답은 아래 형태입니다.
+
+    ```json
+    { "success": true, "code": "COMMON200", "message": "성공입니다.", "result": {} }
+    ```
+
+    - 성공 envelope의 `code`는 HTTP status와 무관하게 **항상 `COMMON200`** 입니다.
+      `201`로 응답하는 API도 마찬가지입니다.
+    - 따라서 성공 판정에는 `code`가 아니라 HTTP status 또는 `success`를 사용하세요.
+    - `result`가 없는 응답에서는 `result` 필드 자체가 생략됩니다 (`null`로 오지 않습니다).
+    - 실패 응답도 `result`에 구조화된 추가 정보를 실을 수 있습니다.
+      쿨다운 오류는 `nextStampAvailableAt`을 함께 반환하므로 FE가 서버 시각을 재계산하지 않아도 됩니다.
+    - 화면에 정확히 표시해야 하는 정보는 `message`를 파싱하지 말고 `result`의 구조화된 필드를 쓰세요.
+
+    ## 인증 주체
+
+    | 주체 | 방식 |
+    |---|---|
+    | 미인증 사용자 | 없음. 현재 Poll 목록만 조회 가능 |
+    | UMC 회원 | `Authorization: Bearer {accessToken}` |
+    | 외부 방문자 | 데모데이 전용 HttpOnly Cookie (`withCredentials: true`) |
+    | 관리자 | `Authorization: Bearer {accessToken}` + `SUPER_ADMIN` 권한 |
+
+    `참여자` 인증이 걸린 경로는 회원 Bearer 또는 외부 방문자 Cookie 중 **하나면** 통과합니다.
+
+    ---
+
+    ### 이 문서의 삭제 시점 (서버팀용)
+
+    운영자 준비 API·참가자 투표 경로를 구현하는 각 PR에서 **해당 경로를 이 파일에서 지웁니다.**
+    마지막 경로가 빠지면 이 파일과 `static/docs/scalar.html`의 `sources` 항목을 함께 삭제합니다.
+
+# OpenApiConfig.servers()와 동일하게 유지할 것 (URL·description 모두).
+servers:
+  - url: https://dev.api.university.neordinary.com
+    description: Development
+  - url: http://localhost:8080
+    description: Local
+  - url: https://api.university.neordinary.com
+    description: Production
+
+# 기본값은 참여자 인증 — 회원 Bearer 또는 외부 방문자 Cookie 중 "하나만" 있으면 통과한다
+# (배열의 각 항목은 OR로 결합된다).
+# 공개 경로는 operation에서 `security: []`로, 관리자 경로는 Bearer 단독으로 덮어쓴다.
+security:
+  - 'Access Token': []
+  - DemodayParticipantCookie: []
+
+tags:
+  - name: 데모데이 - 참여자
+    description: 회원과 외부 방문자가 사용하는 현장 투표 경로.
+  - name: 데모데이 - 관리자
+    description: '`SUPER_ADMIN` 전용 운영 경로.'
+
+paths:
+  # ------------------------------------------------------------------
+  # 참여자
+  # ------------------------------------------------------------------
+  /api/v1/demoday/polls:
+    get:
+      tags: [데모데이 - 참여자]
+      operationId: getDemodayPolls
+      summary: 현재 행사 Poll 목록 조회
+      description: |
+        사이트 최초 진입 시 인증 이전 상태에서 호출하는 공개 API입니다.
+
+        - 어떤 Poll이 현재 행사인지 판정하는 책임은 서버에 있습니다. FE는 판정 규칙을 구현하지 않습니다.
+        - 아직 열리지 않은 Poll도 목록에 포함됩니다.
+        - 반환할 Poll이 없으면 `polls`는 빈 배열입니다.
+
+        ### 진입 버튼 활성 조건
+
+        `status`는 시간에서 파생되는 값이 아니라 운영진이 Poll을 활성화했다는 명시적 의사입니다.
+        따라서 `status` 하나로는 화면 상태가 결정되지 않습니다.
+
+        진입 버튼을 활성화하는 조건은 `status == "OPEN" && opensAt <= now < closesAt` 하나뿐이고
+        나머지는 모두 비활성입니다. 경계는 `opensAt`을 포함하고 `closesAt`은 포함하지 않습니다.
+
+        | `status` | 현재 시각 | 화면 상태 | 진입 버튼 |
+        |---|---|---|---|
+        | `OPEN` | `opensAt` 이전 | 시작 전 | 비활성 · 시작 시각 안내 |
+        | `OPEN` | `opensAt` 이상 `closesAt` 미만 | 투표 진행 중 | **활성** |
+        | `OPEN` | `closesAt` 이상 | 종료 | 비활성 · 종료 안내 |
+        | `CLOSED` | `closesAt` 미만 | 준비 중 | 비활성 · 시작 시각 안내 |
+        | `CLOSED` | `closesAt` 이상 | 종료 | 비활성 · 종료 안내 |
+
+        `시작 전`과 `종료`는 `status`만으로 구분되지 않습니다. 두 경우 모두 `CLOSED`일 수 있으므로
+        반드시 `closesAt`과 현재 시각을 비교하세요.
+
+        이 판정은 화면 표시용입니다. 서버는 각 명령에서 같은 조건을 다시 검증하고
+        `DEMODAY-0400`(시작 전) 또는 `DEMODAY-0401`(종료)로 거절합니다.
+      security: []
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/PollListResult'
+
+  /api/v1/demoday/polls/{pollId}/participations/guest:
+    post:
+      tags: [데모데이 - 참여자]
+      operationId: startGuestParticipation
+      summary: 입장 코드 사용 및 외부 방문자 참여 시작
+      description: |
+        외부 방문자가 현장에서 받은 입장 코드를 제출해 참여를 시작합니다.
+
+        성공하면 서버가 코드를 사용 처리하고 요청한 브라우저에 1회 바인딩한 뒤,
+        데모데이 전용 participant token을 **HttpOnly Cookie로 설정**합니다.
+        token은 JSON 본문에 노출되지 않으며, `result`에는 `GET /participations/me`와 같은 참여 상태가 담깁니다.
+
+        ### 도메인 규칙
+
+        - 입장 코드는 1회용이고 Poll 단위로 발급됩니다.
+        - 하나의 코드는 발급된 Poll에서만 씁니다. 금요일·토요일에 모두 참여하는 방문자는
+          Poll마다 다른 코드를 받아 이 API를 각각 호출해야 합니다.
+          금요일 Cookie로 토요일 `pollId`를 호출하면 실패합니다.
+        - 한 번 사용한 코드는 다른 브라우저·기기에서 다시 쓸 수 없습니다.
+        - **이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시 제출하면 성공으로 처리합니다.**
+          네트워크 타임아웃 뒤의 재시도가 사용자를 잠그지 않도록 하기 위한 규칙입니다.
+        - Cookie를 잃으면 같은 코드로 복구할 수 없습니다. 현장 운영진의 코드 재발급이 유일한 경로입니다.
+        - Cookie와 입장 코드의 수명은 Poll 종료 시점까지이며, 그 전에 관리자가 무효화할 수 있습니다.
+        - 재접속한 같은 브라우저는 Cookie로 `GET /participations/me`를 호출해 상태를 이어갑니다.
+
+        ### FE 설정
+
+        ```ts
+        const demodayApi = axios.create({ baseURL: API_BASE_URL, withCredentials: true });
+        // 또는
+        fetch(url, { credentials: 'include' });
+        ```
+
+        participant token은 FE가 읽거나 `localStorage`·`sessionStorage`에 저장하지 않습니다.
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GuestParticipationRequest'
+      responses:
+        '201':
+          description: |
+            참여 시작 성공. 데모데이 전용 participant token이 HttpOnly Cookie로 설정됩니다.
+          headers:
+            Set-Cookie:
+              description: 데모데이 전용 participant token. HttpOnly이므로 FE가 읽지 않습니다.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/ParticipationResult'
+        '409':
+          description: |
+            이미 사용한 입장 코드 (`DEMODAY-0300`).
+
+            같은 브라우저의 재제출은 실패가 아니라 `201`입니다. 이 오류는 **다른** 브라우저·기기에서
+            이미 사용된 코드를 제출했을 때 발생합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              example:
+                success: false
+                code: DEMODAY-0300
+                message: 이미 사용된 입장 코드입니다.
+
+  /api/v1/demoday/polls/{pollId}/participations/me:
+    get:
+      tags: [데모데이 - 참여자]
+      operationId: getMyParticipation
+      summary: 현재 참여 상태와 스탬프 현황 조회
+      description: |
+        **회원은 로그인 직후 이 API를 호출해 참여 흐름에 진입합니다.** 회원 전용 참여 시작 API는 따로 없습니다.
+        참여 행을 만들지 않고 유효한 스탬프·투표 기록에서 상태를 계산하므로,
+        반복 호출해도 같은 결과를 반환하는 멱등 조회입니다.
+
+        외부 방문자는 `Authorization` 대신 HttpOnly Cookie가 자동 첨부됩니다.
+
+        ### 참여 자격
+
+        - 유효한 UMC 회원이면 기수와 무관하게 참여할 수 있습니다. 인증이 통과하면 자격도 충족한 것입니다.
+        - 회원 한 명은 Poll마다 하나의 논리적 참여 주체로 식별되며, 금요일·토요일 Poll에 각각 한 번씩 참여합니다.
+        - 향후 자격에 조건이 붙으면(기수 제한, 제재 회원 차단 등) **이 API가 `403`으로 거절합니다.**
+          자격 확인 전용 엔드포인트는 두지 않습니다. 자격은 `/stamps`·`/vote-authorizations`·`/votes`에서도
+          다시 검증되므로, 사전 조회용 엔드포인트를 따로 두면 같은 판정이 두 곳으로 갈라집니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/ParticipationResult'
+        '401':
+          $ref: '#/components/responses/ParticipantUnauthorized'
+        '403':
+          description: 참여 자격 미충족. 향후 자격 조건이 추가되면 이 경로가 거절합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /api/v1/demoday/polls/{pollId}/stamps:
+    post:
+      tags: [데모데이 - 참여자]
+      operationId: collectStamp
+      summary: 부스 QR을 통한 스탬프 적립
+      description: |
+        부스에 비치된 QR을 스캔해 스탬프를 적립합니다.
+        외부 방문자는 `Authorization` 대신 HttpOnly Cookie가 자동 첨부됩니다.
+
+        ### 도메인 규칙
+
+        - 스탬프 QR credential은 서버 상태와 대조하는 opaque 값입니다.
+        - 서로 다른 부스의 스탬프를 **최대 6개**까지 적립합니다.
+        - 같은 Poll·참여자·부스 조합은 중복 적립할 수 없습니다.
+        - 성공한 적립 사이에는 **5분의 쿨다운**이 있으며, 판정은 서버 시각 기준입니다.
+        - 여섯 번째 적립 후 `nextStampAvailableAt`은 `null`, `canEnterVotePage`는 `true`가 됩니다.
+
+        ### QR 값에서 credential 추출
+
+        QR에는 API URL이 아니라 FE 스캔 처리 화면으로 이동하는 값이 들어갑니다.
+        FE는 URL에서 `qrCredential`을 추출한 뒤 이 API를 호출합니다.
+
+        ```text
+        https://vote.example.com/demoday/polls/101/stamp#credential=sq_opaque_credential
+        ```
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StampCollectRequest'
+      responses:
+        '201':
+          description: 적립 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/StampCollectResult'
+        '401':
+          $ref: '#/components/responses/ParticipantUnauthorized'
+        '409':
+          description: |
+            적립 거절. 상황별 `code`는 다음과 같습니다.
+
+            | 상황 | `code` |
+            |---|---|
+            | 동일 부스 스탬프 중복 | `DEMODAY-0501` |
+            | QR과 요청 Poll 불일치 | `DEMODAY-0503` |
+            | 5분 쿨다운 미경과 | 서버 구현 시 확정 |
+            | 스탬프 최대 6개 초과 | 서버 구현 시 확정 |
+            | 유효하지 않거나 만료된 QR credential | 서버 구현 시 확정 |
+
+            **쿨다운 오류의 `result`에는 `nextStampAvailableAt`이 담깁니다.**
+            FE가 서버 시각을 다시 계산하지 않도록 하기 위한 규칙입니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                중복 적립:
+                  value:
+                    success: false
+                    code: DEMODAY-0501
+                    message: 이미 스탬프를 적립한 부스입니다.
+                쿨다운 미경과:
+                  value:
+                    success: false
+                    code: DEMODAY-XXXX
+                    message: 아직 다음 스탬프를 적립할 수 없습니다.
+                    result:
+                      nextStampAvailableAt: '2026-08-14T10:25:00+09:00'
+
+  /api/v1/demoday/polls/{pollId}/booths:
+    get:
+      tags: [데모데이 - 참여자]
+      operationId: getVoteBooths
+      summary: 투표 대상 부스 목록 조회
+      description: |
+        ### 도메인 규칙과 FE 책임
+
+        - 스탬프 6개를 모두 모은 참여자만 투표 화면에 진입합니다. FE는 `canEnterVotePage`를 확인한 뒤 이동합니다.
+        - **부스 목록 자체는 인증된 참여자면 스탬프 수와 무관하게 조회할 수 있습니다.**
+          투표 자격은 `POST /vote-authorizations`와 `POST /votes`에서 서버가 다시 검증합니다.
+        - 부스 목록과 개인 참여 상태는 분리합니다.
+          `전체 구역`·`스탬프 완료` 필터는 FE가 이 목록과 `participations/me.stamps`를 `boothId`로 결합해 처리합니다.
+        - 부스 배치도·구역·테이블 번호 등 화면 배치 정보는 FE 정적 데이터입니다.
+        - 이 API에는 필터 query parameter를 두지 않습니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/BoothListResult'
+        '401':
+          $ref: '#/components/responses/ParticipantUnauthorized'
+
+  /api/v1/demoday/polls/{pollId}/vote-authorizations:
+    post:
+      tags: [데모데이 - 참여자]
+      operationId: createVoteAuthorization
+      summary: INFO QR 재인증 및 5분 투표 권한 발급
+      description: |
+        사용자는 투표할 부스를 **먼저 선택한 뒤** INFO 부스에서 QR을 스캔합니다.
+        FE는 스캔한 `qrToken`과 이미 선택한 `boothId`를 함께 전달합니다.
+
+        ### 도메인 규칙
+
+        - INFO QR은 서버가 서명한 signed token이며 운영 화면에서 **1시간마다 교체**됩니다.
+        - QR의 남은 유효 시간은 참여자에게 공개하지 않습니다.
+        - 서버는 서명, 용도, `pollId`, 발급 시각, 만료 시각을 검증합니다.
+        - 인증에 성공하면 선택한 `boothId`에 **결합된** 투표 권한을 발급합니다.
+        - 투표 권한은 INFO QR 자체의 만료와 **독립적으로** 인증 성공 시점부터 5분간 유효합니다.
+          QR 만료 직전에 발급받았더라도 이미 발급된 권한은 자신의 5분 만료 시각까지 살아 있습니다.
+        - 스탬프가 6개 미만이거나 이미 투표했다면 발급하지 않습니다.
+
+        ### FE 책임
+
+        - `selectedBooth`로 최종 투표 대상을 사용자에게 명확히 보여줍니다.
+        - `voteAuthorizationToken`은 최종 제출 전까지 **메모리에만** 보관하고
+          성공·만료·화면 이탈 시 제거합니다.
+
+        개념적인 INFO QR 값:
+
+        ```text
+        https://vote.example.com/demoday/polls/101/vote-authorization#token={signedToken}
+        ```
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoteAuthorizationRequest'
+      responses:
+        '201':
+          description: 투표 권한 발급 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/VoteAuthorizationResult'
+        '401':
+          $ref: '#/components/responses/ParticipantUnauthorized'
+        '409':
+          description: |
+            발급 거절. 상황별 `code`는 다음과 같습니다.
+
+            | 상황 | `code` |
+            |---|---|
+            | 아직 투표 시작 전 | `DEMODAY-0400` |
+            | 투표 종료 | `DEMODAY-0401` |
+            | 이미 투표함 | `DEMODAY-0402` |
+            | 스탬프 6개 미만 | 서버 구현 시 확정 |
+            | 유효하지 않거나 만료된 INFO QR token | 서버 구현 시 확정 |
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /api/v1/demoday/polls/{pollId}/votes:
+    post:
+      tags: [데모데이 - 참여자]
+      operationId: castVote
+      summary: 선택한 부스에 최종 투표
+      description: |
+        ### 도메인 규칙
+
+        - 최종 투표는 사용자의 **명시적인 버튼 동작으로만** 실행합니다.
+        - **`boothId`는 다시 받지 않습니다.** 투표 대상은 앞서 발급한 투표 권한에 이미 결합되어 있습니다.
+        - 서버는 투표 권한의 참여자, Poll, 선택 부스, 만료 여부, 미사용 여부를 검증합니다.
+        - 회원과 외부 방문자 모두 Poll마다 **한 번만** 투표할 수 있습니다.
+        - 성공한 투표 권한은 다시 사용할 수 없습니다.
+
+        FE는 최종 제출 직전에 `selectedBooth`를 다시 안내합니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoteRequest'
+      responses:
+        '201':
+          description: 투표 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/VoteResult'
+        '401':
+          $ref: '#/components/responses/ParticipantUnauthorized'
+        '409':
+          description: |
+            투표 거절. 상황별 `code`는 다음과 같습니다.
+
+            | 상황 | `code` |
+            |---|---|
+            | 아직 투표 시작 전 | `DEMODAY-0400` |
+            | 투표 종료 | `DEMODAY-0401` |
+            | 이미 투표함 | `DEMODAY-0402` |
+            | 투표 권한과 요청 Poll 불일치 | `DEMODAY-0404` |
+            | 유효하지 않거나 만료·사용 완료된 투표 권한 | 서버 구현 시 확정 |
+            | 투표 권한과 현재 참여자 불일치 | 서버 구현 시 확정 |
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  # ------------------------------------------------------------------
+  # 관리자
+  # ------------------------------------------------------------------
+  /api/v1/demoday/admin/polls/{pollId}/dashboard:
+    get:
+      tags: [데모데이 - 관리자]
+      operationId: getAdminDashboard
+      security:
+        - 'Access Token': []
+      summary: Poll 대시보드 통계 스냅샷 조회
+      description: |
+        요약 지표·투표 랭킹·스탬프 히트맵을 **하나의 스냅샷으로** 반환합니다.
+        세 가지 모두 같은 Poll을 기준으로 하고, 데이터 규모가 부스 수 수준이며,
+        같은 화면에서 비슷한 주기로 갱신되고, 같은 권한을 쓰기 때문에 API를 분리하지 않았습니다.
+
+        FE는 WebSocket을 쓰지 않고 이 API를 폴링합니다. 주기는 FE 운영 설정으로 관리하며,
+        이전 요청이 끝나기 전에 같은 요청을 중첩하지 않습니다.
+
+        ### 무효 처리된 데이터의 집계 제외
+
+        `summary.totalVoteCount`, `rankings[].voteCount`, `stampHeatmap[].stampCount`는
+        모두 **무효 처리되지 않은 행만 집계합니다.** 이 수치가 시상 근거이므로
+        어드민이 부정표를 무효화하면 즉시 수치와 순위에서 빠집니다.
+
+        이 제외 규칙은 대시보드 집계에만 적용됩니다. 투표 기록 조회 목록은 무효 처리된 표도 반환하므로
+        **`totalVoteCount`와 투표 기록 목록의 행 수는 다를 수 있으며 이는 의도된 차이입니다.**
+
+        ### 정렬과 표시
+
+        `rankings`는 `voteCount` 내림차순, 동점이면 `boothId` 오름차순입니다.
+        화면에 표시할 상위 개수는 FE가 정합니다.
+
+        `stampHeatmap`에는 스탬프 수가 `0`인 부스도 포함됩니다.
+        부스 구역·좌표는 FE 정적 데이터이므로 서버는 반환하지 않습니다. FE가 `boothId`로 결합하세요.
+
+        ### 현재 제외한 통계
+
+        쿨다운 중 발생한 빠른 스탬프 시도 수, 만료 등으로 거절된 투표 권한 검증 실패 수는
+        포함하지 않습니다. 도메인 거절 로그로 남길 수는 있지만 해당 수치에 따라 운영진이 수행할 조치가
+        아직 정의되지 않았습니다. 명확한 운영 유스케이스가 생기면 별도 결정으로 추가합니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/DashboardResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+
+  /api/v1/demoday/admin/polls/{pollId}/vote-qr:
+    get:
+      tags: [데모데이 - 관리자]
+      operationId: getAdminVoteQr
+      security:
+        - 'Access Token': []
+      summary: 현재 시간 구간의 INFO 투표 인증 QR 조회
+      description: |
+        **이 API는 호출할 때마다 새 QR을 생성하는 명령이 아닙니다.**
+        현재 시간 구간에서 유효한 INFO 투표 인증 QR을 조회합니다.
+
+        INFO QR credential은 서버가 발급한 토큰이며 1시간마다 변경됩니다.
+        같은 유효 구간에서는 여러 운영자가 조회하거나 화면을 새로고침해도
+        논리적으로 동일한 credential을 반환합니다.
+
+        `qrValue`는 FE가 추가로 조립하지 않고 그대로 QR 이미지로 렌더링할 수 있는 완성된 값입니다.
+        예시의 호스트와 FE 경로는 배포 환경에 따라 달라집니다.
+
+        ### 서버가 검증하는 것
+
+        서명이 유효한지, 투표 인증 목적의 token인지, 요청한 Poll과 token의 Poll이 같은지, 만료되지 않았는지.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/VoteQrResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+
+  /api/v1/demoday/admin/polls/{pollId}/stamp-qrs:
+    get:
+      tags: [데모데이 - 관리자]
+      operationId: getAdminStampQrs
+      security:
+        - 'Access Token': []
+      summary: 부스별 스탬프 QR 목록 조회
+      description: |
+        ### 설계 원칙
+
+        - **목록 조회는 QR을 새로 생성하지 않습니다.**
+        - 아직 최초 생성되지 않은 부스도 `NOT_CREATED` 상태로 포함합니다.
+        - 이미 생성된 QR은 저장된 값을 복원해 재출력할 수 있습니다.
+        - credential은 민감한 운영 정보이므로 응답을 브라우저·중간 캐시에 저장하지 않습니다
+          (`Cache-Control: no-store`). 관리자 FE에서도 불필요하게 로컬 저장하지 마세요.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: 조회 성공
+          headers:
+            Cache-Control:
+              description: 항상 `no-store`. credential이 캐시에 남지 않도록 합니다.
+              schema:
+                type: string
+                examples: [no-store]
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/StampQrListResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+
+    post:
+      tags: [데모데이 - 관리자]
+      operationId: generateAdminStampQrs
+      security:
+        - 'Access Token': []
+      summary: QR이 없는 부스의 스탬프 QR 최초 일괄 생성
+      description: |
+        Poll에 속한 부스 중 **`NOT_CREATED` 상태인 부스에 대해서만** 최초 opaque credential을 생성합니다.
+        `CREATED` 부스의 기존 credential은 유지됩니다.
+
+        이미 모든 부스의 QR이 생성된 상태에서 다시 호출해도 credential을 바꾸지 않고
+        `generatedCount`를 `0`으로 반환합니다.
+        목록 조회나 관리자 화면 새로고침이 이 동작을 암묵적으로 호출하지는 않습니다.
+
+        **성공 status가 `201`이 아니라 `200`인 이유**는 생성 대상이 하나도 없을 수 있기 때문입니다.
+        재발급은 항상 새 credential을 만들므로 `201`을 씁니다.
+
+        응답에는 요청 이후의 **전체 부스 QR 상태**가 담기므로 FE는 목록을 재조회하지 않아도 됩니다.
+
+        운영 상태를 변경하는 관리자 행위이므로 감사 로그 대상입니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+      responses:
+        '200':
+          description: |
+            생성 성공. 생성 대상이 하나도 없어도 성공이며 이때 `generatedCount`는 `0`입니다.
+          headers:
+            Cache-Control:
+              description: 항상 `no-store`.
+              schema:
+                type: string
+                examples: [no-store]
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/StampQrBatchResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+
+  /api/v1/demoday/admin/polls/{pollId}/booths/{boothId}/stamp-qr/reissue:
+    post:
+      tags: [데모데이 - 관리자]
+      operationId: reissueAdminStampQr
+      security:
+        - 'Access Token': []
+      summary: 특정 부스의 스탬프 QR 재발급
+      description: |
+        재발급은 QR 출력물이 분실·훼손된 **예외적인 운영 상황에서만** 수행합니다.
+
+        - **재발급 성공 즉시 이전 QR은 유효하지 않습니다.**
+        - 재발급 전에 최초 QR이 생성되어 있어야 합니다.
+        - `{boothId}`는 반드시 `{pollId}`에 속한 부스여야 합니다.
+        - 재발급과 이후 스탬프 적립이 경합해도, 적립 시점에 저장된 현재 credential을 기준으로 검증합니다.
+
+        FE는 재발급 버튼을 누르면 **기존 출력물이 즉시 무효화된다는 사실을 확인 대화상자로 분명히 알려야 합니다.**
+
+        재발급도 감사 로그 대상입니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+        - $ref: '#/components/parameters/BoothId'
+      responses:
+        '201':
+          description: 재발급 성공
+          headers:
+            Cache-Control:
+              description: 항상 `no-store`.
+              schema:
+                type: string
+                examples: [no-store]
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/StampQrReissueResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+        '404':
+          description: |
+            Poll을 찾을 수 없거나, 해당 Poll 범위에서 부스를 찾을 수 없습니다. `code`는 서버 구현 시 확정합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: |
+            최초 QR이 아직 생성되지 않았습니다. 최초 일괄 생성을 먼저 수행해야 합니다.
+            `code`는 서버 구현 시 확정합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /api/v1/demoday/admin/polls/{pollId}/votes:
+    get:
+      tags: [데모데이 - 관리자]
+      operationId: getAdminVotes
+      security:
+        - 'Access Token': []
+      summary: 투표 기록 목록 조회 (커서 페이지네이션)
+      description: |
+        투표자 규모가 400~500명 수준이고 화면이 무한 스크롤이므로 커서 페이지네이션을 씁니다.
+
+        - 최신 투표가 먼저 오도록 `voteId` **내림차순**으로 정렬합니다.
+        - `nextCursor`는 현재 페이지 마지막 행의 `voteId`이며, 다음 페이지가 없으면 `null`입니다.
+        - `boothId`와 `participantName`은 함께 쓸 수 있고 AND로 결합합니다.
+        - **필터를 변경하면 `cursor`를 버리고 첫 페이지부터 다시 조회하세요.**
+          커서는 특정 필터 조건에서의 위치를 가리키므로, 조건이 바뀐 뒤 재사용하면 결과가 어긋납니다.
+
+        ### 무효 처리된 표의 포함
+
+        이 목록은 **무효 처리된 표도 함께 반환합니다.** 무효화된 표가 사라지면 무효 해제 대상을
+        화면에서 찾을 수 없기 때문입니다. 대시보드 집계 규칙과 정반대이며 의도된 차이입니다.
+        대시보드는 시상 근거라 무효 행을 빼야 하고, 이 목록은 운영 도구라 무효 행을 보여야 합니다.
+
+        FE는 `status`로 행을 구분해 표시하고 `REVOKED` 행에는 무효 해제 동작을 노출합니다.
+
+        ### 부스는 열 하나로 표시
+
+        와이어프레임에는 부스 번호(`Team 01`)와 서비스명이 두 열로 나뉘어 있었지만,
+        **서버는 부스 번호를 저장하지 않습니다.** `booth.displayName` 한 값만 내려가므로 열도 하나만 두세요.
+
+        ### 조회 감사
+
+        개인 투표 내역은 어드민에 노출하되 **조회 행위 자체를 서버 로그로 귀속합니다.**
+        누가 언제 이 목록을 조회했는지 남지 않으면 개인 투표 성향이 열람된 사실을 사후에 확인할 수 없습니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+        - name: cursor
+          in: query
+          required: false
+          description: 이전 응답의 `nextCursor`. 생략하면 첫 페이지입니다.
+          schema:
+            type: integer
+            format: int64
+        - name: size
+          in: query
+          required: false
+          description: 페이지 크기.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: boothId
+          in: query
+          required: false
+          description: 투표 대상 부스로 필터링합니다.
+          schema:
+            type: integer
+            format: int64
+        - name: participantName
+          in: query
+          required: false
+          description: |
+            회원명 부분 일치 검색. **회원만 대상입니다.**
+            외부 방문자는 서버가 이름을 저장하지 않으므로 이름으로 검색할 수 없습니다.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/AdminVoteListResult'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+
+  /api/v1/demoday/admin/polls/{pollId}/votes/{voteId}/revocation:
+    post:
+      tags: [데모데이 - 관리자]
+      operationId: revokeAdminVote
+      security:
+        - 'Access Token': []
+      summary: 특정 표 무효화
+      description: |
+        ### 처리 규칙
+
+        - 표를 물리적으로 삭제하지 않고 무효 시각만 기록합니다.
+        - 무효화 즉시 대시보드 집계와 순위에서 제외됩니다.
+        - **투표 진행 중에도 무효화할 수 있습니다.** 부정표를 행사 종료까지 기다리지 않고 즉시 차단하기 위해서이며,
+          이 경우 대시보드 순위가 실시간으로 바뀔 수 있습니다.
+        - **무효화해도 해당 참여자가 다시 투표할 수는 없습니다.** 1인 1표 제약이 무효 행을 포함해 적용되므로,
+          무효화는 표를 집계에서 빼는 동작이지 재투표 기회를 주는 동작이 아닙니다.
+        - 잘못 무효화한 경우의 복구 경로는 무효 해제뿐입니다.
+
+        FE는 무효화 버튼을 누르면 확인 대화상자에서 사유를 입력받은 뒤 요청하고,
+        응답으로 **해당 행만 갱신**하며 목록을 다시 조회하지 않습니다.
+
+        무효화는 감사 로그 대상입니다. 행위자·Poll·표 ID·사유·수행 시각을 남깁니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+        - $ref: '#/components/parameters/VoteId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoteStatusChangeRequest'
+            example:
+              reason: 동일 인물의 중복 투표로 확인됨
+      responses:
+        '201':
+          description: 무효화 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/VoteStatusResult'
+              example:
+                success: true
+                code: COMMON200
+                message: 성공입니다.
+                result:
+                  voteId: 9000
+                  status: REVOKED
+                  revokedAt: '2026-08-14T14:10:00+09:00'
+        '400':
+          description: '`reason` 누락 또는 길이 위반. `code`는 서버 구현 시 확정합니다.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+        '404':
+          description: |
+            Poll이 존재하지 않거나, 표가 해당 Poll에 속하지 않거나 존재하지 않습니다.
+            `code`는 서버 구현 시 확정합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: 이미 무효 처리된 표 (`DEMODAY-0403`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              example:
+                success: false
+                code: DEMODAY-0403
+                message: 이미 무효 처리된 표입니다.
+
+  /api/v1/demoday/admin/polls/{pollId}/votes/{voteId}/restoration:
+    post:
+      tags: [데모데이 - 관리자]
+      operationId: restoreAdminVote
+      security:
+        - 'Access Token': []
+      summary: 무효 처리된 표의 무효 해제
+      description: |
+        무효 시각을 제거해 표를 다시 유효하게 만들고 대시보드 집계·순위에 다시 포함시킵니다.
+
+        - 무효 해제는 **원래 표를 되살리는 동작**입니다. 참여자가 선택했던 부스가 그대로 복원되며
+          새로 투표하는 것이 아닙니다.
+        - `VALID` 상태인 표에는 수행할 수 없습니다.
+        - 무효화와 해제를 반복해도 표는 하나이고 부스 선택은 바뀌지 않습니다.
+
+        무효 해제도 감사 로그 대상입니다.
+      parameters:
+        - $ref: '#/components/parameters/PollId'
+        - $ref: '#/components/parameters/VoteId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoteStatusChangeRequest'
+            example:
+              reason: 오탐으로 확인되어 무효화를 취소함
+      responses:
+        '201':
+          description: 무효 해제 성공
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEnvelope'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/VoteStatusResult'
+              example:
+                success: true
+                code: COMMON200
+                message: 성공입니다.
+                result:
+                  voteId: 9000
+                  status: VALID
+                  revokedAt: null
+        '400':
+          description: '`reason` 누락 또는 길이 위반. `code`는 서버 구현 시 확정합니다.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          $ref: '#/components/responses/AdminUnauthorized'
+        '403':
+          $ref: '#/components/responses/AdminForbidden'
+        '404':
+          description: |
+            Poll이 존재하지 않거나, 표가 해당 Poll에 속하지 않거나 존재하지 않습니다.
+            `code`는 서버 구현 시 확정합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: 무효 처리되지 않은 표. `code`는 서버 구현 시 확정합니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+# ====================================================================
+components:
+
+  securitySchemes:
+    # 이름을 OpenApiConfig.securityComponents()와 동일하게 유지할 것.
+    # 자동 생성본으로 갈아탈 때 이 문자열이 다르면 FE의 인증 설정이 깨진다.
+    #
+    # OpenAPI 명세상 components 하위 키는 ^[a-zA-Z0-9.\-_]+$ 라 공백을 못 쓰지만,
+    # 이미 운영 중인 /docs-json 이 같은 이름을 내보내고 있고 Scalar 도 정상 렌더링한다.
+    # 여기서 고치면 초안과 자동 생성본의 인증 스키마 이름이 갈라지므로 일부러 맞춘다.
+    'Access Token':
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: 아래에 Access Token을 넣어주세요.
+
+    # 신규 스키마라 맞출 자동 생성본이 없다. 위와 달리 명세를 지키는 이름을 쓴다.
+    # 실제 Cookie 이름은 서버 구현 시 확정하며 아래 name 값은 자리표시자다.
+    # HttpOnly라 FE가 읽지 않고 withCredentials로 자동 첨부되므로 FE 코드에는 영향이 없다.
+    DemodayParticipantCookie:
+      type: apiKey
+      in: cookie
+      name: DEMODAY_PARTICIPANT
+      description: |
+        외부 방문자용 데모데이 전용 participant token.
+
+        `POST /participations/guest` 성공 시 서버가 HttpOnly Cookie로 설정하며,
+        FE는 값을 읽거나 저장하지 않고 `withCredentials: true`로 자동 첨부되게만 하면 됩니다.
+        **Cookie 이름은 서버 구현 시 확정되는 자리표시자입니다.**
+
+  parameters:
+    PollId:
+      name: pollId
+      in: path
+      required: true
+      description: |
+        대상 Poll ID. 금요일 Poll과 토요일 Poll은 서로 다른 Poll이므로
+        통계·QR·스탬프·투표 데이터가 모두 독립적으로 처리됩니다.
+      schema:
+        type: integer
+        format: int64
+      example: 101
+
+    BoothId:
+      name: boothId
+      in: path
+      required: true
+      description: 대상 부스 ID. 반드시 `pollId`에 속한 부스여야 합니다.
+      schema:
+        type: integer
+        format: int64
+      example: 1
+
+    VoteId:
+      name: voteId
+      in: path
+      required: true
+      description: 대상 표 ID. 투표 기록 조회의 `content[].voteId`입니다.
+      schema:
+        type: integer
+        format: int64
+      example: 9000
+
+  responses:
+    ParticipantUnauthorized:
+      description: |
+        참여자 인증이 없거나 만료되었습니다. `code`는 서버 구현 시 확정합니다.
+
+        외부 방문자가 Cookie를 잃은 경우 같은 입장 코드로는 복구할 수 없으며,
+        현장 운영진의 코드 재발급이 유일한 경로입니다.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+
+    AdminUnauthorized:
+      description: Access Token이 없거나 유효하지 않습니다.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+
+    AdminForbidden:
+      description: 인증됐지만 `SUPER_ADMIN`이 아닙니다.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+
+  schemas:
+    # ----- 공통 envelope (global/response/ApiResponse.java 와 동일) -----
+    SuccessEnvelope:
+      type: object
+      description: |
+        공통 성공 응답 래퍼. 필드 순서는 `success` / `code` / `message` / `result`입니다.
+        `code`는 HTTP status와 무관하게 항상 `COMMON200`이므로 성공 판정에 쓰지 마세요.
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        code:
+          type: string
+          examples: [COMMON200]
+        message:
+          type: string
+          examples: [성공입니다.]
+      required: [success, code, message]
+
+    ErrorEnvelope:
+      type: object
+      description: |
+        공통 실패 응답 래퍼. FE는 화면 분기에 HTTP status와 안정된 `code`를 사용합니다.
+        `result`에 구조화된 추가 정보가 실릴 수 있습니다 (예: 쿨다운 오류의 `nextStampAvailableAt`).
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        code:
+          type: string
+          description: 안정된 오류 코드. `DEMODAY-XXXX` 표기는 서버 구현 시 확정됩니다.
+          examples: [DEMODAY-0402]
+        message:
+          type: string
+          description: 사용자 안내 또는 기본 오류 문구. **파싱하지 마세요.**
+          examples: [요청을 처리할 수 없습니다.]
+        result:
+          type: [object, 'null']
+          description: 오류별 구조화된 추가 정보. 없으면 필드 자체가 생략됩니다.
+      required: [success, code, message]
+
+    # ----- 공통 도메인 -----
+    Booth:
+      type: object
+      description: |
+        투표 대상 부스.
+
+        `displayName`은 **화면에 그대로 표시할 이름이며 항상 값이 있습니다.**
+        UPMS에 등록된 프로젝트 부스면 `project.name`, 외부 부스면 부스에 직접 입력된 이름입니다.
+        FE는 `projectId` 유무로 분기해 이름을 조합하지 마세요.
+        `projectId`는 프로젝트 상세로 연결하는 등 UPMS 프로젝트와 이어야 할 때만 씁니다.
+
+        **서버는 `Team 01` 같은 부스 번호를 저장하지 않습니다.** 화면에도 부스 이름 열 하나만 두세요.
+      properties:
+        boothId:
+          type: integer
+          format: int64
+          examples: [12]
+        projectId:
+          type: [integer, 'null']
+          format: int64
+          description: UPMS에 등록된 프로젝트 부스만 값을 가집니다. 외부 부스는 `null`입니다.
+          examples: [501]
+        displayName:
+          type: string
+          examples: [잇픽]
+      required: [boothId, projectId, displayName]
+
+    Stamp:
+      type: object
+      properties:
+        boothId:
+          type: integer
+          format: int64
+          examples: [1]
+        collectedAt:
+          type: string
+          format: date-time
+          examples: ['2026-08-14T10:05:00+09:00']
+      required: [boothId, collectedAt]
+
+    # ----- 참여자: Poll 목록 -----
+    PollListResult:
+      type: object
+      properties:
+        polls:
+          type: array
+          description: 반환할 Poll이 없으면 빈 배열입니다.
+          items:
+            $ref: '#/components/schemas/Poll'
+      required: [polls]
+
+    Poll:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        name:
+          type: string
+          examples: [2026 데모데이 금요일]
+        opensAt:
+          type: string
+          format: date-time
+          examples: ['2026-08-14T10:00:00+09:00']
+        closesAt:
+          type: string
+          format: date-time
+          examples: ['2026-08-14T18:00:00+09:00']
+        status:
+          type: string
+          enum: [OPEN, CLOSED]
+          description: |
+            운영 상태이며 **시간 창에서 파생되는 값이 아닙니다.**
+            운영진이 해당 Poll을 활성화했다는 명시적 의사만 나타냅니다.
+            Poll은 생성 시 항상 `CLOSED`이고 운영진의 명시적 행위로만 `OPEN`이 됩니다.
+      required: [pollId, name, opensAt, closesAt, status]
+
+    # ----- 참여자: 참여 상태 -----
+    GuestParticipationRequest:
+      type: object
+      properties:
+        admissionCode:
+          type: string
+          description: 현장에서 배포한 1회용 입장 코드. Poll 단위로 발급됩니다.
+          examples: [GUEST-A1B2C3]
+      required: [admissionCode]
+
+    ParticipationResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        participantType:
+          type: string
+          enum: [MEMBER, GUEST]
+        stampCount:
+          type: integer
+          description: 현재 유효한 스탬프 수. 최대 6입니다.
+          examples: [2]
+        requiredStampCount:
+          type: integer
+          description: |
+            투표 화면 진입에 필요한 스탬프 수. 현재 6입니다.
+            **값이 바뀔 수 있으니 6을 상수로 박지 말고 이 필드를 쓰세요.**
+          examples: [6]
+        stamps:
+          type: array
+          items:
+            $ref: '#/components/schemas/Stamp'
+        nextStampAvailableAt:
+          type: [string, 'null']
+          format: date-time
+          description: |
+            다음 스탬프를 적립할 수 있는 **서버 기준 절대 시각**.
+            여섯 번째 스탬프까지 모두 적립했거나 적용할 쿨다운이 없으면 `null`입니다.
+            FE는 이 절대 시각으로 쿨다운을 표시하고 남은 시간을 자체 계산하지 않습니다.
+          examples: ['2026-08-14T10:15:00+09:00']
+        hasVoted:
+          type: boolean
+          description: 해당 Poll의 최종 투표 완료 여부.
+        canEnterVotePage:
+          type: boolean
+          description: |
+            스탬프 수와 투표 상태로 서버가 계산한 투표 화면 진입 가능 여부.
+            `false`면 FE는 투표 화면 진입을 막습니다.
+      required:
+        - pollId
+        - participantType
+        - stampCount
+        - requiredStampCount
+        - stamps
+        - nextStampAvailableAt
+        - hasVoted
+        - canEnterVotePage
+
+    # ----- 참여자: 스탬프 -----
+    StampCollectRequest:
+      type: object
+      properties:
+        qrCredential:
+          type: string
+          description: |
+            부스 QR에서 추출한 opaque credential. 서버 상태와 대조합니다.
+            QR 값이 `...#credential=sq_opaque_credential` 형태이므로 FE가 여기서 추출해 전달합니다.
+          examples: [sq_opaque_credential]
+      required: [qrCredential]
+
+    StampCollectResult:
+      type: object
+      properties:
+        stamp:
+          $ref: '#/components/schemas/Stamp'
+        stampCount:
+          type: integer
+          examples: [3]
+        requiredStampCount:
+          type: integer
+          examples: [6]
+        nextStampAvailableAt:
+          type: [string, 'null']
+          format: date-time
+          description: 여섯 번째 적립 후에는 `null`입니다.
+          examples: ['2026-08-14T10:25:00+09:00']
+        canEnterVotePage:
+          type: boolean
+      required: [stamp, stampCount, requiredStampCount, nextStampAvailableAt, canEnterVotePage]
+
+    # ----- 참여자: 부스와 투표 -----
+    BoothListResult:
+      type: object
+      properties:
+        booths:
+          type: array
+          items:
+            $ref: '#/components/schemas/Booth'
+      required: [booths]
+
+    VoteAuthorizationRequest:
+      type: object
+      properties:
+        boothId:
+          type: integer
+          format: int64
+          description: 사용자가 **이미 선택한** 투표 대상 부스.
+          examples: [12]
+        qrToken:
+          type: string
+          description: INFO 부스에서 스캔한 서명된 token. QR 값의 `#token=` 뒤에서 추출합니다.
+          examples: [signed-info-qr-token]
+      required: [boothId, qrToken]
+
+    VoteAuthorizationResult:
+      type: object
+      properties:
+        voteAuthorizationToken:
+          type: string
+          description: |
+            최종 투표에 사용할 opaque token.
+            **메모리에만 보관**하고 성공·만료·화면 이탈 시 제거하세요.
+          examples: [va_opaque_token]
+        selectedBooth:
+          $ref: '#/components/schemas/Booth'
+        expiresAt:
+          type: string
+          format: date-time
+          description: |
+            인증 성공 시점부터 5분 뒤. INFO QR 자체의 만료와 독립적입니다.
+          examples: ['2026-08-14T11:35:00+09:00']
+      required: [voteAuthorizationToken, selectedBooth, expiresAt]
+
+    VoteRequest:
+      type: object
+      properties:
+        voteAuthorizationToken:
+          type: string
+          description: |
+            `POST /vote-authorizations`로 발급받은 token.
+            **`boothId`는 다시 보내지 않습니다.** 투표 대상은 이 token에 이미 결합되어 있습니다.
+          examples: [va_opaque_token]
+      required: [voteAuthorizationToken]
+
+    VoteResult:
+      type: object
+      properties:
+        voteId:
+          type: integer
+          format: int64
+          examples: [9001]
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        selectedBooth:
+          $ref: '#/components/schemas/Booth'
+        votedAt:
+          type: string
+          format: date-time
+          examples: ['2026-08-14T11:32:00+09:00']
+      required: [voteId, pollId, selectedBooth, votedAt]
+
+    # ----- 관리자: 대시보드 -----
+    DashboardResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        generatedAt:
+          type: string
+          format: date-time
+          description: 서버가 통계 스냅샷을 생성한 시각.
+          examples: ['2026-08-14T15:30:00+09:00']
+        summary:
+          type: object
+          properties:
+            boothCount:
+              type: integer
+              description: 해당 Poll에서 운영하는 전체 부스 수.
+              examples: [30]
+            totalVoteCount:
+              type: integer
+              description: |
+                해당 Poll에서 **유효한** 전체 투표 수. 무효 처리된 표는 제외됩니다.
+                투표 기록 목록의 행 수와 다를 수 있으며 이는 의도된 차이입니다.
+              examples: [275]
+          required: [boothCount, totalVoteCount]
+        rankings:
+          type: array
+          description: |
+            득표 순으로 정렬된 **전체** 부스 목록.
+            `voteCount` 내림차순, 동점이면 `boothId` 오름차순입니다.
+            화면에 표시할 상위 개수는 FE가 정합니다.
+          items:
+            $ref: '#/components/schemas/RankingEntry'
+        stampHeatmap:
+          type: array
+          description: |
+            스탬프 획득 수를 포함한 **전체** 부스 목록. 스탬프 수가 `0`인 부스도 포함됩니다.
+            구역·좌표는 서버가 반환하지 않으므로 FE가 `boothId`로 정적 배치 데이터와 결합합니다.
+          items:
+            $ref: '#/components/schemas/StampHeatmapEntry'
+      required: [pollId, generatedAt, summary, rankings, stampHeatmap]
+
+    RankingEntry:
+      type: object
+      properties:
+        rank:
+          type: integer
+          description: 서버가 계산한 표시 순위.
+          examples: [1]
+        boothId:
+          type: integer
+          format: int64
+          examples: [9]
+        projectId:
+          type: [integer, 'null']
+          format: int64
+          examples: [509]
+        displayName:
+          type: string
+          examples: [잇픽]
+        voteCount:
+          type: integer
+          description: 해당 부스의 **유효** 득표 수. 무효 처리된 표는 제외됩니다.
+          examples: [20]
+      required: [rank, boothId, projectId, displayName, voteCount]
+
+    StampHeatmapEntry:
+      type: object
+      properties:
+        boothId:
+          type: integer
+          format: int64
+          examples: [4]
+        projectId:
+          type: [integer, 'null']
+          format: int64
+          examples: [504]
+        displayName:
+          type: string
+          examples: [모디]
+        stampCount:
+          type: integer
+          description: 해당 부스에서 참여자에게 **유효하게** 적립된 스탬프 수.
+          examples: [123]
+      required: [boothId, projectId, displayName, stampCount]
+
+    # ----- 관리자: QR -----
+    VoteQrResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        qrValue:
+          type: string
+          description: FE가 그대로 QR 이미지로 렌더링할 **완성된** 전체 문자열. 조립하지 마세요.
+          examples: ['https://vote.example.com/demoday/polls/101/vote-authorization#token=eyJ...']
+        generatedAt:
+          type: string
+          format: date-time
+          description: 현재 QR 유효 구간의 시작 시각.
+          examples: ['2026-08-14T15:00:00+09:00']
+        expiresAt:
+          type: string
+          format: date-time
+          description: INFO QR credential 만료 시각. 1시간 주기로 교체됩니다.
+          examples: ['2026-08-14T16:00:00+09:00']
+      required: [pollId, qrValue, generatedAt, expiresAt]
+
+    StampQr:
+      type: object
+      description: |
+        `qrValue`와 `generatedAt`은 `credentialStatus`가 `NOT_CREATED`일 때만 `null`입니다.
+        `CREATED`이면 두 값이 항상 함께 존재합니다.
+      properties:
+        boothId:
+          type: integer
+          format: int64
+          examples: [1]
+        projectId:
+          type: [integer, 'null']
+          format: int64
+          examples: [501]
+        displayName:
+          type: string
+          examples: [잇픽]
+        credentialStatus:
+          type: string
+          enum: [CREATED, NOT_CREATED]
+          description: QR이 존재하는 상태는 `CREATED`로 표현합니다.
+        qrValue:
+          type: [string, 'null']
+          description: 그대로 QR 이미지로 렌더링할 전체 문자열. 민감한 운영 정보이므로 로컬 저장·로깅 금지.
+          examples: ['https://vote.example.com/demoday/polls/101/stamp#credential=sq_opaque_value']
+        generatedAt:
+          type: [string, 'null']
+          format: date-time
+          description: 현재 credential이 생성된 시각.
+          examples: ['2026-08-13T12:00:00+09:00']
+      required: [boothId, projectId, displayName, credentialStatus, qrValue, generatedAt]
+
+    StampQrListResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        stampQrs:
+          type: array
+          description: 아직 최초 생성되지 않은 부스도 `NOT_CREATED` 상태로 포함됩니다.
+          items:
+            $ref: '#/components/schemas/StampQr'
+      required: [pollId, stampQrs]
+
+    StampQrBatchResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        generatedCount:
+          type: integer
+          description: 이번 호출에서 새로 생성된 credential 수. 생성 대상이 없으면 `0`입니다.
+          examples: [2]
+        stampQrs:
+          type: array
+          description: 생성 요청 이후의 **전체** 부스 QR 상태. FE는 목록을 재조회하지 않아도 됩니다.
+          items:
+            $ref: '#/components/schemas/StampQr'
+      required: [pollId, generatedCount, stampQrs]
+
+    StampQrReissueResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        stampQr:
+          $ref: '#/components/schemas/StampQr'
+      required: [pollId, stampQr]
+
+    # ----- 관리자: 투표 기록 -----
+    AdminVoteListResult:
+      type: object
+      properties:
+        pollId:
+          type: integer
+          format: int64
+          examples: [101]
+        content:
+          type: array
+          description: '`voteId` 내림차순. 무효 처리된 표도 포함됩니다.'
+          items:
+            $ref: '#/components/schemas/AdminVote'
+        nextCursor:
+          type: [integer, 'null']
+          format: int64
+          description: 현재 페이지 마지막 행의 `voteId`. 다음 페이지가 없으면 `null`입니다.
+          examples: [9000]
+        hasNext:
+          type: boolean
+      required: [pollId, content, nextCursor, hasNext]
+
+    AdminVote:
+      type: object
+      properties:
+        voteId:
+          type: integer
+          format: int64
+          description: 표 ID. 무효화·무효 해제의 대상 식별자입니다.
+          examples: [9001]
+        votedAt:
+          type: string
+          format: date-time
+          examples: ['2026-08-14T13:54:00+09:00']
+        participant:
+          $ref: '#/components/schemas/AdminVoteParticipant'
+        booth:
+          $ref: '#/components/schemas/Booth'
+        status:
+          type: string
+          enum: [VALID, REVOKED]
+        revokedAt:
+          type: [string, 'null']
+          format: date-time
+          description: 무효 처리된 시각. `VALID`이면 `null`입니다.
+          examples: ['2026-08-14T14:10:00+09:00']
+      required: [voteId, votedAt, participant, booth, status, revokedAt]
+
+    AdminVoteParticipant:
+      type: object
+      description: |
+        ### 외부 방문자 표시 규칙
+
+        외부 방문자에게는 `외부인 12번` 형태의 **입장 순번**을 붙여 표시합니다.
+        서버가 외부 방문자에 대해 저장하는 값은 입장 코드의 해시뿐이라
+        이름·연락처·코드 원문 중 어느 것도 표시할 수 없고, 행을 구분할 수단이 따로 필요하기 때문입니다.
+
+        - 해당 Poll에서 **입장 코드를 교환한 순서**로 `1`부터 부여합니다.
+        - 순번은 **Poll 전체 기준**으로 계산하며 필터나 페이지 결과 안에서 다시 매기지 않습니다.
+          그렇게 하면 부스 필터를 걸 때마다 같은 사람의 번호가 달라져 번호가 사람을 가리키지 못합니다.
+        - 교환 시각은 최초 1회만 기록되므로 **이미 화면에 표시된 번호는 행사 도중에도 바뀌지 않습니다.**
+        - 표를 던진 외부 방문자는 반드시 코드를 교환한 상태이므로 이 목록의 행은 순번이 항상 존재합니다.
+
+        이 번호는 목록 안에서 행을 구분하기 위한 것이며,
+        **현장에서 배포한 물리 코드와 대조하는 용도로는 쓸 수 없습니다.**
+      properties:
+        type:
+          type: string
+          enum: [MEMBER, GUEST]
+        displayName:
+          type: string
+          description: 회원은 회원명, 외부 방문자는 `외부인 12번` 형태의 입장 순번.
+          examples: [이재원]
+      required: [type, displayName]
+
+    VoteStatusChangeRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: 무효화 또는 무효 해제 사유. 감사 로그에 남습니다.
+      required: [reason]
+
+    VoteStatusResult:
+      type: object
+      description: FE는 이 응답으로 해당 행만 갱신하고 목록을 다시 조회하지 않습니다.
+      properties:
+        voteId:
+          type: integer
+          format: int64
+          examples: [9000]
+        status:
+          type: string
+          enum: [VALID, REVOKED]
+        revokedAt:
+          type: [string, 'null']
+          format: date-time
+          description: 무효 해제된 경우 `null`입니다.
+          examples: ['2026-08-14T14:10:00+09:00']
+      required: [voteId, status, revokedAt]

--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -20,7 +20,7 @@ info:
   description: |
     ## 이 문서의 성격
 
-    데모데이 현장 투표 API의 **구현 전 계약 초안**입니다. 서버 컨트롤러가 아직 없어
+    데모데이 현장 투표 API의 **초안**입니다. 서버 컨트롤러가 아직 없어
     자동 생성 문서(`UMC PRODUCT API`)에는 이 경로들이 나타나지 않습니다.
     데모데이는 날짜가 고정된 현장 행사라 FE와 서버가 순차로 진행하면 일정을 맞출 수 없어,
     영속성 작업 기간에 계약을 먼저 확정해 배포합니다.
@@ -30,12 +30,87 @@ info:
 
     ### 여기에 없는 것
 
-    - **로그인 API** (`/api/v1/auth/**`) — 이미 구현되어 있으므로 자동 생성본을 보세요.
-      UMC 회원은 이메일·Google·Kakao 로그인으로 AT를 발급받은 뒤
-      `GET /demoday/polls/{pollId}/participations/me`로 참여 흐름에 진입합니다.
+    - **로그인 API** — 이미 구현되어 있으므로 [Scalar 자동 생성본](/docs/scalar.html)의
+      `UMC PRODUCT API`에서 아래 경로를 확인하세요.
+      - 이메일: `POST /api/v1/auth/login/email` (`Authentication | 로그인`)
+      - Google: `POST /api/v1/auth/login/google` (`Authentication | 소셜 로그인`)
+      - Kakao: `POST /api/v1/auth/login/kakao` (`Authentication | 소셜 로그인`)
+
+      UMC 회원은 위 API로 AT를 발급받은 뒤
+      `GET /api/v1/demoday/polls/{pollId}/participations/me`로 참여 흐름에 진입합니다.
     - 부스 등록 API — 이번 기수에는 관리자 화면 없이 운영자가 직접 호출하며 계약이 아직 없습니다.
-    - 이상 패턴 조회, Poll 구성 관리(생성·수정·상태 변경) — 아직 설계 전입니다.
+    - Poll 구성 관리(생성·수정·상태 변경) - 아직 미설계
+    - 이상 패턴 조회 — 이번 기수에서는 개발하지 않을 예정입니다.(시간 부족..)
     - QR 이미지 렌더링 — `qrValue` 문자열을 FE가 그대로 렌더링합니다.
+
+    ## API 호출 흐름 — FE 구현 순서
+
+    아래 경로는 `/api/v1`을 포함한 실제 호출 경로입니다. 참여 상태는 Poll별로 독립적입니다.
+    `{pollId}`가 바뀌면 회원은 새 Poll의 상태를 조회하고, 외부 방문자는 해당 Poll의 게스트 참여 등록을 다시 거쳐야 합니다.
+
+    ### 참여자 화면
+
+    ```text
+    사이트 진입
+      └─ GET /api/v1/demoday/polls
+         └─ Poll 선택
+            ├─ UMC 회원
+            │  ├─ POST /api/v1/auth/login/email | /api/v1/auth/login/google | /api/v1/auth/login/kakao
+            │  └─ GET /api/v1/demoday/polls/{pollId}/participations/me
+            └─ 외부 방문자
+               └─ POST /api/v1/demoday/polls/{pollId}/participations/guest
+                  └─ HttpOnly Cookie와 현재 참여 상태 수신
+
+    현재 참여 상태
+      ├─ 스탬프 미달
+      │  └─ 스탬프 QR 스캔
+      │     └─ POST /api/v1/demoday/polls/{pollId}/stamps
+      │        └─ 응답 상태로 화면 갱신
+      └─ canEnterVotePage == true
+         └─ GET /api/v1/demoday/polls/{pollId}/booths
+            └─ 투표할 부스 선택
+               └─ INFO QR 스캔
+                  └─ POST /api/v1/demoday/polls/{pollId}/vote-authorizations
+                     └─ selectedBooth와 expiresAt 최종 확인
+                        └─ POST /api/v1/demoday/polls/{pollId}/votes
+    ```
+
+    - 외부 방문자의 최초 참여 응답에는 현재 참여 상태가 포함되므로 곧바로 다시 조회할 필요가 없습니다.
+      새로고침·재접속 시에는 Cookie를 첨부해 `GET /api/v1/demoday/polls/{pollId}/participations/me`를 호출합니다.
+    - 스탬프 등록 후에는 응답의 `requiredStampCount`, `nextStampAvailableAt`, `canEnterVotePage`로 화면을 갱신합니다.
+    - `voteAuthorizationToken`은 메모리에만 보관하고, 최종 투표 요청에는 `boothId`가 아니라 이 토큰만 보냅니다.
+    - 처음으로·스탬프 현황으로 돌아가기·다시 선택하기는 FE 화면 이동이며 별도 API가 없습니다.
+
+    ### 관리자 화면
+
+    모든 관리자 호출에는 Bearer Access Token과 `SUPER_ADMIN` 권한이 필요합니다.
+
+    ```text
+    관리자 로그인 → Poll 선택
+      ├─ 현황판
+      │  └─ GET /api/v1/demoday/admin/polls/{pollId}/dashboard (polling)
+      ├─ 스탬프 QR 관리
+      │  ├─ GET  /api/v1/demoday/admin/polls/{pollId}/stamp-qrs
+      │  ├─ POST /api/v1/demoday/admin/polls/{pollId}/stamp-qrs
+      │  └─ POST /api/v1/demoday/admin/polls/{pollId}/booths/{boothId}/stamp-qr/reissue
+      ├─ INFO QR 표시
+      │  └─ GET /api/v1/demoday/admin/polls/{pollId}/vote-qr
+      └─ 투표 기록 관리
+         └─ GET /api/v1/demoday/admin/polls/{pollId}/votes
+            ├─ POST /api/v1/demoday/admin/polls/{pollId}/votes/{voteId}/revocation
+            └─ POST /api/v1/demoday/admin/polls/{pollId}/votes/{voteId}/restoration
+    ```
+
+    - 대시보드는 WebSocket이 아니라 polling으로 갱신하며, 같은 요청이 겹치지 않도록 이전 요청 완료 후 다음 요청을 보냅니다.
+    - 스탬프 QR 목록 조회는 QR을 생성하지 않습니다. 일괄 생성은 아직 없는 QR만 만들고, 재발급하면 이전 QR은 즉시 무효화됩니다.
+    - INFO QR은 응답의 `expiresAt`에 맞춰 다시 조회하고, 두 QR 모두 `qrValue` 전체를 수정 없이 렌더링합니다.
+
+    ### QR 전달 관계
+
+    ```text
+    관리자 스탬프 QR 조회·생성 → qrValue 렌더링 → 참여자 스캔 → POST .../stamps
+    관리자 INFO QR 조회          → qrValue 렌더링 → 참여자 스캔 → POST .../vote-authorizations → POST .../votes
+    ```
 
     ## 바뀌지 않는 것 — 이 계약에 맞춰 구현해도 됩니다
 
@@ -47,16 +122,22 @@ info:
       Poll당 1인 1표, Poll 간 완전 독립
     - 이미 번호가 붙은 오류 코드 (`DEMODAY-0300`, `0400`~`0404`, `0501`, `0503`)
 
-    ## 바뀔 수 있는 것 — 여기에 의존하지 마세요
+    ## 아직 확정되지 않은 것 — 화면 분기 기준으로 사용하지 마세요
 
     - **`code` 문자열이 `DEMODAY-XXXX`로 표기된 오류** — 서버 구현 시 확정해 별도 공유합니다.
       해당 상황의 HTTP status와 도메인 규칙은 확정이므로, 화면 분기는 status 기준으로 먼저 만드세요.
     - **외부 방문자 HttpOnly Cookie의 이름과 세부 속성** (`SameSite`·만료·CSRF 방어).
-      HttpOnly라 FE가 읽지 않고 `withCredentials`로 자동 첨부되므로 FE 코드에는 영향이 없습니다.
+      인증 방식 자체는 HttpOnly Cookie로 확정이며, 이름과 서버 보안 정책만 구현 시 확정합니다.
+
+    ## FE 구현 시 주의사항 — 값을 하드코딩하거나 조립하지 마세요
+
+    - 외부 방문자 인증 Cookie는 HttpOnly이므로 FE에서 직접 읽거나 저장하지 않습니다.
+      요청 시 `withCredentials`를 사용하면 브라우저가 자동으로 첨부합니다.
     - **`qrValue`의 호스트와 경로** — 배포 환경에 따라 달라집니다.
       FE는 조립하지 않고 받은 문자열을 그대로 렌더링합니다.
-    - `requiredStampCount`의 값 (현재 6). 서버가 내려주는 값을 쓰고 6을 상수로 박지 마세요.
-    - 관리자 대시보드에 향후 추가될 수 있는 통계 필드.
+    - `requiredStampCount`는 현재 계약상 6이지만, FE는 서버가 내려주는 값을 사용하고
+      6을 상수로 박지 마세요.
+    - 관리자 대시보드 응답에는 향후 통계 필드가 추가될 수 있으므로, 알 수 없는 필드를 허용하세요.
 
     ## 공통 응답 envelope
 

--- a/src/main/resources/static/docs/scalar.html
+++ b/src/main/resources/static/docs/scalar.html
@@ -17,9 +17,25 @@
 
 <script>
     Scalar.createApiReference(document.getElementById('app'), {
-        spec: {
-            url: '/docs-json'
-        },
+        // 목록의 첫 항목이 기본 문서다. default: true 로 명시해 순서에 의존하지 않는다.
+        sources: [
+            {
+                title: 'UMC PRODUCT API',
+                slug: 'umc-product-api',
+                url: '/docs-json',   // springdoc 자동 생성. 컨트롤러가 있는 API 전체.
+                default: true
+            },
+            {
+                // 컨트롤러 구현 전 FE 착수용으로 손으로 쓴 계약 초안.
+                //
+                // 구현 PR 에서 해당 경로를 demoday-draft.yaml 에서 지우고,
+                // 마지막 경로가 빠지면 그 파일과 이 sources 항목을 함께 삭제한다.
+                // 같은 경로가 양쪽 문서에 다 보이면 자동 생성본이 정본이다.
+                title: '데모데이 현장 투표 (구현 전 초안)',
+                slug: 'demoday-draft',
+                url: '/docs/demoday-draft.yaml'
+            }
+        ],
 
         // --- UI / 테마 설정 ---
         default: "light",

--- a/src/main/resources/static/docs/scalar.html
+++ b/src/main/resources/static/docs/scalar.html
@@ -31,7 +31,7 @@
                 // 구현 PR 에서 해당 경로를 demoday-draft.yaml 에서 지우고,
                 // 마지막 경로가 빠지면 그 파일과 이 sources 항목을 함께 삭제한다.
                 // 같은 경로가 양쪽 문서에 다 보이면 자동 생성본이 정본이다.
-                title: '데모데이 현장 투표 (구현 전 초안)',
+                title: '데모데이 현장 투표 (초안)',
                 slug: 'demoday-draft',
                 url: '/docs/demoday-draft.yaml'
             }


### PR DESCRIPTION
## 🚀 작업 내용

- 컨트롤러 구현 전에도 FE가 데모데이 현장 투표 화면을 개발할 수 있도록 OpenAPI 3.1 초안을 추가했습니다.
- 참여자와 관리자용 14개 경로, 15개 API 동작의 요청·응답 예시, 인증 주체, 오류 계약을 정의했습니다.
- Scalar를 다중 문서 방식으로 전환해 자동 생성본과 데모데이 초안을 함께 조회할 수 있도록 했습니다.
- 이슈 작성 이후 확정된 외부 방문자 HttpOnly Cookie 인증을 계약에 반영하고, 참여자·관리자별 API 호출 흐름을 문서 상단에 정리했습니다.
- 외부 부스의 `projectId`는 관련 응답 전반에서 nullable로 통일했습니다. 실패 응답의 `result`는 실제 직렬화처럼 필드가 생략될 수 있도록 `required`에서 제외했습니다.
- 구현된 경로를 초안에서 순차적으로 제거하고, 마지막 경로가 자동 생성본으로 옮겨지면 초안과 Scalar source를 함께 삭제하도록 수명 주기를 명시했습니다.

Resolves #1198

## 💬 리뷰 중점사항

- 참여자와 관리자 호출 흐름이 FE 구현 순서와 맞는지 확인 부탁드립니다.
- 외부 방문자 인증 방식은 HttpOnly Cookie로 확정했습니다. `DEMODAY_PARTICIPANT`는 Cookie 이름 자리표시자이며, `SameSite`, 만료, CSRF 방어는 서버 구현 시 확정할 항목입니다.
- `Access Token` security scheme 이름은 현재 `OpenApiConfig`와 `/docs-json`에 맞추기 위해 공백을 유지했습니다. 이 때문에 components 하위 키 공백에 대한 lint 오류 1건은 의도적으로 남아 있습니다.
- 외부 부스의 `projectId` nullable 범위와 실패 응답에서 `result` 생략을 허용한 계약이 클라이언트 처리 방식과 맞는지 함께 봐주시면 좋겠습니다.
