### PR TITLE
[Feat] 실행 환경별 보유 도메인 와일드카드 기반으로 CORS 허용 오리진으로 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,11 @@ FIREBASE_CONFIGURATION=
 # ------------------------------------------------------------------
 # CORS
 # ------------------------------------------------------------------
+# 우리가 소유한 도메인은 application.yml 의 app.cors.trusted-origin-patterns 에서
+# 프로필별로 항상 허용된다. (prod: *.university.neordinary.com,
+# alpha: *.alpha.university.neordinary.com)
+# 아래 환경변수에는 소유 도메인 밖의 오리진(로컬 프론트엔드, 외부 파트너 등)만 콤마로 나열한다.
+# 예: http://localhost:5173,http://localhost:3000
 CORS_ALLOWED_ORIGIN_PATTERNS=
 
 # ------------------------------------------------------------------

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.umc.product.global.config;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -23,6 +25,7 @@ import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -54,7 +57,15 @@ public class SecurityConfig {
     private final ApiAccessDeniedHandler accessDeniedHandler;
     private final RequestMappingHandlerMapping requestMappingHandlerMapping;
 
-    // application.yml에서 cors.allowed-origin-patterns 값을 List 형태로 주입받음
+    /**
+     * 우리가 소유한 도메인이라 Origin 위변조가 불가능하므로 프로필별로 서브도메인 전체를 허용한다.
+     * <p>
+     * prod: {@code *.university.neordinary.com} / alpha: {@code *.alpha.university.neordinary.com}
+     */
+    @Value("${app.cors.trusted-origin-patterns}")
+    private List<String> trustedOriginPatterns;
+
+    // 소유 도메인 밖에서 추가로 허용할 오리진 (환경변수 CORS_ALLOWED_ORIGIN_PATTERNS)
     @Value("${app.cors.allowed-origin-patterns}")
     private List<String> allowedOriginPatterns;
 
@@ -185,10 +196,12 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        log.info("Allowed Origin Patterns for CORS: {}", allowedOriginPatterns);
+        List<String> originPatterns = mergeOriginPatterns(trustedOriginPatterns, allowedOriginPatterns);
+        log.info("Allowed Origin Patterns for CORS: {} (trusted={}, configured={})",
+            originPatterns, trustedOriginPatterns, allowedOriginPatterns);
 
         // Swagger CORS 설정
-        configuration.setAllowedOriginPatterns(allowedOriginPatterns);
+        configuration.setAllowedOriginPatterns(originPatterns);
 
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
@@ -199,5 +212,18 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    /**
+     * 소유 도메인 패턴과 환경변수로 추가된 패턴을 순서를 유지한 채 합치고 중복을 제거한다. 빈 문자열 항목은 설정이 비어 있는 프로필에서 들어올 수 있으므로 걸러낸다.
+     */
+    static List<String> mergeOriginPatterns(List<String> trusted, List<String> configured) {
+        return Stream.of(trusted, configured)
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .filter(StringUtils::hasText)
+            .map(String::trim)
+            .distinct()
+            .toList();
     }
 }

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -70,6 +70,15 @@ public class SecurityConfig {
     private List<String> allowedOriginPatterns;
 
     /**
+     * 허용 패턴보다 우선해서 차단할 오리진. Spring 의 origin pattern 에서 {@code *} 는 점을 넘어 매칭되므로, prod 의
+     * {@code *.university.neordinary.com} 은 하위 환경인 {@code alpha.university.neordinary.com} 까지 포함한다. SSO 로그인 쿠키가
+     * {@code .university.neordinary.com} 도메인으로 발급되어 하위 환경에도 실려 가고, alpha 와 prod 는 same-site 라 SameSite 로도 막히지
+     * 않는다. 따라서 낮은 신뢰 환경의 오리진은 여기서 명시적으로 제외한다.
+     */
+    @Value("${app.cors.denied-origin-patterns}")
+    private List<String> deniedOriginPatterns;
+
+    /**
      * 점검 모드 필터. JWT 다음에 동작해서 점검 중 일반 사용자 요청을 503 으로 차단한다. {@code @Component} 가 아닌 명시 {@code @Bean} 으로 두는 이유: 슬라이스 테스트
      * ({@code @WebMvcTest}) 의 자동 Filter 디스커버리가 본 필터의 의존성까지 끌어와 컨텍스트 로딩을 실패시키는 것을 막기 위함이다. SecurityConfig 는 슬라이스 테스트에
      * 포함되지 않으므로 본 빈도 함께 제외된다.
@@ -194,11 +203,12 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-
         List<String> originPatterns = mergeOriginPatterns(trustedOriginPatterns, allowedOriginPatterns);
-        log.info("Allowed Origin Patterns for CORS: {} (trusted={}, configured={})",
-            originPatterns, trustedOriginPatterns, allowedOriginPatterns);
+        List<String> denyPatterns = mergeOriginPatterns(deniedOriginPatterns, List.of());
+        log.info("Allowed Origin Patterns for CORS: {} (trusted={}, configured={}, denied={})",
+            originPatterns, trustedOriginPatterns, allowedOriginPatterns, denyPatterns);
+
+        CorsConfiguration configuration = new DenyAwareCorsConfiguration(denyPatterns);
 
         // Swagger CORS 설정
         configuration.setAllowedOriginPatterns(originPatterns);
@@ -225,5 +235,34 @@ public class SecurityConfig {
             .map(String::trim)
             .distinct()
             .toList();
+    }
+
+    /**
+     * 차단 패턴을 허용 패턴보다 먼저 평가하는 {@link CorsConfiguration}.
+     * <p>
+     * 차단 패턴 매칭에도 Spring 의 origin pattern 문법을 그대로 쓰기 위해, 패턴만 담은 별도 {@link CorsConfiguration} 의
+     * {@link CorsConfiguration#checkOrigin} 을 매처로 재사용한다. 차단된 오리진은 허용 목록에 없는 오리진과 동일하게 {@code null} 을 돌려주므로, preflight 는
+     * 403 이 되고 실제 요청에는 {@code Access-Control-Allow-Origin} 헤더가 붙지 않는다.
+     */
+    static final class DenyAwareCorsConfiguration extends CorsConfiguration {
+
+        private final CorsConfiguration denyMatcher;
+
+        DenyAwareCorsConfiguration(List<String> denyPatterns) {
+            if (denyPatterns.isEmpty()) {
+                this.denyMatcher = null;
+            } else {
+                this.denyMatcher = new CorsConfiguration();
+                this.denyMatcher.setAllowedOriginPatterns(denyPatterns);
+            }
+        }
+
+        @Override
+        public String checkOrigin(String requestOrigin) {
+            if (denyMatcher != null && denyMatcher.checkOrigin(requestOrigin) != null) {
+                return null;
+            }
+            return super.checkOrigin(requestOrigin);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -480,6 +480,9 @@ app:
     trusted-origin-patterns: ""
     # 소유 도메인 밖의 오리진(로컬 프론트엔드, 외부 파트너 등)만 환경변수로 추가한다.
     allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:}
+    # 허용 패턴보다 우선해서 차단한다. origin pattern 의 * 가 점을 넘어 매칭되므로,
+    # 상위 도메인을 여는 환경에서 하위 환경 오리진을 명시적으로 제외하는 용도다.
+    denied-origin-patterns: ""
 
   webhook:
     telegram:
@@ -592,6 +595,9 @@ spring:
 app:
   cors:
     trusted-origin-patterns: https://university.neordinary.com,https://*.university.neordinary.com
+    # alpha 는 prod 도메인의 하위 서브도메인이라 위 패턴에 자동으로 포함된다.
+    # 낮은 신뢰 환경이므로 prod 에서는 명시적으로 차단한다.
+    denied-origin-patterns: https://alpha.university.neordinary.com,https://*.alpha.university.neordinary.com
 
 
 # ==================================================================

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -475,6 +475,10 @@ app:
     firebase-configuration: ${FIREBASE_CONFIGURATION:}
 
   cors:
+    # 우리가 소유한 도메인이라 Origin 위변조가 불가능하므로, 환경별 소유 도메인은 서브도메인까지 통째로 허용한다.
+    # 프로필별 문서(prod / alpha)에서 재정의하며, 그 외 프로필(local, test)은 비워 둔다.
+    trusted-origin-patterns: ""
+    # 소유 도메인 밖의 오리진(로컬 프론트엔드, 외부 파트너 등)만 환경변수로 추가한다.
     allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:}
 
   webhook:
@@ -576,6 +580,21 @@ storage:
 
 
 # ==================================================================
+# configuration override for prod profile
+# ==================================================================
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+app:
+  cors:
+    trusted-origin-patterns: https://university.neordinary.com,https://*.university.neordinary.com
+
+
+# ==================================================================
 # configuration override for alpha profile
 # ==================================================================
 
@@ -592,6 +611,9 @@ spring:
       enabled: ${GRAPHQL_GRAPHIQL_ENABLED:true}
 
 app:
+  cors:
+    trusted-origin-patterns: https://alpha.university.neordinary.com,https://*.alpha.university.neordinary.com
+
   client-context:
     origins:
       - origin: http://localhost:5173

--- a/src/test/java/com/umc/product/global/config/SecurityConfigCorsTest.java
+++ b/src/test/java/com/umc/product/global/config/SecurityConfigCorsTest.java
@@ -1,0 +1,230 @@
+package com.umc.product.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+/**
+ * SecurityConfig 의 CORS 오리진 정책 단위 테스트.
+ * <p>
+ * 소유 도메인(university.neordinary.com)은 프로필별로 서브도메인까지 통째로 허용하고, 그 밖의 오리진은 환경변수로 지정한 패턴만 허용하는지 확인한다.
+ */
+@DisplayName("SecurityConfig CORS 오리진 정책")
+class SecurityConfigCorsTest {
+
+    private static final List<String> PROD_TRUSTED = List.of(
+        "https://university.neordinary.com",
+        "https://*.university.neordinary.com"
+    );
+
+    private static final List<String> ALPHA_TRUSTED = List.of(
+        "https://alpha.university.neordinary.com",
+        "https://*.alpha.university.neordinary.com"
+    );
+
+    private static CorsConfiguration corsConfiguration(List<String> trusted, List<String> configured) {
+        SecurityConfig securityConfig = new SecurityConfig(null, null, null, null);
+        ReflectionTestUtils.setField(securityConfig, "trustedOriginPatterns", trusted);
+        ReflectionTestUtils.setField(securityConfig, "allowedOriginPatterns", configured);
+
+        CorsConfigurationSource source = securityConfig.corsConfigurationSource();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/members/me");
+        CorsConfiguration configuration = source.getCorsConfiguration(request);
+
+        assertThat(configuration).isNotNull();
+        return configuration;
+    }
+
+    @Nested
+    @DisplayName("prod 프로필")
+    class Prod {
+
+        private final CorsConfiguration configuration = corsConfiguration(PROD_TRUSTED, List.of());
+
+        @Test
+        @DisplayName("소유 도메인의 서브도메인은 별도 등록 없이 모두 허용한다")
+        void 소유_도메인_서브도메인은_모두_허용된다() {
+            // given
+            String origin = "https://backoffice.university.neordinary.com";
+
+            // when
+            String allowed = configuration.checkOrigin(origin);
+
+            // then
+            assertThat(allowed).isEqualTo(origin);
+        }
+
+        @Test
+        @DisplayName("소유 도메인의 apex 오리진도 허용한다")
+        void apex_오리진도_허용된다() {
+            // given
+            String origin = "https://university.neordinary.com";
+
+            // when & then
+            assertThat(configuration.checkOrigin(origin)).isEqualTo(origin);
+        }
+
+        @Test
+        @DisplayName("중첩 서브도메인도 허용한다")
+        void 중첩_서브도메인도_허용된다() {
+            // given
+            String origin = "https://tech.blog.university.neordinary.com";
+
+            // when & then
+            assertThat(configuration.checkOrigin(origin)).isEqualTo(origin);
+        }
+
+        @Test
+        @DisplayName("소유 도메인이 아닌 오리진은 차단한다")
+        void 외부_오리진은_차단된다() {
+            // when & then
+            assertThat(configuration.checkOrigin("https://evil.com")).isNull();
+            assertThat(configuration.checkOrigin("https://university.neordinary.com.evil.com")).isNull();
+            assertThat(configuration.checkOrigin("https://evil-university.neordinary.com")).isNull();
+        }
+
+        @Test
+        @DisplayName("http 스킴은 허용하지 않는다")
+        void http_스킴은_차단된다() {
+            // when & then
+            assertThat(configuration.checkOrigin("http://backoffice.university.neordinary.com")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("alpha 프로필")
+    class Alpha {
+
+        private final CorsConfiguration configuration = corsConfiguration(ALPHA_TRUSTED, List.of());
+
+        @Test
+        @DisplayName("alpha 소유 도메인의 서브도메인은 모두 허용한다")
+        void alpha_서브도메인은_모두_허용된다() {
+            // given
+            String origin = "https://admin.alpha.university.neordinary.com";
+
+            // when & then
+            assertThat(configuration.checkOrigin(origin)).isEqualTo(origin);
+        }
+
+        @Test
+        @DisplayName("alpha apex 오리진도 허용한다")
+        void alpha_apex_오리진도_허용된다() {
+            // given
+            String origin = "https://alpha.university.neordinary.com";
+
+            // when & then
+            assertThat(configuration.checkOrigin(origin)).isEqualTo(origin);
+        }
+
+        @Test
+        @DisplayName("prod 오리진은 alpha 환경에서 허용하지 않는다")
+        void prod_오리진은_차단된다() {
+            // when & then
+            assertThat(configuration.checkOrigin("https://backoffice.university.neordinary.com")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("환경변수로 추가한 오리진")
+    class ConfiguredOrigins {
+
+        @Test
+        @DisplayName("소유 도메인 패턴과 환경변수 패턴을 함께 허용한다")
+        void 소유_도메인과_환경변수_패턴을_모두_허용한다() {
+            // given
+            CorsConfiguration configuration = corsConfiguration(PROD_TRUSTED, List.of("http://localhost:5173"));
+
+            // when & then
+            assertThat(configuration.checkOrigin("http://localhost:5173")).isEqualTo("http://localhost:5173");
+            assertThat(configuration.checkOrigin("https://backoffice.university.neordinary.com"))
+                .isEqualTo("https://backoffice.university.neordinary.com");
+        }
+
+        @Test
+        @DisplayName("소유 도메인 설정이 비어 있으면 환경변수 패턴만 허용한다")
+        void 소유_도메인_설정이_비면_환경변수_패턴만_허용한다() {
+            // given (local/test 프로필처럼 trusted 값이 빈 문자열로 주입되는 경우)
+            CorsConfiguration configuration = corsConfiguration(List.of(""), List.of("http://localhost:5173"));
+
+            // when & then
+            assertThat(configuration.checkOrigin("http://localhost:5173")).isEqualTo("http://localhost:5173");
+            assertThat(configuration.checkOrigin("https://backoffice.university.neordinary.com")).isNull();
+        }
+
+        @Test
+        @DisplayName("빈 값과 중복 패턴은 제거하고 순서를 유지한다")
+        void 빈_값과_중복은_제거된다() {
+            // when
+            List<String> merged = SecurityConfig.mergeOriginPatterns(
+                List.of("https://university.neordinary.com", " ", "https://*.university.neordinary.com"),
+                List.of("https://university.neordinary.com", "http://localhost:5173", "")
+            );
+
+            // then
+            assertThat(merged).containsExactly(
+                "https://university.neordinary.com",
+                "https://*.university.neordinary.com",
+                "http://localhost:5173"
+            );
+        }
+
+        @Test
+        @DisplayName("설정이 모두 비어 있으면 어떤 오리진도 허용하지 않는다")
+        void 설정이_모두_비면_모든_오리진을_차단한다() {
+            // given
+            CorsConfiguration configuration = corsConfiguration(List.of(""), List.of());
+
+            // when & then
+            assertThat(configuration.checkOrigin("https://backoffice.university.neordinary.com")).isNull();
+            assertThat(configuration.checkOrigin("http://localhost:5173")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("application.yml 프로필별 소유 도메인 설정")
+    class TrustedOriginPatternsByProfile {
+
+        private static String trustedOriginPatterns(String profile) {
+            AtomicReference<String> value = new AtomicReference<>();
+            new ApplicationContextRunner()
+                .withInitializer(new ConfigDataApplicationContextInitializer())
+                .withPropertyValues("spring.profiles.active=" + profile)
+                .run(context -> value.set(
+                    context.getEnvironment().getProperty("app.cors.trusted-origin-patterns")
+                ));
+            return value.get();
+        }
+
+        @Test
+        @DisplayName("prod 프로필은 university.neordinary.com 전체를 허용한다")
+        void prod_프로필_소유_도메인() {
+            assertThat(trustedOriginPatterns("prod"))
+                .isEqualTo("https://university.neordinary.com,https://*.university.neordinary.com");
+        }
+
+        @Test
+        @DisplayName("alpha 프로필은 alpha.university.neordinary.com 전체를 허용한다")
+        void alpha_프로필_소유_도메인() {
+            assertThat(trustedOriginPatterns("alpha"))
+                .isEqualTo("https://alpha.university.neordinary.com,https://*.alpha.university.neordinary.com");
+        }
+
+        @Test
+        @DisplayName("local 프로필은 소유 도메인을 자동 허용하지 않는다")
+        void local_프로필은_비어있다() {
+            assertThat(trustedOriginPatterns("local")).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/umc/product/global/config/SecurityConfigCorsTest.java
+++ b/src/test/java/com/umc/product/global/config/SecurityConfigCorsTest.java
@@ -28,15 +28,29 @@ class SecurityConfigCorsTest {
         "https://*.university.neordinary.com"
     );
 
+    private static final List<String> PROD_DENIED = List.of(
+        "https://alpha.university.neordinary.com",
+        "https://*.alpha.university.neordinary.com"
+    );
+
     private static final List<String> ALPHA_TRUSTED = List.of(
         "https://alpha.university.neordinary.com",
         "https://*.alpha.university.neordinary.com"
     );
 
     private static CorsConfiguration corsConfiguration(List<String> trusted, List<String> configured) {
+        return corsConfiguration(trusted, configured, List.of());
+    }
+
+    private static CorsConfiguration corsConfiguration(
+        List<String> trusted,
+        List<String> configured,
+        List<String> denied
+    ) {
         SecurityConfig securityConfig = new SecurityConfig(null, null, null, null);
         ReflectionTestUtils.setField(securityConfig, "trustedOriginPatterns", trusted);
         ReflectionTestUtils.setField(securityConfig, "allowedOriginPatterns", configured);
+        ReflectionTestUtils.setField(securityConfig, "deniedOriginPatterns", denied);
 
         CorsConfigurationSource source = securityConfig.corsConfigurationSource();
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/members/me");
@@ -50,7 +64,7 @@ class SecurityConfigCorsTest {
     @DisplayName("prod 프로필")
     class Prod {
 
-        private final CorsConfiguration configuration = corsConfiguration(PROD_TRUSTED, List.of());
+        private final CorsConfiguration configuration = corsConfiguration(PROD_TRUSTED, List.of(), PROD_DENIED);
 
         @Test
         @DisplayName("소유 도메인의 서브도메인은 별도 등록 없이 모두 허용한다")
@@ -99,6 +113,30 @@ class SecurityConfigCorsTest {
         void http_스킴은_차단된다() {
             // when & then
             assertThat(configuration.checkOrigin("http://backoffice.university.neordinary.com")).isNull();
+        }
+
+        @Test
+        @DisplayName("하위 환경인 alpha 오리진은 소유 도메인 패턴에 걸리더라도 차단한다")
+        void alpha_오리진은_차단된다() {
+            // given (origin pattern 의 * 는 점을 넘어 매칭되므로 차단 목록이 없으면 아래 오리진들이 모두 통과한다)
+            CorsConfiguration denyDisabled = corsConfiguration(PROD_TRUSTED, List.of());
+            assertThat(denyDisabled.checkOrigin("https://alpha.university.neordinary.com")).isNotNull();
+            assertThat(denyDisabled.checkOrigin("https://api.alpha.university.neordinary.com")).isNotNull();
+
+            // when & then
+            assertThat(configuration.checkOrigin("https://alpha.university.neordinary.com")).isNull();
+            assertThat(configuration.checkOrigin("https://api.alpha.university.neordinary.com")).isNull();
+            assertThat(configuration.checkOrigin("https://admin.alpha.university.neordinary.com")).isNull();
+        }
+
+        @Test
+        @DisplayName("alpha 를 차단해도 prod 오리진은 그대로 허용한다")
+        void alpha_차단이_prod_오리진에는_영향이_없다() {
+            // when & then
+            assertThat(configuration.checkOrigin("https://api.university.neordinary.com"))
+                .isEqualTo("https://api.university.neordinary.com");
+            assertThat(configuration.checkOrigin("https://alphabet.university.neordinary.com"))
+                .isEqualTo("https://alphabet.university.neordinary.com");
         }
     }
 
@@ -196,15 +234,21 @@ class SecurityConfigCorsTest {
     @DisplayName("application.yml 프로필별 소유 도메인 설정")
     class TrustedOriginPatternsByProfile {
 
-        private static String trustedOriginPatterns(String profile) {
+        private static String property(String profile, String key) {
             AtomicReference<String> value = new AtomicReference<>();
             new ApplicationContextRunner()
                 .withInitializer(new ConfigDataApplicationContextInitializer())
                 .withPropertyValues("spring.profiles.active=" + profile)
-                .run(context -> value.set(
-                    context.getEnvironment().getProperty("app.cors.trusted-origin-patterns")
-                ));
+                .run(context -> value.set(context.getEnvironment().getProperty(key)));
             return value.get();
+        }
+
+        private static String trustedOriginPatterns(String profile) {
+            return property(profile, "app.cors.trusted-origin-patterns");
+        }
+
+        private static String deniedOriginPatterns(String profile) {
+            return property(profile, "app.cors.denied-origin-patterns");
         }
 
         @Test
@@ -212,6 +256,19 @@ class SecurityConfigCorsTest {
         void prod_프로필_소유_도메인() {
             assertThat(trustedOriginPatterns("prod"))
                 .isEqualTo("https://university.neordinary.com,https://*.university.neordinary.com");
+        }
+
+        @Test
+        @DisplayName("prod 프로필은 alpha 서브트리를 차단 목록에 둔다")
+        void prod_프로필_alpha_차단() {
+            assertThat(deniedOriginPatterns("prod"))
+                .isEqualTo("https://alpha.university.neordinary.com,https://*.alpha.university.neordinary.com");
+        }
+
+        @Test
+        @DisplayName("alpha 프로필에는 차단 목록이 없다")
+        void alpha_프로필_차단_목록_없음() {
+            assertThat(deniedOriginPatterns("alpha")).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
## 🚀 작업 내용

### 변경 범위 요약

- `global/config/SecurityConfig.java` 의 CORS 설정과 `application.yml` 의 프로필별 설정을 건드렸어요. API 스펙이나 도메인 로직 변경은 없어요.

### 작업 단위별 상세

1. **무엇을**: 우리가 소유한 `university.neordinary.com` 도메인의 서브도메인을 환경별로 CORS 허용 오리진에 항상 포함하도록 `app.cors.trusted-origin-patterns` 설정을 추가했어요.
   - **어떻게**: `application.yml` 에 프로필별 문서로 값을 나눠 뒀어요. `prod` 프로필은 `https://university.neordinary.com`, `https://*.university.neordinary.com` 을, `alpha` 프로필은 `https://alpha.university.neordinary.com`, `https://*.alpha.university.neordinary.com` 을 허용하고, `local`·`test` 프로필은 비워 뒀어요.
   - **왜**: 우리가 소유한 도메인이라 Origin 위변조가 불가능한데도, 프론트엔드 서브도메인이 하나 늘어날 때마다 `CORS_ALLOWED_ORIGIN_PATTERNS` 환경변수를 SSM에서 고쳐야 했어요. 소유 도메인은 통째로 열어 두고 배포 없이 서브도메인을 추가할 수 있게 했어요.

2. **무엇을**: prod 에서 하위 환경인 alpha 오리진을 명시적으로 차단하는 `app.cors.denied-origin-patterns` 를 추가했어요.
   - **어떻게**: Spring 의 origin pattern 에서 `*` 는 `.*` 로 컴파일돼서 점을 넘어 매칭돼요. 그래서 prod 의 `https://*.university.neordinary.com` 은 `https://alpha.university.neordinary.com` 과 `https://api.alpha.university.neordinary.com` 까지 전부 매칭해요. 패턴 문법만으로는 하위 환경을 뺄 수 없어서, 허용 검사보다 먼저 차단 패턴을 평가하는 `DenyAwareCorsConfiguration` 을 두고 prod 프로필에서 alpha 서브트리를 차단했어요. 차단된 오리진은 허용 목록에 없는 오리진과 똑같이 `checkOrigin` 이 `null` 을 돌려주므로 preflight 는 403 이 되고 실제 요청에는 `Access-Control-Allow-Origin` 이 붙지 않아요. (`src/main/java/com/umc/product/global/config/SecurityConfig.java:227`)
   - **왜**: alpha 는 prod 도메인의 서브도메인이라 "소유 도메인 전체 허용" 규칙에 구조적으로 딸려 들어와요. 그런데 SSO 로그인 쿠키가 `.university.neordinary.com` 도메인으로 발급돼서 alpha 호스트에도 실려 가고, alpha 와 prod 는 same-site 라 `SameSite=Lax` 로도 막히지 않아요. alpha 는 seed API·GraphiQL·introspection 이 켜진 낮은 신뢰 환경이라, 여기서 XSS 가 하나 나면 그대로 prod API 를 credentialed 로 호출해 응답까지 읽을 수 있어요. CORS 가 유일한 경계라서 명시적으로 끊었어요.

3. **무엇을**: 소유 도메인 패턴과 기존 환경변수 패턴을 합치는 `SecurityConfig#mergeOriginPatterns` 를 추가했어요.
   - **어떻게**: 두 목록을 순서를 유지한 채 이어 붙이고, 빈 문자열을 걸러낸 뒤 중복을 제거해서 `CorsConfiguration#setAllowedOriginPatterns` 에 넘겨요. 어떤 패턴이 최종 적용됐는지 파악할 수 있도록 기동 로그에 `trusted`·`configured`·`denied` 를 나눠서 남겨요.
   - **왜**: 기존 `CORS_ALLOWED_ORIGIN_PATTERNS` 환경변수를 그대로 살려서, 로컬 프론트엔드나 외부 파트너처럼 소유 도메인 밖의 오리진은 계속 환경변수로 추가할 수 있게 하려고요. SSM 값을 지금 당장 손볼 필요는 없어요.

4. **무엇을**: `SecurityConfigCorsTest` 를 추가했어요. (19개 케이스)
   - **어떻게**: 서브도메인·apex·중첩 서브도메인 허용, `evil.com` / `university.neordinary.com.evil.com` / `evil-university.neordinary.com` / http 스킴 차단, alpha 프로필에서 prod 오리진 차단, 환경변수 패턴과의 병합·중복 제거를 검증해요. prod 의 alpha 차단은 "차단 목록이 없으면 통과한다"는 것까지 같은 테스트에서 확인해서 회귀를 잡을 수 있게 했고, `alphabet.university.neordinary.com` 처럼 이름만 비슷한 오리진은 차단되지 않는 것도 함께 검증해요. 여기에 더해 `ApplicationContextRunner` + `ConfigDataApplicationContextInitializer` 로 `application.yml` 이 실제로 프로필별 값을 내려주는지도 확인해요.
   - **왜**: 오리진 허용 범위는 잘못 넓어지면 바로 보안 문제가 되는 지점이라, 허용 케이스뿐 아니라 차단 케이스까지 회귀 테스트로 묶어 두려고요.

5. **무엇을**: `.env.example` 의 CORS 섹션에 설명을 덧붙였어요.
   - **어떻게**: 소유 도메인은 `application.yml` 에서 프로필별로 자동 허용되고, 환경변수에는 그 밖의 오리진만 나열하면 된다고 적었어요.
   - **왜**: 새로 배포 환경을 세팅하는 사람이 소유 도메인을 환경변수에 중복으로 넣지 않도록 하려고요.

## 💬 리뷰 중점사항

- **차단 목록이 실제 alpha 호스트를 다 덮는지 봐주세요.** 지금은 `alpha.university.neordinary.com` 과 그 하위만 차단해요. 레포에 남아 있는 alpha 관련 설정은 아직 `dev.` 접두사 체계라(`application.yml` 의 alpha 프로필 SSO 클라이언트가 `dev.admin.university.neordinary.com` 등, `OpenApiConfig.java:86` 과 `infra/terraform/envs/dev/main.tf:10` 이 `dev.api.university.neordinary.com`), 만약 아직 `dev.*` 호스트가 살아 있다면 그쪽도 prod 차단 목록에 넣거나 alpha 로 정리해야 해요.
- **`DenyAwareCorsConfiguration` 접근 방식을 봐주세요.** Spring 의 origin pattern 에는 단일 라벨 와일드카드가 없어서 `CorsConfiguration` 을 상속해 `checkOrigin` 을 오버라이드했어요. 이 레포에는 `@CrossOrigin` 이나 `addCorsMappings` 가 없어서 `CorsConfiguration#combine` 경로를 타지 않는 걸 확인했는데, 앞으로 핸들러 단위 CORS 를 쓰게 되면 combine 과정에서 오버라이드가 사라질 수 있어요.
- 설정 변경(`application.yml`, `.env.example`)이 포함되어 있어요. 기존 `CORS_ALLOWED_ORIGIN_PATTERNS` 는 그대로 동작하므로 SSM 파라미터 변경 없이 배포할 수 있어요.
