### PR TITLE
[Feat] 데모데이 참여 조회에 유효 투표 영수증 추가

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryController.java
@@ -44,7 +44,8 @@ public class DemodayPollQueryController {
     @Operation(
         summary = "내 투표 참여 정보 조회",
         description = "스탬프와 투표 기록을 기반으로 내 투표 참여 정보를 조회합니다. 회원 Bearer 또는 게스트 participant "
-            + "Cookie 둘 중 하나만 있으면 통과합니다."
+            + "Cookie 둘 중 하나만 있으면 통과합니다. 현재 유효한 표가 있으면 activeVoteReceipt를 반환하며, "
+            + "투표하지 않았거나 표가 취소된 경우에는 null을 반환합니다."
     )
     @GetMapping("/{pollId}/participations/me")
     public DemodayParticipationResponse getMyParticipation(

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayParticipationResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayParticipationResponse.java
@@ -26,7 +26,9 @@ public record DemodayParticipationResponse(
         @Schema(description = "취소 여부와 무관하게 이번 Poll의 투표 기회를 이미 사용했는지", example = "false")
         boolean hasUsedVoteSlot,
         @Schema(description = "스탬프 조건을 충족하고 투표 기회를 사용하지 않아 INFO QR 인증을 요청할 수 있는지", example = "false")
-        boolean canRequestVoteAuthorization
+        boolean canRequestVoteAuthorization,
+        @Schema(description = "현재 집계에 포함되는 유효한 표의 영수증", nullable = true)
+        DemodayVoteReceiptResponse activeVoteReceipt
 ) {
 
     public static DemodayParticipationResponse from(DemodayParticipationInfo info) {
@@ -39,7 +41,8 @@ public record DemodayParticipationResponse(
                 info.nextStampAvailableAt(),
                 info.hasActiveVote(),
                 info.hasUsedVoteSlot(),
-                info.canRequestVoteAuthorization()
+                info.canRequestVoteAuthorization(),
+                info.activeVoteReceipt() == null ? null : DemodayVoteReceiptResponse.from(info.activeVoteReceipt())
         );
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayVoteReceiptResponse.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/response/DemodayVoteReceiptResponse.java
@@ -1,0 +1,25 @@
+package com.umc.product.demoday.adapter.in.web.dto.response;
+
+import java.time.Instant;
+
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteReceiptInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DemodayVoteReceiptResponse(
+    @Schema(description = "유효한 표 ID", example = "9001")
+    Long voteId,
+    @Schema(description = "최종 투표한 부스")
+    DemodayBoothResponse selectedBooth,
+    @Schema(description = "서버에 표가 저장된 시각")
+    Instant votedAt
+) {
+
+    public static DemodayVoteReceiptResponse from(DemodayVoteReceiptInfo info) {
+        return new DemodayVoteReceiptResponse(
+            info.voteId(),
+            DemodayBoothResponse.from(info.selectedBooth()),
+            info.votedAt()
+        );
+    }
+}

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayParticipationInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayParticipationInfo.java
@@ -14,6 +14,7 @@ public record DemodayParticipationInfo(
         Instant nextStampAvailableAt,
         boolean hasActiveVote,
         boolean hasUsedVoteSlot,
-        boolean canRequestVoteAuthorization
+        boolean canRequestVoteAuthorization,
+        DemodayVoteReceiptInfo activeVoteReceipt
 ) {
 }

--- a/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayVoteReceiptInfo.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/query/dto/DemodayVoteReceiptInfo.java
@@ -1,0 +1,10 @@
+package com.umc.product.demoday.application.port.in.query.dto;
+
+import java.time.Instant;
+
+public record DemodayVoteReceiptInfo(
+    Long voteId,
+    DemodayBoothInfo selectedBooth,
+    Instant votedAt
+) {
+}

--- a/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/query/DemodayPollQueryService.java
@@ -1,10 +1,11 @@
 package com.umc.product.demoday.application.service.query;
 
-import static java.util.stream.Collectors.toUnmodifiableSet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayPollInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteReceiptInfo;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
 import com.umc.product.demoday.application.port.out.LoadDemodayBoothPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
@@ -60,21 +62,24 @@ public class DemodayPollQueryService implements
     public DemodayParticipationInfo getParticipation(Long pollId, DemodayParticipant participant) {
         validatePollExists(pollId);
 
-        Set<Long> boothIds = loadDemodayBoothPort.listByPollId(pollId)
+        Map<Long, DemodayBooth> boothsById = loadDemodayBoothPort.listByPollId(pollId)
             .stream()
-            .map(DemodayBooth::getId)
-            .collect(toUnmodifiableSet());
+            .collect(toUnmodifiableMap(DemodayBooth::getId, identity()));
 
         List<DemodayStampInfo> stamps = loadStamps(participant)
             .stream()
             .filter(stamp -> !stamp.isRevoked())
-            .filter(stamp -> boothIds.contains(stamp.getBoothId()))
+            .filter(stamp -> boothsById.containsKey(stamp.getBoothId()))
             .map(this::toStampInfo)
             .toList();
 
         Optional<DemodayVote> vote = findVote(pollId, participant);
-        boolean hasActiveVote = vote.filter(existingVote -> !existingVote.isRevoked()).isPresent();
+        Optional<DemodayVote> activeVote = vote.filter(existingVote -> !existingVote.isRevoked());
+        boolean hasActiveVote = activeVote.isPresent();
         boolean hasUsedVoteSlot = vote.isPresent();
+        DemodayVoteReceiptInfo activeVoteReceipt = activeVote
+            .map(existingVote -> toVoteReceiptInfo(existingVote, boothsById))
+            .orElse(null);
 
         int stampCount = stamps.size();
 
@@ -87,7 +92,8 @@ public class DemodayPollQueryService implements
                 null,
                 hasActiveVote,
                 hasUsedVoteSlot,
-                DemodayParticipationPolicy.canRequestVoteAuthorization(stampCount, hasUsedVoteSlot)
+                DemodayParticipationPolicy.canRequestVoteAuthorization(stampCount, hasUsedVoteSlot),
+                activeVoteReceipt
         );
     }
 
@@ -129,5 +135,19 @@ public class DemodayPollQueryService implements
 
     private DemodayStampInfo toStampInfo(DemodayStamp stamp) {
         return new DemodayStampInfo(stamp.getBoothId(), stamp.getCreatedAt());
+    }
+
+    private DemodayVoteReceiptInfo toVoteReceiptInfo(
+        DemodayVote vote,
+        Map<Long, DemodayBooth> boothsById
+    ) {
+        DemodayBooth selectedBooth = Optional.ofNullable(boothsById.get(vote.getTargetBoothId()))
+            .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_BOOTH_NOT_FOUND));
+
+        return new DemodayVoteReceiptInfo(
+            vote.getId(),
+            DemodayBoothInfo.from(selectedBooth),
+            vote.getCreatedAt()
+        );
     }
 }

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
@@ -111,7 +111,7 @@ class DemodayParticipationCommandControllerTest {
 
         DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
             POLL_ID, DemodayParticipantType.GUEST, 0, 6,
-            List.of(), null, false, false, false);
+            List.of(), null, false, false, false, null);
 
         StartDemodayGuestParticipationInfo info =
             new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
