### PR TITLE
[Feat] 외부인 인증 코드 일괄 발급 기능 구현

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -11,9 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.demoday.adapter.in.web.dto.request.ChangeDemodayPollStatusRequest;
 import com.umc.product.demoday.adapter.in.web.dto.request.CreateDemodayPollRequest;
+import com.umc.product.demoday.adapter.in.web.dto.request.GenerateDemodayEntryCodesRequest;
+import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayEntryCodeResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayPollResponse;
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
+import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 
@@ -34,6 +38,7 @@ public class DemodayPollAdminController {
 
     private final CreateDemodayPollUseCase createDemodayPollUseCase;
     private final ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
+    private final CreateDemodayEntryCodeUseCase createDemodayEntryCodeUseCase;
 
     @Operation(
         operationId = "createDemodayPoll",
@@ -75,5 +80,20 @@ public class DemodayPollAdminController {
         @Valid @RequestBody ChangeDemodayPollStatusRequest request) {
 
         changeDemodayPollStatusUseCase.changeStatus(request.toCommand(pollId, memberPrincipal.getMemberId()));
+    }
+
+    @PostMapping("/{pollId}/entry-codes")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateDemodayEntryCodeResponse createEntryCodes(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal principal,
+        @PathVariable("pollId") Long pollId,
+        @Valid @RequestBody GenerateDemodayEntryCodesRequest request
+        ) {
+
+        CreateDemodayEntryCodesInfo demodayEntryCodesInfo = createDemodayEntryCodeUseCase.create(
+            principal.getMemberId(), request.toCommand(pollId));
+
+        return CreateDemodayEntryCodeResponse.from(demodayEntryCodesInfo);
+
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -44,7 +44,7 @@ public class DemodayPollAdminController {
         operationId = "createDemodayPoll",
         summary = "데모데이 투표 행사 생성",
         description = """
-            데모데이 투표를 CLOSED 상태로 생성합니다.
+                데모데이 투표를 READY 상태로 생성합니다.
 
             요청자는 요청한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
             opensAt과 closesAt은 실제 투표 가능 시간이며, 시간이 되어도 운영 상태가 자동으로 바뀌지는 않습니다.
@@ -65,11 +65,11 @@ public class DemodayPollAdminController {
         operationId = "changeDemodayPollStatus",
         summary = "데모데이 투표 상태 변경",
         description = """
-            데모데이 투표의 운영 상태를 OPEN 또는 CLOSED로 변경합니다.
+                데모데이 투표의 운영 상태를 READY → OPEN → CLOSED 순서로 변경합니다.
 
-            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
-            CLOSED 상태의 투표를 다시 OPEN하여 재개할 수 있으며, 이미 같은 상태라면 409 응답을 반환합니다.
-            운영 상태는 opensAt, closesAt과 독립적이므로 기간이 지나도 자동으로 변경되지 않습니다.
+                요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+                상태 변경 요청에는 OPEN과 CLOSED만 사용할 수 있으며, 허용되지 않은 상태 전이 또는 이미 같은 상태라면 409 응답을 반환합니다.
+                운영 상태는 opensAt, closesAt과 독립적이므로 기간이 지나도 자동으로 변경되지 않습니다.
             """
     )
     @PatchMapping("/{pollId}/status")

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/ChangeDemodayPollStatusRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/ChangeDemodayPollStatusRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "데모데이 투표 운영 상태 변경 요청")
 public record ChangeDemodayPollStatusRequest(
     @Schema(
-        description = "변경할 운영 상태. OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.",
+        description = "변경할 운영 상태. OPEN은 투표 시작, CLOSED는 투표 종료를 의미합니다.",
         example = "OPEN",
         allowableValues = {"OPEN", "CLOSED"}
     )

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GenerateDemodayEntryCodesRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GenerateDemodayEntryCodesRequest.java
@@ -1,0 +1,15 @@
+package com.umc.product.demoday.adapter.in.web.dto.request;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodeCommand;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record GenerateDemodayEntryCodesRequest(
+    @NotNull @Min(1) @Max(64) Integer count
+) {
+    public CreateDemodayEntryCodeCommand toCommand(Long pollId) {
+        return new CreateDemodayEntryCodeCommand(pollId, count);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayEntryCodeResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayEntryCodeResponse.java
@@ -1,0 +1,12 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.util.List;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+
+public record CreateDemodayEntryCodeResponse(List<String> codes) {
+
+    public static CreateDemodayEntryCodeResponse from(CreateDemodayEntryCodesInfo info) {
+        return new CreateDemodayEntryCodeResponse(info.codes());
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayEntryCodeHasher.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayEntryCodeHasher.java
@@ -5,8 +5,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 
-import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
 
 @Component
 public class SHA256DemodayEntryCodeHasher implements HashDemodayEntryCodePort {

--- a/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayEntryCodeHasher.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayEntryCodeHasher.java
@@ -1,0 +1,26 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SHA256DemodayEntryCodeHasher implements HashDemodayEntryCodePort {
+
+    @Override
+    public String hash(String rawCode) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawCode.getBytes(StandardCharsets.UTF_8));
+
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "JVM에서 SHA-256 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
@@ -2,8 +2,9 @@ package com.umc.product.demoday.adapter.out;
 
 import java.security.SecureRandom;
 
-import com.umc.product.demoday.application.port.out.GenerateDemodayEntryCodePort;
 import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.GenerateDemodayEntryCodePort;
 
 @Component
 public class SecureRandomDemodayEntryCodeGenerator implements GenerateDemodayEntryCodePort {

--- a/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
@@ -1,0 +1,29 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.security.SecureRandom;
+
+import com.umc.product.demoday.application.port.out.GenerateDemodayEntryCodePort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecureRandomDemodayEntryCodeGenerator implements GenerateDemodayEntryCodePort {
+
+    // O, I, L, 0, 1을 제거하여 입력 시 혼동을 줄이기 위함
+    private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int CODE_LENGTH = 16;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String generate() {
+        StringBuilder code = new StringBuilder(CODE_LENGTH);
+
+        // 80비트의 엔트로피를 가진 code 생성
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int index = secureRandom.nextInt(ALPHABET.length());
+            code.append(ALPHABET.charAt(index));
+        }
+
+        return code.toString();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayEntryCodeUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayEntryCodeUseCase.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodeCommand;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+
+public interface CreateDemodayEntryCodeUseCase {
+
+    CreateDemodayEntryCodesInfo create(Long memberId, CreateDemodayEntryCodeCommand command);
+
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayEntryCodeCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayEntryCodeCommand.java
@@ -1,0 +1,7 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+public record CreateDemodayEntryCodeCommand(
+    Long pollId,
+    int count
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayEntryCodesInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateDemodayEntryCodesInfo.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.util.List;
+
+public record CreateDemodayEntryCodesInfo(List<String> codes) {
+
+    public static CreateDemodayEntryCodesInfo from(List<String> rawCodes) {
+        return new CreateDemodayEntryCodesInfo(List.copyOf(rawCodes));
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayEntryCodePort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayEntryCodePort.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface GenerateDemodayEntryCodePort {
+
+    String generate();
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayEntryCodePort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayEntryCodePort.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface HashDemodayEntryCodePort {
+
+    String hash(String rawCode);
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandService.java
@@ -28,6 +28,7 @@ public class ChangeDemodayPollStatusCommandService implements ChangeDemodayPollS
         DemodayPoll poll = getDemodayPoll(command);
 
         switch (command.status()) {
+            case READY -> throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_INVALID_STATUS_TRANSITION);
             case OPEN -> poll.open();
             case CLOSED -> poll.close();
         }

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandService.java
@@ -1,0 +1,62 @@
+package com.umc.product.demoday.application.service.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodeCommand;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+import com.umc.product.demoday.application.port.out.GenerateDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayEntryCodePort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class CreateDemodayEntryCodeCommandService implements CreateDemodayEntryCodeUseCase {
+
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final SaveDemodayEntryCodePort saveDemodayEntryCodePort;
+    private final DemodayAdminAccessChecker demodayAdminAccessChecker;
+    private final GenerateDemodayEntryCodePort generateDemodayEntryCodePort;
+    private final HashDemodayEntryCodePort hashDemodayEntryCodePort;
+
+    @Override
+    public CreateDemodayEntryCodesInfo create(Long memberId, CreateDemodayEntryCodeCommand command) {
+
+        DemodayPoll demodayPoll = loadDemodayPollPort.findById(command.pollId())
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        if (!demodayPoll.canGenerateEtnryCode()) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_GENERATION_NOT_ALLOWED);
+        }
+
+        demodayAdminAccessChecker.validateAdminAccess(memberId, demodayPoll.getGisuId());
+
+        List<String> rawCodes = new ArrayList<>();
+        List<DemodayEntryCode> entryCodes = new ArrayList<>();
+
+        for (int i = 0; i < command.count(); i++) {
+            String rawCode = generateDemodayEntryCodePort.generate();
+            String hashCode = hashDemodayEntryCodePort.hash(rawCode);
+
+            rawCodes.add(rawCode);
+            entryCodes.add(DemodayEntryCode.create(command.pollId(), hashCode));
+        }
+
+        saveDemodayEntryCodePort.saveAll(entryCodes);
+
+        return CreateDemodayEntryCodesInfo.from(rawCodes);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandService.java
@@ -1,5 +1,6 @@
 package com.umc.product.demoday.application.service.command;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +42,8 @@ public class CreateDemodayEntryCodeCommandService implements CreateDemodayEntryC
         if (!demodayPoll.canGenerateEtnryCode()) {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_GENERATION_NOT_ALLOWED);
         }
+
+        demodayPoll.validEntryCodeGenerationAvailable(Instant.now());
 
         demodayAdminAccessChecker.validateAdminAccess(memberId, demodayPoll.getGisuId());
 

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
@@ -31,8 +31,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class DemodayPollQueryService implements ListDemodayPollUseCase, GetDemodayParticipationUseCase,
-        ListDemodayBoothUseCase {
+public class DemodayPollQueryService implements
+    ListDemodayPollUseCase, GetDemodayParticipationUseCase, ListDemodayBoothUseCase {
 
     private static final int REQUIRED_STAMP_COUNT = 6;
 

--- a/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
@@ -191,4 +191,24 @@ public class DemodayPoll extends BaseEntity {
 
         status = DemodayPollStatus.CLOSED;
     }
+
+    public boolean canGenerateEtnryCode() {
+        return status == DemodayPollStatus.READY || status == DemodayPollStatus.OPEN;
+    }
+
+    public void validEntryCodeGenerationAvailable(Instant now) {
+        if (!now.isBefore(closesAt)) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_GENERATION_NOT_ALLOWED);
+        }
+    }
+
+    public void validParticipationAvailable(Instant now) {
+        if (!isOpen() || now.isBefore(opensAt) || !now.isBefore(closesAt)) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND);
+        }
+    }
+
+    private boolean isOpen() {
+        return status == DemodayPollStatus.OPEN;
+    }
 }

--- a/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
@@ -85,8 +85,9 @@ public class DemodayPoll extends BaseEntity {
             .name(normalizeName(name))
             // status는 창에서 파생하지 않는다.
             // 창(opensAt ~ closesAt)은 예정 시각이고, status는 운영진의 활성화 의사다.
-            // 생성 시점에는 항상 close 상태여야 하고, 명시적인 행위를 통해서만 상태를 변경한다.
-            .status(DemodayPollStatus.CLOSED)
+            // 생성 시점에는 행사 전 코드 발급이 가능한 준비 상태여야 하고,
+            // 명시적인 행위를 통해서만 상태를 변경한다.
+            .status(DemodayPollStatus.READY)
             .opensAt(opensAt)
             .closesAt(closesAt)
             .build();
@@ -180,6 +181,9 @@ public class DemodayPoll extends BaseEntity {
         if (DemodayPollStatus.OPEN == status) {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_ALREADY_OPEN);
         }
+        if (DemodayPollStatus.READY != status) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_INVALID_STATUS_TRANSITION);
+        }
 
         status = DemodayPollStatus.OPEN;
     }
@@ -187,6 +191,9 @@ public class DemodayPoll extends BaseEntity {
     public void close() {
         if (DemodayPollStatus.CLOSED == status) {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_ALREADY_CLOSED);
+        }
+        if (DemodayPollStatus.OPEN != status) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_INVALID_STATUS_TRANSITION);
         }
 
         status = DemodayPollStatus.CLOSED;

--- a/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
+++ b/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
@@ -2,7 +2,7 @@ package com.umc.product.demoday.domain.enums;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "데모데이 투표 운영 상태. OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.")
+@Schema(description = "데모데이 투표 운영 상태. READY는 행사 전 준비, OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.")
 public enum DemodayPollStatus {
     READY,
     OPEN,

--- a/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
+++ b/src/main/java/com/umc/product/demoday/domain/enums/DemodayPollStatus.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "데모데이 투표 운영 상태. OPEN은 투표 진행, CLOSED는 투표 종료를 의미합니다.")
 public enum DemodayPollStatus {
+    READY,
     OPEN,
     CLOSED
 }

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -20,12 +20,14 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_POLL_ALREADY_OPEN(HttpStatus.CONFLICT, "DEMODAY-0108", "이미 오픈된 데모데이 투표 행사 입니다."),
     DEMODAY_POLL_ALREADY_CLOSED(HttpStatus.CONFLICT, "DEMODAY-0109", "이미 종료된 데모데이 투표 행사 입니다."),
     DEMODAY_POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "DEMODAY-0110", "데모데이 투표 행사를 찾을 수 없습니다."),
+    DEMODAY_POLL_NOT_OPEN(HttpStatus.NOT_FOUND, "DEMODAY-0111", "데모데이 투표 행사가 아직 시작되지 않았습니다."),
 
     DEMODAY_BOOTH_INVALID_IDENTIFIER(HttpStatus.BAD_REQUEST, "DEMODAY-0200", "부스는 등록된 프로젝트나 표시 이름 중 하나를 가져야 합니다."),
     DEMODAY_BOOTH_INVALID_NAME(HttpStatus.BAD_REQUEST, "DEMODAY-0201", "부스 이름은 1자 이상 255자 이하로 작성해주세요."),
 
     DEMODAY_ENTRY_CODE_ALREADY_REDEEMED(HttpStatus.CONFLICT, "DEMODAY-0300", "이미 사용된 인증 코드예요."),
     DEMODAY_ENTRY_CODE_ALREADY_BOUND(HttpStatus.CONFLICT, "DEMODAY-0301", "이미 다른 계정에 연결된 인증 코드예요."),
+    DEMODAY_ENTRY_CODE_GENERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "DEMODAY-0302","행사 진행 전 또는 진행 중에만 생성할 수 있습니다"),
 
     DEMODAY_VOTE_NOT_OPENED_YET(HttpStatus.CONFLICT, "DEMODAY-0400", "아직 투표 시간이 아니에요."),
     DEMODAY_VOTE_CLOSED(HttpStatus.CONFLICT, "DEMODAY-0401", "투표가 종료되었어요."),

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -21,6 +21,7 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_POLL_ALREADY_CLOSED(HttpStatus.CONFLICT, "DEMODAY-0109", "이미 종료된 데모데이 투표 행사 입니다."),
     DEMODAY_POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "DEMODAY-0110", "데모데이 투표 행사를 찾을 수 없습니다."),
     DEMODAY_POLL_NOT_OPEN(HttpStatus.NOT_FOUND, "DEMODAY-0111", "데모데이 투표 행사가 아직 시작되지 않았습니다."),
+    DEMODAY_POLL_INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "DEMODAY-0112", "허용되지 않는 데모데이 투표 상태 전이입니다."),
 
     DEMODAY_BOOTH_INVALID_IDENTIFIER(HttpStatus.BAD_REQUEST, "DEMODAY-0200", "부스는 등록된 프로젝트나 표시 이름 중 하나를 가져야 합니다."),
     DEMODAY_BOOTH_INVALID_NAME(HttpStatus.BAD_REQUEST, "DEMODAY-0201", "부스 이름은 1자 이상 255자 이하로 작성해주세요."),

--- a/src/main/resources/db/migration/V2026.07.26.10.44__create_demoday_vote_domain.sql
+++ b/src/main/resources/db/migration/V2026.07.26.10.44__create_demoday_vote_domain.sql
@@ -106,10 +106,9 @@ CREATE UNIQUE INDEX uk_demoday_stamp_member_booth
 CREATE UNIQUE INDEX uk_demoday_stamp_entry_code_booth
     ON demoday_stamp (entry_code_id, booth_id) WHERE entry_code_id IS NOT NULL;
 
--- 한 사람(소셜 계정)이 투표당 코드를 하나만 바인딩 할 수 있도록 제한한다.
+-- 한 사람이 투표당 코드를 하나만 바인딩 할 수 있도록 제한한다.
 -- 분실된 인증 코드를 주워 1인 N투표를 하는 것을 방지하기 위한 제약이다.
 -- demoday_vote의 UNIQUE(entry_code_id)와 합쳐져 1인당 1표를 제한한다.
--- 소셜 로그인 미도입 시에는 전 행이 NULL이기 때문에 인덱스가 비어버리게 되어 아무것도 제약하지 않게 된다.
 CREATE UNIQUE INDEX uk_demoday_entry_code_identity
     ON demoday_entry_code (demoday_poll_id, bound_identity_hash) WHERE bound_identity_hash IS NOT NULL;
 

--- a/src/main/resources/db/migration/V2026.07.26.10.44__create_demoday_vote_domain.sql
+++ b/src/main/resources/db/migration/V2026.07.26.10.44__create_demoday_vote_domain.sql
@@ -106,9 +106,10 @@ CREATE UNIQUE INDEX uk_demoday_stamp_member_booth
 CREATE UNIQUE INDEX uk_demoday_stamp_entry_code_booth
     ON demoday_stamp (entry_code_id, booth_id) WHERE entry_code_id IS NOT NULL;
 
--- 한 사람이 투표당 코드를 하나만 바인딩 할 수 있도록 제한한다.
+-- 한 사람(소셜 계정)이 투표당 코드를 하나만 바인딩 할 수 있도록 제한한다.
 -- 분실된 인증 코드를 주워 1인 N투표를 하는 것을 방지하기 위한 제약이다.
 -- demoday_vote의 UNIQUE(entry_code_id)와 합쳐져 1인당 1표를 제한한다.
+-- 소셜 로그인 미도입 시에는 전 행이 NULL이기 때문에 인덱스가 비어버리게 되어 아무것도 제약하지 않게 된다.
 CREATE UNIQUE INDEX uk_demoday_entry_code_identity
     ON demoday_entry_code (demoday_poll_id, bound_identity_hash) WHERE bound_identity_hash IS NOT NULL;
 

--- a/src/main/resources/db/migration/V2026.08.17.00.00__add_ready_status_to_demoday_poll.sql
+++ b/src/main/resources/db/migration/V2026.08.17.00.00__add_ready_status_to_demoday_poll.sql
@@ -1,0 +1,6 @@
+ALTER TABLE demoday_poll
+    DROP CONSTRAINT demoday_poll_status_check;
+
+ALTER TABLE demoday_poll
+    ADD CONSTRAINT demoday_poll_status_check
+    CHECK (status IN ('READY', 'OPEN', 'CLOSED'));

--- a/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/ChangeDemodayPollStatusCommandServiceTest.java
@@ -48,10 +48,10 @@ class ChangeDemodayPollStatusCommandServiceTest {
     private ChangeDemodayPollStatusCommandService service;
 
     @Test
-    @DisplayName("닫힌 투표를 열고 저장한다")
-    void openClosedPoll() {
+    @DisplayName("준비 상태의 투표를 열고 저장한다")
+    void openReadyPoll() {
         // given
-        DemodayPoll poll = createClosedPoll();
+        DemodayPoll poll = createReadyPoll();
         ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.OPEN);
         given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
 
@@ -68,7 +68,7 @@ class ChangeDemodayPollStatusCommandServiceTest {
     @DisplayName("열린 투표를 닫고 저장한다")
     void closeOpenPoll() {
         // given
-        DemodayPoll poll = createClosedPoll();
+        DemodayPoll poll = createReadyPoll();
         poll.open();
         ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.CLOSED);
         given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
@@ -103,7 +103,7 @@ class ChangeDemodayPollStatusCommandServiceTest {
     @DisplayName("관리자 권한이 없으면 상태를 변경하거나 저장하지 않는다")
     void doNotChangeOrSavePollWhenAdminAccessIsDenied() {
         // given
-        DemodayPoll poll = createClosedPoll();
+        DemodayPoll poll = createReadyPoll();
         ChangeDemodayPollStatusCommand command = commandOf(DemodayPollStatus.OPEN);
         DemodayDomainException expectedException =
                 new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
@@ -114,11 +114,11 @@ class ChangeDemodayPollStatusCommandServiceTest {
 
         // when & then
         assertThatThrownBy(() -> service.changeStatus(command)).isSameAs(expectedException);
-        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.CLOSED);
+        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.READY);
         then(saveDemodayPollPort).shouldHaveNoInteractions();
     }
 
-    private DemodayPoll createClosedPoll() {
+    private DemodayPoll createReadyPoll() {
         return DemodayPoll.create(GISU_ID, POLL_NAME, OPENS_AT, CLOSES_AT);
     }
 

--- a/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayEntryCodeCommandServiceTest.java
@@ -1,0 +1,157 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodeCommand;
+import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+import com.umc.product.demoday.application.port.out.GenerateDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayEntryCodePort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+
+@ExtendWith(MockitoExtension.class)
+class CreateDemodayEntryCodeCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 1L;
+    private static final Long GISU_ID = 8L;
+    private static final String POLL_NAME = "8기 데모데이 투표";
+    private static final Instant FUTURE_OPENS_AT = Instant.parse("2100-08-15T09:00:00Z");
+    private static final Instant FUTURE_CLOSES_AT = Instant.parse("2100-08-15T12:00:00Z");
+    private static final Instant PAST_OPENS_AT = Instant.parse("2000-08-15T09:00:00Z");
+    private static final Instant PAST_CLOSES_AT = Instant.parse("2000-08-15T12:00:00Z");
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private SaveDemodayEntryCodePort saveDemodayEntryCodePort;
+
+    @Mock
+    private DemodayAdminAccessChecker demodayAdminAccessChecker;
+
+    @Mock
+    private GenerateDemodayEntryCodePort generateDemodayEntryCodePort;
+
+    @Mock
+    private HashDemodayEntryCodePort hashDemodayEntryCodePort;
+
+    @InjectMocks
+    private CreateDemodayEntryCodeCommandService createDemodayEntryCodeCommandService;
+
+    @Test
+    @DisplayName("준비 상태의 투표 행사에서 여러 인증 코드를 발급한다")
+    void createEntryCodesWhenPollIsReady() {
+        // given
+        DemodayPoll demodayPoll = createPoll(FUTURE_OPENS_AT, FUTURE_CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(demodayPoll));
+        given(generateDemodayEntryCodePort.generate()).willReturn("CODE-A", "CODE-B");
+        given(hashDemodayEntryCodePort.hash("CODE-A")).willReturn("hash-A");
+        given(hashDemodayEntryCodePort.hash("CODE-B")).willReturn("hash-B");
+
+        // when
+        CreateDemodayEntryCodesInfo result = createDemodayEntryCodeCommandService.create(
+            MEMBER_ID,
+            new CreateDemodayEntryCodeCommand(POLL_ID, 2)
+        );
+
+        // then
+        assertThat(result.codes()).containsExactly("CODE-A", "CODE-B");
+        then(demodayAdminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayEntryCodePort).should()
+            .saveAll(argThat(entryCodes -> hasEntryCodes(entryCodes, List.of("hash-A", "hash-B"))));
+    }
+
+    @Test
+    @DisplayName("진행 중인 투표 행사에서 인증 코드를 추가로 발급한다")
+    void createEntryCodesWhenPollIsOpen() {
+        // given
+        DemodayPoll demodayPoll = createPoll(FUTURE_OPENS_AT, FUTURE_CLOSES_AT);
+        demodayPoll.open();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(demodayPoll));
+        given(generateDemodayEntryCodePort.generate()).willReturn("CODE-C");
+        given(hashDemodayEntryCodePort.hash("CODE-C")).willReturn("hash-C");
+
+        // when
+        CreateDemodayEntryCodesInfo result = createDemodayEntryCodeCommandService.create(
+            MEMBER_ID,
+            new CreateDemodayEntryCodeCommand(POLL_ID, 1)
+        );
+
+        // then
+        assertThat(result.codes()).containsExactly("CODE-C");
+        then(demodayAdminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(saveDemodayEntryCodePort).should()
+            .saveAll(argThat(entryCodes -> hasEntryCodes(entryCodes, List.of("hash-C"))));
+    }
+
+    @Test
+    @DisplayName("종료 상태의 투표 행사에서는 인증 코드 발급을 거부한다")
+    void rejectEntryCodeCreationWhenPollIsClosed() {
+        // given
+        DemodayPoll demodayPoll = createPoll(FUTURE_OPENS_AT, FUTURE_CLOSES_AT);
+        demodayPoll.open();
+        demodayPoll.close();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(demodayPoll));
+
+        // when & then
+        assertThatThrownBy(() -> createDemodayEntryCodeCommandService.create(
+            MEMBER_ID, new CreateDemodayEntryCodeCommand(POLL_ID, 1)))
+            .isInstanceOf(DemodayDomainException.class);
+
+        then(demodayAdminAccessChecker).shouldHaveNoInteractions();
+        then(generateDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(hashDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("마감 시각이 지난 투표 행사에서는 인증 코드 발급을 거부한다")
+    void rejectEntryCodeCreationWhenPollIsExpired() {
+        // given
+        DemodayPoll demodayPoll = createPoll(PAST_OPENS_AT, PAST_CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(demodayPoll));
+
+        // when & then
+        assertThatThrownBy(() -> createDemodayEntryCodeCommandService.create(
+            MEMBER_ID, new CreateDemodayEntryCodeCommand(POLL_ID, 1)))
+            .isInstanceOf(DemodayDomainException.class);
+
+        then(demodayAdminAccessChecker).shouldHaveNoInteractions();
+        then(generateDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(hashDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    private static DemodayPoll createPoll(Instant opensAt, Instant closesAt) {
+        return DemodayPoll.create(GISU_ID, POLL_NAME, opensAt, closesAt);
+    }
+
+    private static boolean hasEntryCodes(List<DemodayEntryCode> entryCodes, List<String> expectedCodeHashes) {
+        return entryCodes.size() == expectedCodeHashes.size()
+            && entryCodes.stream().allMatch(entryCode -> entryCode.getPollId().equals(POLL_ID))
+            && entryCodes.stream()
+                .map(DemodayEntryCode::getCodeHash)
+                .toList()
+                .equals(expectedCodeHashes);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayAdminBoothQueryServiceTest.java
@@ -57,7 +57,7 @@ class DemodayAdminBoothQueryServiceTest {
     @DisplayName("닫힌 투표의 부스 목록과 등록 개수를 조회하고 아직 추가할 수 있다고 알린다")
     void listBoothsOfClosedPoll() {
         // given
-        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(persistedPoll()));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(persistedClosedPoll()));
         given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(
             booth(20L, 101L, null),
             booth(21L, null, "외부 참가팀 A")
@@ -133,6 +133,13 @@ class DemodayAdminBoothQueryServiceTest {
     private DemodayPoll persistedPoll() {
         DemodayPoll poll = DemodayPoll.create(GISU_ID, POLL_NAME, OPENS_AT, CLOSES_AT);
         ReflectionTestUtils.setField(poll, "id", POLL_ID);
+        return poll;
+    }
+
+    private DemodayPoll persistedClosedPoll() {
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+        poll.close();
         return poll;
     }
 

--- a/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
+++ b/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
@@ -25,8 +25,8 @@ class DemodayPollTest {
     private static final Instant CLOSES_AT = Instant.parse("2026-08-01T08:00:00Z");
 
     @Test
-    @DisplayName("생성된 투표는 창을 그대로 보관하고 항상 닫힌 상태로 시작한다")
-    void initializePollAsClosed() {
+    @DisplayName("생성된 투표는 창을 그대로 보관하고 준비 상태로 시작한다")
+    void initializePollAsReady() {
         // when
         DemodayPoll poll = DemodayPoll.create(GISU_ID, NAME, OPENS_AT, CLOSES_AT);
 
@@ -35,7 +35,7 @@ class DemodayPollTest {
         assertThat(poll.getName()).isEqualTo(NAME);
         assertThat(poll.getOpensAt()).isEqualTo(OPENS_AT);
         assertThat(poll.getClosesAt()).isEqualTo(CLOSES_AT);
-        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.CLOSED);
+        assertThat(poll.getStatus()).isEqualTo(DemodayPollStatus.READY);
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용

외부인 입장 인증 코드를 행사 준비(READY)·진행(OPEN) 상태에서 필요한 수만큼 일괄 발급할 수 있도록 구현했습니다. 코드는 응답으로만 원문을 노출하고, 저장 시에는 SHA-256 해시를 사용합니다.

- 관리자 전용 발급 API와 요청·응답 DTO를 추가했습니다. 한 번에 1~64개를 발급할 수 있습니다.
- SecureRandom 기반 코드 생성기와 해시 포트를 분리했습니다. 중복 코드는 DB UNIQUE 제약으로 막고, 충돌하면 재생성 없이 해당 발급 트랜잭션을 실패시킵니다.
- 행사 상태를 READY → OPEN → CLOSED로 확장해, 행사 시작 전과 진행 중 모두 추가 발급할 수 있게 했습니다.
- 발급 서비스 단위 테스트를 추가해 정상 발급, 권한 거부, 비활성/마감 행사 거부를 확인했습니다.

Closes #1255

## 💬 리뷰 중점사항

- 인증 코드 발급 가능 여부를 Poll 도메인이 상태와 시간으로 함께 판단하도록 둔 부분을 봐주시면 좋겠습니다.
- 중복 코드가 발생했을 때 재생성하지 않고 트랜잭션을 실패시키는 정책이 의도와 맞는지 확인 부탁드립니다.