### PR TITLE
[Feat] 게스트 입장 코드 제출의 안전한 재시도 보장

### DIFF
--- a/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandController.java
@@ -61,7 +61,8 @@ public class DemodayParticipationCommandController {
 
             성공하면 서버가 코드를 사용 처리하고 요청한 브라우저에 1회 바인딩한 뒤,
             데모데이 전용 participant token을 HttpOnly Cookie로 설정합니다.
-            이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시 제출하면 성공으로 처리합니다.
+            같은 코드와 requestId로 재시도하면 Cookie를 다시 발급합니다. 다른 requestId로 이미 사용된
+            코드를 제출하면 거절합니다. requestId를 생략한 기존 클라이언트는 기존 Cookie 기반 동작을 유지합니다.
             Cookie와 입장 코드의 수명은 Poll 종료 시점까지입니다.
             """
     )

--- a/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GuestParticipationRequest.java
+++ b/src/main/java/com/umc/product/demoday/adapter/in/web/dto/request/GuestParticipationRequest.java
@@ -2,12 +2,24 @@ package com.umc.product.demoday.adapter.in.web.dto.request;
 
 import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record GuestParticipationRequest(
-    @NotBlank String admissionCode
+    @NotBlank String admissionCode,
+    @Schema(
+        description = "동일한 입장 시도의 안전한 재시도를 위한 UUID v4. 기존 클라이언트는 생략할 수 있습니다.",
+        example = "0f43f02a-6ecf-4bb3-82ce-625029bd3e09",
+        nullable = true
+    )
+    @Pattern(
+        regexp = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        message = "requestId는 소문자 UUID v4 형식이어야 합니다."
+    )
+    String requestId
 ) {
     public StartDemodayGuestParticipationCommand toCommand(Long pollId, Long existingEntryCodeId) {
-        return new StartDemodayGuestParticipationCommand(pollId, admissionCode, existingEntryCodeId);
+        return new StartDemodayGuestParticipationCommand(pollId, admissionCode, requestId, existingEntryCodeId);
     }
 }

--- a/src/main/java/com/umc/product/demoday/adapter/out/Sha256DemodayParticipationRequestIdHasher.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/Sha256DemodayParticipationRequestIdHasher.java
@@ -1,0 +1,27 @@
+package com.umc.product.demoday.adapter.out;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.product.demoday.application.port.out.HashDemodayParticipationRequestIdPort;
+
+@Component
+public class Sha256DemodayParticipationRequestIdHasher implements HashDemodayParticipationRequestIdPort {
+
+    @Override
+    public String hash(String requestId) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(requestId.getBytes(StandardCharsets.UTF_8));
+
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                "JVM에서 SHA-256 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodeJpaRepository.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodeJpaRepository.java
@@ -4,12 +4,19 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.umc.product.demoday.domain.DemodayEntryCode;
 
 public interface DemodayEntryCodeJpaRepository extends JpaRepository<DemodayEntryCode, Long> {
 
     Optional<DemodayEntryCode> findByCodeHash(String codeHash);
+
+    @Lock(jakarta.persistence.LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT entryCode FROM DemodayEntryCode entryCode WHERE entryCode.codeHash = :codeHash")
+    Optional<DemodayEntryCode> findByCodeHashForUpdate(@Param("codeHash") String codeHash);
 
     List<DemodayEntryCode> findAllByPollIdAndRedeemedAtIsNotNullOrderByRedeemedAtAscIdAsc(Long pollId);
 }

--- a/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodePersistenceAdapter.java
+++ b/src/main/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodePersistenceAdapter.java
@@ -29,6 +29,11 @@ public class DemodayEntryCodePersistenceAdapter
     }
 
     @Override
+    public Optional<DemodayEntryCode> findByCodeHashForRedemption(String codeHash) {
+        return repository.findByCodeHashForUpdate(codeHash);
+    }
+
+    @Override
     public List<DemodayEntryCode> listRedeemedByPollId(Long pollId) {
         return repository.findAllByPollIdAndRedeemedAtIsNotNullOrderByRedeemedAtAscIdAsc(pollId);
     }

--- a/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationCommand.java
+++ b/src/main/java/com/umc/product/demoday/application/port/in/command/dto/StartDemodayGuestParticipationCommand.java
@@ -1,13 +1,13 @@
 package com.umc.product.demoday.application.port.in.command.dto;
 
 /**
- * {@code existingEntryCodeId}는 요청에 이미 유효한 게스트 participant Cookie가 있을 때만 채워진다(nullable).
- * 같은 브라우저의 재제출 멱등 처리(계약: "이미 유효한 Cookie를 가진 같은 브라우저가 같은 코드를 다시
- * 제출하면 성공으로 처리")에 쓰인다. 이 값이 지금 제출된 코드의 entryCodeId와 같으면 re-redeem 하지 않는다.
+ * {@code requestId}는 응답과 Cookie가 유실되어도 같은 입장 시도를 재개하기 위한 선택 UUID다.
+ * {@code existingEntryCodeId}는 기존 클라이언트의 Cookie 기반 재제출 호환성을 위해 사용한다.
  */
 public record StartDemodayGuestParticipationCommand(
     Long pollId,
     String admissionCode,
+    String requestId,
     Long existingEntryCodeId
 ) {
 }

--- a/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayParticipationRequestIdPort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/HashDemodayParticipationRequestIdPort.java
@@ -1,0 +1,6 @@
+package com.umc.product.demoday.application.port.out;
+
+public interface HashDemodayParticipationRequestIdPort {
+
+    String hash(String requestId);
+}

--- a/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayEntryCodePort.java
+++ b/src/main/java/com/umc/product/demoday/application/port/out/LoadDemodayEntryCodePort.java
@@ -11,5 +11,7 @@ public interface LoadDemodayEntryCodePort {
 
     Optional<DemodayEntryCode> findByCodeHash(String codeHash);
 
+    Optional<DemodayEntryCode> findByCodeHashForRedemption(String codeHash);
+
     List<DemodayEntryCode> listRedeemedByPollId(Long pollId);
 }

--- a/src/main/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandService.java
+++ b/src/main/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandService.java
@@ -13,6 +13,7 @@ import com.umc.product.demoday.application.port.in.query.GetDemodayParticipation
 import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipationInfo;
 import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
 import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.HashDemodayParticipationRequestIdPort;
 import com.umc.product.demoday.application.port.out.IssueDemodayParticipantTokenPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
@@ -33,6 +34,7 @@ public class StartDemodayGuestParticipationCommandService implements StartDemoda
     private final LoadDemodayEntryCodePort loadDemodayEntryCodePort;
     private final SaveDemodayEntryCodePort saveDemodayEntryCodePort;
     private final HashDemodayEntryCodePort hashDemodayEntryCodePort;
+    private final HashDemodayParticipationRequestIdPort hashDemodayParticipationRequestIdPort;
     private final IssueDemodayParticipantTokenPort issueDemodayParticipantTokenPort;
     private final GetDemodayParticipationUseCase getDemodayParticipationUseCase;
 
@@ -42,14 +44,16 @@ public class StartDemodayGuestParticipationCommandService implements StartDemoda
             .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_POLL_NOT_FOUND));
 
         String codeHash = hashDemodayEntryCodePort.hash(command.admissionCode());
-        DemodayEntryCode entryCode = loadDemodayEntryCodePort.findByCodeHash(codeHash)
+        DemodayEntryCode entryCode = loadDemodayEntryCodePort.findByCodeHashForRedemption(codeHash)
             .orElseThrow(() -> new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_NOT_FOUND));
 
         if (!Objects.equals(entryCode.getPollId(), poll.getId())) {
             throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_POLL_MISMATCH);
         }
 
-        if (!isIsResubmissionByExistingHolder(command, entryCode)) {
+        if (command.requestId() != null) {
+            redeemOrResume(command.requestId(), entryCode);
+        } else if (!isLegacyResubmissionByExistingHolder(command, entryCode)) {
             entryCode.redeem(Instant.now());
             saveDemodayEntryCodePort.save(entryCode);
         }
@@ -62,7 +66,14 @@ public class StartDemodayGuestParticipationCommandService implements StartDemoda
         return new StartDemodayGuestParticipationInfo(participantToken, poll.getClosesAt(), participation);
     }
 
-    private static boolean isIsResubmissionByExistingHolder(
+    private void redeemOrResume(String requestId, DemodayEntryCode entryCode) {
+        String requestIdHash = hashDemodayParticipationRequestIdPort.hash(requestId);
+        if (entryCode.redeemOrResume(Instant.now(), requestIdHash)) {
+            saveDemodayEntryCodePort.save(entryCode);
+        }
+    }
+
+    private static boolean isLegacyResubmissionByExistingHolder(
         StartDemodayGuestParticipationCommand command, DemodayEntryCode entryCode) {
 
         return command.existingEntryCodeId() != null

--- a/src/main/java/com/umc/product/demoday/domain/DemodayEntryCode.java
+++ b/src/main/java/com/umc/product/demoday/domain/DemodayEntryCode.java
@@ -56,6 +56,9 @@ public class DemodayEntryCode extends BaseEntity {
     @Column(name = "redeemed_at")
     private Instant redeemedAt;
 
+    @Column(name = "redemption_request_id_hash", length = HASH_LENGTH)
+    private String redemptionRequestIdHash;
+
     @Builder(access = AccessLevel.PRIVATE)
     private DemodayEntryCode(Long pollId, String codeHash) {
         this.pollId = pollId;
@@ -78,6 +81,23 @@ public class DemodayEntryCode extends BaseEntity {
         }
 
         this.redeemedAt = now;
+    }
+
+    public boolean redeemOrResume(Instant now, String requestIdHash) {
+        Objects.requireNonNull(now, "now must not be null");
+        Objects.requireNonNull(requestIdHash, "requestIdHash must not be null");
+
+        if (!isRedeemed()) {
+            this.redeemedAt = now;
+            this.redemptionRequestIdHash = requestIdHash;
+            return true;
+        }
+
+        if (requestIdHash.equals(redemptionRequestIdHash)) {
+            return false;
+        }
+
+        throw new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED);
     }
 
     public boolean isRedeemed() {

--- a/src/main/resources/db/migration/V2026.08.21.00.00__add_redemption_request_id_to_demoday_entry_code.sql
+++ b/src/main/resources/db/migration/V2026.08.21.00.00__add_redemption_request_id_to_demoday_entry_code.sql
@@ -1,0 +1,6 @@
+ALTER TABLE demoday_entry_code
+    ADD COLUMN redemption_request_id_hash VARCHAR(64);
+
+ALTER TABLE demoday_entry_code
+    ADD CONSTRAINT ck_demoday_entry_code_request_after_redemption
+        CHECK (redemption_request_id_hash IS NULL OR redeemed_at IS NOT NULL);

--- a/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/in/web/DemodayParticipationCommandControllerTest.java
@@ -67,6 +67,7 @@ class DemodayParticipationCommandControllerTest {
     private static final Long MEMBER_ID = 1L;
     private static final Long BOOTH_ID = 20L;
     private static final int BOOTH_CODE = 11;
+    private static final String REQUEST_ID = "0f43f02a-6ecf-4bb3-82ce-625029bd3e09";
     // MockHttpServletResponse의 Set-Cookie 파서(MockCookie#parse)는 Max-Age를 int로 파싱한다.
     // 실제 poll.closesAt은 항상 근시일이라 문제되지 않지만, 테스트 데이터는 그 한계를 넘지 않게 근접 미래로 둔다.
     private static final Instant CLOSES_AT = Instant.now().plusSeconds(3600);
@@ -117,7 +118,7 @@ class DemodayParticipationCommandControllerTest {
             new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
 
         given(startDemodayGuestParticipationUseCase.start(
-            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", null)))
+            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", null, null)))
             .willReturn(info);
 
         // when
@@ -154,7 +155,7 @@ class DemodayParticipationCommandControllerTest {
             new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
 
         given(startDemodayGuestParticipationUseCase.start(
-            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", ENTRY_CODE_ID)))
+            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", null, ENTRY_CODE_ID)))
             .willReturn(info);
 
         // when & then
@@ -166,7 +167,33 @@ class DemodayParticipationCommandControllerTest {
             .andExpect(status().isCreated());
 
         then(startDemodayGuestParticipationUseCase).should().start(
-            eq(new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", ENTRY_CODE_ID)));
+            eq(new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", null, ENTRY_CODE_ID)));
+    }
+
+    @Test
+    @DisplayName("requestId를 제출하면 커맨드에 전달한다")
+    void startGuestParticipationWithRequestId() throws Exception {
+        // given
+        given(demodayParticipantTokenProvider.parseEntryCodeId(null)).willReturn(Optional.empty());
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 0, 6,
+            List.of(), null, false, false, false, null);
+        StartDemodayGuestParticipationInfo info =
+            new StartDemodayGuestParticipationInfo("issued-token", CLOSES_AT, participationInfo);
+        given(startDemodayGuestParticipationUseCase.start(
+            new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", REQUEST_ID, null)))
+            .willReturn(info);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"admissionCode":"GUEST-A1B2C3","requestId":"%s"}
+                    """.formatted(REQUEST_ID)))
+            .andExpect(status().isCreated());
+
+        then(startDemodayGuestParticipationUseCase).should().start(
+            eq(new StartDemodayGuestParticipationCommand(POLL_ID, "GUEST-A1B2C3", REQUEST_ID, null)));
     }
 
     @Test
