### PR TITLE
[Fix] 통합 테스트가 백그라운드 스케줄러와 DB 초기화 경합으로 간헐 실패하는 문제

### DIFF
--- a/docs/onboarding/scheduler.md
+++ b/docs/onboarding/scheduler.md
@@ -33,9 +33,20 @@
 - Adapter: `MatchingRoundDeadlineScheduler`
 - Handler: `MatchingRoundDeadlineHandler`
 - 활성 조건: `scheduler.matching-round-deadline.enabled=true` 또는 property 미설정
+- 비활성 시 대체: `NoOpMatchingRoundDeadlineScheduler`
 - 전용 pool size: 2
 
 이 풀은 project 자동 선발 발화를 위해서만 사용한다. 일반 batch, polling, notification 작업을 이 풀에 올리면 안 된다.
+
+`ScheduleMatchingRoundDeadlinePort`는 `ProjectMatchingRoundCommandService`의 생성자 필수 의존이다. 스케줄러를 끌 때 실제 adapter만 없애면 주입 대상이 사라져 컨텍스트 기동이 실패하므로, `enabled=false`에서는 `NoOpMatchingRoundDeadlineScheduler`가 대신 등록된다. 두 구현의 조건은 배타적이며, 끈 상태에서 자동 선발은 운영진 수동 호출로만 실행된다.
+
+### 테스트 프로필
+
+`@Scheduled` 작업은 `SchedulingConfig`가 `@Profile("!test")`라 test 프로필에서 잠든다. 매칭 데드라인 스케줄러는 `@ConditionalOnProperty`로만 제어되므로 별도로 `src/test/resources/application-test.yml`에서 `scheduler.matching-round-deadline.enabled=false`로 끈다.
+
+끄지 않으면 테스트 fixture의 `decisionDeadline`이 모두 과거 시각이라 등록 즉시 발화하고, `matching-deadline-` 스레드의 자동 선발 트랜잭션이 `@DatabaseIsolation`의 `TRUNCATE`와 겹친다. 락 경합이 나거나 TRUNCATE 이후 커밋된 행이 다음 테스트로 새어 나가, 단독 실행은 통과하고 전체 실행에서만 깨지는 간헐 실패가 된다.
+
+이 격리는 `BackgroundSchedulerIsolationTest`가 고정한다. 특정 테스트에서 스케줄러 동작을 검증해야 하면 전역으로 켜지 말고 `@TestPropertySource`로 그 테스트에서만 켜고, 발화한 task가 끝난 뒤 테스트를 종료한다.
 
 ## Webhook 알림
 

--- a/src/main/java/com/umc/product/project/adapter/out/scheduler/NoOpMatchingRoundDeadlineScheduler.java
+++ b/src/main/java/com/umc/product/project/adapter/out/scheduler/NoOpMatchingRoundDeadlineScheduler.java
@@ -1,0 +1,47 @@
+package com.umc.product.project.adapter.out.scheduler;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
+import com.umc.product.project.domain.ProjectMatchingRound;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@code scheduler.matching-round-deadline.enabled=false} 일 때
+ * {@link MatchingRoundDeadlineScheduler} 대신 주입되는 null object 구현.
+ * <p>
+ * {@link ScheduleMatchingRoundDeadlinePort} 는 {@code ProjectMatchingRoundCommandService} 가
+ * 생성자로 요구하는 필수 의존이다. 실제 스케줄러만 {@code @ConditionalOnProperty} 로 끄면
+ * 주입 대상이 사라져 컨텍스트 기동 자체가 실패하므로, off 스위치를 실제로 쓸 수 있도록
+ * no-op 대체 구현을 함께 등록한다.
+ * <p>
+ * 두 구현의 조건은 서로 배타적이다. 실제 스케줄러는 {@code true} 또는 property 미설정에서,
+ * 본 구현은 {@code false} 에서만 등록된다.
+ * <p>
+ * 스케줄을 등록하지 않으므로 결정 마감 시점의 자동 선발이 발화하지 않는다.
+ * 운영 환경에서 끄는 경우 자동 선발은 운영진 수동 호출로만 실행된다.
+ */
+@Component
+@ConditionalOnProperty(
+    name = "scheduler.matching-round-deadline.enabled",
+    havingValue = "false"
+)
+@Slf4j
+public class NoOpMatchingRoundDeadlineScheduler implements ScheduleMatchingRoundDeadlinePort {
+
+    public NoOpMatchingRoundDeadlineScheduler() {
+        log.info("matching round deadline scheduler is disabled: auto decision will not be triggered by schedule");
+    }
+
+    @Override
+    public void schedule(ProjectMatchingRound round) {
+        // no-op: 스케줄러 비활성화 상태에서는 마감 task 를 등록하지 않는다.
+    }
+
+    @Override
+    public void cancel(Long roundId) {
+        // no-op: 등록된 task 가 없으므로 취소할 대상도 없다.
+    }
+}

