### PR TITLE
[Feat] SSM Parameter Store 기반 환경변수 관리 도구 및 가이드 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,30 +2,40 @@
 # UMC PRODUCT API Server 환경변수 예시
 # - 실제 비밀값은 커밋하지 말고 배포 환경 또는 로컬 .env 에만 설정한다.
 # - 기본값이 application.yml 에 정의된 항목은 동일한 기본값을 기재했다.
+# - 섹션과 순서는 application.yml 의 정의 순서를 따른다.
+# - 배포 환경 값은 SSM Parameter Store 로 관리한다.
+#   업로드: ./scripts/upload-env-to-ssm.sh <ENV_FILE> <ENVIRONMENT>
+#   가이드: docs/infra/ssm-parameter-store-guide.md
 # ==================================================================
+
+# ------------------------------------------------------------------
+# Server / Tomcat
+# ------------------------------------------------------------------
+SERVER_PORT=8080
+TOMCAT_MAX_THREADS=200
+TOMCAT_MIN_SPARE_THREADS=10
+TOMCAT_MAX_CONNECTIONS=8192
+TOMCAT_ACCEPT_COUNT=100
 
 # ------------------------------------------------------------------
 # Application / Profile
 # ------------------------------------------------------------------
 SPRING_APPLICATION_NAME=x-umc-product
 SPRING_PROFILES_ACTIVE=local
+# spring.profiles.active 가 콤마 구분 다중 profile 일 때 단일 라벨을 명시적으로 override 한다.
 APP_ENVIRONMENT=local
 
 # 로컬 개발자/인스턴스 식별자. 미설정 시 USER/USERNAME/HOSTNAME fallback 사용.
 LOCAL_DEVELOPER_ID=
-# HOSTNAME=
-# USER=
-# USERNAME=
 
 # ------------------------------------------------------------------
-# Server / Tomcat
+# GraphQL
 # ------------------------------------------------------------------
-SERVER_PORT=8080
-MANAGEMENT_PORT=9090
-TOMCAT_MAX_THREADS=200
-TOMCAT_MIN_SPARE_THREADS=10
-TOMCAT_MAX_CONNECTIONS=8192
-TOMCAT_ACCEPT_COUNT=100
+# local/dev 프로필은 기본 true, 그 외 기본 false.
+GRAPHQL_GRAPHIQL_ENABLED=false
+GRAPHQL_TIMEOUT=5s
+GRAPHQL_MAX_DEPTH=15
+GRAPHQL_MAX_COMPLEXITY=200
 
 # ------------------------------------------------------------------
 # Database / Connection Pool / Flyway
@@ -35,18 +45,12 @@ DATABASE_USERNAME=umc_product
 DATABASE_PASSWORD=umc_product_password
 
 HIKARI_MAX_POOL_SIZE=10
-HIKARI_MIN_IDLE=10
+HIKARI_MIN_IDLE=2
+# -1 이면 커넥션 초기화 실패 시에도 부팅을 계속한다.
+HIKARI_INITIALIZATION_FAIL_TIMEOUT=-1
 
 FLYWAY_BASELINE_ON_MIGRATE=false
 FLYWAY_OUT_OF_ORDER=false
-
-# ------------------------------------------------------------------
-# Mail
-# ------------------------------------------------------------------
-MAIL_HOST=
-MAIL_PORT=
-MAIL_USERNAME=
-MAIL_PASSWORD=
 
 # ------------------------------------------------------------------
 # JWT / Token
@@ -61,19 +65,27 @@ JWT_REFRESH_TOKEN_VALIDITY_IN_SECONDS=604800
 JWT_VERIFICATION_TOKEN_VALIDITY_IN_SECONDS=600
 
 # ------------------------------------------------------------------
-# Swagger / API Docs
+# OpenAPI / API Docs (Scalar)
+# SWAGGER_ENABLE / SWAGGER_ENABLE_ACTUATOR 는 legacy alias 로, OPENAPI_* 가 우선한다.
 # ------------------------------------------------------------------
-SWAGGER_ENABLE=false
-SWAGGER_ENABLE_ACTUATOR=false
-SWAGGER_AUTH_USERNAME=username
-SWAGGER_AUTH_PASSWORD=password
+OPENAPI_ENABLE=false
+OPENAPI_ENABLE_ACTUATOR=false
+
+# ------------------------------------------------------------------
+# P6Spy / SQL 라인 로깅
+# 환경변수 기본값: local=true / dev·staging·prod·test=false
+# ------------------------------------------------------------------
+P6SPY_ENABLE_LOGGING=false
 
 # ------------------------------------------------------------------
 # Logging / Metrics / Tracing
 # ------------------------------------------------------------------
 LOGGING_APP_LEVEL=INFO
+MANAGEMENT_PORT=9090
 TRACE_SAMPLING_PROBABILITY=1.0
 
+# OTEL_URL 하나만 설정하면 logs/traces/metrics 엔드포인트가 함께 유도된다.
+# 개별 URL/헤더는 필요한 경우에만 override 한다.
 OTEL_URL=http://localhost:4318
 OTEL_AUTH_HEADER=
 OTEL_LOGS_URL=http://localhost:4318/v1/logs
@@ -84,47 +96,27 @@ PROM_URL=http://localhost:4318/v1/metrics
 PROM_AUTH_HEADER=
 
 # ------------------------------------------------------------------
-# CORS
+# Observability (app.observability.tracing)
 # ------------------------------------------------------------------
-CORS_ALLOWED_ORIGIN_PATTERNS=
+APP_OBSERVABILITY_TRACING_ENABLED=true
+APP_OBSERVABILITY_USE_CASE_SPANS=true
+APP_OBSERVABILITY_ADAPTER_SPANS=true
+APP_OBSERVABILITY_DB_SPANS=true
+# SQL 원문에는 개인정보/토큰성 값이 포함될 수 있으므로 기본값은 비활성화한다.
+APP_OBSERVABILITY_INCLUDE_SQL=false
+APP_OBSERVABILITY_MAX_SQL_LENGTH=500
 
 # ------------------------------------------------------------------
-# Notification / FCM
+# SSO / Authorization Code + PKCE
 # ------------------------------------------------------------------
-FCM_ENABLED=false
-FCM_OUTBOX_INTERVAL_MS=60000
-# 다중 인스턴스에서는 토큰 검증을 담당할 배치 인스턴스에서만 true로 둔다.
-FCM_TOKEN_VALIDATION_ENABLED=true
-FCM_TOKEN_VALIDATION_INTERVAL_MS=86400000
-FCM_TOKEN_VALIDATION_BATCH_SIZE=500
-FCM_TOKEN_VALIDATION_STALE_DURATION=P30D
-FIREBASE_CONFIGURATION=
-
-# ------------------------------------------------------------------
-# Event Outbox
-# ------------------------------------------------------------------
-EVENT_OUTBOX_RELAY_ENABLED=true
-EVENT_OUTBOX_POLL_INTERVAL_MS=1000
-EVENT_OUTBOX_BATCH_SIZE=100
-EVENT_OUTBOX_MAX_ATTEMPTS=5
-
-# ------------------------------------------------------------------
-# Webhook
-# ------------------------------------------------------------------
-WEBHOOK_BUFFER_ENABLED=true
-WEBHOOK_BUFFER_FLUSH_INTERVAL_MS=60000
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
-SLACK_WEBHOOK_URL=
-DISCORD_WEBHOOK_URL=
-
-# ------------------------------------------------------------------
-# Seed API
-# ------------------------------------------------------------------
-APP_SEED_ENABLED=false
-APP_SEED_SKIP_THRESHOLD=0
-APP_SEED_EMAIL_DOMAIN=test.umc.it.kr
-APP_SEED_DEFAULT_PASSWORD=password12!
+SSO_ISSUER=https://api.university.neordinary.com
+SSO_AUTHORIZATION_CODE_TTL=PT3M
+SSO_BROWSER_LOGIN_TTL=PT12H
+SSO_BROWSER_LOGIN_COOKIE_NAME=UMC_SSO_LOGIN
+# 로컬/localhost에서는 비워둔다. 운영 예시: .university.neordinary.com
+SSO_BROWSER_LOGIN_COOKIE_DOMAIN=
+SSO_BROWSER_LOGIN_COOKIE_SECURE=true
+SSO_BROWSER_LOGIN_COOKIE_SAME_SITE=Lax
 
 # ------------------------------------------------------------------
 # Project / Matching Round
