### PR TITLE
[Fix] dev 프로파일 로그 출력 활성화

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,8 +39,7 @@
     <!--
         ========== JSON 구조화 로그 어펜더 (ADR-016) ==========
         dev / staging / prod 환경의 stdout 을 JSON 한 줄로 출력.
-        본 커밋(#2)에서는 정의만 하고 어떤 root 에도 연결하지 않는다 (dead-code).
-        root 연결은 Commit #3 에서 수행한다.
+        각 프로파일의 SANITIZED 어펜더를 거쳐 root 에 연결한다.
     -->
     <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE_JSON">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
@@ -125,8 +124,8 @@
         </root>
     </springProfile>
 
-    <!-- ========== staging: dev 와 동일 구성 ========== -->
-    <springProfile name="staging">
+    <!-- ========== dev / staging: stdout JSON + OTLP logs ========== -->
+    <springProfile name="dev | staging">
         <logger name="com.umc.product" level="${LOGGING_APP_LEVEL:-INFO}"/>
 
         <appender name="SANITIZED" class="com.umc.product.global.logging.SanitizingAppender">

--- a/src/test/java/com/umc/product/global/logging/LogbackAppenderTopologyTest.java
+++ b/src/test/java/com/umc/product/global/logging/LogbackAppenderTopologyTest.java
@@ -13,6 +13,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.env.Profiles;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -89,6 +92,26 @@ class LogbackAppenderTopologyTest {
                 }
             }
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dev", "staging", "prod"})
+    @DisplayName("서버 프로파일은 정제된 JSON 및 OTEL 출력 구성을 활성화한다")
+    void 서버_프로파일의_로그_출력이_활성화된다(String activeProfile) {
+        // Given
+        List<Element> activeProfiles = elementsByTag(config.getDocumentElement(), "springProfile").stream()
+            .filter(profile -> Profiles.of(profile.getAttribute("name")).matches(activeProfile::equals))
+            .toList();
+
+        // When / Then
+        assertThat(activeProfiles).as("%s 프로파일의 로그 설정", activeProfile).hasSize(1);
+        Element profile = activeProfiles.getFirst();
+        Element sanitizingAppender = elementsByTag(profile, "appender").stream()
+            .filter(appender -> SANITIZING_APPENDER.equals(appender.getAttribute("class")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(activeProfile + " 프로파일에 정제 어펜더가 없다"));
+
+        assertThat(appenderRefs(sanitizingAppender)).containsExactly("CONSOLE_JSON", "OTEL");
     }
 
     private Element topLevelAppender(String name) {


### PR DESCRIPTION
## 변경 사항
- dev에서 누락된 Logback 프로필을 기존 staging 구성과 연결합니다.
- 기존 SANITIZED 경로의 JSON stdout 및 OTEL 로그를 사용하며 prod 설정과 로그 레벨은 변경하지 않습니다.
- dev/staging/prod 활성 프로필 및 출력 경로를 검사하는 회귀 테스트를 추가합니다.

## 검증
- 수정 전 dev 케이스 실패 재현
- logging 및 민감정보 정제 관련 테스트 40개 통과
- Spotless 및 Checkstyle 통과(한국어 테스트명 경고 있음)
- 전체 통합 검사는 이 PR의 CI에서 확인합니다.

## 배포
- develop 반영 후 기존 GitOps 발행 파이프라인으로 dev만 갱신합니다.
- 새 Pod Ready와 Loki dev 로그 수집을 확인합니다.