@@ -175,6 +202,15 @@ class DemodayParticipationCommandControllerTest {
         mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"admissionCode\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("requestId가 UUID v4 형식이 아니면 400을 반환한다")
+    void startGuestParticipationWithInvalidRequestId() throws Exception {
+        mockMvc.perform(post("/api/v1/demoday/polls/{pollId}/participations/guest", POLL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"admissionCode\":\"GUEST-A1B2C3\",\"requestId\":\"predictable-id\"}"))
             .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodePersistenceAdapterTest.java
+++ b/src/test/java/com/umc/product/demoday/adapter/out/persistence/DemodayEntryCodePersistenceAdapterTest.java
@@ -52,10 +52,14 @@ class DemodayEntryCodePersistenceAdapterTest {
         // When
         DemodayEntryCode foundById = loadDemodayEntryCodePort.findById(entryCode.getId()).orElseThrow();
         DemodayEntryCode foundByHash = loadDemodayEntryCodePort.findByCodeHash(entryCode.getCodeHash()).orElseThrow();
+        DemodayEntryCode foundForRedemption = loadDemodayEntryCodePort
+            .findByCodeHashForRedemption(entryCode.getCodeHash())
+            .orElseThrow();
 
         // Then
         assertThat(foundById.getId()).isEqualTo(entryCode.getId());
         assertThat(foundByHash.getId()).isEqualTo(entryCode.getId());
+        assertThat(foundForRedemption.getId()).isEqualTo(entryCode.getId());
     }
 
     @Test
@@ -75,6 +79,24 @@ class DemodayEntryCodePersistenceAdapterTest {
         assertThat(saved)
             .extracting(DemodayEntryCode::getCodeHash)
             .containsExactly(entryCodes.get(0).getCodeHash(), entryCodes.get(1).getCodeHash());
+    }
+
+    @Test
+    @DisplayName("입장 코드 사용 요청 식별자는 해시로 저장하고 다시 조회할 수 있다")
+    void saveAndFindRedemptionRequestIdHash() {
+        // Given
+        DemodayPoll poll = savePoll();
+        DemodayEntryCode entryCode = newEntryCode(poll, "c");
+        String requestIdHash = "d".repeat(DemodayEntryCode.HASH_LENGTH);
+        entryCode.redeemOrResume(Instant.parse("2026-07-27T10:00:00Z"), requestIdHash);
+        DemodayEntryCode saved = saveDemodayEntryCodePort.save(entryCode);
+        clearPersistenceContext();
+
+        // When
+        DemodayEntryCode found = loadDemodayEntryCodePort.findById(saved.getId()).orElseThrow();
+
+        // Then
+        assertThat(found.getRedemptionRequestIdHash()).isEqualTo(requestIdHash);
     }
 
     private DemodayPoll savePoll() {

--- a/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationCommandServiceTest.java
@@ -28,6 +28,7 @@ import com.umc.product.demoday.application.port.in.query.dto.DemodayParticipatio
 import com.umc.product.demoday.application.port.in.query.participant.DemodayParticipantType;
 import com.umc.product.demoday.application.port.in.query.participant.GuestDemodayParticipant;
 import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.HashDemodayParticipationRequestIdPort;
 import com.umc.product.demoday.application.port.out.IssueDemodayParticipantTokenPort;
 import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
 import com.umc.product.demoday.application.port.out.LoadDemodayPollPort;
@@ -46,6 +47,8 @@ class StartDemodayGuestParticipationCommandServiceTest {
     private static final Instant CLOSES_AT = Instant.parse("2100-08-15T12:00:00Z");
     private static final String ADMISSION_CODE = "GUEST-A1B2C3";
     private static final String CODE_HASH = "hashed-code";
+    private static final String REQUEST_ID = "0f43f02a-6ecf-4bb3-82ce-625029bd3e09";
+    private static final String REQUEST_ID_HASH = "hashed-request-id";
     private static final String PARTICIPANT_TOKEN = "participant-token";
 
     @Mock
@@ -59,6 +62,9 @@ class StartDemodayGuestParticipationCommandServiceTest {
 
     @Mock
     private HashDemodayEntryCodePort hashDemodayEntryCodePort;
+
+    @Mock
+    private HashDemodayParticipationRequestIdPort hashDemodayParticipationRequestIdPort;
 
     @Mock
     private IssueDemodayParticipantTokenPort issueDemodayParticipantTokenPort;
@@ -75,7 +81,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
         // given
         given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.empty());
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, null);
 
         // when & then
         assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
@@ -92,9 +98,9 @@ class StartDemodayGuestParticipationCommandServiceTest {
         // given
         given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(mock(DemodayPoll.class)));
         given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
-        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.empty());
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.empty());
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, null);
 
         // when & then
         assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
