### PR TITLE
[Feat] 데모데이 관리자 대시보드 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminController.java
@@ -15,11 +15,13 @@ import com.umc.product.demoday.adapter.in.web.dto.request.CreateDemodayPollReque
 import com.umc.product.demoday.adapter.in.web.dto.request.GenerateDemodayEntryCodesRequest;
 import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayEntryCodeResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.CreateDemodayPollResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayDashboardResponse;
 import com.umc.product.demoday.adapter.in.web.dto.response.DemodayVoteQrResponse;
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
 import com.umc.product.demoday.application.port.in.command.dto.CreateDemodayEntryCodesInfo;
+import com.umc.product.demoday.application.port.in.query.GetDemodayDashboardUseCase;
 import com.umc.product.demoday.application.port.in.query.GetDemodayVoteQrUseCase;
 import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.global.security.annotation.CurrentMember;
@@ -43,6 +45,7 @@ public class DemodayPollAdminController {
     private final ChangeDemodayPollStatusUseCase changeDemodayPollStatusUseCase;
     private final CreateDemodayEntryCodeUseCase createDemodayEntryCodeUseCase;
     private final GetDemodayVoteQrUseCase getDemodayVoteQrUseCase;
+    private final GetDemodayDashboardUseCase getDemodayDashboardUseCase;
 
     @Operation(
         operationId = "createDemodayPoll",
@@ -125,5 +128,44 @@ public class DemodayPollAdminController {
         @PathVariable("pollId") Long pollId) {
 
         return DemodayVoteQrResponse.from(getDemodayVoteQrUseCase.get(pollId, memberPrincipal.getMemberId()));
+    }
+
+    @Operation(
+        operationId = "getAdminDashboard",
+        summary = "Poll 대시보드 통계 스냅샷 조회",
+        description = """
+            요약 지표·투표 랭킹·스탬프 히트맵을 **하나의 스냅샷으로** 반환합니다.
+            세 가지 모두 같은 Poll을 기준으로 하고, 데이터 규모가 부스 수 수준이며,
+            같은 화면에서 비슷한 주기로 갱신되고, 같은 권한을 쓰기 때문에 API를 분리하지 않았습니다.
+
+            FE는 WebSocket을 쓰지 않고 이 API를 폴링합니다. 주기는 FE 운영 설정으로 관리하며,
+            이전 요청이 끝나기 전에 같은 요청을 중첩하지 않습니다.
+
+            ### 무효 처리된 데이터의 집계 제외
+
+            `summary.totalVoteCount`, `rankings[].voteCount`, `stampHeatmap[].stampCount`는
+            모두 **무효 처리되지 않은 행만 집계합니다.** 이 수치가 시상 근거이므로
+            어드민이 부정표를 무효화하면 즉시 수치와 순위에서 빠집니다.
+
+            ### 정렬과 순위
+
+            `rankings`는 `voteCount` 내림차순, 동점이면 `boothId` 오름차순인 **전체** 부스 목록입니다.
+            `rank`는 표준 경쟁 순위입니다. 동점 부스는 같은 순위를 공유하고, 다음 순위는 동점자 수만큼
+            건너뜁니다(1, 2, 2, 4). 화면에 표시할 상위 개수는 FE가 정합니다.
+
+            `stampHeatmap`에는 스탬프 수가 `0`인 부스도 포함됩니다.
+            부스 구역·좌표는 FE 정적 데이터이므로 서버는 반환하지 않습니다. FE가 `boothId`로 결합하세요.
+
+            요청자는 투표가 속한 기수의 총괄단이거나 SUPER_ADMIN이어야 합니다.
+            """
+    )
+    @GetMapping("/{pollId}/dashboard")
+    public DemodayDashboardResponse getDashboard(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal memberPrincipal,
+        @Parameter(description = "대시보드를 조회할 데모데이 투표 ID", required = true, example = "1")
+        @PathVariable("pollId") Long pollId) {
+
+        return DemodayDashboardResponse.from(
+            getDemodayDashboardUseCase.getDashboard(pollId, memberPrincipal.getMemberId()));
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayDashboardResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayDashboardResponse.java
@@ -1,0 +1,89 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DemodayDashboardResponse(
+        @Schema(description = "투표 ID", example = "101")
+        Long pollId,
+        @Schema(description = "서버가 통계 스냅샷을 생성한 시각", example = "2026-08-14T15:30:00+09:00")
+        Instant generatedAt,
+        @Schema(description = "요약 지표")
+        SummaryResponse summary,
+        @Schema(description = "득표 순으로 정렬된 전체 부스 목록")
+        List<RankingEntryResponse> rankings,
+        @Schema(description = "스탬프 획득 수를 포함한 전체 부스 목록")
+        List<StampHeatmapEntryResponse> stampHeatmap
+) {
+
+    public static DemodayDashboardResponse from(DemodayDashboardInfo info) {
+        return new DemodayDashboardResponse(
+                info.pollId(),
+                info.generatedAt(),
+                SummaryResponse.from(info.summary()),
+                info.rankings().stream().map(RankingEntryResponse::from).toList(),
+                info.stampHeatmap().stream().map(StampHeatmapEntryResponse::from).toList()
+        );
+    }
+
+    public record SummaryResponse(
+            @Schema(description = "해당 Poll에서 운영하는 전체 부스 수", example = "30")
+            int boothCount,
+            @Schema(description = "해당 Poll에서 유효한 전체 투표 수. 무효 처리된 표는 제외됩니다.", example = "275")
+            int totalVoteCount
+    ) {
+
+        public static SummaryResponse from(DemodayDashboardInfo.SummaryInfo info) {
+            return new SummaryResponse(info.boothCount(), info.totalVoteCount());
+        }
+    }
+
+    public record RankingEntryResponse(
+            @Schema(description = "서버가 계산한 표시 순위. 동점이면 같은 값을 공유합니다.", example = "1")
+            int rank,
+            @Schema(description = "부스 ID", example = "9")
+            Long boothId,
+            @Schema(description = "UPMS에 등록된 프로젝트 부스만 값을 가집니다. 외부 부스는 null입니다.", example = "509")
+            Long projectId,
+            @Schema(description = "화면에 표시할 부스 이름", example = "잇픽")
+            String displayName,
+            @Schema(description = "해당 부스의 유효 득표 수. 무효 처리된 표는 제외됩니다.", example = "20")
+            int voteCount
+    ) {
+
+        public static RankingEntryResponse from(DemodayDashboardInfo.RankingInfo info) {
+            return new RankingEntryResponse(
+                    info.rank(),
+                    info.boothId(),
+                    info.projectId(),
+                    info.displayName(),
+                    info.voteCount()
+            );
+        }
+    }
+
+    public record StampHeatmapEntryResponse(
+            @Schema(description = "부스 ID", example = "4")
+            Long boothId,
+            @Schema(description = "UPMS에 등록된 프로젝트 부스만 값을 가집니다. 외부 부스는 null입니다.", example = "504")
+            Long projectId,
+            @Schema(description = "화면에 표시할 부스 이름", example = "모디")
+            String displayName,
+            @Schema(description = "해당 부스에서 유효하게 적립된 스탬프 수", example = "123")
+            int stampCount
+    ) {
+
+        public static StampHeatmapEntryResponse from(DemodayDashboardInfo.StampHeatmapInfo info) {
+            return new StampHeatmapEntryResponse(
+                    info.boothId(),
+                    info.projectId(),
+                    info.displayName(),
+                    info.stampCount()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayDashboardPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayDashboardPersistenceAdapter.java
@@ -1,0 +1,26 @@
+package com.umc.product.demoday.adapter.out.persistence;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.LoadDemodayDashboardPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DemodayDashboardPersistenceAdapter implements LoadDemodayDashboardPort {
+
+    private final DemodayDashboardQueryRepository queryRepository;
+
+    @Override
+    public Map<Long, Long> countActiveVotesByBooth(Long pollId) {
+        return queryRepository.countActiveVotesByBooth(pollId);
+    }
+
+    @Override
+    public Map<Long, Long> countActiveStampsByBooth(Long pollId) {
+        return queryRepository.countActiveStampsByBooth(pollId);
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayDashboardQueryRepository.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayDashboardQueryRepository.java
@@ -1,0 +1,65 @@
+package com.umc.product.demoday.adapter.out.persistence;
+
+import static com.umc.product.demoday.domain.QDemodayBooth.demodayBooth;
+import static com.umc.product.demoday.domain.QDemodayStamp.demodayStamp;
+import static com.umc.product.demoday.domain.QDemodayVote.demodayVote;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DemodayDashboardQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Map<Long, Long> countActiveVotesByBooth(Long pollId) {
+        NumberExpression<Long> voteCount = demodayVote.id.count();
+
+        List<Tuple> rows = queryFactory
+            .select(demodayVote.targetBoothId, voteCount)
+            .from(demodayVote)
+            .where(
+                demodayVote.pollId.eq(pollId),
+                demodayVote.revokedAt.isNull()
+            )
+            .groupBy(demodayVote.targetBoothId)
+            .fetch();
+
+        return rows.stream()
+            .collect(Collectors.toMap(
+                row -> row.get(demodayVote.targetBoothId),
+                row -> row.get(voteCount)
+            ));
+    }
+
+    public Map<Long, Long> countActiveStampsByBooth(Long pollId) {
+        NumberExpression<Long> stampCount = demodayStamp.id.count();
+
+        List<Tuple> rows = queryFactory
+            .select(demodayStamp.boothId, stampCount)
+            .from(demodayStamp)
+            .join(demodayBooth).on(demodayBooth.id.eq(demodayStamp.boothId))
+            .where(
+                demodayBooth.pollId.eq(pollId),
+                demodayStamp.revokedAt.isNull()
+            )
+            .groupBy(demodayStamp.boothId)
+            .fetch();
+
+        return rows.stream()
+            .collect(Collectors.toMap(
+                row -> row.get(demodayStamp.boothId),
+                row -> row.get(stampCount)
+            ));
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/GetDemodayDashboardUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/GetDemodayDashboardUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.in.query;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo;
+
+public interface GetDemodayDashboardUseCase {
+
+    DemodayDashboardInfo getDashboard(Long pollId, Long memberId);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayDashboardInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayDashboardInfo.java
@@ -1,0 +1,36 @@
+package com.umc.product.demoday.application.port.in.query.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DemodayDashboardInfo(
+        Long pollId,
+        Instant generatedAt,
+        SummaryInfo summary,
+        List<RankingInfo> rankings,
+        List<StampHeatmapInfo> stampHeatmap
+) {
+
+    public record SummaryInfo(
+            int boothCount,
+            int totalVoteCount
+    ) {
+    }
+
+    public record RankingInfo(
+            int rank,
+            Long boothId,
+            Long projectId,
+            String displayName,
+            int voteCount
+    ) {
+    }
+
+    public record StampHeatmapInfo(
+            Long boothId,
+            Long projectId,
+            String displayName,
+            int stampCount
+    ) {
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayDashboardPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayDashboardPort.java
@@ -1,0 +1,22 @@
+package com.umc.product.demoday.application.port.out;
+
+import java.util.Map;
+
+public interface LoadDemodayDashboardPort {
+
+    /**
+     * Poll에 속한 부스별 유효(무효 처리되지 않은) 득표 수를 집계한다.
+     *
+     * <p>득표가 하나도 없는 부스는 이 맵에 나타나지 않는다. 0표 부스까지 포함한 전체 목록을 만드는 책임은
+     * 호출자(부스 전체 목록을 아는 쪽)에게 있다.
+     */
+    Map<Long, Long> countActiveVotesByBooth(Long pollId);
+
+    /**
+     * Poll에 속한 부스별 유효(무효 처리되지 않은) 스탬프 수를 집계한다.
+     *
+     * <p>스탬프가 하나도 없는 부스는 이 맵에 나타나지 않는다. 0개 부스까지 포함한 전체 목록을 만드는 책임은
+     * 호출자에게 있다.
+     */
+    Map<Long, Long> countActiveStampsByBooth(Long pollId);
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayDashboardQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayDashboardQueryService.java
@@ -1,0 +1,162 @@
+package com.umc.product.demoday.application.service.query;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.demoday.application.port.in.query.GetDemodayDashboardUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo.RankingInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo.StampHeatmapInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo.SummaryInfo;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayDashboardPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Poll 대시보드 스냅샷을 조립한다.
+ *
+ * <p>요약 지표·투표 랭킹·스탬프 히트맵은 서로 다른 소스(부스 전체 목록, 득표 집계, 스탬프 집계, 프로젝트 이름)에서
+ * 왔지만 하나의 스냅샷으로 묶여야 한다. 그래서 세 값을 각자 조회하는 별도 API 대신 이 서비스가 한 트랜잭션에서
+ * 모두 모아 한 번에 반환한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DemodayDashboardQueryService implements GetDemodayDashboardUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final LoadDemodayPollPort loadDemodayPollPort;
+    private final LoadDemodayBoothPort loadDemodayBoothPort;
+    private final LoadDemodayDashboardPort loadDemodayDashboardPort;
+    private final GetProjectUseCase getProjectUseCase;
+    private final Clock clock;
+
+    @Override
+    public DemodayDashboardInfo getDashboard(Long pollId, Long memberId) {
+        DemodayPoll poll = loadDemodayPollPort.findById(pollId)
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
+
+        adminAccessChecker.validateAdminAccess(memberId, poll.getGisuId());
+
+        List<DemodayBooth> booths = loadDemodayBoothPort.listByPollId(pollId);
+        Map<Long, Long> voteCounts = loadDemodayDashboardPort.countActiveVotesByBooth(pollId);
+        Map<Long, Long> stampCounts = loadDemodayDashboardPort.countActiveStampsByBooth(pollId);
+        Map<Long, ProjectInfo> projectsById = getProjectUseCase.findAllByIds(projectIdsOf(booths));
+
+        int totalVoteCount = voteCounts
+            .values()
+            .stream()
+            .mapToInt(Long::intValue)
+            .sum();
+
+        return new DemodayDashboardInfo(
+            pollId,
+            Instant.now(clock),
+            new SummaryInfo(booths.size(), totalVoteCount),
+            buildRankings(booths, voteCounts, projectsById),
+            buildStampHeatmap(booths, stampCounts, projectsById)
+        );
+    }
+
+    private Set<Long> projectIdsOf(List<DemodayBooth> booths) {
+        return booths.stream()
+            .map(DemodayBooth::getProjectId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * 득표 내림차순, 동점이면 boothId 오름차순으로 정렬한 뒤 표준 경쟁 순위를 매긴다.
+     *
+     * <p>동점 부스는 같은 rank를 공유하고, 다음 rank는 동점자 수만큼 건너뛴다(1, 2, 2, 4).
+     * 시상 발표에서 "공동 2위"를 그대로 표현할 수 있어야 하기 때문이다.
+     */
+    private List<RankingInfo> buildRankings(
+        List<DemodayBooth> booths,
+        Map<Long, Long> voteCounts,
+        Map<Long, ProjectInfo> projectsById
+    ) {
+        List<DemodayBooth> sorted = booths.stream()
+            .sorted(Comparator
+                .comparingLong((DemodayBooth booth) -> voteCountOf(booth, voteCounts))
+                .reversed()
+                .thenComparing(DemodayBooth::getId))
+            .toList();
+
+        List<RankingInfo> rankings = new ArrayList<>();
+        int rank = 0;
+        int position = 0;
+        int previousVoteCount = -1;
+        for (DemodayBooth booth : sorted) {
+            position++;
+            int voteCount = voteCountOf(booth, voteCounts);
+            if (voteCount != previousVoteCount) {
+                rank = position;
+                previousVoteCount = voteCount;
+            }
+            rankings.add(new RankingInfo(
+                rank,
+                booth.getId(),
+                booth.getProjectId(),
+                resolveDisplayName(booth, projectsById),
+                voteCount
+            ));
+        }
+        return rankings;
+    }
+
+    private List<StampHeatmapInfo> buildStampHeatmap(
+        List<DemodayBooth> booths,
+        Map<Long, Long> stampCounts,
+        Map<Long, ProjectInfo> projectsById
+    ) {
+        return booths.stream()
+            .sorted(Comparator.comparing(DemodayBooth::getId))
+            .map(booth -> new StampHeatmapInfo(
+                booth.getId(),
+                booth.getProjectId(),
+                resolveDisplayName(booth, projectsById),
+                stampCounts.getOrDefault(booth.getId(), 0L).intValue()
+            ))
+            .toList();
+    }
+
+    private int voteCountOf(DemodayBooth booth, Map<Long, Long> voteCounts) {
+        return voteCounts.getOrDefault(booth.getId(), 0L).intValue();
+    }
+
+    /**
+     * 외부 부스는 자기 displayName을 그대로 쓰고, 프로젝트 부스는 project 도메인의 이름을 쓴다.
+     *
+     * <p>{@link DemodayBooth#forProject}는 displayName을 채우지 않으므로 프로젝트 부스는 이 해석 없이는
+     * 이름이 비어 있다. 참조하는 프로젝트를 찾지 못한 경우(정합성이 깨진 예외 상황)에도 대시보드 전체가
+     * 실패하지 않도록 booth의 displayName으로 대체한다.
+     */
+    private String resolveDisplayName(DemodayBooth booth, Map<Long, ProjectInfo> projectsById) {
+        if (booth.getProjectId() == null) {
+            return booth.getDisplayName();
+        }
+
+        ProjectInfo projectInfo = projectsById.get(booth.getProjectId());
+        return projectInfo != null ? projectInfo.name() : booth.getDisplayName();
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/SeedController.java
@@ -15,6 +15,8 @@ import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleRequest;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedChallengerRoleResponse;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberRequest;
 import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberResponse;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberSystemRoleRequest;
+import com.umc.product.test.adapter.in.web.dto.CreateSeedMemberSystemRoleResponse;
 import com.umc.product.test.adapter.in.web.dto.DeleteSeedProjectDataRequest;
 import com.umc.product.test.adapter.in.web.dto.DeleteSeedProjectDataResponse;
 import com.umc.product.test.adapter.in.web.dto.SeedChallengerPointsRequest;
@@ -35,6 +37,7 @@ import com.umc.product.test.adapter.in.web.dto.SeedProjectsRequest;
 import com.umc.product.test.adapter.in.web.dto.SeedProjectsResponse;
 import com.umc.product.test.application.port.in.command.CreateSeedChallengerRoleUseCase;
 import com.umc.product.test.application.port.in.command.CreateSeedChallengerUseCase;
+import com.umc.product.test.application.port.in.command.CreateSeedMemberSystemRoleUseCase;
 import com.umc.product.test.application.port.in.command.CreateSeedMemberUseCase;
 import com.umc.product.test.application.port.in.command.DeleteSeedProjectDataUseCase;
 import com.umc.product.test.application.port.in.command.SeedChallengerPointsUseCase;
@@ -71,6 +74,7 @@ public class SeedController {
 
     private final SeedMembersUseCase seedMembersUseCase;
     private final CreateSeedMemberUseCase createSeedMemberUseCase;
+    private final CreateSeedMemberSystemRoleUseCase createSeedMemberSystemRoleUseCase;
     private final SeedChallengersUseCase seedChallengersUseCase;
     private final CreateSeedChallengerUseCase createSeedChallengerUseCase;
     private final CreateSeedChallengerRoleUseCase createSeedChallengerRoleUseCase;
@@ -110,6 +114,22 @@ public class SeedController {
     @PostMapping("/member")
     public CreateSeedMemberResponse createMember(@RequestBody @Valid CreateSeedMemberRequest request) {
         return CreateSeedMemberResponse.from(createSeedMemberUseCase.create(request.toCommand()));
+    }
+
+    @Operation(
+        operationId = "SEED-001-R",
+        summary = "테스트 회원 시스템 역할 부여",
+        description = """
+            회원 ID와 시스템 역할을 받아 비운영 환경의 테스트 회원에게 역할을 부여합니다.
+            현재 지원되는 역할은 SUPER_ADMIN이며, 같은 역할이 이미 있으면 새 행을 만들지 않습니다.
+            """
+    )
+    @PostMapping("/member-system-role")
+    public CreateSeedMemberSystemRoleResponse createMemberSystemRole(
+        @RequestBody @Valid CreateSeedMemberSystemRoleRequest request
+    ) {
+        return CreateSeedMemberSystemRoleResponse.from(
+            createSeedMemberSystemRoleUseCase.create(request.toCommand()));
     }
 
     @Operation(

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberSystemRoleRequest.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberSystemRoleRequest.java
@@ -1,0 +1,21 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "테스트 회원 시스템 역할 부여 요청")
+public record CreateSeedMemberSystemRoleRequest(
+    @Schema(description = "시스템 역할을 부여할 회원 ID", example = "1")
+    @NotNull(message = "회원 ID는 필수입니다") Long memberId,
+
+    @Schema(description = "부여할 시스템 역할", example = "SUPER_ADMIN")
+    @NotNull(message = "시스템 역할은 필수입니다") MemberSystemRoleType roleType
+) {
+
+    public CreateSeedMemberSystemRoleCommand toCommand() {
+        return new CreateSeedMemberSystemRoleCommand(memberId, roleType);
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberSystemRoleResponse.java
+++ b/src/main/java/com/umc/product/test/adapter/in/web/dto/CreateSeedMemberSystemRoleResponse.java
@@ -1,0 +1,27 @@
+package com.umc.product.test.adapter.in.web.dto;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleResult;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "테스트 회원 시스템 역할 부여 결과")
+public record CreateSeedMemberSystemRoleResponse(
+    @Schema(description = "시스템 역할을 부여한 회원 ID", example = "1")
+    Long memberId,
+
+    @Schema(description = "부여한 시스템 역할", example = "SUPER_ADMIN")
+    MemberSystemRoleType roleType,
+
+    @Schema(description = "이번 요청에서 새 역할 행을 생성했는지 여부", example = "true")
+    boolean created
+) {
+
+    public static CreateSeedMemberSystemRoleResponse from(CreateSeedMemberSystemRoleResult result) {
+        return new CreateSeedMemberSystemRoleResponse(
+            result.memberId(),
+            result.roleType(),
+            result.created()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/test/adapter/out/persistence/MemberSystemRoleSeedPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/test/adapter/out/persistence/MemberSystemRoleSeedPersistenceAdapter.java
@@ -1,0 +1,34 @@
+package com.umc.product.test.adapter.out.persistence;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.test.application.port.out.AssignSeedMemberSystemRolePort;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class MemberSystemRoleSeedPersistenceAdapter implements AssignSeedMemberSystemRolePort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public boolean assignIfAbsent(Long memberId, MemberSystemRoleType roleType) {
+        int inserted = entityManager.createNativeQuery("""
+                INSERT INTO member_system_role (created_at, updated_at, member_id, role_type)
+                VALUES (now(), now(), :memberId, :roleType)
+                ON CONFLICT (member_id, role_type) DO NOTHING
+                """)
+            .setParameter("memberId", memberId)
+            .setParameter("roleType", roleType.name())
+            .executeUpdate();
+
+        return inserted == 1;
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedMemberSystemRoleUseCase.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/CreateSeedMemberSystemRoleUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.test.application.port.in.command;
+
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleResult;
+
+public interface CreateSeedMemberSystemRoleUseCase {
+
+    CreateSeedMemberSystemRoleResult create(CreateSeedMemberSystemRoleCommand command);
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberSystemRoleCommand.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberSystemRoleCommand.java
@@ -1,0 +1,9 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+
+public record CreateSeedMemberSystemRoleCommand(
+    Long memberId,
+    MemberSystemRoleType roleType
+) {
+}

--- a/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberSystemRoleResult.java
+++ b/src/main/java/com/umc/product/test/application/port/in/command/dto/CreateSeedMemberSystemRoleResult.java
@@ -1,0 +1,18 @@
+package com.umc.product.test.application.port.in.command.dto;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+
+public record CreateSeedMemberSystemRoleResult(
+    Long memberId,
+    MemberSystemRoleType roleType,
+    boolean created
+) {
+
+    public static CreateSeedMemberSystemRoleResult of(
+        Long memberId,
+        MemberSystemRoleType roleType,
+        boolean created
+    ) {
+        return new CreateSeedMemberSystemRoleResult(memberId, roleType, created);
+    }
+}

--- a/src/main/java/com/umc/product/test/application/port/out/AssignSeedMemberSystemRolePort.java
+++ b/src/main/java/com/umc/product/test/application/port/out/AssignSeedMemberSystemRolePort.java
@@ -1,0 +1,8 @@
+package com.umc.product.test.application.port.out;
+
+import com.umc.product.member.domain.MemberSystemRoleType;
+
+public interface AssignSeedMemberSystemRolePort {
+
+    boolean assignIfAbsent(Long memberId, MemberSystemRoleType roleType);
+}

--- a/src/main/java/com/umc/product/test/application/service/MemberSystemRoleSeedService.java
+++ b/src/main/java/com/umc/product/test/application/service/MemberSystemRoleSeedService.java
@@ -1,0 +1,45 @@
+package com.umc.product.test.application.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.authorization.application.port.in.command.EvictAuthoritySnapshotCacheUseCase;
+import com.umc.product.member.application.port.in.query.CheckMemberExistenceUseCase;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+import com.umc.product.test.application.port.in.command.CreateSeedMemberSystemRoleUseCase;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleResult;
+import com.umc.product.test.application.port.out.AssignSeedMemberSystemRolePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class MemberSystemRoleSeedService implements CreateSeedMemberSystemRoleUseCase {
+
+    private final CheckMemberExistenceUseCase checkMemberExistenceUseCase;
+    private final AssignSeedMemberSystemRolePort assignSeedMemberSystemRolePort;
+    private final EvictAuthoritySnapshotCacheUseCase evictAuthoritySnapshotCacheUseCase;
+
+    @Override
+    @Transactional
+    public CreateSeedMemberSystemRoleResult create(CreateSeedMemberSystemRoleCommand command) {
+        if (!checkMemberExistenceUseCase.existsById(command.memberId())) {
+            throw new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        boolean created = assignSeedMemberSystemRolePort.assignIfAbsent(
+            command.memberId(), command.roleType());
+
+        // 기존 행이 있더라도 이전 테스트에서 남은 instance-local snapshot을 제거한다.
+        evictAuthoritySnapshotCacheUseCase.evictByMemberId(command.memberId());
+
+        return CreateSeedMemberSystemRoleResult.of(
+            command.memberId(), command.roleType(), created);
+    }
+}

--- a/src/main/resources/static/docs/demoday-draft.yaml
+++ b/src/main/resources/static/docs/demoday-draft.yaml
@@ -640,8 +640,10 @@ paths:
       operationId: getAdminDashboard
       security:
         - 'Access Token': []
-      summary: Poll 대시보드 통계 스냅샷 조회
+      summary: Poll 대시보드 통계 스냅샷 조회(제작 완료)
       description: |
+        제작 완료되었으므로 [Scalar 자동 생성본](/docs/scalar.html)를 확인해주세요
+
         요약 지표·투표 랭킹·스탬프 히트맵을 **하나의 스냅샷으로** 반환합니다.
         세 가지 모두 같은 Poll을 기준으로 하고, 데이터 규모가 부스 수 수준이며,
         같은 화면에서 비슷한 주기로 갱신되고, 같은 권한을 쓰기 때문에 API를 분리하지 않았습니다.

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollAdminControllerTest.java
@@ -26,7 +26,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.umc.product.demoday.application.port.in.command.ChangeDemodayPollStatusUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayEntryCodeUseCase;
 import com.umc.product.demoday.application.port.in.command.CreateDemodayPollUseCase;
+import com.umc.product.demoday.application.port.in.query.GetDemodayDashboardUseCase;
 import com.umc.product.demoday.application.port.in.query.GetDemodayVoteQrUseCase;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteQrInfo;
 import com.umc.product.demoday.domain.exception.DemodayDomainException;
 import com.umc.product.demoday.domain.exception.DemodayErrorCode;
@@ -54,6 +56,8 @@ class DemodayPollAdminControllerTest {
     @MockitoBean private CreateDemodayEntryCodeUseCase createDemodayEntryCodeUseCase;
 
     @MockitoBean private GetDemodayVoteQrUseCase getDemodayVoteQrUseCase;
+
+    @MockitoBean private GetDemodayDashboardUseCase getDemodayDashboardUseCase;
 
     @BeforeEach
     void setUp() {
@@ -114,6 +118,70 @@ class DemodayPollAdminControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/vote-qr", POLL_ID))
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED.getCode()));
+    }
+
+    @Test
+    @DisplayName("대시보드를 조회하면 요약·랭킹·히트맵을 하나의 스냅샷으로 반환한다")
+    void getDashboard() throws Exception {
+        // given
+        Instant generatedAt = Instant.parse("2026-08-14T06:30:00Z");
+        DemodayDashboardInfo info = new DemodayDashboardInfo(
+            POLL_ID,
+            generatedAt,
+            new DemodayDashboardInfo.SummaryInfo(3, 35),
+            List.of(
+                new DemodayDashboardInfo.RankingInfo(1, 9L, 509L, "잇픽", 20),
+                new DemodayDashboardInfo.RankingInfo(2, 4L, 504L, "모디", 15),
+                new DemodayDashboardInfo.RankingInfo(2, 7L, null, "외부 참가팀 A", 15)
+            ),
+            List.of(
+                new DemodayDashboardInfo.StampHeatmapInfo(4L, 504L, "모디", 123),
+                new DemodayDashboardInfo.StampHeatmapInfo(7L, null, "외부 참가팀 A", 0),
+                new DemodayDashboardInfo.StampHeatmapInfo(9L, 509L, "잇픽", 88)
+            )
+        );
+        given(getDemodayDashboardUseCase.getDashboard(POLL_ID, MEMBER_ID)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/dashboard", POLL_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.pollId").value(POLL_ID))
+            .andExpect(jsonPath("$.result.summary.boothCount").value(3))
+            .andExpect(jsonPath("$.result.summary.totalVoteCount").value(35))
+            .andExpect(jsonPath("$.result.rankings[0].rank").value(1))
+            .andExpect(jsonPath("$.result.rankings[0].boothId").value(9))
+            .andExpect(jsonPath("$.result.rankings[1].rank").value(2))
+            .andExpect(jsonPath("$.result.rankings[2].rank").value(2))
+            .andExpect(jsonPath("$.result.rankings[2].projectId").doesNotExist())
+            .andExpect(jsonPath("$.result.stampHeatmap[1].stampCount").value(0));
+
+        then(getDemodayDashboardUseCase).should().getDashboard(POLL_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Poll을 대시보드로 조회하면 오류 코드를 반환한다")
+    void getDashboardWhenPollNotFound() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND))
+            .given(getDemodayDashboardUseCase)
+            .getDashboard(POLL_ID, MEMBER_ID);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/dashboard", POLL_ID))
+            .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 대시보드 조회도 접근 오류 코드를 반환한다")
+    void getDashboardWhenNotAdmin() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED))
+            .given(getDemodayDashboardUseCase)
+            .getDashboard(POLL_ID, MEMBER_ID);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/admin/polls/{pollId}/dashboard", POLL_ID))
             .andExpect(jsonPath("$.code").value(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED.getCode()));
     }
 }

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayDashboardQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayDashboardQueryServiceTest.java
@@ -1,0 +1,155 @@
+package com.umc.product.demoday.application.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayDashboardInfo;
+import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayDashboardPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.project.application.port.in.query.GetProjectUseCase;
+import com.umc.product.project.application.port.in.query.dto.ProjectInfo;
+
+@ExtendWith(MockitoExtension.class)
+class DemodayDashboardQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GISU_ID = 8L;
+    private static final Long POLL_ID = 10L;
+
+    @Mock private DemodayAdminAccessChecker adminAccessChecker;
+    @Mock private LoadDemodayPollPort loadDemodayPollPort;
+    @Mock private LoadDemodayBoothPort loadDemodayBoothPort;
+    @Mock private LoadDemodayDashboardPort loadDemodayDashboardPort;
+    @Mock private GetProjectUseCase getProjectUseCase;
+
+    private DemodayDashboardQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-14T06:30:00Z"), ZoneOffset.UTC);
+        service = new DemodayDashboardQueryService(
+            adminAccessChecker,
+            loadDemodayPollPort,
+            loadDemodayBoothPort,
+            loadDemodayDashboardPort,
+            getProjectUseCase,
+            clock
+        );
+    }
+
+    @Test
+    @DisplayName("득표가 동점이면 같은 rank를 공유하고 다음 rank는 동점자 수만큼 건너뛴다")
+    void assignsCompetitionRanking() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getGisuId()).willReturn(GISU_ID);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        DemodayBooth booth1 = projectBooth(1L, 501L);
+        DemodayBooth booth2 = projectBooth(2L, 502L);
+        DemodayBooth booth3 = externalBooth(3L, "외부 참가팀 A");
+        DemodayBooth booth4 = externalBooth(4L, "외부 참가팀 B");
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(booth1, booth2, booth3, booth4));
+
+        given(loadDemodayDashboardPort.countActiveVotesByBooth(POLL_ID)).willReturn(Map.of(
+            1L, 20L,
+            2L, 15L,
+            3L, 15L
+            // booth4는 집계에 없음 -> 0표로 취급되어야 한다
+        ));
+        given(loadDemodayDashboardPort.countActiveStampsByBooth(POLL_ID)).willReturn(Map.of());
+        given(getProjectUseCase.findAllByIds(Set.of(501L, 502L))).willReturn(Map.of(
+            501L, projectInfo(501L, "잇픽"),
+            502L, projectInfo(502L, "모디")
+        ));
+
+        // when
+        DemodayDashboardInfo info = service.getDashboard(POLL_ID, MEMBER_ID);
+
+        // then
+        assertThat(info.summary().boothCount()).isEqualTo(4);
+        assertThat(info.summary().totalVoteCount()).isEqualTo(50);
+
+        List<DemodayDashboardInfo.RankingInfo> rankings = info.rankings();
+        assertThat(rankings).containsExactly(
+            new DemodayDashboardInfo.RankingInfo(1, 1L, 501L, "잇픽", 20),
+            new DemodayDashboardInfo.RankingInfo(2, 2L, 502L, "모디", 15),
+            new DemodayDashboardInfo.RankingInfo(2, 3L, null, "외부 참가팀 A", 15),
+            new DemodayDashboardInfo.RankingInfo(4, 4L, null, "외부 참가팀 B", 0)
+        );
+
+        verifyAdminAccessValidated();
+    }
+
+    @Test
+    @DisplayName("스탬프가 0건인 부스도 boothId 오름차순으로 히트맵에 포함된다")
+    void includesZeroStampBoothsInHeatmap() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getGisuId()).willReturn(GISU_ID);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+
+        DemodayBooth booth1 = externalBooth(1L, "부스 A");
+        DemodayBooth booth2 = externalBooth(2L, "부스 B");
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(booth2, booth1));
+
+        given(loadDemodayDashboardPort.countActiveVotesByBooth(POLL_ID)).willReturn(Map.of());
+        given(loadDemodayDashboardPort.countActiveStampsByBooth(POLL_ID)).willReturn(Map.of(1L, 5L));
+        given(getProjectUseCase.findAllByIds(Set.of())).willReturn(Map.of());
+
+        // when
+        DemodayDashboardInfo info = service.getDashboard(POLL_ID, MEMBER_ID);
+
+        // then
+        assertThat(info.stampHeatmap()).containsExactly(
+            new DemodayDashboardInfo.StampHeatmapInfo(1L, null, "부스 A", 5),
+            new DemodayDashboardInfo.StampHeatmapInfo(2L, null, "부스 B", 0)
+        );
+    }
+
+    private void verifyAdminAccessValidated() {
+        then(adminAccessChecker).should().validateAdminAccess(MEMBER_ID, GISU_ID);
+    }
+
+    private DemodayBooth projectBooth(Long boothId, Long projectId) {
+        DemodayBooth booth = mock(DemodayBooth.class);
+        given(booth.getId()).willReturn(boothId);
+        given(booth.getProjectId()).willReturn(projectId);
+        return booth;
+    }
+
+    private DemodayBooth externalBooth(Long boothId, String displayName) {
+        DemodayBooth booth = mock(DemodayBooth.class);
+        given(booth.getId()).willReturn(boothId);
+        // Mockito는 미스텁 boxed Long을 null이 아닌 0L로 기본 응답한다. projectId가 없는
+        // 부스임을 명시하기 위해 null을 직접 스텁해야 projectIdsOf()의 nonNull 필터가 정확히 동작한다.
+        given(booth.getProjectId()).willReturn(null);
+        given(booth.getDisplayName()).willReturn(displayName);
+        return booth;
+    }
+
+    private ProjectInfo projectInfo(Long projectId, String name) {
+        return ProjectInfo.builder().id(projectId).name(name).build();
+    }
+}

--- a/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
+++ b/src/test/java/com/umc/product/test/adapter/in/web/SeedControllerBeanRegistrationTest.java
@@ -8,12 +8,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 
+import com.umc.product.test.adapter.out.persistence.MemberSystemRoleSeedPersistenceAdapter;
 import com.umc.product.test.application.service.ChallengerSeedService;
 import com.umc.product.test.application.service.CurriculumSeedService;
 import com.umc.product.test.application.service.DummyCurriculumFactory;
 import com.umc.product.test.application.service.DummyMemberFactory;
 import com.umc.product.test.application.service.DummyNoticeFactory;
 import com.umc.product.test.application.service.MemberSeedService;
+import com.umc.product.test.application.service.MemberSystemRoleSeedService;
 import com.umc.product.test.application.service.NoticeSeedService;
 import com.umc.product.test.application.service.PartAssignmentPolicy;
 import com.umc.product.test.application.service.ProjectApplicationSeedService;
@@ -34,6 +36,8 @@ class SeedControllerBeanRegistrationTest {
     @ValueSource(classes = {
         SeedController.class,
         MemberSeedService.class,
+        MemberSystemRoleSeedService.class,
+        MemberSystemRoleSeedPersistenceAdapter.class,
         ChallengerSeedService.class,
         ProjectSeedService.class,
         ProjectSeedDataCleanupService.class,

--- a/src/test/java/com/umc/product/test/adapter/out/persistence/MemberSystemRoleSeedPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/test/adapter/out/persistence/MemberSystemRoleSeedPersistenceAdapterTest.java
@@ -1,0 +1,55 @@
+package com.umc.product.test.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.umc.product.member.domain.Member;
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "app.seed.enabled=true")
+@Import(MemberSystemRoleSeedPersistenceAdapter.class)
+class MemberSystemRoleSeedPersistenceAdapterTest {
+
+    @Autowired private TestEntityManager entityManager;
+    @Autowired private MemberSystemRoleSeedPersistenceAdapter sut;
+
+    @Test
+    @DisplayName("같은 회원의 SUPER_ADMIN 역할은 한 행만 생성한다")
+    void assignSuperAdminOnlyOnce() {
+        // given
+        Member member = Member.create("테스트 관리자", "테스트관리자", "seed-admin@test.com", null, null);
+        entityManager.persistAndFlush(member);
+
+        // when
+        boolean firstCreated = sut.assignIfAbsent(member.getId(), MemberSystemRoleType.SUPER_ADMIN);
+        boolean secondCreated = sut.assignIfAbsent(member.getId(), MemberSystemRoleType.SUPER_ADMIN);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Long count = entityManager.getEntityManager()
+            .createQuery("""
+                SELECT count(role)
+                FROM MemberSystemRole role
+                WHERE role.memberId = :memberId
+                  AND role.roleType = :roleType
+                """, Long.class)
+            .setParameter("memberId", member.getId())
+            .setParameter("roleType", MemberSystemRoleType.SUPER_ADMIN)
+            .getSingleResult();
+
+        assertThat(firstCreated).isTrue();
+        assertThat(secondCreated).isFalse();
+        assertThat(count).isOne();
+    }
+}

--- a/src/test/java/com/umc/product/test/application/service/MemberSystemRoleSeedServiceTest.java
+++ b/src/test/java/com/umc/product/test/application/service/MemberSystemRoleSeedServiceTest.java
@@ -1,0 +1,87 @@
+package com.umc.product.test.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.authorization.application.port.in.command.EvictAuthoritySnapshotCacheUseCase;
+import com.umc.product.member.application.port.in.query.CheckMemberExistenceUseCase;
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleCommand;
+import com.umc.product.test.application.port.in.command.dto.CreateSeedMemberSystemRoleResult;
+import com.umc.product.test.application.port.out.AssignSeedMemberSystemRolePort;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberSystemRoleSeedService")
+class MemberSystemRoleSeedServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock private CheckMemberExistenceUseCase checkMemberExistenceUseCase;
+    @Mock private AssignSeedMemberSystemRolePort assignSeedMemberSystemRolePort;
+    @Mock private EvictAuthoritySnapshotCacheUseCase evictAuthoritySnapshotCacheUseCase;
+
+    @InjectMocks private MemberSystemRoleSeedService sut;
+
+    @Test
+    @DisplayName("존재하는 회원에게 SUPER_ADMIN 역할을 새로 부여한다")
+    void createSuperAdminRole() {
+        // given
+        given(checkMemberExistenceUseCase.existsById(MEMBER_ID)).willReturn(true);
+        given(assignSeedMemberSystemRolePort.assignIfAbsent(
+            MEMBER_ID, MemberSystemRoleType.SUPER_ADMIN)).willReturn(true);
+
+        // when
+        CreateSeedMemberSystemRoleResult result = sut.create(command());
+
+        // then
+        assertThat(result.memberId()).isEqualTo(MEMBER_ID);
+        assertThat(result.roleType()).isEqualTo(MemberSystemRoleType.SUPER_ADMIN);
+        assertThat(result.created()).isTrue();
+        then(evictAuthoritySnapshotCacheUseCase).should().evictByMemberId(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("이미 같은 역할이 있으면 중복 행 없이 권한 캐시만 제거한다")
+    void keepExistingSuperAdminRole() {
+        // given
+        given(checkMemberExistenceUseCase.existsById(MEMBER_ID)).willReturn(true);
+        given(assignSeedMemberSystemRolePort.assignIfAbsent(
+            MEMBER_ID, MemberSystemRoleType.SUPER_ADMIN)).willReturn(false);
+
+        // when
+        CreateSeedMemberSystemRoleResult result = sut.create(command());
+
+        // then
+        assertThat(result.created()).isFalse();
+        then(evictAuthoritySnapshotCacheUseCase).should().evictByMemberId(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원에게는 시스템 역할을 부여하지 않는다")
+    void rejectMissingMember() {
+        // given
+        given(checkMemberExistenceUseCase.existsById(MEMBER_ID)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> sut.create(command()))
+            .isInstanceOf(MemberDomainException.class);
+        then(assignSeedMemberSystemRolePort).should(never())
+            .assignIfAbsent(MEMBER_ID, MemberSystemRoleType.SUPER_ADMIN);
+        then(evictAuthoritySnapshotCacheUseCase).shouldHaveNoInteractions();
+    }
+
+    private CreateSeedMemberSystemRoleCommand command() {
+        return new CreateSeedMemberSystemRoleCommand(MEMBER_ID, MemberSystemRoleType.SUPER_ADMIN);
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

resolves #1261

### 무엇을
데모데이 관리자용 대시보드 조회 API(`GET /api/v1/demoday/admin/polls/{pollId}/dashboard`)를 추가했다. 부스별 요약 지표, 득표 랭킹, 스탬프 히트맵을 하나의 스냅샷으로 반환한다.

### 어떻게
- Hexagonal 구조를 따라 `GetDemodayDashboardUseCase` / `LoadDemodayDashboardPort`를 새로 정의하고, QueryDSL 기반 `DemodayDashboardQueryRepository` → `DemodayDashboardPersistenceAdapter`에서 부스별 유효(무효 처리 제외) 득표수·스탬프수를 집계한다.
- `DemodayDashboardQueryService`가 poll 조회 → 관리자 권한 검증(`DemodayAdminAccessChecker`) → 부스 전체 목록 조회 → 득표/스탬프 집계 → `GetProjectUseCase.findAllByIds`로 프로젝트명 배치 조회 순으로 하나의 읽기 전용 트랜잭션에서 스냅샷을 조립한다.
- 득표 랭킹은 득표 내림차순 + boothId 오름차순 정렬 후 표준 경쟁 순위(동점이면 같은 rank 공유, 다음 rank는 동점자 수만큼 skip)로 매긴다.
- 랭킹·히트맵 모두 집계 결과에 없는 부스(득표/스탬프 0건)도 부스 전체 목록 기준으로 0으로 채워 반환한다.
- 프로젝트 연동 부스는 project 도메인에서 이름을 조회하고, 참조가 깨졌거나 외부 참가팀 부스면 booth 자체의 displayName으로 대체한다.

### 왜
운영진이 투표 마감 후 결과를 확인하려면 별도 정산 없이 바로 볼 수 있는 화면이 필요했다. 동점 부스를 같은 순위로 보여주고 득표·스탬프가 0건인 부스도 누락 없이 노출해야 시상 발표에서 "공동 2위"나 무득표 참가팀을 정확히 전달할 수 있어서, 두 요건을 대시보드 조립 로직에 명시적으로 반영했다.

### 결과
- 신규 유닛 테스트 2건(`DemodayDashboardQueryServiceTest`): 동점 랭킹 산정, 0-스탬프 부스가 히트맵에 포함되는지 검증
- 컨트롤러 슬라이스 테스트 3건(`DemodayPollAdminControllerTest`): 정상 응답, poll 미존재, 관리자 권한 없음
- API 명세(`demoday-draft.yaml`)에 제작 완료 표시 반영

## 💬 리뷰 중점사항

- `DemodayDashboardQueryRepository` / `DemodayDashboardPersistenceAdapter` — 무효 처리(revoked) 제외 조건과, `demoday_stamp`에 poll_id 컬럼이 없어 booth 조인으로 poll을 스코프하는 집계 쿼리
- `DemodayDashboardQueryService.buildRankings()` — 표준 경쟁 순위(동점 처리) 로직
- `DemodayDashboardQueryService.resolveDisplayName()` — 프로젝트 참조가 깨졌을 때의 displayName 폴백 처리
