### PR TITLE
[Feat] 11기 커리큘럼 목차 준비와 0주차 조회 지원

### DIFF
--- a/scripts/data/11th-curriculum-outline.json
+++ b/scripts/data/11th-curriculum-outline.json
@@ -1,0 +1,223 @@
+{
+  "generation": 11,
+  "curricula": [
+    {
+      "track": "PLAN",
+      "weeks": [
+        {
+          "weekNo": 0,
+          "title": "서비스 기획 입문"
+        },
+        {
+          "weekNo": 1,
+          "title": "문제 정의와 리서치 (1)"
+        },
+        {
+          "weekNo": 2,
+          "title": "문제 정의와 리서치 (2)"
+        },
+        {
+          "weekNo": 3,
+          "title": "서비스 정의와 비즈니스 모델링"
+        },
+        {
+          "weekNo": 4,
+          "title": "기획 산출물 (1) UX 설계"
+        },
+        {
+          "weekNo": 5,
+          "title": "기획 산출물 (2) 상세 기능 정의"
+        },
+        {
+          "weekNo": 6,
+          "title": "기획 산출물 (3) 기획 문서 작성"
+        },
+        {
+          "weekNo": 7,
+          "title": "기획 산출물 (4) 화면 설계"
+        },
+        {
+          "weekNo": 8,
+          "title": "프로젝트 관리 및 협업"
+        },
+        {
+          "weekNo": 9,
+          "title": "서비스 품질 검증"
+        },
+        {
+          "weekNo": 10,
+          "title": "그로스 전략 설계"
+        }
+      ]
+    },
+    {
+      "track": "DESIGN",
+      "weeks": [
+        {
+          "weekNo": 0,
+          "title": "피그마 기초 학습"
+        },
+        {
+          "weekNo": 1,
+          "title": "UI 디자인 입문: 클론 디자인 App & Web"
+        },
+        {
+          "weekNo": 2,
+          "title": "리디자인: Pain Point 분석"
+        },
+        {
+          "weekNo": 3,
+          "title": "리디자인: Solution 탐구"
+        },
+        {
+          "weekNo": 4,
+          "title": "와이어프레임 & 디자인 시스템 구축"
+        },
+        {
+          "weekNo": 5,
+          "title": "UI 디자인 진행"
+        },
+        {
+          "weekNo": 6,
+          "title": "UI 디자인 확장 & 포트폴리오 제작"
+        },
+        {
+          "weekNo": 7,
+          "title": "프로토타입 제작 & 복습 가이드"
+        },
+        {
+          "weekNo": 8,
+          "title": "매칭 프로젝트 디자인 (1)"
+        },
+        {
+          "weekNo": 9,
+          "title": "매칭 프로젝트 디자인 (2)"
+        },
+        {
+          "weekNo": 10,
+          "title": "매칭 프로젝트 디자인 (3)"
+        },
+        {
+          "weekNo": 1,
+          "isExtra": true,
+          "title": "협업 가이드"
+        },
+        {
+          "weekNo": 2,
+          "isExtra": true,
+          "title": "디자인 인사이트"
+        }
+      ]
+    },
+    {
+      "track": "MOBILE_PRODUCT_ENGINEER",
+      "weeks": [
+        {
+          "weekNo": 1,
+          "title": "데이터 모델링과 앱 UI 기초"
+        },
+        {
+          "weekNo": 2,
+          "title": "SQL 데이터 조작과 사용자 입력 폼"
+        },
+        {
+          "weekNo": 3,
+          "title": "서버 환경 세팅과 앱 화면 내비게이션"
+        },
+        {
+          "weekNo": 4,
+          "title": "ORM 기반 CRUD와 비동기 UI 처리"
+        },
+        {
+          "weekNo": 5,
+          "title": "Public API 설계와 앱 아키텍처 정립"
+        },
+        {
+          "weekNo": 6,
+          "title": "CRUD API 구축과 네트워크 통신"
+        },
+        {
+          "weekNo": 7,
+          "title": "JWT 인증/인가와 사용자 토큰 관리"
+        },
+        {
+          "weekNo": 8,
+          "title": "핵심 비즈니스 로직과 데이터 상태 관리"
+        },
+        {
+          "weekNo": 9,
+          "title": "API 명세 확정과 심화 기능 연동"
+        },
+        {
+          "weekNo": 10,
+          "title": "클라우드 환경 분리 배포와 앱 출시"
+        }
+      ]
+    },
+    {
+      "track": "WEB_PRODUCT_ENGINEER",
+      "weeks": [
+        {
+          "weekNo": 1,
+          "title": "데이터 모델링과 타입 시스템 기초"
+        },
+        {
+          "weekNo": 2,
+          "title": "SQL 데이터 조작과 React UI 기초"
+        },
+        {
+          "weekNo": 3,
+          "title": "서버 환경 세팅과 웹 화면 라우팅"
+        },
+        {
+          "weekNo": 4,
+          "title": "ORM 기반 CRUD와 클라이언트 상태 관리"
+        },
+        {
+          "weekNo": 5,
+          "title": "Public API 구축과 웹 API 연동"
+        },
+        {
+          "weekNo": 6,
+          "title": "CRUD API와 서버 상태 관리"
+        },
+        {
+          "weekNo": 7,
+          "title": "JWT 인증/인가와 사용자 인증 연동"
+        },
+        {
+          "weekNo": 8,
+          "title": "핵심 비즈니스 로직과 사용자 기능 연동"
+        },
+        {
+          "weekNo": 9,
+          "title": "API 안정화와 Next.js 웹 개발"
+        },
+        {
+          "weekNo": 10,
+          "title": "운영 환경 분리와 웹 서비스 배포"
+        }
+      ]
+    }
+  ],
+  "deferredCurricula": [
+    {
+      "track": "INFRA_PLUS",
+      "weeks": [
+        {
+          "weekNo": 1,
+          "title": "신뢰할 수 있는 배포 파이프라인"
+        },
+        {
+          "weekNo": 2,
+          "title": "관측 가능한 시스템 만들기"
+        },
+        {
+          "weekNo": 3,
+          "title": "장애를 견디는 시스템 만들기"
+        }
+      ]
+    }
+  ],
+  "scheduleStatus": "PENDING"
+}

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetBestWorkbooksRequest.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetBestWorkbooksRequest.java
@@ -15,7 +15,7 @@ public record GetBestWorkbooksRequest(
     Long gisuId,
     Set<@Positive Long> schoolIds,
     Set<ChallengerPart> parts,
-    List<@Positive Long> weekNos,
+    List<@PositiveOrZero Long> weekNos,
     List<@Positive Long> studyGroupIds,
     @PositiveOrZero Integer page,
     @Positive @Max(100) Integer size,

--- a/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetStudyMemberSubmissionsRequest.java
+++ b/src/main/java/com/umc/product/curriculum/adapter/in/web/v2/dto/request/GetStudyMemberSubmissionsRequest.java
@@ -6,6 +6,7 @@ import com.umc.product.curriculum.application.port.in.query.dto.StudyMemberSubmi
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 /**
  * 스터디원 제출 현황 조회 요청.
@@ -17,7 +18,7 @@ import jakarta.validation.constraints.Positive;
  */
 public record GetStudyMemberSubmissionsRequest(
     @Positive Long studyGroupId,
-    List<@Positive Long> weekNos,
+    List<@PositiveOrZero Long> weekNos,
     @Positive Long cursor,
     @Positive @Max(100) Integer size,
     @Positive Long gisuId

--- a/src/test/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2ControllerTest.java
+++ b/src/test/java/com/umc/product/curriculum/adapter/in/web/v2/WorkbookQueryV2ControllerTest.java
@@ -1,6 +1,7 @@
 package com.umc.product.curriculum.adapter.in.web.v2;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -128,6 +129,32 @@ class WorkbookQueryV2ControllerTest {
     }
 
     @Test
+    @DisplayName("0주차 필터로 베스트 워크북을 조회한다")
+    void bestWorkbook_zeroWeekAccepted() throws Exception {
+        given(getWeeklyBestWorkbookUseCase.searchBestWorkbooks(any()))
+            .willReturn(new WeeklyBestWorkbookPageInfo(List.of(), 0, 20, 0, 0, false, false));
+
+        mockMvc.perform(get("/api/v2/curriculums/weekly-best-workbooks")
+                .param("weekNos", "0"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.content").isArray())
+            .andExpect(jsonPath("$.result.totalElements").value(0));
+
+        then(getWeeklyBestWorkbookUseCase).should()
+            .searchBestWorkbooks(argThat(query -> query.weekNos().equals(List.of(0L))));
+    }
+
+    @Test
+    @DisplayName("베스트 워크북 조회에서 음수 주차를 거부한다")
+    void bestWorkbook_negativeWeekRejected() throws Exception {
+        mockMvc.perform(get("/api/v2/curriculums/weekly-best-workbooks")
+                .param("weekNos", "-1"))
+            .andExpect(status().isBadRequest());
+
+        then(getWeeklyBestWorkbookUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
     @DisplayName("스터디원 제출 현황을 커서 응답으로 반환하고 미배포 인원도 포함한다")
     void studyMemberSubmissions_returnsCursorResponse() throws Exception {
         given(getStudyMemberSubmissionUseCase.getStudyMemberSubmissions(any())).willReturn(List.of(
@@ -166,6 +193,45 @@ class WorkbookQueryV2ControllerTest {
     void studyMemberSubmissions_size101Rejected() throws Exception {
         mockMvc.perform(get("/api/v2/curriculums/workbook-submissions")
                 .param("size", "101"))
+            .andExpect(status().isBadRequest());
+
+        then(getStudyMemberSubmissionUseCase).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("0주차 필터로 스터디원 제출 현황을 조회한다")
+    void studyMemberSubmissions_zeroWeekAccepted() throws Exception {
+        given(getStudyMemberSubmissionUseCase.getStudyMemberSubmissions(any())).willReturn(List.of(
+            StudyMemberSubmissionInfo.builder()
+                .studyGroupMemberId(51L)
+                .memberId(100L)
+                .studyGroupId(10L)
+                .weeks(List.of(WeeklySubmissionInfo.builder()
+                    .weekNo(0L)
+                    .weeklyCurriculumId(20L)
+                    .weeklyCurriculumTitle("Chapter 0")
+                    .status(ChallengerWorkbookStatus.NOT_SUBMITTED)
+                    .isBest(false)
+                    .build()))
+                .build()
+        ));
+
+        mockMvc.perform(get("/api/v2/curriculums/workbook-submissions")
+                .param("studyGroupId", "10")
+                .param("weekNos", "0"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.content[0].weeks[0].weekNo").value(0))
+            .andExpect(jsonPath("$.result.content[0].weeks[0].weeklyCurriculumTitle").value("Chapter 0"));
+
+        then(getStudyMemberSubmissionUseCase).should()
+            .getStudyMemberSubmissions(argThat(query -> query.weekNos().equals(List.of(0L))));
+    }
+
+    @Test
+    @DisplayName("스터디원 제출 현황 조회에서 음수 주차를 거부한다")
+    void studyMemberSubmissions_negativeWeekRejected() throws Exception {
+        mockMvc.perform(get("/api/v2/curriculums/workbook-submissions")
+                .param("weekNos", "-1"))
             .andExpect(status().isBadRequest());
 
         then(getStudyMemberSubmissionUseCase).shouldHaveNoInteractions();


### PR DESCRIPTION
11기 워크북 TFT가 공유한 목차를 Track별 데이터로 정리하고, Chapter 0을 조회할 때 발생하는 API 검증 불일치를 수정합니다.

- PLAN 11개, DESIGN 13개(부록 2개 포함), MOBILE_PRODUCT_ENGINEER 10개, WEB_PRODUCT_ENGINEER 10개로 기본 목차 44개를 정리합니다.
- Plan·Design의 Chapter 0은 `weekNo=0`, Design 부록 1·2는 `isExtra=true`로 구분합니다. Flutter 목차는 MOBILE_PRODUCT_ENGINEER에 연결합니다.
- Infra 3개 목차는 `deferredCurricula`에 보관합니다. 앞서 보류한 INFRA_PLUS 지원 범위는 유지합니다.
- 제출 현황·우수 워크북 조회의 `weekNos`에 0을 허용합니다. 음수 주차는 계속 거부하며 기존 응답 구조를 유지합니다.

목차 JSON은 일정 확정 후 데이터 마이그레이션에 사용할 원본입니다. 현재 `WeeklyCurriculum`은 시작·종료일이 필수여서 `scheduleStatus=PENDING`으로 두었으며, 실제 주차 등록 Flyway는 아직 추가하지 않았습니다. 주차별 일정과 Chapter 0·부록 기간을 받은 뒤 이 PR에 추가할 예정입니다. 기존 부록 정렬 방식은 유지합니다.

운영진 챌린저 코드 발급·사용 처리, DB 적용, 배포는 수행하지 않습니다. 최종 검토와 병합은 사용자가 직접 진행합니다.

검증: 목차의 Track별 개수·주차/부록 중복·제목 길이를 확인했습니다. 컨트롤러 회귀 테스트는 두 API의 0주차 조회 성공과 음수 거부를 확인합니다.

`spotlessCheck`, `checkstyleMain`, `checkstyleTest`, Java 컴파일과 `WorkbookQueryV2ControllerTest` 10개가 모두 통과했습니다.
