### PR TITLE
[Feat] 배포 환경 Flyway 자동 실행 분리 및 수동 마이그레이션 워크플로우 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,16 @@ HIKARI_MIN_IDLE=2
 # -1 이면 커넥션 초기화 실패 시에도 부팅을 계속한다.
 HIKARI_INITIALIZATION_FAIL_TIMEOUT=-1
 
+# 부팅 시 Flyway 자동 migrate 여부.
+# 로컬/테스트는 true. 배포 환경(prod/alpha)의 SSM 에는 반드시 false 를 넣어
+# 배포가 DB 스키마를 변경하지 못하게 한다 (마이그레이션은 DB Migrate 워크플로우로 수동 실행).
+FLYWAY_ENABLED=true
 FLYWAY_BASELINE_ON_MIGRATE=false
 FLYWAY_OUT_OF_ORDER=false
+
+# Hibernate ddl-auto. 기본값 validate(DB 변경 없음, 엔티티-스키마 대조 검증)를 유지한다.
+# expand-contract 중간 단계처럼 스키마 불일치를 감수해야 할 때만 일시적으로 none 을 사용한다.
+JPA_DDL_AUTO=validate
 
 # ------------------------------------------------------------------
 # JWT / Token

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,267 @@
+# 배포와 분리된 DB 마이그레이션 실행 워크플로우.
+#
+# 배포 환경(prod/alpha)은 SSM 의 FLYWAY_ENABLED=false 로 부팅 시 자동 migrate 를 끄고,
+# 스키마 변경은 이 워크플로우(workflow_dispatch)로만 수행한다.
+# 런북: docs/infra/flyway-migration-runbook.md
+#
+# Required repository secrets:
+# - secrets.AWS_ACCESS_KEY_ID
+# - secrets.AWS_SECRET_ACCESS_KEY
+# Optional repository secrets:
+# - secrets.DISCORD_CD_WEBHOOK_URL
+# Optional repository variables:
+# - vars.AWS_REGION (default: ap-northeast-2)
+# - vars.SSM_BASE_PATH (default: /umc-product/cygnus-server)
+#   ${SSM_BASE_PATH}/{prod|alpha}/DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD 를 읽는다.
+# - vars.FLYWAY_IMAGE (default: flyway/flyway:11-alpine)
+#   Spring Boot 3.5.x 가 관리하는 flyway-core 11.x 와 major 를 맞춘다.
+#
+# 사전 조건: GitHub-hosted 러너에서 RDS 5432 로 접속할 수 있어야 한다.
+# RDS 보안 그룹이 러너 IP 를 허용하지 않으면 이 워크플로우는 접속 단계에서 실패한다
+# (해결 방법은 런북의 "네트워크 경로" 절 참고).
+
+name: DB Migrate [Flyway]
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "대상 환경"
+        required: true
+        type: choice
+        options:
+          - Development
+          - Production
+      command:
+        description: "Flyway 명령 (info=조회, validate=검증, migrate=적용, repair=히스토리 복구)"
+        required: true
+        default: info
+        type: choice
+        options:
+          - info
+          - validate
+          - migrate
+          - repair
+      confirm:
+        description: "Production 에 migrate/repair 할 때만 필요. 'Production' 을 그대로 입력"
+        required: false
+        type: string
+      out_of_order:
+        description: "이미 적용된 버전보다 낮은 버전의 신규 마이그레이션 허용"
+        required: false
+        type: boolean
+        default: false
+      baseline_on_migrate:
+        description: "히스토리 테이블이 없는 DB 에 baseline 생성 (신규 DB 초기화 전용)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # 같은 환경에 동시에 두 개의 마이그레이션이 붙지 않도록 직렬화한다.
+  group: db-migrate-${{ inputs.environment }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  flyway:
+    name: Flyway ${{ inputs.command }} (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    # Production 환경에 required reviewer 를 걸어두면 여기서 승인 게이트가 동작한다.
+    environment: ${{ inputs.environment }}
+
+    env:
+      ENVIRONMENT: ${{ inputs.environment }}
+      FLYWAY_COMMAND: ${{ inputs.command }}
+      CONFIRM_INPUT: ${{ inputs.confirm }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      SSM_BASE_PATH: ${{ vars.SSM_BASE_PATH || '/umc-product/cygnus-server' }}
+      FLYWAY_IMAGE: ${{ vars.FLYWAY_IMAGE || 'flyway/flyway:11-alpine' }}
+      MIGRATION_DIR: src/main/resources/db/migration
+      FLYWAY_OUT_OF_ORDER: ${{ inputs.out_of_order }}
+      FLYWAY_BASELINE_ON_MIGRATE: ${{ inputs.baseline_on_migrate }}
+      FLYWAY_CLEAN_DISABLED: "true"
+
+    steps:
+      - name: 🔒 입력 검증
+        run: |
+          set -euo pipefail
+
+          # migrate/repair 는 DB 상태를 바꾸므로 Production 에서는 환경명 재입력을 요구한다.
+          if [[ "${ENVIRONMENT}" == "Production" && "${FLYWAY_COMMAND}" =~ ^(migrate|repair)$ ]]; then
+            if [[ "${CONFIRM_INPUT}" != "Production" ]]; then
+              echo "::error::Production 에 ${FLYWAY_COMMAND} 를 실행하려면 confirm 입력에 'Production' 을 정확히 입력해야 합니다."
+              exit 1
+            fi
+          fi
+
+          if [[ "${FLYWAY_BASELINE_ON_MIGRATE}" == "true" ]]; then
+            echo "::warning::baseline_on_migrate=true 입니다. 기존 스키마가 있는 DB 에서 사용하면 미적용 마이그레이션이 건너뛰어질 수 있습니다."
+          fi
+
+          if [[ "${FLYWAY_COMMAND}" == "repair" ]]; then
+            echo "::warning::repair 는 flyway_schema_history 의 checksum/실패 기록을 재작성합니다. 스키마 자체는 고치지 않습니다."
+          fi
+
+      - name: 📦 코드베이스 체크아웃
+        uses: actions/checkout@v4
+
+      - name: 🔑 AWS 인증
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: 🔐 SSM 에서 DB 접속 정보 로드
+        run: |
+          set -euo pipefail
+
+          case "${ENVIRONMENT}" in
+            Production) SSM_ENV="prod" ;;
+            Development) SSM_ENV="alpha" ;;
+            *) echo "::error::지원하지 않는 환경: ${ENVIRONMENT}"; exit 1 ;;
+          esac
+
+          PARAM_PATH="${SSM_BASE_PATH}/${SSM_ENV}"
+          echo "SSM path: ${PARAM_PATH}"
+
+          fetch() {
+            aws ssm get-parameter \
+              --name "${PARAM_PATH}/$1" \
+              --with-decryption \
+              --region "${AWS_REGION}" \
+              --query 'Parameter.Value' \
+              --output text
+          }
+
+          DB_URL="$(fetch DATABASE_URL)"
+          DB_USER="$(fetch DATABASE_USERNAME)"
+          DB_PASSWORD="$(fetch DATABASE_PASSWORD)"
+
+          # 로그 유출 방지. URL 에도 호스트가 들어가므로 함께 마스킹한다.
+          echo "::add-mask::${DB_URL}"
+          echo "::add-mask::${DB_USER}"
+          echo "::add-mask::${DB_PASSWORD}"
+
+          {
+            echo "FLYWAY_URL=${DB_URL}"
+            echo "FLYWAY_USER=${DB_USER}"
+            echo "FLYWAY_PASSWORD=${DB_PASSWORD}"
+          } >> "$GITHUB_ENV"
+
+          echo "SSM_ENV=${SSM_ENV}" >> "$GITHUB_ENV"
+
+          # 이 워크플로우가 의미를 가지려면 앱의 부팅 시 자동 migrate 가 꺼져 있어야 한다.
+          FLYWAY_ENABLED_PARAM="$(aws ssm get-parameter \
+            --name "${PARAM_PATH}/FLYWAY_ENABLED" \
+            --with-decryption \
+            --region "${AWS_REGION}" \
+            --query 'Parameter.Value' \
+            --output text 2>/dev/null || echo "__MISSING__")"
+
+          if [[ "${FLYWAY_ENABLED_PARAM}" != "false" ]]; then
+            echo "::warning::${PARAM_PATH}/FLYWAY_ENABLED 가 'false' 가 아닙니다 (현재: ${FLYWAY_ENABLED_PARAM}). 앱이 부팅 시 자동으로 migrate 를 수행합니다."
+          fi
+
+      - name: 🧭 Flyway 실행
+        run: |
+          set -euo pipefail
+
+          # baseline-version 은 application.yml 을 단일 출처로 삼아 drift 를 막는다.
+          BASELINE_VERSION="$(grep -m1 -E '^\s*baseline-version:' src/main/resources/application.yml | awk '{print $2}')"
+          if [[ -z "${BASELINE_VERSION}" ]]; then
+            echo "::error::application.yml 에서 spring.flyway.baseline-version 을 찾지 못했습니다."
+            exit 1
+          fi
+          echo "Baseline version: ${BASELINE_VERSION}"
+
+          run_flyway() {
+            # 비밀값은 값 없는 -e 로 전달해 docker 인자(ps 출력)에 남지 않게 한다.
+            # schemas 는 지정하지 않는다 — 앱(Spring Boot Flyway 자동설정)과 동일하게
+            # 커넥션의 기본 스키마를 쓰도록 두어야 flyway_schema_history 위치가 어긋나지 않는다.
+            docker run --rm \
+              -v "${GITHUB_WORKSPACE}/${MIGRATION_DIR}:/flyway/sql:ro" \
+              -e FLYWAY_URL \
+              -e FLYWAY_USER \
+              -e FLYWAY_PASSWORD \
+              -e FLYWAY_LOCATIONS="filesystem:/flyway/sql" \
+              -e FLYWAY_BASELINE_VERSION="${BASELINE_VERSION}" \
+              -e FLYWAY_BASELINE_ON_MIGRATE \
+              -e FLYWAY_OUT_OF_ORDER \
+              -e FLYWAY_CLEAN_DISABLED \
+              -e FLYWAY_CONNECT_RETRIES=3 \
+              "${FLYWAY_IMAGE}" "$@"
+          }
+
+          echo "──────── flyway info (실행 전) ────────"
+          run_flyway info | tee /tmp/flyway-info-before.txt
+
+          if [[ "${FLYWAY_COMMAND}" != "info" ]]; then
+            echo "──────── flyway ${FLYWAY_COMMAND} ────────"
+            run_flyway "${FLYWAY_COMMAND}" | tee /tmp/flyway-command.txt
+
+            echo "──────── flyway info (실행 후) ────────"
+            run_flyway info | tee /tmp/flyway-info-after.txt
+          fi
+
+      - name: 📊 실행 결과 요약
+        if: always()
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### 🗃️ Flyway ${FLYWAY_COMMAND} — ${ENVIRONMENT}"
+            echo ""
+            echo "| 항목 | 값 |"
+            echo "|------|-----|"
+            echo "| 🌍 Environment | \`${ENVIRONMENT}\` |"
+            echo "| 🧭 Command | \`${FLYWAY_COMMAND}\` |"
+            echo "| 🌿 Branch | \`${GITHUB_REF_NAME}\` |"
+            echo "| 🔀 out-of-order | \`${FLYWAY_OUT_OF_ORDER}\` |"
+            echo "| 🧱 baseline-on-migrate | \`${FLYWAY_BASELINE_ON_MIGRATE}\` |"
+            echo "| ✅ Status | \`${{ job.status }}\` |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          append_block() {
+            local title="$1" file="$2"
+            [[ -s "${file}" ]] || return 0
+            {
+              echo "<details><summary>${title}</summary>"
+              echo ""
+              echo '```text'
+              cat "${file}"
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          append_block "flyway info (실행 전)" /tmp/flyway-info-before.txt
+          append_block "flyway ${FLYWAY_COMMAND} 출력" /tmp/flyway-command.txt
+          append_block "flyway info (실행 후)" /tmp/flyway-info-after.txt
+
+      - name: ❌ 마이그레이션 실패 알림
+        if: failure()
+        run: |
+          echo "::error::${ENVIRONMENT} 환경의 flyway ${FLYWAY_COMMAND} 실행이 실패했습니다."
+          echo "flyway_schema_history 의 마지막 행(success=false 여부)을 먼저 확인하고, 필요 시 repair 를 검토하세요."
+
+      - name: Discord 실행 결과 알림
+        if: always()
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CD_WEBHOOK_URL }}
+          DEPLOY_WORKFLOW: ${{ github.workflow }}
+          DEPLOY_STATUS: ${{ job.status }}
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_IMAGE_TAG: flyway ${{ inputs.command }}
+          DEPLOY_TARGET: DB Migration
+          DEPLOY_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node .github/scripts/discord-deploy-notify.mjs