@@ -139,6 +131,78 @@ PROJECT_MATCHING_ROUND_DEADLINE_BUFFER_MINUTES=1
 # ------------------------------------------------------------------
 # true 면 SUPER_ADMIN 이 DRAFT 프로젝트/지원서 단건을 조회할 수 있다. 초기 배포 모니터링용으로만 켜고 안정화 후 끈다.
 SUPER_ADMIN_ALLOW_DRAFT_READ=false
+
+# ------------------------------------------------------------------
+# API Rate Limit
+# ------------------------------------------------------------------
+API_RATE_LIMIT_ENABLED=true
+API_RATE_LIMIT_AUTH_REQUESTS_PER_SECOND=20
+API_RATE_LIMIT_AUTH_REQUESTS_PER_MINUTE=300
+API_RATE_LIMIT_ANON_REQUESTS_PER_SECOND=5
+API_RATE_LIMIT_ANON_REQUESTS_PER_MINUTE=60
+API_RATE_LIMIT_CACHE_MAXIMUM_SIZE=100000
+API_RATE_LIMIT_CACHE_EXPIRE_AFTER_ACCESS=PT10M
+
+# ------------------------------------------------------------------
+# WebSocket Broker
+# WEBSOCKET_BROKER_MODE: simple(기본, 내장 브로커) | relay(외부 STOMP 브로커)
+# relay 모드일 때만 WEBSOCKET_BROKER_RELAY_* 를 주입한다.
+# ------------------------------------------------------------------
+WEBSOCKET_BROKER_MODE=simple
+WEBSOCKET_BROKER_RELAY_HOST=
+WEBSOCKET_BROKER_RELAY_PORT=
+WEBSOCKET_BROKER_RELAY_TLS_ENABLED=true
+WEBSOCKET_BROKER_RELAY_VIRTUAL_HOST=
+WEBSOCKET_BROKER_RELAY_SYSTEM_LOGIN=
+WEBSOCKET_BROKER_RELAY_SYSTEM_PASSWORD=
+WEBSOCKET_BROKER_RELAY_CLIENT_LOGIN=
+WEBSOCKET_BROKER_RELAY_CLIENT_PASSWORD=
+WEBSOCKET_BROKER_RELAY_HEARTBEAT_SEND_INTERVAL=PT10S
+WEBSOCKET_BROKER_RELAY_HEARTBEAT_RECEIVE_INTERVAL=PT10S
+WEBSOCKET_BROKER_RELAY_STARTUP_TIMEOUT=PT5S
+
+# ------------------------------------------------------------------
+# Event Outbox
+# ------------------------------------------------------------------
+EVENT_OUTBOX_RELAY_ENABLED=true
+EVENT_OUTBOX_POLL_INTERVAL_MS=1000
+EVENT_OUTBOX_BATCH_SIZE=100
+EVENT_OUTBOX_MAX_ATTEMPTS=5
+
+# ------------------------------------------------------------------
+# Notification / FCM
+# ------------------------------------------------------------------
+FCM_ENABLED=false
+FCM_OUTBOX_INTERVAL_MS=60000
+# 다중 인스턴스에서는 토큰 검증을 담당할 배치 인스턴스에서만 true로 둔다.
+FCM_TOKEN_VALIDATION_ENABLED=true
+FCM_TOKEN_VALIDATION_INTERVAL_MS=86400000
+FCM_TOKEN_VALIDATION_BATCH_SIZE=500
+FCM_TOKEN_VALIDATION_STALE_DURATION=P30D
+# Firebase 서비스 계정 JSON. 크기가 4KB를 넘으면 SSM Advanced tier 로 저장된다.
+FIREBASE_CONFIGURATION=
+
+# ------------------------------------------------------------------
+# CORS
+# ------------------------------------------------------------------
+CORS_ALLOWED_ORIGIN_PATTERNS=
+
+# ------------------------------------------------------------------
+# Webhook
+# ------------------------------------------------------------------
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+SLACK_WEBHOOK_URL=
+DISCORD_WEBHOOK_URL=
+
+# ------------------------------------------------------------------
+# Seed API (ADR-017)
+# prod 가 아닌 환경에서 APP_SEED_ENABLED=true 로 켜야 시딩 API 가 노출된다.
+# ------------------------------------------------------------------
+APP_SEED_ENABLED=false
+APP_SEED_SKIP_THRESHOLD=0
+APP_SEED_EMAIL_DOMAIN=test.umc.it.kr
+APP_SEED_DEFAULT_PASSWORD=password12!
 
 # ------------------------------------------------------------------
 # OAuth2 / Social Login
@@ -163,20 +227,9 @@ KAKAO_JWKS_CACHE_TTL=PT24H
 KAKAO_JWKS_CACHE_MAX_SIZE=1
 
 # ------------------------------------------------------------------
-# SSO / Authorization Code + PKCE
-# ------------------------------------------------------------------
-SSO_ISSUER=https://api.university.neordinary.com
-SSO_AUTHORIZATION_CODE_TTL=PT3M
-SSO_BROWSER_LOGIN_TTL=PT12H
-SSO_BROWSER_LOGIN_COOKIE_NAME=UMC_SSO_LOGIN
-# 로컬/localhost에서는 비워둔다. 운영 예시: .university.neordinary.com
-SSO_BROWSER_LOGIN_COOKIE_DOMAIN=
-SSO_BROWSER_LOGIN_COOKIE_SECURE=true
-SSO_BROWSER_LOGIN_COOKIE_SAME_SITE=Lax
-
-# ------------------------------------------------------------------
 # LLM / Spring AI
 # LLM_PROVIDER: mock, openai, vertexai-gemini, google-genai
+# provider 별 필수 환경변수는 application.yml 상단 주석 참고.
 # ------------------------------------------------------------------
 LLM_PROVIDER=mock
 LLM_MODEL=gemini-2.5-flash-lite
@@ -201,6 +254,31 @@ LLM_GEMINI_API_KEY=
 LLM_GOOGLE_GENAI_VERTEX_AI=false
 
 # ------------------------------------------------------------------
+# Email (SES v2)
+# access-key/secret 을 비워두면 DefaultCredentialsProvider 체인으로 폴백한다.
+# ------------------------------------------------------------------
+SES_REGION=ap-northeast-2
+SES_ACCESS_KEY_ID=
+SES_SECRET_ACCESS_KEY=
+# 바운스/컴플레인트 트래킹이 필요할 때만 주입한다.
+SES_CONFIGURATION_SET=
+EMAIL_NO_REPLY_ADDRESS=
+EMAIL_NO_REPLY_DISPLAY_NAME=University MakeUs Challenge
+
+# ------------------------------------------------------------------
+# SSM (app.ssm — CloudFront private key 등 파라미터 직접 조회용)
+# access-key/secret 을 비워두면 기본 자격증명 체인(IAM Role 등)을 사용한다.
+# ------------------------------------------------------------------
+SSM_REGION=ap-northeast-2
+SSM_ACCESS_KEY_ID=
+SSM_SECRET_ACCESS_KEY=
+
+# ------------------------------------------------------------------
+# Certificate
+# ------------------------------------------------------------------
+CERTIFICATE_VERIFICATION_URL_TEMPLATE=/api/v1/certificates/verify/{serialNumber}
+
+# ------------------------------------------------------------------
 # Storage
 # STORAGE_PROVIDER: s3
 # ------------------------------------------------------------------
@@ -214,10 +292,6 @@ S3_SECRET_ACCESS_KEY=
 AWS_CLOUDFRONT_ENABLED=false
 AWS_CLOUDFRONT_DISTRIBUTION_DOMAIN=cdn.umc.it.kr
 CDN_KEY_PAIR_ID=
+# 직접 값 주입 대신 SSM 파라미터 이름으로 조회할 수도 있다 (아래 CDN_PRIVATE_KEY_PARAMETER_NAME).
 CDN_PRIVATE_KEY=
-
-SES_REGION=
-SES_ACCESS_KEY_ID=
-SES_SECRET_ACCESS_KEY=
-EMAIL_NO_REPLY_ADDRESS=
-EMAIL_NO_REPLY_DISPLAY_NAME=
+CDN_PRIVATE_KEY_PARAMETER_NAME=/umc/common/cloudfront/private-key

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ LOCAL_DEVELOPER_ID=
 # ------------------------------------------------------------------
 # GraphQL
 # ------------------------------------------------------------------
