### PR TITLE
[Feat] 11기 커리큘럼 목차 44개 Flyway 등록

### DIFF
--- a/scripts/data/11th-curriculum-outline.json
+++ b/scripts/data/11th-curriculum-outline.json
@@ -219,5 +219,5 @@
       ]
     }
   ],
-  "scheduleStatus": "PENDING"
+  "scheduleStatus": "TEMPORARY_GISU_PERIOD"
 }

--- a/src/main/resources/db/migration/V2026.09.10.02.00__seed_11th_weekly_curricula.sql
+++ b/src/main/resources/db/migration/V2026.09.10.02.00__seed_11th_weekly_curricula.sql
@@ -1,0 +1,77 @@
+-- 11기 목차를 등록한다. 실제 주차 일정 확정 전까지 모든 항목에 기수 전체 기간을 사용한다.
+DO $$
+DECLARE
+    target_gisu_id BIGINT;
+BEGIN
+    -- 앞선 마이그레이션이 만든 11기와 Track 커리큘럼을 재사용한다.
+    SELECT id INTO STRICT target_gisu_id
+    FROM public.gisu
+    WHERE generation = 11 AND learning_type = 'TRACK';
+
+    IF (
+        SELECT COUNT(*) FROM public.curriculum
+        WHERE gisu_id = target_gisu_id
+            AND track IN ('PLAN', 'DESIGN', 'WEB_PRODUCT_ENGINEER', 'MOBILE_PRODUCT_ENGINEER')
+    ) <> 4 THEN
+        RAISE EXCEPTION '11기의 기본 Track 커리큘럼 4개가 필요합니다.';
+    END IF;
+
+    -- weekly_curriculum의 날짜는 TIMESTAMP WITHOUT TIME ZONE이므로 UTC 시각을 명시한다.
+    -- Chapter 0은 0주차, Design Appendix 1·2는 같은 번호의 본문과 is_extra로 구분한다.
+    INSERT INTO public.weekly_curriculum (
+        curriculum_id, week_no, is_extra, title, starts_at, ends_at, created_at, updated_at
+    )
+    SELECT curriculum.id, seed.week_no, seed.is_extra, seed.title,
+        gisu.start_at AT TIME ZONE 'UTC', gisu.end_at AT TIME ZONE 'UTC',
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC', CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+    FROM (VALUES
+        ('PLAN', 0, FALSE, '서비스 기획 입문'),
+        ('PLAN', 1, FALSE, '문제 정의와 리서치 (1)'),
+        ('PLAN', 2, FALSE, '문제 정의와 리서치 (2)'),
+        ('PLAN', 3, FALSE, '서비스 정의와 비즈니스 모델링'),
+        ('PLAN', 4, FALSE, '기획 산출물 (1) UX 설계'),
+        ('PLAN', 5, FALSE, '기획 산출물 (2) 상세 기능 정의'),
+        ('PLAN', 6, FALSE, '기획 산출물 (3) 기획 문서 작성'),
+        ('PLAN', 7, FALSE, '기획 산출물 (4) 화면 설계'),
+        ('PLAN', 8, FALSE, '프로젝트 관리 및 협업'),
+        ('PLAN', 9, FALSE, '서비스 품질 검증'),
+        ('PLAN', 10, FALSE, '그로스 전략 설계'),
+        ('DESIGN', 0, FALSE, '피그마 기초 학습'),
+        ('DESIGN', 1, FALSE, 'UI 디자인 입문: 클론 디자인 App & Web'),
+        ('DESIGN', 2, FALSE, '리디자인: Pain Point 분석'),
+        ('DESIGN', 3, FALSE, '리디자인: Solution 탐구'),
+        ('DESIGN', 4, FALSE, '와이어프레임 & 디자인 시스템 구축'),
+        ('DESIGN', 5, FALSE, 'UI 디자인 진행'),
+        ('DESIGN', 6, FALSE, 'UI 디자인 확장 & 포트폴리오 제작'),
+        ('DESIGN', 7, FALSE, '프로토타입 제작 & 복습 가이드'),
+        ('DESIGN', 8, FALSE, '매칭 프로젝트 디자인 (1)'),
+        ('DESIGN', 9, FALSE, '매칭 프로젝트 디자인 (2)'),
+        ('DESIGN', 10, FALSE, '매칭 프로젝트 디자인 (3)'),
+        ('DESIGN', 1, TRUE, '협업 가이드'),
+        ('DESIGN', 2, TRUE, '디자인 인사이트'),
+        ('MOBILE_PRODUCT_ENGINEER', 1, FALSE, '데이터 모델링과 앱 UI 기초'),
+        ('MOBILE_PRODUCT_ENGINEER', 2, FALSE, 'SQL 데이터 조작과 사용자 입력 폼'),
+        ('MOBILE_PRODUCT_ENGINEER', 3, FALSE, '서버 환경 세팅과 앱 화면 내비게이션'),
+        ('MOBILE_PRODUCT_ENGINEER', 4, FALSE, 'ORM 기반 CRUD와 비동기 UI 처리'),
+        ('MOBILE_PRODUCT_ENGINEER', 5, FALSE, 'Public API 설계와 앱 아키텍처 정립'),
+        ('MOBILE_PRODUCT_ENGINEER', 6, FALSE, 'CRUD API 구축과 네트워크 통신'),
+        ('MOBILE_PRODUCT_ENGINEER', 7, FALSE, 'JWT 인증/인가와 사용자 토큰 관리'),
+        ('MOBILE_PRODUCT_ENGINEER', 8, FALSE, '핵심 비즈니스 로직과 데이터 상태 관리'),
+        ('MOBILE_PRODUCT_ENGINEER', 9, FALSE, 'API 명세 확정과 심화 기능 연동'),
+        ('MOBILE_PRODUCT_ENGINEER', 10, FALSE, '클라우드 환경 분리 배포와 앱 출시'),
+        ('WEB_PRODUCT_ENGINEER', 1, FALSE, '데이터 모델링과 타입 시스템 기초'),
+        ('WEB_PRODUCT_ENGINEER', 2, FALSE, 'SQL 데이터 조작과 React UI 기초'),
+        ('WEB_PRODUCT_ENGINEER', 3, FALSE, '서버 환경 세팅과 웹 화면 라우팅'),
+        ('WEB_PRODUCT_ENGINEER', 4, FALSE, 'ORM 기반 CRUD와 클라이언트 상태 관리'),
+        ('WEB_PRODUCT_ENGINEER', 5, FALSE, 'Public API 구축과 웹 API 연동'),
+        ('WEB_PRODUCT_ENGINEER', 6, FALSE, 'CRUD API와 서버 상태 관리'),
+        ('WEB_PRODUCT_ENGINEER', 7, FALSE, 'JWT 인증/인가와 사용자 인증 연동'),
+        ('WEB_PRODUCT_ENGINEER', 8, FALSE, '핵심 비즈니스 로직과 사용자 기능 연동'),
+        ('WEB_PRODUCT_ENGINEER', 9, FALSE, 'API 안정화와 Next.js 웹 개발'),
+        ('WEB_PRODUCT_ENGINEER', 10, FALSE, '운영 환경 분리와 웹 서비스 배포')
+    ) AS seed(track, week_no, is_extra, title)
+    JOIN public.curriculum curriculum ON curriculum.gisu_id = target_gisu_id AND curriculum.track = seed.track
+    JOIN public.gisu gisu ON gisu.id = target_gisu_id
+    -- 이미 등록한 주차의 ID·제목·일정과 연결된 워크북은 보존한다.
+    ON CONFLICT (curriculum_id, week_no, is_extra) DO NOTHING;
+END $$;

