### PR TITLE
[Chore] README 배지와 Grafana 대시보드 이름을 cygnus-server로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # UMC PRODUCT SERVER
 
-[![codecov](https://codecov.io/gh/UMC-PRODUCT/umc-product-server/graph/badge.svg?token=0GUPQZQ40J)](https://codecov.io/gh/UMC-PRODUCT/umc-product-server)
-![GitHub Actions](https://github.com/UMC-PRODUCT/umc-product-server/actions/workflows/ci.yml/badge.svg)
-![GitHub Actions](https://github.com/UMC-PRODUCT/umc-product-server/actions/workflows/cd-asg.yml/badge.svg)
-![Version](https://img.shields.io/github/v/release/UMC-PRODUCT/umc-product-server)
+[![codecov](https://codecov.io/gh/UMC-PRODUCT/cygnus-server/graph/badge.svg?token=0GUPQZQ40J)](https://codecov.io/gh/UMC-PRODUCT/cygnus-server)
+![GitHub Actions](https://github.com/UMC-PRODUCT/cygnus-server/actions/workflows/ci.yml/badge.svg)
+![GitHub Actions](https://github.com/UMC-PRODUCT/cygnus-server/actions/workflows/cd-asg.yml/badge.svg)
+![Version](https://img.shields.io/github/v/release/UMC-PRODUCT/cygnus-server)
 
 <img alt="banner" width="1000" src="https://github.com/user-attachments/assets/42fbe96a-f3ef-40d4-956c-461a9d7f1600" />
 
@@ -34,7 +34,7 @@
 
 **_founded & maintained by_**
 
-  <a href="https://github.com/umc-product/umc-product-server/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=umc-product/umc-product-server" />
+  <a href="https://github.com/umc-product/cygnus-server/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=umc-product/cygnus-server" />
   </a>
 </div>

--- a/infra/monitoring/grafana/config/grafana/dashboards/github.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/github.json
@@ -52,7 +52,7 @@
                         },
                         "owner": "UMC-PRODUCT",
                         "queryType": "Pull_Requests",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },
@@ -207,7 +207,7 @@
                         },
                         "owner": "UMC-PRODUCT",
                         "queryType": "Issues",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },
@@ -289,7 +289,7 @@
                       "spec": {
                         "owner": "UMC-PRODUCT",
                         "queryType": "Issues",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },
@@ -443,7 +443,7 @@
                         },
                         "owner": "UMC-PRODUCT",
                         "queryType": "Pull_Requests",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },
@@ -529,7 +529,7 @@
                         },
                         "owner": "UMC-PRODUCT",
                         "queryType": "Pull_Requests",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },
@@ -631,7 +631,7 @@
                         },
                         "owner": "UMC-PRODUCT",
                         "queryType": "Pull_Requests",
-                        "repository": "umc-product-server"
+                        "repository": "cygnus-server"
                       },
                       "version": "v0"
                     },

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-default.json
@@ -2,7 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
-    "name": "umc-product-server-default"
+    "name": "cygnus-server-default"
   },
   "spec": {
     "annotations": [

--- a/infra/monitoring/grafana/config/grafana/dashboards/server-logs.json
+++ b/infra/monitoring/grafana/config/grafana/dashboards/server-logs.json
@@ -2,7 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
-    "name": "umc-product-server-logs"
+    "name": "cygnus-server-logs"
   },
   "spec": {
     "annotations": [


### PR DESCRIPTION
## 🚀 작업 내용

### 변경 범위 요약

- 코드 동작과 무관한 이름 참조만 변경했어요: `README.md` 와 `infra/monitoring/grafana/config/grafana/dashboards/` 3개 파일이에요.

### 작업 단위별 상세

1. **무엇을**: README 상단의 codecov·GitHub Actions·release 배지와 contributors 링크의 repo 슬러그를 `umc-product-server` → `cygnus-server` 로 변경했어요.
   - **어떻게**: URL 문자열 치환이라 렌더링 외 동작 변화는 없어요.
   - **왜**: 레포지토리 명칭을 `cygnus-server` 로 변경하는 작업의 사전 준비예요. GitHub 배지는 rename 후 redirect 로도 동작하지만, codecov 배지는 rename 전까지는 이미지가 깨져 보여요.

2. **무엇을**: Grafana `github.json` 대시보드의 GitHub datasource 조회 대상 repository 를 `cygnus-server` 로 변경했어요.
   - **어떻게**: 쿼리 변수의 `"repository"` 값만 바꿨어요.
   - **왜**: 이 대시보드는 GitHub API 를 repo 이름으로 조회해서, rename 후 옛 이름으로는 데이터가 끊기기 때문이에요.

3. **무엇을**: `server-logs`, `server-default` 대시보드의 리소스 이름(`metadata.name`)을 `cygnus-server-logs`, `cygnus-server-default` 로 rename 했어요.
   - **어떻게**: Grafana v2 Dashboard 리소스의 식별자만 변경했고 패널·쿼리는 그대로예요.
   - **왜**: 대시보드 이름을 새 레포 명칭과 일치시키기 위해서예요.

## 💬 리뷰 중점사항

- 이 PR 은 **레포 rename 과 같은 시점에 머지**하는 걸 권장해요. rename 전에 머지되면 codecov 배지와 github.json 대시보드가 옛 이름을 못 찾아 일시적으로 깨져 보여요 (기능 영향은 없어요).
- `metadata.name` 은 Grafana 리소스 식별자라서, 재프로비저닝 시 새 이름의 대시보드로 등록되고 기존 이름으로 저장해 둔 북마크/링크는 갱신이 필요해요.