-# local/dev 프로필은 기본 true, 그 외 기본 false.
+# local/alpha 프로필은 기본 true, 그 외 기본 false.
 GRAPHQL_GRAPHIQL_ENABLED=false
 GRAPHQL_TIMEOUT=5s
 GRAPHQL_MAX_DEPTH=15
@@ -73,7 +73,7 @@ OPENAPI_ENABLE_ACTUATOR=false
 
 # ------------------------------------------------------------------
 # P6Spy / SQL 라인 로깅
-# 환경변수 기본값: local=true / dev·staging·prod·test=false
+# 환경변수 기본값: local=true / alpha·staging·prod·test=false
 # ------------------------------------------------------------------
 P6SPY_ENABLE_LOGGING=false
 

--- a/.github/workflows/cd-asg.yml
+++ b/.github/workflows/cd-asg.yml
@@ -127,12 +127,11 @@ jobs:
           fi
 
           # SPRING_PROFILE 은 Spring profile 이름, SSM_ENV 는 SSM 경로 세그먼트다.
-          # Spring profile 이 alpha 로 rename 되기 전까지 dev/alpha 매핑이 서로 다르다.
           case "${ENVIRONMENT}" in
             Production) SPRING_PROFILE="prod"; SSM_ENV="prod" ;;
-            Development) SPRING_PROFILE="dev"; SSM_ENV="alpha" ;;
+            Development) SPRING_PROFILE="alpha"; SSM_ENV="alpha" ;;
             Test) SPRING_PROFILE="test"; SSM_ENV="alpha" ;;
-            *) SPRING_PROFILE="dev"; SSM_ENV="alpha" ;;
+            *) SPRING_PROFILE="alpha"; SSM_ENV="alpha" ;;
           esac
 
           SSM_PARAMETER_PATH="${SSM_BASE_PATH}/${SSM_ENV}"

--- a/.github/workflows/cd-asg.yml
+++ b/.github/workflows/cd-asg.yml
@@ -2,8 +2,11 @@
 # - vars.UMC_GITHUB_APP_CLIENT_ID (used by reusable CI feedback)
 # - vars.ASG_NAME
 # - vars.LAUNCH_TEMPLATE_NAME
-# - vars.SECRET_S3_URI
 # Optional repository variables:
+# - vars.SSM_BASE_PATH (default: /umc-product/cygnus-server)
+#   환경변수는 부팅 시 인스턴스가 ${SSM_BASE_PATH}/{prod|alpha}/ 에서 직접 내려받는다.
+#   Launch Template 의 instance profile(IAM Role)에 해당 경로의
+#   ssm:GetParametersByPath + kms:Decrypt(aws/ssm) 권한이 필요하다.
 # - vars.AWS_REGION (default: ap-northeast-2)
 # - vars.ECR_REPOSITORY (default: umc-product-server)
 # - vars.APP_PORT (default: 8080)
@@ -81,7 +84,7 @@ jobs:
       LAUNCH_TEMPLATE_NAME: ${{ vars.LAUNCH_TEMPLATE_NAME }}
       APP_PORT: ${{ vars.APP_PORT || '8080' }}
       MANAGEMENT_PORT: ${{ vars.MANAGEMENT_PORT || '9090' }}
-      SECRET_S3_URI: ${{ vars.SECRET_S3_URI }}
+      SSM_BASE_PATH: ${{ vars.SSM_BASE_PATH || '/umc-product/cygnus-server' }}
       MIN_HEALTHY_PERCENTAGE: ${{ vars.ASG_MIN_HEALTHY_PERCENTAGE || '100' }}
       MAX_HEALTHY_PERCENTAGE: ${{ vars.ASG_MAX_HEALTHY_PERCENTAGE || '200' }}
       INSTANCE_WARMUP: ${{ vars.ASG_INSTANCE_WARMUP || '300' }}
@@ -117,18 +120,22 @@ jobs:
           : "${ECR_REPOSITORY:?ECR_REPOSITORY is required}"
           : "${APP_PORT:?APP_PORT is required}"
           : "${MANAGEMENT_PORT:?MANAGEMENT_PORT is required}"
-          : "${SECRET_S3_URI:?SECRET_S3_URI is required}"
+          : "${SSM_BASE_PATH:?SSM_BASE_PATH is required}"
 
           if [[ -z "${AWS_ACCOUNT_ID}" ]]; then
             AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
           fi
 
+          # SPRING_PROFILE 은 Spring profile 이름, SSM_ENV 는 SSM 경로 세그먼트다.
+          # Spring profile 이 alpha 로 rename 되기 전까지 dev/alpha 매핑이 서로 다르다.
           case "${ENVIRONMENT}" in
-            Production) SPRING_PROFILE="prod" ;;
-            Development) SPRING_PROFILE="dev" ;;
-            Test) SPRING_PROFILE="test" ;;
-            *) SPRING_PROFILE="dev" ;;
+            Production) SPRING_PROFILE="prod"; SSM_ENV="prod" ;;
+            Development) SPRING_PROFILE="dev"; SSM_ENV="alpha" ;;
+            Test) SPRING_PROFILE="test"; SSM_ENV="alpha" ;;
+            *) SPRING_PROFILE="dev"; SSM_ENV="alpha" ;;
           esac
+
+          SSM_PARAMETER_PATH="${SSM_BASE_PATH}/${SSM_ENV}"
 
           cp infra/asg/user-data.sh /tmp/user-data.sh
 
@@ -138,7 +145,7 @@ jobs:
           sed -i "s|__IMAGE_TAG__|${IMAGE_TAG}|g" /tmp/user-data.sh
           sed -i "s|__APP_PORT__|${APP_PORT}|g" /tmp/user-data.sh
           sed -i "s|__MANAGEMENT_PORT__|${MANAGEMENT_PORT}|g" /tmp/user-data.sh
-          sed -i "s|__SECRET_S3_URI__|${SECRET_S3_URI}|g" /tmp/user-data.sh
+          sed -i "s|__SSM_PARAMETER_PATH__|${SSM_PARAMETER_PATH}|g" /tmp/user-data.sh
           sed -i "s|__SPRING_PROFILE__|${SPRING_PROFILE}|g" /tmp/user-data.sh
 
           USER_DATA_BASE64=$(base64 -w 0 /tmp/user-data.sh)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -223,9 +223,9 @@ jobs:
 
             case "${{ env.ENVIRONMENT }}" in
               "Production") PROFILE="prod" ;;
-              "Development") PROFILE="dev" ;;
+              "Development") PROFILE="alpha" ;;
               "Test") PROFILE="test" ;;
-              *) PROFILE="dev" ;;
+              *) PROFILE="alpha" ;;
             esac
 
             echo "📝 Docker Compose 치환 전용 .env 파일 생성 중..."

--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     env_file:
       - app.env
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-alpha}
       SERVER_PORT: ${APP_PORT:-8080}
       MANAGEMENT_PORT: ${MANAGEMENT_PORT:-9090}
       DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}