@@ -115,10 +121,10 @@ class StartDemodayGuestParticipationCommandServiceTest {
 
         DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
         given(entryCode.getPollId()).willReturn(999L);
-        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
 
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, null);
 
         // when & then
         assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
@@ -140,13 +146,13 @@ class StartDemodayGuestParticipationCommandServiceTest {
 
         DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
         given(entryCode.getPollId()).willReturn(POLL_ID);
-        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
         willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED))
             .given(entryCode).redeem(any());
 
         // 다른 브라우저이므로 existingEntryCodeId가 없다(없거나 이 코드와 다른 값)
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, null);
 
         // when & then
         assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
@@ -171,7 +177,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
         DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
         given(entryCode.getPollId()).willReturn(POLL_ID);
         given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
-        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
         given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
 
         DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
@@ -183,7 +189,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
             .willReturn(participationInfo);
 
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, null);
 
         // when
         StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
@@ -209,7 +215,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
         DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
         given(entryCode.getPollId()).willReturn(POLL_ID);
         given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
-        given(loadDemodayEntryCodePort.findByCodeHash(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
 
         given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
 
@@ -220,7 +226,7 @@ class StartDemodayGuestParticipationCommandServiceTest {
             .willReturn(participationInfo);
 
         StartDemodayGuestParticipationCommand command =
-            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, ENTRY_CODE_ID);
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, null, ENTRY_CODE_ID);
 
         // when
         StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
@@ -229,5 +235,105 @@ class StartDemodayGuestParticipationCommandServiceTest {
         assertThat(result.participantToken()).isEqualTo(PARTICIPANT_TOKEN);
         then(entryCode).should(never()).redeem(any());
         then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("요청 식별자가 있는 코드를 처음 제출하면 사용 처리하고 토큰을 발급한다")
+    void startWithRequestIdWhenNewRedemption() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(poll.getClosesAt()).willReturn(CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+        given(hashDemodayParticipationRequestIdPort.hash(REQUEST_ID)).willReturn(REQUEST_ID_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
+        given(entryCode.redeemOrResume(any(), eq(REQUEST_ID_HASH))).willReturn(true);
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
+        givenParticipationInfo();
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, REQUEST_ID, null);
+
+        // when
+        StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
+
+        // then
+        assertThat(result.participantToken()).isEqualTo(PARTICIPANT_TOKEN);
+        then(entryCode).should().redeemOrResume(any(), eq(REQUEST_ID_HASH));
+        then(saveDemodayEntryCodePort).should().save(entryCode);
+    }
+
+    @Test
+    @DisplayName("같은 요청 식별자로 사용된 코드를 다시 제출하면 토큰을 재발급한다")
+    void startWithSameRequestIdWhenAlreadyRedeemed() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(poll.getClosesAt()).willReturn(CLOSES_AT);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+        given(hashDemodayParticipationRequestIdPort.hash(REQUEST_ID)).willReturn(REQUEST_ID_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(entryCode.getId()).willReturn(ENTRY_CODE_ID);
+        given(entryCode.redeemOrResume(any(), eq(REQUEST_ID_HASH))).willReturn(false);
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
+        given(issueDemodayParticipantTokenPort.issue(ENTRY_CODE_ID, CLOSES_AT)).willReturn(PARTICIPANT_TOKEN);
+        givenParticipationInfo();
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, REQUEST_ID, null);
+
+        // when
+        StartDemodayGuestParticipationInfo result = startDemodayGuestParticipationCommandService.start(command);
+
+        // then
+        assertThat(result.participantToken()).isEqualTo(PARTICIPANT_TOKEN);
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("다른 요청 식별자로 이미 사용된 코드를 제출하면 거부한다")
+    void startWithDifferentRequestIdWhenAlreadyRedeemed() {
+        // given
+        DemodayPoll poll = mock(DemodayPoll.class);
+        given(poll.getId()).willReturn(POLL_ID);
+        given(loadDemodayPollPort.findById(POLL_ID)).willReturn(Optional.of(poll));
+        given(hashDemodayEntryCodePort.hash(ADMISSION_CODE)).willReturn(CODE_HASH);
+        given(hashDemodayParticipationRequestIdPort.hash(REQUEST_ID)).willReturn(REQUEST_ID_HASH);
+
+        DemodayEntryCode entryCode = mock(DemodayEntryCode.class);
+        given(entryCode.getPollId()).willReturn(POLL_ID);
+        given(loadDemodayEntryCodePort.findByCodeHashForRedemption(CODE_HASH)).willReturn(Optional.of(entryCode));
+        willThrow(new DemodayDomainException(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED))
+            .given(entryCode).redeemOrResume(any(), eq(REQUEST_ID_HASH));
+
+        StartDemodayGuestParticipationCommand command =
+            new StartDemodayGuestParticipationCommand(POLL_ID, ADMISSION_CODE, REQUEST_ID, null);
+
+        // when & then
+        assertThatThrownBy(() -> startDemodayGuestParticipationCommandService.start(command))
+            .isInstanceOfSatisfying(DemodayDomainException.class, exception ->
+                assertThat(exception.getBaseCode())
+                    .isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED));
+
+        then(saveDemodayEntryCodePort).shouldHaveNoInteractions();
+        then(issueDemodayParticipantTokenPort).shouldHaveNoInteractions();
+    }
+
+    private DemodayParticipationInfo givenParticipationInfo() {
+        DemodayParticipationInfo participationInfo = new DemodayParticipationInfo(
+            POLL_ID, DemodayParticipantType.GUEST, 0, 6, List.of(),
+            null, false, false, false, null);
+        given(getDemodayParticipationUseCase.getParticipation(
+            eq(POLL_ID), eq(new GuestDemodayParticipant(ENTRY_CODE_ID))))
+            .willReturn(participationInfo);
+        return participationInfo;
     }
 }