--- a/docs/infra/flyway-migration-runbook.md
+++ b/docs/infra/flyway-migration-runbook.md
@@ -1,0 +1,111 @@
+# Flyway 마이그레이션 런북 (배포와 분리 실행)
+
+배포 환경(prod/alpha)에서는 **애플리케이션 배포가 DB 스키마를 변경하지 않는다.**
+스키마 변경은 `DB Migrate [Flyway]` 워크플로우를 수동 실행(workflow_dispatch)해서만 수행한다.
+
+## 왜 분리했나
+
+- 배포(ASG instance refresh)와 스키마 변경이 한 트랜잭션처럼 묶여 있으면, 롤백 시 코드만 되돌아가고
+  스키마는 되돌아가지 않는다. 실행 시점을 사람이 정할 수 있어야 한다.
+- 부팅마다 수십 개 마이그레이션의 checksum 을 비교하는 비용도 사라진다
+  (참고: [부팅/빌드 최적화 리포트](../analysis/boot-and-build-optimization-report.md) 2.2.5).
+
+## 구성
+
+| 스위치 | 값 | 위치 | 효과 |
+|--------|-----|------|------|
+| `FLYWAY_ENABLED` | `false` | SSM (prod/alpha) | 부팅 시 자동 migrate 비활성화 |
+| `FLYWAY_ENABLED` | `true` (기본값) | 로컬/테스트 | 지금까지와 동일하게 자동 migrate |
+| `JPA_DDL_AUTO` | `validate` (기본값) | 전 환경 | 엔티티-스키마 대조 검증 (**DB 변경 없음**) |
+
+`ddl-auto: validate` 는 스키마 메타데이터를 읽어 엔티티와 대조만 하는 읽기 전용 검증이다.
+DB 를 실제로 변경하는 것은 Flyway `migrate` 와 `ddl-auto` 의 `create`/`update` 계열뿐이다.
+
+그래서 `validate` 는 끄지 않고 **안전장치로 유지한다.** 마이그레이션을 빠뜨린 채 신버전을 배포하면
+부팅이 실패하고, ASG instance refresh 는 health check 실패 시 교체를 중단하므로 구버전이 그대로
+살아남는다 — DB 는 아무것도 바뀌지 않은 상태로.
+
+`JPA_DDL_AUTO=none` 은 expand-contract 중간 단계처럼 "스키마가 아직 안 맞아도 일단 떠야 하는"
+상황에서만 일시적으로 쓴다. 상시로 꺼두면 부팅은 되는데 런타임 쿼리가 터지는 더 나쁜 실패 모드가 된다.
+`create`/`create-drop`/`update` 는 어떤 배포 환경에도 절대 주입하지 않는다.
+
+### SSM 설정 (환경별 1회)
+
+```bash
+for ENV in prod alpha; do
+  aws ssm put-parameter \
+    --name "/umc-product/cygnus-server/${ENV}/FLYWAY_ENABLED" \
+    --type SecureString --tier Intelligent-Tiering \
+    --value "false" --overwrite
+done
+```
+
+값 반영은 재배포(인스턴스 교체) 시점부터다. 자세한 SSM 사용법은
+[SSM Parameter Store 가이드](./ssm-parameter-store-guide.md) 참고.
+
+## 표준 절차
+
+새 마이그레이션이 포함된 변경을 배포할 때:
+
+1. **PR 머지** — 마이그레이션 SQL 이 default 브랜치에 들어간다.
+2. **`DB Migrate [Flyway]` 실행 (`command: info`)** — 미적용(Pending) 목록을 눈으로 확인한다.
+3. **`DB Migrate [Flyway]` 실행 (`command: migrate`)** — 스키마를 먼저 올린다.
+4. **`CD [ASG]` 실행** — 새 코드를 배포한다. 부팅 시 `validate` 가 통과해야 한다.
+
+> 순서 원칙: **스키마 먼저, 코드 나중.** 컬럼/테이블 추가 같은 additive 변경은 구버전 코드와
+> 공존하므로 이 순서가 안전하다. 컬럼 삭제/제약 강화 같은 destructive 변경은
+> expand-contract 로 나눠서 "① 추가 마이그레이션 → ② 코드 배포 → ③ 제거 마이그레이션"
+> 세 단계로 진행한다. 한 번에 하지 않는다.
+
+## 워크플로우 입력
+
+`Actions → DB Migrate [Flyway] → Run workflow`
+
+| 입력 | 설명 |
+|------|------|
+| `environment` | `Development`(→ SSM `alpha`) / `Production`(→ SSM `prod`) |
+| `command` | `info` 조회 / `validate` 검증 / `migrate` 적용 / `repair` 히스토리 복구 |
+| `confirm` | Production 에 `migrate`/`repair` 할 때만 필요. `Production` 을 그대로 입력 |
+| `out_of_order` | 이미 적용된 버전보다 낮은 신규 마이그레이션 허용 (기본 false) |
+| `baseline_on_migrate` | 히스토리 테이블이 없는 신규 DB 초기화 전용 (기본 false) |
+
+동작 방식:
+
+- 실행 전/후로 `flyway info` 를 찍어 Step Summary 에 접이식 블록으로 남긴다.
+- DB 접속 정보는 SSM(`DATABASE_URL` / `DATABASE_USERNAME` / `DATABASE_PASSWORD`)에서 읽고
+  전부 마스킹한다. 마이그레이션 SQL 은 체크아웃한 `src/main/resources/db/migration` 을 그대로 마운트한다.
+- `clean` 은 `FLYWAY_CLEAN_DISABLED=true` 로 아예 봉인되어 있다. 선택지에도 없다.
+- `concurrency` 로 환경별 직렬화되어 같은 DB 에 두 실행이 동시에 붙지 않는다.
+- Flyway CLI 는 `flyway/flyway:11-alpine` 을 쓴다. 앱이 쓰는 flyway-core(Spring Boot 3.5.x → 11.x)와
+  major 를 맞춘 것이므로, Boot 를 올려 flyway major 가 바뀌면 `vars.FLYWAY_IMAGE` 도 함께 올린다.
+
+## 명령별 주의
+
+- **`validate`**: 미적용(Pending) 마이그레이션이 있으면 실패한다. "DB 가 이 커밋 기준으로 최신인가"를
+  묻는 용도라서 의도된 동작이다. 단순 현황 조회는 `info` 를 쓴다.
+- **`repair`**: `flyway_schema_history` 의 checksum/실패 기록만 재작성한다. **스키마 자체는 고치지 않는다.**
+  실패한 마이그레이션이 DDL 을 일부만 적용했다면, repair 전에 DB 실제 상태부터 확인해야 한다.
+- **`baseline_on_migrate`**: 기존 스키마가 있는 DB 에서 켜면 baseline 이전 마이그레이션이 통째로
+  "적용된 것으로 간주"되어 건너뛰어진다. 신규 DB 초기화 외에는 쓰지 않는다.
+
+## 실패 시
+
+1. Step Summary 의 `flyway info` 출력에서 어느 버전에서 멈췄는지 확인한다.
+2. `flyway_schema_history` 의 마지막 행이 `success=false` 면, PostgreSQL 은 DDL 이 트랜잭션 안에서
+   롤백되므로 대개 해당 마이그레이션은 통째로 되돌아가 있다. SQL 을 고쳐 새 버전으로 다시 올리는 것이
+   원칙이고, 이미 배포된 파일을 수정하는 것은 금지다
+   ([migration 규약](../../src/main/resources/db/migration/AGENTS.md)).
+3. 실패 행이 남아 재실행이 막히면 `repair` 로 실패 기록을 정리한 뒤 재시도한다.
+4. 앱은 아직 구버전이 떠 있는 상태이므로 서비스는 살아 있다. 서두르지 않아도 된다.
+
+## 네트워크 경로
+
+이 워크플로우는 GitHub-hosted 러너에서 RDS 5432 로 직접 접속한다. RDS 보안 그룹이 러너 IP 를
+허용하지 않으면 `flyway info` 단계에서 접속 실패로 끝난다. 선택지는 셋이다:
+
+1. RDS 를 접속 가능한 상태로 두고 IP 제한 + 강한 자격증명으로 통제 (현재 개발자 로컬 실행
+   `./scripts/run-alpha.sh` 가 의존하는 경로와 동일)
+2. self-hosted 러너를 VPC 안에 두고 `runs-on` 을 교체
+3. SSM Run Command 로 VPC 내 인스턴스에서 Flyway 컨테이너를 실행하도록 워크플로우를 변경
+
+1번이 안 되는 환경이라면 2번을 먼저 검토한다. 워크플로우 구조는 그대로 두고 `runs-on` 한 줄만 바꾸면 된다.

