### PR TITLE
[Feat] 데모데이 INFO QR 조회 API 구현 (#1257)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -309,3 +309,12 @@ CDN_PRIVATE_KEY_PARAMETER_NAME=/umc/common/cloudfront/private-key
 # ------------------------------------------------------------------
 # Base64-encoded 32-byte AES-256-GCM key
 DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY=<BASE64_ENCODED_32_BYTE_KEY>
+
+# ------------------------------------------------------------------
+# Demoday Domain QR
+# ------------------------------------------------------------------
+
+# FE가 QR로 렌더링할 URL의 origin. 스킴+호스트만 담고 경로는 붙이지 않는다.
+DEMODAY_QR_BASE_URL=
+# INFO QR credential(signed token) 서명용 HMAC 키. 32바이트 이상.
+DEMODAY_VOTE_QR_SIGNING_KEY=

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -1,6 +1,7 @@
 package com.umc.product.demoday.adapter.in.web;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,10 +15,12 @@ import com.umc.product.demoday.adapter.in.web.dto.request.CreateDemodayPollReque
 import com.umc.product.demoday.adapter.in.web.dto.request.GenerateDemodayEntryCodesRequest;
 import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayEntryCodeResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayPollResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayVoteQrResponse;
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+import com.umc.product.demoday.application.port.in.query.GetDemodayVoteQrUseCase;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
 
@@ -39,6 +42,7 @@ public class DemodayPollAdminController {
     private final CreateDemodayPollUseCase createDemodayPollUseCase;
     private final ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
     private final CreateDemodayEntryCodeUseCase createDemodayEntryCodeUseCase;
+    private final GetDemodayVoteQrUseCase getDemodayVoteQrUseCase;
 
     @Operation(
         operationId = "createDemodayPoll",
@@ -95,5 +99,31 @@ public class DemodayPollAdminController {
 
         return CreateDemodayEntryCodeResponse.from(demodayEntryCodesInfo);
 
+    }
+
+    @Operation(
+        operationId = "getAdminVoteQr",
+        summary = "현재 시간 구간의 INFO 투표 인증 QR 조회",
+        description = """
+            **이 API는 호출할 때마다 새 QR을 생성하는 명령이 아닙니다.**
+            현재 시간 구간에서 유효한 INFO 투표 인증 QR을 조회합니다.
+
+            INFO QR credential은 서버가 발급한 토큰이며 1시간마다 변경됩니다.
+            같은 유효 구간에서는 여러 운영자가 조회하거나 화면을 새로고침해도
+            논리적으로 동일한 credential을 반환합니다.
+
+            `qrValue`는 FE가 추가로 조립하지 않고 그대로 QR 이미지로 렌더링할 수 있는 완성된 값입니다.
+
+            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 하며,
+            투표가 OPEN 상태이고 투표 기간 안일 때만 조회할 수 있습니다(404 DEMODAY-0111).
+            """
+    )
+    @GetMapping("/{pollId}/vote-qr")
+    public DemodayVoteQrResponse getVoteQr(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "INFO QR을 조회할 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId) {
+
+        return DemodayVoteQrResponse.from(getDemodayVoteQrUseCase.get(pollId, memberPrincipal.getMemberId()));
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayVoteQrResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayVoteQrResponse.java
@@ -1,0 +1,27 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "현재 시간 구간의 INFO 투표 인증 QR 조회 결과")
+public record DemodayVoteQrResponse(
+    @Schema(description = "투표 행사 ID", example = "1")
+    Long pollId,
+    @Schema(
+        description = "FE가 그대로 QR 이미지로 렌더링할 완성된 전체 문자열. 조립하지 마세요.",
+        example = "https://vote.umc.it.kr/demoday/polls/1/vote-authorization#token=eyJ..."
+    )
+    String qrValue,
+    @Schema(description = "현재 QR 유효 구간의 시작 시각", example = "2026-08-17T15:00:00Z")
+    Instant generatedAt,
+    @Schema(description = "INFO QR credential 만료 시각. 1시간 주기로 교체됩니다.", example = "2026-08-17T16:00:00Z")
+    Instant expiresAt
+) {
+
+    public static DemodayVoteQrResponse from(DemodayVoteQrInfo info) {
+        return new DemodayVoteQrResponse(info.pollId(), info.qrValue(), info.generatedAt(), info.expiresAt());
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenGenerator.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenGenerator.java
@@ -1,0 +1,45 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.GenerateDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.config.DemodayVoteQrProperties;
+import com.umc.product.demoday.domain.enums.DemodayVoteQrPurpose;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtDemodayVoteQrTokenGenerator implements GenerateDemodayVoteQrCredentialPort {
+
+    private static final String PURPOSE_CLAIM = "purpose";
+    private static final String POLL_ID_CLAIM = "pollId";
+
+    private final SecretKey signingKey;
+
+    public JwtDemodayVoteQrTokenGenerator(DemodayVoteQrProperties properties) {
+        this.signingKey = Keys.hmacShaKeyFor(properties.signingKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * 같은 pollId·같은 구간이면 항상 같은 서명 결과를 반환한다. HMAC 서명은 입력(header+claims)과 키가
+     * 같으면 결정적이므로, 이 메서드가 매 호출마다 같은 claim 값만 넣으면 재발급 여부와 무관하게
+     * 동일한 문자열이 나온다. jti 같은 무작위 claim은 추가하지 않는다.
+     */
+    @Override
+    public String generate(Long pollId, Instant issuedAt, Instant expiresAt) {
+        return Jwts.builder()
+            .claim(PURPOSE_CLAIM, DemodayVoteQrPurpose.VOTE_AUTH.name())
+            .claim(POLL_ID_CLAIM, pollId)
+            .issuedAt(Date.from(issuedAt))
+            .expiration(Date.from(expiresAt))
+            .signWith(signingKey)
+            .compact();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenVerifier.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenVerifier.java
@@ -1,0 +1,75 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.DemodayVoteQrTokenClaims;
+import com.umc.product.demoday.application.port.out.VerifyDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.config.DemodayVoteQrProperties;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtDemodayVoteQrTokenVerifier implements VerifyDemodayVoteQrCredentialPort {
+
+    private static final String PURPOSE_CLAIM = "purpose";
+    private static final String POLL_ID_CLAIM = "pollId";
+
+    /**
+     * 시간 구간 경계 직전에 발급된 token이 구간 교체 직후 요청에서 부당하게 거부되지 않도록, 검증 시점에만 허용하는 유예 폭이다.
+     * 발급 쪽 claim(iat/exp)에는 영향을 주지 않으므로 조회 응답의 expiresAt은 항상 정시로 유지된다.
+     */
+    private static final long ALLOWED_CLOCK_SKEW_SECONDS = 60;
+
+    private final SecretKey signingKey;
+    private final Clock clock;
+
+    public JwtDemodayVoteQrTokenVerifier(DemodayVoteQrProperties properties, Clock clock) {
+        this.signingKey = Keys.hmacShaKeyFor(properties.signingKey().getBytes(StandardCharsets.UTF_8));
+        this.clock = clock;
+    }
+
+    @Override
+    public DemodayVoteQrTokenClaims verify(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                .verifyWith(signingKey)
+                .clockSkewSeconds(ALLOWED_CLOCK_SKEW_SECONDS)
+                .clock(() -> Date.from(clock.instant()))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+            return new DemodayVoteQrTokenClaims(
+                claims.get(PURPOSE_CLAIM, String.class),
+                toPollId(claims),
+                claims.getIssuedAt().toInstant(),
+                claims.getExpiration().toInstant()
+            );
+        } catch (ExpiredJwtException exception) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_VOTE_QR_EXPIRED);
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_VOTE_QR_INVALID);
+        }
+    }
+
+    private Long toPollId(Claims claims) {
+        //Ineger와 Long 상관없이 받을 수 있도록 하는 방어코드
+        Number pollId = claims.get(POLL_ID_CLAIM, Number.class);
+        if (pollId == null) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_VOTE_QR_INVALID);
+        }
+        return pollId.longValue();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/GetDemodayVoteQrUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/GetDemodayVoteQrUseCase.java
@@ -1,0 +1,11 @@
+package com.umc.product.demoday.application.port.in.query;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
+
+public interface GetDemodayVoteQrUseCase {
+
+    /**
+     * 현재 시간 구간에서 유효한 INFO QR credential을 조회한다. 호출할 때마다 새로 만들지 않는다.
+     */
+    DemodayVoteQrInfo get(Long pollId, Long memberId);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayVoteQrInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayVoteQrInfo.java
@@ -1,0 +1,11 @@
+package com.umc.product.demoday.application.port.in.query.dto;
+
+import java.time.Instant;
+
+public record DemodayVoteQrInfo(
+    Long pollId,
+    String qrValue,
+    Instant generatedAt,
+    Instant expiresAt
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/DemodayVoteQrTokenClaims.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/DemodayVoteQrTokenClaims.java
@@ -1,0 +1,11 @@
+package com.umc.product.demoday.application.port.out;
+
+import java.time.Instant;
+
+public record DemodayVoteQrTokenClaims(
+    String purpose,
+    Long pollId,
+    Instant issuedAt,
+    Instant expiresAt
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayVoteQrCredentialPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/GenerateDemodayVoteQrCredentialPort.java
@@ -1,0 +1,14 @@
+package com.umc.product.demoday.application.port.out;
+
+import java.time.Instant;
+
+public interface GenerateDemodayVoteQrCredentialPort {
+
+    /**
+     * 주어진 시간 구간(issuedAt~expiresAt)의 INFO QR credential을 결정적으로 생성한다.
+     *
+     * <p>같은 pollId와 같은 구간이 주어지면 항상 같은 문자열을 반환해야 한다. 호출할 때마다 새 값을
+     * 만드는 명령이 아니라, 그 구간에 대응하는 값을 계산해 돌려주는 함수다.
+     */
+    String generate(Long pollId, Instant issuedAt, Instant expiresAt);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/VerifyDemodayVoteQrCredentialPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/VerifyDemodayVoteQrCredentialPort.java
@@ -1,0 +1,14 @@
+package com.umc.product.demoday.application.port.out;
+
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+
+public interface VerifyDemodayVoteQrCredentialPort {
+
+    /**
+     * INFO QR credential의 서명과 만료 여부를 검증하고 claim을 반환한다.
+     *
+     * <p>서명이 유효하지 않거나(변조·형식 오류) 허용된 clock skew를 넘겨 만료됐으면 {@link DemodayDomainException}을 던진다.
+     * 용도(purpose)·Poll 일치 여부는 이 Port의 책임이 아니다 — 호출자가 반환된 claim으로 판단한다.
+     */
+    DemodayVoteQrTokenClaims verify(String token);
+}

--- a/src/main/java/com/umc/product/demoday/application/service/DemodayVoteQrCredentialValidator.java
+++ b/src/main/java/com/umc/product/demoday/application/service/DemodayVoteQrCredentialValidator.java
@@ -1,0 +1,37 @@
+package com.umc.product.demoday.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.DemodayVoteQrTokenClaims;
+import com.umc.product.demoday.application.port.out.VerifyDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.domain.enums.DemodayVoteQrPurpose;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * INFO QR credential이 이 Poll의 투표 인증에 실제로 쓰일 수 있는지 검증한다.
+ *
+ * <p>서명·만료 검증은 {@link VerifyDemodayVoteQrCredentialPort}(암호 경계)가 맡고, 이 클래스는 그 결과로
+ * 받은 claim이 용도·Poll 조건을 만족하는지 판단하는 애플리케이션 규칙을 담당한다.
+ * VoteAuthorization 발급 흐름이 해당 클래스를 호출한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class DemodayVoteQrCredentialValidator {
+
+    private final VerifyDemodayVoteQrCredentialPort verifyDemodayVoteQrCredentialPort;
+
+    public void validate(Long pollId, String token) {
+        DemodayVoteQrTokenClaims claims = verifyDemodayVoteQrCredentialPort.verify(token);
+
+        if (!DemodayVoteQrPurpose.VOTE_AUTH.name().equals(claims.purpose())) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_VOTE_QR_PURPOSE_MISMATCH);
+        }
+
+        if (!pollId.equals(claims.pollId())) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_VOTE_QR_POLL_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayVoteQrQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayVoteQrQueryService.java
@@ -1,0 +1,69 @@
+package com.umc.product.demoday.application.service.query;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.query.GetDemodayVoteQrUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
+import com.umc.product.demoday.application.port.out.GenerateDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.config.DemodayQrProperties;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * INFO QR credential은 요청마다 새로 만들지 않는다. 현재 시각이 속한 QR_DURATION_TIME 구간의 시작·끝을 계산해
+ * {@link GenerateDemodayVoteQrCredentialPort}에 넘기면, 같은 구간에서는 항상 같은 문자열이 결정적으로
+ * 나온다(ADR-023). 그래서 이 클래스는 credential을 "생성"하지 않고 "그 구간의 값을 조회"한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DemodayVoteQrQueryService implements GetDemodayVoteQrUseCase {
+
+    public static final int QR_DURATION_TIME = 1;
+    private static final Duration WINDOW = Duration.ofHours(QR_DURATION_TIME);
+
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final GenerateDemodayVoteQrCredentialPort generateDemodayVoteQrCredentialPort;
+    private final DemodayQrProperties demodayQrProperties;
+    private final Clock clock;
+
+    @Override
+    public DemodayVoteQrInfo get(Long pollId, Long memberId) {
+        DemodayPoll poll = loadDemodayPollPort.findById(pollId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(memberId, poll.getGisuId());
+
+        Instant now = clock.instant();
+        poll.validVoteQrAvailable(now);
+
+        Instant windowStart = now.truncatedTo(ChronoUnit.HOURS);
+        Instant windowEnd = windowStart.plus(WINDOW);
+
+        String token = generateDemodayVoteQrCredentialPort.generate(pollId, windowStart, windowEnd);
+        String qrValue = buildQrValue(pollId, token);
+
+        log.info("demoday vote-qr generated pollId={} windowStart={} windowEnd={}", pollId, windowStart, windowEnd);
+
+        return new DemodayVoteQrInfo(pollId, qrValue, windowStart, windowEnd);
+    }
+
+    private String buildQrValue(Long pollId, String token) {
+        return "%s/demoday/polls/%d/vote-authorization#token=%s"
+            .formatted(demodayQrProperties.baseUrl(), pollId, token);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/config/DemodayVoteQrProperties.java
+++ b/src/main/java/com/umc/product/demoday/config/DemodayVoteQrProperties.java
@@ -1,0 +1,7 @@
+package com.umc.product.demoday.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "demoday.vote-qr")
+public record DemodayVoteQrProperties(String signingKey) {
+}

--- a/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayPoll.java
@@ -215,6 +215,19 @@ public class DemodayPoll extends BaseEntity {
         }
     }
 
+    /**
+     * INFO QR을 표시할 수 있는지 검증한다.
+     *
+     * <p>INFO QR은 참여자가 투표 재인증에 사용하므로 {@link #validParticipationAvailable(Instant)}와 같은
+     * 조건(OPEN 상태이면서 투표 기간 안)을 요구한다. 이 창 밖에서 QR을 보여줘도 뒤이은 재인증이 성공할 수
+     * 없으므로, 조회 시점에 운영진 화면에 명시적인 오류로 알린다.
+     */
+    public void validVoteQrAvailable(Instant now) {
+        if (!isOpen() || now.isBefore(opensAt) || !now.isBefore(closesAt)) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN);
+        }
+    }
+
     private boolean isOpen() {
         return status == DemodayPollStatus.OPEN;
     }

--- a/src/main/java/com/umc/product/demoday/domain/enums/DemodayVoteQrPurpose.java
+++ b/src/main/java/com/umc/product/demoday/domain/enums/DemodayVoteQrPurpose.java
@@ -1,0 +1,5 @@
+package com.umc.product.demoday.domain.enums;
+
+public enum DemodayVoteQrPurpose {
+    VOTE_AUTH
+}

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -36,6 +36,10 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_VOTE_ALREADY_CAST(HttpStatus.CONFLICT, "DEMODAY-0402", "이미 투표를 완료했어요."),
     DEMODAY_VOTE_ALREADY_REVOKED(HttpStatus.CONFLICT, "DEMODAY-0403", "이미 무효 처리된 표에요"),
     DEMODAY_VOTE_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0404", "이번 데모데이의 부스에만 투표할 수 있어요."),
+    DEMODAY_VOTE_QR_INVALID(HttpStatus.UNAUTHORIZED, "DEMODAY-0405", "QR 서명이 유효하지 않아요."),
+    DEMODAY_VOTE_QR_EXPIRED(HttpStatus.UNAUTHORIZED, "DEMODAY-0406", "만료된 QR이에요. 다시 스캔해주세요."),
+    DEMODAY_VOTE_QR_PURPOSE_MISMATCH(HttpStatus.UNAUTHORIZED, "DEMODAY-0407", "투표 인증 용도의 QR이 아니에요."),
+    DEMODAY_VOTE_QR_POLL_MISMATCH(HttpStatus.UNAUTHORIZED, "DEMODAY-0408", "이번 데모데이의 QR이 아니에요."),
 
     DEMODAY_STAMP_ALREADY_COLLECTED(HttpStatus.CONFLICT, "DEMODAY-0501", "이미 스탬프를 받은 부스예요."),
     DEMODAY_STAMP_ALREADY_REVOKED(HttpStatus.CONFLICT, "DEMODAY-0502", "이미 무효 처리된 스탬프예요."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -175,6 +175,8 @@ demoday:
     base-url: ${DEMODAY_QR_BASE_URL}
   stamp-credential:
     encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}
+  vote-qr:
+    signing-key: ${DEMODAY_VOTE_QR_SIGNING_KEY}
 
 # OpenAPI / Scalar 문서 설정
 springdoc:

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminControllerTest.java
@@ -1,0 +1,119 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
+import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
+import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.demoday.application.port.in.query.GetDemodayVoteQrUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+
+@WebMvcTest(controllers = DemodayPollAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(JacksonConfig.class)
+@DisplayName("DemodayPollAdminController")
+class DemodayPollAdminControllerTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 10L;
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean private CreateDemodayPollUseCase createDemodayPollUseCase;
+
+    @MockitoBean private ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
+
+    @MockitoBean private CreateDemodayEntryCodeUseCase createDemodayEntryCodeUseCase;
+
+    @MockitoBean private GetDemodayVoteQrUseCase getDemodayVoteQrUseCase;
+
+    @BeforeEach
+    void setUp() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("현재 구간의 INFO QR을 조회하면 200과 QR 정보를 반환한다")
+    void getVoteQr() throws Exception {
+        // given
+        Instant generatedAt = Instant.parse("2026-08-17T15:00:00Z");
+        Instant expiresAt = Instant.parse("2026-08-17T16:00:00Z");
+        DemodayVoteQrInfo info = new DemodayVoteQrInfo(
+            POLL_ID,
+            "https://vote.umc.it.kr/demoday/polls/10/vote-authorization#token=eyJ",
+            generatedAt,
+            expiresAt);
+        given(getDemodayVoteQrUseCase.get(POLL_ID, MEMBER_ID)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/vote-qr", POLL_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.pollId").value(POLL_ID))
+            .andExpect(jsonPath("$.result.qrValue").value(info.qrValue()))
+            .andExpect(jsonPath("$.result.generatedAt").exists())
+            .andExpect(jsonPath("$.result.expiresAt").exists());
+
+        then(getDemodayVoteQrUseCase).should().get(POLL_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("운영 중이 아닌 Poll을 조회하면 오류 코드를 반환한다")
+    void getVoteQrWhenPollIsNotOpen() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN))
+            .given(getDemodayVoteQrUseCase)
+            .get(POLL_ID, MEMBER_ID);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/vote-qr", POLL_ID))
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN.getCode()));
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 접근 오류 코드를 반환한다")
+    void getVoteQrWhenNotAdmin() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED))
+            .given(getDemodayVoteQrUseCase)
+            .get(POLL_ID, MEMBER_ID);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/vote-qr", POLL_ID))
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED.getCode()));
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenGeneratorTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenGeneratorTest.java
@@ -1,0 +1,54 @@
+package com.umc.product.demoday.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.umc.product.demoday.config.DemodayVoteQrProperties;
+
+class JwtDemodayVoteQrTokenGeneratorTest {
+
+    private static final String SIGNING_KEY = "unit-test-demoday-vote-qr-signing-key-needs-32-bytes-minimum";
+    private static final Long POLL_ID = 1L;
+    private static final Instant WINDOW_START = Instant.parse("2026-08-17T15:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-17T16:00:00Z");
+
+    private final JwtDemodayVoteQrTokenGenerator generator =
+        new JwtDemodayVoteQrTokenGenerator(new DemodayVoteQrProperties(SIGNING_KEY));
+
+    @Test
+    @DisplayName("같은 pollId·같은 구간이면 항상 같은 문자열을 생성한다")
+    void generateIsDeterministicForSameWindow() {
+        // when
+        String first = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        String second = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+
+        // then
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("구간이 다르면 다른 문자열을 생성한다")
+    void generateDiffersForDifferentWindow() {
+        // when
+        String current = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        String next = generator.generate(POLL_ID, WINDOW_END, WINDOW_END.plusSeconds(3600));
+
+        // then
+        assertThat(current).isNotEqualTo(next);
+    }
+
+    @Test
+    @DisplayName("Poll이 다르면 다른 문자열을 생성한다")
+    void generateDiffersForDifferentPoll() {
+        // when
+        String pollOne = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        String pollTwo = generator.generate(POLL_ID + 1, WINDOW_START, WINDOW_END);
+
+        // then
+        assertThat(pollOne).isNotEqualTo(pollTwo);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenVerifierTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/JwtDemodayVoteQrTokenVerifierTest.java
@@ -1,0 +1,106 @@
+package com.umc.product.demoday.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.umc.product.demoday.application.port.out.DemodayVoteQrTokenClaims;
+import com.umc.product.demoday.config.DemodayVoteQrProperties;
+import com.umc.product.demoday.domain.enums.DemodayVoteQrPurpose;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+class JwtDemodayVoteQrTokenVerifierTest {
+
+    private static final String SIGNING_KEY = "unit-test-demoday-vote-qr-signing-key-needs-32-bytes-minimum";
+    private static final String OTHER_SIGNING_KEY = "unit-test-other-demoday-vote-qr-signing-key-needs-32-bytes-min";
+    private static final Long POLL_ID = 1L;
+    private static final Instant WINDOW_START = Instant.parse("2026-08-17T15:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-17T16:00:00Z");
+
+    private final JwtDemodayVoteQrTokenGenerator generator =
+        new JwtDemodayVoteQrTokenGenerator(new DemodayVoteQrProperties(SIGNING_KEY));
+
+    @Test
+    @DisplayName("유효 구간 안에서 검증하면 발급 claim을 그대로 반환한다")
+    void verifyValidTokenReturnsClaims() {
+        // given
+        String token = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        JwtDemodayVoteQrTokenVerifier verifier = verifierAt(WINDOW_START.plusSeconds(1800));
+
+        // when
+        DemodayVoteQrTokenClaims claims = verifier.verify(token);
+
+        // then
+        assertThat(claims.purpose()).isEqualTo(DemodayVoteQrPurpose.VOTE_AUTH.name());
+        assertThat(claims.pollId()).isEqualTo(POLL_ID);
+        assertThat(claims.issuedAt()).isEqualTo(WINDOW_START);
+        assertThat(claims.expiresAt()).isEqualTo(WINDOW_END);
+    }
+
+    @Test
+    @DisplayName("구간 만료 후 60초까지는 clock skew로 허용한다")
+    void verifyAllowsSixtySecondSkewAfterExpiry() {
+        // given
+        String token = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        JwtDemodayVoteQrTokenVerifier verifier = verifierAt(WINDOW_END.plusSeconds(60));
+
+        // when & then
+        assertThat(verifier.verify(token).pollId()).isEqualTo(POLL_ID);
+    }
+
+    @Test
+    @DisplayName("구간 만료 61초 뒤에는 만료로 거부한다")
+    void verifyRejectsAfterSixtyOneSeconds() {
+        // given
+        String token = generator.generate(POLL_ID, WINDOW_START, WINDOW_END);
+        JwtDemodayVoteQrTokenVerifier verifier = verifierAt(WINDOW_END.plusSeconds(61));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(token))
+            .isInstanceOfSatisfying(DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_VOTE_QR_EXPIRED));
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명되거나 변조된 token은 거부한다")
+    void verifyRejectsTamperedSignature() {
+        // given
+        String tokenFromOtherKey = new JwtDemodayVoteQrTokenGenerator(
+            new DemodayVoteQrProperties(OTHER_SIGNING_KEY))
+            .generate(POLL_ID, WINDOW_START, WINDOW_END);
+        JwtDemodayVoteQrTokenVerifier verifier = verifierAt(WINDOW_START.plusSeconds(1800));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(tokenFromOtherKey))
+            .isInstanceOfSatisfying(DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_VOTE_QR_INVALID));
+    }
+
+    @Test
+    @DisplayName("형식이 깨진 token은 거부한다")
+    void verifyRejectsMalformedToken() {
+        // given
+        JwtDemodayVoteQrTokenVerifier verifier = verifierAt(WINDOW_START.plusSeconds(1800));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify("not-a-jwt"))
+            .isInstanceOfSatisfying(DemodayDomainException.class,
+                exception -> assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_VOTE_QR_INVALID));
+    }
+
+    private JwtDemodayVoteQrTokenVerifier verifierAt(Instant now) {
+        return new JwtDemodayVoteQrTokenVerifier(
+            new DemodayVoteQrProperties(SIGNING_KEY),
+            Clock.fixed(now, ZoneOffset.UTC));
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/DemodayVoteQrCredentialValidatorTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/DemodayVoteQrCredentialValidatorTest.java
@@ -1,0 +1,74 @@
+package com.umc.product.demoday.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.out.DemodayVoteQrTokenClaims;
+import com.umc.product.demoday.application.port.out.VerifyDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.domain.enums.DemodayVoteQrPurpose;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("데모데이 INFO QR credential 검증")
+class DemodayVoteQrCredentialValidatorTest {
+
+    private static final Long POLL_ID = 1L;
+    private static final String TOKEN = "token-value";
+    private static final Instant ISSUED_AT = Instant.parse("2026-08-17T15:00:00Z");
+    private static final Instant EXPIRES_AT = Instant.parse("2026-08-17T16:00:00Z");
+
+    @Mock
+    private VerifyDemodayVoteQrCredentialPort verifyDemodayVoteQrCredentialPort;
+
+    @InjectMocks
+    private DemodayVoteQrCredentialValidator validator;
+
+    @Test
+    @DisplayName("용도와 Poll이 모두 일치하면 통과한다")
+    void validatePassesWhenPurposeAndPollMatch() {
+        // given
+        given(verifyDemodayVoteQrCredentialPort.verify(TOKEN)).willReturn(
+            new DemodayVoteQrTokenClaims(DemodayVoteQrPurpose.VOTE_AUTH.name(), POLL_ID, ISSUED_AT, EXPIRES_AT));
+
+        // when & then
+        assertThatCode(() -> validator.validate(POLL_ID, TOKEN)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("용도가 다르면 거부한다")
+    void validateRejectsPurposeMismatch() {
+        // given
+        given(verifyDemodayVoteQrCredentialPort.verify(TOKEN)).willReturn(
+            new DemodayVoteQrTokenClaims("OTHER_PURPOSE", POLL_ID, ISSUED_AT, EXPIRES_AT));
+
+        // when & then
+        assertThatThrownBy(() -> validator.validate(POLL_ID, TOKEN))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_VOTE_QR_PURPOSE_MISMATCH));
+    }
+
+    @Test
+    @DisplayName("token의 Poll이 요청한 Poll과 다르면 거부한다")
+    void validateRejectsPollMismatch() {
+        // given
+        given(verifyDemodayVoteQrCredentialPort.verify(TOKEN)).willReturn(
+            new DemodayVoteQrTokenClaims(DemodayVoteQrPurpose.VOTE_AUTH.name(), POLL_ID + 1, ISSUED_AT, EXPIRES_AT));
+
+        // when & then
+        assertThatThrownBy(() -> validator.validate(POLL_ID, TOKEN))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_VOTE_QR_POLL_MISMATCH));
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayVoteQrQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayVoteQrQueryServiceTest.java
@@ -1,0 +1,125 @@
+package com.umc.product.demoday.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
+import com.umc.product.demoday.application.port.out.GenerateDemodayVoteQrCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.config.DemodayQrProperties;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("데모데이 INFO QR 조회")
+class DemodayVoteQrQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long POLL_ID = 10L;
+    private static final Long GISU_ID = 8L;
+    private static final String POLL_NAME = "8기 데모데이 투표";
+    private static final Instant NOW = Instant.parse("2026-08-17T15:30:00Z");
+    private static final Instant WINDOW_START = Instant.parse("2026-08-17T15:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-17T16:00:00Z");
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private GenerateDemodayVoteQrCredentialPort generateDemodayVoteQrCredentialPort;
+
+    @Test
+    @DisplayName("OPEN 상태이고 투표 기간 안이면 현재 구간의 QR을 조회한다")
+    void getVoteQrWhenPollIsOpen() {
+        // given
+        DemodayVoteQrQueryService service = serviceWithClock(clockAt(NOW));
+        DemodayPoll poll = openPoll();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(generateDemodayVoteQrCredentialPort.generate(POLL_ID, WINDOW_START, WINDOW_END))
+            .willReturn("signed-token");
+
+        // when
+        DemodayVoteQrInfo info = service.get(POLL_ID, MEMBER_ID);
+
+        // then
+        assertThat(info.pollId()).isEqualTo(POLL_ID);
+        assertThat(info.qrValue())
+            .isEqualTo("https://vote.test.umc.it.kr/demoday/polls/10/vote-authorization#token=signed-token");
+        assertThat(info.generatedAt()).isEqualTo(WINDOW_START);
+        assertThat(info.expiresAt()).isEqualTo(WINDOW_END);
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Poll을 조회하면 404를 던진다")
+    void getVoteQrWhenPollNotFound() {
+        // given
+        DemodayVoteQrQueryService service = serviceWithClock(clockAt(NOW));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.get(POLL_ID, MEMBER_ID))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        then(generateDemodayVoteQrCredentialPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("READY 상태의 Poll은 조회할 수 없다")
+    void getVoteQrWhenPollIsNotOpen() {
+        // given
+        DemodayVoteQrQueryService service = serviceWithClock(clockAt(NOW));
+        DemodayPoll poll = createPoll();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        // when & then
+        assertThatThrownBy(() -> service.get(POLL_ID, MEMBER_ID))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN));
+
+        then(generateDemodayVoteQrCredentialPort).shouldHaveNoInteractions();
+    }
+
+    private DemodayVoteQrQueryService serviceWithClock(Clock clock) {
+        return new DemodayVoteQrQueryService(
+            loadDemodayPollPort,
+            adminAccessChecker,
+            generateDemodayVoteQrCredentialPort,
+            new DemodayQrProperties("https://vote.test.umc.it.kr"),
+            clock);
+    }
+
+    private static Clock clockAt(Instant instant) {
+        return Clock.fixed(instant, ZoneOffset.UTC);
+    }
+
+    private static DemodayPoll createPoll() {
+        return DemodayPoll.create(
+            GISU_ID, POLL_NAME, Instant.parse("2026-08-17T09:00:00Z"), Instant.parse("2026-08-17T21:00:00Z"));
+    }
+
+    private static DemodayPoll openPoll() {
+        DemodayPoll poll = createPoll();
+        poll.open();
+        return poll;
+    }
+}

--- a/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
+++ b/src/test/java/com/umc/product/demoday/domain/DemodayPollTest.java
@@ -249,4 +249,43 @@ class DemodayPollTest {
         ReflectionTestUtils.setField(poll, "id", POLL_ID);
         return poll;
     }
+
+    @Test
+    @DisplayName("OPEN 상태이고 투표 기간 안이면 INFO QR을 조회할 수 있다")
+    void allowVoteQrWhenOpenAndWithinWindow() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+
+        // when & then
+        assertThatCode(() -> poll.validVoteQrAvailable(OPENS_AT.plusSeconds(60)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("READY 상태에서는 INFO QR을 조회할 수 없다")
+    void rejectVoteQrWhenNotOpen() {
+        // given
+        DemodayPoll poll = persistedPoll();
+
+        // when & then
+        assertThatThrownBy(() -> poll.validVoteQrAvailable(OPENS_AT.plusSeconds(60)))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN);
+    }
+
+    @Test
+    @DisplayName("OPEN 상태여도 투표 기간을 벗어나면 INFO QR을 조회할 수 없다")
+    void rejectVoteQrWhenOutsideWindow() {
+        // given
+        DemodayPoll poll = persistedPoll();
+        poll.open();
+
+        // when & then
+        assertThatThrownBy(() -> poll.validVoteQrAvailable(CLOSES_AT))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("baseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_OPEN);
+    }
 }


### PR DESCRIPTION
resolves #1257

## 🚀 작업 내용

- 참여자는 스탬프 6개를 다 모으고 투표할 부스를 정한 뒤, INFO 부스에 표시된 QR로 현장에 있음을 다시 인증합니다. 이 QR은 1시간마다 새 값으로 바뀌는데, 운영진 화면이 지금 유효한 QR을 띄우려면 서버에서 그 값을 받아올 수 있어야 해서 조회 API 하나를 추가했습니다.

- QR 값은 서버가 매번 계산해서 새로 내려주는 게 아니라, 발급 시각·만료 시각·용도·투표 ID를 담아 서명해둔 토큰입니다. 서버가 현재 시간 구간만 보고 그때그때 값을 계산하는 방식도 검토했는데, 그러면 14시 59분 59초에 정상적으로 스캔한 사람이 그 직후 QR이 바뀌면서 걸리는 경계 문제가 생기고, 그걸 막으려면 이전 구간까지 허용하는 예외 규칙이 따로 필요해집니다. 토큰 안에 만료 시각을 못박아두면 그 문제를 이 API 밖에서, 재인증으로 얻는 투표 권한 쪽 로직으로 넘길 수 있어서 이번엔 이 방식으로 갔습니다.

- 호출할 때마다 새 QR을 만드는 명령이 아니라, 지금 시간 구간에 대응하는 값을 계산해서 돌려주는 조회입니다. 여러 운영진이 같은 화면을 동시에 열어도 같은 값을 받습니다.

- 토큰을 검증하는 로직도 이번에 같이 만들어뒀는데, 이 API에서는 아직 쓰지 않습니다. 참여자가 QR을 스캔해서 재인증하는 API에서 쓸 예정이라 미리 준비해뒀습니다.

## 💬 리뷰 중점사항

- 서명 키는 `demoday.vote-qr.signing-key`로 뺐습니다. 배포 환경에 실제 값을 채우는 절차가 남아 있어서, 그 부분도 같이 봐주시면 좋을 것 같아요.
- 투표가 OPEN 상태이고 투표 기간 안일 때만 조회가 되도록 막아뒀습니다. 그 경계 조건이 의도대로 동작하는지 테스트 위주로 봐주세요
