### PR TITLE
[Feat] 모집 Round 삭제를 soft delete로 전환하고 복구 API 추가

### DIFF
--- a/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingAdminGraphQlController.java
@@ -34,10 +34,12 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruitingRoundCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingEvaluationStatisticsUseCase;
@@ -66,6 +68,7 @@ public class RecruitingAdminGraphQlController {
     private final UpdateRecruitingRoundUseCase updateRoundUseCase;
     private final CloneRecruitingRoundUseCase cloneRoundUseCase;
     private final DeleteRecruitingRoundUseCase deleteRoundUseCase;
+    private final RestoreRecruitingRoundUseCase restoreRoundUseCase;
     private final GetRecruitingFormQueryUseCase getRecruitingFormQueryUseCase;
     private final RecruitingGraphQlPermissionSupport permissionSupport;
 
@@ -246,6 +249,21 @@ public class RecruitingAdminGraphQlController {
     ) {
         Long requesterMemberId = permissionSupport.currentMemberId(memberPrincipal);
         deleteRoundUseCase.deleteRound(DeleteRecruitingRoundCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .requesterMemberId(requesterMemberId)
+            .build());
+        return true;
+    }
+
+    @MutationMapping
+    public Boolean restoreRecruitingRound(
+        @Nullable @CurrentMember MemberPrincipal memberPrincipal,
+        @Argument Long seasonId,
+        @Argument Long roundId
+    ) {
+        Long requesterMemberId = permissionSupport.currentMemberId(memberPrincipal);
+        restoreRoundUseCase.restoreRound(RestoreRecruitingRoundCommand.builder()
             .seasonId(seasonId)
             .roundId(roundId)
             .requesterMemberId(requesterMemberId)

--- a/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminController.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminController.java
@@ -36,10 +36,12 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruitingRoundCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonConfigurationUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
@@ -71,6 +73,7 @@ public class RecruitingSeasonAdminController {
     private final CheckRecruitingRoundTitleUseCase checkRoundTitleUseCase;
     private final CloneRecruitingRoundUseCase cloneRoundUseCase;
     private final DeleteRecruitingRoundUseCase deleteRoundUseCase;
+    private final RestoreRecruitingRoundUseCase restoreRoundUseCase;
 
     @GetMapping("/rounds")
     @CheckAccess(resourceType = ResourceType.RECRUITMENT, permission = PermissionType.READ)
@@ -261,7 +264,7 @@ public class RecruitingSeasonAdminController {
     @Operation(
         operationId = "RECRUITING-ADMIN-017",
         summary = "모집 Round 삭제",
-        description = "지원서와 Form 응답이 없는 DRAFT Round와 소유한 Form 구조를 완전히 삭제합니다."
+        description = "지원서와 Form 응답이 없는 DRAFT Round를 삭제 상태로 표시합니다. Form 구조를 비롯한 하위 데이터는 남아 있어 복구 API로 되돌릴 수 있습니다."
     )
     public void deleteRound(
         @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
@@ -269,6 +272,25 @@ public class RecruitingSeasonAdminController {
         @PathVariable @Positive Long roundId
     ) {
         deleteRoundUseCase.deleteRound(DeleteRecruitingRoundCommand.builder()
+            .seasonId(seasonId)
+            .roundId(roundId)
+            .requesterMemberId(memberPrincipal.getMemberId())
+            .build());
+    }
+
+    @PostMapping("/seasons/{seasonId}/rounds/{roundId}/restore")
+    @CheckAccess(resourceType = ResourceType.RECRUITMENT, resourceId = "#seasonId", permission = PermissionType.EDIT)
+    @Operation(
+        operationId = "RECRUITING-ADMIN-018",
+        summary = "모집 Round 복구",
+        description = "삭제한 Round를 되돌립니다. 삭제된 사이에 같은 차수 번호나 제목이 다시 사용된 경우에는 복구할 수 없습니다."
+    )
+    public void restoreRound(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @PathVariable @Positive Long seasonId,
+        @PathVariable @Positive Long roundId
+    ) {
+        restoreRoundUseCase.restoreRound(RestoreRecruitingRoundCommand.builder()
             .seasonId(seasonId)
             .roundId(roundId)
             .requesterMemberId(memberPrincipal.getMemberId())

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundJpaRepository.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundJpaRepository.java
@@ -15,29 +15,58 @@ import com.umc.product.recruiting.domain.enums.RecruitingRoundType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
 
+/**
+ * 삭제된(soft delete) 차수는 조회에서 제외한다.
+ * 상속 메서드인 {@code findById}는 이 조건을 걸 수 없으므로 사용하지 않고
+ * {@link #findActiveById}를 사용한다.
+ */
 public interface RecruitingRoundJpaRepository extends JpaRepository<RecruitingRound, Long> {
+
+    @Query("SELECT round FROM RecruitingRound round WHERE round.id = :id AND round.deletedAt IS NULL")
+    Optional<RecruitingRound> findActiveById(@Param("id") Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
-    @Query("SELECT round FROM RecruitingRound round JOIN FETCH round.season WHERE round.id = :id")
+    @Query("""
+        SELECT round FROM RecruitingRound round
+        JOIN FETCH round.season
+        WHERE round.id = :id
+          AND round.deletedAt IS NULL
+        """)
     Optional<RecruitingRound> findByIdForUpdate(@Param("id") Long id);
 
-    List<RecruitingRound> findAllBySeason_IdOrderByRoundNoAscIdAsc(Long seasonId);
+    /** 복구 전용. 삭제된 차수까지 포함해 잠금 조회한다. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT round FROM RecruitingRound round JOIN FETCH round.season WHERE round.id = :id")
+    Optional<RecruitingRound> findByIdForUpdateIncludingDeleted(@Param("id") Long id);
 
-    @Query("SELECT round FROM RecruitingRound round JOIN FETCH round.season WHERE round.season.id IN :seasonIds")
+    List<RecruitingRound> findAllBySeason_IdAndDeletedAtIsNullOrderByRoundNoAscIdAsc(Long seasonId);
+
+    @Query("""
+        SELECT round FROM RecruitingRound round
+        JOIN FETCH round.season
+        WHERE round.season.id IN :seasonIds
+          AND round.deletedAt IS NULL
+        """)
     List<RecruitingRound> findAllBySeasonIds(@Param("seasonIds") List<Long> seasonIds);
 
-    boolean existsBySeason_IdAndTypeAndRoundNo(Long seasonId, RecruitingRoundType type, Integer roundNo);
+    boolean existsBySeason_IdAndTypeAndRoundNoAndDeletedAtIsNull(
+        Long seasonId,
+        RecruitingRoundType type,
+        Integer roundNo
+    );
 
-    boolean existsBySeason_IdAndTitleIgnoreCase(Long seasonId, String title);
+    boolean existsBySeason_IdAndTitleIgnoreCaseAndDeletedAtIsNull(Long seasonId, String title);
 
-    boolean existsBySeason_IdAndTitleIgnoreCaseAndIdNot(Long seasonId, String title, Long id);
+    boolean existsBySeason_IdAndTitleIgnoreCaseAndIdNotAndDeletedAtIsNull(Long seasonId, String title, Long id);
 
     @Query("""
         SELECT COALESCE(MAX(round.roundNo), 0)
         FROM RecruitingRound round
         WHERE round.season.id = :seasonId
           AND round.type = com.umc.product.recruiting.domain.enums.RecruitingRoundType.ADDITIONAL
+          AND round.deletedAt IS NULL
         """)
     int findMaxAdditionalRoundNo(@Param("seasonId") Long seasonId);
 

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundPersistenceAdapter.java
@@ -86,9 +86,4 @@ public class RecruitingRoundPersistenceAdapter implements LoadRecruitingRoundPor
     public RecruitingRound save(RecruitingRound round) {
         return recruitingRoundJpaRepository.save(round);
     }
-
-    @Override
-    public void delete(RecruitingRound round) {
-        recruitingRoundJpaRepository.delete(round);
-    }
 }

--- a/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingRoundPersistenceAdapter.java
@@ -22,7 +22,7 @@ public class RecruitingRoundPersistenceAdapter implements LoadRecruitingRoundPor
 
     @Override
     public Optional<RecruitingRound> findById(Long id) {
-        return recruitingRoundJpaRepository.findById(id);
+        return recruitingRoundJpaRepository.findActiveById(id);
     }
 
     @Override
@@ -40,8 +40,16 @@ public class RecruitingRoundPersistenceAdapter implements LoadRecruitingRoundPor
     }
 
     @Override
+    public RecruitingRound getByIdForUpdateIncludingDeleted(Long id) {
+        return RecruitingLockExceptionTranslator.translate(() ->
+            recruitingRoundJpaRepository.findByIdForUpdateIncludingDeleted(id)
+                .orElseThrow(() -> new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_NOT_FOUND))
+        );
+    }
+
+    @Override
     public List<RecruitingRound> listBySeasonId(Long seasonId) {
-        return recruitingRoundJpaRepository.findAllBySeason_IdOrderByRoundNoAscIdAsc(seasonId);
+        return recruitingRoundJpaRepository.findAllBySeason_IdAndDeletedAtIsNullOrderByRoundNoAscIdAsc(seasonId);
     }
 
     @Override
@@ -54,17 +62,19 @@ public class RecruitingRoundPersistenceAdapter implements LoadRecruitingRoundPor
 
     @Override
     public boolean existsBySeasonIdAndTypeAndRoundNo(Long seasonId, RecruitingRoundType type, Integer roundNo) {
-        return recruitingRoundJpaRepository.existsBySeason_IdAndTypeAndRoundNo(seasonId, type, roundNo);
+        return recruitingRoundJpaRepository
+            .existsBySeason_IdAndTypeAndRoundNoAndDeletedAtIsNull(seasonId, type, roundNo);
     }
 
     @Override
     public boolean existsBySeasonIdAndTitleIgnoreCase(Long seasonId, String title) {
-        return recruitingRoundJpaRepository.existsBySeason_IdAndTitleIgnoreCase(seasonId, title);
+        return recruitingRoundJpaRepository.existsBySeason_IdAndTitleIgnoreCaseAndDeletedAtIsNull(seasonId, title);
     }
 
     @Override
     public boolean existsBySeasonIdAndTitleIgnoreCaseAndIdNot(Long seasonId, String title, Long id) {
-        return recruitingRoundJpaRepository.existsBySeason_IdAndTitleIgnoreCaseAndIdNot(seasonId, title, id);
+        return recruitingRoundJpaRepository
+            .existsBySeason_IdAndTitleIgnoreCaseAndIdNotAndDeletedAtIsNull(seasonId, title, id);
     }
 
     @Override

--- a/src/main/java/com/umc/product/recruiting/application/port/in/command/RestoreRecruitingRoundUseCase.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/command/RestoreRecruitingRoundUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.recruiting.application.port.in.command;
+
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
+
+public interface RestoreRecruitingRoundUseCase {
+
+    void restoreRound(RestoreRecruitingRoundCommand command);
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/in/command/dto/RestoreRecruitingRoundCommand.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/in/command/dto/RestoreRecruitingRoundCommand.java
@@ -1,0 +1,11 @@
+package com.umc.product.recruiting.application.port.in.command.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RestoreRecruitingRoundCommand(
+    Long seasonId,
+    Long roundId,
+    Long requesterMemberId
+) {
+}

--- a/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingRoundPort.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/out/LoadRecruitingRoundPort.java
@@ -6,6 +6,11 @@ import java.util.Optional;
 import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.enums.RecruitingRoundType;
 
+/**
+ * 삭제된(soft delete) 차수는 모든 조회에서 제외한다.
+ * 삭제된 차수에 접근해야 하는 복구 경로만 {@link #getByIdForUpdateIncludingDeleted}를 사용하며,
+ * 그 외 경로는 삭제된 차수를 조회할 수 없어 자연히 {@code RECRUITING_ROUND_NOT_FOUND}로 처리된다.
+ */
 public interface LoadRecruitingRoundPort {
 
     Optional<RecruitingRound> findById(Long id);
@@ -13,6 +18,9 @@ public interface LoadRecruitingRoundPort {
     RecruitingRound getById(Long id);
 
     RecruitingRound getByIdForUpdate(Long id);
+
+    /** 복구 전용. 삭제된 차수까지 포함해 조회한다. */
+    RecruitingRound getByIdForUpdateIncludingDeleted(Long id);
 
     List<RecruitingRound> listBySeasonId(Long seasonId);
 

--- a/src/main/java/com/umc/product/recruiting/application/port/out/SaveRecruitingRoundPort.java
+++ b/src/main/java/com/umc/product/recruiting/application/port/out/SaveRecruitingRoundPort.java
@@ -5,6 +5,4 @@ import com.umc.product.recruiting.domain.RecruitingRound;
 public interface SaveRecruitingRoundPort {
 
     RecruitingRound save(RecruitingRound round);
-
-    void delete(RecruitingRound round);
 }

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
@@ -17,11 +17,13 @@ import com.umc.product.recruiting.application.port.in.command.AuthorizeRecruitin
 import com.umc.product.recruiting.application.port.in.command.CloneRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingApplicationFormUseCase;
 import com.umc.product.recruiting.application.port.in.command.dto.CloneRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.RecruitingRoundConfigurationCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand.OptionEntry;
 import com.umc.product.recruiting.application.port.in.command.dto.UpsertRecruitingApplicationFormCommand.QuestionEntry;
@@ -48,6 +50,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RecruitingRoundLifecycleCommandService implements
     DeleteRecruitingRoundUseCase,
+    RestoreRecruitingRoundUseCase,
     CloneRecruitingRoundUseCase {
 
     private final LoadRecruitingRoundPort loadRoundPort;
@@ -82,6 +85,32 @@ public class RecruitingRoundLifecycleCommandService implements
         }
 
         round.delete(clock.instant());
+        saveRoundPort.save(round);
+    }
+
+    /**
+     * 삭제 기간에 제한이 없어, 삭제된 사이에 같은 (유형, 차수 번호)나 제목이 다시 사용될 수 있다.
+     * 활성 차수만 대상으로 하는 부분 유니크 인덱스가 슬롯을 풀어 주기 때문이며,
+     * 그대로 복구하면 인덱스 위반이 나므로 선점 여부를 먼저 확인한다.
+     */
+    @Override
+    public void restoreRound(RestoreRecruitingRoundCommand command) {
+        authorizeManagementUseCase.authorizeSeasonManagement(command.requesterMemberId(), command.seasonId());
+        RecruitingRound round = loadRoundPort.getByIdForUpdateIncludingDeleted(command.roundId());
+        validateRoundInSeason(round, command.seasonId());
+        if (!round.isDeleted()) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_NOT_DELETED);
+        }
+        boolean slotTaken = loadRoundPort.existsBySeasonIdAndTypeAndRoundNo(
+            command.seasonId(),
+            round.getType(),
+            round.getRoundNo()
+        );
+        if (slotTaken || loadRoundPort.existsBySeasonIdAndTitleIgnoreCase(command.seasonId(), round.getTitle())) {
+            throw new RecruitingDomainException(RecruitingErrorCode.RECRUITING_ROUND_RESTORE_CONFLICT);
+        }
+
+        round.restore();
         saveRoundPort.save(round);
     }
 

--- a/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
+++ b/src/main/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandService.java
@@ -1,5 +1,6 @@
 package com.umc.product.recruiting.application.service.command;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -9,8 +10,6 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.umc.product.form.application.port.in.command.ManageFormUseCase;
-import com.umc.product.form.application.port.in.command.dto.DeleteFormCommand;
 import com.umc.product.form.application.port.in.query.GetFormResponseUseCase;
 import com.umc.product.form.application.port.in.query.GetFormUseCase;
 import com.umc.product.form.application.port.in.query.dto.FormWithStructureInfo;
@@ -32,10 +31,6 @@ import com.umc.product.recruiting.application.port.out.LoadRecruitingApplication
 import com.umc.product.recruiting.application.port.out.LoadRecruitingFormSectionPolicyPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundInterviewQuestionPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingApplicationFormPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingFormSectionPolicyPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingInterviewSessionPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundEvaluatorPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundInterviewQuestionPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundPort;
 import com.umc.product.recruiting.domain.RecruitingApplicationForm;
@@ -57,21 +52,17 @@ public class RecruitingRoundLifecycleCommandService implements
 
     private final LoadRecruitingRoundPort loadRoundPort;
     private final SaveRecruitingRoundPort saveRoundPort;
-    private final SaveRecruitingInterviewSessionPort saveInterviewSessionPort;
     private final LoadRecruitingApplicationPort loadApplicationPort;
     private final LoadRecruitingApplicationFormPort loadApplicationFormPort;
-    private final SaveRecruitingApplicationFormPort saveApplicationFormPort;
     private final LoadRecruitingFormSectionPolicyPort loadPolicyPort;
-    private final SaveRecruitingFormSectionPolicyPort savePolicyPort;
-    private final SaveRecruitingRoundEvaluatorPort saveEvaluatorPort;
     private final LoadRecruitingRoundInterviewQuestionPort loadQuestionPort;
     private final SaveRecruitingRoundInterviewQuestionPort saveQuestionPort;
-    private final ManageFormUseCase manageFormUseCase;
     private final GetFormUseCase getFormUseCase;
     private final GetFormResponseUseCase getFormResponseUseCase;
     private final CreateRecruitingRoundUseCase createRoundUseCase;
     private final UpsertRecruitingApplicationFormUseCase upsertFormUseCase;
     private final AuthorizeRecruitingManagementUseCase authorizeManagementUseCase;
+    private final Clock clock;
 
     @Override
     public void deleteRound(DeleteRecruitingRoundCommand command) {
@@ -90,18 +81,8 @@ public class RecruitingRoundLifecycleCommandService implements
             throw deleteConflict();
         }
 
-        saveEvaluatorPort.deleteByRoundId(round.getId());
-        saveQuestionPort.deleteByRoundId(round.getId());
-        saveInterviewSessionPort.deleteByRoundId(round.getId());
-        if (applicationForm != null) {
-            savePolicyPort.deleteByApplicationFormId(applicationForm.getId());
-            saveApplicationFormPort.delete(applicationForm);
-            manageFormUseCase.deleteForm(DeleteFormCommand.builder()
-                .formId(applicationForm.getFormId())
-                .requesterMemberId(command.requesterMemberId())
-                .build());
-        }
-        saveRoundPort.delete(round);
+        round.delete(clock.instant());
+        saveRoundPort.save(round);
     }
 
     @Override

--- a/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
+++ b/src/main/java/com/umc/product/recruiting/domain/RecruitingRound.java
@@ -27,20 +27,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * (recruiting_season_id, type, round_no) 유일성은 활성 차수에만 적용된다.
+ * 삭제된 차수가 슬롯을 점유하지 않도록 DB에 부분 유니크 인덱스로 정의되어 있으며,
+ * JPA로는 표현할 수 없어 {@code @UniqueConstraint}를 선언하지 않는다.
+ */
 @Entity
-@Table(
-    name = "recruiting_round",
-    uniqueConstraints = @UniqueConstraint(
-        name = "uk_recruiting_round_season_type_no",
-        columnNames = {"recruiting_season_id", "type", "round_no"}
-    )
-)
+@Table(name = "recruiting_round")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecruitingRound extends BaseEntity {
@@ -112,6 +110,9 @@ public class RecruitingRound extends BaseEntity {
 
     @Column(name = "created_by_member_id")
     private Long createdByMemberId;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
     private RecruitingRound(
@@ -320,6 +321,27 @@ public class RecruitingRound extends BaseEntity {
     public void unpublish() {
         validateStatus(RecruitingRoundStatus.OPEN);
         this.status = RecruitingRoundStatus.DRAFT;
+    }
+
+    /**
+     * 삭제 여부만 표시하고 하위 데이터(평가자, 면접 질문·세션, 지원 Form 구조)는 그대로 둔다.
+     * 복구가 이 플래그를 되돌리는 것만으로 끝나야 하기 때문이다.
+     */
+    public void delete(Instant deletedAt) {
+        if (this.deletedAt == null) {
+            if (deletedAt == null) {
+                throw new IllegalArgumentException("deletedAt must not be null");
+            }
+            this.deletedAt = deletedAt;
+        }
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 
     private static void validateRoundNo(Integer roundNo) {

--- a/src/main/java/com/umc/product/recruiting/domain/exception/RecruitingErrorCode.java
+++ b/src/main/java/com/umc/product/recruiting/domain/exception/RecruitingErrorCode.java
@@ -40,6 +40,8 @@ public enum RecruitingErrorCode implements BaseCode {
     RECRUITING_ROUND_NO_SEQUENCE_CONFLICT(HttpStatus.CONFLICT, "RECRUITING-0116", "추가모집 차수는 이전 차수 다음 번호여야 해요."),
     RECRUITING_ROUND_DELETE_CONFLICT(HttpStatus.CONFLICT, "RECRUITING-0117", "초안이며 지원서와 Form 응답이 없는 모집만 삭제할 수 있어요."),
     RECRUITING_ROUND_UNPUBLISH_CONFLICT(HttpStatus.CONFLICT, "RECRUITING-0118", "지원서 또는 Form 응답이 있는 모집은 비공개할 수 없어요."),
+    RECRUITING_ROUND_NOT_DELETED(HttpStatus.CONFLICT, "RECRUITING-0120", "삭제된 모집만 복구할 수 있어요."),
+    RECRUITING_ROUND_RESTORE_CONFLICT(HttpStatus.CONFLICT, "RECRUITING-0121", "같은 번호나 제목의 모집이 이미 있어 복구할 수 없어요."),
     RECRUITING_APPLICATION_FORM_INVALID(HttpStatus.BAD_REQUEST, "RECRUITING-0200", "지원 폼 정보가 올바르지 않아요."),
     RECRUITING_APPLICATION_FORM_INVALID_TRANSITION(HttpStatus.BAD_REQUEST, "RECRUITING-0201", "현재 지원 폼 상태에서는 할 수 없는 작업이에요."),
     RECRUITING_APPLICATION_FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "RECRUITING-0202", "이미 해당 모집 차수에 연결된 지원 폼이에요."),

--- a/src/main/resources/db/migration/V2026.08.16.00.27__add_deleted_at_to_recruiting_round.sql
+++ b/src/main/resources/db/migration/V2026.08.16.00.27__add_deleted_at_to_recruiting_round.sql
@@ -1,0 +1,15 @@
+-- 모집 공고 삭제를 되돌릴 수 있도록 차수를 물리 삭제 대신 soft delete로 전환한다.
+ALTER TABLE public.recruiting_round
+    ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN public.recruiting_round.deleted_at
+    IS '차수를 삭제한 시각. NULL이면 활성 차수이며, 값이 있으면 복구 가능한 삭제 상태.';
+
+-- 삭제된 차수가 (시즌, 유형, 차수 번호) 슬롯을 계속 점유하면 같은 번호로 다시 만들 수 없다.
+-- 활성 차수끼리만 유일성을 강제하도록 부분 유니크 인덱스로 교체한다.
+ALTER TABLE public.recruiting_round
+    DROP CONSTRAINT uk_recruiting_round_season_type_no;
+
+CREATE UNIQUE INDEX uk_recruiting_round_season_type_no
+    ON public.recruiting_round (recruiting_season_id, type, round_no)
+    WHERE deleted_at IS NULL;

--- a/src/main/resources/graphql/recruiting.graphqls
+++ b/src/main/resources/graphql/recruiting.graphqls
@@ -63,6 +63,7 @@ type Mutation {
     input: CloneRecruitingRoundInput!
   ): RecruitingIdPayload!
   deleteRecruitingRound(seasonId: ID!, roundId: ID!): Boolean!
+  restoreRecruitingRound(seasonId: ID!, roundId: ID!): Boolean!
   addRecruitingRoundEvaluator(
     seasonId: ID!
     roundId: ID!

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
@@ -38,6 +38,7 @@ import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingRoundCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.UpdateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingApplicationQueryUseCase;
@@ -217,6 +218,26 @@ class RecruitingRoundAdminGraphQlControllerTest {
             .isEqualTo(Instant.parse("2026-08-01T00:00:00Z"));
         assertThat(captor.getValue().configuration().availabilityFormId()).isEqualTo(100L);
         assertThat(captor.getValue().configuration().availabilityScheduleQuestionId()).isEqualTo(200L);
+    }
+
+    @Test
+    @DisplayName("GraphQL 차수 복구는 seasonId와 roundId를 command로 전달한다")
+    void restoreRound() {
+        graphQlTester.document("""
+                mutation {
+                  restoreRecruitingRound(seasonId: 10, roundId: 20)
+                }
+                """)
+            .execute()
+            .path("restoreRecruitingRound")
+            .entity(Boolean.class)
+            .isEqualTo(true);
+
+        ArgumentCaptor<RestoreRecruitingRoundCommand> captor =
+            ArgumentCaptor.forClass(RestoreRecruitingRoundCommand.class);
+        then(restoreRoundUseCase).should().restoreRound(captor.capture());
+        assertThat(captor.getValue().seasonId()).isEqualTo(10L);
+        assertThat(captor.getValue().roundId()).isEqualTo(20L);
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingRoundAdminGraphQlControllerTest.java
@@ -33,6 +33,7 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
@@ -81,6 +82,9 @@ class RecruitingRoundAdminGraphQlControllerTest {
     CloneRecruitingRoundUseCase cloneRoundUseCase;
     @MockitoBean
     DeleteRecruitingRoundUseCase deleteRoundUseCase;
+
+    @MockitoBean
+    RestoreRecruitingRoundUseCase restoreRoundUseCase;
     @MockitoBean
     CreateRecruitingSeasonUseCase createSeasonUseCase;
     @MockitoBean

--- a/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/graphql/RecruitingSeasonAdminGraphQlControllerTest.java
@@ -37,6 +37,7 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
@@ -106,6 +107,9 @@ class RecruitingSeasonAdminGraphQlControllerTest {
     CloneRecruitingRoundUseCase cloneRoundUseCase;
     @MockitoBean
     DeleteRecruitingRoundUseCase deleteRoundUseCase;
+
+    @MockitoBean
+    RestoreRecruitingRoundUseCase restoreRoundUseCase;
     @MockitoBean
     CreateRecruitingSeasonUseCase createSeasonUseCase;
     @MockitoBean

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRestContractTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRestContractTest.java
@@ -85,6 +85,7 @@ class RecruitingRestContractTest {
                 "RECRUITING-ADMIN-015",
                 "RECRUITING-ADMIN-016",
                 "RECRUITING-ADMIN-017",
+                "RECRUITING-ADMIN-018",
                 "RECRUITING-ADMIN-021",
                 "RECRUITING-ADMIN-022",
                 "RECRUITING-ADMIN-031",

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRoundAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingRoundAdminControllerTest.java
@@ -37,6 +37,7 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
@@ -104,6 +105,9 @@ class RecruitingRoundAdminControllerTest {
     CloneRecruitingRoundUseCase cloneRoundUseCase;
     @MockitoBean
     DeleteRecruitingRoundUseCase deleteRoundUseCase;
+
+    @MockitoBean
+    RestoreRecruitingRoundUseCase restoreRoundUseCase;
 
     @BeforeEach
     void authenticate() {

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -43,7 +44,9 @@ import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingSeasonCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.ReplaceRecruitingSeasonTrackQuotasCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.query.CheckRecruitingRoundTitleUseCase;
 import com.umc.product.recruiting.application.port.in.query.GetRecruitingSeasonConfigurationUseCase;
 import com.umc.product.recruiting.application.port.in.query.SearchRecruitingRoundGroupUseCase;
@@ -181,6 +184,43 @@ class RecruitingSeasonAdminControllerTest {
             .andExpect(jsonPath("$.result.chapterTotalTargetCount").value(740))
             .andExpect(jsonPath("$.result.rounds[0].availabilityFormId").value(100L))
             .andExpect(jsonPath("$.result.rounds[0].availabilityScheduleQuestionId").value(200L));
+    }
+
+    @Test
+    @DisplayName("차수 삭제 요청은 seasonId와 roundId를 command로 전달한다")
+    void deleteRoundPassesIdsToCommand() throws Exception {
+        mockMvc.perform(delete("/api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}", 10L, 20L))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<DeleteRecruitingRoundCommand> captor =
+            ArgumentCaptor.forClass(DeleteRecruitingRoundCommand.class);
+        then(deleteRoundUseCase).should().deleteRound(captor.capture());
+        assertThat(captor.getValue().seasonId()).isEqualTo(10L);
+        assertThat(captor.getValue().roundId()).isEqualTo(20L);
+        assertThat(captor.getValue().requesterMemberId()).isEqualTo(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("차수 복구 요청은 현재 회원과 함께 command로 전달한다")
+    void restoreRoundPassesIdsToCommand() throws Exception {
+        mockMvc.perform(post("/api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/restore", 10L, 20L))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<RestoreRecruitingRoundCommand> captor =
+            ArgumentCaptor.forClass(RestoreRecruitingRoundCommand.class);
+        then(restoreRoundUseCase).should().restoreRound(captor.capture());
+        assertThat(captor.getValue().seasonId()).isEqualTo(10L);
+        assertThat(captor.getValue().roundId()).isEqualTo(20L);
+        assertThat(captor.getValue().requesterMemberId()).isEqualTo(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("양수가 아닌 roundId 복구 요청은 400을 반환한다")
+    void restoreRoundRejectsNonPositiveRoundId() throws Exception {
+        mockMvc.perform(post("/api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/restore", 10L, 0L))
+            .andExpect(status().isBadRequest());
+
+        then(restoreRoundUseCase).should(never()).restoreRound(any());
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/in/web/RecruitingSeasonAdminControllerTest.java
@@ -37,6 +37,7 @@ import com.umc.product.recruiting.application.port.in.command.CreateRecruitingRo
 import com.umc.product.recruiting.application.port.in.command.CreateRecruitingSeasonUseCase;
 import com.umc.product.recruiting.application.port.in.command.DeleteRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.ReplaceRecruitingSeasonTrackQuotasUseCase;
+import com.umc.product.recruiting.application.port.in.command.RestoreRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundStatusUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingRoundUseCase;
 import com.umc.product.recruiting.application.port.in.command.UpdateRecruitingSeasonUseCase;
@@ -94,6 +95,9 @@ class RecruitingSeasonAdminControllerTest {
     CloneRecruitingRoundUseCase cloneRoundUseCase;
     @MockitoBean
     DeleteRecruitingRoundUseCase deleteRoundUseCase;
+
+    @MockitoBean
+    RestoreRecruitingRoundUseCase restoreRoundUseCase;
 
     @BeforeEach
     void authenticate() {

--- a/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingSeasonRoundPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingSeasonRoundPersistenceAdapterTest.java
@@ -18,6 +18,7 @@ import com.umc.product.recruiting.domain.RecruitingRound;
 import com.umc.product.recruiting.domain.RecruitingRoundConfiguration;
 import com.umc.product.recruiting.domain.RecruitingSeason;
 import com.umc.product.recruiting.domain.RecruitingSeasonTrackQuota;
+import com.umc.product.recruiting.domain.enums.RecruitingRoundType;
 import com.umc.product.support.PersistenceAdapterTest;
 
 @PersistenceAdapterTest
@@ -121,6 +122,80 @@ class RecruitingSeasonRoundPersistenceAdapterTest {
         assertThat(roundAdapter.listBySeasonIds(List.of(firstSeason.getId(), secondSeason.getId())))
             .extracting(RecruitingRound::getId)
             .containsExactlyInAnyOrder(firstRound.getId(), secondRound.getId());
+    }
+
+    @Test
+    @DisplayName("삭제된 차수는 목록, 단건, 제목 중복 검사, 추가모집 채번에서 제외된다")
+    void deletedRoundIsExcludedFromQueries() {
+        RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(15L, 160L));
+        RecruitingRound round = roundAdapter.save(RecruitingRound.createRegular(
+            season,
+            "본모집",
+            noInterviewConfiguration()
+        ));
+        roundAdapter.save(RecruitingRound.createAdditional(season, 1, "추가모집 1차", noInterviewConfiguration()));
+        em.flush();
+
+        round.delete(Instant.parse("2026-08-16T00:00:00Z"));
+        roundAdapter.save(round);
+        em.flush();
+        em.clear();
+
+        assertThat(roundAdapter.findById(round.getId())).isEmpty();
+        assertThat(roundAdapter.listBySeasonId(season.getId()))
+            .extracting(RecruitingRound::getTitle)
+            .containsExactly("추가모집 1차");
+        assertThat(roundAdapter.listBySeasonIds(List.of(season.getId())))
+            .hasSize(1);
+        assertThat(roundAdapter.existsBySeasonIdAndTitleIgnoreCase(season.getId(), "본모집")).isFalse();
+        assertThat(roundAdapter.existsBySeasonIdAndTypeAndRoundNo(
+            season.getId(),
+            RecruitingRoundType.REGULAR,
+            1
+        )).isFalse();
+        assertThat(roundAdapter.getByIdForUpdateIncludingDeleted(round.getId()).isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("삭제된 차수는 슬롯을 점유하지 않아 같은 유형과 번호로 다시 만들 수 있다")
+    void deletedRoundReleasesUniqueSlot() {
+        RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(16L, 170L));
+        RecruitingRound round = roundAdapter.save(RecruitingRound.createRegular(
+            season,
+            "본모집",
+            noInterviewConfiguration()
+        ));
+        em.flush();
+
+        round.delete(Instant.parse("2026-08-16T00:00:00Z"));
+        roundAdapter.save(round);
+        em.flush();
+
+        RecruitingRound recreated = roundAdapter.save(RecruitingRound.createRegular(
+            season,
+            "새 본모집",
+            noInterviewConfiguration()
+        ));
+        em.flush();
+        em.clear();
+
+        assertThat(recreated.getRoundNo()).isEqualTo(1);
+        assertThat(roundAdapter.listBySeasonId(season.getId()))
+            .extracting(RecruitingRound::getTitle)
+            .containsExactly("새 본모집");
+    }
+
+    @Test
+    @DisplayName("활성 차수끼리는 같은 유형과 번호를 가질 수 없다")
+    void activeRoundsKeepUniqueSlot() {
+        RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(17L, 180L));
+        roundAdapter.save(RecruitingRound.createRegular(season, "본모집", noInterviewConfiguration()));
+        em.flush();
+
+        assertThatThrownBy(() -> {
+            roundAdapter.save(RecruitingRound.createRegular(season, "본모집 중복", noInterviewConfiguration()));
+            em.flush();
+        }).isInstanceOf(DataIntegrityViolationException.class);
     }
 
     private RecruitingRoundConfiguration noInterviewConfiguration() {

--- a/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingSeasonRoundPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/recruiting/adapter/out/persistence/RecruitingSeasonRoundPersistenceAdapterTest.java
@@ -157,6 +157,42 @@ class RecruitingSeasonRoundPersistenceAdapterTest {
     }
 
     @Test
+    @DisplayName("복구한 차수는 삭제 시각이 비워지고 일반 조회에 다시 잡힌다")
+    void restoredRoundBecomesVisibleAgain() {
+        RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(18L, 190L));
+        RecruitingRound round = roundAdapter.save(RecruitingRound.createRegular(
+            season,
+            "본모집",
+            noInterviewConfiguration()
+        ));
+        roundAdapter.save(RecruitingRound.createAdditional(season, 1, "추가모집 1차", noInterviewConfiguration()));
+        round.delete(Instant.parse("2026-08-16T00:00:00Z"));
+        roundAdapter.save(round);
+        em.flush();
+        em.clear();
+
+        RecruitingRound deleted = roundAdapter.getByIdForUpdateIncludingDeleted(round.getId());
+        deleted.restore();
+        roundAdapter.save(deleted);
+        em.flush();
+        em.clear();
+
+        RecruitingRound restored = roundAdapter.getById(round.getId());
+        assertThat(restored.isDeleted()).isFalse();
+        assertThat(restored.getDeletedAt()).isNull();
+        assertThat(roundAdapter.findById(round.getId())).isPresent();
+        assertThat(roundAdapter.listBySeasonId(season.getId()))
+            .extracting(RecruitingRound::getTitle)
+            .containsExactly("본모집", "추가모집 1차");
+        assertThat(roundAdapter.existsBySeasonIdAndTitleIgnoreCase(season.getId(), "본모집")).isTrue();
+        assertThat(roundAdapter.existsBySeasonIdAndTypeAndRoundNo(
+            season.getId(),
+            RecruitingRoundType.REGULAR,
+            1
+        )).isTrue();
+    }
+
+    @Test
     @DisplayName("삭제된 차수는 슬롯을 점유하지 않아 같은 유형과 번호로 다시 만들 수 있다")
     void deletedRoundReleasesUniqueSlot() {
         RecruitingSeason season = seasonAdapter.save(RecruitingSeason.create(16L, 170L));

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
@@ -5,9 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.inOrder;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,13 +17,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.common.domain.enums.ChallengerTrack;
-import com.umc.product.form.application.port.in.command.ManageFormUseCase;
 import com.umc.product.form.application.port.in.query.GetFormResponseUseCase;
 import com.umc.product.form.application.port.in.query.GetFormUseCase;
 import com.umc.product.form.application.port.in.query.dto.FormResponseInfo;
@@ -39,10 +38,6 @@ import com.umc.product.recruiting.application.port.out.LoadRecruitingApplication
 import com.umc.product.recruiting.application.port.out.LoadRecruitingFormSectionPolicyPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundInterviewQuestionPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingRoundPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingApplicationFormPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingFormSectionPolicyPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingInterviewSessionPort;
-import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundEvaluatorPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundInterviewQuestionPort;
 import com.umc.product.recruiting.application.port.out.SaveRecruitingRoundPort;
 import com.umc.product.recruiting.domain.RecruitingApplicationForm;
@@ -59,21 +54,18 @@ class RecruitingRoundLifecycleCommandServiceTest {
 
     @Mock LoadRecruitingRoundPort loadRoundPort;
     @Mock SaveRecruitingRoundPort saveRoundPort;
-    @Mock SaveRecruitingInterviewSessionPort saveInterviewSessionPort;
     @Mock LoadRecruitingApplicationPort loadApplicationPort;
     @Mock LoadRecruitingApplicationFormPort loadApplicationFormPort;
-    @Mock SaveRecruitingApplicationFormPort saveApplicationFormPort;
     @Mock LoadRecruitingFormSectionPolicyPort loadPolicyPort;
-    @Mock SaveRecruitingFormSectionPolicyPort savePolicyPort;
-    @Mock SaveRecruitingRoundEvaluatorPort saveEvaluatorPort;
     @Mock LoadRecruitingRoundInterviewQuestionPort loadQuestionPort;
     @Mock SaveRecruitingRoundInterviewQuestionPort saveQuestionPort;
-    @Mock ManageFormUseCase manageFormUseCase;
     @Mock GetFormUseCase getFormUseCase;
     @Mock GetFormResponseUseCase getFormResponseUseCase;
     @Mock CreateRecruitingRoundUseCase createRoundUseCase;
     @Mock UpsertRecruitingApplicationFormUseCase upsertFormUseCase;
     @Mock AuthorizeRecruitingManagementUseCase authorizeManagementUseCase;
+
+    static final Instant NOW = Instant.parse("2026-08-16T00:00:00Z");
 
     RecruitingRoundLifecycleCommandService sut;
     RecruitingRound source;
@@ -83,27 +75,23 @@ class RecruitingRoundLifecycleCommandServiceTest {
         sut = new RecruitingRoundLifecycleCommandService(
             loadRoundPort,
             saveRoundPort,
-            saveInterviewSessionPort,
             loadApplicationPort,
             loadApplicationFormPort,
-            saveApplicationFormPort,
             loadPolicyPort,
-            savePolicyPort,
-            saveEvaluatorPort,
             loadQuestionPort,
             saveQuestionPort,
-            manageFormUseCase,
             getFormUseCase,
             getFormResponseUseCase,
             createRoundUseCase,
             upsertFormUseCase,
-            authorizeManagementUseCase
+            authorizeManagementUseCase,
+            Clock.fixed(NOW, ZoneOffset.UTC)
         );
         source = round(10L, 20L, true, 999L, 1999L);
     }
 
     @Test
-    @DisplayName("응답이 존재하는 DRAFT Round는 hard delete하지 않는다")
+    @DisplayName("응답이 존재하는 DRAFT Round는 삭제되지 않는다")
     void rejectDeleteWhenFormResponseExists() {
         RecruitingApplicationForm form = RecruitingApplicationForm.create(source, 100L);
         given(loadRoundPort.getByIdForUpdate(20L)).willReturn(source);
@@ -122,12 +110,11 @@ class RecruitingRoundLifecycleCommandServiceTest {
             .isEqualTo(RecruitingErrorCode.RECRUITING_ROUND_DELETE_CONFLICT);
 
         then(saveRoundPort).shouldHaveNoInteractions();
-        then(manageFormUseCase).shouldHaveNoInteractions();
     }
 
     @Test
-    @DisplayName("지원서와 응답이 없는 DRAFT Round는 명시적인 자식 삭제 순서로 hard delete한다")
-    void hardDeleteDraftRoundInExplicitOrder() {
+    @DisplayName("지원서와 응답이 없는 DRAFT Round는 삭제 시각만 기록하고 하위 데이터는 남긴다")
+    void softDeleteDraftRound() {
         RecruitingApplicationForm form = RecruitingApplicationForm.create(source, 100L);
         ReflectionTestUtils.setField(form, "id", 200L);
         given(loadRoundPort.getByIdForUpdate(20L)).willReturn(source);
@@ -140,22 +127,9 @@ class RecruitingRoundLifecycleCommandServiceTest {
             .requesterMemberId(99L)
             .build());
 
-        InOrder order = inOrder(
-            saveEvaluatorPort,
-            saveQuestionPort,
-            saveInterviewSessionPort,
-            savePolicyPort,
-            saveApplicationFormPort,
-            manageFormUseCase,
-            saveRoundPort
-        );
-        then(saveEvaluatorPort).should(order).deleteByRoundId(20L);
-        then(saveQuestionPort).should(order).deleteByRoundId(20L);
-        then(saveInterviewSessionPort).should(order).deleteByRoundId(20L);
-        then(savePolicyPort).should(order).deleteByApplicationFormId(200L);
-        then(saveApplicationFormPort).should(order).delete(form);
-        then(manageFormUseCase).should(order).deleteForm(any());
-        then(saveRoundPort).should(order).delete(source);
+        assertThat(source.isDeleted()).isTrue();
+        assertThat(source.getDeletedAt()).isEqualTo(NOW);
+        then(saveRoundPort).should().save(source);
     }
 
     @Test

--- a/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
+++ b/src/test/java/com/umc/product/recruiting/application/service/command/RecruitingRoundLifecycleCommandServiceTest.java
@@ -33,6 +33,7 @@ import com.umc.product.recruiting.application.port.in.command.UpsertRecruitingAp
 import com.umc.product.recruiting.application.port.in.command.dto.CloneRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.CreateRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.in.command.dto.DeleteRecruitingRoundCommand;
+import com.umc.product.recruiting.application.port.in.command.dto.RestoreRecruitingRoundCommand;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationFormPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingApplicationPort;
 import com.umc.product.recruiting.application.port.out.LoadRecruitingFormSectionPolicyPort;
@@ -130,6 +131,77 @@ class RecruitingRoundLifecycleCommandServiceTest {
         assertThat(source.isDeleted()).isTrue();
         assertThat(source.getDeletedAt()).isEqualTo(NOW);
         then(saveRoundPort).should().save(source);
+    }
+
+    @Test
+    @DisplayName("삭제된 Round 복구는 삭제 시각을 비우고 저장한다")
+    void restoreDeletedRound() {
+        source.delete(NOW);
+        given(loadRoundPort.getByIdForUpdateIncludingDeleted(20L)).willReturn(source);
+        given(loadRoundPort.existsBySeasonIdAndTypeAndRoundNo(10L, source.getType(), source.getRoundNo()))
+            .willReturn(false);
+        given(loadRoundPort.existsBySeasonIdAndTitleIgnoreCase(10L, source.getTitle())).willReturn(false);
+
+        sut.restoreRound(restoreCommand());
+
+        assertThat(source.isDeleted()).isFalse();
+        assertThat(source.getDeletedAt()).isNull();
+        then(saveRoundPort).should().save(source);
+    }
+
+    @Test
+    @DisplayName("삭제 상태가 아닌 Round는 복구할 수 없다")
+    void rejectRestoreWhenRoundIsNotDeleted() {
+        given(loadRoundPort.getByIdForUpdateIncludingDeleted(20L)).willReturn(source);
+
+        assertThatThrownBy(() -> sut.restoreRound(restoreCommand()))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_ROUND_NOT_DELETED);
+
+        then(saveRoundPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("삭제된 사이에 같은 차수 번호가 선점되면 복구를 거절한다")
+    void rejectRestoreWhenRoundNoIsTaken() {
+        source.delete(NOW);
+        given(loadRoundPort.getByIdForUpdateIncludingDeleted(20L)).willReturn(source);
+        given(loadRoundPort.existsBySeasonIdAndTypeAndRoundNo(10L, source.getType(), source.getRoundNo()))
+            .willReturn(true);
+
+        assertThatThrownBy(() -> sut.restoreRound(restoreCommand()))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_ROUND_RESTORE_CONFLICT);
+
+        assertThat(source.isDeleted()).isTrue();
+        then(saveRoundPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("삭제된 사이에 같은 제목이 선점되면 복구를 거절한다")
+    void rejectRestoreWhenTitleIsTaken() {
+        source.delete(NOW);
+        given(loadRoundPort.getByIdForUpdateIncludingDeleted(20L)).willReturn(source);
+        given(loadRoundPort.existsBySeasonIdAndTypeAndRoundNo(10L, source.getType(), source.getRoundNo()))
+            .willReturn(false);
+        given(loadRoundPort.existsBySeasonIdAndTitleIgnoreCase(10L, source.getTitle())).willReturn(true);
+
+        assertThatThrownBy(() -> sut.restoreRound(restoreCommand()))
+            .isInstanceOf(RecruitingDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(RecruitingErrorCode.RECRUITING_ROUND_RESTORE_CONFLICT);
+
+        then(saveRoundPort).shouldHaveNoInteractions();
+    }
+
+    private RestoreRecruitingRoundCommand restoreCommand() {
+        return RestoreRecruitingRoundCommand.builder()
+            .seasonId(10L)
+            .roundId(20L)
+            .requesterMemberId(99L)
+            .build();
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용

closes #1269 

**무엇을**

모집 차수 삭제를 물리 삭제에서 soft delete로 전환하고 복구 API를 추가합니다.

**왜**

기존 `deleteRound`는 차수와 평가자·면접 질문·면접 세션·지원 폼·Form 구조를 모두 물리 삭제해 복구 수단이 없었습니다. 삭제 토스트의 `취소하기`가 실제로 동작하려면 서버에 되돌릴 경로가 있어야 합니다.

**어떻게**

- `recruiting_round`에 `deleted_at`을 추가하고, 하위 데이터는 건드리지 않습니다. 복구가 플래그를 되돌리는 것만으로 끝나게 하기 위함입니다. 삭제 허용 조건(DRAFT, 지원서·Form 응답 없음)은 그대로입니다.
- 조회 포트에서 삭제된 차수를 제외합니다. 명령 경로마다 가드를 넣지 않아도 기존 `RECRUITING-0002`(NOT_FOUND)로 처리됩니다. 목록·제목 중복 검사·추가모집 채번·잠금 조회에 적용했습니다.
- `(시즌, 유형, 차수 번호)` 유일성 제약을 부분 유니크 인덱스(`WHERE deleted_at IS NULL`)로 교체했습니다. 삭제된 차수가 슬롯을 점유하면 같은 번호로 다시 만들 수 없기 때문입니다.
- 복구 경로를 추가했습니다.
  - `POST /api/v1/recruiting/admin/seasons/{seasonId}/rounds/{roundId}/restore` (`RECRUITING-ADMIN-018`)
  - GraphQL `restoreRecruitingRound(seasonId: ID!, roundId: ID!): Boolean!`
  - `RECRUITING-0120` 삭제 상태가 아닌 차수 / `RECRUITING-0121` 차수 번호·제목 선점

삭제 API의 요청·응답 계약은 변경되지 않습니다.

## 💬 리뷰 중점사항

- 부분 유니크 인덱스와 복구 충돌 검사는 한 쌍입니다. 인덱스가 슬롯을 풀어 주는 대신 삭제된 동안 번호·제목이 선점될 수 있어, 그대로 복구하면 인덱스 위반이 납니다.
- 명령 경로에 삭제 여부 가드를 넣지 않았습니다. 조회 포트에서 이미 걸러집니다. 이 전제가 깨지는 경로가 보이면 알려주세요.
- 통합 테스트는 넣지 않았습니다. 하위 삭제 의존성 자체를 제거해 구조적으로 보장되고, 복구 왕복은 영속성 슬라이스에서 Testcontainers Postgres로 검증했습니다.