--- a/docs/infra/ssm-parameter-store-guide.md
+++ b/docs/infra/ssm-parameter-store-guide.md
@@ -180,6 +180,10 @@ AWS_PROFILE=umc ./scripts/upload-env-to-ssm.sh .env.alpha alpha
   변경 후 재배포(인스턴스 refresh)가 필요하다.
 - 4KB 초과 값은 Advanced tier 로 저장되어 파라미터당 월 $0.05 가 과금된다.
   큰 JSON 은 가급적 base64 압축 전에 필요한 필드만 남기는 것을 검토한다.
+- **`FLYWAY_ENABLED` 는 prod/alpha 모두 `false` 로 유지한다.** 배포가 DB 스키마를 변경하지 않도록
+  하는 스위치이며, 마이그레이션은 `DB Migrate [Flyway]` 워크플로우로 따로 실행한다.
+  `JPA_DDL_AUTO` 는 기본값 `validate` 를 유지한다 (DB 를 변경하지 않는 검증이고, 마이그레이션 누락 시
+  부팅을 실패시켜 배포를 막아준다). 자세한 내용은 [Flyway 마이그레이션 런북](./flyway-migration-runbook.md).
 
 ## 콘솔 UI
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,14 +70,22 @@ spring:
       keepalive-time: 60000 # DB에 1분마다 생존 신고 (유휴 커넥션 방지)
 
   flyway:
