### PR TITLE
[Feat] 데모데이 부스 스탬프 QR 발급 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -303,3 +303,9 @@ CDN_KEY_PAIR_ID=
 # 직접 값 주입 대신 SSM 파라미터 이름으로 조회할 수도 있다 (아래 CDN_PRIVATE_KEY_PARAMETER_NAME).
 CDN_PRIVATE_KEY=
 CDN_PRIVATE_KEY_PARAMETER_NAME=/umc/common/cloudfront/private-key
+
+# ------------------------------------------------------------------
+# Demoday
+# ------------------------------------------------------------------
+# Base64-encoded 32-byte AES-256-GCM key
+DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY=<BASE64_ENCODED_32_BYTE_KEY>

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
@@ -114,7 +114,8 @@ public class DemodayBoothAdminController {
             해당 부스의 스탬프 QR을 생성합니다. 이미 생성된 QR이 있으면 새 QR로 교체되고,
             이전 QR은 즉시 무효가 됩니다.
 
-            QR 값은 이 응답에서만 확인할 수 있으므로 운영자는 안전하게 전달·보관해야 합니다.
+            QR 값은 스탬프 적립 화면으로 이동하는 URL입니다. URL fragment에 포함된 credential은
+            이 응답에서만 확인할 수 있으므로 운영자는 안전하게 전달·보관해야 합니다.
             """
     )
     @PostMapping("/{boothId}/stamp-qr")

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminController.java
@@ -13,10 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.demoday.adapter.in.web.dto.request.RegisterDemodayBoothBatchRequest;
 import com.umc.product.demoday.adapter.in.web.dto.request.RegisterDemodayBoothRequest;
+import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayStampQrResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayAdminBoothListResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.RegisterDemodayBoothBatchResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.RegisterDemodayBoothResponse;
+import com.umc.product.demoday.application.port.in.command.CreateDemodayStampUseCase;
 import com.umc.product.demoday.application.port.in.command.RegisterDemodayBoothUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateStampCredentialCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StampCredentialInfo;
 import com.umc.product.demoday.application.port.in.query.ListDemodayAdminBoothUseCase;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayAdminBoothListInfo;
 import com.umc.product.global.security.MemberPrincipal;
@@ -37,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DemodayBoothAdminController {
 
+    private final CreateDemodayStampUseCase createDemodayStampUseCase;
     private final RegisterDemodayBoothUseCase registerDemodayBoothUseCase;
     private final ListDemodayAdminBoothUseCase listDemodayAdminBoothUseCase;
 
@@ -100,6 +105,31 @@ public class DemodayBoothAdminController {
             request.toCommand(pollId, memberPrincipal.getMemberId()));
 
         return RegisterDemodayBoothBatchResponse.from(boothIds);
+    }
+
+    @Operation(
+        operationId = "createOrReissueDemodayBoothStampQr",
+        summary = "데모데이 부스 스탬프 QR 생성 또는 재발급",
+        description = """
+            해당 부스의 스탬프 QR을 생성합니다. 이미 생성된 QR이 있으면 새 QR로 교체되고,
+            이전 QR은 즉시 무효가 됩니다.
+
+            QR 값은 이 응답에서만 확인할 수 있으므로 운영자는 안전하게 전달·보관해야 합니다.
+            """
+    )
+    @PostMapping("/{boothId}/stamp-qr")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateDemodayStampQrResponse createOrReissueStampQr(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "부스가 속한 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId,
+        @Parameter(description = "스탬프 QR을 생성하거나 재발급할 부스 ID", required = true, example = "1")
+        @PathVariable("boothId") Long boothId) {
+
+        StampCredentialInfo stampCredentialInfo = createDemodayStampUseCase.create(
+            memberPrincipal.getMemberId(), new CreateStampCredentialCommand(pollId, boothId));
+
+        return CreateDemodayStampQrResponse.from(stampCredentialInfo);
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayStampQrResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayStampQrResponse.java
@@ -1,0 +1,26 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.command.dto.StampCredentialInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 부스 스탬프 QR 생성 또는 재발급 결과")
+public record CreateDemodayStampQrResponse(
+    @Schema(
+        description = "스탬프 적립에 사용하는 QR 값",
+        example = "sE2pIo7OMja2LLK1tWlM9G26WhxfZxuPw7Qqk6S8aF0="
+    )
+    String qrValue,
+    @Schema(description = "스탬프 QR 생성 또는 재발급 시각", example = "2026-08-17T10:00:00Z")
+    Instant generatedAt
+) {
+
+    public static CreateDemodayStampQrResponse from(StampCredentialInfo stampCredentialInfo) {
+        return new CreateDemodayStampQrResponse(
+            stampCredentialInfo.qrValue(),
+            stampCredentialInfo.generatedAt()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayStampQrResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/CreateDemodayStampQrResponse.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "데모데이 부스 스탬프 QR 생성 또는 재발급 결과")
 public record CreateDemodayStampQrResponse(
     @Schema(
-        description = "스탬프 적립에 사용하는 QR 값",
-        example = "sE2pIo7OMja2LLK1tWlM9G26WhxfZxuPw7Qqk6S8aF0="
+            description = "스탬프 적립 화면으로 이동하는 QR URL",
+            example = "https://vote.example.com/demoday/polls/1/stamp#credential=AbC123_-"
     )
     String qrValue,
     @Schema(description = "스탬프 QR 생성 또는 재발급 시각", example = "2026-08-17T10:00:00Z")

--- a/src/main/java/com/umc/product/demoday/adapter/out/AesGcmDemodayStampCredentialEncryptor.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/AesGcmDemodayStampCredentialEncryptor.java
@@ -1,0 +1,100 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.EncryptDemodayStampCredentialPort;
+import com.umc.product.demoday.config.DemodayStampCredentialProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AesGcmDemodayStampCredentialEncryptor implements EncryptDemodayStampCredentialPort {
+
+    private static final int AES_256_KEY_LENGTH = 32;
+    private static final int IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final SecretKey secretKey;
+
+    public AesGcmDemodayStampCredentialEncryptor(
+        DemodayStampCredentialProperties properties
+    ) {
+        byte[] keyBytes = Base64.getDecoder().decode(properties.encryptionKey());
+
+        if (keyBytes.length != AES_256_KEY_LENGTH) {
+            throw new IllegalStateException("Demoday 스탬프 credential 암호화 키는 32바이트여야 합니다.");
+        }
+
+        this.secretKey = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    @Override
+    public String encrypt(String plainText) {
+        try {
+            byte[] iv = new byte[IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(
+                Cipher.ENCRYPT_MODE,
+                secretKey,
+                new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+            );
+
+            //Java GCM의 결과값에는 tag가 뒤에 붙음
+            byte[] cipherTextWithTag = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            byte[] encrypted = ByteBuffer.allocate(iv.length + cipherTextWithTag.length)
+                .put(iv)
+                .put(cipherTextWithTag)
+                .array();
+
+            return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(encrypted);
+        } catch (GeneralSecurityException exception) {
+            throw new IllegalStateException("스탬프 credential 암호화에 실패했습니다.", exception);
+        }
+    }
+
+    @Override
+    public String decrypt(String encryptedText) {
+        try {
+            byte[] encrypted = Base64.getDecoder().decode(encryptedText);
+
+            if (encrypted.length <= IV_LENGTH) {
+                throw new IllegalArgumentException("암호문 형식이 올바르지 않습니다.");
+            }
+
+            byte[] iv = Arrays.copyOfRange(encrypted, 0, IV_LENGTH);
+            byte[] cipherTextWithTag = Arrays.copyOfRange(encrypted, IV_LENGTH, encrypted.length);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                secretKey,
+                new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+            );
+
+            byte[] plainText = cipher.doFinal(cipherTextWithTag);
+            return new String(plainText, StandardCharsets.UTF_8);
+
+        } catch (GeneralSecurityException | IllegalArgumentException exception) {
+            throw new IllegalStateException("스탬프 credential 복호화에 실패했습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/AesGcmDemodayStampCredentialEncryptor.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/AesGcmDemodayStampCredentialEncryptor.java
@@ -17,10 +17,7 @@ import org.springframework.stereotype.Component;
 import com.umc.product.demoday.application.port.out.EncryptDemodayStampCredentialPort;
 import com.umc.product.demoday.config.DemodayStampCredentialProperties;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class AesGcmDemodayStampCredentialEncryptor implements EncryptDemodayStampCredentialPort {
 
     private static final int AES_256_KEY_LENGTH = 32;
@@ -74,7 +71,7 @@ public class AesGcmDemodayStampCredentialEncryptor implements EncryptDemodayStam
     @Override
     public String decrypt(String encryptedText) {
         try {
-            byte[] encrypted = Base64.getDecoder().decode(encryptedText);
+            byte[] encrypted = Base64.getUrlDecoder().decode(encryptedText);
 
             if (encrypted.length <= IV_LENGTH) {
                 throw new IllegalArgumentException("암호문 형식이 올바르지 않습니다.");

--- a/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayStampCredentialHasher.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SHA256DemodayStampCredentialHasher.java
@@ -1,0 +1,27 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
+
+@Component
+public class SHA256DemodayStampCredentialHasher implements HashDemodayStampCredentialPort {
+
+    @Override
+    public String hash(String credential) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+
+            byte[] hash = messageDigest.digest(credential.getBytes(StandardCharsets.UTF_8));
+
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayStampCredentialGenerator.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayStampCredentialGenerator.java
@@ -1,0 +1,26 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.GenerateDemodayStampCredentialPort;
+
+@Component
+public class SecureRandomDemodayStampCredentialGenerator implements GenerateDemodayStampCredentialPort {
+
+    private static final int CREDENTIAL_BYTE_LENGTH = 44;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String generate() {
+        byte[] bytes = new byte[CREDENTIAL_BYTE_LENGTH];
+        secureRandom.nextBytes(bytes);
+
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(bytes);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayStampUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/CreateDemodayStampUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateStampCredentialCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StampCredentialInfo;
+
+public interface CreateDemodayStampUseCase {
+
+    StampCredentialInfo create(Long memberId, CreateStampCredentialCommand command);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateStampCredentialCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateStampCredentialCommand.java
@@ -1,6 +1,7 @@
 package com.umc.product.demoday.application.port.in.command.dto;
 
 public record CreateStampCredentialCommand(
+    Long pollId,
     Long boothId
 ) {
 }

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateStampCredentialCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CreateStampCredentialCommand.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+public record CreateStampCredentialCommand(
+    Long boothId
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StampCredentialInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StampCredentialInfo.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.time.Instant;
+
+public record StampCredentialInfo(
+    String qrValue,
+    Instant generatedAT
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StampCredentialInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StampCredentialInfo.java
@@ -4,6 +4,6 @@ import java.time.Instant;
 
 public record StampCredentialInfo(
     String qrValue,
-    Instant generatedAT
+    Instant generatedAt
 ) {
 }

--- a/src/main/java/com/umc/product/demoday/application/port/out/EncryptDemodayStampCredentialPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/EncryptDemodayStampCredentialPort.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface EncryptDemodayStampCredentialPort {
+
+    String encrypt(String plainText);
+
+    String decrypt(String encryptedText);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayStampCredentialPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayStampCredentialPort.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface GenerateDemodayStampCredentialPort {
+
+    String generate();
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayStampCredentialPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayStampCredentialPort.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface HashDemodayStampCredentialPort {
+
+    String hash(String credential);
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
@@ -1,0 +1,52 @@
+package com.umc.product.demoday.application.service.command;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.CreateDemodayStampUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CreateStampCredentialCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StampCredentialInfo;
+import com.umc.product.demoday.application.port.out.EncryptDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.GenerateDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateDemodayStampCommandService implements CreateDemodayStampUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final LoadDemodayBoothPort loadDemodayBoothPort;
+    private final EncryptDemodayStampCredentialPort encryptDemodayStampCredentialPort;
+    private final GenerateDemodayStampCredentialPort generateDemodayStampCredentialPort;
+    private final HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
+
+    private final Clock clock;
+
+    @Override
+    public StampCredentialInfo create(Long memberId, CreateStampCredentialCommand command) {
+        DemodayBooth demodayBooth = loadDemodayBoothPort.findById(command.boothId())
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(memberId, demodayBooth.getPollId());
+
+        String credential = generateDemodayStampCredentialPort.generate();
+        String credentialHash = hashDemodayStampCredentialPort.hash(credential);
+        String encryptedCredential = encryptDemodayStampCredentialPort.encrypt(credentialHash);
+        Instant generatedAt = clock.instant();
+
+        demodayBooth.applyStampCredential(credentialHash, encryptedCredential, Instant.now());
+
+        return new StampCredentialInfo(credential, generatedAt);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
@@ -15,6 +15,7 @@ import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPo
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.config.DemodayQrProperties;
 import com.umc.product.demoday.domain.DemodayBooth;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
@@ -35,6 +36,7 @@ public class CreateDemodayStampCommandService implements CreateDemodayStampUseCa
     private final HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
 
     private final Clock clock;
+    private final DemodayQrProperties demodayQrProperties;
 
     @Override
     public StampCredentialInfo create(Long memberId, CreateStampCredentialCommand command) {
@@ -57,6 +59,13 @@ public class CreateDemodayStampCommandService implements CreateDemodayStampUseCa
 
         demodayBooth.applyStampCredential(credentialHash, encryptedCredential, generatedAt);
 
-        return new StampCredentialInfo(credential, generatedAt);
+        return new StampCredentialInfo(
+            "%s/demoday/polls/%d/stamp#credential=%s".formatted(
+                demodayQrProperties.baseUrl(),
+                command.pollId(),
+                credential
+            ),
+            generatedAt
+        );
     }
 }

--- a/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandService.java
@@ -13,8 +13,10 @@ import com.umc.product.demoday.application.port.out.EncryptDemodayStampCredentia
 import com.umc.product.demoday.application.port.out.GenerateDemodayStampCredentialPort;
 import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
 import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;
 
@@ -27,6 +29,7 @@ public class CreateDemodayStampCommandService implements CreateDemodayStampUseCa
 
     private final DemodayAdminAccessChecker adminAccessChecker;
     private final LoadDemodayBoothPort loadDemodayBoothPort;
+    private final LoadDemodayPollPort loadDemodayPollPort;
     private final EncryptDemodayStampCredentialPort encryptDemodayStampCredentialPort;
     private final GenerateDemodayStampCredentialPort generateDemodayStampCredentialPort;
     private final HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
@@ -38,14 +41,21 @@ public class CreateDemodayStampCommandService implements CreateDemodayStampUseCa
         DemodayBooth demodayBooth = loadDemodayBoothPort.findById(command.boothId())
             .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_NOT_FOUND));
 
-        adminAccessChecker.validateAdminAccess(memberId, demodayBooth.getPollId());
+        if (!demodayBooth.getPollId().equals(command.pollId())) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_NOT_FOUND);
+        }
+
+        DemodayPoll demodayPoll = loadDemodayPollPort.findById(command.pollId())
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(memberId, demodayPoll.getGisuId());
 
         String credential = generateDemodayStampCredentialPort.generate();
         String credentialHash = hashDemodayStampCredentialPort.hash(credential);
-        String encryptedCredential = encryptDemodayStampCredentialPort.encrypt(credentialHash);
+        String encryptedCredential = encryptDemodayStampCredentialPort.encrypt(credential);
         Instant generatedAt = clock.instant();
 
-        demodayBooth.applyStampCredential(credentialHash, encryptedCredential, Instant.now());
+        demodayBooth.applyStampCredential(credentialHash, encryptedCredential, generatedAt);
 
         return new StampCredentialInfo(credential, generatedAt);
     }

--- a/src/main/java/com/umc/product/demoday/config/DemodayQrProperties.java
+++ b/src/main/java/com/umc/product/demoday/config/DemodayQrProperties.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "demoday.qr")
+public record DemodayQrProperties(
+    String baseUrl
+) {
+}

--- a/src/main/java/com/umc/product/demoday/config/DemodayStampCredentialProperties.java
+++ b/src/main/java/com/umc/product/demoday/config/DemodayStampCredentialProperties.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "demoday.stamp-credential")
+public record DemodayStampCredentialProperties(
+    String encryptionKey
+) {
+}

--- a/src/main/java/com/umc/product/demoday/domain/DemodayBooth.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayBooth.java
@@ -1,5 +1,6 @@
 package com.umc.product.demoday.domain;
 
+import java.time.Instant;
 import java.util.Objects;
 
 import com.umc.product.common.BaseEntity;
@@ -41,6 +42,15 @@ public class DemodayBooth extends BaseEntity {
     @Column(name = "display_name")
     private String displayName;
 
+    @Column(name = "stamp_credential_hash")
+    private String stampCredentialHash;
+
+    @Column(name = "stamp_credential_cipher")
+    private String stampCredentialCipher;
+
+    @Column(name = "stamp_credential_generated_at")
+    private Instant stampCredentialGeneratedAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private DemodayBooth(Long pollId, Long projectId, String displayName) {
         this.pollId = pollId;
@@ -65,6 +75,24 @@ public class DemodayBooth extends BaseEntity {
             .displayName(normalizedName)
             .build();
     }
+
+    public void applyStampCredential(
+        String stampCredentialHash,
+        String stampCredentialCipher,
+        Instant stampCredentialGeneratedAt
+    ) {
+        this.stampCredentialHash = Objects.requireNonNull(stampCredentialHash);
+        this.stampCredentialCipher = Objects.requireNonNull(stampCredentialCipher);
+        this.stampCredentialGeneratedAt = Objects.requireNonNull(stampCredentialGeneratedAt);
+    }
+
+    public boolean hasStampCredential() {
+        return stampCredentialHash != null
+            && stampCredentialCipher != null
+            && stampCredentialGeneratedAt != null;
+    }
+
+    //=== Private Method ===
 
     private static void validateProject(Long projectId) {
         if (projectId == null) {

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -25,6 +25,7 @@ public enum DemodayErrorCode implements BaseCode {
 
     DEMODAY_BOOTH_INVALID_IDENTIFIER(HttpStatus.BAD_REQUEST, "DEMODAY-0200", "부스는 등록된 프로젝트나 표시 이름 중 하나를 가져야 합니다."),
     DEMODAY_BOOTH_INVALID_NAME(HttpStatus.BAD_REQUEST, "DEMODAY-0201", "부스 이름은 1자 이상 255자 이하로 작성해주세요."),
+    DEMODAY_BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "DEMODAY-0202", "부스를 찾을 수 없습니다."),
 
     DEMODAY_ENTRY_CODE_ALREADY_REDEEMED(HttpStatus.CONFLICT, "DEMODAY-0300", "이미 사용된 인증 코드예요."),
     DEMODAY_ENTRY_CODE_ALREADY_BOUND(HttpStatus.CONFLICT, "DEMODAY-0301", "이미 다른 계정에 연결된 인증 코드예요."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -652,3 +652,11 @@ app:
   websocket:
     broker:
       mode: ${WEBSOCKET_BROKER_MODE:simple}
+
+# ==================================================================
+# configuration for demdoay domain
+# ==================================================================
+
+demoday:
+  stamp-credential:
+    encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,6 +170,12 @@ jwt:
   refresh-token-validity-in-seconds: ${JWT_REFRESH_TOKEN_VALIDITY_IN_SECONDS:604800}
   verification-token-validity-in-seconds: ${JWT_VERIFICATION_TOKEN_VALIDITY_IN_SECONDS:600}
 
+demoday:
+  qr:
+    base-url: ${DEMODAY_QR_BASE_URL}
+  stamp-credential:
+    encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}
+
 # OpenAPI / Scalar 문서 설정
 springdoc:
   swagger-ui:
@@ -652,11 +658,3 @@ app:
   websocket:
     broker:
       mode: ${WEBSOCKET_BROKER_MODE:simple}
-
-# ==================================================================
-# configuration for demdoay domain
-# ==================================================================
-
-demoday:
-  stamp-credential:
-    encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}

--- a/src/main/resources/db/migration/V2026.08.17.14.36__add_stamp_credential_to_demoday_booth.sql
+++ b/src/main/resources/db/migration/V2026.08.17.14.36__add_stamp_credential_to_demoday_booth.sql
@@ -1,0 +1,8 @@
+ALTER TABLE demoday_booth
+    ADD COLUMN stamp_credential_hash VARCHAR(64),
+    ADD COLUMN stamp_credential_cipher VARCHAR(255),
+    ADD COLUMN stamp_credential_generated_at TIMESTAMP WITH TIME ZONE,
+    -- 해시 충돌 확률보다는 애플리케이션 버그로 동일한 credential이
+    -- 여러 부스에 할당되는 것을 방지하여 credential과 부스의 1:1 관계를 보장한다.
+    ADD CONSTRAINT uk_demoday_booth_stamp_credential_hash
+    UNIQUE (stamp_credential_hash);

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayBoothAdminControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.umc.product.demoday.application.port.in.command.CreateDemodayStampUseCase;
 import com.umc.product.demoday.application.port.in.command.RegisterDemodayBoothUseCase;
 import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand;
 import com.umc.product.demoday.application.port.in.command.dto.RegisterDemodayBoothBatchCommand.BoothRegistration;
@@ -57,6 +58,8 @@ class DemodayBoothAdminControllerTest {
     @MockitoBean private RegisterDemodayBoothUseCase registerDemodayBoothUseCase;
 
     @MockitoBean private ListDemodayAdminBoothUseCase listDemodayAdminBoothUseCase;
+
+    @MockitoBean private CreateDemodayStampUseCase createDemodayStampUseCase;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayStampCredentialGeneratorTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayStampCredentialGeneratorTest.java
@@ -1,0 +1,24 @@
+package com.umc.product.demoday.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SecureRandomDemodayStampCredentialGeneratorTest {
+
+    private final SecureRandomDemodayStampCredentialGenerator generator = new SecureRandomDemodayStampCredentialGenerator();
+
+    @Test
+    @DisplayName("44바이트 난수를 패딩 없는 Base64 URL 문자열로 생성한다")
+    void generate() {
+        // when
+        String credential = generator.generate();
+
+        // then
+        assertThat(credential).doesNotContain("=");
+        assertThat(Base64.getUrlDecoder().decode(credential)).hasSize(44);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandServiceTest.java
@@ -23,6 +23,7 @@ import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPo
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.config.DemodayQrProperties;
 import com.umc.product.demoday.domain.DemodayBooth;
 import com.umc.product.demoday.domain.DemodayPoll;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
@@ -37,6 +38,7 @@ class CreateDemodayStampCommandServiceTest {
     private static final String CREDENTIAL = "stamp-credential";
     private static final String CREDENTIAL_HASH = "credential-hash";
     private static final String ENCRYPTED_CREDENTIAL = "encrypted-credential";
+    private static final String QR_BASE_URL = "https://vote.example.com";
     private static final Instant GENERATED_AT = Instant.parse("2026-08-17T00:00:00Z");
 
     @Mock
@@ -56,6 +58,9 @@ class CreateDemodayStampCommandServiceTest {
 
     @Mock
     private HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
+
+    @Mock
+    private DemodayQrProperties demodayQrProperties;
 
     @Mock
     private Clock clock;
@@ -82,12 +87,15 @@ class CreateDemodayStampCommandServiceTest {
         given(hashDemodayStampCredentialPort.hash(CREDENTIAL)).willReturn(CREDENTIAL_HASH);
         given(encryptDemodayStampCredentialPort.encrypt(CREDENTIAL)).willReturn(ENCRYPTED_CREDENTIAL);
         given(clock.instant()).willReturn(GENERATED_AT);
+        given(demodayQrProperties.baseUrl()).willReturn(QR_BASE_URL);
 
         // when
         var result = createDemodayStampCommandService.create(MEMBER_ID, command);
 
         // then
-        assertThat(result.qrValue()).isEqualTo(CREDENTIAL);
+        assertThat(result.qrValue()).isEqualTo(
+            "%s/demoday/polls/%d/stamp#credential=%s".formatted(QR_BASE_URL, POLL_ID, CREDENTIAL)
+        );
         assertThat(result.generatedAt()).isEqualTo(GENERATED_AT);
         assertThat(demodayBooth.getStampCredentialHash()).isEqualTo(CREDENTIAL_HASH);
         assertThat(demodayBooth.getStampCredentialCipher()).isEqualTo(ENCRYPTED_CREDENTIAL);
@@ -98,6 +106,7 @@ class CreateDemodayStampCommandServiceTest {
         then(hashDemodayStampCredentialPort).should().hash(CREDENTIAL);
         then(encryptDemodayStampCredentialPort).should().encrypt(CREDENTIAL);
         then(clock).should().instant();
+        then(demodayQrProperties).should().baseUrl();
     }
 
     @Test
@@ -116,6 +125,7 @@ class CreateDemodayStampCommandServiceTest {
         then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(demodayQrProperties).shouldHaveNoInteractions();
         then(clock).shouldHaveNoInteractions();
     }
 
@@ -137,6 +147,7 @@ class CreateDemodayStampCommandServiceTest {
         then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(demodayQrProperties).shouldHaveNoInteractions();
         then(clock).shouldHaveNoInteractions();
     }
 
@@ -157,6 +168,7 @@ class CreateDemodayStampCommandServiceTest {
         then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
         then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(demodayQrProperties).shouldHaveNoInteractions();
         then(clock).shouldHaveNoInteractions();
     }
 }

--- a/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CreateDemodayStampCommandServiceTest.java
@@ -1,0 +1,162 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.command.dto.CreateStampCredentialCommand;
+import com.umc.product.demoday.application.port.out.EncryptDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.GenerateDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+
+@ExtendWith(MockitoExtension.class)
+class CreateDemodayStampCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 2L;
+    private static final Long BOOTH_ID = 3L;
+    private static final Long GISU_ID = 4L;
+    private static final String CREDENTIAL = "stamp-credential";
+    private static final String CREDENTIAL_HASH = "credential-hash";
+    private static final String ENCRYPTED_CREDENTIAL = "encrypted-credential";
+    private static final Instant GENERATED_AT = Instant.parse("2026-08-17T00:00:00Z");
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private LoadDemodayBoothPort loadDemodayBoothPort;
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private EncryptDemodayStampCredentialPort encryptDemodayStampCredentialPort;
+
+    @Mock
+    private GenerateDemodayStampCredentialPort generateDemodayStampCredentialPort;
+
+    @Mock
+    private HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private CreateDemodayStampCommandService createDemodayStampCommandService;
+
+    @Test
+    @DisplayName("관리자가 부스의 스탬프 QR을 발급하면 QR 값과 발급 정보를 일관되게 저장하고 반환한다")
+    void createStampCredential() {
+        // given
+        DemodayBooth demodayBooth = DemodayBooth.forExternal(POLL_ID, "UMC PRODUCT");
+        DemodayPoll demodayPoll = DemodayPoll.create(
+            GISU_ID,
+            "데모데이",
+            GENERATED_AT,
+            GENERATED_AT.plusSeconds(3600)
+        );
+        CreateStampCredentialCommand command = new CreateStampCredentialCommand(POLL_ID, BOOTH_ID);
+
+        given(loadDemodayBoothPort.findById(BOOTH_ID)).willReturn(Optional.of(demodayBooth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(demodayPoll));
+        given(generateDemodayStampCredentialPort.generate()).willReturn(CREDENTIAL);
+        given(hashDemodayStampCredentialPort.hash(CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(encryptDemodayStampCredentialPort.encrypt(CREDENTIAL)).willReturn(ENCRYPTED_CREDENTIAL);
+        given(clock.instant()).willReturn(GENERATED_AT);
+
+        // when
+        var result = createDemodayStampCommandService.create(MEMBER_ID, command);
+
+        // then
+        assertThat(result.qrValue()).isEqualTo(CREDENTIAL);
+        assertThat(result.generatedAt()).isEqualTo(GENERATED_AT);
+        assertThat(demodayBooth.getStampCredentialHash()).isEqualTo(CREDENTIAL_HASH);
+        assertThat(demodayBooth.getStampCredentialCipher()).isEqualTo(ENCRYPTED_CREDENTIAL);
+        assertThat(demodayBooth.getStampCredentialGeneratedAt()).isEqualTo(GENERATED_AT);
+
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+        then(generateDemodayStampCredentialPort).should().generate();
+        then(hashDemodayStampCredentialPort).should().hash(CREDENTIAL);
+        then(encryptDemodayStampCredentialPort).should().encrypt(CREDENTIAL);
+        then(clock).should().instant();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 부스의 스탬프 QR 발급 요청은 실패한다")
+    void throwExceptionWhenBoothDoesNotExist() {
+        // given
+        CreateStampCredentialCommand command = new CreateStampCredentialCommand(POLL_ID, BOOTH_ID);
+        given(loadDemodayBoothPort.findById(BOOTH_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createDemodayStampCommandService.create(MEMBER_ID, command))
+                .isInstanceOf(DemodayDomainException.class);
+
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(loadDemodayPollPort).shouldHaveNoInteractions();
+        then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(clock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 투표 행사에 속한 부스의 스탬프 QR 발급 요청은 실패한다")
+    void throwExceptionWhenBoothDoesNotBelongToPoll() {
+        // given
+        Long anotherPollId = 4L;
+        DemodayBooth demodayBooth = DemodayBooth.forExternal(anotherPollId, "UMC PRODUCT");
+        CreateStampCredentialCommand command = new CreateStampCredentialCommand(POLL_ID, BOOTH_ID);
+        given(loadDemodayBoothPort.findById(BOOTH_ID)).willReturn(Optional.of(demodayBooth));
+
+        // when & then
+        assertThatThrownBy(() -> createDemodayStampCommandService.create(MEMBER_ID, command))
+                .isInstanceOf(DemodayDomainException.class);
+
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(loadDemodayPollPort).shouldHaveNoInteractions();
+        then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(clock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 데모데이 투표의 스탬프 QR 발급 요청은 실패한다")
+    void throwExceptionWhenPollDoesNotExist() {
+        // given
+        DemodayBooth demodayBooth = DemodayBooth.forExternal(POLL_ID, "팀 리버");
+        CreateStampCredentialCommand command = new CreateStampCredentialCommand(POLL_ID, BOOTH_ID);
+        given(loadDemodayBoothPort.findById(BOOTH_ID)).willReturn(Optional.of(demodayBooth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> createDemodayStampCommandService.create(MEMBER_ID, command))
+                .isInstanceOf(DemodayDomainException.class);
+
+        then(adminAccessChecker).shouldHaveNoInteractions();
+        then(generateDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(hashDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(encryptDemodayStampCredentialPort).shouldHaveNoInteractions();
+        then(clock).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,6 +39,8 @@ demoday:
     base-url: https://vote.test.umc.it.kr
   vote-qr:
     signing-key: test-dummy-vote-qr-signing-key-needs-32-bytes-min
+  stamp-credential:
+    encryption-key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
 
 management:
   tracing:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,6 +34,11 @@ jwt:
   refresh-token-validity-in-seconds: 604800
   verification-token-validity-in-seconds: 600
 
+demoday:
+  qr:
+    base-url: https://vote.test.umc.it.kr
+  vote-qr:
+    signing-key: test-dummy-vote-qr-signing-key-needs-32-bytes-min
 
 management:
   tracing:
@@ -111,10 +116,3 @@ app:
     google:
       client-id-list: apps.googleusercontent.com
 
-# ==================================================================
-# configuration for demdoay domain
-# ==================================================================
-
-demoday:
-  stamp-credential:
-    encryption-key: test-dummy-encryption-key-value

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -110,3 +110,11 @@ app:
   oauth2:
     google:
       client-id-list: apps.googleusercontent.com
+
+# ==================================================================
+# configuration for demdoay domain
+# ==================================================================
+
+demoday:
+  stamp-credential:
+    encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -117,4 +117,4 @@ app:
 
 demoday:
   stamp-credential:
-    encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}
+    encryption-key: test-dummy-encryption-key-value


### PR DESCRIPTION
Resolves #1256

## 🚀 작업 내용

데모데이 운영진이 부스별 스탬프 QR을 발급·재발급할 수 있도록 관리자 API를 추가했습니다. 발급과 재발급은 동일한 흐름으로 처리하며, 요청마다 기존 credential을 새 값으로 교체합니다.

- 관리자 부스 컨트롤러에 스탬프 QR 발급 API 추가
- 난수 credential 생성, SHA-256 해시 저장, AES-256-GCM 암호문 저장 구현
- 재출력을 위해 원문 credential을 암호화하고, 조회용으로는 해시를 사용하도록 분리
- credential 세 필드(hash/cipher/generatedAt)의 all-or-none 불변식 적용
- credential hash 중복을 막는 DB UNIQUE 제약 및 Flyway 마이그레이션 추가
- 응답에서 raw credential 대신 `demoday.qr.base-url` 기반의 QR URL 생성
- URL-safe Base64 복호화 및 gisu 기준 권한 검증 보완
- Command Service 및 credential generator 단위 테스트 추가
- WebMvc 테스트에서 신규 UseCase 의존성을 mock 처리

## 💬 리뷰 중점사항

- AES-256-GCM 암호화 대상이 hash가 아닌 원문 credential인지 확인 부탁드립니다.
- 재발급 시 세 credential 필드가 함께 갱신되고, hash UNIQUE 제약으로 중복 적립 대상을 방지하는 흐름을 봐주세요.
- 운영 환경에서 암호화 키와 `demoday.qr.base-url`이 환경 변수로 올바르게 주입되는지 확인이 필요합니다.