@@ -148,7 +148,7 @@ class DemodayParticipationCommandControllerTest {
 
         DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
             POLL_ID, DemodayParticipantType.GUEST, 2, 6,
-            List.of(), null, false, false, false);
+            List.of(), null, false, false, false, null);
 
         StartDemodayGuestParticipationInfo info =
             new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayPollQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.umc.product.demoday.adapter.in.web;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -31,6 +32,7 @@ import com.umc.product.demoday.application.port.in.query.dto.DemodayBoothInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayPollInfo;
 import com.umc.product.demoday.application.port.in.query.dto.DemodayStampInfo;
+import com.umc.product.demoday.application.port.in.query.dto.DemodayVoteReceiptInfo;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipant;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantResolver;
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
@@ -124,9 +126,53 @@ class DemodayPollQueryControllerTest {
                 .andExpect(jsonPath("$.result.stamps[0].boothId").value(20L))
                 .andExpect(jsonPath("$.result.hasActiveVote").value(false))
                 .andExpect(jsonPath("$.result.hasUsedVoteSlot").value(false))
-                .andExpect(jsonPath("$.result.canRequestVoteAuthorization").value(true));
+                .andExpect(jsonPath("$.result.canRequestVoteAuthorization").value(true))
+                .andExpect(jsonPath("$.result.activeVoteReceipt").value(nullValue()));
 
         then(participantResolver).should().resolve(principal);
+        then(getDemodayParticipationUseCase).should().getParticipation(POLL_ID, participant);
+    }
+
+    @Test
+    @DisplayName("유효한 표가 있으면 참여 정보에 최종 투표 영수증을 반환한다")
+    void getMyParticipationWithActiveVoteReceipt() throws Exception {
+        // given
+        DemodayParticipant participant = new MemberDemodayParticipant(MEMBER_ID);
+        DemodayBoothInfo selectedBooth = new DemodayBoothInfo(20L, BOOTH_CODE, 30L, "PRODUCT 프로젝트");
+        DemodayVoteReceiptInfo receipt = new DemodayVoteReceiptInfo(
+            100L,
+            selectedBooth,
+            Instant.parse("2026-08-21T01:00:00Z")
+        );
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID,
+            DemodayParticipantType.MEMBER,
+            STAMP_COUNT,
+            REQUIRED_STAMP_COUNT,
+            List.of(),
+            null,
+            true,
+            true,
+            false,
+            receipt
+        );
+
+        given(participantResolver.resolve(principal)).willReturn(participant);
+        given(getDemodayParticipationUseCase.getParticipation(POLL_ID, participant))
+            .willReturn(participationInfo);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/demoday/polls/{pollId}/participations/me", POLL_ID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.hasActiveVote").value(true))
+            .andExpect(jsonPath("$.result.hasUsedVoteSlot").value(true))
+            .andExpect(jsonPath("$.result.canRequestVoteAuthorization").value(false))
+            .andExpect(jsonPath("$.result.activeVoteReceipt.voteId").value(100L))
+            .andExpect(jsonPath("$.result.activeVoteReceipt.selectedBooth.boothId").value(20L))
+            .andExpect(jsonPath("$.result.activeVoteReceipt.selectedBooth.boothCode").value(BOOTH_CODE))
+            .andExpect(jsonPath("$.result.activeVoteReceipt.selectedBooth.projectId").value(30L))
+            .andExpect(jsonPath("$.result.activeVoteReceipt.votedAt").value("2026-08-21T01:00:00Z"));
+
         then(getDemodayParticipationUseCase).should().getParticipation(POLL_ID, participant);
     }
 