-    enabled: true
+    # 부팅 시 자동 migrate 여부. 로컬/테스트는 true(기본값), 배포 환경(prod/alpha)은
+    # SSM 에 FLYWAY_ENABLED=false 를 넣어 끈다. 배포 환경의 마이그레이션은
+    # `DB Migrate [Flyway]` 워크플로우(workflow_dispatch)로만 수행한다.
+    # 참고: docs/infra/flyway-migration-runbook.md
+    enabled: ${FLYWAY_ENABLED:true}
     baseline-version: 2026.02.25.01.30
     baseline-on-migrate: ${FLYWAY_BASELINE_ON_MIGRATE:false}
     out-of-order: ${FLYWAY_OUT_OF_ORDER:false}
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      # validate 는 DB를 변경하지 않는 읽기 전용 검증이다. 마이그레이션 없이 신버전이 배포되면
+      # 부팅이 실패하고 ASG instance refresh 가 중단되므로 안전장치로 유지한다.
+      # expand-contract 중간 단계처럼 "스키마가 아직 안 맞아도 떠야 하는" 예외 상황에서만
+      # JPA_DDL_AUTO=none 으로 일시 완화한다. create/update 계열은 절대 주입하지 않는다.
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/db/migration/AGENTS.md
+++ b/src/main/resources/db/migration/AGENTS.md
@@ -14,6 +14,11 @@ This directory contains PostgreSQL/PostGIS Flyway migrations. Files are ordered 
 - Match application entity changes with a migration in the same work item.
 - Baseline is `2026.02.25.01.30`; do not rewrite historical migrations after they have shipped.
 - PostgreSQL-specific SQL is acceptable; this project targets PostgreSQL with PostGIS.