--- a/src/test/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumOutlineMigrationTest.java
+++ b/src/test/java/com/umc/product/curriculum/adapter/out/persistence/CurriculumOutlineMigrationTest.java
@@ -1,0 +1,233 @@
+package com.umc.product.curriculum.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@DisplayName("11기 커리큘럼 목차 Flyway 마이그레이션")
+class CurriculumOutlineMigrationTest {
+
+    private static final String MIGRATION_PATH =
+        "db/migration/V2026.09.10.02.00__seed_11th_weekly_curricula.sql";
+    private static final LocalDateTime START_AT = LocalDateTime.parse("2026-08-31T15:00:00");
+    private static final LocalDateTime END_AT = LocalDateTime.parse("2027-02-27T14:59:59.999999");
+
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private Long gisuId;
+
+    @BeforeEach
+    void prepareEmptyEleventhCurricula() {
+        List<Long> existingGisuIds = jdbcTemplate.queryForList(
+            "SELECT id FROM gisu WHERE generation = 11", Long.class);
+        if (existingGisuIds.isEmpty()) {
+            gisuId = jdbcTemplate.queryForObject("""
+                INSERT INTO gisu (generation, is_active, learning_type, start_at, end_at, created_at, updated_at)
+                VALUES (11, false, 'TRACK', '2026-09-01T00:00:00+09:00',
+                    '2027-02-27T23:59:59.999999+09:00', now(), now())
+                RETURNING id
+                """, Long.class);
+        } else {
+            assertThat(existingGisuIds).hasSize(1);
+            gisuId = existingGisuIds.getFirst();
+            jdbcTemplate.update("""
+                UPDATE gisu SET learning_type = 'TRACK',
+                    start_at = TIMESTAMPTZ '2026-09-01T00:00:00+09:00',
+                    end_at = TIMESTAMPTZ '2027-02-27T23:59:59.999999+09:00'
+                WHERE id = ?
+                """, gisuId);
+        }
+        jdbcTemplate.update("""
+            INSERT INTO curriculum (gisu_id, track, title, created_at, updated_at)
+            SELECT ?, track, track || ' 커리큘럼', now(), now()
+            FROM (VALUES ('PLAN'), ('DESIGN'), ('MOBILE_PRODUCT_ENGINEER'), ('WEB_PRODUCT_ENGINEER')) AS seed(track)
+            ON CONFLICT (gisu_id, track) DO NOTHING
+            """, gisuId);
+        jdbcTemplate.update("""
+            DELETE FROM weekly_curriculum
+            WHERE curriculum_id IN (SELECT id FROM curriculum WHERE gisu_id = ?)
+            """, gisuId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UTC", "Asia/Seoul"})
+    @DisplayName("세션 시간대와 관계없이 승인된 44개 목차를 기수 전체 기간의 UTC 시각으로 등록한다")
+    void importsApprovedOutlineWithUtcDates(String timeZone) throws Exception {
+        // Given
+        jdbcTemplate.execute("SET LOCAL TIME ZONE '" + timeZone + "'");
+        Map<String, Long> previousCounts = nonWeeklyCounts();
+
+        // When
+        executeMigration();
+
+        // Then
+        var weeks = readWeeks(gisuId);
+        assertThat(weeks).hasSize(44);
+        assertThat(weeks.stream().collect(Collectors.groupingBy(WeeklyRow::track, Collectors.counting())))
+            .isEqualTo(Map.of("PLAN", 11L, "DESIGN", 13L,
+                "MOBILE_PRODUCT_ENGINEER", 10L, "WEB_PRODUCT_ENGINEER", 10L));
+        assertThat(weeks).allSatisfy(week -> {
+            assertThat(week.startsAt()).isEqualTo(START_AT);
+            assertThat(week.endsAt()).isEqualTo(END_AT);
+        });
+        assertThat(weeks.stream().map(week -> new OutlineRow(
+            week.track(), week.weekNo(), week.extra(), week.title())).toList())
+            .containsExactlyInAnyOrderElementsOf(readApprovedOutline());
+        assertThat(weeks).filteredOn(week -> week.weekNo() == 0)
+            .extracting(WeeklyRow::track).containsExactlyInAnyOrder("PLAN", "DESIGN");
+        assertThat(weeks).filteredOn(WeeklyRow::extra)
+            .extracting(WeeklyRow::title).containsExactlyInAnyOrder("협업 가이드", "디자인 인사이트");
+        assertThat(nonWeeklyCounts()).isEqualTo(previousCounts);
+    }
+
+    @Test
+    @DisplayName("기존 주차의 ID·제목·기간과 연결 워크북 및 다른 기수를 보존하고 누락된 목차만 등록한다")
+    void preservesExistingContentAndOtherGisuOnRerun() throws Exception {
+        // Given
+        Long curriculumId = jdbcTemplate.queryForObject(
+            "SELECT id FROM curriculum WHERE gisu_id = ? AND track = 'PLAN'", Long.class, gisuId);
+        Long existingWeeklyId = insertWeekly(curriculumId, "수정한 기획 1주차");
+        Long workbookId = jdbcTemplate.queryForObject("""
+            INSERT INTO original_workbook
+                (weekly_curriculum_id, title, content, type, original_workbook_status, created_at, updated_at)
+            VALUES (?, '이미 작성한 워크북', '보존할 학습 내용', 'MAIN', 'DRAFT', now(), now())
+            RETURNING id
+            """, Long.class, existingWeeklyId);
+        WeeklyRow existingWeek = readWeeks(gisuId).getFirst();
+        var existingWorkbook = jdbcTemplate.queryForMap("SELECT * FROM original_workbook WHERE id = ?", workbookId);
+        Long otherGisuId = jdbcTemplate.queryForObject("""
+            INSERT INTO gisu (generation, is_active, learning_type, start_at, end_at, created_at, updated_at)
+            VALUES (77, false, 'PART', '2025-03-01T00:00:00Z', '2025-08-31T00:00:00Z', now(), now())
+            RETURNING id
+            """, Long.class);
+        Long otherCurriculumId = jdbcTemplate.queryForObject("""
+            INSERT INTO curriculum (gisu_id, part, title, created_at, updated_at)
+            VALUES (?, 'WEB', '기존 기수 웹', now(), now()) RETURNING id
+            """, Long.class, otherGisuId);
+        insertWeekly(otherCurriculumId, "기존 기수 주차");
+        var otherWeeks = readWeeks(otherGisuId);
+
+        // When
+        executeMigration();
+
+        // Then
+        var weeks = readWeeks(gisuId);
+        assertThat(weeks).hasSize(44).contains(existingWeek);
+        assertThat(readWeeks(otherGisuId)).isEqualTo(otherWeeks);
+        assertThat(jdbcTemplate.queryForMap("SELECT * FROM original_workbook WHERE id = ?", workbookId))
+            .isEqualTo(existingWorkbook);
+
+        // When
+        executeMigration();
+
+        // Then
+        assertThat(readWeeks(gisuId)).isEqualTo(weeks);
+        assertThat(readWeeks(otherGisuId)).isEqualTo(otherWeeks);
+        assertThat(jdbcTemplate.queryForMap("SELECT * FROM original_workbook WHERE id = ?", workbookId))
+            .isEqualTo(existingWorkbook);
+    }
+
+    @Test
+    @DisplayName("기본 Track 부모 커리큘럼이 하나라도 없으면 다른 Track의 목차도 생성하지 않는다")
+    void rejectsMissingParentBeforeCreatingAnyWeek() {
+        // Given
+        jdbcTemplate.update("DELETE FROM curriculum WHERE gisu_id = ? AND track = 'DESIGN'", gisuId);
+
+        // When / Then
+        assertThatThrownBy(this::executeMigration).isInstanceOf(DataAccessException.class)
+            .hasMessageContaining("기본 Track 커리큘럼 4개가 필요합니다");
+        assertThat(readWeeks(gisuId)).isEmpty();
+    }
+
+    private Long insertWeekly(Long curriculumId, String title) {
+        return jdbcTemplate.queryForObject("""
+            INSERT INTO weekly_curriculum
+                (curriculum_id, week_no, is_extra, title, starts_at, ends_at, created_at, updated_at)
+            VALUES (?, 1, false, ?, TIMESTAMP '2026-10-01 03:00:00',
+                TIMESTAMP '2026-10-08 03:00:00', now(), now())
+            RETURNING id
+            """, Long.class, curriculumId, title);
+    }
+
+    private void executeMigration() throws Exception {
+        String sql = new ClassPathResource(MIGRATION_PATH).getContentAsString(StandardCharsets.UTF_8);
+        jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
+            var savepoint = connection.setSavepoint();
+            try (var statement = connection.createStatement()) {
+                statement.execute(sql);
+            } catch (SQLException exception) {
+                connection.rollback(savepoint);
+                throw exception;
+            } finally {
+                connection.releaseSavepoint(savepoint);
+            }
+            return null;
+        });
+    }
+
+    private List<WeeklyRow> readWeeks(Long targetGisuId) {
+        return jdbcTemplate.query("""
+            SELECT weekly.id, weekly.curriculum_id, curriculum.track, weekly.week_no,
+                weekly.is_extra, weekly.title, weekly.starts_at, weekly.ends_at
+            FROM weekly_curriculum weekly
+            JOIN curriculum ON curriculum.id = weekly.curriculum_id
+            WHERE curriculum.gisu_id = ?
+            ORDER BY curriculum.track, weekly.is_extra, weekly.week_no, weekly.id
+            """, (row, rowNum) -> new WeeklyRow(row.getLong("id"), row.getLong("curriculum_id"),
+            row.getString("track"), row.getLong("week_no"), row.getBoolean("is_extra"), row.getString("title"),
+            row.getObject("starts_at", LocalDateTime.class), row.getObject("ends_at", LocalDateTime.class)), targetGisuId);
+    }
+
+    private Map<String, Long> nonWeeklyCounts() {
+        return Map.of(
+            "curriculum", jdbcTemplate.queryForObject("SELECT count(*) FROM curriculum", Long.class),
+            "workbook", jdbcTemplate.queryForObject("SELECT count(*) FROM original_workbook", Long.class),
+            "mission", jdbcTemplate.queryForObject("SELECT count(*) FROM original_workbook_mission", Long.class),
+            "challengerRecord", jdbcTemplate.queryForObject("SELECT count(*) FROM challenger_record", Long.class));
+    }
+
+    private List<OutlineRow> readApprovedOutline() throws Exception {
+        JsonNode outline = new ObjectMapper().readTree(Path.of("scripts/data/11th-curriculum-outline.json").toFile());
+        List<OutlineRow> result = new ArrayList<>();
+        for (JsonNode curriculum : outline.path("curricula")) {
+            for (JsonNode week : curriculum.path("weeks")) {
+                result.add(new OutlineRow(curriculum.path("track").asText(), week.path("weekNo").asLong(),
+                    week.path("isExtra").asBoolean(), week.path("title").asText()));
+            }
+        }
+        return result;
+    }
+
+    private record OutlineRow(String track, long weekNo, boolean extra, String title) {
+    }
+
+    private record WeeklyRow(
+        long id, long curriculumId, String track, long weekNo, boolean extra, String title,
+        LocalDateTime startsAt, LocalDateTime endsAt
+    ) {
+    }
+}


