### PR TITLE
[Feat] 데모데이 게스트 Rate Limit을 참가자 단위로 분리

### DIFF
--- a/docs/onboarding/api-rate-limiter.md
+++ b/docs/onboarding/api-rate-limiter.md
@@ -97,6 +97,7 @@ Bucket key는 다음 형식이다.
 
 ```text
 member:42:GET:/api/v1/projects/{projectId}
+guest:73:GET:/api/v1/demoday/polls/{pollId}/participations/me
 ip:203.0.113.7:POST:/api/v1/projects/{projectId}/applications
 ```
 
@@ -136,13 +137,18 @@ flowchart TD
 
 ## Client key 결정
 
-`RateLimitClientKeyResolver`는 인증 정보가 있으면 `MemberPrincipal.memberId`를 사용한다.
+`RateLimitClientKeyResolver`는 인증 principal 종류에 따라 회원 또는 데모데이 게스트 식별자를 사용한다.
 
 ```text
 member:{memberId}
+guest:{entryCodeId}
 ```
 
-인증 정보가 없으면 `request.getRemoteAddr()` 값을 사용한다.
+따라서 공용 Wi-Fi나 NAT 환경에서도 인증된 데모데이 게스트는 같은 IP의 다른 게스트와 bucket을 공유하지 않는다.
+게스트 입장 코드 제출은 인증 전 요청이므로 이 전역 정책에서 제외하고, 별도의 IP 기반
+`DemodayGuestRateLimitInterceptor`와 `demoday.guest-rate-limit` 설정으로 제한한다.
+
+지원하는 인증 principal이 없으면 `request.getRemoteAddr()` 값을 사용한다.
 
 ```text
 ip:{remoteAddr}
@@ -156,7 +162,7 @@ ip:{remoteAddr}
 
 | 대상 | 초당 제한 | 분당 제한 |
 |---|---:|---:|
-| 인증 사용자 | 20 req/s | 300 req/min |
+| 인증 사용자(회원·데모데이 게스트) | 20 req/s | 300 req/min |
 | 익명 IP | 5 req/s | 60 req/min |
 
 현재 기본 설정에는 endpoint별 route override가 없다. 실제 서비스에 비싼 API가 생기면 `app.api-rate-limit.route-policies`에 명시적으로 추가한다.
@@ -255,9 +261,9 @@ tag는 다음과 같다.
 | `rule` | `authenticated-default`, `anonymous-default`, `custom` |
 | `method` | `GET`, `POST` |
 | `uriTemplate` | `/api/v1/projects/{projectId}`, `unmapped` |
-| `clientType` | `WEB`, `ANONYMOUS`, `UNKNOWN` |
+| `clientType` | `WEB`, `GUEST`, `ANONYMOUS`, `UNKNOWN` |
 
-metric tag에는 raw `memberId`나 raw IP를 넣지 않는다. 차단 로그도 `method`, `routePattern`, `clientType`, `retryAfterSeconds`, `keyHash`만 남긴다.
+metric tag에는 raw `memberId`, `entryCodeId`, IP를 넣지 않는다. 차단 로그도 `method`, `routePattern`, `clientType`, `retryAfterSeconds`, `keyHash`만 남긴다.
 
 ## 운영 시 주의사항
 

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationPrincipal.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/security/DemodayParticipationPrincipal.java
@@ -4,8 +4,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
-import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
+
+import com.umc.product.global.security.RateLimitPrincipal;
 
 /**
  * 게스트(외부 방문자) 참여 인증 principal.
@@ -14,7 +15,7 @@ import org.springframework.security.core.GrantedAuthority;
  * 인증을 완전히 독립된 Principal 타입으로 분리했다. 신원은 입장 코드 단위({@code entryCodeId})로만
  * 식별되며, 이 값은 {@link DemodayParticipantTokenProvider}가 서명한 participant token의 subject다.
  */
-public class DemodayParticipationPrincipal implements AuthenticatedPrincipal {
+public class DemodayParticipationPrincipal implements RateLimitPrincipal {
 
     private final Long entryCodeId;
 
@@ -28,6 +29,16 @@ public class DemodayParticipationPrincipal implements AuthenticatedPrincipal {
 
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public String rateLimitKey() {
+        return "guest:" + entryCodeId;
+    }
+
+    @Override
+    public String rateLimitClientType() {
+        return "GUEST";
     }
 
     @Override

--- a/src/main/java/com/umc/product/global/ratelimit/RateLimitClientKeyResolver.java
+++ b/src/main/java/com/umc/product/global/ratelimit/RateLimitClientKeyResolver.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import com.umc.product.global.security.MemberPrincipal;
+import com.umc.product.global.security.RateLimitPrincipal;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -12,17 +12,16 @@ import jakarta.servlet.http.HttpServletRequest;
 public class RateLimitClientKeyResolver {
 
     private static final String CLIENT_TYPE_ANONYMOUS = "ANONYMOUS";
-    private static final String CLIENT_TYPE_UNKNOWN = "UNKNOWN";
 
     public RateLimitClientKey resolve(HttpServletRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null
             && authentication.isAuthenticated()
-            && authentication.getPrincipal() instanceof MemberPrincipal memberPrincipal) {
+            && authentication.getPrincipal() instanceof RateLimitPrincipal principal) {
             return new RateLimitClientKey(
-                "member:" + memberPrincipal.getMemberId(),
+                principal.rateLimitKey(),
                 true,
-                memberPrincipal.getClientType() == null ? CLIENT_TYPE_UNKNOWN : memberPrincipal.getClientType().name()
+                principal.rateLimitClientType()
             );
         }
 

--- a/src/main/java/com/umc/product/global/security/MemberPrincipal.java
+++ b/src/main/java/com/umc/product/global/security/MemberPrincipal.java
@@ -3,7 +3,6 @@ package com.umc.product.global.security;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 
 import com.umc.product.common.domain.enums.ClientType;
@@ -13,7 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MemberPrincipal implements AuthenticatedPrincipal {
+public class MemberPrincipal implements RateLimitPrincipal {
 
     private final Long memberId;
 
@@ -43,16 +42,26 @@ public class MemberPrincipal implements AuthenticatedPrincipal {
     }
 
     @Override
+    public String rateLimitKey() {
+        return "member:" + memberId;
+    }
+
+    @Override
+    public String rateLimitClientType() {
+        return clientType == null ? "UNKNOWN" : clientType.name();
+    }
+
+    @Override
     public String getName() {
         return String.valueOf(memberId);
     }
 
     @Override
     public String toString() {
-        return "MemberPrincipal{" +
-                "memberId=" + memberId +
-                ", clientType=" + clientType +
-                ", clientContextClaims=" + clientContextClaims +
-                '}';
+        return "MemberPrincipal{"
+            + "memberId=" + memberId
+            + ", clientType=" + clientType
+            + ", clientContextClaims=" + clientContextClaims
+            + '}';
     }
 }

--- a/src/main/java/com/umc/product/global/security/RateLimitPrincipal.java
+++ b/src/main/java/com/umc/product/global/security/RateLimitPrincipal.java
@@ -1,0 +1,13 @@
+package com.umc.product.global.security;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+
+/**
+ * 인증 주체가 API Rate Limiter에 제공하는 안정적인 식별 정보다.
+ */
+public interface RateLimitPrincipal extends AuthenticatedPrincipal {
+
+    String rateLimitKey();
+
+    String rateLimitClientType();
+}

--- a/src/test/java/com/umc/product/global/ratelimit/ApiRateLimitInterceptorTest.java
+++ b/src/test/java/com/umc/product/global/ratelimit/ApiRateLimitInterceptorTest.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
 import com.umc.product.global.client.ClientContextProperties;
 import com.umc.product.global.client.ClientOriginRegistry;
 import com.umc.product.global.client.ClientRequestClassifier;
@@ -79,6 +80,41 @@ class ApiRateLimitInterceptorTest {
             .andExpect(jsonPath("$.code").value(CommonErrorCode.TOO_MANY_REQUESTS.getCode()));
 
         assertThat(controller.invocations()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("같은 IP의 게스트들은 참가자별 한도를 사용하고 한 게스트의 초과가 다른 게스트에 영향 주지 않는다")
+    void demoday_guests_on_same_ip_use_independent_buckets() throws Exception {
+        DemodayParticipationController controller = new DemodayParticipationController();
+        MockMvc mockMvc = mockMvc(controller, guestLimitedProperties());
+
+        authenticateGuest(101L);
+        mockMvc.perform(get("/api/v1/demoday/polls/1/participations/me")
+                .with(request -> {
+                    request.setRemoteAddr("10.0.0.10");
+                    return request;
+                }))
+            .andExpect(status().isOk())
+            .andExpect(header().string("X-RateLimit-Limit", "1"));
+
+        mockMvc.perform(get("/api/v1/demoday/polls/1/participations/me")
+                .with(request -> {
+                    request.setRemoteAddr("10.0.0.10");
+                    return request;
+                }))
+            .andExpect(status().isTooManyRequests())
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.TOO_MANY_REQUESTS.getCode()));
+
+        authenticateGuest(202L);
+        mockMvc.perform(get("/api/v1/demoday/polls/1/participations/me")
+                .with(request -> {
+                    request.setRemoteAddr("10.0.0.10");
+                    return request;
+                }))
+            .andExpect(status().isOk())
+            .andExpect(header().string("X-RateLimit-Limit", "1"));
+
+        assertThat(controller.invocations()).isEqualTo(2);
     }
 
     @Test
@@ -168,6 +204,27 @@ class ApiRateLimitInterceptorTest {
         );
     }
 
+    private static ApiRateLimitProperties guestLimitedProperties() {
+        ApiRateLimitProperties.Limit oneRequest = new ApiRateLimitProperties.Limit(1, 1);
+        ApiRateLimitProperties.Limit anonymousLimit = new ApiRateLimitProperties.Limit(5, 5);
+        return new ApiRateLimitProperties(
+            true,
+            List.of("/api/**"),
+            ApiRateLimitProperties.defaultExcludedPaths(),
+            oneRequest,
+            anonymousLimit,
+            List.of(),
+            new ApiRateLimitProperties.Cache(10_000, Duration.ofMinutes(10))
+        );
+    }
+
+    private static void authenticateGuest(Long entryCodeId) {
+        DemodayParticipationPrincipal principal = new DemodayParticipationPrincipal(entryCodeId);
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, List.of())
+        );
+    }
+
     @RestController
     private static class ProductController {
 
@@ -197,6 +254,22 @@ class ApiRateLimitInterceptorTest {
         String graphql() {
             invocations.incrementAndGet();
             return "graphql";
+        }
+
+        int invocations() {
+            return invocations.get();
+        }
+    }
+
+    @RestController
+    private static class DemodayParticipationController {
+
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        @GetMapping("/api/v1/demoday/polls/{pollId}/participations/me")
+        String participation(@PathVariable Long pollId) {
+            invocations.incrementAndGet();
+            return "participation-" + pollId;
         }
 
         int invocations() {

--- a/src/test/java/com/umc/product/global/ratelimit/RateLimitClientKeyResolverTest.java
+++ b/src/test/java/com/umc/product/global/ratelimit/RateLimitClientKeyResolverTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.umc.product.common.domain.enums.ClientType;
+import com.umc.product.demoday.adapter.in.web.security.DemodayParticipationPrincipal;
 import com.umc.product.global.security.MemberPrincipal;
 
 class RateLimitClientKeyResolverTest {
@@ -39,6 +40,24 @@ class RateLimitClientKeyResolverTest {
         assertThat(clientKey.value()).isEqualTo("member:42");
         assertThat(clientKey.authenticated()).isTrue();
         assertThat(clientKey.clientType()).isEqualTo("WEB");
+    }
+
+    @Test
+    @DisplayName("인증된 데모데이 게스트가 있으면 입장 코드 ID 기준 key를 사용한다")
+    void resolve_authenticated_demoday_guest_key() {
+        DemodayParticipationPrincipal principal = new DemodayParticipationPrincipal(73L);
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList())
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("10.0.0.10");
+
+        RateLimitClientKey clientKey = resolver.resolve(request);
+
+        assertThat(clientKey.value()).isEqualTo("guest:73");
+        assertThat(clientKey.authenticated()).isTrue();
+        assertThat(clientKey.clientType()).isEqualTo("GUEST");
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용

### 무엇을

- 인증된 데모데이 게스트의 스탬프·투표·참여 조회 요청을 공용 IP가 아닌 게스트 참가자 단위로 제한합니다.
- 회원 요청은 `memberId`, 일반 익명 요청과 인증 전 게스트 입장 요청은 기존 IP 기준 정책을 유지합니다.
- Rate Limit 식별 규칙과 운영 시 주의사항을 온보딩 문서에 반영합니다.

### 어떻게

- 인증 principal이 안정적인 bucket key와 metric용 client type을 제공하도록 공용 `RateLimitPrincipal` 계약을 추가했습니다.
- `MemberPrincipal`은 `member:{memberId}`, `DemodayParticipationPrincipal`은 `guest:{entryCodeId}`를 제공하도록 구현했습니다.
- `RateLimitClientKeyResolver`는 특정 도메인 타입 대신 `RateLimitPrincipal`을 처리하고, 지원하는 인증 principal이 없을 때만 `ip:{remoteAddr}`로 fallback합니다.
- 인증된 게스트는 기존 `authenticated-default` 정책을 사용하고, 게스트 입장 코드 제출 경로는 기존 `DemodayGuestRateLimitInterceptor`가 IP 기준으로 계속 관장합니다.
- 같은 IP의 게스트 두 명이 bucket을 공유하지 않는지, 한 게스트의 429가 다른 게스트에 영향을 주지 않는지 회귀 테스트를 추가했습니다.

### 왜

행사장 공용 Wi-Fi나 NAT 환경에서는 여러 참가자가 하나의 발신 IP를 공유합니다. 기존 구현은 `MemberPrincipal`만 인증 사용자로 인식했기 때문에, 유효한 게스트 Cookie가 있어도 게스트 요청을 익명 IP bucket에 넣어 정상 참가자끼리 한도를 소진했습니다.

고려한 대안과 판단 과정은 다음과 같습니다.

- **게스트 요청 제한 전체 해제**: 정상 요청의 오차단은 없어지지만 반복 요청과 서버 부하를 제어할 수 없어 제외했습니다.
- **IP 단위 한도 일괄 상향**: 오차단 가능성만 낮출 뿐 참가자 간 영향을 분리하지 못하고, 악의적 요청에 허용량만 늘려 제외했습니다.
- **데모데이 전용 인터셉터를 인증 이후 모든 경로로 확대**: 도메인별 한도를 독립 설정할 수 있지만 전역 Rate Limiter의 route·bucket·metric 로직을 중복하고 대상 경로를 계속 관리해야 해 제외했습니다.
- **전역 resolver가 `DemodayParticipationPrincipal`을 직접 참조**: 구현은 가장 작지만 공용 계층이 데모데이 adapter에 의존하게 됩니다. 의존 방향을 지키기 위해 공용 `RateLimitPrincipal` 계약을 두고 각 principal이 식별 정보를 제공하도록 결정했습니다.

별도 게스트 한도는 요구사항이 식별 기준 분리에 있고 한도 수치 변경에는 없으므로 추가하지 않았습니다. 인증된 게스트는 기존 인증 사용자 기본값인 초당 20회·분당 300회를 참가자별로 사용합니다.

### 결과

- 같은 IP의 서로 다른 게스트는 독립된 Rate Limit bucket을 사용합니다.
- 한 게스트가 한도를 초과해 429를 받아도 다른 게스트 요청은 정상 처리됩니다.
- 기존 회원·일반 익명·인증 전 게스트 입장 요청의 식별 기준과 설정값은 유지됩니다.
- 대상 테스트 3개 클래스의 10개 테스트와 `spotlessCheck`, `checkstyleMain`, `checkstyleTest`가 통과했습니다.

Resolves #1306

## 💬 리뷰 중점사항

- `RateLimitPrincipal`을 공용 security 계약으로 둔 의존 방향이 적절한지 확인해주세요.
- 인증된 게스트가 별도 정책이 아닌 기존 `authenticated-default`를 참가자별로 사용하는 판단을 확인해주세요.
- 게스트 입장 코드 제출 경로만 기존 IP 기반 전용 인터셉터에 남아 있는지 확인해주세요.