+- Deployed environments (prod/alpha) do NOT migrate on boot: `FLYWAY_ENABLED=false` in SSM.
+  Schema changes there are applied by the `DB Migrate [Flyway]` workflow, run manually before the
+  app deploy. Local and test keep the default `FLYWAY_ENABLED=true`.
+- Order of operations for a shipped change: migrate first, deploy code second. Destructive changes
+  (column drops, constraint tightening) must be split expand-contract across two deploys.
 
 ## WHERE TO LOOK
 
@@ -22,6 +27,8 @@ This directory contains PostgreSQL/PostGIS Flyway migrations. Files are ordered 
 | Baseline schema | `V2026.02.25.01.30__init_schema.sql` | Large initial schema |
 | Flyway settings | `src/main/resources/application.yml` | baseline, out-of-order, validate behavior |
 | Duplicate check | `build.gradle.kts` | custom Gradle migration version check |
+| Deploy-time runbook | `docs/infra/flyway-migration-runbook.md` | manual migration workflow, failure handling |
+| Migration workflow | `.github/workflows/db-migrate.yml` | workflow_dispatch: info/validate/migrate/repair |
 
 ## ANTI-PATTERNS
 


### PR DESCRIPTION
> **Stacked PR**: base 가 `develop` 이 아니라 #1281 의 브랜치(`infra/aws-ssm-deployment-workflow`)입니다.
> 런북이 #1281 에서 추가된 SSM 가이드 문서를 참조하기 때문입니다. #1281 머지 후 base 를 `develop` 으로 바꿔주세요.