--- a/src/test/java/com/umc/product/project/adapter/out/scheduler/NoOpMatchingRoundDeadlineSchedulerTest.java
+++ b/src/test/java/com/umc/product/project/adapter/out/scheduler/NoOpMatchingRoundDeadlineSchedulerTest.java
@@ -1,0 +1,54 @@
+package com.umc.product.project.adapter.out.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
+
+@DisplayName("NoOpMatchingRoundDeadlineScheduler")
+class NoOpMatchingRoundDeadlineSchedulerTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(NoOpMatchingRoundDeadlineScheduler.class);
+
+    @Test
+    @DisplayName("스케줄러를 끄면 ScheduleMatchingRoundDeadlinePort 의 no-op 구현이 대신 등록된다")
+    void 스케줄러_비활성화시_no_op_port_구현을_등록한다() {
+        contextRunner
+            .withPropertyValues("scheduler.matching-round-deadline.enabled=false")
+            .run(context -> assertThat(context)
+                .hasSingleBean(ScheduleMatchingRoundDeadlinePort.class)
+                .getBean(ScheduleMatchingRoundDeadlinePort.class)
+                .isInstanceOf(NoOpMatchingRoundDeadlineScheduler.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러가 켜져 있으면 no-op 구현을 등록하지 않는다")
+    void 스케줄러_활성화시_no_op_구현을_등록하지_않는다() {
+        contextRunner
+            .withPropertyValues("scheduler.matching-round-deadline.enabled=true")
+            .run(context -> assertThat(context).doesNotHaveBean(NoOpMatchingRoundDeadlineScheduler.class));
+    }
+
+    @Test
+    @DisplayName("property 미설정은 활성화로 간주하므로 no-op 구현을 등록하지 않는다")
+    void property_미설정시_no_op_구현을_등록하지_않는다() {
+        contextRunner.run(context ->
+            assertThat(context).doesNotHaveBean(NoOpMatchingRoundDeadlineScheduler.class));
+    }
+
+    @Test
+    @DisplayName("schedule 과 cancel 은 아무것도 하지 않고 예외 없이 통과한다")
+    void schedule_과_cancel_은_예외_없이_통과한다() {
+        NoOpMatchingRoundDeadlineScheduler sut = new NoOpMatchingRoundDeadlineScheduler();
+
+        assertThatCode(() -> {
+            sut.schedule(null);
+            sut.cancel(1L);
+        }).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/umc/product/support/isolation/BackgroundSchedulerIsolationTest.java
+++ b/src/test/java/com/umc/product/support/isolation/BackgroundSchedulerIsolationTest.java
@@ -1,0 +1,56 @@
+package com.umc.product.support.isolation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.config.TaskManagementConfigUtils;
+
+import com.umc.product.project.adapter.out.scheduler.MatchingRoundDeadlineScheduler;
+import com.umc.product.project.adapter.out.scheduler.NoOpMatchingRoundDeadlineScheduler;
+import com.umc.product.project.application.port.out.ScheduleMatchingRoundDeadlinePort;
+import com.umc.product.support.IntegrationTestSupport;
+
+/**
+ * test 프로필에서 DB 에 쓰는 백그라운드 스케줄러가 하나도 살아 있지 않음을 고정한다.
+ * <p>
+ * {@link DatabaseIsolation} 은 각 테스트 종료 후 전체 테이블을 TRUNCATE 한다. 테스트가
+ * 제어하지 못하는 스레드가 같은 DB 에 쓰고 있으면 TRUNCATE 와 락이 겹치거나, TRUNCATE 이후
+ * 커밋된 행이 다음 테스트로 새어 나가 전체 실행에서만 재현되는 간헐 실패가 된다.
+ * <p>
+ * 이 테스트가 깨졌다면 스케줄러를 다시 켠 것이다. 켜야 한다면 해당 테스트에서만
+ * {@code @TestPropertySource} 로 국소 활성화하고, 발화한 task 가 끝날 때까지 기다린 뒤
+ * 종료해야 한다.
+ */
+@DisplayName("test 프로필 백그라운드 스케줄러 격리")
+class BackgroundSchedulerIsolationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private ScheduleMatchingRoundDeadlinePort scheduleMatchingRoundDeadlinePort;
+
+    @Test
+    @DisplayName("@Scheduled 를 구동하는 스케줄링 인프라가 등록되지 않는다")
+    void scheduling_인프라가_등록되지_않는다() {
+        assertThat(applicationContext.containsBean(
+            TaskManagementConfigUtils.SCHEDULED_ANNOTATION_PROCESSOR_BEAN_NAME)).isFalse();
+        assertThat(applicationContext.containsBean("taskScheduler")).isFalse();
+    }
+
+    @Test
+    @DisplayName("매칭 차수 마감 전용 스케줄러 풀을 등록하지 않는다")
+    void 매칭_마감_전용_스케줄러_풀을_등록하지_않는다() {
+        assertThat(applicationContext.containsBean("matchingDeadlineTaskScheduler")).isFalse();
+        assertThat(applicationContext.getBeanNamesForType(MatchingRoundDeadlineScheduler.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("매칭 차수 마감 Port 는 no-op 구현이 주입된다")
+    void 매칭_마감_port_는_no_op_구현이_주입된다() {
+        assertThat(scheduleMatchingRoundDeadlinePort).isInstanceOf(NoOpMatchingRoundDeadlineScheduler.class);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,6 +18,15 @@ spring:
     enabled: true
     out-of-order: true
 
+# 통합 테스트 격리: 매칭 차수 마감 스케줄러를 끈다.
+# @Scheduled 는 SchedulingConfig 의 @Profile("!test") 로 이미 잠들지만, 이 스케줄러는
+# @ConditionalOnProperty 로만 제어되는 전용 풀(matching-deadline-)이라 test 프로필에서도 살아 있었다.
+# 테스트 fixture 의 decisionDeadline 은 모두 과거 시각이라 등록 즉시 발화하고,
+# 백그라운드 자동 선발 트랜잭션이 @DatabaseIsolation 의 TRUNCATE 와 겹쳐 간헐 실패를 만든다.
+scheduler:
+  matching-round-deadline:
+    enabled: false
+
 # 테스트(Testcontainers) 콘솔에서 SQL flood 제거 — 명시적으로 OFF 유지.
 decorator:
   datasource:


### PR DESCRIPTION
## 🚀 작업 내용

resolves #1264

전체 테스트 실행에서 `ProjectMatchingRoundControllerIntegrationTest` 가 간헐적으로 실패하고 단독 실행은 통과하던 문제를 해결합니다.

### 무엇이 문제였나

매칭 차수 마감 스케줄러는 `@Scheduled` 가 아니라 `@ConditionalOnProperty` 로만 제어되는 **전용 스레드 풀**(`matching-deadline-`)입니다. 그래서 `SchedulingConfig` 의 `@Profile("!test")` 로 잠들지 않고 `test` 프로필에서도 살아 있었습니다.

테스트 fixture 의 `decisionDeadline` 은 전부 과거 시각이라, 스케줄 등록 시 대기 시간이 음수가 되어 0으로 클램프됩니다. 즉 **등록하는 순간 자동 선발이 곧바로 실행**됩니다. 이 자동 선발은 테스트가 완료를 기다리지 않는 백그라운드 트랜잭션이라, `@DatabaseIsolation` 의 `TRUNCATE` 와 겹치면 서로의 상태를 덮어씁니다. 겹치는 타이밍에서만 실패하므로 간헐적으로 보였고, 단독 실행에서는 겹칠 상대가 없어 통과했습니다.

확인 근거로 실행 중 `matching-deadline-1` 스레드가 살아 있는 것과, `schedule()` 직후 이미 자동 선발이 실행 완료된 상태(등록과 실행 사이 대기 없음)를 확인했습니다.

### 어떻게 고쳤나

1. `application-test.yml` 에서 `scheduler.matching-round-deadline.enabled=false` 로 스케줄러를 끕니다.
2. `NoOpMatchingRoundDeadlineScheduler` 를 추가합니다. 기존에는 `ScheduleMatchingRoundDeadlinePort` 의 구현이 `MatchingRoundDeadlineScheduler` 하나뿐이라, **문서화된 `enabled=false` 스위치를 실제로 쓰면 의존성 해석이 실패해 기동 자체가 되지 않았습니다.** 끄기 위해 필요한 동시에, 운영에서도 문서대로 끌 수 있게 만드는 수정입니다.
3. 회귀 방지 테스트 2개를 추가합니다.
   - `BackgroundSchedulerIsolationTest` — `test` 프로필에 스케줄링 인프라와 전용 풀이 등록되지 않고, port 에 no-op 구현이 주입되는지 고정
   - `NoOpMatchingRoundDeadlineSchedulerTest` — property 값별(`false` / `true` / 미설정) 빈 등록 조건 검증
4. `docs/onboarding/scheduler.md` 에 활성 조건과 테스트 프로필 항목을 반영합니다.

### 검증

- 수정 전 기준선: 3,871건 / 실패 0건
- 수정 후: **3,878건 / 실패 0건 / skip 41건**
- `spotlessCheck`, `checkstyleMain`, `checkstyleTest` 통과

---

> [!IMPORTANT]
> **이 PR 은 현재 빨간 CI 를 초록으로 만들지 않습니다.**
> 지금 `develop` 의 대량 실패(3,871건 중 509건)는 이 경합과 무관합니다. GitHub 러너 이미지가 `20260720.247` → `20260810.271` 로 바뀌면서 드러난 로그 새니타이저 `StackOverflowError` 가 원인이고, **#1228** 에서 별도로 추적 중입니다. 그쪽이 고쳐지기 전까지는 어떤 PR 도 CI 를 통과하지 못합니다.
>
> 참고로 #1228 은 최초 제보 시점엔 재시도로 우회되는 간헐 실패였지만, 구 러너 이미지가 풀에서 빠지면서 현재는 재시도로 피할 수 없는 상태입니다. (같은 커밋 3회 시도 전부 509건 실패로 동일)

## 💬 리뷰 중점사항

- **`NoOpMatchingRoundDeadlineScheduler` 의 위치와 형태** — outbound adapter 로 두고 `@ConditionalOnProperty(havingValue = "false")` 로 등록합니다. null object 로 채우는 방식이 이 레포의 hexagonal 관례에 맞는지 봐주세요. 대안은 `ProjectMatchingRoundCommandService` 에서 port 를 `Optional` 로 받는 것인데, 호출부가 매번 분기해야 해서 택하지 않았습니다.
- **`application-test.yml` 로 끈 선택** — 프로덕션 코드에 `@Profile("test")` 를 넣지 않고 설정으로만 끕니다. 프로덕션 동작에는 변화가 없습니다.
- **테스트가 실제로 회귀를 잡는지** — `BackgroundSchedulerIsolationTest` 는 설정을 되돌리면 깨지도록 작성했습니다. 이 단언들이 충분한지 봐주세요.
- 스케줄러를 끈 만큼 `test` 프로필에서 자동 선발 경로 자체는 더 이상 스케줄로 검증되지 않습니다. 해당 로직은 기존 서비스 단위 테스트가 직접 호출해 검증합니다.