@@ -171,6 +217,7 @@ class DemodayPollQueryControllerTest {
             null,
             false,
             false,
-            true);
+            true,
+            null);
     }
 }

--- a/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
@@ -176,7 +176,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
 
         DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
             POLL_ID, DemodayParticipantType.GUEST, 0, 6, List.of(),
-            null, false, false, false);
+            null, false, false, false, null);
 
         given(getDemodayParticipationUseCase.getParticipation(
             eq(POLL_ID), eq(new GuestDemodayParticipant(ENTRY_CODE_ID))))
@@ -214,7 +214,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
         given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
 
         DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
-            POLL_ID, DemodayParticipantType.GUEST, 2, 6, List.of(), null, false, false, false);
+            POLL_ID, DemodayParticipantType.GUEST, 2, 6, List.of(), null, false, false, false, null);
         given(getDemodayParticipationUseCase.getParticipation(
             eq(POLL_ID), eq(new GuestDemodayParticipant(ENTRY_CODE_ID))))
             .willReturn(participationInfo);

--- a/src/test/java/com/umc/product/demoday/application/service/query/DemodayPollQueryServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/query/DemodayPollQueryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.LongStream;
@@ -41,6 +42,9 @@ import com.umc.product.demoday.domain.exception.DemodayErrorCode;
 class DemodayPollQueryServiceTest {
 
     private static final Long POLL_ID = 1L;
+    private static final Long BOOTH_ID = 20L;
+    private static final Long VOTE_ID = 100L;
+    private static final Instant VOTED_AT = Instant.parse("2026-08-21T01:00:00Z");
 
     @Mock
     private LoadDemodayPollPort loadDemodayPollPort;
@@ -81,7 +85,64 @@ class DemodayPollQueryServiceTest {
         assertThat(info.hasActiveVote()).isFalse();
         assertThat(info.hasUsedVoteSlot()).isFalse();
         assertThat(info.canRequestVoteAuthorization()).isFalse();
+        assertThat(info.activeVoteReceipt()).isNull();
         verify(loadDemodayStampPort).listVisitorStamps(entryCodeId);
+        verify(loadDemodayVotePort).findVisitorVote(entryCodeId);
+    }
+
+    @Test
+    @DisplayName("회원에게 유효한 표가 있으면 선택 부스와 저장 시각을 영수증으로 반환한다")
+    void activeMemberVoteReturnsReceipt() {
+        // given
+        Long memberId = 10L;
+        DemodayBooth selectedBooth = projectBooth();
+        DemodayVote activeVote = activeVote();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(mock(DemodayPoll.class)));
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(selectedBooth));
+        given(loadDemodayStampPort.listMemberStamps(memberId)).willReturn(List.of());
+        given(loadDemodayVotePort.findMemberVote(POLL_ID, memberId)).willReturn(Optional.of(activeVote));
+
+        // when
+        DemodayParticipationInfo info = demodayPollQueryService.getParticipation(
+            POLL_ID,
+            new MemberDemodayParticipant(memberId)
+        );
+
+        // then
+        assertThat(info.hasActiveVote()).isTrue();
+        assertThat(info.hasUsedVoteSlot()).isTrue();
+        assertThat(info.canRequestVoteAuthorization()).isFalse();
+        assertThat(info.activeVoteReceipt()).isNotNull();
+        assertThat(info.activeVoteReceipt().voteId()).isEqualTo(VOTE_ID);
+        assertThat(info.activeVoteReceipt().selectedBooth().boothId()).isEqualTo(BOOTH_ID);
+        assertThat(info.activeVoteReceipt().selectedBooth().boothCode()).isEqualTo(11);
+        assertThat(info.activeVoteReceipt().votedAt()).isEqualTo(VOTED_AT);
+        verify(loadDemodayVotePort).findMemberVote(POLL_ID, memberId);
+    }
+
+    @Test
+    @DisplayName("게스트도 회원과 동일한 유효 투표 영수증을 반환한다")
+    void activeGuestVoteReturnsReceipt() {
+        // given
+        Long entryCodeId = 42L;
+        DemodayBooth selectedBooth = projectBooth();
+        DemodayVote activeVote = activeVote();
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(mock(DemodayPoll.class)));
+        given(loadDemodayBoothPort.listByPollId(POLL_ID)).willReturn(List.of(selectedBooth));
+        given(loadDemodayStampPort.listVisitorStamps(entryCodeId)).willReturn(List.of());
+        given(loadDemodayVotePort.findVisitorVote(entryCodeId)).willReturn(Optional.of(activeVote));
+
+        // when
+        DemodayParticipationInfo info = demodayPollQueryService.getParticipation(
+            POLL_ID,
+            new GuestDemodayParticipant(entryCodeId)
+        );
+
+        // then
+        assertThat(info.activeVoteReceipt()).isNotNull();
+        assertThat(info.activeVoteReceipt().voteId()).isEqualTo(VOTE_ID);
+        assertThat(info.activeVoteReceipt().selectedBooth().boothId()).isEqualTo(BOOTH_ID);
+        assertThat(info.activeVoteReceipt().votedAt()).isEqualTo(VOTED_AT);
         verify(loadDemodayVotePort).findVisitorVote(entryCodeId);
     }
 