## 배경

배포(ASG instance refresh)와 DB 스키마 변경이 한 덩어리로 묶여 있으면, 롤백 시 코드만 되돌아가고
스키마는 남는다. 실행 시점을 사람이 정할 수 있도록 **배포에서 마이그레이션을 분리**한다.

정리해두면:

- **DB 를 실제로 변경하는 것은 Flyway `migrate` 와 `ddl-auto` 의 `create`/`update` 계열뿐이다.**
- `ddl-auto: validate` 는 스키마 메타데이터를 읽어 엔티티와 대조만 하는 **읽기 전용 검증**이다.
  끄지 않고 그대로 두는 쪽이 오히려 안전장치가 된다 — 마이그레이션을 빠뜨린 채 신버전을 배포하면
  부팅이 실패하고, ASG instance refresh 는 health check 실패 시 교체를 중단하므로 구버전이 그대로
  살아남는다. DB 는 아무것도 안 바뀐 상태로.

## 변경 사항

### 1. 스위치 두 개를 환경변수로 노출 (`application.yml`)

```yaml
flyway:
  enabled: ${FLYWAY_ENABLED:true}          # 로컬/테스트는 지금과 동일, 배포 환경만 false
jpa:
  hibernate:
    ddl-auto: ${JPA_DDL_AUTO:validate}     # 평소엔 validate 유지
```

