### PR TITLE
[Fix] 모집 기수 삭제 시 발생하는 외래키 제약조건 예외 해결

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationFormPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingApplicationFormPersistenceAdapter.java
@@ -80,5 +80,6 @@ public class RecruitingApplicationFormPersistenceAdapter
     @Override
     public void delete(RecruitingApplicationForm applicationForm) {
         recruitingApplicationFormJpaRepository.delete(applicationForm);
+        recruitingApplicationFormJpaRepository.flush();
     }
 }

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.umc.product.organization.exception.OrganizationDomainException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -83,6 +84,18 @@ public class RecruitingSeasonCommandService implements
         }
         if (getChallengerRoleUseCase.isSuperAdmin(requesterMemberId)) {
             return;
+        }
+        try {
+            ChapterInfo chapter = getChapterUseCase.byGisuAndSchool(command.gisuId(), command.schoolId());
+            if (getChallengerRoleUseCase.isChapterPresidentInGisu(
+                requesterMemberId,
+                command.gisuId(),
+                chapter.id()
+            )) {
+                return;
+            }
+        } catch (OrganizationDomainException ignored) {
+            // 해당 기수/학교에 지부가 매핑되어 있지 않으면 무시합니다.
         }
         throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_SEASON_CREATION_FORBIDDEN);
     }

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandService.java
@@ -6,8 +6,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.umc.product.organization.exception.OrganizationDomainException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +13,7 @@ import com.umc.product.authorization.application.port.in.query.GetChallengerRole
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.exception.OrganizationDomainException;
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingSeasonCommandServiceTest.java
@@ -166,6 +166,7 @@ class RecruitingSeasonCommandServiceTest {
             .schoolId(10L)
             .build();
         given(getChallengerRoleUseCase.isSchoolCoreInGisu(99L, 1L, 10L)).willReturn(false);
+        given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(100L, "A 지부"));
 
         assertThatThrownBy(() -> sut.createSeason(command))
             .isInstanceOf(RecruitingDomainException.class)
@@ -186,6 +187,7 @@ class RecruitingSeasonCommandServiceTest {
             .schoolId(10L)
             .build();
         given(getChallengerRoleUseCase.isCentralCoreInGisu(99L, 1L)).willReturn(false);
+        given(getChapterUseCase.byGisuAndSchool(1L, 10L)).willReturn(new ChapterInfo(100L, "A 지부"));
 
         assertThatThrownBy(() -> sut.createSeason(command))
             .isInstanceOf(RecruitingDomainException.class)


### PR DESCRIPTION
## 🚀 작업 내용
1. DRAFT 상태의 모집 기수(`RecruitingRound`) 삭제 시 발생하는 외래키(FK) 제약조건 에러(`COMMON-0001`) 해결
- JPA의 삭제 쿼리 실행 순서가 보장되지 않아 자식(폼)보다 부모(기수)가 먼저 삭제되려던 문제 수정
- `RecruitingApplicationFormPersistenceAdapter.delete()` 내부에서 `flush()`를 명시적으로 호출하여 자식 데이터인 폼 구조가 DB에서 우선적으로 즉시 삭제되도록 보장

2. 지부장의 소속 학교 모집 시즌(초기 TO) 생성 403 권한 에러 해결
- 지부장이 소속 지부 학교의 모집 인원(TO)을 최초 설정(시즌 생성)할 때 권한 부족으로 실패하던 문제 해결
- `RecruitingSeasonCommandService.validateSeasonCreationPermission()` 로직에 해당 학교의 지부장(`CHAPTER_PRESIDENT`) 여부를 확인하는 검증 코드를 추가하여 정상 동작하도록 조치

- Resolves #1265

## 💬 리뷰 중점사항