### PR TITLE
[Chore] GitHub Actions environment를 Development에서 Alpha로 전환

### DIFF
--- a/.github/workflows/cd-asg.yml
+++ b/.github/workflows/cd-asg.yml
@@ -44,7 +44,7 @@ on:
         required: true
         type: choice
         options:
-          - Development
+          - Alpha
           - Production
 
 concurrency:
@@ -129,7 +129,7 @@ jobs:
           # SPRING_PROFILE 은 Spring profile 이름, SSM_ENV 는 SSM 경로 세그먼트다.
           case "${ENVIRONMENT}" in
             Production) SPRING_PROFILE="prod"; SSM_ENV="prod" ;;
-            Development) SPRING_PROFILE="alpha"; SSM_ENV="alpha" ;;
+            Alpha) SPRING_PROFILE="alpha"; SSM_ENV="alpha" ;;
             Test) SPRING_PROFILE="test"; SSM_ENV="alpha" ;;
             *) SPRING_PROFILE="alpha"; SSM_ENV="alpha" ;;
           esac

--- a/.github/workflows/cd-dev-home.yml
+++ b/.github/workflows/cd-dev-home.yml
@@ -56,14 +56,14 @@ jobs:
       deployments: write
     secrets: inherit
     with:
-      environment: Development
+      environment: Alpha
 
   deploy:
     name: Deploy to Develop Home Server
     needs: ci-and-build
-    if: (github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch') && needs.ci-and-build.outputs.environment == 'Development'
+    if: (github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch') && needs.ci-and-build.outputs.environment == 'Alpha'
     runs-on: ubuntu-latest
-    environment: Development
+    environment: Alpha
 
     env:
       ENVIRONMENT: ${{ needs.ci-and-build.outputs.environment }}

--- a/.github/workflows/cd-ecr.yml
+++ b/.github/workflows/cd-ecr.yml
@@ -27,7 +27,7 @@ on:
         required: true
         type: choice
         options:
-          - Development
+          - Alpha
           - Production
 
 jobs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ on:
         required: true
         type: choice
         options:
-          - Development
+          - Alpha
           - Production
 
 jobs:
@@ -223,7 +223,7 @@ jobs:
 
             case "${{ env.ENVIRONMENT }}" in
               "Production") PROFILE="prod" ;;
-              "Development") PROFILE="alpha" ;;
+              "Alpha") PROFILE="alpha" ;;
               "Test") PROFILE="test" ;;
               *) PROFILE="alpha" ;;
             esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ on:
         required: true
         type: choice
         options:
-          - Development
+          - Alpha
           - Production
           - Test
 
@@ -113,7 +113,7 @@ jobs:
           elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             ENVIRONMENT="Production"
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
-            ENVIRONMENT="Development"
+            ENVIRONMENT="Alpha"
           else
             ENVIRONMENT="Test"
           fi


### PR DESCRIPTION
## 🚀 작업 내용

### 변경 범위 요약

- `.github/workflows/` 5개 파일(ci, cd, cd-asg, cd-ecr, cd-dev-home)의 environment 이름 문자열만 변경했어요.

### 작업 단위별 상세

1. **무엇을**: GitHub Actions environment 이름을 `Development` → `Alpha` 로 전환했어요.
   - **어떻게**: workflow_dispatch choice 옵션, develop 브랜치 push 시 환경 결정 로직(ci.yml), 각 CD 의 case 분기, job 의 `environment:` 필드, cd-dev-home 의 실행 조건 비교 문자열을 일괄 치환했어요. 5개 파일 모두 YAML 유효성을 확인했어요.
   - **왜**: 팀 환경 명칭이 prod/alpha 로 통일되면서 (#1281 의 Spring profile alpha rename 에 이어) GitHub environment 이름도 일치시키기 위해서예요.

2. **무엇을**: 저장소 설정에 `Alpha` environment 를 생성하고 variables 를 이관했어요 (코드 외 작업).
   - **어떻게**: GitHub API 로 `Alpha` environment 를 만들고 `ASG_NAME`, `LAUNCH_TEMPLATE_NAME` 을 복사했어요. `SECRET_S3_URI` 는 SSM 전환(#1281)으로 불필요해져 이관하지 않았어요.
   - **왜**: 이 PR 이 머지되기 전에 Alpha environment 가 존재해야 해요. 없으면 GitHub 이 빈 environment 를 자동 생성해서 `ASG_NAME` 없이 배포가 실패해요.

### 부수 효과

- ci.yml 의 `lower_environment` 가 ECR 편의 태그로 쓰여서, `development-latest` 태그가 `alpha-latest` 로 바뀌어요. 코드베이스에서 이 태그를 참조하는 소비처가 없는 것을 확인했어요.

## 💬 리뷰 중점사항

- 머지 후 workflow_dispatch 로 Alpha 배포가 정상 동작하는 것을 확인하면, 기존 `Development` environment 는 삭제해도 돼요 (남아 있는 SSH/ECS 계열 secrets 는 비활성화된 cd.yml/cd-ecr.yml 전용이라 Alpha 로 이관하지 않았어요 — 해당 flow 를 다시 쓸 계획이 있다면 삭제 전에 알려주세요).
- 옛 `development-latest` ECR 태그를 참조하는 외부 스크립트나 로컬 습관이 있다면 `alpha-latest` 로 바꿔야 해요.