기본값이 기존 값과 같으므로 **로컬/CI/테스트 동작은 변하지 않는다.**
`JPA_DDL_AUTO` 는 expand-contract 중간 단계처럼 "스키마가 아직 안 맞아도 일단 떠야 하는" 예외를 위해
열어둔 것이고, 평소에는 `validate` 를 유지한다. 상시로 꺼두면 부팅은 되는데 런타임 쿼리가 터지는
더 나쁜 실패 모드가 된다.

### 2. `DB Migrate [Flyway]` 워크플로우 (`.github/workflows/db-migrate.yml`)

`workflow_dispatch` 전용. SSM(`DATABASE_URL`/`DATABASE_USERNAME`/`DATABASE_PASSWORD`)에서 접속 정보를
읽어 `flyway/flyway:11-alpine` 컨테이너로 실행한다.

| 입력 | 설명 |
|------|------|
| `environment` | `Development`(→ SSM `alpha`) / `Production`(→ SSM `prod`) |
| `command` | `info` / `validate` / `migrate` / `repair` |
| `confirm` | Production 에 `migrate`/`repair` 할 때 `Production` 재입력 요구 |
| `out_of_order`, `baseline_on_migrate` | 기본 false |

안전장치:

- `clean` 은 `FLYWAY_CLEAN_DISABLED=true` 로 봉인 — 선택지에도 없다.
- 실행 전/후 `flyway info` 를 Step Summary 에 접이식으로 남긴다.
- `concurrency` 로 환경별 직렬화 — 같은 DB 에 두 실행이 동시에 붙지 않는다.
- 비밀값은 전부 `::add-mask::`, docker 인자가 아닌 값 없는 `-e` 로 전달해 `ps` 에도 남지 않는다.
- `baseline-version` 은 `application.yml` 에서 읽어 drift 를 막는다.
- 대상 환경의 SSM `FLYWAY_ENABLED` 가 `false` 가 아니면 warning 을 띄운다.
- `environment:` 를 지정했으므로 Production 에 required reviewer 를 걸면 승인 게이트가 동작한다.