--- a/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/umc/product/demoday/application/service/command/StartDemodayGuestParticipationConcurrencyIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.umc.product.demoday.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.umc.product.demoday.application.port.in.command.StartDemodayGuestParticipationUseCase;
+import com.umc.product.demoday.application.port.in.command.dto.StartDemodayGuestParticipationCommand;
+import com.umc.product.demoday.application.port.out.HashDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.HashDemodayParticipationRequestIdPort;
+import com.umc.product.demoday.application.port.out.LoadDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.SaveDemodayEntryCodePort;
+import com.umc.product.demoday.application.port.out.SaveDemodayPollPort;
+import com.umc.product.demoday.domain.DemodayEntryCode;
+import com.umc.product.demoday.domain.DemodayPoll;
+import com.umc.product.demoday.domain.exception.DemodayDomainException;
+import com.umc.product.demoday.domain.exception.DemodayErrorCode;
+import com.umc.product.support.IntegrationTestSupport;
+
+@DisplayName("게스트 참여 시작 동시 제출")
+class StartDemodayGuestParticipationConcurrencyIntegrationTest extends IntegrationTestSupport {
+
+    private static final String ADMISSION_CODE = "GUEST-CONCURRENT";
+    private static final String FIRST_REQUEST_ID = "0f43f02a-6ecf-4bb3-82ce-625029bd3e09";
+    private static final String SECOND_REQUEST_ID = "b716e41f-48c2-47bc-8f43-1b44bb890f48";
+
+    @Autowired private StartDemodayGuestParticipationUseCase startDemodayGuestParticipationUseCase;
+    @Autowired private SaveDemodayPollPort saveDemodayPollPort;
+    @Autowired private SaveDemodayEntryCodePort saveDemodayEntryCodePort;
+    @Autowired private LoadDemodayEntryCodePort loadDemodayEntryCodePort;
+    @Autowired private HashDemodayEntryCodePort hashDemodayEntryCodePort;
+    @Autowired private HashDemodayParticipationRequestIdPort hashDemodayParticipationRequestIdPort;
+    @Autowired private Clock clock;
+
+    @Test
+    @DisplayName("서로 다른 요청 식별자가 같은 코드를 동시에 제출하면 하나만 코드에 귀속된다")
+    void acceptOnlyOneConcurrentRequestId() throws Exception {
+        // given
+        Instant now = clock.instant();
+        DemodayPoll poll = saveDemodayPollPort.save(
+            DemodayPoll.create(1L, "게스트 동시 제출 Poll", now.minusSeconds(60), now.plusSeconds(3600)));
+        String codeHash = hashDemodayEntryCodePort.hash(ADMISSION_CODE);
+        saveDemodayEntryCodePort.save(DemodayEntryCode.create(poll.getId(), codeHash));
+
+        // when
+        List<Optional<DemodayErrorCode>> results = race(poll.getId());
+
+        // then
+        assertThat(results).containsExactlyInAnyOrder(
+            Optional.empty(),
+            Optional.of(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED)
+        );
+
+        DemodayEntryCode entryCode = loadDemodayEntryCodePort.findByCodeHash(codeHash).orElseThrow();
+        assertThat(entryCode.getRedemptionRequestIdHash()).isIn(
+            hashDemodayParticipationRequestIdPort.hash(FIRST_REQUEST_ID),
+            hashDemodayParticipationRequestIdPort.hash(SECOND_REQUEST_ID)
+        );
+    }
+
+    private List<Optional<DemodayErrorCode>> race(Long pollId) throws Exception {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Optional<DemodayErrorCode>> first = executor.submit(
+                () -> startAfterSignal(pollId, FIRST_REQUEST_ID, ready, start));
+            Future<Optional<DemodayErrorCode>> second = executor.submit(
+                () -> startAfterSignal(pollId, SECOND_REQUEST_ID, ready, start));
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            return List.of(first.get(10, TimeUnit.SECONDS), second.get(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private Optional<DemodayErrorCode> startAfterSignal(
+        Long pollId,
+        String requestId,
+        CountDownLatch ready,
+        CountDownLatch start
+    ) throws Exception {
+        ready.countDown();
+        if (!start.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("demoday guest participation concurrency start timed out");
+        }
+
+        try {
+            startDemodayGuestParticipationUseCase.start(
+                new StartDemodayGuestParticipationCommand(pollId, ADMISSION_CODE, requestId, null));
+            return Optional.empty();
+        } catch (DemodayDomainException exception) {
+            return Optional.of((DemodayErrorCode) exception.getBaseCode());
+        }
+    }
+}

--- a/src/test/java/com/umc/product/demoday/domain/DemodayEntryCodeTest.java
+++ b/src/test/java/com/umc/product/demoday/domain/DemodayEntryCodeTest.java
@@ -16,6 +16,7 @@ class DemodayEntryCodeTest {
 
     private static final Long POLL_ID = 1L;
     private static final String CODE_HASH = "code hash";
+    private static final String REQUEST_ID_HASH = "request id hash";
 
     @Test
     @DisplayName("입장 코드를 생성하면 투표와 코드 해시를 보관한다.")
@@ -28,6 +29,7 @@ class DemodayEntryCodeTest {
         assertThat(entryCode.getCodeHash()).isEqualTo(CODE_HASH);
         assertThat(entryCode.getBoundIdentityHash()).isNull();
         assertThat(entryCode.getRedeemedAt()).isNull();
+        assertThat(entryCode.getRedemptionRequestIdHash()).isNull();
         assertThat(entryCode.isRedeemed()).isFalse();
     }
 
@@ -45,6 +47,55 @@ class DemodayEntryCodeTest {
         assertThat(entryCode.getRedeemedAt()).isEqualTo(redeemedAt);
         assertThat(entryCode.isRedeemed()).isTrue();
         assertThatThrownBy(() -> entryCode.redeem(redeemedAt))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("BaseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED);
+    }
+
+    @Test
+    @DisplayName("동일한 요청 식별자로 사용을 재개하면 최초 사용 시각을 유지한다.")
+    void resumeEntryCodeWithSameRequestId() {
+        // given
+        DemodayEntryCode entryCode = DemodayEntryCode.create(POLL_ID, CODE_HASH);
+        Instant redeemedAt = Instant.parse("2026-08-01T05:30:00Z");
+        Instant retriedAt = redeemedAt.plusSeconds(10);
+
+        // when
+        boolean firstRedemption = entryCode.redeemOrResume(redeemedAt, REQUEST_ID_HASH);
+        boolean resumed = entryCode.redeemOrResume(retriedAt, REQUEST_ID_HASH);
+
+        // then
+        assertThat(firstRedemption).isTrue();
+        assertThat(resumed).isFalse();
+        assertThat(entryCode.getRedeemedAt()).isEqualTo(redeemedAt);
+        assertThat(entryCode.getRedemptionRequestIdHash()).isEqualTo(REQUEST_ID_HASH);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 입장 코드를 다른 요청 식별자로 재개할 수 없다.")
+    void rejectDifferentRequestId() {
+        // given
+        DemodayEntryCode entryCode = DemodayEntryCode.create(POLL_ID, CODE_HASH);
+        Instant redeemedAt = Instant.parse("2026-08-01T05:30:00Z");
+        entryCode.redeemOrResume(redeemedAt, REQUEST_ID_HASH);
+
+        // when & then
+        assertThatThrownBy(() -> entryCode.redeemOrResume(redeemedAt, "another request id hash"))
+            .isInstanceOf(DemodayDomainException.class)
+            .extracting("BaseCode")
+            .isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED);
+    }
+
+    @Test
+    @DisplayName("식별자 없이 사용된 기존 입장 코드는 새 요청 식별자에 귀속되지 않는다.")
+    void rejectRequestIdForLegacyRedemption() {
+        // given
+        DemodayEntryCode entryCode = DemodayEntryCode.create(POLL_ID, CODE_HASH);
+        Instant redeemedAt = Instant.parse("2026-08-01T05:30:00Z");
+        entryCode.redeem(redeemedAt);
+
+        // when & then
+        assertThatThrownBy(() -> entryCode.redeemOrResume(redeemedAt, REQUEST_ID_HASH))
             .isInstanceOf(DemodayDomainException.class)
             .extracting("BaseCode")
             .isEqualTo(DemodayErrorCode.DEMODAY_ENTRY_CODE_ALREADY_REDEEMED);


### PR DESCRIPTION
## 🚀 작업 내용

### 무엇을

- 게스트 입장 코드 제출 API에 선택적 UUID v4 `requestId`를 추가했습니다.
- 동일한 입장 코드와 동일한 `requestId`로 재시도하면 참여 Cookie를 다시 발급합니다.
- 이미 사용된 코드를 다른 `requestId`로 제출하면 기존과 동일하게 거절합니다.
- `requestId`가 없는 기존 클라이언트의 Cookie 기반 재제출 동작은 유지합니다.

### 어떻게

- 최초 사용 시 입장 코드에 `requestId`의 SHA-256 해시와 사용 시각을 함께 저장합니다. 원문 입장 코드와 요청 식별자는 DB, 로그, 응답에 노출하지 않습니다.
- 동일 해시가 저장된 코드의 재제출은 사용 시각을 변경하지 않고 기존 참여자 토큰을 다시 발급합니다.
- 입장 코드 조회에 `PESSIMISTIC_WRITE` 행 잠금을 적용해 서로 다른 요청이 동시에 같은 코드를 선점하지 못하게 했습니다.
- `redemption_request_id_hash` nullable 컬럼과 사용 상태 불변식을 보호하는 CHECK 제약을 additive Flyway migration으로 추가해 기존 데이터를 유지했습니다.
- 도메인, 애플리케이션 서비스, 웹 DTO, 영속성, 실제 PostgreSQL 동시성 테스트를 함께 추가했습니다.

### 왜

서버가 입장 코드를 정상적으로 사용 처리한 뒤 응답이나 Cookie가 유실되면, 기존 방식에서는 사용자가 같은 코드를 재제출해도 이미 사용된 코드로 거절됩니다. 정상 참가자가 네트워크 문제만으로 참여할 수 없게 되는 상황을 복구해야 했습니다.

고려한 대안과 판단 과정은 다음과 같습니다.

1. **사용된 입장 코드만 확인해 Cookie 재발급**: 입장 코드 자체가 반복 로그인 수단이 되어 탈취·재사용 위험이 커지므로 제외했습니다.
2. **timeout 이후 참여 상태만 조회**: Cookie가 함께 유실된 경우 요청자를 인증할 수 없어 복구 수단이 되지 못하므로 제외했습니다.
3. **운영진이 입장 코드를 수동 초기화**: 온라인-only 운영과 즉각적인 현장 복구 요구를 충족하지 못해 제외했습니다.
4. **동일한 입장 시도만 재개**: 예측하기 어려운 `requestId`로 최초 시도를 코드에 귀속하면 정상 사용자의 응답 유실은 복구하면서 다른 브라우저의 재사용은 차단할 수 있어 선택했습니다.

### 결과

- 최초 제출: 참여 Cookie 발급
- 동일 코드·동일 `requestId` 재시도: 참여 Cookie 재발급
- 동일 코드·다른 `requestId` 제출: `DEMODAY-0300`으로 거절
- 서로 다른 동시 제출: 하나의 요청만 코드에 귀속
- 기존 요청: `requestId` 생략 가능하며 기존 Cookie 기반 동작 유지
- 검증: 컴파일, 변경 범위 단위·웹·영속성·동시성 테스트, Spotless, Checkstyle 통과

resolves #1308

## 💬 리뷰 중점사항

- 선택 필드인 `requestId`가 기존 클라이언트 계약을 깨지 않는지 확인 부탁드립니다.
- 입장 코드 행 잠금의 트랜잭션 범위와 동시 제출 직렬화 방식이 적절한지 확인 부탁드립니다.
- 요청 식별자를 원문이 아닌 SHA-256 해시로 저장하고 응답·로그에 노출하지 않는 경계가 충분한지 확인 부탁드립니다.
- 운영 배포 전 Flyway migration이 먼저 적용되어야 합니다.