@@ -107,6 +168,7 @@ class DemodayPollQueryServiceTest {
         assertThat(info.hasActiveVote()).isFalse();
         assertThat(info.hasUsedVoteSlot()).isTrue();
         assertThat(info.canRequestVoteAuthorization()).isFalse();
+        assertThat(info.activeVoteReceipt()).isNull();
     }
 
     @Test
@@ -204,5 +266,20 @@ class DemodayPollQueryServiceTest {
         assertThat(booths)
             .extracting(booth -> booth.boothId())
             .containsExactly(10L);
+    }
+
+    private DemodayBooth projectBooth() {
+        DemodayBooth booth = DemodayBooth.forProject(POLL_ID, 11, 101L);
+        ReflectionTestUtils.setField(booth, "id", BOOTH_ID);
+        return booth;
+    }
+
+    private DemodayVote activeVote() {
+        DemodayVote vote = mock(DemodayVote.class);
+        given(vote.isRevoked()).willReturn(false);
+        given(vote.getId()).willReturn(VOTE_ID);
+        given(vote.getTargetBoothId()).willReturn(BOOTH_ID);
+        given(vote.getCreatedAt()).willReturn(VOTED_AT);
+        return vote;
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

### 무엇을

- 데모데이 참여 조회 응답에 현재 유효한 투표의 영수증인 `activeVoteReceipt`를 nullable 필드로 추가했습니다.
- 영수증은 `voteId`, `selectedBooth`, `votedAt`을 제공합니다.
- `resolves #1307`

### 어떻게

- 조회 계층에 `DemodayVoteReceiptInfo`를 추가하고, Web 응답 계층에서 `DemodayVoteReceiptResponse`로 변환하도록 분리했습니다.
- 참여 조회에서 기존에 불러오던 Poll 부스 목록을 ID 기준 Map으로 구성해 스탬프 필터링과 선택 부스 조립에 함께 사용했습니다. 영수증 때문에 추가 DB 조회가 발생하지 않습니다.
- 조회한 투표 중 취소되지 않은 표만 `activeVoteReceipt`로 변환하고, 투표가 없거나 취소된 경우에는 `null`을 반환합니다.
- 회원과 게스트의 투표 조회 분기는 유지하면서 같은 영수증 조립 로직을 통과하도록 구성했습니다.
- 서비스 테스트와 Web MVC 테스트에서 회원·게스트 활성 표, 미투표, 취소 표, JSON 응답 계약을 검증했습니다.

### 왜

- 느린 네트워크에서는 최종 투표가 서버에 저장된 뒤 성공 응답만 유실될 수 있습니다. 기존 참여 조회의 `hasActiveVote`만으로는 사용자가 선택한 부스에 정확히 투표됐는지 복구할 수 없어, 서버에 저장된 최종 결과를 읽기 요청으로 다시 확인할 수 있어야 했습니다.
- FE가 제출 당시 선택한 부스를 로컬 상태로 유지하는 대안은 새로고침이나 로컬 상태 유실 후 검증할 수 없어 제외했습니다.
- 투표 존재 여부만 제공하는 대안은 실제 선택 부스를 확인할 수 없어 문제를 해결하지 못한다고 판단했습니다.
- 최종 투표 요청을 다시 제출하는 대안은 결과 확인을 위해 중복 제출과 오류 처리를 추가하므로 제외했습니다.
- 별도 투표 조회 API를 추가하는 대신 기존 참여 조회에 필드를 추가했습니다. 참여 상태를 복구하는 한 번의 읽기 요청으로 기존 상태와 최종 투표 결과를 함께 확인할 수 있고, 기존 클라이언트 계약도 깨지지 않는 additive 변경이기 때문입니다.
- 필드명은 `voteReceipt`보다 활성 표 전용이라는 의미가 분명한 `activeVoteReceipt`를 선택했습니다. 취소된 표는 `hasUsedVoteSlot=true`이지만 영수증은 `null`이므로 두 상태를 구분할 수 있습니다.

### 결과

- 활성 표가 있으면 서버에 저장된 표 ID, 선택 부스, 저장 시각을 참여 조회에서 복구할 수 있습니다.
- 미투표와 취소 표는 `activeVoteReceipt: null`로 명확하게 표현됩니다.
- 기존 `hasActiveVote`, `hasUsedVoteSlot`, `canRequestVoteAuthorization` 계산 의미는 유지됩니다.
- 관련 테스트 30건과 `spotlessCheck`, `checkstyleMain`, `checkstyleTest`, `git diff --check`가 통과했습니다. 전체 테스트 스위트는 실행하지 않고 변경 범위의 대상 테스트를 실행했습니다.

## 💬 리뷰 중점사항

- 취소 표가 `hasUsedVoteSlot=true`, `activeVoteReceipt=null`로 반환되어 기존 투표 기회 사용 의미를 유지하는지 확인 부탁드립니다.
- `selectedBooth`를 기존 Poll 부스 조회 결과에서 조립해 추가 DB 조회 없이 응답하는 흐름을 확인 부탁드립니다.
- `activeVoteReceipt`가 기존 클라이언트에 영향을 주지 않는 nullable additive 계약인지 확인 부탁드립니다.
