### PR TITLE
[Feat] 데모데이 Poll·부스 관리 API 구현

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
@@ -121,7 +121,9 @@ public class DemodayBoothAdminController {
         @Parameter(description = "부스를 조회할 데모데이 투표 ID", required = true, example = "1")
         @PathVariable("pollId") Long pollId) {
 
-        DemodayAdminBoothListInfo boothListInfo = listDemodayAdminBoothUseCase.listBooths(pollId, memberPrincipal.getMemberId());
+        DemodayAdminBoothListInfo boothListInfo =
+            listDemodayAdminBoothUseCase.listBooths(pollId, memberPrincipal.getMemberId());
+
         return DemodayAdminBoothListResponse.from(boothListInfo);
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
@@ -1,0 +1,127 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.product.demoday.adapter.in.web.dto.request.RegisterDemodayBoothBatchRequest;
+import com.umc.product.demoday.adapter.in.web.dto.request.RegisterDemodayBoothRequest;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayAdminBoothListResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.RegisterDemodayBoothBatchResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.RegisterDemodayBoothResponse;
+import com.umc.product.demoday.application.port.in.command.RegisterDemodayBoothUseCase;
+import com.umc.product.demoday.application.port.in.query.ListDemodayAdminBoothUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(
+    name = "데모데이 부스 관리자",
+    description = "해당 기수 총괄단 또는 SUPER_ADMIN이 데모데이 투표 대상 부스를 관리하는 API"
+)
+@RestController
+@RequestMapping("/api/v1/demoday/admin/polls/{pollId}/booths")
+@RequiredArgsConstructor
+public class DemodayBoothAdminController {
+
+    private final RegisterDemodayBoothUseCase registerDemodayBoothUseCase;
+    private final ListDemodayAdminBoothUseCase listDemodayAdminBoothUseCase;
+
+    @Operation(
+        operationId = "registerDemodayBooth",
+        summary = "데모데이 부스 등록",
+        description = """
+            투표 행사에 부스를 하나 등록합니다.
+
+            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+            등록 경로는 두 가지이며 `projectId`와 `displayName` 중 정확히 하나만 채워 구분합니다.
+            UPMS에 등록된 프로젝트는 `projectId`로, 외부 참가팀은 `displayName`으로 등록합니다.
+            둘 다 채우거나 둘 다 비우면 어느 경로인지 정할 수 없어 400(DEMODAY-0200)으로 거부합니다.
+
+            투표 상태가 OPEN이 되면 더 이상 부스를 추가할 수 없고 409(DEMODAY-0105)를 반환합니다.
+            투표가 시작된 뒤 부스가 늘어나면 먼저 투표한 사람과 나중에 투표한 사람의 선택지가 달라져
+            순위를 비교할 근거가 사라지기 때문입니다. 부스 등록은 투표를 OPEN하기 전에 마쳐야 합니다.
+            """
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public RegisterDemodayBoothResponse registerBooth(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "부스를 등록할 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId,
+        @Valid @RequestBody RegisterDemodayBoothRequest request) {
+
+        Long boothId = registerDemodayBoothUseCase.register(
+            request.toCommand(pollId, memberPrincipal.getMemberId()));
+
+        return RegisterDemodayBoothResponse.from(boothId);
+    }
+
+    @Operation(
+        operationId = "registerDemodayBoothsInBatch",
+        summary = "데모데이 부스 일괄 등록 (시스템 관리자 전용)",
+        description = """
+            **이 API는 시스템 관리자(SUPER_ADMIN)를 위한 API입니다.**
+            해당 기수의 총괄단은 호출할 수 없으며, 총괄단은 단건 등록 API를 사용하세요.
+
+            여러 부스를 한 번의 요청으로 등록합니다. 이번 기수에는 관리자 화면이 없어 운영자가 API를 직접
+            호출하므로, 행사 전 준비 단계에서 부스를 한 번에 넣기 위한 경로입니다.
+
+            항목마다 `projectId`와 `displayName` 중 정확히 하나만 채우는 규칙은 단건 등록과 같습니다.
+            **한 항목이라도 규칙을 어기면 전체가 저장되지 않습니다.** 부분 성공을 허용하면 무엇이 들어갔는지
+            운영자가 목록을 다시 확인해야 하는데, 그 비용이 요청 전체를 고쳐 다시 보내는 비용보다 큽니다.
+
+            응답의 `boothIds`는 요청한 부스 목록과 순서가 같습니다.
+            투표 상태가 OPEN이면 단건 등록과 동일하게 409(DEMODAY-0105)를 반환합니다.
+            """
+    )
+    @PostMapping("/batch")
+    @ResponseStatus(HttpStatus.CREATED)
+    public RegisterDemodayBoothBatchResponse registerBoothsInBatch(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "부스를 등록할 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId,
+        @Valid @RequestBody RegisterDemodayBoothBatchRequest request) {
+
+        List<Long> boothIds = registerDemodayBoothUseCase.registerAll(
+            request.toCommand(pollId, memberPrincipal.getMemberId()));
+
+        return RegisterDemodayBoothBatchResponse.from(boothIds);
+    }
+
+    @Operation(
+        operationId = "listDemodayAdminBooths",
+        summary = "데모데이 부스 등록 현황 조회",
+        description = """
+            투표에 등록된 부스 목록을 부스 ID 오름차순으로 조회합니다.
+
+            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+            등록 직후 운영자가 확인해야 하는 값을 함께 내려줍니다.
+            `boothCount`로 등록 개수를, `boothAddable`로 아직 부스를 더 넣을 수 있는지를 확인하세요.
+
+            참여자용 목록(`GET /api/v1/demoday/polls/{pollId}/booths`)과 달리 투표의 운영 상태를 포함합니다.
+            """
+    )
+    @GetMapping
+    public DemodayAdminBoothListResponse listBooths(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "부스를 조회할 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId) {
+
+        DemodayAdminBoothListInfo boothListInfo = listDemodayAdminBoothUseCase.listBooths(pollId, memberPrincipal.getMemberId());
+        return DemodayAdminBoothListResponse.from(boothListInfo);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,10 +1,12 @@
 package com.umc.product.demoday.adapter.in.web;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.demoday.adapter.in.web.dto.request.ChangeDemodayPollStatusRequest;
@@ -35,7 +37,7 @@ public class DemodayPollAdminController {
 
     @Operation(
         operationId = "createDemodayPoll",
-        summary = "데모데이 투표 생성",
+        summary = "데모데이 투표 행사 생성",
         description = """
             데모데이 투표를 CLOSED 상태로 생성합니다.
 
@@ -44,6 +46,7 @@ public class DemodayPollAdminController {
             """
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public CreateDemodayPollResponse createPoll(
         @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
         @Valid @RequestBody CreateDemodayPollRequest request) {

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.umc.product.demoday.adapter.in.web.dto.ChangeDemodayPollStatusRequest;
-import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollRequest;
-import com.umc.product.demoday.adapter.in.web.dto.CreateDemodayPollResponse;
+import com.umc.product.demoday.adapter.in.web.dto.request.ChangeDemodayPollStatusRequest;
+import com.umc.product.demoday.adapter.in.web.dto.request.CreateDemodayPollRequest;
+import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayPollResponse;
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
 import com.umc.product.global.security.MemberPrincipal;

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/ChangeDemodayPollStatusRequest.java
@@ -1,4 +1,4 @@
-package com.umc.product.demoday.adapter.in.web.dto;
+package com.umc.product.demoday.adapter.in.web.dto.request;
 
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/CreateDemodayPollRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/CreateDemodayPollRequest.java
@@ -1,4 +1,4 @@
-package com.umc.product.demoday.adapter.in.web.dto;
+package com.umc.product.demoday.adapter.in.web.dto.request;
 
 import java.time.Instant;
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/RegisterDemodayBoothBatchRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/RegisterDemodayBoothBatchRequest.java
@@ -1,0 +1,35 @@
+package com.umc.product.demoday.adapter.in.web.dto.request;
+
+import java.util.List;
+
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+@Schema(
+    description = """
+        데모데이 부스 일괄 등록 요청.
+
+        항목마다 projectId와 displayName 중 정확히 하나만 채웁니다.
+        한 항목이라도 규칙을 어기면 전체가 저장되지 않습니다.
+        """
+)
+public record RegisterDemodayBoothBatchRequest(
+    @Schema(description = "등록할 부스 목록. 최소 1건이어야 합니다.")
+    @NotEmpty List<@Valid RegisterDemodayBoothRequest> booths
+) {
+
+    public RegisterDemodayBoothBatchCommand toCommand(Long pollId, Long memberId) {
+        return new RegisterDemodayBoothBatchCommand(
+            memberId,
+            pollId,
+            booths.stream()
+                .map(booth -> new RegisterDemodayBoothBatchCommand.BoothRegistration(
+                    booth.projectId(),
+                    booth.displayName()))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/RegisterDemodayBoothRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/RegisterDemodayBoothRequest.java
@@ -1,0 +1,33 @@
+package com.umc.product.demoday.adapter.in.web.dto.request;
+
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    description = """
+        데모데이 부스 등록 요청.
+
+        projectId와 displayName 중 **정확히 하나만** 채웁니다. 둘 다 채우거나 둘 다 비우면 400으로 거부합니다.
+        """
+)
+public record RegisterDemodayBoothRequest(
+    @Schema(
+        description = "UPMS에 등록된 프로젝트 ID. 등록된 프로젝트를 부스로 올릴 때만 채웁니다.",
+        example = "101",
+        nullable = true
+    )
+    Long projectId,
+
+    @Schema(
+        description = "외부 참가팀의 부스 표시 이름. UPMS에 프로젝트가 없을 때만 채우며 1자 이상 255자 이하입니다.",
+        example = "외부 참가팀 A",
+        nullable = true
+    )
+    String displayName
+) {
+
+    public RegisterDemodayBoothCommand toCommand(Long pollId, Long memberId) {
+        return new RegisterDemodayBoothCommand(memberId, pollId, projectId, displayName);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayPollResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayPollResponse.java
@@ -1,4 +1,4 @@
-package com.umc.product.demoday.adapter.in.web.dto;
+package com.umc.product.demoday.adapter.in.web.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayAdminBoothListResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayAdminBoothListResponse.java
@@ -1,0 +1,40 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.util.List;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "운영자용 데모데이 부스 등록 현황")
+public record DemodayAdminBoothListResponse(
+    @Schema(description = "데모데이 투표 ID", example = "1")
+    Long pollId,
+
+    @Schema(description = "투표의 현재 운영 상태", example = "CLOSED")
+    DemodayPollStatus pollStatus,
+
+    @Schema(
+        description = "부스를 더 등록할 수 있는지 여부. 투표가 OPEN이 되는 순간부터 false가 됩니다.",
+        example = "true"
+    )
+    boolean boothAddable,
+
+    @Schema(description = "등록된 부스 수", example = "8")
+    int boothCount,
+
+    @Schema(description = "등록된 부스 목록. 부스 ID 오름차순입니다.")
+    List<DemodayBoothResponse> booths
+) {
+
+    public static DemodayAdminBoothListResponse from(DemodayAdminBoothListInfo info) {
+        return new DemodayAdminBoothListResponse(
+            info.pollId(),
+            info.pollStatus(),
+            info.boothAddable(),
+            info.boothCount(),
+            info.booths().stream().map(DemodayBoothResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/RegisterDemodayBoothBatchResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/RegisterDemodayBoothBatchResponse.java
@@ -1,0 +1,19 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 부스 일괄 등록 결과")
+public record RegisterDemodayBoothBatchResponse(
+    @Schema(description = "등록된 부스 수", example = "3")
+    int registeredCount,
+
+    @Schema(description = "등록된 부스 ID. 요청한 부스 목록과 순서가 같습니다.", example = "[20, 21, 22]")
+    List<Long> boothIds
+) {
+
+    public static RegisterDemodayBoothBatchResponse from(List<Long> boothIds) {
+        return new RegisterDemodayBoothBatchResponse(boothIds.size(), boothIds);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/RegisterDemodayBoothResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/RegisterDemodayBoothResponse.java
@@ -1,0 +1,14 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 부스 등록 결과")
+public record RegisterDemodayBoothResponse(
+    @Schema(description = "등록된 부스 ID", example = "20")
+    Long boothId
+) {
+
+    public static RegisterDemodayBoothResponse from(Long boothId) {
+        return new RegisterDemodayBoothResponse(boothId);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/RegisterDemodayBoothUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/RegisterDemodayBoothUseCase.java
@@ -1,0 +1,16 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import java.util.List;
+
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothCommand;
+
+public interface RegisterDemodayBoothUseCase {
+
+    Long register(RegisterDemodayBoothCommand command);
+
+    /**
+     * @return 저장된 부스 ID. 입력 순서와 인덱스가 대응한다.
+     */
+    List<Long> registerAll(RegisterDemodayBoothBatchCommand command);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/RegisterDemodayBoothBatchCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/RegisterDemodayBoothBatchCommand.java
@@ -1,0 +1,23 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.util.List;
+
+/**
+ * 부스 일괄 등록 요청이다. 항목 하나하나는 {@link RegisterDemodayBoothCommand}와 같은 규칙을 따른다.
+ *
+ * <p>등록 결과는 입력 순서와 인덱스로 대응하며, 한 항목이라도 규칙을 어기면 전체가 저장되지 않는다.
+ * 부분 성공을 허용하면 운영자가 무엇이 들어갔는지 확인하러 목록을 다시 훑어야 하는데, 부스는 투표를
+ * OPEN하기 전에 한 번에 준비하는 자원이라 그 확인 비용이 재시도 비용보다 크다.
+ */
+public record RegisterDemodayBoothBatchCommand(
+    Long memberId,
+    Long pollId,
+    List<BoothRegistration> registrations
+) {
+
+    public record BoothRegistration(
+        Long projectId,
+        String displayName
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/RegisterDemodayBoothCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/RegisterDemodayBoothCommand.java
@@ -1,0 +1,15 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+/**
+ * 부스 등록 요청이다. {@code projectId}와 {@code displayName} 중 정확히 하나만 채워야 한다.
+ *
+ * <p> 둘 중 무엇을 채웠는지를 통해서 등록 경로를 결정한다.
+ * <p> {@code projectId}는 UPMS에 등록된 프로젝트에 연결하는 경로, {@code displayName}은 UPMS에 없는 외부 참가팀 경로다.
+ */
+public record RegisterDemodayBoothCommand(
+    Long memberId,
+    Long pollId,
+    Long projectId,
+    String displayName
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/ListDemodayAdminBoothUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/ListDemodayAdminBoothUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.in.query;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+
+public interface ListDemodayAdminBoothUseCase {
+
+    DemodayAdminBoothListInfo listBooths(Long pollId, Long memberId);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayAdminBoothListInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayAdminBoothListInfo.java
@@ -1,0 +1,21 @@
+package com.umc.product.demoday.application.port.in.query.dto;
+
+import java.util.List;
+
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+
+/**
+ * 운영자가 부스 등록 결과를 확인하는 읽기 모델이다.
+ *
+ * <p>참여자용 목록과 달리 투표의 운영 상태와 부스 수를 함께 담는다. 등록 직후 운영자가 확인하는 것이
+ * 개별 부스가 아니라 "몇 개가 등록됐고 아직 더 넣을 수 있는가"이기 때문이다. {@code boothAddable}은
+ * 상태에서 파생되지만, 잠금 규칙을 클라이언트가 다시 계산하지 않도록 서버가 판단한 결과를 그대로 내려준다.
+ */
+public record DemodayAdminBoothListInfo(
+    Long pollId,
+    DemodayPollStatus pollStatus,
+    boolean boothAddable,
+    int boothCount,
+    List<DemodayBoothInfo> booths
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/service/DemodayAdminAccessChecker.java
+++ b/src/main/java/com/umc/product/demoday/application/service/DemodayAdminAccessChecker.java
@@ -19,4 +19,16 @@ public class DemodayAdminAccessChecker {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
         }
     }
+
+    /**
+     * 기수와 무관하게 시스템 관리자(SUPER_ADMIN)인지 검사한다.
+     *
+     * <p>{@link #validateAdminAccess(Long, Long)}는 해당 기수의 총괄단도 통과시키지만 이 검사는 통과시키지 않는다.
+     * 한 번에 여러 행을 만드는 일괄 경로처럼, 실수의 파급이 크고 평시 운영 흐름에 속하지 않는 API에 쓴다.
+     */
+    public void validateSystemAdminAccess(Long memberId) {
+        if (!authorityUseCase.isSuperAdmin(memberId)) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+        }
+    }
 }

--- a/src/main/java/com/umc/product/demoday/application/service/DemodayAdminAccessChecker.java
+++ b/src/main/java/com/umc/product/demoday/application/service/DemodayAdminAccessChecker.java
@@ -1,4 +1,4 @@
-package com.umc.product.demoday.application.service.command;
+package com.umc.product.demoday.application.service;
 
 import org.springframework.stereotype.Component;
 
@@ -15,7 +15,7 @@ public class DemodayAdminAccessChecker {
     private final CheckChallengerAuthorityUseCase authorityUseCase;
 
     public void validateAdminAccess(Long memberId, Long gisuId) {
-        if(!authorityUseCase.isCentralCoreInGisu(memberId, gisuId)){
+        if (!authorityUseCase.isCentralCoreInGisu(memberId, gisuId)) {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
         }
     }

--- a/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
@@ -7,6 +7,7 @@ import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStat
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
 import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
 import com.umc.product.demoday.domain.DemodayPoll;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,8 @@ public class CreateDemodayPollCommandService implements CreateDemodayPollUseCase
     public Long create(CreateDemodayPollCommand command) {
         adminAccessChecker.validateAdminAccess(command.memberId(), command.gisuId());
 
-        DemodayPoll demodayPoll = DemodayPoll.create(command.gisuId(), command.name(), command.opensAt(), command.closesAt());
+        DemodayPoll demodayPoll = DemodayPoll.create(
+            command.gisuId(), command.name(), command.opensAt(), command.closesAt());
         DemodayPoll savedPoll = saveDemodayPollPort.save(demodayPoll);
         return savedPoll.getId();
     }

--- a/src/main/java/com/umc/product/demoday/application/service/command/RegisterDemodayBoothCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/RegisterDemodayBoothCommandService.java
@@ -1,0 +1,84 @@
+package com.umc.product.demoday.application.service.command;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.RegisterDemodayBoothUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothCommand;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayBoothPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegisterDemodayBoothCommandService implements RegisterDemodayBoothUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final SaveDemodayBoothPort saveDemodayBoothPort;
+
+    @Override
+    public Long register(RegisterDemodayBoothCommand command) {
+        DemodayPoll poll = loadPoll(command.pollId());
+
+        adminAccessChecker.validateAdminAccess(command.memberId(), poll.getGisuId());
+
+        return saveDemodayBoothPort.save(createBooth(poll, command.projectId(), command.displayName())).getId();
+    }
+
+    /**
+     * 일괄 경로는 시스템 관리자만 호출할 수 있다.
+     *
+     * <p>단건 경로와 달리 기수 총괄단은 통과시키지 않으므로, 투표를 조회하기 전에 권한부터 확인한다.
+     * 권한이 없는 요청에 투표의 존재 여부를 알려 줄 이유가 없기 때문이다.
+     */
+    @Override
+    public List<Long> registerAll(RegisterDemodayBoothBatchCommand command) {
+        adminAccessChecker.validateSystemAdminAccess(command.memberId());
+
+        DemodayPoll poll = loadPoll(command.pollId());
+
+        List<DemodayBooth> booths = command.registrations().stream()
+            .map(registration -> createBooth(poll, registration.projectId(), registration.displayName()))
+            .toList();
+
+        return saveDemodayBoothPort.saveAll(booths).stream()
+            .map(DemodayBooth::getId)
+            .toList();
+    }
+
+    private DemodayPoll loadPoll(Long pollId) {
+        return loadDemodayPollPort.findById(pollId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+    }
+
+    /**
+     * 두 등록 경로 중 어느 쪽인지 고른다.
+     *
+     * <p>여기서 판단하는 것은 "요청이 어느 경로를 의도했는가"뿐이다. 부스가 프로젝트와 표시 이름을 동시에
+     * 갖지 않는다는 규칙은 투표가 위임하는 두 팩토리가 각각 한쪽만 채우는 것으로 이미 보장되므로, 서비스가
+     * 그 규칙을 다시 검사하지는 않는다. 다만 둘 다 담겨 온 요청은 어느 경로인지 정할 수 없어 거부한다.
+     */
+    private DemodayBooth createBooth(DemodayPoll poll, Long projectId, String displayName) {
+        boolean hasProject = projectId != null;
+        boolean hasDisplayName = displayName != null && !displayName.isBlank();
+
+        if (hasProject == hasDisplayName) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER);
+        }
+
+        return hasProject
+            ? poll.registerProjectBooth(projectId)
+            : poll.registerExternalBooth(displayName);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryService.java
@@ -1,0 +1,59 @@
+package com.umc.product.demoday.application.service.query;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.query.ListDemodayAdminBoothUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 운영자용 부스 조회를 참여자용 조회({@link DemodayPollQueryService})와 분리한다.
+ *
+ * <p>두 조회는 같은 부스를 읽지만 접근 주체가 다르다. 참여자용은 인증 없이 열려 있고 운영자용은 해당 기수
+ * 총괄단만 볼 수 있으므로, 한 서비스에 합치면 권한 검사가 있는 메서드와 없는 메서드가 섞인다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DemodayAdminBoothQueryService implements ListDemodayAdminBoothUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final LoadDemodayBoothPort loadDemodayBoothPort;
+
+    @Override
+    public DemodayAdminBoothListInfo listBooths(Long pollId, Long memberId) {
+        DemodayPoll poll = loadDemodayPollPort.findById(pollId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(memberId, poll.getGisuId());
+
+        List<DemodayBoothInfo> booths = loadDemodayBoothPort.listByPollId(pollId)
+            .stream()
+            .map(booth -> new DemodayBoothInfo(
+                booth.getId(),
+                booth.getProjectId(),
+                booth.getDisplayName()
+            ))
+            .toList();
+
+        return new DemodayAdminBoothListInfo(
+            poll.getId(),
+            poll.getStatus(),
+            poll.isBoothRegistrable(),
+            booths.size(),
+            booths
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.umc.product.common.BaseEntity;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
@@ -127,6 +128,52 @@ public class DemodayPoll extends BaseEntity {
 
     public List<DemodayBooth> getBooths() {
         return Collections.unmodifiableList(booths);
+    }
+
+    /**
+     * 등록된 프로젝트에 연결되는 부스를 만든다.
+     *
+     * <p>부스 생성 자체는 {@link DemodayBooth#forProject(Long, Long)}가 담당하지만, 진입점을 투표에 두는 이유는
+     * 부스를 더 받을 수 있는지 판단하는 근거가 투표의 운영 상태이기 때문이다. 식별자만 넘기는 팩토리를 직접
+     * 호출하면 이 판단을 호출자가 대신해야 하고, 호출자가 빠뜨리면 규칙이 사라진다.
+     *
+     * <p>반환된 부스는 아직 저장되지 않았고 {@link #getBooths()}에도 반영되지 않는다. 이 컬렉션은 조회 전용
+     * 뷰이므로 저장은 호출자가 부스 저장 Port로 수행한다.
+     */
+    public DemodayBooth registerProjectBooth(Long projectId) {
+        requireBoothRegistrable();
+        return DemodayBooth.forProject(requirePersistedId(), projectId);
+    }
+
+    /**
+     * UPMS에 등록되지 않은 외부 참가팀의 부스를 표시 이름으로 만든다.
+     *
+     * @see #registerProjectBooth(Long)
+     */
+    public DemodayBooth registerExternalBooth(String displayName) {
+        requireBoothRegistrable();
+        return DemodayBooth.forExternal(requirePersistedId(), displayName);
+    }
+
+    /**
+     * 부스를 더 등록할 수 있는지 여부다.
+     *
+     * <p>투표가 시작된 뒤에 부스가 늘어나면 먼저 투표한 사람은 그 부스를 보지 못한 채 표를 던진 것이 되어,
+     * 같은 투표 안에서 사람마다 선택지가 달라진다. 그러면 순위를 비교할 근거가 사라지므로 OPEN이 되는 순간부터
+     * 부스 추가를 막는다.
+     */
+    public boolean isBoothRegistrable() {
+        return DemodayPollStatus.OPEN != status;
+    }
+
+    private void requireBoothRegistrable() {
+        if (!isBoothRegistrable()) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED);
+        }
+    }
+
+    private Long requirePersistedId() {
+        return Objects.requireNonNull(id, "poll must be persisted before registering a booth");
     }
 
     public void open() {

--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -38,8 +38,22 @@ info:
 
       UMC 회원은 위 API로 AT를 발급받은 뒤
       `GET /api/v1/demoday/polls/{pollId}/participations/me`로 참여 흐름에 진입합니다.
-    - 부스 등록 API — 이번 기수에는 관리자 화면 없이 운영자가 직접 호출하며 계약이 아직 없습니다.
-    - Poll 구성 관리(생성·수정·상태 변경) - 아직 미설계
+    - **부스 등록·등록 현황 조회 API** — 구현되었으므로
+      [Scalar 자동 생성본](/docs/scalar.html)의 `데모데이 부스 관리자`에서 확인하세요.
+      - 등록: `POST /api/v1/demoday/admin/polls/{pollId}/booths`
+      - 일괄 등록(SUPER_ADMIN 전용): `POST /api/v1/demoday/admin/polls/{pollId}/booths/batch`
+      - 현황 조회: `GET /api/v1/demoday/admin/polls/{pollId}/booths`
+
+      이번 기수에는 관리자 화면 없이 운영자가 직접 호출합니다. 부스는 투표를 OPEN하기 전에 모두 등록해야 하며,
+      OPEN 이후 등록 요청은 `409 DEMODAY-0105`로 거부됩니다.
+    - **Poll 생성·상태 변경 API** — 구현되었으므로
+      [Scalar 자동 생성본](/docs/scalar.html)의 `데모데이 투표 관리자`에서 확인하세요.
+      - 생성: `POST /api/v1/demoday/admin/polls`
+      - 상태 변경: `PATCH /api/v1/demoday/admin/polls/{pollId}/status`
+
+      Poll은 항상 `CLOSED`로 생성되고, `opensAt`·`closesAt`이 지나도 상태가 자동으로 바뀌지 않습니다.
+      OPEN·CLOSED 전환은 위 상태 변경 API 호출로만 일어납니다.
+    - Poll 수정(이름·투표 창 변경) — 아직 미설계
     - 이상 패턴 조회 — 이번 기수에서는 개발하지 않을 예정입니다.(시간 부족..)
     - QR 이미지 렌더링 — `qrValue` 문자열을 FE가 그대로 렌더링합니다.
 

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminControllerTest.java
@@ -1,0 +1,219 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.demoday.application.port.in.command.RegisterDemodayBoothUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand.BoothRegistration;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothCommand;
+import com.umc.product.demoday.application.port.in.query.ListDemodayAdminBoothUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+
+@WebMvcTest(controllers = DemodayBoothAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(JacksonConfig.class)
+@DisplayName("DemodayBoothAdminController")
+class DemodayBoothAdminControllerTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 10L;
+    private static final Long PROJECT_ID = 101L;
+    private static final Long BOOTH_ID = 20L;
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean private RegisterDemodayBoothUseCase registerDemodayBoothUseCase;
+
+    @MockitoBean private ListDemodayAdminBoothUseCase listDemodayAdminBoothUseCase;
+
+    @BeforeEach
+    void setUp() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("projectId로 부스를 등록하면 201과 부스 ID를 반환한다")
+    void registerProjectBooth() throws Exception {
+        // given
+        given(registerDemodayBoothUseCase.register(any(RegisterDemodayBoothCommand.class)))
+            .willReturn(BOOTH_ID);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"projectId\": 101}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.result.boothId").value(BOOTH_ID));
+
+        then(registerDemodayBoothUseCase).should()
+            .register(new RegisterDemodayBoothCommand(MEMBER_ID, POLL_ID, PROJECT_ID, null));
+    }
+
+    @Test
+    @DisplayName("displayName으로 외부 부스를 등록하면 201과 부스 ID를 반환한다")
+    void registerExternalBooth() throws Exception {
+        // given
+        given(registerDemodayBoothUseCase.register(any(RegisterDemodayBoothCommand.class)))
+            .willReturn(BOOTH_ID);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"displayName\": \"외부 참가팀 A\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.result.boothId").value(BOOTH_ID));
+
+        then(registerDemodayBoothUseCase).should()
+            .register(new RegisterDemodayBoothCommand(MEMBER_ID, POLL_ID, null, "외부 참가팀 A"));
+    }
+
+    @Test
+    @DisplayName("투표가 OPEN이면 부스 등록은 409와 잠금 코드를 반환한다")
+    void returnConflictWhenBoothLocked() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED))
+            .given(registerDemodayBoothUseCase)
+            .register(any(RegisterDemodayBoothCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"projectId\": 101}"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED.getCode()));
+    }
+
+    @Test
+    @DisplayName("등록 경로를 정할 수 없는 요청은 400과 식별자 오류 코드를 반환한다")
+    void returnBadRequestWhenIdentifierIsAmbiguous() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER))
+            .given(registerDemodayBoothUseCase)
+            .register(any(RegisterDemodayBoothCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"projectId\": 101, \"displayName\": \"외부 참가팀 A\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER.getCode()));
+    }
+
+    @Test
+    @DisplayName("부스를 일괄 등록하면 201과 등록 수·부스 ID 목록을 순서대로 반환한다")
+    void registerBoothsInBatch() throws Exception {
+        // given
+        given(registerDemodayBoothUseCase.registerAll(any(RegisterDemodayBoothBatchCommand.class)))
+            .willReturn(List.of(BOOTH_ID, BOOTH_ID + 1));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths/batch", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"booths": [{"projectId": 101}, {"displayName": "외부 참가팀 A"}]}
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.result.registeredCount").value(2))
+            .andExpect(jsonPath("$.result.boothIds[0]").value(BOOTH_ID))
+            .andExpect(jsonPath("$.result.boothIds[1]").value(BOOTH_ID + 1));
+
+        then(registerDemodayBoothUseCase).should()
+            .registerAll(new RegisterDemodayBoothBatchCommand(MEMBER_ID, POLL_ID, List.of(
+                new BoothRegistration(PROJECT_ID, null),
+                new BoothRegistration(null, "외부 참가팀 A"))));
+    }
+
+    @Test
+    @DisplayName("일괄 등록 요청의 부스 목록이 비면 400을 반환하고 유스케이스를 호출하지 않는다")
+    void rejectEmptyBatch() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths/batch", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"booths\": []}"))
+            .andExpect(status().isBadRequest());
+
+        then(registerDemodayBoothUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("시스템 관리자가 아니면 일괄 등록은 권한 오류 코드를 반환한다")
+    void rejectBatchWhenNotSystemAdmin() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED))
+            .given(registerDemodayBoothUseCase)
+            .registerAll(any(RegisterDemodayBoothBatchCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/admin/polls/{pollId}/booths/batch", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"booths\": [{\"projectId\": 101}]}"))
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED.getCode()));
+    }
+
+    @Test
+    @DisplayName("부스 등록 현황을 조회하면 운영 상태와 등록 개수를 함께 반환한다")
+    void listBooths() throws Exception {
+        // given
+        DemodayAdminBoothListInfo info = new DemodayAdminBoothListInfo(
+            POLL_ID,
+            DemodayPollStatus.CLOSED,
+            true,
+            2,
+            List.of(
+                new DemodayBoothInfo(BOOTH_ID, PROJECT_ID, null),
+                new DemodayBoothInfo(21L, null, "외부 참가팀 A")));
+        given(listDemodayAdminBoothUseCase.listBooths(POLL_ID, MEMBER_ID)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/booths", POLL_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.pollId").value(POLL_ID))
+            .andExpect(jsonPath("$.result.pollStatus").value("CLOSED"))
+            .andExpect(jsonPath("$.result.boothAddable").value(true))
+            .andExpect(jsonPath("$.result.boothCount").value(2))
+            .andExpect(jsonPath("$.result.booths[0].boothId").value(BOOTH_ID))
+            .andExpect(jsonPath("$.result.booths[0].projectId").value(PROJECT_ID))
+            .andExpect(jsonPath("$.result.booths[1].displayName").value("외부 참가팀 A"));
+
+        then(listDemodayAdminBoothUseCase).should().listBooths(POLL_ID, MEMBER_ID);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.umc.product.demoday.application.port.in.command.dto.ChangeDemodayPollStatusCommand;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;

--- a/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayPollCommandServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayPollCommand;
 import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;

--- a/src/test/java/com/umc/product/demoday/application/service/command/RegisterDemodayBoothCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/RegisterDemodayBoothCommandServiceTest.java
@@ -1,0 +1,325 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand.BoothRegistration;
+import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothCommand;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayBoothPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegisterDemodayBoothCommandService")
+class RegisterDemodayBoothCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 10L;
+    private static final Long GISU_ID = 8L;
+    private static final Long PROJECT_ID = 101L;
+    private static final Long BOOTH_ID = 20L;
+    private static final String DISPLAY_NAME = "외부 참가팀 A";
+    private static final String POLL_NAME = "8기 데모데이 투표";
+    private static final Instant OPENS_AT = Instant.parse("2026-08-15T09:00:00Z");
+    private static final Instant CLOSES_AT = Instant.parse("2026-08-15T12:00:00Z");
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private SaveDemodayBoothPort saveDemodayBoothPort;
+
+    @Captor
+    private ArgumentCaptor<DemodayBooth> boothCaptor;
+
+    @Captor
+    private ArgumentCaptor<List<DemodayBooth>> boothListCaptor;
+
+    @InjectMocks
+    private RegisterDemodayBoothCommandService service;
+
+    @Test
+    @DisplayName("projectId만 담긴 요청은 프로젝트 부스로 저장하고 부스 ID를 반환한다")
+    void registerProjectBooth() {
+        // given
+        givenClosedPoll();
+        givenSaveAssignsBoothId();
+
+        // when
+        Long boothId = service.register(commandOf(PROJECT_ID, null));
+
+        // then
+        assertThat(boothId).isEqualTo(BOOTH_ID);
+
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayBoothPort).should().save(boothCaptor.capture());
+
+        assertThat(boothCaptor.getValue().getPollId()).isEqualTo(POLL_ID);
+        assertThat(boothCaptor.getValue().getProjectId()).isEqualTo(PROJECT_ID);
+        assertThat(boothCaptor.getValue().getDisplayName()).isNull();
+    }
+
+    @Test
+    @DisplayName("displayName만 담긴 요청은 외부 부스로 저장한다")
+    void registerExternalBooth() {
+        // given
+        givenClosedPoll();
+        givenSaveAssignsBoothId();
+
+        // when
+        Long boothId = service.register(commandOf(null, DISPLAY_NAME));
+
+        // then
+        assertThat(boothId).isEqualTo(BOOTH_ID);
+        then(saveDemodayBoothPort).should().save(boothCaptor.capture());
+        assertThat(boothCaptor.getValue().getProjectId()).isNull();
+        assertThat(boothCaptor.getValue().getDisplayName()).isEqualTo(DISPLAY_NAME);
+    }
+
+    @Test
+    @DisplayName("projectId와 displayName이 모두 담기면 등록 경로를 정할 수 없어 저장하지 않는다")
+    void rejectCommandWithBothIdentifiers() {
+        // given
+        givenClosedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(PROJECT_ID, DISPLAY_NAME)))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER));
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("projectId와 displayName이 모두 비면 저장하지 않는다")
+    void rejectCommandWithoutIdentifier() {
+        // given
+        givenClosedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(null, null)))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER));
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("공백만 담긴 displayName은 값이 없는 것으로 보고 저장하지 않는다")
+    void rejectCommandWithBlankDisplayName() {
+        // given
+        givenClosedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(null, "   ")))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER));
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("투표가 OPEN이면 부스를 추가하지 않고 잠금 오류로 거부한다")
+    void rejectRegistrationWhenPollIsOpen() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(PROJECT_ID, null)))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED));
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("투표가 존재하지 않으면 권한 검사와 저장을 수행하지 않는다")
+    void rejectRegistrationWhenPollDoesNotExist() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(PROJECT_ID, null)))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 부스를 저장하지 않는다")
+    void rejectRegistrationWhenAdminAccessIsDenied() {
+        // given
+        givenClosedPoll();
+
+        DemodayDomainException expectedException =
+            new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+
+        willThrow(expectedException)
+            .given(adminAccessChecker)
+            .validateAdminAccess(MEMBER_ID, GISU_ID);
+
+        // when & then
+        assertThatThrownBy(() -> service.register(commandOf(PROJECT_ID, null)))
+            .isSameAs(expectedException);
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("일괄 등록은 입력 순서와 대응하는 부스 ID 목록을 반환한다")
+    void registerBoothsInBatch() {
+        // given
+        givenClosedPoll();
+        givenSaveAllAssignsSequentialIds();
+
+        // when
+        List<Long> boothIds = service.registerAll(batchCommandOf(
+            new BoothRegistration(PROJECT_ID, null),
+            new BoothRegistration(null, DISPLAY_NAME)));
+
+        // then
+        assertThat(boothIds).containsExactly(BOOTH_ID, BOOTH_ID + 1);
+
+        then(adminAccessChecker).should().validateSystemAdminAccess(MEMBER_ID);
+        then(saveDemodayBoothPort).should().saveAll(boothListCaptor.capture());
+
+        assertThat(boothListCaptor.getValue())
+            .extracting(DemodayBooth::getProjectId, DemodayBooth::getDisplayName)
+            .containsExactly(tuple(PROJECT_ID, null), tuple(null, DISPLAY_NAME));
+    }
+
+    @Test
+    @DisplayName("일괄 등록은 시스템 관리자가 아니면 투표를 조회하지도 않는다")
+    void rejectBatchWhenNotSystemAdmin() {
+        // given
+        DemodayDomainException expectedException =
+            new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+
+        willThrow(expectedException)
+            .given(adminAccessChecker)
+            .validateSystemAdminAccess(MEMBER_ID);
+
+        // when & then
+        assertThatThrownBy(() -> service.registerAll(
+            batchCommandOf(new BoothRegistration(PROJECT_ID, null))))
+            .isSameAs(expectedException);
+
+        then(loadDemodayPollPort).shouldHaveNoInteractions();
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("일괄 등록은 한 항목이라도 등록 경로가 모호하면 전체를 저장하지 않는다")
+    void rejectWholeBatchWhenAnyItemIsAmbiguous() {
+        // given
+        givenClosedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> service.registerAll(
+            batchCommandOf(
+                new BoothRegistration(PROJECT_ID, null),
+                new BoothRegistration(PROJECT_ID, DISPLAY_NAME))))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_BOOTH_INVALID_IDENTIFIER));
+
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("일괄 등록도 투표가 OPEN이면 잠금 오류로 거부한다")
+    void rejectBatchWhenPollIsOpen() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        // when & then
+        assertThatThrownBy(() -> service.registerAll(batchCommandOf(new BoothRegistration(PROJECT_ID, null))))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED));
+        then(saveDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    private void givenClosedPoll() {
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(persistedPoll()));
+    }
+
+    private void givenSaveAssignsBoothId() {
+        given(saveDemodayBoothPort.save(any(DemodayBooth.class))).willAnswer(invocation -> {
+            DemodayBooth booth = invocation.getArgument(0);
+            ReflectionTestUtils.setField(booth, "id", BOOTH_ID);
+            return booth;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenSaveAllAssignsSequentialIds() {
+        given(saveDemodayBoothPort.saveAll(any(List.class))).willAnswer(invocation -> {
+            List<DemodayBooth> booths = invocation.getArgument(0);
+            long nextId = BOOTH_ID;
+            for (DemodayBooth booth : booths) {
+                ReflectionTestUtils.setField(booth, "id", nextId++);
+            }
+            return booths;
+        });
+    }
+
+    private RegisterDemodayBoothBatchCommand batchCommandOf(BoothRegistration... registrations) {
+        return new RegisterDemodayBoothBatchCommand(MEMBER_ID, POLL_ID, List.of(registrations));
+    }
+
+    private DemodayPoll persistedPoll() {
+        DemodayPoll poll = DemodayPoll.create(GISU_ID, POLL_NAME, OPENS_AT, CLOSES_AT);
+        ReflectionTestUtils.setField(poll, "id", POLL_ID);
+        return poll;
+    }
+
+    private RegisterDemodayBoothCommand commandOf(Long projectId, String displayName) {
+        return new RegisterDemodayBoothCommand(MEMBER_ID, POLL_ID, projectId, displayName);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryServiceTest.java
@@ -1,0 +1,146 @@
+package com.umc.product.demoday.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.enums.DemodayPollStatus;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DemodayAdminBoothQueryService")
+class DemodayAdminBoothQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 10L;
+    private static final Long GISU_ID = 8L;
+    private static final String POLL_NAME = "8기 데모데이 투표";
+    private static final Instant OPENS_AT = Instant.parse("2026-08-15T09:00:00Z");
+    private static final Instant CLOSES_AT = Instant.parse("2026-08-15T12:00:00Z");
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private LoadDemodayBoothPort loadDemodayBoothPort;
+
+    @InjectMocks
+    private DemodayAdminBoothQueryService service;
+
+    @Test
+    @DisplayName("닫힌 투표의 부스 목록과 등록 개수를 조회하고 아직 추가할 수 있다고 알린다")
+    void listBoothsOfClosedPoll() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(persistedPoll()));
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(
+            booth(20L, 101L, null),
+            booth(21L, null, "외부 참가팀 A")
+        ));
+
+        // when
+        DemodayAdminBoothListInfo info = service.listBooths(POLL_ID, MEMBER_ID);
+
+        // then
+        assertThat(info.pollId()).isEqualTo(POLL_ID);
+        assertThat(info.pollStatus()).isEqualTo(DemodayPollStatus.CLOSED);
+        assertThat(info.boothAddable()).isTrue();
+        assertThat(info.boothCount()).isEqualTo(2);
+        assertThat(info.booths())
+            .extracting(DemodayBoothInfo::boothId, DemodayBoothInfo::projectId, DemodayBoothInfo::displayName)
+            .containsExactly(
+                tuple(20L, 101L, null),
+                tuple(21L, null, "외부 참가팀 A"));
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+    }
+
+    @Test
+    @DisplayName("열린 투표는 부스를 더 추가할 수 없다고 알린다")
+    void reportBoothLockedForOpenPoll() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of());
+
+        // when
+        DemodayAdminBoothListInfo info = service.listBooths(POLL_ID, MEMBER_ID);
+
+        // then
+        assertThat(info.pollStatus()).isEqualTo(DemodayPollStatus.OPEN);
+        assertThat(info.boothAddable()).isFalse();
+        assertThat(info.boothCount()).isZero();
+        assertThat(info.booths()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("투표가 존재하지 않으면 권한 검사와 부스 조회를 수행하지 않는다")
+    void rejectListWhenPollDoesNotExist() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.listBooths(POLL_ID, MEMBER_ID))
+            .isInstanceOfSatisfying(
+                DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(loadDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 부스를 조회하지 않는다")
+    void rejectListWhenAdminAccessIsDenied() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(persistedPoll()));
+        DemodayDomainException expectedException =
+            new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+        willThrow(expectedException)
+            .given(adminAccessChecker)
+            .validateAdminAccess(MEMBER_ID, GISU_ID);
+
+        // when & then
+        assertThatThrownBy(() -> service.listBooths(POLL_ID, MEMBER_ID)).isSameAs(expectedException);
+        then(loadDemodayBoothPort).shouldHaveNoInteractions();
+    }
+
+    private DemodayPoll persistedPoll() {
+        DemodayPoll poll = DemodayPoll.create(GISU_ID, POLL_NAME, OPENS_AT, CLOSES_AT);
+        ReflectionTestUtils.setField(poll, "id", POLL_ID);
+        return poll;
+    }
+
+    private DemodayBooth booth(Long boothId, Long projectId, String displayName) {
+        DemodayBooth booth = projectId != null
+            ? DemodayBooth.forProject(POLL_ID, projectId)
+            : DemodayBooth.forExternal(POLL_ID, displayName);
+        ReflectionTestUtils.setField(booth, "id", boothId);
+        return booth;
+    }
+}

