### PR TITLE
[Feat] 부스 QR을 통한 스탬프 적립 API 구현

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
@@ -10,11 +10,17 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.product.demoday.adapter.in.web.dto.request.GuestParticipationRequest;
+import com.umc.product.demoday.adapter.in.web.dto.request.StampCollectRequest;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayParticipationResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayStampCollectResponse;
+import com.umc.product.demoday.adapter.in.web.security.CurrentDemodayParticipant;
 import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantCookieWriter;
 import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantTokenProvider;
+import com.umc.product.demoday.application.port.in.command.CollectDemodayStampUseCase;
 import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
 import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
 import com.umc.product.global.security.annotation.Public;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class DemodayParticipationCommandController {
 
     private final StartDemodayGuestParticipationUseCase startDemodayGuestParticipationUseCase;
+    private final CollectDemodayStampUseCase collectDemodayStampUseCase;
     private final DemodayParticipantTokenProvider demodayParticipantTokenProvider;
     private final DemodayParticipantCookieWriter demodayParticipantCookieWriter;
 
@@ -64,5 +71,28 @@ public class DemodayParticipationCommandController {
         demodayParticipantCookieWriter.writeParticipantCookie(response, info.participantToken(), info.expiresAt());
 
         return DemodayParticipationResponse.from(info.participation());
+    }
+
+    @Operation(
+        operationId = "collectStamp",
+        summary = "부스 QR을 통한 스탬프 적립",
+        description = """
+            부스에 비치된 QR을 스캔해 스탬프를 적립합니다.
+
+            서로 다른 부스의 스탬프를 최대 6개까지 적립하며, 새로 적립된 스탬프 사이에는 서버 시각 기준
+            5분의 쿨다운이 있습니다. 같은 부스를 다시 스캔해도 새 스탬프를 만들지 않고 항상 현재 상태와
+            함께 성공(201)으로 응답합니다. 재스캔은 쿨다운을 새로 시작하지 않습니다.
+            """
+    )
+    @PostMapping("/{pollId}/stamps")
+    @ResponseStatus(HttpStatus.CREATED)
+    public DemodayStampCollectResponse collectStamp(
+        @Parameter(description = "투표 ID", example = "1") @PathVariable Long pollId,
+        @Valid @RequestBody StampCollectRequest request,
+        @Parameter(hidden = true) @CurrentDemodayParticipant DemodayParticipant participant
+    ) {
+        DemodayStampCollectInfo info = collectDemodayStampUseCase.collect(request.toCommand(pollId, participant));
+
+        return DemodayStampCollectResponse.from(info);
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/StampCollectRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/StampCollectRequest.java
@@ -1,0 +1,14 @@
+package com.umc.product.demoday.adapter.in.web.dto.request;
+
+import com.umc.product.demoday.application.port.in.command.dto.CollectDemodayStampCommand;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StampCollectRequest(
+    @NotBlank String qrCredential
+) {
+    public CollectDemodayStampCommand toCommand(Long pollId, DemodayParticipant participant) {
+        return new CollectDemodayStampCommand(pollId, qrCredential, participant);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayStampCollectResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayStampCollectResponse.java
@@ -1,0 +1,31 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DemodayStampCollectResponse(
+        @Schema(description = "적립된(또는 재스캔된) 스탬프")
+        DemodayStampResponse stamp,
+        @Schema(description = "적립한 스탬프 수", example = "4")
+        int stampCount,
+        @Schema(description = "투표 페이지 진입에 필요한 스탬프 수", example = "6")
+        int requiredStampCount,
+        @Schema(description = "다음 스탬프 적립 가능 시각. 여섯 번째 적립 후에는 null", nullable = true)
+        Instant nextStampAvailableAt,
+        @Schema(description = "투표 페이지 진입 가능 여부", example = "false")
+        boolean canEnterVotePage
+) {
+
+    public static DemodayStampCollectResponse from(DemodayStampCollectInfo info) {
+        return new DemodayStampCollectResponse(
+                DemodayStampResponse.from(info.stamp()),
+                info.stampCount(),
+                info.requiredStampCount(),
+                info.nextStampAvailableAt(),
+                info.canEnterVotePage()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothJpaRepository.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothJpaRepository.java
@@ -1,6 +1,7 @@
 package com.umc.product.demoday.adapter.out.persistence;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import com.umc.product.demoday.domain.DemodayBooth;
 public interface DemodayBoothJpaRepository extends JpaRepository<DemodayBooth, Long> {
 
     List<DemodayBooth> findAllByPollId(Long pollId, Sort sort);
+
+    Optional<DemodayBooth> findByStampCredentialHash(String stampCredentialHash);
 }

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothPersistenceAdapter.java
@@ -26,6 +26,11 @@ public class DemodayBoothPersistenceAdapter implements LoadDemodayBoothPort, Sav
     }
 
     @Override
+    public Optional<DemodayBooth> findByStampCredentialHash(String stampCredentialHash) {
+        return repository.findByStampCredentialHash(stampCredentialHash);
+    }
+
+    @Override
     public List<DemodayBooth> listByPollId(Long pollId) {
         return repository.findAllByPollId(pollId, BOOTH_ORDER);
     }

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampJpaRepository.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampJpaRepository.java
@@ -17,4 +17,12 @@ public interface DemodayStampJpaRepository extends JpaRepository<DemodayStamp, L
     List<DemodayStamp> findAllByMemberId(Long memberId, Sort sort);
 
     List<DemodayStamp> findAllByEntryCodeId(Long entryCodeId, Sort sort);
+
+    int countByMemberIdAndRevokedAtIsNull(Long memberId);
+
+    int countByEntryCodeIdAndRevokedAtIsNull(Long entryCodeId);
+
+    Optional<DemodayStamp> findFirstByMemberIdAndRevokedAtIsNullOrderByCreatedAtDesc(Long memberId);
+
+    Optional<DemodayStamp> findFirstByEntryCodeIdAndRevokedAtIsNullOrderByCreatedAtDesc(Long entryCodeId);
 }

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampPersistenceAdapter.java
@@ -56,6 +56,26 @@ public class DemodayStampPersistenceAdapter implements LoadDemodayStampPort, Sav
     }
 
     @Override
+    public int countActiveMemberStamps(Long memberId) {
+        return repository.countByMemberIdAndRevokedAtIsNull(memberId);
+    }
+
+    @Override
+    public int countActiveVisitorStamps(Long entryCodeId) {
+        return repository.countByEntryCodeIdAndRevokedAtIsNull(entryCodeId);
+    }
+
+    @Override
+    public Optional<DemodayStamp> findLatestActiveMemberStamp(Long memberId) {
+        return repository.findFirstByMemberIdAndRevokedAtIsNullOrderByCreatedAtDesc(memberId);
+    }
+
+    @Override
+    public Optional<DemodayStamp> findLatestActiveVisitorStamp(Long entryCodeId) {
+        return repository.findFirstByEntryCodeIdAndRevokedAtIsNullOrderByCreatedAtDesc(entryCodeId);
+    }
+
+    @Override
     public DemodayStamp save(DemodayStamp stamp) {
         try {
             return repository.saveAndFlush(stamp);

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/CollectDemodayStampUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/CollectDemodayStampUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.CollectDemodayStampCommand;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
+
+public interface CollectDemodayStampUseCase {
+
+    DemodayStampCollectInfo collect(CollectDemodayStampCommand command);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CollectDemodayStampCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/CollectDemodayStampCommand.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+
+public record CollectDemodayStampCommand(
+    Long pollId,
+    String qrCredential,
+    DemodayParticipant participant
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/DemodayStampCollectInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/DemodayStampCollectInfo.java
@@ -1,0 +1,14 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
+
+public record DemodayStampCollectInfo(
+    DemodayStampInfo stamp,
+    int stampCount,
+    int requiredStampCount,
+    Instant nextStampAvailableAt,
+    boolean canEnterVotePage
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayBoothPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayBoothPort.java
@@ -9,5 +9,7 @@ public interface LoadDemodayBoothPort {
 
     Optional<DemodayBooth> findById(Long boothId);
 
+    Optional<DemodayBooth> findByStampCredentialHash(String stampCredentialHash);
+
     List<DemodayBooth> listByPollId(Long pollId);
 }

--- a/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayStampPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayStampPort.java
@@ -16,4 +16,12 @@ public interface LoadDemodayStampPort {
     List<DemodayStamp> listMemberStamps(Long memberId);
 
     List<DemodayStamp> listVisitorStamps(Long entryCodeId);
+
+    int countActiveMemberStamps(Long memberId);
+
+    int countActiveVisitorStamps(Long entryCodeId);
+
+    Optional<DemodayStamp> findLatestActiveMemberStamp(Long memberId);
+
+    Optional<DemodayStamp> findLatestActiveVisitorStamp(Long entryCodeId);
 }

--- a/src/main/java/com/umc/product/demoday/application/service/command/CollectDemodayStampCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/CollectDemodayStampCommandService.java
@@ -1,0 +1,183 @@
+package com.umc.product.demoday.application.service.command;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.command.CollectDemodayStampUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CollectDemodayStampCommand;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayStampPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayStampPort;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.DemodayStamp;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * QR 스캔은 제출이 아니라 카메라를 갖다 대는 동작이라 같은 요청이 정상적으로 반복된다.
+ * 그래서 같은 부스 재스캔은 새 스탬프를 만들지 않고 항상 현재 상태를 {@code 201}로 돌려준다(멱등 보장).
+ * 재스캔 판정은 저장 전 사전 조회로 하지만, 사전 조회와 저장 사이의 경합까지는 막지 못하므로 DB unique 제약을 최종 방어선으로
+ * 함께 쓴다({@link DemodayStampPersistenceAdapter}가 이미 이 위반을 {@code DEMODAY_STAMP_ALREADY_COLLECTED}로 변환해준다).
+ * 재스캔 경로는 최대 개수·쿨다운 체크를 타지 않는다.
+ *
+ * <p>{@code DemodayPoll}의 {@code OPEN} 상태는 행사 전체(부스 스탬프 수집 포함)의 시작을 의미한다.
+ * {@code READY} 상태에서는 아직 참여자 활동이 시작되지 않았으므로, 부스가 등록돼 있고 credential이
+ * 유효하더라도 poll이 열리기 전에는 스탬프를 적립할 수 없다.
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CollectDemodayStampCommandService implements CollectDemodayStampUseCase {
+
+    private static final int REQUIRED_STAMP_COUNT = 6;
+    private static final Duration STAMP_COOLDOWN = Duration.ofMinutes(5);
+
+    private final LoadDemodayBoothPort loadDemodayBoothPort;
+    private final LoadDemodayEntryCodePort loadDemodayEntryCodePort;
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final LoadDemodayStampPort loadDemodayStampPort;
+    private final SaveDemodayStampPort saveDemodayStampPort;
+    private final HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
+    private final Clock clock;
+
+    @Override
+    public DemodayStampCollectInfo collect(CollectDemodayStampCommand command) {
+        DemodayParticipant participant = command.participant();
+        DemodayBooth booth = loadBoothByCredential(command.qrCredential());
+        validateSamePoll(command.pollId(), booth);
+        validatePollOpen(command.pollId());
+
+        Optional<DemodayStamp> existingStamp = findExistingStamp(participant, booth.getId());
+        if (existingStamp.isPresent()) {
+            log.info(
+                "demoday stamp rescanned participantType={} participantId={} boothId={}",
+                participant.participantType(), participant.participantId(), booth.getId()
+            );
+            return buildResult(participant, existingStamp.get());
+        }
+
+        DemodayStamp collected = collectNewStamp(participant, booth);
+        return buildResult(participant, collected);
+    }
+
+    private DemodayBooth loadBoothByCredential(String qrCredential) {
+        String credentialHash = hashDemodayStampCredentialPort.hash(qrCredential);
+        return loadDemodayBoothPort.findByStampCredentialHash(credentialHash)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_STAMP_CREDENTIAL_INVALID));
+    }
+
+    private void validateSamePoll(Long pollId, DemodayBooth booth) {
+        if (!booth.getPollId().equals(pollId)) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_STAMP_POLL_MISMATCH);
+        }
+    }
+
+    private void validatePollOpen(Long pollId) {
+        DemodayPoll poll = loadDemodayPollPort.findById(pollId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+        poll.validParticipationAvailable(clock.instant());
+    }
+
+    private DemodayStamp collectNewStamp(DemodayParticipant participant, DemodayBooth booth) {
+        validateNotMaxed(participant);
+        validateCooldownElapsed(participant);
+
+        DemodayStamp stamp = createStamp(participant, booth);
+
+        try {
+            return saveDemodayStampPort.save(stamp);
+        } catch (DemodayDomainException exception) {
+            if (exception.getBaseCode() != DemodayErrorCode.DEMODAY_STAMP_ALREADY_COLLECTED) {
+                throw exception;
+            }
+            log.info(
+                "demoday stamp collect lost the race, returning current state participantType={} participantId={} boothId={}",
+                participant.participantType(), participant.participantId(), booth.getId()
+            );
+
+            return findExistingStamp(participant, booth.getId()).orElseThrow(() -> exception);
+        }
+    }
+
+    private void validateNotMaxed(DemodayParticipant participant) {
+        if (countActiveStamps(participant) >= REQUIRED_STAMP_COUNT) {
+            throw new DemodayDomainException(DemodayErrorCode.DEMODAY_STAMP_MAX_COUNT_REACHED);
+        }
+    }
+
+    private void validateCooldownElapsed(DemodayParticipant participant) {
+        findLatestActiveStamp(participant).ifPresent(latestStamp -> {
+            Instant nextAvailableAt = latestStamp.getCreatedAt().plus(STAMP_COOLDOWN);
+            if (clock.instant().isBefore(nextAvailableAt)) {
+                throw new DemodayDomainException(DemodayErrorCode.DEMODAY_STAMP_COOLDOWN_ACTIVE);
+            }
+        });
+    }
+
+    private DemodayStamp createStamp(DemodayParticipant participant, DemodayBooth booth) {
+        return switch (participant.participantType()) {
+            case MEMBER -> DemodayStamp.forMember(participant.participantId(), booth);
+            case GUEST -> DemodayStamp.forVisitor(loadEntryCode(participant.participantId()), booth);
+        };
+    }
+
+    private DemodayEntryCode loadEntryCode(Long entryCodeId) {
+        return loadDemodayEntryCodePort.findById(entryCodeId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_NOT_FOUND));
+    }
+
+    private Optional<DemodayStamp> findExistingStamp(DemodayParticipant participant, Long boothId) {
+        return switch (participant.participantType()) {
+            case MEMBER -> loadDemodayStampPort.findMemberStamp(participant.participantId(), boothId);
+            case GUEST -> loadDemodayStampPort.findVisitorStamp(participant.participantId(), boothId);
+        };
+    }
+
+    private int countActiveStamps(DemodayParticipant participant) {
+        return switch (participant.participantType()) {
+            case MEMBER -> loadDemodayStampPort.countActiveMemberStamps(participant.participantId());
+            case GUEST -> loadDemodayStampPort.countActiveVisitorStamps(participant.participantId());
+        };
+    }
+
+    private Optional<DemodayStamp> findLatestActiveStamp(DemodayParticipant participant) {
+        return switch (participant.participantType()) {
+            case MEMBER -> loadDemodayStampPort.findLatestActiveMemberStamp(participant.participantId());
+            case GUEST -> loadDemodayStampPort.findLatestActiveVisitorStamp(participant.participantId());
+        };
+    }
+
+    private DemodayStampCollectInfo buildResult(DemodayParticipant participant, DemodayStamp stamp) {
+        int stampCount = countActiveStamps(participant);
+        boolean maxed = stampCount >= REQUIRED_STAMP_COUNT;
+        Instant nextStampAvailableAt = maxed
+            ? null
+            : findLatestActiveStamp(participant).map(
+                latest -> latest.getCreatedAt().plus(STAMP_COOLDOWN)).orElse(null);
+
+        return new DemodayStampCollectInfo(
+            new DemodayStampInfo(stamp.getBoothId(), stamp.getCreatedAt()),
+            stampCount,
+            REQUIRED_STAMP_COUNT,
+            nextStampAvailableAt,
+            maxed
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
@@ -85,7 +85,7 @@ public class DemodayPollQueryService implements
                 stamps,
                 null,
                 hasVoted,
-                stampCount >= REQUIRED_STAMP_COUNT && !hasVoted
+                stampCount >= REQUIRED_STAMP_COUNT
         );
     }
 

--- a/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/exception/DemodayErrorCode.java
@@ -46,6 +46,9 @@ public enum DemodayErrorCode implements BaseCode {
     DEMODAY_STAMP_ALREADY_COLLECTED(HttpStatus.CONFLICT, "DEMODAY-0501", "이미 스탬프를 받은 부스예요."),
     DEMODAY_STAMP_ALREADY_REVOKED(HttpStatus.CONFLICT, "DEMODAY-0502", "이미 무효 처리된 스탬프예요."),
     DEMODAY_STAMP_POLL_MISMATCH(HttpStatus.CONFLICT, "DEMODAY-0503", "이번 데모데이의 부스에만 스탬프를 받을 수 있어요."),
+    DEMODAY_STAMP_CREDENTIAL_INVALID(HttpStatus.CONFLICT, "DEMODAY-0504", "유효하지 않은 스탬프 QR이에요."),
+    DEMODAY_STAMP_COOLDOWN_ACTIVE(HttpStatus.CONFLICT, "DEMODAY-0505", "아직 다음 스탬프를 적립할 수 없어요."),
+    DEMODAY_STAMP_MAX_COUNT_REACHED(HttpStatus.CONFLICT, "DEMODAY-0506", "이미 모든 부스의 스탬프를 받았어요."),
 
     DEMODAY_ADMIN_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "DEMODAY-0600", "접근 권한이 없는 사용자입니다.")
     ;

--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -397,7 +397,7 @@ paths:
     post:
       tags: [데모데이 - 참여자]
       operationId: collectStamp
-      summary: 부스 QR을 통한 스탬프 적립
+      summary: 부스 QR을 통한 스탬프 적립(제작 완료)
       description: |
         부스에 비치된 QR을 스캔해 스탬프를 적립합니다.
         외부 방문자는 `Authorization` 대신 HttpOnly Cookie가 자동 첨부됩니다.
@@ -453,9 +453,12 @@ paths:
             | 상황 | `code` |
             |---|---|
             | QR과 요청 Poll 불일치 | `DEMODAY-0503` |
-            | 5분 쿨다운 미경과 | 서버 구현 시 확정 |
-            | 스탬프 최대 6개 초과 | 서버 구현 시 확정 |
-            | 유효하지 않거나 만료된 QR credential | 서버 구현 시 확정 |
+            | 유효하지 않은 QR credential | `DEMODAY-0504` |
+            | 5분 쿨다운 미경과 | `DEMODAY-0505` |
+            | 스탬프 최대 6개 초과 | `DEMODAY-0506` |
+
+            credential은 재발급되면 이전 값이 그대로 대체되어 사라지므로, 시간 만료가 아니라
+            "그런 credential이 없음"으로 판정합니다.
 
             **쿨다운 오류의 `result`에는 `nextStampAvailableAt`이 담깁니다.**
             FE가 서버 시각을 다시 계산하지 않도록 하기 위한 규칙입니다.
@@ -467,7 +470,7 @@ paths:
                 쿨다운 미경과:
                   value:
                     success: false
-                    code: DEMODAY-XXXX
+                    code: DEMODAY-0505
                     message: 아직 다음 스탬프를 적립할 수 없습니다.
                     result:
                       nextStampAvailableAt: '2026-08-14T10:25:00+09:00'

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
@@ -12,6 +12,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,28 +21,42 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantCookieWriter;
 import com.umc.product.demoday.adapter.in.web.security.DemodayParticipantTokenProvider;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
+import com.umc.product.demoday.adapter.in.web.support.DemodayParticipantResolverConfig;
+import com.umc.product.demoday.application.port.in.command.CollectDemodayStampUseCase;
 import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.CollectDemodayStampCommand;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
 import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
 import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
+import com.umc.product.demoday.application.port.in.query.participant.MemberDemodayParticipant;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
 
 @WebMvcTest(controllers = DemodayParticipationCommandController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import({JacksonConfig.class, DemodayParticipantCookieWriter.class})
+@Import({JacksonConfig.class, DemodayParticipantCookieWriter.class, DemodayParticipantResolverConfig.class})
 @DisplayName("DemodayParticipationCommandController")
 class DemodayParticipationCommandControllerTest {
 
     private static final Long POLL_ID = 10L;
     private static final Long ENTRY_CODE_ID = 42L;
+    private static final Long MEMBER_ID = 1L;
+    private static final Long BOOTH_ID = 20L;
     // MockHttpServletResponse의 Set-Cookie 파서(MockCookie#parse)는 Max-Age를 int로 파싱한다.
     // 실제 poll.closesAt은 항상 근시일이라 문제되지 않지만, 테스트 데이터는 그 한계를 넘지 않게 근접 미래로 둔다.
     private static final Instant CLOSES_AT = Instant.now().plusSeconds(3600);
@@ -51,7 +67,27 @@ class DemodayParticipationCommandControllerTest {
 
     @MockitoBean private StartDemodayGuestParticipationUseCase startDemodayGuestParticipationUseCase;
 
+    @MockitoBean private CollectDemodayStampUseCase collectDemodayStampUseCase;
+
     @MockitoBean private DemodayParticipantTokenProvider demodayParticipantTokenProvider;
+
+    @MockitoBean private DemodayParticipantResolver<MemberPrincipal> memberDemodayParticipantResolver;
+
+    @MockitoBean private DemodayParticipantResolver<DemodayParticipationPrincipal> guestDemodayParticipantResolver;
+
+    private MemberPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
 
     @Test
     @DisplayName("정상 코드를 제출하면 201과 함께 HttpOnly Cookie를 설정한다")
@@ -125,6 +161,43 @@ class DemodayParticipationCommandControllerTest {
         mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"admissionCode\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원이 부스 QR을 스캔하면 201과 함께 적립 결과를 반환한다")
+    void collectStamp() throws Exception {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        given(memberDemodayParticipantResolver.resolve(principal)).willReturn(participant);
+
+        DemodayStampCollectInfo info = new DemodayStampCollectInfo(
+            new DemodayStampInfo(BOOTH_ID, Instant.parse("2026-08-19T10:00:00Z")),
+            1, 6, null, false);
+        given(collectDemodayStampUseCase.collect(
+            new CollectDemodayStampCommand(POLL_ID, "sq_opaque_credential", participant)))
+            .willReturn(info);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/stamps", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"qrCredential\":\"sq_opaque_credential\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.result.stamp.boothId").value(BOOTH_ID))
+            .andExpect(jsonPath("$.result.stampCount").value(1))
+            .andExpect(jsonPath("$.result.requiredStampCount").value(6))
+            .andExpect(jsonPath("$.result.canEnterVotePage").value(false));
+
+        then(collectDemodayStampUseCase).should().collect(
+            eq(new CollectDemodayStampCommand(POLL_ID, "sq_opaque_credential", participant)));
+    }
+
+    @Test
+    @DisplayName("qrCredential이 비어 있으면 400을 반환한다")
+    void collectStampWithBlankCredential() throws Exception {
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/stamps", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"qrCredential\":\"\"}"))
             .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayBoothPersistenceAdapterTest.java
@@ -95,6 +95,25 @@ class DemodayBoothPersistenceAdapterTest {
             .containsExactly(booths.get(0).getId(), booths.get(1).getId());
     }
 
+    @Test
+    @DisplayName("스탬프 credential 해시로 부스를 조회한다")
+    void findBoothByStampCredentialHash() {
+        // Given
+        DemodayPoll poll = savePoll();
+        DemodayBooth booth = DemodayBooth.forProject(poll.getId(), 1L);
+        booth.applyStampCredential("credential-hash", "encrypted-credential", Instant.parse("2026-08-19T00:00:00Z"));
+        DemodayBooth saved = saveDemodayBoothPort.save(booth);
+        clearPersistenceContext();
+
+        // When & Then
+        assertThat(loadDemodayBoothPort.findByStampCredentialHash("credential-hash"))
+            .get()
+            .extracting(DemodayBooth::getId)
+            .isEqualTo(saved.getId());
+        assertThat(loadDemodayBoothPort.findByStampCredentialHash("no-such-hash"))
+            .isEmpty();
+    }
+
     private DemodayPoll savePoll() {
         return saveDemodayPollPort.save(DemodayPoll.create(9L, "9기 데모데이", OPENS_AT, CLOSES_AT));
     }

--- a/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayStampPersistenceAdapterTest.java
@@ -152,6 +152,30 @@ class DemodayStampPersistenceAdapterTest {
     }
 
     @Test
+    @DisplayName("무효화된 스탬프는 활성 스탬프 개수와 최근 활성 스탬프 조회에서 제외된다")
+    void excludeRevokedStampFromActiveCountAndLatest() {
+        // Given
+        DemodayPoll poll = savePoll("무효화 스탬프 제외");
+        List<DemodayBooth> booths = saveDemodayBoothPort.saveAll(List.of(
+            DemodayBooth.forProject(poll.getId(), 1L),
+            DemodayBooth.forProject(poll.getId(), 2L)
+        ));
+        DemodayStamp activeStamp = saveDemodayStampPort.save(DemodayStamp.forMember(MEMBER_ID, booths.get(0)));
+        DemodayStamp revokedStamp = saveDemodayStampPort.save(DemodayStamp.forMember(MEMBER_ID, booths.get(1)));
+        revokedStamp.revoke(Instant.parse("2026-08-19T10:00:00Z"));
+        saveDemodayStampPort.save(revokedStamp);
+
+        entityManager.clear();
+
+        // When & Then
+        assertThat(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).isEqualTo(1);
+        assertThat(loadDemodayStampPort.findLatestActiveMemberStamp(MEMBER_ID))
+            .get()
+            .extracting(DemodayStamp::getId)
+            .isEqualTo(activeStamp.getId());
+    }
+
+    @Test
     @DisplayName("영속화 후 다시 조회한 입장 코드와 부스의 투표가 다르면 스탬프를 생성할 수 없다")
     void rejectVisitorStampForBoothFromDifferentPollAfterReload() {
         // Given

--- a/src/test/java/com/umc/product/demoday/application/service/command/CollectDemodayStampCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/CollectDemodayStampCommandServiceTest.java
@@ -1,0 +1,319 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.umc.product.demoday.application.port.in.command.dto.CollectDemodayStampCommand;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayStampCollectInfo;
+import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
+import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
+import com.umc.product.demoday.application.port.in.query.participant.MemberDemodayParticipant;
+import com.umc.product.demoday.application.port.out.HashDemodayStampCredentialPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayStampPort;
+import com.umc.product.demoday.application.port.out.SaveDemodayStampPort;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.DemodayStamp;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class CollectDemodayStampCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long ENTRY_CODE_ID = 2L;
+    private static final Long POLL_ID = 10L;
+    private static final Long BOOTH_ID = 20L;
+    private static final String QR_CREDENTIAL = "sq_opaque_credential";
+    private static final String CREDENTIAL_HASH = "credential-hash";
+    private static final Instant NOW = Instant.parse("2026-08-19T10:00:00Z");
+
+    @Mock
+    private LoadDemodayBoothPort loadDemodayBoothPort;
+
+    @Mock
+    private LoadDemodayEntryCodePort loadDemodayEntryCodePort;
+
+    @Mock
+    private LoadDemodayPollPort loadDemodayPollPort;
+
+    @Mock
+    private LoadDemodayStampPort loadDemodayStampPort;
+
+    @Mock
+    private SaveDemodayStampPort saveDemodayStampPort;
+
+    @Mock
+    private HashDemodayStampCredentialPort hashDemodayStampCredentialPort;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private CollectDemodayStampCommandService collectDemodayStampCommandService;
+
+    @Test
+    @DisplayName("처음 스캔한 부스는 새 스탬프를 적립한다")
+    void collectNewStamp() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findMemberStamp(MEMBER_ID, BOOTH_ID)).willReturn(Optional.empty());
+        given(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).willReturn(0, 1);
+        given(loadDemodayStampPort.findLatestActiveMemberStamp(MEMBER_ID)).willReturn(Optional.empty());
+        given(clock.instant()).willReturn(NOW);
+        given(saveDemodayStampPort.save(any(DemodayStamp.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        DemodayStampCollectInfo result = collectDemodayStampCommandService.collect(command);
+
+        // then
+        assertThat(result.stamp().boothId()).isEqualTo(BOOTH_ID);
+        assertThat(result.stampCount()).isEqualTo(1);
+        assertThat(result.requiredStampCount()).isEqualTo(6);
+        assertThat(result.nextStampAvailableAt()).isNull();
+        assertThat(result.canEnterVotePage()).isFalse();
+
+        then(saveDemodayStampPort).should().save(any(DemodayStamp.class));
+    }
+
+    @Test
+    @DisplayName("같은 부스를 재스캔하면 새 스탬프를 만들지 않고 현재 상태를 그대로 응답한다")
+    void rescanReturnsCurrentStateWithoutCreatingNewStamp() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        DemodayStamp existingStamp = stampWithCreatedAt(DemodayStamp.forMember(MEMBER_ID, booth), NOW.minusSeconds(600));
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findMemberStamp(MEMBER_ID, BOOTH_ID)).willReturn(Optional.of(existingStamp));
+        given(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).willReturn(3);
+        given(loadDemodayStampPort.findLatestActiveMemberStamp(MEMBER_ID)).willReturn(Optional.of(existingStamp));
+        given(clock.instant()).willReturn(NOW);
+
+        // when
+        DemodayStampCollectInfo result = collectDemodayStampCommandService.collect(command);
+
+        // then
+        assertThat(result.stampCount()).isEqualTo(3);
+        then(saveDemodayStampPort).should(never()).save(any(DemodayStamp.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 QR credential은 실패한다")
+    void throwExceptionWhenCredentialInvalid() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> collectDemodayStampCommandService.collect(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_STAMP_CREDENTIAL_INVALID));
+
+        then(loadDemodayPollPort).shouldHaveNoInteractions();
+        then(saveDemodayStampPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 투표 행사의 부스 QR이면 실패한다")
+    void throwExceptionWhenPollMismatch() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(99L);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+
+        // when & then
+        assertThatThrownBy(() -> collectDemodayStampCommandService.collect(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_STAMP_POLL_MISMATCH));
+
+        then(loadDemodayPollPort).shouldHaveNoInteractions();
+        then(loadDemodayStampPort).shouldHaveNoInteractions();
+        then(saveDemodayStampPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("아직 열리지 않은 데모데이의 부스 QR이면 실패한다")
+    void throwExceptionWhenPollNotOpenYet() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        DemodayPoll readyPoll = DemodayPoll.create(9L, "테스트 데모데이", NOW.minusSeconds(3600), NOW.plusSeconds(3600));
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(readyPoll));
+        given(clock.instant()).willReturn(NOW);
+
+        // when & then
+        assertThatThrownBy(() -> collectDemodayStampCommandService.collect(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        then(loadDemodayStampPort).shouldHaveNoInteractions();
+        then(saveDemodayStampPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("이미 6개를 적립했으면 새 스탬프 적립이 거절된다")
+    void throwExceptionWhenMaxCountReached() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findMemberStamp(MEMBER_ID, BOOTH_ID)).willReturn(Optional.empty());
+        given(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).willReturn(6);
+        given(clock.instant()).willReturn(NOW);
+
+        // when & then
+        assertThatThrownBy(() -> collectDemodayStampCommandService.collect(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_STAMP_MAX_COUNT_REACHED));
+
+        then(saveDemodayStampPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("직전 스탬프 이후 5분이 지나지 않았으면 다음 스탬프 적립이 거절된다")
+    void throwExceptionWhenCooldownNotElapsed() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        DemodayBooth previousBooth = boothOf(POLL_ID);
+        DemodayStamp latestStamp = stampWithCreatedAt(
+            DemodayStamp.forMember(MEMBER_ID, previousBooth), NOW.minusSeconds(60));
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findMemberStamp(MEMBER_ID, BOOTH_ID)).willReturn(Optional.empty());
+        given(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).willReturn(1);
+        given(loadDemodayStampPort.findLatestActiveMemberStamp(MEMBER_ID)).willReturn(Optional.of(latestStamp));
+        given(clock.instant()).willReturn(NOW);
+
+        // when & then
+        assertThatThrownBy(() -> collectDemodayStampCommandService.collect(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode()).isEqualTo(DemodayErrorCode.DEMODAY_STAMP_COOLDOWN_ACTIVE));
+
+        then(saveDemodayStampPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("경합으로 저장이 중복 제약에 걸리면 예외 대신 현재 상태를 반환한다")
+    void fallsBackToCurrentStateWhenSaveLosesRace() {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        DemodayStamp winnerStamp = stampWithCreatedAt(DemodayStamp.forMember(MEMBER_ID, booth), NOW);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findMemberStamp(MEMBER_ID, BOOTH_ID)).willReturn(Optional.empty(), Optional.of(winnerStamp));
+        given(loadDemodayStampPort.countActiveMemberStamps(MEMBER_ID)).willReturn(0, 1);
+        given(loadDemodayStampPort.findLatestActiveMemberStamp(MEMBER_ID)).willReturn(Optional.empty());
+        given(clock.instant()).willReturn(NOW);
+        given(saveDemodayStampPort.save(any(DemodayStamp.class)))
+            .willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_STAMP_ALREADY_COLLECTED));
+
+        // when
+        DemodayStampCollectInfo result = collectDemodayStampCommandService.collect(command);
+
+        // then
+        assertThat(result.stamp().boothId()).isEqualTo(BOOTH_ID);
+        assertThat(result.stampCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("외부 방문자는 입장 코드 엔티티를 로드해 스탬프를 적립한다")
+    void collectStampForGuestParticipant() {
+        // given
+        DemodayParticipant participant = new GuestDemodayParticipant(ENTRY_CODE_ID);
+        DemodayBooth booth = boothOf(POLL_ID);
+        DemodayEntryCode entryCode = entryCodeOf(POLL_ID);
+        CollectDemodayStampCommand command = new CollectDemodayStampCommand(POLL_ID, QR_CREDENTIAL, participant);
+
+        given(hashDemodayStampCredentialPort.hash(QR_CREDENTIAL)).willReturn(CREDENTIAL_HASH);
+        given(loadDemodayBoothPort.findByStampCredentialHash(CREDENTIAL_HASH)).willReturn(Optional.of(booth));
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(openPoll()));
+        given(loadDemodayStampPort.findVisitorStamp(ENTRY_CODE_ID, BOOTH_ID)).willReturn(Optional.empty());
+        given(loadDemodayStampPort.countActiveVisitorStamps(ENTRY_CODE_ID)).willReturn(0, 1);
+        given(loadDemodayStampPort.findLatestActiveVisitorStamp(ENTRY_CODE_ID)).willReturn(Optional.empty());
+        given(loadDemodayEntryCodePort.findById(ENTRY_CODE_ID)).willReturn(Optional.of(entryCode));
+        given(clock.instant()).willReturn(NOW);
+        given(saveDemodayStampPort.save(any(DemodayStamp.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        DemodayStampCollectInfo result = collectDemodayStampCommandService.collect(command);
+
+        // then
+        assertThat(result.stamp().boothId()).isEqualTo(BOOTH_ID);
+        then(loadDemodayEntryCodePort).should().findById(ENTRY_CODE_ID);
+    }
+
+    private static DemodayPoll openPoll() {
+        DemodayPoll poll = DemodayPoll.create(9L, "테스트 데모데이", NOW.minusSeconds(3600), NOW.plusSeconds(3600));
+        poll.open();
+        return poll;
+    }
+
+    private static DemodayBooth boothOf(Long pollId) {
+        DemodayBooth booth = DemodayBooth.forExternal(pollId, "테스트 부스");
+        ReflectionTestUtils.setField(booth, "id", BOOTH_ID);
+        return booth;
+    }
+
+    private static DemodayEntryCode entryCodeOf(Long pollId) {
+        DemodayEntryCode entryCode = DemodayEntryCode.create(pollId, "code-hash");
+        ReflectionTestUtils.setField(entryCode, "id", ENTRY_CODE_ID);
+        return entryCode;
+    }
+
+    private static DemodayStamp stampWithCreatedAt(DemodayStamp stamp, Instant createdAt) {
+        ReflectionTestUtils.setField(stamp, "createdAt", createdAt);
+        return stamp;
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

**무엇을**

- 부스에 비치된 QR을 스캔해 스탬프를 적립하는 API(`POST /api/v1/demoday/polls/{pollId}/stamps`)를 추가했다.
- 같은 부스를 재스캔해도 새 스탬프를 만들지 않고 현재 상태를 그대로 반환하는 멱등성을 보장했다.
- poll이 OPEN 상태일 때만 스탬프 적립이 가능하도록 검증을 추가했다.
- `canEnterVotePage` 계산에서 `hasVoted` 조건을 제거해, 이미 투표를 마친 참여자도 부스 목록 등 참여 페이지 접근은 계속 허용하도록 정정했다.

**어떻게**

- `LoadDemodayBoothPort`에 credential hash로 부스를 조회하는 `findByStampCredentialHash`를 추가했다.
- `LoadDemodayStampPort`에 활성 스탬프 개수 조회, 최근 활성 스탬프 조회 포트 메서드 4개(회원/방문자 각 2개)를 추가했다.
- `CollectDemodayStampCommandService`에서 credential 검증, poll OPEN 검증, 최대 개수(6개) 검증, 5분 쿨다운 검증을 순서대로 거친 뒤 스탬프를 생성한다.
- 저장 전 사전 조회로 재스캔을 감지하되, 사전 조회와 저장 사이의 경합은 DB unique 제약(`uk_demoday_stamp_member_booth`, `uk_demoday_stamp_entry_code_booth`)을 최종 방어선으로 둔다. 저장 시점에 제약 위반이 발생하면 예외를 그대로 던지지 않고 현재 상태를 재조회해 반환한다.
- 무효화된 스탬프는 최대 개수·쿨다운 판정에서 제외한다.
- 새 에러 코드 3개(`DEMODAY-0504` credential 무효, `DEMODAY-0505` 쿨다운 진행 중, `DEMODAY-0506` 최대 개수 도달)를 추가하고, OpenAPI 초안 문서를 구현에 맞게 갱신했다.

**왜**

- QR 스캔은 제출이 아니라 카메라를 갖다 대는 동작이라 같은 요청이 정상적으로 반복된다. 재스캔마다 새 스탬프가 쌓이면 안 되므로 멱등성이 핵심 요구였다.
- poll의 OPEN 전이는 행사 전체(부스 스탬프 수집 포함)의 시작을 의미한다. 부스가 등록돼 있고 credential이 유효해도, poll이 열리기 전에는 참여자 활동이 아직 시작되지 않은 상태이므로 스탬프를 적립할 수 없어야 한다.
- 이미 투표를 마친 참여자도 부스 목록 확인 같은 페이지 접근은 계속 가능해야 한다. 막아야 할 것은 투표 자체이지 페이지 진입이 아니다.

**결과**

- `com.umc.product.demoday.*` 패키지 전체 테스트가 통과한다.
- 이 엔드포인트에는 rate-limit을 도입하지 않기로 했다. credential이 SecureRandom 44바이트(352비트) 기반 opaque 토큰이라 무차별 대입이 방어가 필요한 수준의 위협이 아니기 때문이다.
- repository 메서드 네이밍은 기존 Spring Data JPA derived query 컨벤션을 그대로 유지했다. 레포 안에 이미 `findFirstBy...OrderBy...Desc` 패턴을 쓰는 선례(`ChallengerJpaRepository` 등)가 있어 일관성을 맞췄다.

관련 이슈: resolves #1259

## 💬 리뷰 중점사항

- `CollectDemodayStampCommandService`의 검증 순서(credential → poll OPEN → 최대 개수 → 쿨다운)와, 저장 시점 제약 위반을 잡아 현재 상태로 폴백하는 경합 처리 로직을 중점적으로 봐주시면 좋겠다.
- `StampCollectRequest`, `DemodayStampCollectResponse`, `DemodayParticipationCommandController`의 신규 엔드포인트 요청/응답 스펙 확인 필요.
- `DemodayBoothJpaRepository`, `DemodayStampJpaRepository`, 각 PersistenceAdapter의 신규 조회 쿼리 확인 필요.
- `DemodayPollQueryService`의 `canEnterVotePage` 정책 변경(`hasVoted` 조건 제거) 확인 필요.
- 신규/변경 테스트 4건(`CollectDemodayStampCommandServiceTest`, `DemodayParticipationCommandControllerTest`, `DemodayBoothPersistenceAdapterTest`, `DemodayStampPersistenceAdapterTest`) 커버리지 확인 필요.
