### PR TITLE
[Refactor] 게스트 입장 코드 형식 변경

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GenerateDemodayEntryCodesRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GenerateDemodayEntryCodesRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record GenerateDemodayEntryCodesRequest(
-    @NotNull @Min(1) @Max(64) Integer count
+    @NotNull @Min(1) @Max(100) Integer count
 ) {
     public CreateDemodayEntryCodeCommand toCommand(Long pollId) {
         return new CreateDemodayEntryCodeCommand(pollId, count);

--- a/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGenerator.java
@@ -11,15 +11,16 @@ public class SecureRandomDemodayEntryCodeGenerator implements GenerateDemodayEnt
 
     // O, I, L, 0, 1을 제거하여 입력 시 혼동을 줄이기 위함
     private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-    private static final int CODE_LENGTH = 16;
+    private static final String PREFIX = "GUEST-";
+    private static final int CODE_LENGTH = 6;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Override
     public String generate() {
-        StringBuilder code = new StringBuilder(CODE_LENGTH);
+        StringBuilder code = new StringBuilder(PREFIX.length() + CODE_LENGTH);
+        code.append(PREFIX);
 
-        // 80비트의 엔트로피를 가진 code 생성
         for (int i = 0; i < CODE_LENGTH; i++) {
             int index = secureRandom.nextInt(ALPHABET.length());
             code.append(ALPHABET.charAt(index));

--- a/src/test/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGeneratorTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/SecureRandomDemodayEntryCodeGeneratorTest.java
@@ -1,0 +1,22 @@
+package com.umc.product.demoday.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SecureRandomDemodayEntryCodeGeneratorTest {
+
+    private final SecureRandomDemodayEntryCodeGenerator generator = new SecureRandomDemodayEntryCodeGenerator();
+
+    @Test
+    @DisplayName("GUEST- 접두어와 혼동 문자를 제외한 6자리로 코드를 생성한다")
+    void generate() {
+        // when
+        String code = generator.generate();
+
+        // then
+        assertThat(code).startsWith("GUEST-");
+        assertThat(code).matches("GUEST-[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}");
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

resolves #1289

### 1. 입장 코드 형식을 FE 계약에 맞춤
- **무엇을**: `SecureRandomDemodayEntryCodeGenerator`가 생성하던 16자 무접두 코드(32자 알파벳, 80비트 엔트로피)를 `GUEST-` 접두어 + 6자리(같은 32자 알파벳)로 바꿨습니다.
- **어떻게**: `PREFIX`("GUEST-") 상수를 추가하고 `CODE_LENGTH`를 16에서 6으로 줄여, `generate()`가 접두어를 먼저 붙인 뒤 6자리 랜덤 문자를 이어붙이도록 했습니다. 혼동 문자(`O`,`I`,`L`,`0`,`1`)를 제외한 32자 알파벳은 그대로 유지했습니다.
- **왜**: 이미 FE와 합의해 배포한 API 계약 문서(`demoday-draft.yaml`)의 `admissionCode` 예시가 `GUEST-A1B2C3`(접두어+6자리)였는데 보안을 신경쓰다보니 발급 로직은 이 계약과 무관하게 구현돼 있었습니다. 이 코드는 방문자가 행사 현장에서 직접 타이핑해야 하는 값이라, 형식이 계약과 다르면 FE 입력 UI(길이 제한 등)와 실제 값이 어긋날 위험이 있었습니다.
- **결과**: 새 형식(`GUEST-` + 32자 알파벳 6자리)을 검증하는 단위 테스트를 추가했고, 기존 `CreateDemodayEntryCodeCommandServiceTest` 등 관련 테스트도 회귀 없이 통과합니다. `demoday-draft.yaml`은 애초에 올바른 예시를 담고 있어 문서 쪽 수정은 필요 없었습니다.

### 2. 코드 일괄 발급 개수 상한 조정
- **무엇을**: `GenerateDemodayEntryCodesRequest`의 `count` 상한을 64에서 100으로 올렸습니다.
- **왜**: 운영측과 소통 결과 하루에 100명 이상이 방문할 예정이라고 전달받았습니다. 따라서 기존 상한(64)이 부족할 수 있다 판단했습니다.
- **결과**: 관리자가 한 번의 API 호출로 최대 100개까지 코드를 발급할 수 있습니다.

## 💬 리뷰 중점사항

- `adapter/out/SecureRandomDemodayEntryCodeGenerator.java` — 발급 코드 형식(접두어·길이·문자셋)이 FE 계약(`demoday-draft.yaml`의 `GUEST-A1B2C3` 예시)과 일치하는지 확인 필요
- `adapter/in/web/dto/request/GenerateDemodayEntryCodesRequest.java` — `count` 상한 100 상향이 실제 행사 규모 추정과 맞는지 확인 필요
- `src/test/.../adapter/out/SecureRandomDemodayEntryCodeGeneratorTest.java` — 신규 형식 검증 테스트 커버리지 확인 필요