### PR DESCRIPTION
앞선 PR에는 11기 목차 JSON만 있어 배포해도 실제 주차 커리큘럼이 생성되지 않았습니다. 공통 Flyway 마이그레이션을 추가해 새 서버 기동 시 기본 Track 4개의 목차 44개를 DB에 등록합니다.

선행 마이그레이션 `V2026.09.10.01.00`은 11기가 없으면 생성하고, 기존 11기가 있으면 같은 ID를 재사용합니다. 이후 다른 활성 기수를 비활성화하고 11기만 `TRACK` 활성 기수로 전환하며 기본 커리큘럼 4개를 준비합니다. 이번 `V2026.09.10.02.00`은 그 다음에 목차 44개를 등록합니다.

- PLAN 11개, DESIGN 13개(부록 2개 포함), MOBILE_PRODUCT_ENGINEER 10개, WEB_PRODUCT_ENGINEER 10개를 등록합니다. 목차 제목은 TFT가 공유한 원문을 사용합니다.
- Chapter 0은 `week_no=0`, Design 부록 1·2는 `is_extra=true`로 구분합니다.
- 모든 새 주차에 승인된 임시 일정인 11기 전체 기간을 적용합니다. 현재 11기 기간은 한국시간 2026-09-01 00:00:00부터 2027-02-27 23:59:59.999999까지이며, 날짜는 기수에서 가져와 UTC 기준으로 저장합니다.
- 환경마다 다른 기수·커리큘럼 ID를 조회해 연결합니다. 같은 주차·부록이 이미 있으면 기존 ID·제목·일정·워크북을 보존하고 누락된 목차만 추가합니다.
- 11기 Track 기수 또는 기본 커리큘럼이 없으면 오류로 중단합니다. JSON의 일정 상태도 `TEMPORARY_GISU_PERIOD`로 맞춥니다.

원본 워크북 본문·미션, Infra PLUS, 운영진 챌린저 코드는 이 마이그레이션에서 생성하지 않습니다. 실제 주차 일정은 원본 워크북 공개 전에 수정해야 합니다. 공개된 워크북이 있는 주차는 기존 도메인 규칙상 일정 변경이 제한됩니다.

이 PR은 실제 등록 SQL을 포함하며, DB 반영은 해당 코드의 배포와 Flyway 실행이 성공할 때 이루어집니다. PR 병합과 배포는 사용자가 직접 진행합니다.

검증: 커리큘럼 전체 및 Track 학습·시딩 통합 테스트 227개 중 227개 통과, 0개 건너뜀, 실패 0. 실제 PostgreSQL에서 목차 44개 생성, 시간대 독립성, 기존 데이터 보존·재실행, 부모 누락 시 중단을 확인했습니다. `spotlessCheck`, `checkstyleMain`, `checkstyleTest`, Java 컴파일, `bootJar`도 통과했으며 배포 JAR에 새 SQL이 포함된 것을 확인했습니다.