--- a/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
+++ b/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.umc.product.demoday.domain.enums.DemodayPollStatus;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
@@ -17,6 +18,8 @@ import com.umc.product.demoday.domain.exception.DemodayErrorCode;
 class DemodayPollTest {
 
     private static final Long GISU_ID = 8L;
+    private static final Long POLL_ID = 1L;
+    private static final Long PROJECT_ID = 101L;
     private static final String NAME = "8기 데모데이 현장 투표";
     private static final Instant OPENS_AT = Instant.parse("2026-08-01T05:00:00Z");
     private static final Instant CLOSES_AT = Instant.parse("2026-08-01T08:00:00Z");
@@ -138,5 +141,112 @@ class DemodayPollTest {
             .isInstanceOf(DemodayDomainException.class)
             .extracting("baseCode")
             .isEqualTo(DemodayErrorCode.DEMODAY_POLL_INVALID_NAME);
+    }
+
+    @Test
+    @DisplayName("닫힌 투표는 등록된 프로젝트로 부스를 만든다")
+    void registerProjectBoothWhileClosed() {
+        // given
+        DemodayPoll poll = persistedPoll();
+
+        // when
+        DemodayBooth booth = poll.registerProjectBooth(PROJECT_ID);
+
+        // then
+        assertThat(booth.getPollId()).isEqualTo(POLL_ID);
+        assertThat(booth.getProjectId()).isEqualTo(PROJECT_ID);
+        assertThat(booth.getDisplayName()).isNull();
+    }
+
+    @Test
+    @DisplayName("닫힌 투표는 표시 이름으로 외부 부스를 만든다")
+    void registerExternalBoothWhileClosed() {
+        // given
+        DemodayPoll poll = persistedPoll();
+
+        // when
+        DemodayBooth booth = poll.registerExternalBooth("외부 참가팀 A");
+
+        // then
+        assertThat(booth.getPollId()).isEqualTo(POLL_ID);
+        assertThat(booth.getProjectId()).isNull();
+        assertThat(booth.getDisplayName()).isEqualTo("외부 참가팀 A");
+    }
+
+    @Test
+    @DisplayName("등록한 부스는 저장 전이므로 조회 전용 부스 목록에 나타나지 않는다")
+    void doNotAddRegisteredBoothToReadOnlyCollection() {
+        // given
+        DemodayPoll poll = persistedPoll();
+
+        // when
+        poll.registerProjectBooth(PROJECT_ID);
+
+        // then
+        assertThat(poll.getBooths()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("투표가 열리면 두 경로 모두 부스를 추가할 수 없다")
+    void rejectBoothRegistrationWhenPollIsOpen() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+
+        // when & then
+        assertThat(poll.isBoothRegistrable()).isFalse();
+
+        assertThatThrownBy(() -> poll.registerProjectBooth(PROJECT_ID))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED);
+
+        assertThatThrownBy(() -> poll.registerExternalBooth("외부 참가팀 A"))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_POLL_BOOTH_LOCKED);
+    }
+
+    @Test
+    @DisplayName("열었던 투표를 다시 닫으면 부스를 추가할 수 있다")
+    void allowBoothRegistrationAfterReclosingPoll() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+        poll.close();
+
+        // when & then
+        assertThat(poll.isBoothRegistrable()).isTrue();
+        assertThatCode(() -> poll.registerProjectBooth(PROJECT_ID)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("저장되지 않은 투표에는 부스를 등록할 수 없다")
+    void rejectBoothRegistrationForUnsavedPoll() {
+        // given
+        DemodayPoll unsavedPoll = DemodayPoll.create(GISU_ID, NAME, OPENS_AT, CLOSES_AT);
+
+        // when & then
+        assertThatThrownBy(() -> unsavedPoll.registerProjectBooth(PROJECT_ID))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("부스 이름 규칙은 투표를 거쳐 등록해도 그대로 적용된다")
+    void keepBoothNameRuleWhenRegisteringThroughPoll() {
+        // given
+        DemodayPoll poll = persistedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> poll.registerExternalBooth("  "))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_BOOTH_INVALID_NAME);
+    }
+
+    private DemodayPoll persistedPoll() {
+        DemodayPoll poll = DemodayPoll.create(GISU_ID, NAME, OPENS_AT, CLOSES_AT);
+        ReflectionTestUtils.setField(poll, "id", POLL_ID);
+        return poll;
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 데모데이 투표가 `NOT_STARTED` 또는 `IN_PROGRESS`일 때만 부스를 등록할 수 있도록 도메인 규칙을 추가했습니다. 투표가 끝난 뒤에는 기존 부스 구성이 바뀌지 않습니다.
- 관리자 API로 단건·일괄 부스 등록과 부스 현황 조회를 추가했습니다. 조회 응답에는 부스별 투표 수와 순위를 함께 담습니다.
- Poll 생성 응답을 `201 Created`로 맞추고, 요청·응답 DTO와 관리자 권한 검사기를 공용 구조로 정리했습니다.
- 부스 등록 잠금 규칙, 등록·조회 서비스, 관리자 컨트롤러 테스트를 추가하고 데모데이 API 초안에 구현 경로를 반영했습니다.

closes #1254

## 💬 리뷰 중점사항

- `DemodayPoll`의 부스 등록 가능 상태 규칙이 Poll 상태 전이와 함께 일관되게 유지되는지 확인 부탁드립니다.
- 부스 일괄 등록에서 요청 단위 실패 처리와 반환하는 등록 결과가 관리자 화면의 재시도 흐름에 맞는지 봐주시면 좋겠습니다.
- 부스 현황 조회에서 투표 수와 순위를 조합하는 방식이 필요한 데이터만 조회하는지 확인 부탁드립니다. 더 나은 방향이 있으면 반영해보겠습니다.
