### PR TITLE
[Feat] 데모데이 테스트 데이터 초기화 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -307,6 +307,8 @@ CDN_PRIVATE_KEY_PARAMETER_NAME=/umc/common/cloudfront/private-key
 # ------------------------------------------------------------------
 # Demoday
 # ------------------------------------------------------------------
+# 운영 외 환경 전용 테스트 데이터 초기화 API. prod 프로필에서는 true여도 빈이 등록되지 않는다.
+DEMODAY_TEST_DATA_RESET_ENABLED=false
 # Base64-encoded 32-byte AES-256-GCM key
 DEMODAY_STAMP_CREDENTIAL_ENCRYPTION_KEY=<BASE64_ENCODED_32_BYTE_KEY>
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataAdminController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataAdminController.java
@@ -1,0 +1,78 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayTestDataResetApiResponse;
+import com.umc.product.demoday.adapter.in.web.dto.response.DemodayTestDataResetResponse;
+import com.umc.product.demoday.application.port.in.command.ResetDemodayTestDataUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.annotation.CurrentMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(
+    name = "데모데이 테스트 데이터 관리자",
+    description = "비운영 환경에서 SUPER_ADMIN이 데모데이 테스트 데이터를 초기화하는 API"
+)
+@RestController
+@RequestMapping("/api/v1/demoday/admin/test-data")
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "demoday.test-data-reset", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class DemodayTestDataAdminController {
+
+    private final ResetDemodayTestDataUseCase resetDemodayTestDataUseCase;
+
+    @Operation(
+        operationId = "resetDemodayTestData",
+        summary = "데모데이 테스트 데이터 전체 초기화 (SUPER_ADMIN 전용)",
+        description = """
+            **이 API는 비운영 환경에서만 활성화되며 SUPER_ADMIN만 호출할 수 있습니다.**
+            데모데이 Poll, 부스, 외부인 입장 코드, 스탬프, 표를 외래 키에 안전한 순서로 모두 삭제합니다.
+
+            전체 삭제는 하나의 트랜잭션에서 실행되므로 중간에 실패하면 전부 롤백됩니다.
+            이미 데이터가 없는 상태에서 다시 호출해도 성공하며, 각 응답 필드는 `0`을 반환합니다.
+            공통 응답의 `result`는 데이터 종류별로 실제 삭제된 행 수를 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "초기화 성공",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = DemodayTestDataResetApiResponse.class)
+            )
+        ),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+        @ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한이 없음")
+    })
+    @DeleteMapping
+    public DemodayTestDataResetResponse reset(
+        @Parameter(hidden = true) @CurrentMember MemberPrincipal principal
+    ) {
+        DemodayTestDataResetInfo info = resetDemodayTestDataUseCase.reset(requireMemberId(principal));
+        return DemodayTestDataResetResponse.from(info);
+    }
+
+    private Long requireMemberId(MemberPrincipal principal) {
+        if (principal == null) {
+            throw new AccessDeniedException("회원 인증이 필요한 데모데이 관리자 API입니다.");
+        }
+        return principal.getMemberId();
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayTestDataResetApiResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayTestDataResetApiResponse.java
@@ -1,0 +1,19 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 성공 응답으로 감싼 데모데이 테스트 데이터 초기화 결과")
+public record DemodayTestDataResetApiResponse(
+    @Schema(description = "요청 성공 여부", example = "true")
+    boolean success,
+
+    @Schema(description = "응답 코드", example = "COMMON200")
+    String code,
+
+    @Schema(description = "응답 메시지", example = "성공입니다.")
+    String message,
+
+    @Schema(description = "데모데이 테스트 데이터 초기화 결과")
+    DemodayTestDataResetResponse result
+) {
+}

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayTestDataResetResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayTestDataResetResponse.java
@@ -1,0 +1,34 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "데모데이 테스트 데이터 초기화 결과")
+public record DemodayTestDataResetResponse(
+    @Schema(description = "삭제된 Poll 수", example = "1")
+    int deletedPolls,
+
+    @Schema(description = "삭제된 부스 수", example = "20")
+    int deletedBooths,
+
+    @Schema(description = "삭제된 외부인 입장 코드 수", example = "200")
+    int deletedEntryCodes,
+
+    @Schema(description = "삭제된 스탬프 수", example = "500")
+    int deletedStamps,
+
+    @Schema(description = "삭제된 표 수", example = "150")
+    int deletedVotes
+) {
+
+    public static DemodayTestDataResetResponse from(DemodayTestDataResetInfo info) {
+        return new DemodayTestDataResetResponse(
+            info.deletedPolls(),
+            info.deletedBooths(),
+            info.deletedEntryCodes(),
+            info.deletedStamps(),
+            info.deletedVotes()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayTestDataCleanupPersistenceAdapter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayTestDataCleanupPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package com.umc.product.demoday.adapter.out.persistence;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.DeleteDemodayTestDataPort;
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "demoday.test-data-reset", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class DemodayTestDataCleanupPersistenceAdapter implements DeleteDemodayTestDataPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public DemodayTestDataDeletionCounts deleteAll() {
+        int deletedStamps = entityManager.createNativeQuery("DELETE FROM demoday_stamp").executeUpdate();
+        int deletedVotes = entityManager.createNativeQuery("DELETE FROM demoday_vote").executeUpdate();
+        int deletedEntryCodes = entityManager.createNativeQuery("DELETE FROM demoday_entry_code").executeUpdate();
+        int deletedBooths = entityManager.createNativeQuery("DELETE FROM demoday_booth").executeUpdate();
+        int deletedPolls = entityManager.createNativeQuery("DELETE FROM demoday_poll").executeUpdate();
+
+        return new DemodayTestDataDeletionCounts(
+            deletedPolls,
+            deletedBooths,
+            deletedEntryCodes,
+            deletedStamps,
+            deletedVotes
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/ResetDemodayTestDataUseCase.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/ResetDemodayTestDataUseCase.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.in.command;
+
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+
+public interface ResetDemodayTestDataUseCase {
+
+    DemodayTestDataResetInfo reset(Long requesterMemberId);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/DemodayTestDataResetInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/DemodayTestDataResetInfo.java
@@ -1,0 +1,22 @@
+package com.umc.product.demoday.application.port.in.command.dto;
+
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+
+public record DemodayTestDataResetInfo(
+    int deletedPolls,
+    int deletedBooths,
+    int deletedEntryCodes,
+    int deletedStamps,
+    int deletedVotes
+) {
+
+    public static DemodayTestDataResetInfo from(DemodayTestDataDeletionCounts counts) {
+        return new DemodayTestDataResetInfo(
+            counts.deletedPolls(),
+            counts.deletedBooths(),
+            counts.deletedEntryCodes(),
+            counts.deletedStamps(),
+            counts.deletedVotes()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/DeleteDemodayTestDataPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/DeleteDemodayTestDataPort.java
@@ -1,0 +1,8 @@
+package com.umc.product.demoday.application.port.out;
+
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+
+public interface DeleteDemodayTestDataPort {
+
+    DemodayTestDataDeletionCounts deleteAll();
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/dto/DemodayTestDataDeletionCounts.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/dto/DemodayTestDataDeletionCounts.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.out.dto;
+
+public record DemodayTestDataDeletionCounts(
+    int deletedPolls,
+    int deletedBooths,
+    int deletedEntryCodes,
+    int deletedStamps,
+    int deletedVotes
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/service/command/ResetDemodayTestDataCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/ResetDemodayTestDataCommandService.java
@@ -1,0 +1,42 @@
+package com.umc.product.demoday.application.service.command;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.demoday.application.port.in.command.ResetDemodayTestDataUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+import com.umc.product.demoday.application.port.out.DeleteDemodayTestDataPort;
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.global.exception.constant.Domain;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Profile("!prod")
+@ConditionalOnProperty(prefix = "demoday.test-data-reset", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Transactional
+public class ResetDemodayTestDataCommandService implements ResetDemodayTestDataUseCase {
+
+    private final DemodayAdminAccessChecker adminAccessChecker;
+    private final DeleteDemodayTestDataPort deleteDemodayTestDataPort;
+
+    @Override
+    @Audited(
+        domain = Domain.DEMODAY,
+        action = AuditAction.DELETE,
+        targetType = "DemodayTestData",
+        description = "'데모데이 테스트 데이터를 초기화했습니다.'"
+    )
+    public DemodayTestDataResetInfo reset(Long requesterMemberId) {
+        adminAccessChecker.validateSystemAdminAccess(requesterMemberId);
+
+        DemodayTestDataDeletionCounts counts = deleteDemodayTestDataPort.deleteAll();
+        return DemodayTestDataResetInfo.from(counts);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,6 +171,9 @@ jwt:
   verification-token-validity-in-seconds: ${JWT_VERIFICATION_TOKEN_VALIDITY_IN_SECONDS:600}
 
 demoday:
+  # 운영 외 환경의 데모데이 테스트 데이터 초기화 API. 기본은 비활성이고 prod에서는 빈 등록도 차단한다.
+  test-data-reset:
+    enabled: ${DEMODAY_TEST_DATA_RESET_ENABLED:false}
   qr:
     base-url: ${DEMODAY_QR_BASE_URL}
   stamp-credential:
@@ -592,6 +595,10 @@ spring:
         enabled: true
     graphiql:
       enabled: ${GRAPHQL_GRAPHIQL_ENABLED:true}
+
+demoday:
+  test-data-reset:
+    enabled: ${DEMODAY_TEST_DATA_RESET_ENABLED:true}
 
 app:
   client-context:

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataAdminControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataAdminControllerTest.java
@@ -1,0 +1,114 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.umc.product.demoday.application.port.in.command.ResetDemodayTestDataUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.global.config.JacksonConfig;
+import com.umc.product.global.security.JwtTokenProvider;
+import com.umc.product.global.security.MemberPrincipal;
+
+@WebMvcTest(controllers = DemodayTestDataAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(JacksonConfig.class)
+@TestPropertySource(properties = "demoday.test-data-reset.enabled=true")
+@DisplayName("DemodayTestDataAdminController")
+class DemodayTestDataAdminControllerTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String RESET_PATH = "/api/v1/demoday/admin/test-data";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private ResetDemodayTestDataUseCase resetDemodayTestDataUseCase;
+
+    @BeforeEach
+    void setUp() {
+        MemberPrincipal principal = MemberPrincipal.builder().memberId(MEMBER_ID).build();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("테스트 데이터를 초기화하면 200과 테이블별 삭제 건수를 반환한다")
+    void resetTestData() throws Exception {
+        // given
+        DemodayTestDataResetInfo info = new DemodayTestDataResetInfo(2, 3, 4, 5, 6);
+        given(resetDemodayTestDataUseCase.reset(MEMBER_ID)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(delete(RESET_PATH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.deletedPolls").value(2))
+            .andExpect(jsonPath("$.result.deletedBooths").value(3))
+            .andExpect(jsonPath("$.result.deletedEntryCodes").value(4))
+            .andExpect(jsonPath("$.result.deletedStamps").value(5))
+            .andExpect(jsonPath("$.result.deletedVotes").value(6));
+
+        then(resetDemodayTestDataUseCase).should().reset(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN 권한이 없으면 403과 DEMODAY-0600을 반환한다")
+    void rejectResetWhenSystemAdminAccessIsDenied() throws Exception {
+        // given
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED))
+            .given(resetDemodayTestDataUseCase)
+            .reset(MEMBER_ID);
+
+        // when & then
+        mockMvc.perform(delete(RESET_PATH))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("DEMODAY-0600"));
+
+        then(resetDemodayTestDataUseCase).should().reset(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("회원이 아닌 데모데이 참여자 인증은 403으로 거부하고 초기화를 호출하지 않는다")
+    void rejectResetForNonMemberPrincipal() throws Exception {
+        // given
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("demoday-guest", null, List.of()));
+
+        // when & then
+        mockMvc.perform(delete(RESET_PATH))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("COMMON-403"));
+
+        then(resetDemodayTestDataUseCase).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataOpenApiContractIntegrationTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataOpenApiContractIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.umc.product.support.IntegrationTestSupport;
+
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = {
+    "springdoc.api-docs.enabled=true",
+    "demoday.test-data-reset.enabled=true"
+})
+@DisplayName("데모데이 테스트 데이터 초기화 runtime OpenAPI 계약")
+class DemodayTestDataOpenApiContractIntegrationTest extends IntegrationTestSupport {
+
+    private static final String RESET_PATH = "/api/v1/demoday/admin/test-data";
+    private static final String API_RESPONSE_SCHEMA = "DemodayTestDataResetApiResponse";
+    private static final String RESPONSE_SCHEMA = "DemodayTestDataResetResponse";
+    private static final List<String> COUNT_FIELDS = List.of(
+        "deletedPolls",
+        "deletedBooths",
+        "deletedEntryCodes",
+        "deletedStamps",
+        "deletedVotes"
+    );
+
+    @Test
+    @DisplayName("runtime OpenAPI는 초기화 DELETE 경로와 삭제 건수 응답 스키마를 노출한다")
+    void runtimeOpenApiExposesResetContract() throws Exception {
+        // given
+        String openApiJson = mockMvc.perform(get("/docs-json"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        JsonNode openApi = objectMapper.readTree(openApiJson);
+
+        // when
+        JsonNode deleteOperation = openApi.path("paths").path(RESET_PATH).path("delete");
+        JsonNode responseSchema = deleteOperation
+            .path("responses")
+            .path("200")
+            .path("content")
+            .path("application/json")
+            .path("schema");
+        JsonNode apiResponseProperties = openApi
+            .path("components")
+            .path("schemas")
+            .path(API_RESPONSE_SCHEMA)
+            .path("properties");
+        JsonNode countProperties = openApi
+            .path("components")
+            .path("schemas")
+            .path(RESPONSE_SCHEMA)
+            .path("properties");
+
+        // then
+        assertThat(deleteOperation.isMissingNode()).isFalse();
+        assertThat(deleteOperation.path("operationId").asText())
+            .isEqualTo("resetDemodayTestData");
+        assertThat(responseSchema.path("$ref").asText())
+            .isEqualTo("#/components/schemas/" + API_RESPONSE_SCHEMA);
+        assertThat(fieldNames(apiResponseProperties))
+            .containsExactlyInAnyOrder("success", "code", "message", "result");
+        assertThat(apiResponseProperties.path("success").path("type").asText()).isEqualTo("boolean");
+        assertThat(apiResponseProperties.path("code").path("type").asText()).isEqualTo("string");
+        assertThat(apiResponseProperties.path("message").path("type").asText()).isEqualTo("string");
+        assertThat(apiResponseProperties.path("result").path("$ref").asText())
+            .isEqualTo("#/components/schemas/" + RESPONSE_SCHEMA);
+        assertThat(fieldNames(countProperties)).containsExactlyInAnyOrderElementsOf(COUNT_FIELDS);
+        COUNT_FIELDS.forEach(field -> {
+            assertThat(countProperties.path(field).path("type").asText()).isEqualTo("integer");
+            assertThat(countProperties.path(field).path("format").asText()).isEqualTo("int32");
+        });
+    }
+
+    private static List<String> fieldNames(JsonNode node) {
+        List<String> names = new ArrayList<>();
+        node.fieldNames().forEachRemaining(names::add);
+        return List.copyOf(names);
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataResetBeanRegistrationTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayTestDataResetBeanRegistrationTest.java
@@ -1,0 +1,43 @@
+package com.umc.product.demoday.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+
+import com.umc.product.demoday.adapter.out.persistence.DemodayTestDataCleanupPersistenceAdapter;
+import com.umc.product.demoday.application.service.command.ResetDemodayTestDataCommandService;
+
+@DisplayName("데모데이 테스트 데이터 초기화 빈 등록 조건")
+class DemodayTestDataResetBeanRegistrationTest {
+
+    @ParameterizedTest(name = "{0}은 운영 환경 제외 및 활성화 속성 가드를 가진다")
+    @ValueSource(classes = {
+        DemodayTestDataAdminController.class,
+        ResetDemodayTestDataCommandService.class,
+        DemodayTestDataCleanupPersistenceAdapter.class
+    })
+    @DisplayName("모든 초기화 빈은 @Profile(!prod)와 enabled=true 가드를 함께 가진다")
+    void resetBeanGuardAnnotationsExist(Class<?> resetBeanClass) {
+        Profile profile = resetBeanClass.getAnnotation(Profile.class);
+        assertThat(profile)
+            .as("%s는 @Profile 가드가 있어야 한다", resetBeanClass.getSimpleName())
+            .isNotNull();
+        assertThat(profile.value())
+            .as("%s의 @Profile은 !prod를 포함해야 한다", resetBeanClass.getSimpleName())
+            .contains("!prod");
+
+        ConditionalOnProperty property =
+            resetBeanClass.getAnnotation(ConditionalOnProperty.class);
+        assertThat(property)
+            .as("%s는 @ConditionalOnProperty 가드가 있어야 한다", resetBeanClass.getSimpleName())
+            .isNotNull();
+        assertThat(property.prefix()).isEqualTo("demoday.test-data-reset");
+        assertThat(property.name()).containsExactly("enabled");
+        assertThat(property.havingValue()).isEqualTo("true");
+        assertThat(property.matchIfMissing()).isFalse();
+    }
+}

--- a/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayTestDataCleanupPersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayTestDataCleanupPersistenceAdapterTest.java
@@ -1,0 +1,337 @@
+package com.umc.product.demoday.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.umc.product.authorization.domain.ChallengerRole;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.demoday.application.port.out.DeleteDemodayTestDataPort;
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+import com.umc.product.demoday.domain.DemodayBooth;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.DemodayStamp;
+import com.umc.product.demoday.domain.DemodayVote;
+import com.umc.product.member.domain.Member;
+import com.umc.product.member.domain.MemberSystemRole;
+import com.umc.product.member.domain.MemberSystemRoleType;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "demoday.test-data-reset.enabled=true")
+@Import(DemodayTestDataCleanupPersistenceAdapter.class)
+@DisplayName("DemodayTestDataCleanupPersistenceAdapter")
+class DemodayTestDataCleanupPersistenceAdapterTest {
+
+    private static final Instant OPENS_AT = Instant.parse("2026-08-21T09:00:00Z");
+    private static final Instant CLOSES_AT = Instant.parse("2026-08-21T12:00:00Z");
+    private static final Instant GISU_START_AT = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant GISU_END_AT = Instant.parse("2026-12-31T00:00:00Z");
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    DeleteDemodayTestDataPort sut;
+
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    @Test
+    @DisplayName("데모데이 5개 테이블을 FK 역순으로 모두 삭제하고 정확한 건수를 반환한다")
+    void deleteAllDemodayTestData() {
+        // Given
+        NonDemodaySentinels sentinels = persistNonDemodaySentinels();
+        DemodayRows rows = persistDemodayRows(sentinels.gisuId(), sentinels.memberId());
+        em.flush();
+        em.clear();
+
+        // When
+        DemodayTestDataDeletionCounts result = sut.deleteAll();
+        em.clear();
+
+        // Then
+        assertDeletionCounts(result, rows);
+        assertDemodayTableCounts(TableCounts.empty());
+        assertNonDemodaySentinelsExist(sentinels);
+    }
+
+    @Test
+    @DisplayName("이미 비어 있는 데모데이 테스트 데이터 삭제를 반복하면"
+        + " 모든 삭제 건수가 0이다")
+    void returnZeroCountsWhenDeleteAllIsRepeated() {
+        // Given
+        DemodayRows rows = persistDemodayRows(9L, 100L);
+        em.flush();
+        em.clear();
+        assertDeletionCounts(sut.deleteAll(), rows);
+
+        // When
+        DemodayTestDataDeletionCounts result = sut.deleteAll();
+
+        // Then
+        assertDeletionCounts(result, DemodayRows.empty());
+        assertDemodayTableCounts(TableCounts.empty());
+    }
+
+    @Test
+    @DisplayName("일반 DELETE는 데모데이 5개 테이블의 identity sequence를 초기화하지 않는다")
+    void keepDemodayIdentitySequences() {
+        // Given
+        DemodayRows rows = persistDemodayRows(9L, 100L);
+        em.flush();
+        em.clear();
+        sut.deleteAll();
+        em.clear();
+
+        // When
+        DemodayPoll recreatedPoll = em.persist(createPoll(9L, "초기화 후 Poll"));
+        DemodayBooth recreatedBooth = em.persist(DemodayBooth.forProject(recreatedPoll.getId(), 300L));
+        DemodayEntryCode recreatedEntryCode = em.persist(DemodayEntryCode.create(recreatedPoll.getId(), hash('c')));
+        DemodayVote recreatedVote = em.persist(DemodayVote.forVisitor(
+            recreatedPoll.getId(),
+            recreatedEntryCode,
+            recreatedBooth
+        ));
+        DemodayStamp recreatedStamp = em.persist(DemodayStamp.forVisitor(recreatedEntryCode, recreatedBooth));
+        em.flush();
+
+        // Then
+        assertThat(recreatedPoll.getId()).isGreaterThan(rows.maxPollId());
+        assertThat(recreatedBooth.getId()).isGreaterThan(rows.maxBoothId());
+        assertThat(recreatedEntryCode.getId()).isGreaterThan(rows.maxEntryCodeId());
+        assertThat(recreatedStamp.getId()).isGreaterThan(rows.maxStampId());
+        assertThat(recreatedVote.getId()).isGreaterThan(rows.maxVoteId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("삭제 도중 예외가 발생하면 데모데이 5개 테이블의 삭제를 모두 rollback한다")
+    void rollbackAllDeletesWhenTransactionFails() {
+        TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+        DemodayRows rows = transaction.execute(status -> {
+            DemodayRows persistedRows = persistDemodayRows(9L, 100L);
+            em.flush();
+            em.clear();
+            return persistedRows;
+        });
+
+        try {
+            // When & Then
+            assertThatThrownBy(() -> transaction.executeWithoutResult(status -> {
+                sut.deleteAll();
+                throw new IllegalStateException("데모데이 테스트 데이터 삭제 후 강제 실패");
+            }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("데모데이 테스트 데이터 삭제 후 강제 실패");
+
+            TableCounts actual = transaction.execute(status -> currentDemodayTableCounts());
+            assertThat(actual).isEqualTo(rows.toTableCounts());
+        } finally {
+            transaction.executeWithoutResult(status -> {
+                sut.deleteAll();
+                em.clear();
+            });
+        }
+    }
+
+    private NonDemodaySentinels persistNonDemodaySentinels() {
+        School school = em.persist(School.create("보존 대학교", "보존대", null));
+        Gisu gisu = em.persist(Gisu.create(1300L, GISU_START_AT, GISU_END_AT, false));
+        Member member = em.persist(Member.create(
+            "보존회원",
+            "보존회원",
+            "demoday-reset-sentinel@test.com",
+            school.getId(),
+            null
+        ));
+        Challenger challenger = em.persist(new Challenger(
+            member.getId(),
+            ChallengerPart.SPRINGBOOT,
+            gisu.getId()
+        ));
+        ChallengerRole challengerRole = em.persist(ChallengerRole.create(
+            challenger.getId(),
+            ChallengerRoleType.CENTRAL_PRESIDENT,
+            null,
+            null,
+            gisu.getId()
+        ));
+        MemberSystemRole memberSystemRole = em.persist(MemberSystemRole.create(
+            member.getId(),
+            MemberSystemRoleType.SUPER_ADMIN
+        ));
+        Long auditLogId = insertAuditLogSentinel(member.getId());
+
+        return new NonDemodaySentinels(
+            auditLogId,
+            school.getId(),
+            gisu.getId(),
+            member.getId(),
+            challenger.getId(),
+            challengerRole.getId(),
+            memberSystemRole.getId()
+        );
+    }
+
+    private Long insertAuditLogSentinel(Long actorMemberId) {
+        Object id = em.getEntityManager().createNativeQuery("""
+            INSERT INTO audit_log (
+                domain, action, target_type, target_id, actor_member_id,
+                description, details, ip_address, created_at
+            )
+            VALUES (
+                'DEMODAY', 'CREATE', 'Sentinel', 'preserve-me', :actorMemberId,
+                '데모데이 초기화 비대상 감사 로그', '{}'::jsonb, '127.0.0.1', now()
+            )
+            RETURNING id
+            """)
+            .setParameter("actorMemberId", actorMemberId)
+            .getSingleResult();
+        return ((Number) id).longValue();
+    }
+
+    private DemodayRows persistDemodayRows(Long gisuId, Long memberId) {
+        DemodayPoll firstPoll = em.persist(createPoll(gisuId, "첫 번째 데모데이"));
+        DemodayBooth firstBooth = em.persist(DemodayBooth.forProject(firstPoll.getId(), 100L));
+        DemodayBooth secondBooth = em.persist(DemodayBooth.forExternal(firstPoll.getId(), "외부 부스"));
+        DemodayEntryCode firstEntryCode = em.persist(DemodayEntryCode.create(firstPoll.getId(), hash('a')));
+        em.persist(DemodayVote.forMember(firstPoll.getId(), memberId, firstBooth));
+        em.persist(DemodayVote.forVisitor(firstPoll.getId(), firstEntryCode, secondBooth));
+        em.persist(DemodayStamp.forMember(memberId, firstBooth));
+        em.persist(DemodayStamp.forVisitor(firstEntryCode, secondBooth));
+
+        DemodayPoll secondPoll = em.persist(createPoll(gisuId, "두 번째 데모데이"));
+        DemodayBooth thirdBooth = em.persist(DemodayBooth.forProject(secondPoll.getId(), 200L));
+        DemodayEntryCode secondEntryCode = em.persist(DemodayEntryCode.create(secondPoll.getId(), hash('b')));
+        DemodayVote thirdVote = em.persist(DemodayVote.forVisitor(secondPoll.getId(), secondEntryCode, thirdBooth));
+        DemodayStamp thirdStamp = em.persist(DemodayStamp.forVisitor(secondEntryCode, thirdBooth));
+
+        return new DemodayRows(
+            2,
+            3,
+            2,
+            3,
+            3,
+            secondPoll.getId(),
+            thirdBooth.getId(),
+            secondEntryCode.getId(),
+            thirdStamp.getId(),
+            thirdVote.getId()
+        );
+    }
+
+    private DemodayPoll createPoll(Long gisuId, String name) {
+        return DemodayPoll.create(gisuId, name, OPENS_AT, CLOSES_AT);
+    }
+
+    private String hash(char value) {
+        return String.valueOf(value).repeat(DemodayEntryCode.HASH_LENGTH);
+    }
+
+    private void assertDeletionCounts(DemodayTestDataDeletionCounts actual, DemodayRows expected) {
+        assertThat(actual.deletedPolls()).isEqualTo(expected.polls());
+        assertThat(actual.deletedBooths()).isEqualTo(expected.booths());
+        assertThat(actual.deletedEntryCodes()).isEqualTo(expected.entryCodes());
+        assertThat(actual.deletedStamps()).isEqualTo(expected.stamps());
+        assertThat(actual.deletedVotes()).isEqualTo(expected.votes());
+    }
+
+    private void assertDemodayTableCounts(TableCounts expected) {
+        assertThat(currentDemodayTableCounts()).isEqualTo(expected);
+    }
+
+    private TableCounts currentDemodayTableCounts() {
+        return new TableCounts(
+            countRows("demoday_poll"),
+            countRows("demoday_booth"),
+            countRows("demoday_entry_code"),
+            countRows("demoday_stamp"),
+            countRows("demoday_vote")
+        );
+    }
+
+    private long countRows(String tableName) {
+        Object result = em.getEntityManager()
+            .createNativeQuery("SELECT COUNT(*) FROM " + tableName)
+            .getSingleResult();
+        return ((Number) result).longValue();
+    }
+
+    private void assertNonDemodaySentinelsExist(NonDemodaySentinels sentinels) {
+        assertThat(em.find(School.class, sentinels.schoolId())).isNotNull();
+        assertThat(em.find(Gisu.class, sentinels.gisuId())).isNotNull();
+        assertThat(em.find(Member.class, sentinels.memberId())).isNotNull();
+        assertThat(em.find(Challenger.class, sentinels.challengerId())).isNotNull();
+        assertThat(em.find(ChallengerRole.class, sentinels.challengerRoleId())).isNotNull();
+        assertThat(em.find(MemberSystemRole.class, sentinels.memberSystemRoleId())).isNotNull();
+        assertThat(countRowsById("audit_log", sentinels.auditLogId())).isOne();
+    }
+
+    private long countRowsById(String tableName, Long id) {
+        Object result = em.getEntityManager()
+            .createNativeQuery("SELECT COUNT(*) FROM " + tableName + " WHERE id = :id")
+            .setParameter("id", id)
+            .getSingleResult();
+        return ((Number) result).longValue();
+    }
+
+    private record NonDemodaySentinels(
+        Long auditLogId,
+        Long schoolId,
+        Long gisuId,
+        Long memberId,
+        Long challengerId,
+        Long challengerRoleId,
+        Long memberSystemRoleId
+    ) {
+    }
+
+    private record DemodayRows(
+        long polls,
+        long booths,
+        long entryCodes,
+        long stamps,
+        long votes,
+        Long maxPollId,
+        Long maxBoothId,
+        Long maxEntryCodeId,
+        Long maxStampId,
+        Long maxVoteId
+    ) {
+
+        private static DemodayRows empty() {
+            return new DemodayRows(0, 0, 0, 0, 0, null, null, null, null, null);
+        }
+
+        private TableCounts toTableCounts() {
+            return new TableCounts(polls, booths, entryCodes, stamps, votes);
+        }
+    }
+
+    private record TableCounts(long polls, long booths, long entryCodes, long stamps, long votes) {
+
+        private static TableCounts empty() {
+            return new TableCounts(0, 0, 0, 0, 0);
+        }
+    }
+}

--- a/src/test/java/com/umc/product/demoday/application/service/command/ResetDemodayTestDataCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/ResetDemodayTestDataCommandServiceTest.java
@@ -1,0 +1,96 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.audit.application.port.in.annotation.Audited;
+import com.umc.product.audit.domain.AuditAction;
+import com.umc.product.demoday.application.port.in.command.dto.DemodayTestDataResetInfo;
+import com.umc.product.demoday.application.port.out.DeleteDemodayTestDataPort;
+import com.umc.product.demoday.application.port.out.dto.DemodayTestDataDeletionCounts;
+import com.umc.product.demoday.application.service.DemodayAdminAccessChecker;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.global.exception.constant.Domain;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResetDemodayTestDataCommandService")
+class ResetDemodayTestDataCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock
+    private DemodayAdminAccessChecker adminAccessChecker;
+
+    @Mock
+    private DeleteDemodayTestDataPort deleteDemodayTestDataPort;
+
+    @InjectMocks
+    private ResetDemodayTestDataCommandService service;
+
+    @Test
+    @DisplayName("SUPER_ADMIN 권한을 먼저 확인한 뒤 전체 테스트 데이터를 삭제하고 건수를 반환한다")
+    void resetAfterSystemAdminAccessValidation() {
+        // given
+        DemodayTestDataDeletionCounts counts = new DemodayTestDataDeletionCounts(2, 3, 4, 5, 6);
+        given(deleteDemodayTestDataPort.deleteAll()).willReturn(counts);
+
+        // when
+        DemodayTestDataResetInfo result = service.reset(MEMBER_ID);
+
+        // then
+        assertThat(result).isEqualTo(new DemodayTestDataResetInfo(2, 3, 4, 5, 6));
+
+        InOrder invocationOrder = inOrder(adminAccessChecker, deleteDemodayTestDataPort);
+        invocationOrder.verify(adminAccessChecker).validateSystemAdminAccess(MEMBER_ID);
+        invocationOrder.verify(deleteDemodayTestDataPort).deleteAll();
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN 권한이 없으면 테스트 데이터를 삭제하지 않는다")
+    void rejectResetWhenSystemAdminAccessIsDenied() {
+        // given
+        DemodayDomainException expectedException =
+            new DemodayDomainException(DemodayErrorCode.DEMODAY_ADMIN_ACCESS_DENIED);
+        willThrow(expectedException)
+            .given(adminAccessChecker)
+            .validateSystemAdminAccess(MEMBER_ID);
+
+        // when & then
+        assertThatThrownBy(() -> service.reset(MEMBER_ID))
+            .isSameAs(expectedException);
+
+        then(deleteDemodayTestDataPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("성공한 초기화는 데모데이 DELETE 감사 로그 대상으로 선언한다")
+    void declareAuditLogForSuccessfulReset() throws NoSuchMethodException {
+        // given
+        Method resetMethod = ResetDemodayTestDataCommandService.class.getMethod("reset", Long.class);
+
+        // when
+        Audited audited = resetMethod.getAnnotation(Audited.class);
+
+        // then
+        assertThat(audited).isNotNull();
+        assertThat(audited.domain()).isEqualTo(Domain.DEMODAY);
+        assertThat(audited.action()).isEqualTo(AuditAction.DELETE);
+        assertThat(audited.targetType()).isEqualTo("DemodayTestData");
+        assertThat(audited.description()).isNotBlank();
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

### 어떻게

- Controller, Command Service, Persistence Adapter에 `!prod` 프로필과 `demoday.test-data-reset.enabled` 조건을 함께 적용했습니다.
- SUPER_ADMIN 권한을 먼저 검증하고, 하나의 트랜잭션에서 FK 역순인 `stamp → vote → entry_code → booth → poll` 순서로 bulk delete를 수행합니다.
- 기존 감사 기록은 보존하면서 성공한 초기화 작업은 DELETE 감사 로그로 남기고, sequence 초기화와 DB lock은 적용하지 않았습니다.
- 실제 공통 응답 envelope와 일치하도록 OpenAPI 응답 스키마를 명시했습니다.

### 무엇을

- 비운영 환경에서 데모데이 Poll, Booth, EntryCode, Stamp, Vote 데이터를 한 번에 초기화하는 `DELETE /api/v1/demoday/admin/test-data` API를 추가했습니다.
- 응답에는 데이터 종류별 실제 삭제 건수를 반환하며, 이미 비어 있는 상태에서 다시 호출하면 모든 건수가 `0`으로 반환됩니다.

### 왜

- 기존 테스트 데이터와 호환되지 않는 스키마 변경을 공유 개발 환경에 적용할 때, DB에 직접 접근하지 않고 데모데이 데이터만 안전하게 초기화할 수단이 필요했습니다.
- 전역 삭제 기능의 오용과 운영 데이터 삭제를 막기 위해 비운영 환경의 SUPER_ADMIN 전용 기능으로 경계를 제한했습니다.

### 결과

- 데모데이 대상 5종만 삭제되고 Member, Gisu, School, Challenger, 권한, 기존 감사 기록은 보존됩니다.
- 재호출 멱등성, 전체 rollback, identity sequence 유지, 권한 거부, 환경별 Bean 등록, runtime OpenAPI 계약을 테스트로 검증했습니다.
- 데모데이 관련 테스트가 모두 통과했습니다.

Resolves #1300

## 💬 리뷰 중점사항

- 전역 초기화 권한을 SUPER_ADMIN으로 제한한 경계가 적절한지 확인 부탁드립니다.
- FK 역순 native delete와 Command Service의 트랜잭션 범위가 의도한 원자성을 보장하는지 확인 부탁드립니다.
- `!prod`와 opt-in property를 함께 사용한 이중 가드 및 alpha 기본 활성화 정책을 확인 부탁드립니다.
- 실제 `success/code/message/result` 응답 envelope와 OpenAPI 스키마가 일치하는지 확인 부탁드립니다.
