### PR TITLE
[Feat] 데모데이 Poll 생성 및 상태 전이 API 구현

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,5 +1,13 @@
 package com.umc.product.demoday.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +26,10 @@ import com.umc.product.global.security.annotation.CurrentMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(
+    name = "데모데이 투표 관리자",
+    description = "해당 기수 총괄단 또는 SUPER_ADMIN이 데모데이 투표를 관리하는 API"
+)
 @RestController
 @RequestMapping("/api/v1/demoday/admin/polls")
 @RequiredArgsConstructor
@@ -26,9 +38,19 @@ public class DemodayPollAdminController {
     private final CreateDemodayPollUseCase createDemodayPollUseCase;
     private final ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
 
+    @Operation(
+        operationId = "createDemodayPoll",
+        summary = "데모데이 투표 생성",
+        description = """
+            데모데이 투표를 CLOSED 상태로 생성합니다.
+
+            요청자는 요청한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+            opensAt과 closesAt은 실제 투표 가능 시간이며, 시간이 되어도 운영 상태가 자동으로 바뀌지는 않습니다.
+            """
+    )
     @PostMapping
     public CreateDemodayPollResponse createPoll(
-        @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
         @Valid @RequestBody CreateDemodayPollRequest request) {
 
         Long pollId = createDemodayPollUseCase.create(request.toCommand(memberPrincipal.getMemberId()));
@@ -36,9 +58,21 @@ public class DemodayPollAdminController {
         return CreateDemodayPollResponse.from(pollId);
     }
 
+    @Operation(
+        operationId = "changeDemodayPollStatus",
+        summary = "데모데이 투표 상태 변경",
+        description = """
+            데모데이 투표의 운영 상태를 OPEN 또는 CLOSED로 변경합니다.
+
+            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+            CLOSED 상태의 투표를 다시 OPEN하여 재개할 수 있으며, 이미 같은 상태라면 409 응답을 반환합니다.
+            운영 상태는 opensAt, closesAt과 독립적이므로 기간이 지나도 자동으로 변경되지 않습니다.
+            """
+    )
     @PatchMapping("/{pollId}/status")
     public void changePollStatus(
-        @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "상태를 변경할 데모데이 투표 ID", required = true, example = "1")
         @PathVariable("pollId") Long pollId,
         @Valid @RequestBody ChangeDemodayPollStatusRequest request) {
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,5 +1,12 @@
 package com.umc.product.demoday.adapter.in.web;
 
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.umc.product.demoday.adapter.in.web.dto.ChangeDemodayPollStatusRequest;
 import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollRequest;
 import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollResponse;
@@ -7,14 +14,9 @@ import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStat
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/demoday/admin/polls")

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,0 +1,45 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import com.umc.product.demoday.adapter.in.web.dto.ChangeDemodayPollStatusRequest;
+import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollRequest;
+import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollResponse;
+import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
+import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/demoday/admin/polls")
+@RequiredArgsConstructor
+public class DemodayPollAdminController {
+
+    private final CreateDemodayPollUseCase createDemodayPollUseCase;
+    private final ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
+
+    @PostMapping
+    public CreateDemodayPollResponse createPoll(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @Valid @RequestBody CreateDemodayPollRequest request) {
+
+        Long pollId = createDemodayPollUseCase.create(request.toCommand(memberPrincipal.getMemberId()));
+
+        return CreateDemodayPollResponse.from(pollId);
+    }
+
+    @PatchMapping("/{pollId}/status")
+    public void changePollStatus(
+        @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable("pollId") Long pollId,
+        @Valid @RequestBody ChangeDemodayPollStatusRequest request) {
+
+        changeDemodayPollStatusUseCase.changeStatus(request.toCommand(pollId, memberPrincipal.getMemberId()));
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,13 +1,5 @@
 package com.umc.product.demoday.adapter.in.web;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +15,9 @@ import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseC
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
@@ -1,10 +1,10 @@
 package com.umc.product.demoday.adapter.in.web.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "데모데이 투표 운영 상태 변경 요청")
 public record ChangeDemodayPollStatusRequest(

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
@@ -1,10 +1,12 @@
 package com.umc.product.demoday.adapter.in.web.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
 
 public record ChangeDemodayPollStatusRequest(
-    DemodayPollStatus status
+    @NotNull DemodayPollStatus status
 ) {
     public ChangeDemodayPollStatusCommand toCommand(
         Long pollId,

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.demoday.adapter.in.web.dto;
+
+import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+
+public record ChangeDemodayPollStatusRequest(
+    DemodayPollStatus status
+) {
+    public ChangeDemodayPollStatusCommand toCommand(
+        Long pollId,
+        Long memberId
+    ) {
+        return new ChangeDemodayPollStatusCommand(memberId, pollId, status);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/ChangeDemodayPollStatusRequest.java
@@ -1,11 +1,18 @@
 package com.umc.product.demoday.adapter.in.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
 
+@Schema(description = "데모데이 투표 운영 상태 변경 요청")
 public record ChangeDemodayPollStatusRequest(
+    @Schema(
+        description = "변경할 운영 상태. OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.",
+        example = "OPEN",
+        allowableValues = {"OPEN", "CLOSED"}
+    )
     @NotNull DemodayPollStatus status
 ) {
     public ChangeDemodayPollStatusCommand toCommand(

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
@@ -2,10 +2,9 @@ package com.umc.product.demoday.adapter.in.web.dto;
 
 import java.time.Instant;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
@@ -1,10 +1,12 @@
 package com.umc.product.demoday.adapter.in.web.dto;
 
-import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
-import jakarta.validation.constraints.NotBlank;
-import org.jetbrains.annotations.NotNull;
-
 import java.time.Instant;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+
+import jakarta.validation.constraints.NotBlank;
 
 public record CreateDemodayPollRequest(
     @NotNull Long gisuId,

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
@@ -1,0 +1,18 @@
+package com.umc.product.demoday.adapter.in.web.dto;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+import jakarta.validation.constraints.NotBlank;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+public record CreateDemodayPollRequest(
+    @NotNull Long gisuId,
+    @NotBlank String name,
+    @NotNull Instant  opensAt,
+    @NotNull Instant closesAt
+) {
+    public CreateDemodayPollCommand toCommand(Long memberId) {
+        return new CreateDemodayPollCommand(memberId, gisuId, name, opensAt, closesAt);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollRequest.java
@@ -2,16 +2,31 @@ package com.umc.product.demoday.adapter.in.web.dto;
 
 import java.time.Instant;
 
-import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "데모데이 투표 생성 요청")
 public record CreateDemodayPollRequest(
+    @Schema(description = "투표를 생성할 기수 ID", example = "8")
     @NotNull Long gisuId,
+
+    @Schema(description = "투표 이름", example = "8기 데모데이 인기상 투표")
     @NotBlank String name,
-    @NotNull Instant  opensAt,
+
+    @Schema(
+        description = "실제 투표가 가능한 시작 시각. 상태를 자동으로 OPEN으로 변경하지는 않습니다.",
+        example = "2026-08-20T09:00:00Z"
+    )
+    @NotNull Instant opensAt,
+
+    @Schema(
+        description = "실제 투표가 가능한 종료 시각. opensAt보다 뒤여야 하며 상태를 자동으로 CLOSED로 변경하지는 않습니다.",
+        example = "2026-08-20T12:00:00Z"
+    )
     @NotNull Instant closesAt
 ) {
     public CreateDemodayPollCommand toCommand(Long memberId) {

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollResponse.java
@@ -1,6 +1,12 @@
 package com.umc.product.demoday.adapter.in.web.dto;
 
-public record CreateDemodayPollResponse(Long pollId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 투표 생성 결과")
+public record CreateDemodayPollResponse(
+    @Schema(description = "생성된 데모데이 투표 ID", example = "1")
+    Long pollId
+) {
 
     public static CreateDemodayPollResponse from(Long pollId) {
         return new CreateDemodayPollResponse(pollId);

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/CreateDemodayPollResponse.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.adapter.in.web.dto;
+
+public record CreateDemodayPollResponse(Long pollId) {
+
+    public static CreateDemodayPollResponse from(Long pollId) {
+        return new CreateDemodayPollResponse(pollId);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/ChangeDemodayPollStatusUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/ChangeDemodayPollStatusUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
+
+public interface ChangeDemodayPollStatusUseCase {
+
+    void changeStatus(ChangeDemodayPollStatusCommand command);
+
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayPollUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayPollUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+
+public interface CreateDemodayPollUseCase {
+
+    Long create(CreateDemodayPollCommand command);
+
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/ChangeDemodayPollStatusCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/ChangeDemodayPollStatusCommand.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+
+public record ChangeDemodayPollStatusCommand(
+    Long memberId,
+    Long pollId,
+    DemodayPollStatus status
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayPollCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayPollCommand.java
@@ -1,0 +1,12 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.time.Instant;
+
+public record CreateDemodayPollCommand(
+    Long memberId,
+    Long gisuId,
+    String name,
+    Instant opensAt,
+    Instant closesAt
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
@@ -1,0 +1,42 @@
+package com.umc.product.demoday.application.service.command;
+
+import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChangeDemodayPollStatusCommandService implements ChangeDemodayPollStatusUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final SaveDemodayPollPort saveDemodayPollPort;
+    private final LoadDemodayPollPort loadDemodayPollPort;
+
+    @Override
+    public void changeStatus(ChangeDemodayPollStatusCommand command) {
+        DemodayPoll poll = getDemodayPoll(command);
+
+        switch (command.status()) {
+            case OPEN -> poll.open();
+            case CLOSED -> poll.close();
+        }
+
+        saveDemodayPollPort.save(poll);
+    }
+
+    private DemodayPoll getDemodayPoll(ChangeDemodayPollStatusCommand command) {
+        DemodayPoll poll = loadDemodayPollPort.findById(command.pollId())
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(command.memberId(), poll.getGisuId());
+        return poll;
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
@@ -1,5 +1,8 @@
 package com.umc.product.demoday.application.service.command;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
@@ -7,9 +10,8 @@ import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
@@ -1,0 +1,30 @@
+package com.umc.product.demoday.application.service.command;
+
+import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateDemodayPollCommandService implements CreateDemodayPollUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final SaveDemodayPollPort saveDemodayPollPort;
+
+    @Override
+    public Long create(CreateDemodayPollCommand command) {
+        adminAccessChecker.validateAdminAccess(command.memberId(), command.gisuId());
+
+        DemodayPoll demodayPoll = DemodayPoll.create(command.gisuId(), command.name(), command.opensAt(), command.closesAt());
+        DemodayPoll savedPoll = saveDemodayPollPort.save(demodayPoll);
+        return savedPoll.getId();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
@@ -1,15 +1,14 @@
 package com.umc.product.demoday.application.service.command;
 
-import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
-import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
-import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
-import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
-import com.umc.product.demoday.domain.DemodayPoll;
-import com.umc.product.demoday.domain.exception.DemodayDomainException;
-import com.umc.product.demoday.domain.exception.DemodayErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayPoll;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional

--- a/src/main/java/com/umc/product/demoday/application/service/command/DemodayAdminAccessChecker.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/DemodayAdminAccessChecker.java
@@ -1,10 +1,12 @@
 package com.umc.product.demoday.application.service.command;
 
+import org.springframework.stereotype.Component;
+
 import com.umc.product.authorization.application.port.in.query.CheckChallengerAuthorityUseCase;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/product/demoday/application/service/command/DemodayAdminAccessChecker.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/DemodayAdminAccessChecker.java
@@ -1,0 +1,20 @@
+package com.umc.product.demoday.application.service.command;
+
+import com.umc.product.authorization.application.port.in.query.CheckChallengerAuthorityUseCase;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DemodayAdminAccessChecker {
+
+    private final CheckChallengerAuthorityUseCase authorityUseCase;
+
+    public void validateAdminAccess(Long memberId, Long gisuId) {
+        if(!authorityUseCase.isCentralCoreInGisu(memberId, gisuId)){
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
@@ -129,5 +129,19 @@ public class DemodayPoll extends BaseEntity {
         return Collections.unmodifiableList(booths);
     }
 
-    // TODO: 투표 시작과 종료 상태 전이 메서드 제작
+    public void open() {
+        if (DemodayPollStatus.OPEN == status) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_ALREADY_OPEN);
+        }
+
+        status = DemodayPollStatus.OPEN;
+    }
+
+    public void close() {
+        if (DemodayPollStatus.CLOSED == status) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_ALREADY_CLOSED);
+        }
+
+        status = DemodayPollStatus.CLOSED;
+    }
 }

--- a/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
+++ b/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
@@ -1,5 +1,8 @@
 package com.umc.product.demoday.domain.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 투표 운영 상태. OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.")
 public enum DemodayPollStatus {
     OPEN,
     CLOSED

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -17,6 +17,9 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_POLL_BOOTH_LOCKED(HttpStatus.CONFLICT, "DEMODAY-0105", "투표가 시작되어 부스를 추가할 수 없어요."),
     DEMODAY_POLL_INVALID_NAME(HttpStatus.BAD_REQUEST, "DEMODAY-0106", "데모데이 이름은 1자 이상 100자 이하여야 해요."),
     DEMODAY_POLL_GISU_REQUIRED(HttpStatus.BAD_REQUEST, "DEMODAY-0107", "데모데이가 진행되는 기수를 입력해주세요."),
+    DEMODAY_POLL_ALREADY_OPEN(HttpStatus.CONFLICT, "DEMODAY-0108", "이미 오픈된 데모데이 투표 행사 입니다."),
+    DEMODAY_POLL_ALREADY_CLOSED(HttpStatus.CONFLICT, "DEMODAY-0109", "이미 종료된 데모데이 투표 행사 입니다."),
+    DEMODAY_POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "DEMODAY-0110", "데모데이 투표 행사를 찾을 수 없습니다."),
 
     DEMODAY_BOOTH_INVALID_IDENTIFIER(HttpStatus.BAD_REQUEST, "DEMODAY-0200", "부스는 등록된 프로젝트나 표시 이름 중 하나를 가져야 합니다."),
     DEMODAY_BOOTH_INVALID_NAME(HttpStatus.BAD_REQUEST, "DEMODAY-0201", "부스 이름은 1자 이상 255자 이하로 작성해주세요."),
@@ -32,7 +35,10 @@ public enum DemodayErrorCode implements BaseCode {
 
     DEMODAY_STAMP_ALREADY_COLLECTED(HttpStatus.CONFLICT, "DEMODAY-0501", "이미 스탬프를 받은 부스예요."),
     DEMODAY_STAMP_ALREADY_REVOKED(HttpStatus.CONFLICT, "DEMODAY-0502", "이미 무효 처리된 스탬프예요."),
-    DEMODAY_STAMP_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0503", "이번 데모데이의 부스에만 스탬프를 받을 수 있어요.");
+    DEMODAY_STAMP_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0503", "이번 데모데이의 부스에만 스탬프를 받을 수 있어요."),
+
+    DEMODAY_ADMIN_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "DEMODAY-0600", "접근 권한이 없는 사용자입니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
@@ -1,0 +1,127 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ChangeDemodayPollStatusCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 1L;
+    private static final Long GISU_ID = 8L;
+    private static final String POLL_NAME = "8기 데모데이 투표";
+    private static final Instant OPENS_AT = Instant.parse("2026-08-15T09:00:00Z");
+    private static final Instant CLOSES_AT = Instant.parse("2026-08-15T12:00:00Z");
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private SaveDemodayPollPort saveDemodayPollPort;
+
+    @InjectMocks
+    private ChangeDemodayPollStatusCommandService service;
+
+    @Test
+    @DisplayName("닫힌 투표를 열고 저장한다")
+    void openClosedPoll() {
+        // given
+        DemodayPoll poll = createClosedPoll();
+        ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.OPEN);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        // when
+        service.changeStatus(command);
+
+        // then
+        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.OPEN);
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayPollPort).should().save(poll);
+    }
+
+    @Test
+    @DisplayName("열린 투표를 닫고 저장한다")
+    void closeOpenPoll() {
+        // given
+        DemodayPoll poll = createClosedPoll();
+        poll.open();
+        ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.CLOSED);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        // when
+        service.changeStatus(command);
+
+        // then
+        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.CLOSED);
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayPollPort).should().save(poll);
+    }
+
+    @Test
+    @DisplayName("투표가 존재하지 않으면 예외가 발생하고 권한 검사와 저장을 수행하지 않는다")
+    void throwExceptionWhenPollDoesNotExist() {
+        // given
+        ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.OPEN);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.changeStatus(command))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(saveDemodayPollPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 상태를 변경하거나 저장하지 않는다")
+    void doNotChangeOrSavePollWhenAdminAccessIsDenied() {
+        // given
+        DemodayPoll poll = createClosedPoll();
+        ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.OPEN);
+        DemodayDomainException expectedException =
+                new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        willThrow(expectedException)
+                .given(adminAccessChecker)
+                .validateAdminAccess(MEMBER_ID, GISU_ID);
+
+        // when & then
+        assertThatThrownBy(() -> service.changeStatus(command)).isSameAs(expectedException);
+        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.CLOSED);
+        then(saveDemodayPollPort).shouldHaveNoInteractions();
+    }
+
+    private DemodayPoll createClosedPoll() {
+        return DemodayPoll.create(GISU_ID, POLL_NAME, OPENS_AT, CLOSES_AT);
+    }
+
+    private ChangeDemodayPollStatusCommand commandOf(DemodayPollStatus status) {
+        return new ChangeDemodayPollStatusCommand(MEMBER_ID, POLL_ID, status);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandServiceTest.java
@@ -1,0 +1,108 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class CreateDemodayPollCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GISU_ID = 8L;
+    private static final Long POLL_ID = 1L;
+    private static final String NAME = "8기 데모데이 현장 투표";
+    private static final Instant OPENS_AT = Instant.parse("2026-08-01T05:00:00Z");
+    private static final Instant CLOSES_AT = Instant.parse("2026-08-01T08:00:00Z");
+
+    @Mock
+    private SaveDemodayPollPort saveDemodayPollPort;
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @InjectMocks
+    private CreateDemodayPollCommandService service;
+
+
+
+    @Test
+    @DisplayName("데모데이 투표 이벤트가 정상적으로 생성된다")
+    void createPoll() {
+        // given
+        CreateDemodayPollCommand command = createCommand();
+
+        DemodayPoll savedPoll = mock(DemodayPoll.class);
+        given(savedPoll.getId()).willReturn(POLL_ID);
+        given(saveDemodayPollPort.save(any(DemodayPoll.class)))
+            .willReturn(savedPoll);
+
+        // when
+        Long pollId = service.create(command);
+
+        // then
+        assertThat(pollId).isEqualTo(POLL_ID);
+
+        ArgumentCaptor<DemodayPoll> captor =
+            ArgumentCaptor.forClass(DemodayPoll.class);
+
+        then(adminAccessChecker)
+            .should()
+            .validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayPollPort)
+            .should()
+            .save(captor.capture());
+
+        DemodayPoll createdPoll = captor.getValue();
+        assertThat(createdPoll.getGisuId()).isEqualTo(GISU_ID);
+        assertThat(createdPoll.getName()).isEqualTo(NAME);
+        assertThat(createdPoll.getOpensAt()).isEqualTo(OPENS_AT);
+        assertThat(createdPoll.getClosesAt()).isEqualTo(CLOSES_AT);
+    }
+
+    @Test
+    @DisplayName("데모데이 관리자 권한이 없으면 투표 이벤트를 생성할 수 없다.")
+    void createPollWithoutAdminAuthority() {
+        //given
+        CreateDemodayPollCommand command = createCommand();
+
+        DemodayDomainException expectedException =
+            new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+
+        willThrow(expectedException)
+            .given(adminAccessChecker)
+            .validateAdminAccess(MEMBER_ID, GISU_ID);
+
+        //when & then
+        assertThatThrownBy(() -> service.create(command))
+            .isInstanceOf(DemodayDomainException.class);
+
+        then(saveDemodayPollPort)
+            .should(never())
+            .save(any(DemodayPoll.class));
+    }
+
+    private static CreateDemodayPollCommand createCommand() {
+        return new CreateDemodayPollCommand(MEMBER_ID, GISU_ID, NAME, OPENS_AT, CLOSES_AT);
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

데모데이 현장 운영자가 투표를 생성하고 상태를 변경할 수 있도록 관리자 API를 추가했습니다.

- 투표 생성 및 상태 변경 인바운드 UseCase와 Command Service를 구현했습니다.
- 데모데이 관리자 권한은 대상 기수의 총괄단 여부를 `isCentralCoreInGisu`로 확인합니다.
- 상태 변경 시 투표를 먼저 조회한 뒤 해당 투표의 `gisuId`를 기준으로 권한을 검사합니다.
- `DemodayPoll.open()`과 `close()`로 상태 전이 책임을 도메인에 두었습니다.
- 생성 및 상태 변경 API에 OpenAPI 설명과 요청·응답 스키마를 추가해 Scalar에서 계약을 확인할 수 있도록 했습니다.
- 생성과 상태 변경 Command Service의 정상·권한 실패·조회 실패 흐름을 단위 테스트로 검증했습니다.

resolves #1196

## 💬 리뷰 중점사항

- 투표 생성은 요청의 `gisuId`, 상태 변경은 조회한 투표의 `gisuId`를 권한 검사의 기준으로 사용했습니다. 두 경로에서 리소스 기수 기준이 올바르게 적용되는지 확인 부탁드립니다.
- 동일 상태로 다시 변경하는 요청은 도메인 예외로 막고, 종료된 투표의 재오픈은 허용했습니다. 현장 운영 정책과 맞는지 확인 부탁드립니다.
- 성공 응답은 전역 `GlobalResponseWrapper`가 감싸는 구조를 따르며, 컨트롤러에서는 `ApiResponse`를 직접 반환하지 않습니다.