--- a/docs/infra/ssm-parameter-store-guide.md
+++ b/docs/infra/ssm-parameter-store-guide.md
@@ -1,0 +1,188 @@
+# SSM Parameter Store 환경변수 관리 가이드
+
+서버 환경변수(비밀값 포함)는 AWS SSM Parameter Store 에서 관리한다.
+배포 시 인스턴스가 부팅 시점에 파라미터를 내려받아 `.env` 를 구성하므로,
+**환경변수 변경 = SSM 파라미터 변경 + 재배포(또는 인스턴스 교체)** 이다.
+
+## 파라미터 이름 규칙
+
+```text
+/umc-product/<projectName>/<environment>/<KEY>
+
+예)
+/umc-product/cygnus-server/prod/DATABASE_URL
+/umc-product/cygnus-server/alpha/JWT_ACCESS_TOKEN_SECRET
+```
+
+- `<projectName>`: 파라미터를 소유한 프로젝트. 이 저장소(API 서버)는 `cygnus-server` 를 사용한다.
+- `<environment>`: `prod` | `alpha`
+- `<KEY>`: `.env.example` 의 키 이름 그대로 (UPPER_SNAKE_CASE)
+- 타입은 **항상 `SecureString`** 으로 통일한다. 비밀값 여부를 키마다 판단하지 않는다.
+- 어떤 키가 존재하는지의 canonical 목록은 루트 [`.env.example`](../../.env.example) 이다.
+  새 환경변수를 추가할 때는 `.env.example` 과 `application.yml` 을 먼저 갱신한다.
+
+## 사전 준비 (최초 1회)
+
+1. AWS CLI v2 설치
+
+   ```bash
+   # macOS
+   brew install awscli
+
+   # 확인
+   aws --version
+   ```
+
+2. 서버팀 리더에게 IAM 자격증명(Access Key)을 발급받아 프로필로 등록
+
+   ```bash
+   aws configure --profile umc
+   # AWS Access Key ID / Secret Access Key 입력
+   # Default region name: ap-northeast-2
+   # Default output format: json
+   ```
+
+3. 접근 확인
+
+   ```bash
+   aws ssm describe-parameters \
+     --parameter-filters "Key=Path,Values=/umc-product/cygnus-server/alpha/" \
+     --profile umc --region ap-northeast-2 \
+     --query 'Parameters[*].Name' --output table
+   ```
+
+발급되는 IAM 정책은 `/umc-product/*` 경로 하위로 제한되어 있다
+(`ssm:GetParameter*`, `ssm:PutParameter`, `ssm:DeleteParameter`, `ssm:GetParameterHistory` + `kms:Decrypt`).
+prod 쓰기 권한은 서버팀 리더 승인 후 부여된다.
+
+## 자주 쓰는 명령
+
+아래 명령은 모두 `--profile umc --region ap-northeast-2` 를 붙인다고 가정한다.
+(매번 붙이기 귀찮으면 `export AWS_PROFILE=umc AWS_DEFAULT_REGION=ap-northeast-2`)
+
+### 목록 조회
+
+```bash
+aws ssm get-parameters-by-path \
+  --path "/umc-product/cygnus-server/alpha/" --recursive \
+  --query 'Parameters[*].Name' --output table
+```
+
+### 값 조회 (복호화 포함)
+
+```bash
+aws ssm get-parameter \
+  --name "/umc-product/cygnus-server/alpha/DATABASE_URL" \
+  --with-decryption \
+  --query 'Parameter.Value' --output text
+```
+
+### 값 등록 / 수정
+
+```bash
+aws ssm put-parameter \
+  --name "/umc-product/cygnus-server/alpha/LLM_PROVIDER" \
+  --type SecureString \
+  --tier Intelligent-Tiering \
+  --value "google-genai" \
+  --overwrite
+```
+
+- `--tier Intelligent-Tiering`: 4KB 이하는 무료 Standard, 초과분만 Advanced(유료, $0.05/월)로 자동 저장된다.
+- `--overwrite` 를 빼면 이미 존재하는 키에서 에러가 난다 (신규 생성 시 실수 방지용으로 활용 가능).
+
+### 변경 이력 조회
+
+```bash
+aws ssm get-parameter-history \
+  --name "/umc-product/cygnus-server/alpha/LLM_PROVIDER" --with-decryption \
+  --query 'Parameters[*].[Version,LastModifiedDate,LastModifiedUser]' --output table
+```
+
+모든 변경은 버전으로 남고 수정자가 기록되므로, 값이 갑자기 바뀌었을 때 이력부터 확인한다.
+
+### 삭제
+
+```bash
+aws ssm delete-parameter --name "/umc-product/cygnus-server/alpha/OLD_KEY"
+```
+
+삭제는 복구되지 않는다. prod 파라미터 삭제는 반드시 서버팀 리더와 상의 후 진행한다.
+
+### 로컬에서 alpha 환경으로 서버 실행 (파일 생성 없음, 권장)
+
+`.env` 파일을 만들지 않고 실행할 프로세스에만 환경변수를 주입한다.
+값이 디스크에 남지 않으므로 유출 위험이 가장 적다.
+
+```bash
+# alpha 환경변수를 주입해 bootRun (가장 흔한 사용법)
+AWS_PROFILE=umc ./scripts/run-alpha.sh
+
+# 디버거 attach 등 gradle 인자 전달
+AWS_PROFILE=umc ./scripts/run-alpha.sh --debug-jvm
+
+# bootRun 대신 임의 명령 실행
+./scripts/run-alpha.sh -- java -jar build/libs/app.jar
+
+# 특정 값만 로컬에서 덮어쓰기 (env 가 SSM 주입값 이후에 적용됨)
+./scripts/run-alpha.sh -- env APP_SEED_ENABLED=false ./gradlew bootRun
+```
+
+alpha 는 공유 환경이므로 시딩·삭제 등 파괴적인 작업은 주의한다.
+다른 환경/프로젝트가 필요하면 범용 스크립트를 직접 쓴다:
+
+```bash
+./scripts/with-ssm-env.sh prod cygnus-server -- java -jar build/libs/app.jar
+```
+
+IntelliJ 에서 실행하고 싶다면 Run Configuration 을 Gradle 이 아닌
+"Shell Script" 로 만들어 위 명령을 지정하면 된다.
+값이 바뀌었는데 반영이 안 되는 것 같으면 `./gradlew --stop` 후 재실행한다 (데몬 env 캐시).
+
+### 환경 전체를 .env 로 내려받기 (로컬 디버깅용)
+
+```bash
+aws ssm get-parameters-by-path \
+  --path "/umc-product/cygnus-server/alpha/" --recursive --with-decryption \
+  --query "Parameters[*].[Name,Value]" --output text \
+  | while IFS=$'\t' read -r name value; do
+      printf '%s=%s\n' "${name##*/}" "${value}"
+    done > .env.alpha
+chmod 600 .env.alpha
+```
+
+## .env 파일 일괄 업로드
+
+키가 많을 때는 스크립트를 사용한다. `.env` 형식 파일을 통째로 업로드한다.
+
+```bash
+# 미리보기 (업로드 없음)
+DRY_RUN=1 ./scripts/upload-env-to-ssm.sh .env.alpha alpha
+
+# 실제 업로드 (확인 프롬프트 후 진행)
+AWS_PROFILE=umc ./scripts/upload-env-to-ssm.sh .env.alpha alpha
+```
+
+- 빈 값 항목은 자동으로 건너뛴다 (SSM 은 빈 문자열을 허용하지 않는다).
+- 4KB 를 넘는 값에는 Advanced tier 과금 경고를 미리 표시한다.
+- 기존 파라미터는 덮어쓰므로, 실행 전 DRY_RUN 으로 대상 목록을 확인하는 습관을 들인다.
+
+## 주의사항
+
+- **빈 값은 저장할 수 없다.** "값 없음"이 필요하면 파라미터를 만들지 않는다
+  (`application.yml` 기본값이 적용된다).
+- **멀티라인 값 금지.** `APPLE_PRIVATE_KEY`, `FIREBASE_CONFIGURATION` 처럼 개행이 포함된 값은
+  base64 로 인코딩해 한 줄로 저장하거나, CloudFront private key 처럼 파라미터 이름만 env 로 넘기고
+  앱이 SDK 로 직접 조회하는 방식(`CDN_PRIVATE_KEY_PARAMETER_NAME` 패턴)을 사용한다.
+- **조회한 비밀값을 Slack/Discord/PR 에 붙여넣지 않는다.** 로컬에 내려받은 `.env.*` 파일은
+  `.gitignore` 대상인지 확인하고, 사용 후 삭제한다.
+- **prod 값 변경은 즉시 반영되지 않는다.** 실행 중인 인스턴스는 부팅 시점의 값을 사용하므로,
+  변경 후 재배포(인스턴스 refresh)가 필요하다.
+- 4KB 초과 값은 Advanced tier 로 저장되어 파라미터당 월 $0.05 가 과금된다.
+  큰 JSON 은 가급적 base64 압축 전에 필요한 필드만 남기는 것을 검토한다.
+
+## 콘솔 UI
+
+CLI 대신 웹 콘솔에서도 조회/수정할 수 있다:
+[AWS Console → Systems Manager → Parameter Store](https://ap-northeast-2.console.aws.amazon.com/systems-manager/parameters?region=ap-northeast-2)
+(경로 필터에 `/umc-product/` 입력)

--- a/infra/asg/user-data.sh
+++ b/infra/asg/user-data.sh
@@ -9,7 +9,7 @@ ECR_REPOSITORY="__ECR_REPOSITORY__"
 IMAGE_TAG="__IMAGE_TAG__"
 APP_PORT="__APP_PORT__"
 MANAGEMENT_PORT="__MANAGEMENT_PORT__"
-SECRET_S3_URI="__SECRET_S3_URI__"
+SSM_PARAMETER_PATH="__SSM_PARAMETER_PATH__"
 SPRING_PROFILE="__SPRING_PROFILE__"
 
 ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
@@ -47,9 +47,26 @@ systemctl start docker
 mkdir -p "${APP_DIR}"
 cd "${APP_DIR}"
 
-echo "Downloading env file from S3..."
-aws s3 cp "${SECRET_S3_URI}" "${APP_DIR}/.env" --region "${AWS_REGION}"
+# SSM Parameter Store 에서 환경변수를 내려받아 .env 를 구성한다.
+# 인스턴스 프로파일(IAM Role)에 다음 권한이 필요하다:
+#   - ssm:GetParametersByPath on arn:aws:ssm:*:*:parameter${SSM_PARAMETER_PATH}/*
+#   - kms:Decrypt on aws/ssm 키 (SecureString 복호화)
+# 값에 탭/개행이 포함되면 파싱이 깨지므로 멀티라인 값은 base64 로 저장한다 (가이드 참조).
+echo "Fetching env from SSM Parameter Store (${SSM_PARAMETER_PATH})..."
+aws ssm get-parameters-by-path \
+  --path "${SSM_PARAMETER_PATH}/" \
+  --recursive --with-decryption \
+  --region "${AWS_REGION}" \
+  --query "Parameters[*].[Name,Value]" --output text \
+  | while IFS=$'\t' read -r name value; do
+      printf '%s=%s\n' "${name##*/}" "${value}"
+    done > "${APP_DIR}/.env"
 chmod 600 "${APP_DIR}/.env"
+
+if [[ ! -s "${APP_DIR}/.env" ]]; then
+  echo "No parameters found under ${SSM_PARAMETER_PATH}/ (권한 또는 경로 확인)"
+  exit 1
+fi
 
 echo "Logging in to ECR..."
 aws ecr get-login-password --region "${AWS_REGION}" \

--- a/scripts/run-alpha.sh
+++ b/scripts/run-alpha.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SSM 의 alpha 환경변수를 주입해 로컬에서 서버를 실행한다.
+# .env 파일을 만들지 않으며, 값은 실행된 프로세스에만 존재한다.
+#
+# 사용법:
+#   ./scripts/run-alpha.sh [GRADLE_ARGS...]   # ./gradlew bootRun [GRADLE_ARGS...]
+#   ./scripts/run-alpha.sh -- <COMMAND...>    # bootRun 대신 임의 명령 실행
+#
+# 예)
+#   AWS_PROFILE=umc ./scripts/run-alpha.sh
+#   AWS_PROFILE=umc ./scripts/run-alpha.sh --debug-jvm
+#   ./scripts/run-alpha.sh -- java -jar build/libs/app.jar
+#
+#   # 특정 값만 로컬에서 덮어쓰고 싶을 때 (env 가 SSM 주입값보다 나중에 적용됨)
+#   ./scripts/run-alpha.sh -- env APP_SEED_ENABLED=false ./gradlew bootRun
+#
+# 사전 준비: aws cli 로그인 (docs/infra/ssm-parameter-store-guide.md 참고)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+echo "⚠️  alpha 환경(공유 DB·리소스)에 연결합니다. 파괴적인 작업은 주의하세요." >&2
+
+if [[ "${1:-}" == "--" ]]; then
+  shift
+  exec "${SCRIPT_DIR}/with-ssm-env.sh" alpha -- "$@"
+fi
+
+exec "${SCRIPT_DIR}/with-ssm-env.sh" alpha -- ./gradlew bootRun "$@"

--- a/scripts/upload-env-to-ssm.sh
+++ b/scripts/upload-env-to-ssm.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# .env 형식 파일을 AWS SSM Parameter Store 에 SecureString 으로 업로드한다.
+#
+# 사용법:
+#   ./scripts/upload-env-to-ssm.sh <ENV_FILE> <ENVIRONMENT> [PROJECT_NAME]
+#   예) ./scripts/upload-env-to-ssm.sh .env.prod prod
+#       DRY_RUN=1 ./scripts/upload-env-to-ssm.sh .env.example alpha
+#
+# 파라미터 이름 규칙: ${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/${KEY}
+#   예) /umc-product/cygnus-server/prod/DATABASE_URL
+#
+# 환경변수:
+#   SSM_PREFIX   (default: /umc-product)
+#   PROJECT_NAME (default: cygnus-server — 세 번째 인자로도 지정 가능)
+#   AWS_REGION   (default: ap-northeast-2)
+#   AWS_PROFILE  (aws cli 프로필. 비우면 기본 자격증명 체인 사용)
+#   TIER         (default: Intelligent-Tiering — 4KB 이하는 무료 Standard,
+#                 초과 값만 Advanced 로 자동 승격되어 과금을 최소화한다)
+#   KMS_KEY_ID   (비우면 계정 기본 aws/ssm KMS 키 사용)
+#   DRY_RUN      (1이면 실제 업로드 없이 대상 목록만 출력)
+#   ASSUME_YES   (1이면 업로드 전 확인 프롬프트 생략 — CI 용)
+#
+# 규칙:
+#   - 주석(#)과 빈 줄은 무시한다.
+#   - 값이 빈 항목은 업로드하지 않는다 (SSM 은 빈 값을 허용하지 않음).
+#   - 값을 감싼 짝이 맞는 따옴표("..." / '...')는 벗겨서 저장한다
+#     (docker compose v2 의 env_file dotenv 파싱과 동일한 동작).
+#   - 4096 바이트를 넘는 값은 Advanced tier 로 저장되어 비용이 발생하므로 경고를 출력한다.
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+ENV_FILE="${1:-}"
+ENVIRONMENT="${2:-}"
+PROJECT_NAME="${3:-${PROJECT_NAME:-cygnus-server}}"
+[[ -z "${ENV_FILE}" || -z "${ENVIRONMENT}" ]] && usage
+[[ -f "${ENV_FILE}" ]] || { echo "ERROR: 파일을 찾을 수 없습니다: ${ENV_FILE}" >&2; exit 1; }
+
+SSM_PREFIX="${SSM_PREFIX:-/umc-product}"
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+TIER="${TIER:-Intelligent-Tiering}"
+KMS_KEY_ID="${KMS_KEY_ID:-}"
+DRY_RUN="${DRY_RUN:-0}"
+ASSUME_YES="${ASSUME_YES:-0}"
+
+if [[ "${DRY_RUN}" != "1" ]]; then
+  command -v aws >/dev/null 2>&1 || { echo "ERROR: aws cli 가 설치되어 있지 않습니다." >&2; exit 1; }
+fi
+
+# ── 1단계: 파싱 ─────────────────────────────────────────────
+keys=()
+values=()
+skipped_empty=()
+skipped_invalid=()
+
+lineno=0
+while IFS= read -r raw || [[ -n "${raw}" ]]; do
+  lineno=$((lineno + 1))
+  line="${raw%$'\r'}"
+  line="${line#"${line%%[![:space:]]*}"}"           # 앞 공백 제거
+  [[ -z "${line}" || "${line}" == \#* ]] && continue
+  line="${line#export }"
+
+  if [[ "${line}" != *"="* ]]; then
+    skipped_invalid+=("L${lineno}: ${line}")
+    continue
+  fi
+
+  key="${line%%=*}"
+  value="${line#*=}"
+  key="${key%"${key##*[![:space:]]}"}"              # 키 뒤 공백 제거
+
+  if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    skipped_invalid+=("L${lineno}: ${key}")
+    continue
+  fi
+
+  # 짝이 맞는 감싼 따옴표 제거
+  if [[ ${#value} -ge 2 ]]; then
+    if [[ "${value:0:1}" == '"' && "${value: -1}" == '"' ]] \
+      || [[ "${value:0:1}" == "'" && "${value: -1}" == "'" ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+  fi
+
+  if [[ -z "${value}" ]]; then
+    skipped_empty+=("${key}")
+    continue
+  fi
+
+  keys+=("${key}")
+  values+=("${value}")
+done < "${ENV_FILE}"
+
+# ── 2단계: 계획 출력 ────────────────────────────────────────
+echo "════════════════════════════════════════════════════"
+echo " SSM 업로드 계획"
+echo "  파일     : ${ENV_FILE}"
+echo "  대상     : ${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/<KEY>"
+echo "  리전     : ${AWS_REGION}"
+echo "  Tier     : ${TIER}"
+echo "  업로드   : ${#keys[@]}개"
+echo "  빈 값    : ${#skipped_empty[@]}개 (skip)"
+echo "  형식오류 : ${#skipped_invalid[@]}개 (skip)"
+echo "════════════════════════════════════════════════════"
+
+for i in "${!keys[@]}"; do
+  size=${#values[$i]}
+  note=""
+  (( size > 4096 )) && note="  ⚠ ${size}B > 4KB — Advanced tier 과금 발생"
+  printf '  %-55s (%d B)%s\n' "${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/${keys[$i]}" "${size}" "${note}"
+done
+
+if (( ${#skipped_empty[@]} > 0 )); then
+  echo ""
+  echo "값이 비어 있어 업로드하지 않는 키:"
+  printf '  - %s\n' "${skipped_empty[@]}"
+fi
+
+if (( ${#skipped_invalid[@]} > 0 )); then
+  echo ""
+  echo "형식이 올바르지 않아 무시한 줄:"
+  printf '  - %s\n' "${skipped_invalid[@]}"
+fi
+
+if (( ${#keys[@]} == 0 )); then
+  echo ""
+  echo "업로드할 항목이 없습니다."
+  exit 0
+fi
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo ""
+  echo "DRY_RUN=1 — 실제 업로드는 수행하지 않았습니다."
+  exit 0
+fi
+
+# ── 3단계: 확인 후 업로드 ───────────────────────────────────
+if [[ "${ASSUME_YES}" != "1" ]]; then
+  echo ""
+  read -r -p "${#keys[@]}개 파라미터를 업로드(덮어쓰기)합니다. 계속할까요? [y/N] " answer
+  [[ "${answer}" == "y" || "${answer}" == "Y" ]] || { echo "중단했습니다."; exit 1; }
+fi
+
+uploaded=0
+for i in "${!keys[@]}"; do
+  param_name="${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/${keys[$i]}"
+
+  args=(ssm put-parameter
+    --name "${param_name}"
+    --type SecureString
+    --value="${values[$i]}"
+    --tier "${TIER}"
+    --overwrite
+    --region "${AWS_REGION}")
+  [[ -n "${KMS_KEY_ID}" ]] && args+=(--key-id "${KMS_KEY_ID}")
+
+  version="$(aws "${args[@]}" --query 'Version' --output text)"
+  uploaded=$((uploaded + 1))
+  printf '  [%d/%d] %s (version %s)\n' "${uploaded}" "${#keys[@]}" "${param_name}" "${version}"
+done
+
+echo ""
+echo "완료: ${uploaded}개 파라미터를 업로드했습니다."
+echo "확인: aws ssm get-parameters-by-path --path \"${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/\" --recursive --region ${AWS_REGION} --query 'Parameters[*].Name'"

--- a/scripts/with-ssm-env.sh
+++ b/scripts/with-ssm-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SSM Parameter Store 의 값을 디스크에 쓰지 않고,
+# 실행할 명령의 프로세스 환경변수로만 주입한다.
+#
+# 사용법:
+#   ./scripts/with-ssm-env.sh <ENVIRONMENT> [PROJECT_NAME] -- <COMMAND...>
+#   예) ./scripts/with-ssm-env.sh alpha -- ./gradlew bootRun
+#       AWS_PROFILE=umc ./scripts/with-ssm-env.sh alpha -- ./gradlew bootRun
+#       ./scripts/with-ssm-env.sh prod cygnus-server -- java -jar build/libs/app.jar
+#
+# 환경변수:
+#   SSM_PREFIX   (default: /umc-product)
+#   AWS_REGION   (default: ap-northeast-2)
+#   AWS_PROFILE  (aws cli 프로필. 비우면 기본 자격증명 체인 사용)
+#
+# 동작:
+#   /umc-product/<PROJECT_NAME>/<ENVIRONMENT>/ 하위 전체를 복호화 조회한 뒤
+#   exec env 로 명령을 실행한다. 값은 파일로 남지 않고 프로세스 메모리에만 존재한다.
+
+set -euo pipefail
+
+SSM_PREFIX="${SSM_PREFIX:-/umc-product}"
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+
+usage() {
+  echo "사용법: $0 <ENVIRONMENT> [PROJECT_NAME] -- <COMMAND...>" >&2
+  echo "  예) $0 alpha -- ./gradlew bootRun" >&2
+  exit 1
+}
+
+ENVIRONMENT="${1:-}"
+[[ -z "${ENVIRONMENT}" ]] && usage
+shift
+
+PROJECT_NAME="cygnus-server"
+if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+  PROJECT_NAME="$1"
+  shift
+fi
+[[ "${1:-}" == "--" ]] || usage
+shift
+(( $# > 0 )) || usage
+
+PATH_PREFIX="${SSM_PREFIX}/${PROJECT_NAME}/${ENVIRONMENT}/"
+
+env_pairs=()
+while IFS=$'\t' read -r name value; do
+  [[ -z "${name}" ]] && continue
+  env_pairs+=("${name##*/}=${value}")
+done < <(aws ssm get-parameters-by-path \
+  --path "${PATH_PREFIX}" --recursive --with-decryption \
+  --region "${AWS_REGION}" \
+  --query "Parameters[*].[Name,Value]" --output text)
+
+if (( ${#env_pairs[@]} == 0 )); then
+  echo "ERROR: ${PATH_PREFIX} 에서 파라미터를 찾지 못했습니다 (권한 또는 경로 확인)." >&2
+  exit 1
+fi
+
+echo "▶ ${PATH_PREFIX} 파라미터 ${#env_pairs[@]}개를 주입해 실행: $*" >&2
+exec env "${env_pairs[@]}" "$@"

--- a/src/main/java/com/umc/product/certificate/application/service/CertificatePdfPreviewService.java
+++ b/src/main/java/com/umc/product/certificate/application/service/CertificatePdfPreviewService.java
@@ -17,7 +17,7 @@ import com.umc.product.certificate.application.port.out.dto.CertificatePdfRender
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Profile("local | dev")
+@Profile("local | alpha")
 @RequiredArgsConstructor
 public class CertificatePdfPreviewService implements PreviewCertificatePdfUseCase {
 

--- a/src/main/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidator.java
+++ b/src/main/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidator.java
@@ -10,7 +10,7 @@ import org.springframework.util.StringUtils;
 
 public final class WebSocketBrokerPropertiesValidator {
 
-    private static final Profiles SHARED_ENVIRONMENT_PROFILES = Profiles.of("dev", "prod");
+    private static final Profiles SHARED_ENVIRONMENT_PROFILES = Profiles.of("alpha", "prod");
 
     private WebSocketBrokerPropertiesValidator() {
     }

--- a/src/main/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidator.java
+++ b/src/main/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidator.java
@@ -14,7 +14,7 @@ import com.umc.product.global.config.WebSocketBrokerProperties;
 @ConditionalOnProperty(prefix = "app.websocket.broker", name = "mode", havingValue = "relay")
 public class WebSocketBrokerRelayStartupValidator implements ApplicationRunner {
 
-    private static final Profiles SHARED_ENVIRONMENT_PROFILES = Profiles.of("dev", "prod");
+    private static final Profiles SHARED_ENVIRONMENT_PROFILES = Profiles.of("alpha", "prod");
 
     private final WebSocketBrokerProperties properties;
     private final Environment environment;

--- a/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
+++ b/src/main/java/com/umc/product/storage/adapter/out/s3/S3StorageAdapter.java
@@ -401,7 +401,8 @@ public class S3StorageAdapter implements StoragePort {
     private String parseSpringProfileToCloudFrontPath() {
         return switch (springProfile) {
             case "prod" -> "prod";
-            case "dev" -> "dev";
+            // dev → alpha 프로필 rename 이후에도 기존 S3/CDN 객체는 dev/ 경로에 있으므로 저장 경로는 dev 를 유지한다.
+            case "dev", "alpha" -> "dev";
             case "local" -> "local";
             default -> throw new StorageException(StorageErrorCode.INVALID_SPRING_PROFILE);
         };

--- a/src/main/java/com/umc/product/test/adapter/in/web/CertificatePdfTestController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/CertificatePdfTestController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/test/certificates")
-@Profile("local | dev")
+@Profile("local | alpha")
 @RequiredArgsConstructor
 @Public
 @Tag(name = "Test | 인증서 PDF", description = "개발 환경에서 인증서 PDF 템플릿을 미리보기합니다.")

--- a/src/main/java/com/umc/product/test/adapter/in/web/TestController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/TestController.java
@@ -45,7 +45,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
-@Profile("local | dev")
+@Profile("local | alpha")
 @RestController
 @RequestMapping("/test")
 @Tag(name = "Test | 일반 테스트", description = "개발과 테스트 환경에서만 사용하는 점검 API입니다.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -180,7 +180,7 @@ springdoc:
 #     DB span 트레이싱은 그대로 동작한다 (SQL 원문 라인만 사라짐).
 #   - local 프로필은 파일 하단(on-profile: local)에서 enable-logging=true 로 재정의하므로,
 #     로컬 개발자는 별도 env 설정 없이 SQL 라인을 본다.
-# 환경변수 기본값: local=true / dev·staging·prod·test=false
+# 환경변수 기본값: local=true / alpha·staging·prod·test=false
 # ====================================================================
 decorator:
   datasource:
@@ -551,14 +551,14 @@ storage:
 
 
 # ==================================================================
-# configuration override for dev profile
+# configuration override for alpha profile
 # ==================================================================
 
 ---
 spring:
   config:
     activate:
-      on-profile: dev
+      on-profile: alpha
   graphql:
     schema:
       introspection:
@@ -579,7 +579,7 @@ app:
   sso:
     clients:
       backoffice:
-        name: dev backoffice
+        name: alpha backoffice
         service-type: UMC_BACKOFFICE
         environment: DEV
         require-pkce: true
@@ -589,7 +589,7 @@ app:
         allowed-origins:
           - https://dev.admin.university.neordinary.com
       website:
-        name: dev website
+        name: alpha website
         service-type: UMC_WEBSITE
         environment: DEV
         require-pkce: true

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -107,11 +107,11 @@
 
 
     <!--
-        ========== dev: stdout JSON + OTLP logs ==========
-        dev stdout 은 한 줄 JSON 으로 유지하고, 원격 로그는 OpenTelemetryAppender 가
+        ========== alpha: stdout JSON + OTLP logs ==========
+        alpha stdout 은 한 줄 JSON 으로 유지하고, 원격 로그는 OpenTelemetryAppender 가
         OTLP logs 로 Collector 에 송신한다.
     -->
-    <springProfile name="dev">
+    <springProfile name="alpha">
         <!-- 우리 앱 패키지만 DEBUG -->
         <logger name="com.umc.product" level="DEBUG"/>
 

--- a/src/test/java/com/umc/product/authentication/adapter/out/config/SsoClientConfigAdapterTest.java
+++ b/src/test/java/com/umc/product/authentication/adapter/out/config/SsoClientConfigAdapterTest.java
@@ -168,11 +168,11 @@ class SsoClientConfigAdapterTest {
         });
     }
 
-    @DisplayName("dev profile은 웹 client를 localhost로 덮어쓰고 앱 client는 기본 설정을 유지한다")
+    @DisplayName("alpha profile은 웹 client를 localhost로 덮어쓰고 앱 client는 기본 설정을 유지한다")
     @Test
-    void application_yml_dev_sso_client_binding_성공() {
+    void application_yml_alpha_sso_client_binding_성공() {
         contextRunner
-            .withPropertyValues("spring.profiles.active=dev")
+            .withPropertyValues("spring.profiles.active=alpha")
             .run(context -> {
                 SsoClientConfigAdapter adapter = context.getBean(SsoClientConfigAdapter.class);
 

--- a/src/test/java/com/umc/product/global/client/ClientRequestClassifierTest.java
+++ b/src/test/java/com/umc/product/global/client/ClientRequestClassifierTest.java
@@ -97,10 +97,10 @@ class ClientRequestClassifierTest {
     }
 
     @Test
-    @DisplayName("dev profile은 localhost 5173 Origin 하나만 UNKNOWN 서비스와 DEV 환경으로 바인딩한다")
-    void application_yml_dev_client_context_localhost_unknown_바인딩() {
+    @DisplayName("alpha profile은 localhost 5173 Origin 하나만 UNKNOWN 서비스와 DEV 환경으로 바인딩한다")
+    void application_yml_alpha_client_context_localhost_unknown_바인딩() {
         contextRunner
-            .withPropertyValues("spring.profiles.active=dev")
+            .withPropertyValues("spring.profiles.active=alpha")
             .run(context -> {
                 ClientContextProperties properties = context.getBean(ClientContextProperties.class);
 

--- a/src/test/java/com/umc/product/global/config/SecurityPathConfigTest.java
+++ b/src/test/java/com/umc/product/global/config/SecurityPathConfigTest.java
@@ -102,10 +102,10 @@ class SecurityPathConfigTest {
     }
 
     @Test
-    @DisplayName("dev 프로필은 GraphiQL을 기본 활성화한다")
-    void devProfileEnablesGraphiqlByDefault() {
+    @DisplayName("alpha 프로필은 GraphiQL을 기본 활성화한다")
+    void alphaProfileEnablesGraphiqlByDefault() {
         contextRunner
-            .withPropertyValues("spring.profiles.active=dev")
+            .withPropertyValues("spring.profiles.active=alpha")
             .run(context -> assertThat(context.getEnvironment().getProperty("spring.graphql.graphiql.enabled"))
                 .isEqualTo("true"));
     }

--- a/src/test/java/com/umc/product/global/config/WebSocketBrokerPortPolicyTest.java
+++ b/src/test/java/com/umc/product/global/config/WebSocketBrokerPortPolicyTest.java
@@ -60,7 +60,7 @@ class WebSocketBrokerPortPolicyTest {
 
     @Test
     @DisplayName(
-        "dev 또는 prod가 포함된 프로필은 relay port 미공급을 credential 노출 없이 거부한다"
+        "alpha 또는 prod가 포함된 프로필은 relay port 미공급을 credential 노출 없이 거부한다"
     )
     void sharedProfilesRejectMissingPortWithoutExposingCredentials() {
         WebSocketBrokerProperties properties = relayProperties(null);

--- a/src/test/java/com/umc/product/global/config/WebSocketBrokerPortPolicyTest.java
+++ b/src/test/java/com/umc/product/global/config/WebSocketBrokerPortPolicyTest.java
@@ -65,7 +65,7 @@ class WebSocketBrokerPortPolicyTest {
     void sharedProfilesRejectMissingPortWithoutExposingCredentials() {
         WebSocketBrokerProperties properties = relayProperties(null);
 
-        for (String[] profiles : new String[][] {{"test", "dev"}, {"local", "prod"}}) {
+        for (String[] profiles : new String[][] {{"test", "alpha"}, {"local", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profiles);
 

--- a/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
+++ b/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
@@ -28,7 +28,7 @@ class WebSocketBrokerPropertiesValidatorTest {
     @Test
     @DisplayName("dev와 prod 프로필도 single instance에서는 simple broker로 시작할 수 있다")
     void validate_sharedEnvironmentAllowsSimpleBroker() {
-        for (String profile : new String[] {"dev", "prod"}) {
+        for (String profile : new String[] {"alpha", "prod"}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profile);
 
@@ -42,7 +42,7 @@ class WebSocketBrokerPropertiesValidatorTest {
     @Test
     @DisplayName("dev 또는 prod가 포함된 혼합 프로필도 simple broker로 시작할 수 있다")
     void validate_mixedSharedProfilesAllowsSimpleBroker() {
-        for (String[] profiles : new String[][] {{"test", "dev"}, {"local", "prod"}}) {
+        for (String[] profiles : new String[][] {{"test", "alpha"}, {"local", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profiles);
 
@@ -97,7 +97,7 @@ class WebSocketBrokerPropertiesValidatorTest {
             new RelayCredentials("system-user", systemPassword, "client-user", clientPassword)
         );
 
-        for (String[] profiles : new String[][] {{"dev"}, {"test", "prod"}}) {
+        for (String[] profiles : new String[][] {{"alpha"}, {"test", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profiles);
 

--- a/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
+++ b/src/test/java/com/umc/product/global/config/WebSocketBrokerPropertiesValidatorTest.java
@@ -26,7 +26,7 @@ class WebSocketBrokerPropertiesValidatorTest {
     }
 
     @Test
-    @DisplayName("dev와 prod 프로필도 single instance에서는 simple broker로 시작할 수 있다")
+    @DisplayName("alpha와 prod 프로필도 single instance에서는 simple broker로 시작할 수 있다")
     void validate_sharedEnvironmentAllowsSimpleBroker() {
         for (String profile : new String[] {"alpha", "prod"}) {
             MockEnvironment environment = new MockEnvironment();
@@ -40,7 +40,7 @@ class WebSocketBrokerPropertiesValidatorTest {
     }
 
     @Test
-    @DisplayName("dev 또는 prod가 포함된 혼합 프로필도 simple broker로 시작할 수 있다")
+    @DisplayName("alpha 또는 prod가 포함된 혼합 프로필도 simple broker로 시작할 수 있다")
     void validate_mixedSharedProfilesAllowsSimpleBroker() {
         for (String[] profiles : new String[][] {{"test", "alpha"}, {"local", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
@@ -88,7 +88,7 @@ class WebSocketBrokerPropertiesValidatorTest {
     }
 
     @Test
-    @DisplayName("dev 또는 prod는 relay plaintext를 credential 노출 없이 거부한다")
+    @DisplayName("alpha 또는 prod는 relay plaintext를 credential 노출 없이 거부한다")
     void validate_sharedProfileRejectsPlaintextWithoutExposingCredentials() {
         String systemPassword = "system-plaintext-secret";
         String clientPassword = "client-plaintext-secret";

--- a/src/test/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidatorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidatorTest.java
@@ -62,7 +62,7 @@ class WebSocketBrokerRelayStartupValidatorTest {
         WebSocketBrokerProperties properties = relayProperties();
         given(monitor.awaitAvailable(properties.relay().startupTimeout())).willReturn(false);
 
-        for (String[] profiles : new String[][] {{"test", "dev"}, {"local", "prod"}}) {
+        for (String[] profiles : new String[][] {{"test", "alpha"}, {"local", "prod"}}) {
             MockEnvironment environment = new MockEnvironment();
             environment.setActiveProfiles(profiles);
             WebSocketBrokerRelayStartupValidator sut = new WebSocketBrokerRelayStartupValidator(

--- a/src/test/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidatorTest.java
+++ b/src/test/java/com/umc/product/global/websocket/relay/WebSocketBrokerRelayStartupValidatorTest.java
@@ -57,7 +57,7 @@ class WebSocketBrokerRelayStartupValidatorTest {
     }
 
     @Test
-    @DisplayName("dev 또는 prod가 포함된 혼합 프로필은 relay startup readiness를 강제한다")
+    @DisplayName("alpha 또는 prod가 포함된 혼합 프로필은 relay startup readiness를 강제한다")
     void mixedSharedProfilesRequireStartupReadiness() throws InterruptedException {
         WebSocketBrokerProperties properties = relayProperties();
         given(monitor.awaitAvailable(properties.relay().startupTimeout())).willReturn(false);


### PR DESCRIPTION
## 🚀 작업 내용

- related to #1275

### 변경 범위 요약

- 애플리케이션 코드는 건드리지 않았고, `scripts/`(신규 3개), `docs/infra/`(신규 가이드 1개), 루트 `.env.example`만 변경했어요.

### 작업 단위별 상세

1. **무엇을**: 환경변수 저장소를 SSM Parameter Store 로 옮기기 위한 네임스페이스 규칙을 정하고 업로드 스크립트 `scripts/upload-env-to-ssm.sh` 를 추가했어요.
   - **어떻게**: `/umc-product/cygnus-server/{prod|alpha}/{KEY}` 경로에 항상 SecureString 으로 저장하고, tier 는 Intelligent-Tiering 기본값이라 4KB 이하(현재 전체 키 해당)는 무료 Standard 로 들어가요. `.env` 형식 파일을 파싱해서 일괄 업로드하고, 빈 값 자동 skip·`DRY_RUN` 미리보기·업로드 전 확인 프롬프트를 지원해요.
   - **왜**: 팀원마다 `.env` 파일을 수동으로 주고받는 방식은 유출 위험과 버전 불일치 문제가 있어서, 변경 이력과 수정자가 기록되는 중앙 저장소로 옮기기 위해서예요.

2. **무엇을**: 파일 생성 없이 프로세스에만 환경변수를 주입하는 `scripts/with-ssm-env.sh` 와, alpha 환경으로 로컬 서버를 띄우는 단축 스크립트 `scripts/run-alpha.sh` 를 추가했어요.
   - **어떻게**: `get-parameters-by-path --recursive --with-decryption` 으로 경로 하위 전체를 받아 `exec env KEY=VALUE... <명령>` 으로 실행해요. 값이 디스크에 남지 않고, `./scripts/run-alpha.sh -- env KEY=VALUE ./gradlew bootRun` 형태로 특정 값만 로컬 오버라이드도 가능해요.
   - **왜**: 로컬에서 alpha 환경을 붙어볼 때 `.env` 파일을 만들면 비밀값이 디스크에 남아서, 프로세스 메모리에만 존재하도록 하기 위해서예요.

3. **무엇을**: 팀원 온보딩용 운영 가이드 `docs/infra/ssm-parameter-store-guide.md` 를 추가했어요.
   - **어떻게**: 이름 규칙, AWS CLI 초기 설정, 조회/등록/이력/삭제 명령, 스크립트 사용법, 주의사항(빈 값 불가, 멀티라인 값 base64, prod 변경은 재배포 전까지 미반영)을 정리했어요.
   - **왜**: SSM 을 팀원이 직접 다루는 운영 방식으로 전환하면서 셀프서비스 기준 문서가 필요해서예요.

4. **무엇을**: `.env.example` 을 application.yml 이 실제 참조하는 환경변수 기준으로 전면 재정비했어요.
   - **어떻게**: 코드 전수 대조로 잔재 키(`MAIL_*`, `SWAGGER_AUTH_*`, `WEBHOOK_BUFFER_*`)를 제거하고, 누락 키(`WEBSOCKET_BROKER_*`, `API_RATE_LIMIT_*`, `APP_OBSERVABILITY_*`, `SSM_*` 등 약 35개)를 추가했으며, 섹션 순서를 application.yml 정의 순서와 일치시켰어요.
   - **왜**: `.env.example` 이 SSM 파라미터 목록의 canonical 소스 역할을 하게 되어서, 실제 코드와 어긋난 상태로 두면 안 되기 때문이에요.

5. **무엇을**: Spring `dev` profile 을 `alpha` 로 rename 했어요.
   - **어떻게**: application.yml `on-profile` 블록, logback-spring.xml `springProfile` 블록, `@Profile("local | dev")` 3곳, WebSocket 검증기의 `Profiles.of("dev", "prod")` 2곳, cd.yml/cd-asg.yml 의 Development 매핑, docker/develop compose 기본값, 관련 테스트 fixture 를 일괄 전환했어요. S3StorageAdapter 는 alpha profile 을 수용하되 기존 S3/CDN 객체가 `dev/` 경로에 있어서 저장 경로 문자열은 dev 를 유지했어요.
   - **왜**: 팀 환경 명칭이 prod/alpha 로 통일되면서 profile 문자열 기반 분기가 실제 환경명과 어긋나는 것을 막기 위해서예요.


## 💬 리뷰 중점사항

- S3StorageAdapter 의 CloudFront 경로 매핑에서 alpha → "dev" 를 유지한 결정을 봐주세요. "alpha" 로 바꾸면 기존 업로드 파일 URL 이 깨져서 S3 객체/DB 마이그레이션이 선행되어야 해요.

- `.env.example` 에서 제거한 키(`MAIL_*`, `SWAGGER_AUTH_*`, `WEBHOOK_BUFFER_*`)가 정말 어디서도 안 쓰이는 게 맞는지 한 번 더 확인 부탁드려요. 코드 grep 기준으로는 참조가 없었어요.
- projectName `cygnus-server`, 환경명 `prod`/`alpha` 네이밍이 팀 결정과 일치하는지 봐주세요.
- 두 번째 커밋에서 ASG 배포 파이프라인도 전환했어요: 부팅 시 user-data 가 S3 대신 SSM 에서 .env 를 구성해요. instance profile 의 ssm:GetParametersByPath + kms:Decrypt 권한은 콘솔에서 적용을 마쳤고, 배포 전에 /umc-product/cygnus-server/{prod,alpha}/ 파라미터 업로드만 선행되면 돼요.
