### PR TITLE
[Feat] 데모데이 외부 방문자 참여 시작과 Cookie 인증 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -316,5 +316,10 @@ DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY=<BASE64_ENCODED_32_BYTE_KEY>
 
 # FE가 QR로 렌더링할 URL의 origin. 스킴+호스트만 담고 경로는 붙이지 않는다.
 DEMODAY_QR_BASE_URL=
-# INFO QR credential(signed token) 서명용 HMAC 키. 32바이트 이상.
+# INFO QR credential(signed token) 서명용 HMAC 키로 32바이트 이상 필요하다
 DEMODAY_VOTE_QR_SIGNING_KEY=
+# 게스트 participant token(HttpOnly Cookie) 서명용 HMAC 키값으로 회원 JWT와 별개 secret. 32바이트 이상 필요하다
+DEMODAY_PARTICIPANT_TOKEN_SECRET=
+# 게스트 입장 코드 제출 엔드포인트 IP 레이트리밋 설정값이다
+DEMODAY_GUEST_RATE_LIMIT_PER_SECOND=5
+DEMODAY_GUEST_RATE_LIMIT_PER_MINUTE=150

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitConfig.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitConfig.java
@@ -1,0 +1,26 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.umc.product.global.ratelimit.ApiRateLimitMetrics;
+import com.umc.product.global.ratelimit.RateLimitBucketRegistry;
+import com.umc.product.global.ratelimit.RateLimitPolicy;
+import com.umc.product.global.response.ApiErrorResponseWriter;
+
+@Configuration
+public class DemodayGuestRateLimitConfig {
+
+    @Bean
+    public DemodayGuestRateLimitInterceptor demodayGuestRateLimitInterceptor(
+        RateLimitBucketRegistry bucketRegistry,
+        ApiErrorResponseWriter errorResponseWriter,
+        ApiRateLimitMetrics metrics,
+        @Value("${demoday.guest-rate-limit.requests-per-second}") int requestsPerSecond,
+        @Value("${demoday.guest-rate-limit.requests-per-minute}") int requestsPerMinute
+    ) {
+        RateLimitPolicy policy = new RateLimitPolicy("demoday-guest-participation", requestsPerSecond, requestsPerMinute);
+        return new DemodayGuestRateLimitInterceptor(bucketRegistry, errorResponseWriter, metrics, policy);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitInterceptor.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitInterceptor.java
@@ -1,0 +1,57 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.ratelimit.ApiRateLimitMetrics;
+import com.umc.product.global.ratelimit.RateLimitBucketRegistry;
+import com.umc.product.global.ratelimit.RateLimitPolicy;
+import com.umc.product.global.response.ApiErrorResponseWriter;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 게스트 입장 코드 제출 엔드포인트를 IP 단위로 레이트리밋한다. 이 엔드포인트는 인증 이전 단계라
+ * 회원 식별자가 없으므로, 발신 IP를 키로 쓰는 recruiting 도메인 익명 제출 엔드포인트와 같은 방식을 쓴다.
+ */
+@RequiredArgsConstructor
+public class DemodayGuestRateLimitInterceptor implements HandlerInterceptor {
+
+    private static final String POLICY_NAME = "demoday-guest-participation";
+
+    private final RateLimitBucketRegistry bucketRegistry;
+    private final ApiErrorResponseWriter errorResponseWriter;
+    private final ApiRateLimitMetrics metrics;
+    private final RateLimitPolicy policy;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+        throws Exception {
+        String bucketKey = "rest:demoday-guest-participation:ip:" + request.getRemoteAddr();
+        Bucket bucket = bucketRegistry.get(bucketKey, policy);
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+        response.setHeader("X-RateLimit-Limit", String.valueOf(policy.requestsPerMinute()));
+
+        if (!probe.isConsumed()) {
+            response.setHeader("Retry-After", String.valueOf(retryAfterSeconds(probe)));
+            response.setHeader("X-RateLimit-Remaining", "0");
+            metrics.record("blocked", POLICY_NAME, request.getMethod(), request.getRequestURI(), "ANONYMOUS");
+            errorResponseWriter.write(response, CommonErrorCode.TOO_MANY_REQUESTS);
+            return false;
+        }
+
+        response.setHeader("X-RateLimit-Remaining", String.valueOf(probe.getRemainingTokens()));
+        metrics.record("allowed", POLICY_NAME, request.getMethod(), request.getRequestURI(), "ANONYMOUS");
+        return true;
+    }
+
+    private long retryAfterSeconds(ConsumptionProbe probe) {
+        return Math.max(1L, TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill()));
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
@@ -1,0 +1,68 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.product.demoday.adapter.in.web.dto.request.GuestParticipationRequest;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayParticipationResponse;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantCookieWriter;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantTokenProvider;
+import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+import com.umc.product.global.security.annotation.Public;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "데모데이 투표 - 참여자", description = "외부 방문자가 참여를 시작하는 API")
+@RestController
+@RequestMapping("/api/v1/demoday/polls")
+@RequiredArgsConstructor
+public class DemodayParticipationCommandController {
+
+    private final StartDemodayGuestParticipationUseCase startDemodayGuestParticipationUseCase;
+    private final DemodayParticipantTokenProvider demodayParticipantTokenProvider;
+    private final DemodayParticipantCookieWriter demodayParticipantCookieWriter;
+
+    @Operation(
+        operationId = "startGuestParticipation",
+        summary = "입장 코드 사용 및 외부 방문자 참여 시작",
+        description = """
+            외부 방문자가 현장에서 받은 입장 코드를 제출해 참여를 시작합니다.
+
+            성공하면 서버가 코드를 사용 처리하고 요청한 브라우저에 1회 바인딩한 뒤,
+            데모데이 전용 participant token을 HttpOnly Cookie로 설정합니다.
+            이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시 제출하면 성공으로 처리합니다.
+            Cookie와 입장 코드의 수명은 Poll 종료 시점까지입니다.
+            """
+    )
+    @Public
+    @PostMapping("/{pollId}/participations/guest")
+    @ResponseStatus(HttpStatus.CREATED)
+    public DemodayParticipationResponse startGuestParticipation(
+        @Parameter(description = "투표 ID", example = "1") @PathVariable Long pollId,
+        @Valid @RequestBody GuestParticipationRequest request,
+        @Parameter(hidden = true)
+        @CookieValue(name = DemodayParticipantTokenProvider.COOKIE_NAME, required = false) String existingToken,
+        HttpServletResponse response
+    ) {
+        Long existingEntryCodeId = demodayParticipantTokenProvider.parseEntryCodeId(existingToken).orElse(null);
+
+        StartDemodayGuestParticipationInfo info = startDemodayGuestParticipationUseCase.start(
+            request.toCommand(pollId, existingEntryCodeId));
+
+        demodayParticipantCookieWriter.writeParticipantCookie(response, info.participantToken(), info.expiresAt());
+
+        return DemodayParticipationResponse.from(info.participation());
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryController.java
@@ -10,14 +10,13 @@ import org.springframework.web.bind.annotation.RestController;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayBoothListResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayParticipationResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayPollListResponse;
+import com.umc.product.demoday.adapter.in.web.security.CurrentDemodayParticipant;
 import com.umc.product.demoday.application.port.in.query.GetDemodayParticipationUseCase;
 import com.umc.product.demoday.application.port.in.query.ListDemodayBoothUseCase;
 import com.umc.product.demoday.application.port.in.query.ListDemodayPollUseCase;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
-import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
-import com.umc.product.global.security.MemberPrincipal;
-import com.umc.product.global.security.annotation.CurrentMember;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
 import com.umc.product.global.security.annotation.Public;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +33,6 @@ public class DemodayPollQueryController {
     private final ListDemodayPollUseCase listDemodayPollUseCase;
     private final GetDemodayParticipationUseCase getDemodayParticipationUseCase;
     private final ListDemodayBoothUseCase listDemodayBoothUseCase;
-    private final DemodayParticipantResolver<MemberPrincipal> participantResolver;
 
     @Operation(summary = "데모데이 투표 목록 조회", description = "데모데이 투표 목록을 조회합니다.")
     @Public
@@ -43,14 +41,17 @@ public class DemodayPollQueryController {
         return DemodayPollListResponse.from(listDemodayPollUseCase.listPolls());
     }
 
-    @Operation(summary = "내 투표 참여 정보 조회", description = "스탬프와 투표 기록을 기반으로 내 투표 참여 정보를 조회합니다.")
+    @Operation(
+        summary = "내 투표 참여 정보 조회",
+        description = "스탬프와 투표 기록을 기반으로 내 투표 참여 정보를 조회합니다. 회원 Bearer 또는 게스트 participant "
+            + "Cookie 둘 중 하나만 있으면 통과합니다."
+    )
     @GetMapping("/{pollId}/participations/me")
     public DemodayParticipationResponse getMyParticipation(
         @Parameter(description = "투표 ID", example = "1") @PathVariable Long pollId,
-        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal
+        @Parameter(hidden = true) @CurrentDemodayParticipant DemodayParticipant participant
     ) {
-        DemodayParticipationInfo participation = getDemodayParticipationUseCase.getParticipation(
-                pollId, participantResolver.resolve(memberPrincipal));
+        DemodayParticipationInfo participation = getDemodayParticipationUseCase.getParticipation(pollId, participant);
 
         return DemodayParticipationResponse.from(participation);
     }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayWebConfig.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayWebConfig.java
@@ -1,0 +1,21 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class DemodayWebConfig implements WebMvcConfigurer {
+
+    private final ObjectProvider<DemodayGuestRateLimitInterceptor> interceptorProvider;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        interceptorProvider.ifAvailable(interceptor -> registry.addInterceptor(interceptor)
+            .addPathPatterns("/api/v1/demoday/polls/*/participations/guest"));
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GuestParticipationRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GuestParticipationRequest.java
@@ -1,0 +1,13 @@
+package com.umc.product.demoday.adapter.in.web.dto.request;
+
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GuestParticipationRequest(
+    @NotBlank String admissionCode
+) {
+    public StartDemodayGuestParticipationCommand toCommand(Long pollId, Long existingEntryCodeId) {
+        return new StartDemodayGuestParticipationCommand(pollId, admissionCode, existingEntryCodeId);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/CurrentDemodayParticipant.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/CurrentDemodayParticipant.java
@@ -1,0 +1,16 @@
+package com.umc.product.demoday.adapter.in.web.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 회원(Bearer)·게스트(Cookie) 어느 쪽으로 인증됐든 공통 {@code DemodayParticipant}로 받고 싶은
+ * 컨트롤러 파라미터에 붙인다. 실제 principal 타입 분기는
+ * {@code CurrentDemodayParticipantArgumentResolver}가 담당한다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentDemodayParticipant {
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipantCookieWriter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipantCookieWriter.java
@@ -1,0 +1,40 @@
+package com.umc.product.demoday.adapter.in.web.security;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 게스트 participant token Cookie를 응답에 싣는다. Domain 속성은 의도적으로 지정하지 않는다(host-only)
+ * 이 Cookie를 읽는 요청은 항상 이 API를 발급한 호스트로만 가므로 Domain을 넓히면 다른 서브도메인까지
+ * Cookie를 읽게 만들어 공격 표면만 늘어나기 때문이다.
+ */
+@Component
+public class DemodayParticipantCookieWriter {
+
+    // 데모데이에서만 사용하는 쿠키 경로이기 때문에 "/api/v1/demoday"로 변경 필요 있음.
+    // 단, 최종 happy-test 전까지는 "/" 경로로 두고 FE와 연결을 진행할 예정.
+    private static final String COOKIE_PATH = "/";
+
+    public void writeParticipantCookie(HttpServletResponse response, String token, Instant expiresAt) {
+        ResponseCookie cookie = ResponseCookie.from(DemodayParticipantTokenProvider.COOKIE_NAME, token)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Lax")
+            .path(COOKIE_PATH)
+            .maxAge(maxAgeUntil(expiresAt))
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private Duration maxAgeUntil(Instant expiresAt) {
+        Duration maxAge = Duration.between(Instant.now(), expiresAt);
+        return maxAge.isNegative() || maxAge.isZero() ? Duration.ZERO : maxAge;
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipantTokenProvider.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipantTokenProvider.java
@@ -1,0 +1,78 @@
+package com.umc.product.demoday.adapter.in.web.security;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.IssueDemodayParticipantTokenPort;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 게스트 참여(participant) 토큰의 발급·검증을 전담한다.
+ * <p>
+ * 회원 {@code JwtTokenProvider}와는 전용 secret으로 완전히 분리된다.
+ * 기존 인증 코어를 건드리지 않고 게스트 인증을 완전히 별도 경로로 얹기 위함이다.
+ * 세션을 DB에 두지 않고 subject(entryCodeId)만 서명해 무상태로 유지한다.
+ * 참여 진행 상태는 저장하지 않고 스탬프·투표 기록에서 매번 파생하므로,
+ * 이 토큰 자체도 저장된 세션이 아니라 "이 entryCodeId로 입장했다"는 자기서명 증명일 뿐이다.
+ * 만료 시각은 고정 TTL이 아니라 발급 시점의 poll.closesAt을 그대로 받는다(계약: "Cookie와 입장 코드의
+ * 수명은 Poll 종료 시점까지").
+ */
+@Slf4j
+@Component
+public class DemodayParticipantTokenProvider implements IssueDemodayParticipantTokenPort {
+
+    public static final String COOKIE_NAME = "demoday_participant_token";
+
+    private final SecretKey secret;
+
+    public DemodayParticipantTokenProvider(
+        @Value("${demoday.participant-token.secret}") String secret
+    ) {
+        this.secret = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String issue(Long entryCodeId, Instant expiresAt) {
+        return Jwts.builder()
+            .subject(String.valueOf(entryCodeId))
+            .issuedAt(Date.from(Instant.now()))
+            .expiration(Date.from(expiresAt))
+            .signWith(secret)
+            .compact();
+    }
+
+    /**
+     * 서명·형식·만료 중 무엇이 틀려도 예외를 던지지 않고 빈 값을 반환한다.
+     * 필터에서 실패를 인증 거부가 아니라 "이 요청엔 유효한 게스트 세션이 없다"로만 취급하기 위함이다
+     * ({@code JwtAuthenticationFilter}와 동일한 fail-open 원칙).
+     */
+    public Optional<Long> parseEntryCodeId(String token) {
+        if (token == null || token.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            Claims claims = Jwts.parser()
+                .verifyWith(secret)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+            return Optional.of(Long.parseLong(claims.getSubject()));
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("게스트 participant token 파싱 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationCookieFilter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationCookieFilter.java
@@ -1,0 +1,78 @@
+package com.umc.product.demoday.adapter.in.web.security;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 게스트 participant Cookie를 읽어 {@link DemodayParticipationPrincipal}로 SecurityContext를 채운다.
+ * <p>
+ * {@code JwtAuthenticationFilter}와 대칭 구조다 — 검증 실패는 예외로 요청을 끊지 않고 조용히 통과시킨다
+ * (fail-open). "회원 Bearer 또는 게스트 Cookie 둘 중 하나면 통과"(이슈 #1258)를 만족하려면 두 필터 중
+ * 어느 쪽이 실패해도 다른 쪽이 인증을 채울 여지가 남아야 하기 때문이다. 최종 인가는 항상
+ * {@code SecurityConfig}의 {@code anyRequest().authenticated()}가 담당한다.
+ * <p>
+ * {@code @Component}가 아니라 {@code SecurityConfig}의 명시 {@code @Bean}으로 등록한다. {@code @WebMvcTest}
+ * 슬라이스 테스트는 {@code Filter} 구현체를 자동으로 끌어오는데, 이 클래스가 컴포넌트 스캔 대상이면
+ * 그 의존성({@link DemodayParticipantTokenProvider})까지 끌려 들어와 컨텍스트 로딩이 실패한다
+ * (같은 이유로 분리된 {@code MaintenanceFilter} 선례 참고).
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class DemodayParticipationCookieFilter extends OncePerRequestFilter {
+
+    private final DemodayParticipantTokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        /**
+         * 앞선 Bearer 인증 필터가 이미 이 요청의 Authentication을 할당해 뒀는지를 검증한다.
+         * 만약, null이 아닌 할당된 값이 넘어온다면 이미 인증된 member이므로 guest 인증을 스킵한다.
+         */
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            resolveCookieValue(request)
+                .flatMap(tokenProvider::parseEntryCodeId)
+                .ifPresent(this::authenticateAsGuest);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateAsGuest(Long entryCodeId) {
+        DemodayParticipationPrincipal principal = new DemodayParticipationPrincipal(entryCodeId);
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private Optional<String> resolveCookieValue(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+            .filter(cookie -> DemodayParticipantTokenProvider.COOKIE_NAME.equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findFirst();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationPrincipal.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationPrincipal.java
@@ -1,0 +1,42 @@
+package com.umc.product.demoday.adapter.in.web.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * 게스트(외부 방문자) 참여 인증 principal.
+ * <p>
+ * 회원 인증({@code MemberPrincipal})과는 별개의 경로다 — 기존 인증 코어를 수정하지 않고 게스트
+ * 인증을 완전히 독립된 Principal 타입으로 분리했다. 신원은 입장 코드 단위({@code entryCodeId})로만
+ * 식별되며, 이 값은 {@link DemodayParticipantTokenProvider}가 서명한 participant token의 subject다.
+ */
+public class DemodayParticipationPrincipal implements AuthenticatedPrincipal {
+
+    private final Long entryCodeId;
+
+    public DemodayParticipationPrincipal(Long entryCodeId) {
+        this.entryCodeId = Objects.requireNonNull(entryCodeId, "entryCodeId must not be null");
+    }
+
+    public Long getEntryCodeId() {
+        return entryCodeId;
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(entryCodeId);
+    }
+
+    @Override
+    public String toString() {
+        return "DemodayParticipationPrincipal{entryCodeId=" + entryCodeId + '}';
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/support/CurrentDemodayParticipantArgumentResolver.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/support/CurrentDemodayParticipantArgumentResolver.java
@@ -1,0 +1,65 @@
+package com.umc.product.demoday.adapter.in.web.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.umc.product.demoday.adapter.in.web.security.CurrentDemodayParticipant;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
+import com.umc.product.global.security.MemberPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SecurityContext의 principal 타입(MemberPrincipal / DemodayParticipationPrincipal)을 보고
+ * 알맞은 {@link DemodayParticipantResolver}로 위임한다. 두 principal은 서로 무관한 타입이다.
+ * 기존 회원 인증 코어(MemberPrincipal)를 게스트가 공유하도록 고치는 대신 완전히 별도 타입으로
+ * 분리했기 때문에, 컨트롤러 파라미터 슬롯 하나로 받으려면 이 디스패치가 필요하다.
+ * <p>
+ * {@code @Component}가 아니라 {@link DemodayParticipantResolverConfig}의 {@code @Bean}으로만
+ * 등록한다. 이 클래스는 {@code HandlerMethodArgumentResolver}를 구현하는데, 이 인터페이스는
+ * {@code @WebMvcTest} 슬라이스가 자동으로 스캔해 포함시키는 타입이라, {@code @Component}로 두면
+ * 무관한 슬라이스 테스트에서도 이 빈이 즉시 생성되면서 생성자 의존성(양쪽 {@link DemodayParticipantResolver}) 부재로 컨텍스트 로딩이 깨진다.
+ * {@code MaintenanceFilter}·{@code DemodayParticipationCookieFilter}와 같은 이유다.
+ */
+@RequiredArgsConstructor
+public class CurrentDemodayParticipantArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final DemodayParticipantResolver<MemberPrincipal> memberDemodayParticipantResolver;
+    private final DemodayParticipantResolver<DemodayParticipationPrincipal> guestDemodayParticipantResolver;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.hasParameterAnnotation(CurrentDemodayParticipant.class);
+        boolean hasParticipantType = DemodayParticipant.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasAnnotation && hasParticipantType;
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication == null ? null : authentication.getPrincipal();
+
+        if (principal instanceof MemberPrincipal memberPrincipal) {
+            return memberDemodayParticipantResolver.resolve(memberPrincipal);
+        }
+        if (principal instanceof DemodayParticipationPrincipal guestPrincipal) {
+            return guestDemodayParticipantResolver.resolve(guestPrincipal);
+        }
+
+        throw new AccessDeniedException("로그인 또는 게스트 참여 인증이 필요해요.");
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/support/DemodayParticipantResolverConfig.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/support/DemodayParticipantResolverConfig.java
@@ -1,0 +1,21 @@
+package com.umc.product.demoday.adapter.in.web.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
+import com.umc.product.global.security.MemberPrincipal;
+
+@Configuration
+public class DemodayParticipantResolverConfig {
+
+    @Bean
+    public CurrentDemodayParticipantArgumentResolver currentDemodayParticipantArgumentResolver(
+        DemodayParticipantResolver<MemberPrincipal> memberDemodayParticipantResolver,
+        DemodayParticipantResolver<DemodayParticipationPrincipal> guestDemodayParticipantResolver
+    ) {
+        return new CurrentDemodayParticipantArgumentResolver(
+            memberDemodayParticipantResolver, guestDemodayParticipantResolver);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/support/GuestDemodayParticipantResolver.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/support/GuestDemodayParticipantResolver.java
@@ -1,0 +1,17 @@
+package com.umc.product.demoday.adapter.in.web.support;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
+import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
+
+@Component
+public class GuestDemodayParticipantResolver implements DemodayParticipantResolver<DemodayParticipationPrincipal> {
+
+    @Override
+    public DemodayParticipant resolve(DemodayParticipationPrincipal principal) {
+        return new GuestDemodayParticipant(principal.getEntryCodeId());
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/StartDemodayGuestParticipationUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/StartDemodayGuestParticipationUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+
+public interface StartDemodayGuestParticipationUseCase {
+
+    StartDemodayGuestParticipationInfo start(StartDemodayGuestParticipationCommand command);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationCommand.java
@@ -1,0 +1,13 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+/**
+ * {@code existingEntryCodeId}는 요청에 이미 유효한 게스트 participant Cookie가 있을 때만 채워진다(nullable).
+ * 같은 브라우저의 재제출 멱등 처리(계약: "이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시
+ * 제출하면 성공으로 처리")에 쓰인다. 이 값이 지금 제출된 코드의 entryCodeId와 같으면 re-redeem 하지 않는다.
+ */
+public record StartDemodayGuestParticipationCommand(
+    Long pollId,
+    String admissionCode,
+    Long existingEntryCodeId
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationInfo.java
@@ -1,0 +1,12 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
+
+public record StartDemodayGuestParticipationInfo(
+    String participantToken,
+    Instant expiresAt,
+    DemodayParticipationInfo participation
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/participant/GuestDemodayParticipant.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/participant/GuestDemodayParticipant.java
@@ -1,0 +1,20 @@
+package com.umc.product.demoday.application.port.in.query.participant;
+
+import java.util.Objects;
+
+public record GuestDemodayParticipant(Long entryCodeId) implements DemodayParticipant {
+
+    public GuestDemodayParticipant {
+        Objects.requireNonNull(entryCodeId, "entryCodeId는 null일 수 없습니다.");
+    }
+
+    @Override
+    public Long participantId() {
+        return entryCodeId;
+    }
+
+    @Override
+    public DemodayParticipantType participantType() {
+        return DemodayParticipantType.GUEST;
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/IssueDemodayParticipantTokenPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/IssueDemodayParticipantTokenPort.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.out;
+
+import java.time.Instant;
+
+public interface IssueDemodayParticipantTokenPort {
+
+    String issue(Long entryCodeId, Instant expiresAt);
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandService.java
@@ -1,0 +1,71 @@
+package com.umc.product.demoday.application.service.command;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.GetDemodayParticipationUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.IssueDemodayParticipantTokenPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayEntryCodePort;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class StartDemodayGuestParticipationCommandService implements StartDemodayGuestParticipationUseCase {
+
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final LoadDemodayEntryCodePort loadDemodayEntryCodePort;
+    private final SaveDemodayEntryCodePort saveDemodayEntryCodePort;
+    private final HashDemodayEntryCodePort hashDemodayEntryCodePort;
+    private final IssueDemodayParticipantTokenPort issueDemodayParticipantTokenPort;
+    private final GetDemodayParticipationUseCase getDemodayParticipationUseCase;
+
+    @Override
+    public StartDemodayGuestParticipationInfo start(StartDemodayGuestParticipationCommand command) {
+        DemodayPoll poll = loadDemodayPollPort.findById(command.pollId())
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        String codeHash = hashDemodayEntryCodePort.hash(command.admissionCode());
+        DemodayEntryCode entryCode = loadDemodayEntryCodePort.findByCodeHash(codeHash)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_NOT_FOUND));
+
+        if (!Objects.equals(entryCode.getPollId(), poll.getId())) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_POLL_MISMATCH);
+        }
+
+        if (!isIsResubmissionByExistingHolder(command, entryCode)) {
+            entryCode.redeem(Instant.now());
+            saveDemodayEntryCodePort.save(entryCode);
+        }
+
+        String participantToken = issueDemodayParticipantTokenPort.issue(entryCode.getId(), poll.getClosesAt());
+
+        DemodayParticipationInfo participation = getDemodayParticipationUseCase.getParticipation(
+            poll.getId(), new GuestDemodayParticipant(entryCode.getId()));
+
+        return new StartDemodayGuestParticipationInfo(participantToken, poll.getClosesAt(), participation);
+    }
+
+    private static boolean isIsResubmissionByExistingHolder(
+        StartDemodayGuestParticipationCommand command, DemodayEntryCode entryCode) {
+
+        return command.existingEntryCodeId() != null
+            && command.existingEntryCodeId().equals(entryCode.getId());
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
@@ -3,6 +3,7 @@ package com.umc.product.demoday.application.service.query;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
@@ -16,13 +17,13 @@ import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipatio
 import com.umc.product.demoday.application.port.in.query.dto.DemodayPollInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
-import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayStampPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayVotePort;
 import com.umc.product.demoday.domain.DemodayBooth;
 import com.umc.product.demoday.domain.DemodayStamp;
+import com.umc.product.demoday.domain.DemodayVote;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;
 
@@ -58,23 +59,19 @@ public class DemodayPollQueryService implements
     public DemodayParticipationInfo getParticipation(Long pollId, DemodayParticipant participant) {
         validatePollExists(pollId);
 
-        if (participant.participantType() != DemodayParticipantType.MEMBER) {
-            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_PARTICIPATION_UNSUPPORTED);
-        }
-
         Set<Long> boothIds = loadDemodayBoothPort.listByPollId(pollId)
             .stream()
             .map(DemodayBooth::getId)
             .collect(toUnmodifiableSet());
 
-        List<DemodayStampInfo> stamps = loadDemodayStampPort.listMemberStamps(participant.participantId())
+        List<DemodayStampInfo> stamps = loadStamps(participant)
             .stream()
             .filter(stamp -> !stamp.isRevoked())
             .filter(stamp -> boothIds.contains(stamp.getBoothId()))
             .map(this::toStampInfo)
             .toList();
 
-        boolean hasVoted = loadDemodayVotePort.findMemberVote(pollId, participant.participantId())
+        boolean hasVoted = findVote(pollId, participant)
             .filter(vote -> !vote.isRevoked())
             .isPresent();
 
@@ -109,6 +106,24 @@ public class DemodayPollQueryService implements
     private void validatePollExists(Long pollId) {
         loadDemodayPollPort.findById(pollId)
                 .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+    }
+
+    /**
+     * 참여자 유형별 조회 포트가 다르다(회원=memberId, 게스트=entryCodeId). 참여 상태는 저장된 값이 아니라
+     * 스탬프·투표 기록에서 매 요청마다 파생되므로 유형이 늘어날 경우 분기만 추가하면 된다.
+     */
+    private List<DemodayStamp> loadStamps(DemodayParticipant participant) {
+        return switch (participant.participantType()) {
+            case MEMBER -> loadDemodayStampPort.listMemberStamps(participant.participantId());
+            case GUEST -> loadDemodayStampPort.listVisitorStamps(participant.participantId());
+        };
+    }
+
+    private Optional<DemodayVote> findVote(Long pollId, DemodayParticipant participant) {
+        return switch (participant.participantType()) {
+            case MEMBER -> loadDemodayVotePort.findMemberVote(pollId, participant.participantId());
+            case GUEST -> loadDemodayVotePort.findVisitorVote(participant.participantId());
+        };
     }
 
     private DemodayStampInfo toStampInfo(DemodayStamp stamp) {

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -30,6 +30,8 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_ENTRY_CODE_ALREADY_REDEEMED(HttpStatus.CONFLICT, "DEMODAY-0300", "이미 사용된 인증 코드예요."),
     DEMODAY_ENTRY_CODE_ALREADY_BOUND(HttpStatus.CONFLICT, "DEMODAY-0301", "이미 다른 계정에 연결된 인증 코드예요."),
     DEMODAY_ENTRY_CODE_GENERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "DEMODAY-0302","행사 진행 전 또는 진행 중에만 생성할 수 있습니다"),
+    DEMODAY_ENTRY_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEMODAY-0303", "존재하지 않는 입장 코드예요."),
+    DEMODAY_ENTRY_CODE_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0304", "이번 데모데이의 입장 코드가 아니에요."),
 
     DEMODAY_VOTE_NOT_OPENED_YET(HttpStatus.CONFLICT, "DEMODAY-0400", "아직 투표 시간이 아니에요."),
     DEMODAY_VOTE_CLOSED(HttpStatus.CONFLICT, "DEMODAY-0401", "투표가 종료되었어요."),
@@ -45,8 +47,7 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_STAMP_ALREADY_REVOKED(HttpStatus.CONFLICT, "DEMODAY-0502", "이미 무효 처리된 스탬프예요."),
     DEMODAY_STAMP_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0503", "이번 데모데이의 부스에만 스탬프를 받을 수 있어요."),
 
-    DEMODAY_ADMIN_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "DEMODAY-0600", "접근 권한이 없는 사용자입니다."),
-    DEMODAY_PARTICIPATION_UNSUPPORTED(HttpStatus.BAD_REQUEST, "DEMODAY-0601", "현재는 회원 참여 정보만 조회할 수 있습니다.")
+    DEMODAY_ADMIN_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "DEMODAY-0600", "접근 권한이 없는 사용자입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -28,6 +28,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantTokenProvider;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationCookieFilter;
 import com.umc.product.global.response.ApiErrorResponseWriter;
 import com.umc.product.global.security.ApiAccessDeniedHandler;
 import com.umc.product.global.security.ApiAuthenticationEntryPoint;
@@ -71,11 +73,27 @@ public class SecurityConfig {
     }
 
     /**
+     * 게스트(외부 방문자) participant Cookie 인증 필터. {@code @Component}가 아닌 명시 {@code @Bean}으로
+     * 두는 이유는 {@link #maintenanceFilter} javadoc과 동일하다. {@code @WebMvcTest} 슬라이스가 Filter를
+     * 자동으로 끌어와 그 의존성까지 컨텍스트에 요구하는 걸 막기 위함이다.
+     */
+    @Bean
+    public DemodayParticipationCookieFilter demodayParticipationCookieFilter(
+        DemodayParticipantTokenProvider tokenProvider
+    ) {
+        return new DemodayParticipationCookieFilter(tokenProvider);
+    }
+
+    /**
      * 메인 Security 체인. JWT → MaintenanceFilter → 인가 순서로 동작한다.
      */
     @Bean
     @Order(1)
-    public SecurityFilterChain filterChain(HttpSecurity http, MaintenanceFilter maintenanceFilter) throws Exception {
+    public SecurityFilterChain filterChain(
+        HttpSecurity http,
+        MaintenanceFilter maintenanceFilter,
+        DemodayParticipationCookieFilter demodayParticipationCookieFilter
+    ) throws Exception {
         List<PublicEndpointCollector.EndpointMatcher> publicEndpoints = PublicEndpointCollector
             .collectPublicEndpoints(requestMappingHandlerMapping);
 
@@ -120,8 +138,11 @@ public class SecurityConfig {
             })
             // Spring 기본 로그인 필터 동작 전에 JWT 동작
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            // JWT 로 SecurityContext 가 채워진 뒤 점검 필터에서 bypass 판정
-            .addFilterAfter(maintenanceFilter, JwtAuthenticationFilter.class)
+            // 회원 Bearer(JWT)가 채우지 못한 SecurityContext를 게스트 Cookie가 이어서 채운다.
+            // "회원 Bearer 또는 게스트 Cookie 둘 중 하나면 통과"를 위해 JWT 바로 다음에 둔다.
+            .addFilterAfter(demodayParticipationCookieFilter, JwtAuthenticationFilter.class)
+            // JWT/게스트 Cookie 로 SecurityContext 가 채워진 뒤 점검 필터에서 bypass 판정
+            .addFilterAfter(maintenanceFilter, DemodayParticipationCookieFilter.class)
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(authenticationEntryPoint) // 인증 실패 시
                 .accessDeniedHandler(accessDeniedHandler)           // 인가 실패 시

--- a/src/main/java/com/umc/product/global/config/WebMvcConfig.java
+++ b/src/main/java/com/umc/product/global/config/WebMvcConfig.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.umc.product.demoday.adapter.in.web.support.CurrentDemodayParticipantArgumentResolver;
 import com.umc.product.global.client.ClientContextConfig;
 import com.umc.product.global.logging.OperationalMetricsConfig;
 import com.umc.product.global.ratelimit.ApiRateLimitInterceptor;
@@ -28,12 +29,14 @@ import lombok.RequiredArgsConstructor;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final CurrentMemberArgumentResolver currentMemberArgumentResolver;
+    private final ObjectProvider<CurrentDemodayParticipantArgumentResolver> currentDemodayParticipantArgumentResolverProvider;
     private final LoggingInterceptor loggingInterceptor;
     private final ObjectProvider<ApiRateLimitInterceptor> apiRateLimitInterceptorProvider;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentMemberArgumentResolver);
+        currentDemodayParticipantArgumentResolverProvider.ifAvailable(resolvers::add);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -177,6 +177,11 @@ demoday:
     encryption-key: ${DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY}
   vote-qr:
     signing-key: ${DEMODAY_VOTE_QR_SIGNING_KEY}
+  participant-token:
+    secret: ${DEMODAY_PARTICIPANT_TOKEN_SECRET}
+  guest-rate-limit:
+    requests-per-second: ${DEMODAY_GUEST_RATE_LIMIT_PER_SECOND:5}
+    requests-per-minute: ${DEMODAY_GUEST_RATE_LIMIT_PER_MINUTE:150}
 
 # OpenAPI / Scalar 문서 설정
 springdoc:
@@ -424,6 +429,10 @@ app:
       - /webjars/**
       - /umc-logo.svg
       - /error
+      # 데모데이 게스트 입장 코드 제출: 전역 anonymous-default(분당 60회)가 해당 도메인 전용
+      # demoday.guest-rate-limit(분당 150회)보다 먼저 실행되어 해당 경로의 정책을 사실상 무력화하기 때문에 제외한다.
+      # 해당 경로는 전용 인터셉터(DemodayGuestRateLimitInterceptor)가 단독으로 관장한다.
+      - /api/v1/demoday/polls/*/participations/guest
     authenticated-default:
       requests-per-second: ${API_RATE_LIMIT_AUTH_REQUESTS_PER_SECOND:20}
       requests-per-minute: ${API_RATE_LIMIT_AUTH_REQUESTS_PER_MINUTE:300}

--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -277,7 +277,7 @@ paths:
     post:
       tags: [데모데이 - 참여자]
       operationId: startGuestParticipation
-      summary: 입장 코드 사용 및 외부 방문자 참여 시작
+      summary: 입장 코드 사용 및 외부 방문자 참여 시작(제작 완료)
       description: |
         외부 방문자가 현장에서 받은 입장 코드를 제출해 참여를 시작합니다.
 

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitInterceptorTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayGuestRateLimitInterceptorTest.java
@@ -1,0 +1,84 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.global.exception.constant.CommonErrorCode;
+import com.umc.product.global.ratelimit.ApiRateLimitMetrics;
+import com.umc.product.global.ratelimit.ApiRateLimitProperties;
+import com.umc.product.global.ratelimit.RateLimitBucketRegistry;
+import com.umc.product.global.ratelimit.RateLimitPolicy;
+import com.umc.product.global.response.ApiErrorResponseWriter;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class DemodayGuestRateLimitInterceptorTest {
+
+    @Test
+    @DisplayName("같은 IP가 분당 한도를 넘기면 429를 반환하고, 다른 IP는 영향받지 않는다")
+    void blockSameIpAfterLimitExceeded() throws Exception {
+        // 초당 한도는 넉넉하게 둬서 분당 한도만 단독으로 소진되게 만든다
+        // 실제 시각에 의존하지 않고 같은 초 안의 연속 호출만으로 결정적으로 재현하기 위함.
+        MockMvc mockMvc = mockMvcWithPolicy(new RateLimitPolicy("demoday-guest-participation", 10, 2));
+
+        mockMvc.perform(post("/guest").with(request -> {
+                request.setRemoteAddr("10.0.0.1");
+                return request;
+            }))
+            .andExpect(status().isOk())
+            .andExpect(header().string("X-RateLimit-Limit", "2"));
+
+        mockMvc.perform(post("/guest").with(request -> {
+                request.setRemoteAddr("10.0.0.1");
+                return request;
+            }))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/guest").with(request -> {
+                request.setRemoteAddr("10.0.0.1");
+                return request;
+            }))
+            .andExpect(status().isTooManyRequests())
+            .andExpect(header().exists("Retry-After"))
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.TOO_MANY_REQUESTS.getCode()));
+
+        mockMvc.perform(post("/guest").with(request -> {
+                request.setRemoteAddr("10.0.0.2");
+                return request;
+            }))
+            .andExpect(status().isOk());
+    }
+
+    private static MockMvc mockMvcWithPolicy(RateLimitPolicy policy) {
+        ApiRateLimitProperties properties = ApiRateLimitProperties.defaults();
+        DemodayGuestRateLimitInterceptor interceptor = new DemodayGuestRateLimitInterceptor(
+            new RateLimitBucketRegistry(properties),
+            new ApiErrorResponseWriter(new ObjectMapper()),
+            new ApiRateLimitMetrics(new SimpleMeterRegistry()),
+            policy
+        );
+        return MockMvcBuilders.standaloneSetup(new GuestController())
+            .addInterceptors(interceptor)
+            .build();
+    }
+
+    @Controller
+    @ResponseBody
+    private static class GuestController {
+
+        @PostMapping("/guest")
+        void submit() {
+        }
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
@@ -1,0 +1,130 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantCookieWriter;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantTokenProvider;
+import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+
+@WebMvcTest(controllers = DemodayParticipationCommandController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({JacksonConfig.class, DemodayParticipantCookieWriter.class})
+@DisplayName("DemodayParticipationCommandController")
+class DemodayParticipationCommandControllerTest {
+
+    private static final Long POLL_ID = 10L;
+    private static final Long ENTRY_CODE_ID = 42L;
+    // MockHttpServletResponse의 Set-Cookie 파서(MockCookie#parse)는 Max-Age를 int로 파싱한다.
+    // 실제 poll.closesAt은 항상 근시일이라 문제되지 않지만, 테스트 데이터는 그 한계를 넘지 않게 근접 미래로 둔다.
+    private static final Instant CLOSES_AT = Instant.now().plusSeconds(3600);
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean private StartDemodayGuestParticipationUseCase startDemodayGuestParticipationUseCase;
+
+    @MockitoBean private DemodayParticipantTokenProvider demodayParticipantTokenProvider;
+
+    @Test
+    @DisplayName("정상 코드를 제출하면 201과 함께 HttpOnly Cookie를 설정한다")
+    void startGuestParticipation() throws Exception {
+        // given
+        given(demodayParticipantTokenProvider.parseEntryCodeId(null)).willReturn(Optional.empty());
+
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 0, 6,
+            List.of(), null, false, false);
+
+        StartDemodayGuestParticipationInfo info =
+            new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
+
+        given(startDemodayGuestParticipationUseCase.start(
+            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", null)))
+            .willReturn(info);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"admissionCode\":\"GUEST-A1B2C3\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.result.pollId").value(POLL_ID))
+            .andExpect(jsonPath("$.result.participantType").value("GUEST"))
+            .andReturn();
+
+        // then
+        String setCookieHeader = result.getResponse().getHeader("Set-Cookie");
+        assertThat(setCookieHeader).isNotNull();
+        assertThat(setCookieHeader).contains("demoday_participant_token=issued-token");
+        assertThat(setCookieHeader).containsIgnoringCase("httponly");
+        assertThat(setCookieHeader).containsIgnoringCase("secure");
+        assertThat(setCookieHeader).containsIgnoringCase("samesite=lax");
+        assertThat(setCookieHeader).doesNotContainIgnoringCase("domain=");
+    }
+
+    @Test
+    @DisplayName("이미 유효한 Cookie가 있으면 파싱한 entryCodeId를 커맨드에 실어 보낸다")
+    void startGuestParticipationWithExistingCookie() throws Exception {
+        // given
+        given(demodayParticipantTokenProvider.parseEntryCodeId("existing-token"))
+            .willReturn(Optional.of(ENTRY_CODE_ID));
+
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 2, 6,
+            List.of(), null, false, false);
+
+        StartDemodayGuestParticipationInfo info =
+            new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
+
+        given(startDemodayGuestParticipationUseCase.start(
+            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", ENTRY_CODE_ID)))
+            .willReturn(info);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"admissionCode\":\"GUEST-A1B2C3\"}")
+                .cookie(new jakarta.servlet.http.Cookie(
+                    DemodayParticipantTokenProvider.COOKIE_NAME, "existing-token")))
+            .andExpect(status().isCreated());
+
+        then(startDemodayGuestParticipationUseCase).should().start(
+            eq(new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", ENTRY_CODE_ID)));
+    }
+
+    @Test
+    @DisplayName("입장 코드가 비어 있으면 400을 반환한다")
+    void startGuestParticipationWithBlankAdmissionCode() throws Exception {
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"admissionCode\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
+import com.umc.product.demoday.adapter.in.web.support.DemodayParticipantResolverConfig;
 import com.umc.product.demoday.application.port.in.query.GetDemodayParticipationUseCase;
 import com.umc.product.demoday.application.port.in.query.ListDemodayBoothUseCase;
 import com.umc.product.demoday.application.port.in.query.ListDemodayPollUseCase;
@@ -40,7 +42,7 @@ import com.umc.product.global.security.MemberPrincipal;
 
 @WebMvcTest(controllers = DemodayPollQueryController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(JacksonConfig.class)
+@Import({JacksonConfig.class, DemodayParticipantResolverConfig.class})
 @DisplayName("DemodayPollQueryController")
 class DemodayPollQueryControllerTest {
 
@@ -61,6 +63,9 @@ class DemodayPollQueryControllerTest {
 
     @MockitoBean
     private DemodayParticipantResolver<MemberPrincipal> participantResolver;
+
+    @MockitoBean
+    private DemodayParticipantResolver<DemodayParticipationPrincipal> guestDemodayParticipantResolver;
 
     private MemberPrincipal principal;
 

--- a/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
@@ -1,0 +1,233 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.GetDemodayParticipationUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
+import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.IssueDemodayParticipantTokenPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayEntryCodePort;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("게스트 참여 시작 커맨드 서비스")
+class StartDemodayGuestParticipationCommandServiceTest {
+
+    private static final Long POLL_ID = 1L;
+    private static final Long ENTRY_CODE_ID = 42L;
+    private static final Instant CLOSES_AT = Instant.parse("2100-08-15T12:00:00Z");
+    private static final String ADMISSION_CODE = "GUEST-A1B2C3";
+    private static final String CODE_HASH = "hashed-code";
+    private static final String PARTICIPANT_TOKEN = "participant-token";
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private LoadDemodayEntryCodePort loadDemodayEntryCodePort;
+
+    @Mock
+    private SaveDemodayEntryCodePort saveDemodayEntryCodePort;
+
+    @Mock
+    private HashDemodayEntryCodePort hashDemodayEntryCodePort;
+
+    @Mock
+    private IssueDemodayParticipantTokenPort issueDemodayParticipantTokenPort;
+
+    @Mock
+    private GetDemodayParticipationUseCase getDemodayParticipationUseCase;
+
+    @InjectMocks
+    private StartDemodayGuestParticipationCommandService startDemodayGuestParticipationCommandService;
+
+    @Test
+    @DisplayName("존재하지 않는 투표 행사면 거부한다")
+    void startWhenPollNotFound() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+
+        // when & then
+        assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        then(loadDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 입장 코드면 거부한다")
+    void startWhenEntryCodeNotFound() {
+        // given
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(mock(DemodayPoll.class)));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.empty());
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+
+        // when & then
+        assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_NOT_FOUND));
+
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 투표 행사의 입장 코드면 거부한다")
+    void startWhenEntryCodePollMismatch() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(999L);
+        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+
+        // when & then
+        assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_POLL_MISMATCH));
+
+        then(entryCode).should(never()).redeem(any());
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 브라우저가 이미 사용한 코드를 제출하면 거부한다")
+    void startWhenAlreadyRedeemedByDifferentBrowser() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED))
+            .given(entryCode).redeem(any());
+
+        // 다른 브라우저이므로 existingEntryCodeId가 없다(없거나 이 코드와 다른 값)
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+
+        // when & then
+        assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED));
+
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(issueDemodayParticipantTokenPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("정상 코드를 제출하면 사용 처리하고 토큰을 발급한다")
+    void startWhenNewRedemption() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(poll.getClosesAt()).willReturn(CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
+        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
+
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 0, 6, List.of(),
+            null, false, false);
+
+        given(getDemodayParticipationUseCase.getParticipation(
+            eq(POLL_ID), eq(new GuestDemodayParticipant(ENTRY_CODE_ID))))
+            .willReturn(participationInfo);
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+
+        // when
+        StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
+
+        // then
+        assertThat(result.participantToken()).isEqualTo(PARTICIPANT_TOKEN);
+        assertThat(result.expiresAt()).isEqualTo(CLOSES_AT);
+        assertThat(result.participation()).isEqualTo(participationInfo);
+        then(entryCode).should().redeem(any());
+        then(saveDemodayEntryCodePort).should().save(entryCode);
+    }
+
+    @Test
+    @DisplayName("이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시 제출하면 재사용 처리 없이 성공한다")
+    void startWhenResubmittedByExistingHolder() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(poll.getClosesAt()).willReturn(CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
+        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+
+        given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
+
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 2, 6, List.of(), null, false, false);
+        given(getDemodayParticipationUseCase.getParticipation(
+            eq(POLL_ID), eq(new GuestDemodayParticipant(ENTRY_CODE_ID))))
+            .willReturn(participationInfo);
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, ENTRY_CODE_ID);
+
+        // when
+        StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
+
+        // then
+        assertThat(result.participantToken()).isEqualTo(PARTICIPANT_TOKEN);
+        then(entryCode).should(never()).redeem(any());
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayPollQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayPollQueryServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
@@ -47,20 +50,26 @@ class DemodayPollQueryServiceTest {
     private DemodayPollQueryService demodayPollQueryService;
 
     @Test
-    @DisplayName("회원이 아닌 참여자는 참여 정보를 조회할 수 없다")
+    @DisplayName("게스트 참여자는 entryCodeId 기준으로 방문자 전용 포트를 조회한다")
     void getParticipationWithGuest() {
         // given
+        Long entryCodeId = 42L;
         given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(mock(DemodayPoll.class)));
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of());
         DemodayParticipant participant = mock(DemodayParticipant.class);
         given(participant.participantType()).willReturn(DemodayParticipantType.GUEST);
+        given(participant.participantId()).willReturn(entryCodeId);
+        given(loadDemodayStampPort.listVisitorStamps(entryCodeId)).willReturn(List.of());
+        given(loadDemodayVotePort.findVisitorVote(entryCodeId)).willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> demodayPollQueryService.getParticipation(POLL_ID, participant))
-                .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
-                        assertThat(exception.getBaseCode())
-                                .isEqualTo(DemodayErrorCode.DEMODAY_PARTICIPATION_UNSUPPORTED));
+        // when
+        DemodayParticipationInfo info = demodayPollQueryService.getParticipation(POLL_ID, participant);
 
-        verifyNoInteractions(loadDemodayBoothPort, loadDemodayStampPort, loadDemodayVotePort);
+        // then
+        assertThat(info.participantType()).isEqualTo(DemodayParticipantType.GUEST);
+        assertThat(info.hasVoted()).isFalse();
+        verify(loadDemodayStampPort).listVisitorStamps(entryCodeId);
+        verify(loadDemodayVotePort).findVisitorVote(entryCodeId);
     }
 
     @Test

--- a/src/test/java/com/umc/product/global/ratelimit/RateLimitPolicyResolverTest.java
+++ b/src/test/java/com/umc/product/global/ratelimit/RateLimitPolicyResolverTest.java
@@ -142,6 +142,30 @@ class RateLimitPolicyResolverTest {
     }
 
     @Test
+    @DisplayName("게스트 입장 코드 제출 경로는 전역 정책에서 제외되어 전용 인터셉터가 단독으로 관장한다")
+    void exclude_demoday_guest_participation_path() {
+        List<String> excludePaths = new java.util.ArrayList<>(ApiRateLimitProperties.defaultExcludedPaths());
+        excludePaths.add("/api/v1/demoday/polls/*/participations/guest");
+        ApiRateLimitProperties properties = new ApiRateLimitProperties(
+            true,
+            List.of("/api/**"),
+            excludePaths,
+            new ApiRateLimitProperties.Limit(20, 300),
+            new ApiRateLimitProperties.Limit(5, 60),
+            List.of(),
+            new ApiRateLimitProperties.Cache(100_000, Duration.ofMinutes(10))
+        );
+        RateLimitPolicyResolver resolver = new RateLimitPolicyResolver(properties);
+
+        assertThat(resolver.resolve(
+            "POST",
+            "/api/v1/demoday/polls/{pollId}/participations/guest",
+            "/api/v1/demoday/polls/42/participations/guest",
+            false
+        )).isEmpty();
+    }
+
+    @Test
     @DisplayName("비활성화 설정이면 /api/** 요청도 정책을 반환하지 않는다")
     void disabled_properties_returns_empty_policy() {
         ApiRateLimitProperties properties = new ApiRateLimitProperties(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,6 +41,11 @@ demoday:
     signing-key: test-dummy-vote-qr-signing-key-needs-32-bytes-min
   stamp-credential:
     encryption-key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+  participant-token:
+    secret: test-dummy-participant-token-secret-needs-32-bytes-min
+  guest-rate-limit:
+    requests-per-second: 5
+    requests-per-minute: 150
 
 management:
   tracing:


### PR DESCRIPTION
## 🚀 작업 내용

resolves #1258

### 1. 게스트 Cookie 인증 축 추가
- **무엇을**: 회원 Bearer JWT와 완전히 별개인 게스트 인증 경로를 추가했습니다. `DemodayParticipationCookieFilter`가 HttpOnly Cookie를 읽어 SecurityContext를 채우고, `CurrentDemodayParticipantArgumentResolver`가 컨트롤러 파라미터 하나(`@CurrentDemodayParticipant`)로 회원/게스트 어느 쪽이든 받게 했습니다.
- **어떻게**: 두 인증 필터(`JwtAuthenticationFilter`, `DemodayParticipationCookieFilter`)를 모두 fail-open으로 체인에 걸어, 먼저 성공한 쪽이 SecurityContext를 채우도록 했습니다. 인증 코어(`JwtAuthenticationFilter`, `MemberPrincipal`)는 수정하지 않았습니다.
- **왜**: 기존 회원 인증 체계를 건드리지 않고 게스트 인증을 얹어야 했고 컨트롤러 레이어가 "누가 요청했는지"만 알면 되지 인증 방식을 알 필요는 없다고 판단했습니다.
- **결과**: `DemodayParticipantTokenProvider`가 발급하는 JWT(subject=entryCodeId, 만료=poll.closesAt)가 Cookie로 왕복합니다. 회원용 `@WebMvcTest` 슬라이스가 깨지지 않도록 리졸버를 `@Bean`(비-`@Component`)으로 등록했고 기존+신규 테스트 전체 통과를 확인했습니다.

### 2. 참여 조회 API에 게스트 분기 추가
- **무엇을**: 기존 `GET .../participations/me`가 게스트 요청을 거부하던 것을 회원과 동일하게 조회 가능하도록 바꿨습니다.
- **어떻게**: `DemodayPollQueryService`가 `participantType()`으로 분기해 MEMBER는 기존 포트를 GUEST는 entryCodeId 기반 포트(`listVisitorStamps`/`findVisitorVote`)를 호출합니다.
- **왜**: 참여 진행 상태(스탬프 수·투표 여부)는 저장된 상태값이 아니라 항상 도메인 사실에서 파생시킨다는 이 도메인의 원칙을 게스트에도 동일하게 적용해야 했습니다.
- **결과**: `DEMODAY_PARTICIPATION_UNSUPPORTED` 에러코드와 그 분기를 제거했고 게스트 조회 성공 케이스를 서비스·컨트롤러 테스트에 추가했습니다.

### 3. 게스트 입장 코드 제출 및 참여 시작 API 추가
- **무엇을**: `POST /api/v1/demoday/polls/{pollId}/participations/guest`를 새로 만들었습니다. 입장 코드를 검증·소진하고 participant token을 HttpOnly Cookie로 응답합니다.
- **어떻게**: 제출된 코드를 해시해 code_hash로 조회 → poll 일치 검증 → 이미 같은 Cookie 보유자가 재제출한 경우(existingEntryCodeId 일치)는 재소진 없이 통과시키는 멱등 처리 → 신규면 redeem() → 토큰 발급 순서로 처리합니다.
- **왜**: 코드 하나는 한 번만 소진돼야 하지만, 네트워크 재시도나 새로고침으로 같은 브라우저가 같은 코드를 다시 보내는 경우까지 실패로 처리하면 안 됐습니다. 이 판단은 도메인 엔티티가 아니라 "누가 다시 묻는지" 아는 애플리케이션 서비스 레이어에서만 가능해 여기 뒀습니다.
- **결과**: 신규 발급·재제출 경로와 poll 불일치·이미 사용된 코드 등 실패 케이스 6가지를 서비스 테스트로 Set-Cookie 속성(HttpOnly/Secure/SameSite=Lax/host-only)을 컨트롤러 테스트로 직접 검증했습니다.

### 4. 게스트 제출 엔드포인트에 IP 레이트리밋 추가
- **무엇을**: 해당 엔드포인트에 IP 기준 레이트리밋(기본값 초당 5회·분당 150회)을 걸었습니다.
- **어떻게**: 게스트는 로그인 전이라 memberId처럼 신원에 붙는 키를 못 쓰므로 request.getRemoteAddr()만으로 Bucket4j 버킷을 키잉했습니다.
- **왜**: 입장 코드 조합 공간이 매우 넓어 브루트포스 자체는 threshold 값에 거의 영향을 안 받지만 행사장 와이파이·CGNAT로 여러 정상 방문자가 같은 IP로 몰리는 상황에서는 정상 방문자를 막는 오탐이 훨씬 더 큰 대가라고 판단해 방어를 넉넉하게 잡는 쪽을 택했습니다.
- **결과**: 실제 Bucket4j 버킷 소비까지 검증하는 인터셉터 테스트(같은 IP 한도 초과 시 429, 다른 IP는 영향 없음)를 추가했습니다.

### 5. 전역 익명 레이트리밋과의 충돌 수정
- **무엇을**: 4번에서 만든 전용 정책(분당 150회)이 실제로는 적용되지 않고 서버 전역 익명 기본값(분당 60회)이 먼저 걸려 설계 의도가 무력화되고 있던 걸 배포 전에 발견해 고쳤습니다.
- **어떻게**: 이 경로를 전역 레이트리밋 인터셉터의 exclude-paths에 추가해 전용 인터셉터 하나만 이 경로를 단독으로 관장하게 했습니다.
- **왜**: 두 인터셉터가 동시에 걸리는 구조 자체가 문제였습니다. 값을 맞추는 방법(전역 정책에 이 경로만 예외 규칙 추가)도 검토했지만 미검증 기능이었고 값 중복 문제가 남아 정책 결정권을 한 곳으로 좁혀 재발 가능성 자체를 없앴습니다.
- **결과**: 정책 해석기(RateLimitPolicyResolver) 단위 테스트로 이 경로가 전역 정책에서 실제로 제외되는지 검증했습니다.

## 💬 리뷰 중점사항

- `adapter/in/web/DemodayParticipationCommandController.java`, `DemodayPollQueryController.java` — API 스펙·요청/응답 DTO 확인 필요
- `application/service/command/StartDemodayGuestParticipationCommandService.java`, `application/service/query/DemodayPollQueryService.java` — 비즈니스 로직 / 트랜잭션 범위 확인 필요
- `global/config/SecurityConfig.java`, `global/config/WebMvcConfig.java`, `adapter/in/web/security/*` — 인증 필터 체인 순서 및 보안 설정 확인 필요
- `application.yml`의 `app.api-rate-limit.exclude-paths` 및 `demoday.guest-rate-limit` — 레이트리밋 정책 값 확인 필요
- `src/test/` 전반 — 신규 커맨드 서비스·컨트롤러·레이트리밋 인터셉터 테스트 커버리지 확인 필요