### 3. 문서

- `docs/infra/flyway-migration-runbook.md` (신규) — 표준 절차, 명령별 주의, 실패 시 대응, 네트워크 경로
- SSM 가이드 / migration `AGENTS.md` / `.env.example` 갱신

## 머지 후 필요한 작업 (코드 아님)

1. **SSM 에 `FLYWAY_ENABLED=false` 등록** (prod/alpha). 이걸 하기 전까지는 여전히 부팅 시 자동 migrate 다.

   ```bash
   for ENV in prod alpha; do
     aws ssm put-parameter --name "/umc-product/cygnus-server/${ENV}/FLYWAY_ENABLED" \
       --type SecureString --tier Intelligent-Tiering --value "false" --overwrite
   done
   ```

2. 이후 배포 순서는 **`DB Migrate [Flyway]` (migrate) → `CD [ASG]`** 로 굳힌다. 스키마 먼저, 코드 나중.

## 확인 필요 — 네트워크 경로

이 워크플로우는 GitHub-hosted 러너에서 RDS 5432 로 직접 붙는다. 현재 개발자 로컬에서
`./scripts/run-alpha.sh` 로 alpha DB 에 붙는 경로가 동작하니 alpha 는 될 것으로 보이지만,
**러너 IP 가 RDS 보안 그룹에 허용되지 않으면 `flyway info` 단계에서 실패한다.** 안 되는 경우 선택지는
(1) IP 허용, (2) VPC 안 self-hosted 러너로 `runs-on` 교체, (3) SSM Run Command 방식으로 변경이며,
런북의 "네트워크 경로" 절에 정리해뒀다. 워크플로우 구조는 그대로 두고 `runs-on` 한 줄만 바꾸면 되는 (2)를
먼저 검토하는 걸 권한다.

## 테스트

- `./gradlew spotlessCheck` 통과
- `./gradlew test --tests "...StudyGroupSchedulePersistenceAdapterTest"` 통과
  (Testcontainers 로 실제 Postgres 에 Flyway + `validate` 부팅 경로 확인)
- 워크플로우 YAML 파싱 및 모든 `run` 블록 `bash -n` 문법 검증
- 워크플로우 실제 실행은 머지 후 alpha 에 `command: info` 로 먼저 확인 필요
