### PR TITLE
[Feat] 11기 조직 데이터와 챌린저 코드 통합 등록

### DIFF
--- a/scripts/issue-challenger-codes.py
+++ b/scripts/issue-challenger-codes.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""tracks·역할을 함께 지원하는 새 서버 버전의 배포를 확인한 뒤 실행한다.
+
+확정된 비공개 요청 JSON으로 코드를 발급하고, 응답이 불확실하면 재요청을 중단한다.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+from urllib.error import HTTPError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+API_BASES = {
+    "dev": "https://api-dev.university.neordinary.com",
+    "prod": "https://api.university.neordinary.com",
+}
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def save_private(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+    descriptor, temporary = tempfile.mkstemp(prefix=".code-results-", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def canonical_request_tracks(body):
+    tracks, track = body.get("tracks"), body.get("track")
+    if tracks is not None and track is not None:
+        raise ValueError("track과 tracks를 동시에 지정할 수 없습니다.")
+    selected = tracks if tracks is not None else ([] if track is None else [track])
+    if not isinstance(selected, list) or any(not isinstance(value, str) for value in selected):
+        raise ValueError("수강 Track은 문자열 목록이어야 합니다.")
+    return list(dict.fromkeys(selected))
+
+
+def load_requests(path):
+    content = path.read_bytes()
+    data = json.loads(content)
+    environment = data.get("environment")
+    if environment not in API_BASES or data.get("apiBase") != API_BASES[environment]:
+        raise ValueError("요청 파일의 환경과 API 주소가 일치하지 않습니다.")
+    if data.get("readyForIssue") is not True:
+        raise ValueError("Track·직책·중복 처리와 조직 ID가 확정된 요청 파일이 필요합니다.")
+    records = data.get("records")
+    if not isinstance(records, list) or not records:
+        raise ValueError("발급 요청이 없습니다.")
+    keys = set()
+    for record in records:
+        key = record.get("candidateKey")
+        body = record.get("request")
+        if not isinstance(key, str) or not key or key in keys:
+            raise ValueError("발급 대상 키가 없거나 중복되었습니다.")
+        keys.add(key)
+        if not isinstance(body, dict) or "code" in body:
+            raise ValueError("코드는 서버가 생성해야 합니다.")
+        if not isinstance(body.get("memberName"), str) or not body["memberName"].strip():
+            raise ValueError("회원 이름이 비어 있습니다.")
+        if body.get("gisuId") != data.get("gisuId") or not isinstance(body.get("gisuId"), int):
+            raise ValueError("요청의 기수 ID가 환경 설정과 다릅니다.")
+        canonical_request_tracks(body)
+    return data, hashlib.sha256(content).hexdigest()
+
+
+def run(args):
+    os.umask(0o077)
+    input_path = args.input.resolve()
+    data, digest = load_requests(input_path)
+    environment = data["environment"]
+    journal_path = (args.journal or input_path.with_name(f"{environment}-issuance-results.private.json")).resolve()
+    repository = Path(__file__).resolve().parents[1]
+    if input_path.is_relative_to(repository) or journal_path.is_relative_to(repository):
+        raise ValueError("이름·코드 파일은 Git 저장소 밖의 비공개 폴더에 저장해주세요.")
+    if input_path == journal_path:
+        raise ValueError("입력 파일과 결과 파일은 서로 다른 경로여야 합니다.")
+    if not args.execute:
+        print(json.dumps({"environment": environment, "requests": len(data["records"]), "executed": False}))
+        return
+    token = os.environ.get(args.token_env)
+    if not token:
+        raise ValueError("지정한 환경변수에 관리자 Bearer 토큰이 없습니다.")
+    journal_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    journal_path.parent.chmod(0o700)
+    lock = journal_path.with_suffix(journal_path.suffix + ".lock")
+    descriptor = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    try:
+        if journal_path.exists():
+            journal = json.loads(journal_path.read_text(encoding="utf-8"))
+            if journal.get("inputSha256") != digest or journal.get("environment") != environment:
+                raise ValueError("기존 발급 결과와 입력 파일이 다릅니다. 기존 결과를 먼저 대조해주세요.")
+        else:
+            journal = {"environment": environment, "apiBase": data["apiBase"], "inputSha256": digest, "records": {}}
+        expected_records = {record["candidateKey"]: record for record in data["records"]}
+        for key, result in journal["records"].items():
+            if key not in expected_records or result.get("sourceRows") != expected_records[key].get("sourceRows", []):
+                raise ValueError("결과 파일의 발급 대상이 입력과 다릅니다.")
+            if result["status"] == "ISSUED" and (not isinstance(result.get("code"), str) or len(result["code"]) != 6):
+                raise ValueError("기존 발급 결과에 서버 코드가 없습니다.")
+        for result in journal["records"].values():
+            if result["status"] == "IN_FLIGHT":
+                result["status"] = "UNKNOWN"
+        save_private(journal_path, journal)
+        if any(value["status"] != "ISSUED" for value in journal["records"].values()):
+            raise ValueError("미확정·거절 결과가 있습니다. 서버 기록과 대조하기 전에는 재요청하지 않습니다.")
+        opener = build_opener(NoRedirect())
+        for record in data["records"]:
+            key = record["candidateKey"]
+            if key in journal["records"]:
+                continue
+            journal["records"][key] = {"sourceRows": record.get("sourceRows", []), "status": "IN_FLIGHT", "recordId": None, "code": None}
+            save_private(journal_path, journal)
+            result = journal["records"][key]
+            try:
+                request = Request(
+                    data["apiBase"] + "/api/v1/challenger-record",
+                    data=json.dumps(record["request"], ensure_ascii=False).encode("utf-8"),
+                    headers={"Authorization": "Bearer " + token, "Content-Type": "application/json", "Accept": "application/json"},
+                    method="POST",
+                )
+                with opener.open(request, timeout=30) as response:
+                    envelope = json.load(response)
+                payload = envelope.get("result")
+                if envelope.get("success") is not True or not isinstance(payload, dict):
+                    raise ValueError("서버 발급 결과를 확인할 수 없습니다.")
+                record_id, code = payload.get("id"), payload.get("code")
+                if not isinstance(code, str) or len(code) != 6:
+                    raise ValueError("서버의 6자리 코드를 확인할 수 없습니다.")
+                if record_id is not None and (not isinstance(record_id, int) or record_id <= 0):
+                    raise ValueError("서버의 발급 ID를 확인할 수 없습니다.")
+                if any(payload.get(field) != record["request"].get(field) for field in [
+                    "gisuId", "schoolId", "memberName", "challengerRoleType", "chapterId", "part"
+                ]):
+                    raise ValueError("서버 응답이 요청한 발급 대상과 다릅니다.")
+                if payload.get("tracks") != canonical_request_tracks(record["request"]):
+                    raise ValueError("서버 응답의 수강 Track이 요청과 다릅니다.")
+                result.update(status="ISSUED", recordId=record_id, code=code)
+            except HTTPError as error:
+                result.update(status="REJECTED" if 400 <= error.code < 500 else "UNKNOWN", httpStatus=error.code)
+            except (Exception, KeyboardInterrupt) as error:
+                result.update(status="UNKNOWN", errorType=type(error).__name__)
+            save_private(journal_path, journal)
+            if result["status"] != "ISSUED":
+                raise ValueError("요청 결과를 비공개 결과 파일에 기록했습니다. 자동 재시도 없이 중단합니다.")
+            if len(journal["records"]) % 25 == 0:
+                print(json.dumps({"environment": environment, "issued": len(journal["records"])}), flush=True)
+        print(json.dumps({"environment": environment, "issued": len(journal["records"]), "resultPath": str(journal_path)}))
+    finally:
+        lock.unlink()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="환경·조직 ID·매핑이 확정된 비공개 요청 JSON")
+    parser.add_argument("--journal", type=Path, help="결과 JSON 경로. 기본값: 입력 폴더의 dev/prod-issuance-results.private.json")
+    parser.add_argument("--token-env", default="UMC_CODE_API_TOKEN", help="관리자 Bearer 토큰을 읽을 환경변수 이름")
+    parser.add_argument("--execute", action="store_true", help="새 서버 버전 배포 확인 후 발급. 생략하면 외부 요청 없이 입력만 검증")
+    args = parser.parse_args()
+    try:
+        run(args)
+    except (OSError, ValueError, KeyError, TypeError):
+        parser.exit(1, "발급을 중단했습니다. 입력·환경·잠금 및 비공개 결과 파일의 상태를 확인해주세요. 자동 재시도하지 않았습니다.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare-track-gisu.py
+++ b/scripts/prepare-track-gisu.py
@@ -28,9 +28,8 @@ def build_operations(config):
         operations.append({"key": key, "path": path, "body": body, "resultField": result_field})
 
     gisu = dict(config["gisu"])
-    if gisu.get("learningType", "TRACK") != "TRACK":
+    if gisu.pop("learningType", "TRACK") != "TRACK":
         raise ValueError("이 스크립트는 TRACK 기수를 준비합니다.")
-    gisu["learningType"] = "TRACK"
     add("gisu", "/api/v1/gisu", gisu)
     schools = set()
     for i, chapter in enumerate(config.get("chapters", [])):

--- a/scripts/track-gisu.example.json
+++ b/scripts/track-gisu.example.json
@@ -2,8 +2,7 @@
   "gisu": {
     "generation": 99,
     "startAt": "2027-03-01T00:00:00+09:00",
-    "endAt": "2027-08-31T23:59:59+09:00",
-    "learningType": "TRACK"
+    "endAt": "2027-08-31T23:59:59+09:00"
   },
   "chapters": [
     {"name": "예시 지부", "schoolIds": [1]}

--- a/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
+++ b/src/main/java/com/umc/product/authorization/application/service/AuthorizationService.java
@@ -38,6 +38,7 @@ import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.member.domain.exception.MemberErrorCode;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -125,17 +126,17 @@ public class AuthorizationService implements CheckPermissionUseCase {
         // 그 challenger를 기반으로 사용자가 활동했던 모든 기수를 가져옴.
         // 그러면 기수와 학교를 조합해서 챕터들이 나오겠지? 굳 그거 쓰면 될듯
         List<ChallengerInfo> memberChallengerList = getChallengerUseCase.getAllByMemberId(memberId);
+        List<RoleAttribute> roles = loadChallengerRolePort.findByMemberId(memberId).stream()
+            .map(RoleAttribute::from)
+            .toList();
         List<GisuChallengerInfo> chapterIds = memberChallengerList.stream().map((challengerInfo) ->
             GisuChallengerInfo.builder()
                 .gisuId(challengerInfo.gisuId())
-                .chapterId(getChapterUseCase.byGisuAndSchool(challengerInfo.gisuId(), schoolId).id())
+                .chapterId(resolveChapterId(challengerInfo, schoolId, roles))
                 .part(challengerInfo.part())
                 .challengerId(challengerInfo.challengerId())
                 .build()
         ).toList();
-        List<RoleAttribute> roles = loadChallengerRolePort.findByMemberId(memberId).stream()
-            .map(RoleAttribute::from)
-            .toList();
 
         SubjectAttributes subjectAttributes = SubjectAttributes.builder()
             .memberId(memberId)
@@ -150,6 +151,19 @@ public class AuthorizationService implements CheckPermissionUseCase {
             subjectAttributes.gisuChallengerInfos().size());
 
         return subjectAttributes;
+    }
+
+    private Long resolveChapterId(ChallengerInfo challengerInfo, Long schoolId, List<RoleAttribute> roles) {
+        boolean isNonLearningCentralStaff = challengerInfo.part() == null
+            && challengerInfo.tracks() != null && challengerInfo.tracks().isEmpty()
+            && roles.stream().anyMatch(role -> Objects.equals(role.gisuId(), challengerInfo.gisuId())
+                && role.roleType().isAtLeastCentralMember());
+        if (isNonLearningCentralStaff) {
+            return getChapterUseCase.findByGisuAndSchool(challengerInfo.gisuId(), schoolId)
+                .map(ChapterInfo::id)
+                .orElse(null);
+        }
+        return getChapterUseCase.byGisuAndSchool(challengerInfo.gisuId(), schoolId).id();
     }
 
     private Set<SystemRoleType> listSystemRoles(Long memberId) {

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java
@@ -44,7 +44,7 @@ public class ChallengerRecordController {
             각 챌린저 활동 기록에 대해서 발급된 6자리 코드를 입력하여,
             현재 로그인한 계정에 챌린저 기록 및 권한을 추가하는 기능입니다.
 
-            각 코드는 1회만 생성 가능하며, 어떤 계정에, 언제 사용되었는지 기록됩니다.
+            각 코드는 1회만 사용 가능하며, 어떤 계정에, 언제 사용되었는지 기록됩니다.
             """)
     @PostMapping("member")
 //    @WebhookAlarm(
@@ -94,9 +94,12 @@ public class ChallengerRecordController {
     )
     @Operation(operationId = "CHALLENGER-RECORD-002", summary = "챌린저 가입 및 기록용 코드 생성",
         description = """
-            중앙운영사무국 총괄단이 기수의 학습 유형에 맞는 part 또는 기본 track 하나로 6자리 코드를 발급합니다.
-            일반 코드는 이름과 학교가 일치하는 회원의 기수별 최초 가입에 사용합니다.
-            운영진 코드는 기존 part를 담당 파트로 사용하며 수강 track을 함께 지정할 수 없습니다.
+            중앙운영사무국 총괄단이 기수의 학습 유형에 맞는 part 또는 기본 tracks 목록으로 6자리 코드를 발급합니다.
+            TRACK 기수는 기본 트랙을 복수로 지정할 수 있고, 비수강 운영진은 역할과 tracks: []를 사용합니다.
+            기존 단일 track 입력도 지원하지만 tracks와 동시에 지정할 수 없습니다.
+            이름과 학교가 일치하는 회원에게 수강 트랙과 challengerRoleType 역할을 한 코드로 부여합니다.
+            운영진 코드의 part는 수강이 아닌 담당 파트이며, 수강하지 않는 중앙 운영진만 chapterId를 생략할 수 있습니다.
+            PART 기수의 기존 코드 발급과 사용 방식은 유지합니다.
             """)
     @PostMapping
     public ChallengerRecordResponse createChallengerRecord(
@@ -109,6 +112,7 @@ public class ChallengerRecordController {
             CreateChallengerRecordCommand.builder()
                 .part(request.part())
                 .track(request.track())
+                .tracks(request.tracks())
                 .creatorMemberId(memberPrincipal.getMemberId())
                 .gisuId(request.gisuId())
                 .chapterId(request.chapterId())
@@ -141,6 +145,7 @@ public class ChallengerRecordController {
                 .map(req -> CreateChallengerRecordCommand.builder()
                     .part(req.part())
                     .track(req.track())
+                    .tracks(req.tracks())
                     .creatorMemberId(memberPrincipal.getMemberId())
                     .gisuId(req.gisuId())
                     .chapterId(req.chapterId())

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerRecordResponseAssembler.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerRecordResponseAssembler.java
@@ -40,18 +40,20 @@ public class ChallengerRecordResponseAssembler {
     private ChallengerRecordResponse infoToResponse(ChallengerRecordInfo recordInfo) {
         GisuInfo gisuInfo = getGisuUseCase.getById(recordInfo.gisuId());
         SchoolDetailInfo schoolInfo = getSchoolUseCase.getSchoolDetail(recordInfo.schoolId());
-        ChapterInfo chapterInfo = getChapterUseCase.getChapterById(recordInfo.chapterId());
+        ChapterInfo chapterInfo = recordInfo.chapterId() == null
+            ? null : getChapterUseCase.getChapterById(recordInfo.chapterId());
 
         return ChallengerRecordResponse.builder()
             .code(recordInfo.code())
             .part(recordInfo.part())
             .track(recordInfo.track())
+            .tracks(recordInfo.tracks())
             .gisuId(gisuInfo.gisuId())
             .gisu(gisuInfo.generation())
             .schoolId(schoolInfo.schoolId())
             .schoolName(schoolInfo.schoolName())
-            .chapterId(chapterInfo.id())
-            .chapterName(chapterInfo.name())
+            .chapterId(chapterInfo == null ? null : chapterInfo.id())
+            .chapterName(chapterInfo == null ? null : chapterInfo.name())
             .memberName(recordInfo.memberName())
             .challengerRoleType(recordInfo.challengerRoleType())
             .organizationId(recordInfo.organizationId())

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssembler.java
@@ -1,5 +1,13 @@
 package com.umc.product.challenger.adapter.in.web.assembler;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
 import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
 import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
@@ -9,13 +17,8 @@ import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 /**
  * 챌린저 ID를 기반으로 회원 및 기수 정보를 포함한 응답 객체를 조립하는 헬퍼 컴포넌트입니다.
@@ -33,7 +36,8 @@ public class ChallengerResponseAssembler {
         ChallengerInfo challengerInfo = getChallengerUseCase.getById(challengerId);
         MemberInfo memberInfo = getMemberUseCase.getById(challengerInfo.memberId());
         GisuInfo gisuInfo = getGisuUseCase.getById(challengerInfo.gisuId());
-        ChapterInfo chapterInfo = getChapterUseCase.byGisuAndSchool(challengerInfo.gisuId(), memberInfo.schoolId());
+        ChapterInfo chapterInfo = getChapterUseCase.findByGisuAndSchool(challengerInfo.gisuId(), memberInfo.schoolId())
+            .orElse(null);
 
         return ChallengerInfoResponse.from(challengerInfo, memberInfo, gisuInfo, chapterInfo);
     }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java
@@ -1,9 +1,12 @@
 package com.umc.product.challenger.adapter.in.web.dto.request;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.common.domain.enums.OrganizationType;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
@@ -12,13 +15,21 @@ import jakarta.validation.constraints.Size;
 
 public record CreateChallengerRecordRequest(
     @NotNull(message = "기수 ID는 필수입니다") Long gisuId,
-    @NotNull(message = "지부 ID는 필수입니다") Long chapterId,
+    Long chapterId,
     @NotNull(message = "학교 ID는 필수입니다") Long schoolId,
     ChallengerPart part,
     ChallengerTrack track,
     @NotBlank(message = "회원 이름은 필수입니다") @Size(max = 30, message = "회원 이름은 30자 이하여야 합니다") String memberName,
-    ChallengerRoleType challengerRoleType
+    ChallengerRoleType challengerRoleType,
+    List<@NotNull ChallengerTrack> tracks
 ) {
+    public CreateChallengerRecordRequest(
+        Long gisuId, Long chapterId, Long schoolId, ChallengerPart part, ChallengerTrack track,
+        String memberName, ChallengerRoleType challengerRoleType
+    ) {
+        this(gisuId, chapterId, schoolId, part, track, memberName, challengerRoleType, null);
+    }
+
     public CreateChallengerRecordRequest(
         Long gisuId, Long chapterId, Long schoolId, ChallengerPart part,
         String memberName, ChallengerRoleType challengerRoleType
@@ -26,11 +37,25 @@ public record CreateChallengerRecordRequest(
         this(gisuId, chapterId, schoolId, part, null, memberName, challengerRoleType);
     }
 
-    @AssertTrue(message = "파트 또는 기본 트랙 하나를 선택하고, 운영진 코드는 파트를 사용해주세요") @JsonIgnore
+    @AssertTrue(message = "파트 또는 기본 트랙 목록을 선택하고 track과 tracks를 동시에 지정하지 마세요") @JsonIgnore
     public boolean isLearningSelectionValid() {
-        if (challengerRoleType != null) {
-            return part != null && track == null;
+        if (track != null && tracks != null) {
+            return false;
         }
-        return (part != null) != (track != null) && (track == null || track.isBasic());
+        List<ChallengerTrack> selectedTracks = tracks == null ? (track == null ? List.of() : List.of(track)) : tracks;
+        if (selectedTracks.stream().anyMatch(value -> value == null || !value.isBasic())) {
+            return false;
+        }
+        if (challengerRoleType != null) {
+            return true;
+        }
+        return (part != null && selectedTracks.isEmpty()) || (part == null && !selectedTracks.isEmpty());
+    }
+
+    @AssertTrue(message = "수강하지 않는 중앙 운영진 코드만 지부를 생략할 수 있습니다") @JsonIgnore
+    public boolean isChapterSelectionValid() {
+        return chapterId != null || (challengerRoleType != null
+            && challengerRoleType.organizationType() == OrganizationType.CENTRAL
+            && track == null && (tracks == null || tracks.isEmpty()));
     }
 }

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java
@@ -55,8 +55,8 @@ public record ChallengerInfoResponse(
             .gisuId(gisuInfo.gisuId())
             .gisu(gisuInfo.generation())
             // 지부
-            .chapterId(chapterInfo.id())
-            .chapterName(chapterInfo.name())
+            .chapterId(chapterInfo == null ? null : chapterInfo.id())
+            .chapterName(chapterInfo == null ? null : chapterInfo.name())
             .part(info.part())
             .tracks(info.tracks())
             .challengerPoints(info.challengerPoints())
@@ -93,8 +93,8 @@ public record ChallengerInfoResponse(
             .gisuId(gisuInfo.gisuId())
             .gisu(gisuInfo.generation())
             // 지부
-            .chapterId(chapterInfo.id())
-            .chapterName(chapterInfo.name())
+            .chapterId(chapterInfo == null ? null : chapterInfo.id())
+            .chapterName(chapterInfo == null ? null : chapterInfo.name())
             // 파트
             .part(info.part())
             .tracks(info.tracks())

--- a/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerRecordResponse.java
+++ b/src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerRecordResponse.java
@@ -1,5 +1,7 @@
 package com.umc.product.challenger.adapter.in.web.dto.response;
 
+import java.util.List;
+
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
@@ -19,8 +21,23 @@ public record ChallengerRecordResponse(
     String chapterName,
     String memberName,
     ChallengerRoleType challengerRoleType,
-    Long organizationId
+    Long organizationId,
+    List<ChallengerTrack> tracks
 ) {
+    public ChallengerRecordResponse {
+        tracks = tracks == null ? (track == null ? List.of() : List.of(track)) : List.copyOf(tracks);
+        track = tracks.size() == 1 ? tracks.getFirst() : null;
+    }
+
+    public ChallengerRecordResponse(
+        String code, ChallengerPart part, ChallengerTrack track, Long gisuId, Long gisu, Long schoolId,
+        String schoolName, Long chapterId, String chapterName, String memberName,
+        ChallengerRoleType challengerRoleType, Long organizationId
+    ) {
+        this(code, part, track, gisuId, gisu, schoolId, schoolName, chapterId, chapterName, memberName,
+            challengerRoleType, organizationId, null);
+    }
+
     public ChallengerRecordResponse(
         String code, ChallengerPart part, Long gisuId, Long gisu, Long schoolId, String schoolName,
         Long chapterId, String chapterName, String memberName, ChallengerRoleType challengerRoleType,

--- a/src/main/java/com/umc/product/challenger/application/port/in/command/dto/CreateChallengerRecordCommand.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/command/dto/CreateChallengerRecordCommand.java
@@ -1,5 +1,7 @@
 package com.umc.product.challenger.application.port.in.command.dto;
 
+import java.util.List;
+
 import com.umc.product.challenger.domain.ChallengerRecord;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
@@ -18,8 +20,29 @@ public record CreateChallengerRecordCommand(
     ChallengerPart part,
     ChallengerTrack track,
     String memberName,
-    ChallengerRoleType challengerRoleType
+    ChallengerRoleType challengerRoleType,
+    List<ChallengerTrack> tracks
 ) {
+    public CreateChallengerRecordCommand {
+        if (track != null && tracks != null) {
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST,
+                "track과 tracks를 동시에 지정할 수 없습니다.");
+        }
+        tracks = tracks == null ? (track == null ? List.of() : List.of(track)) : tracks;
+        if (tracks.stream().anyMatch(value -> value == null || !value.isBasic())) {
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST);
+        }
+        tracks = List.copyOf(tracks);
+        track = tracks.size() == 1 ? tracks.getFirst() : null;
+    }
+
+    public CreateChallengerRecordCommand(
+        Long creatorMemberId, Long gisuId, Long chapterId, Long schoolId, ChallengerPart part,
+        ChallengerTrack track, String memberName, ChallengerRoleType challengerRoleType
+    ) {
+        this(creatorMemberId, gisuId, chapterId, schoolId, part, track, memberName, challengerRoleType, null);
+    }
+
     public CreateChallengerRecordCommand(
         Long creatorMemberId, Long gisuId, Long chapterId, Long schoolId, ChallengerPart part,
         String memberName, ChallengerRoleType challengerRoleType
@@ -35,7 +58,7 @@ public record CreateChallengerRecordCommand(
             + ", chapterId=" + chapterId
             + ", schoolId=" + schoolId
             + ", part=" + part
-            + ", track=" + track
+            + ", tracks=" + tracks
             + '}';
     }
 
@@ -45,23 +68,19 @@ public record CreateChallengerRecordCommand(
 
     public ChallengerRecord toEntity() {
         if (isAdminRecord()) {
-            if (track != null) {
-                throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST,
-                    "운영진 코드에는 수강 트랙을 지정할 수 없습니다.");
-            }
             Long adminOrganizationId = switch (challengerRoleType.organizationType()) {
                 case CENTRAL -> null; // 중앙운영사무국 소속은 organizationId가 필요없음
                 case CHAPTER -> chapterId; // 챕터 관리자: organizationId는 chapterId
                 case SCHOOL -> schoolId; // 학교 관리자: organizationId는 schoolId
             };
 
-            return ChallengerRecord.createAdmin(
-                creatorMemberId, gisuId, chapterId, schoolId, part, memberName,
+            return ChallengerRecord.createAdminWithTracks(
+                creatorMemberId, gisuId, chapterId, schoolId, part, tracks, memberName,
                 challengerRoleType, adminOrganizationId
             );
         } else {
-            return ChallengerRecord.create(
-                creatorMemberId, gisuId, chapterId, schoolId, part, track, memberName
+            return ChallengerRecord.createWithTracks(
+                creatorMemberId, gisuId, chapterId, schoolId, part, tracks, memberName
             );
         }
     }

--- a/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerRecordInfo.java
+++ b/src/main/java/com/umc/product/challenger/application/port/in/query/dto/ChallengerRecordInfo.java
@@ -1,6 +1,7 @@
 package com.umc.product.challenger.application.port.in.query.dto;
 
 import java.time.Instant;
+import java.util.List;
 
 import com.umc.product.challenger.domain.ChallengerRecord;
 import com.umc.product.common.domain.enums.ChallengerPart;
@@ -24,8 +25,23 @@ public record ChallengerRecordInfo(
     ChallengerTrack track,
     boolean isUsed,
     Long usedMemberId,
-    Instant usedAt
+    Instant usedAt,
+    List<ChallengerTrack> tracks
 ) {
+    public ChallengerRecordInfo {
+        tracks = tracks == null ? (track == null ? List.of() : List.of(track)) : List.copyOf(tracks);
+        track = tracks.size() == 1 ? tracks.getFirst() : null;
+    }
+
+    public ChallengerRecordInfo(
+        Long id, String code, String memberName, ChallengerRoleType challengerRoleType,
+        Long organizationId, Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
+        ChallengerPart part, ChallengerTrack track, boolean isUsed, Long usedMemberId, Instant usedAt
+    ) {
+        this(id, code, memberName, challengerRoleType, organizationId, createdMemberId, gisuId,
+            chapterId, schoolId, part, track, isUsed, usedMemberId, usedAt, null);
+    }
+
     public ChallengerRecordInfo(
         Long id, String code, String memberName, ChallengerRoleType challengerRoleType,
         Long organizationId, Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
@@ -48,6 +64,7 @@ public record ChallengerRecordInfo(
             .schoolId(entity.getSchoolId())
             .part(entity.getPart())
             .track(entity.getTrack())
+            .tracks(entity.getTracks())
             .isUsed(entity.isUsed())
             .usedMemberId(entity.getUsedMemberId())
             .usedAt(entity.getUsedAt())

--- a/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
+++ b/src/main/java/com/umc/product/challenger/application/service/ChallengerRecordCommandService.java
@@ -1,6 +1,8 @@
 package com.umc.product.challenger.application.service;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -9,6 +11,7 @@ import com.umc.product.audit.domain.AuditAction;
 import com.umc.product.authorization.application.port.in.command.EvictAuthoritySnapshotCacheUseCase;
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
+import com.umc.product.authorization.application.port.in.query.ListChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
 import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
@@ -20,7 +23,10 @@ import com.umc.product.challenger.domain.Challenger;
 import com.umc.product.challenger.domain.ChallengerRecord;
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.GisuLearningType;
 import com.umc.product.global.exception.constant.Domain;
+import com.umc.product.member.application.port.in.command.LockMemberUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
@@ -28,6 +34,7 @@ import com.umc.product.notification.application.port.in.dto.SendWebhookAlarmComm
 import com.umc.product.notification.domain.WebhookPlatform;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 
 import jakarta.transaction.Transactional;
@@ -48,7 +55,10 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
 
     private final GetChapterUseCase getChapterUseCase;
     private final GetGisuUseCase getGisuUseCase;
+    private final GetSchoolUseCase getSchoolUseCase;
     private final GetMemberUseCase getMemberUseCase;
+    private final LockMemberUseCase lockMemberUseCase;
+    private final ListChallengerRoleUseCase listChallengerRoleUseCase;
     private final ManageChallengerRoleUseCase manageChallengerRoleUseCase;
     private final EvictAuthoritySnapshotCacheUseCase evictAuthoritySnapshotCacheUseCase;
 
@@ -108,92 +118,99 @@ public class ChallengerRecordCommandService implements ManageChallengerRecordUse
     )
     @Override
     public void consumeCode(ConsumeChallengerRecordCommand command) {
-        String code = command.code();
         Long memberId = command.targetMemberId();
-
-        ChallengerRecord record = loadChallengerRecordPort.getByCodeForUpdate(code);
+        // 서로 다른 코드도 회원 단위로 직렬화한 뒤 최신 소속과 수강 목록을 조회한다.
+        lockMemberUseCase.lockById(memberId);
+        ChallengerRecord record = loadChallengerRecordPort.getByCodeForUpdate(command.code());
         record.validateNotUsed();
 
-        // 운영진 기록, 즉 ChallengerRole 객체를 추가해야하는 상황이라면 Challenger를 생성하지 않음
-        if (record.isAdminRecord()) {
-            Long challengerId = loadChallengerPort.findByMemberIdAndGisuId(memberId, record.getGisuId())
-                .orElseThrow(() -> new ChallengerDomainException(ChallengerErrorCode.NO_CHALLENGER_IN_MEMBER_GISU))
-                .getId();
+        GisuLearningType learningType = getGisuUseCase.getById(record.getGisuId()).learningType();
+        record.validateLearningType(learningType);
+        MemberInfo memberInfo = getMemberUseCase.getById(memberId);
+        record.validateMember(memberInfo.name(), memberInfo.schoolId());
+        validateRecord(record);
 
-            MemberInfo memberInfo = getMemberUseCase.getById(memberId);
-
-            manageChallengerRoleUseCase.createChallengerRole(
-                CreateChallengerRoleCommand.builder()
-                    .challengerId(challengerId)
-                    .roleType(record.getChallengerRoleType())
-                    .organizationId(record.getOrganizationId())
-                    .responsiblePart(record.getPart())
-                    .gisuId(record.getGisuId())
-                    .build()
-            );
-
-            String roleType =
-                record.getChallengerRoleType() != null ? record.getChallengerRoleType().name() : "역할없음";
-            String responsiblePart = record.getPart() != null ? record.getPart().name() : "파트없음";
-
-            sendWebhookAlarmUseCase.sendBuffered(
-                SendWebhookAlarmCommand.builder()
-                    .title("운영진 권한이 추가되었습니다.")
-                    .content(
-                        memberInfo.schoolName() + " " + memberInfo.nickname() + "/" + memberInfo.name() + " 님이 gisuId"
-                            + record.getGisuId() + "에" + roleType + "/" + responsiblePart + " 권한을 가진 코드를 등록하였습니다.")
-                    .platforms(List.of(WebhookPlatform.TELEGRAM, WebhookPlatform.DISCORD))
-                    .build()
-            );
+        Optional<Challenger> existing = loadChallengerPort.findByMemberIdAndGisuId(memberId, record.getGisuId());
+        if (learningType == GisuLearningType.PART) {
+            if (record.isAdminRecord() && existing.isEmpty()) {
+                throw new ChallengerDomainException(ChallengerErrorCode.NO_CHALLENGER_IN_MEMBER_GISU);
+            }
+            if (!record.isAdminRecord() && existing.isPresent()) {
+                throw new ChallengerDomainException(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS);
+            }
+        } else {
+            existing.ifPresent(Challenger::validateChallengerStatus);
         }
 
-        // 챌린저 기록 추가하기
-        else {
-            record.validateLearningType(getGisuUseCase.getById(record.getGisuId()).learningType());
-            MemberInfo memberInfo = getMemberUseCase.getById(memberId);
-            record.validateMember(memberInfo.name(), memberInfo.schoolId());
-
-            // 해당 기수에 챌린저 기록이 없는지 확인
-            loadChallengerPort.findByMemberIdAndGisuId(memberId, record.getGisuId())
-                .ifPresent(challenger -> {
-                    throw new ChallengerDomainException(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS,
-                        "해당 기수에 이미 챌린저 기록이 존재합니다.");
-                });
-
-            saveChallengerPort.save(
-                Challenger.builder()
-                    .memberId(memberId)
-                    .part(record.getPart())
-                    .tracks(record.getTrack() == null ? List.of() : List.of(record.getTrack()))
-                    .gisuId(record.getGisuId())
-                    .build()
-            );
-            evictAuthoritySnapshotCacheUseCase.evictByMemberId(memberId);
-
-            sendWebhookAlarmUseCase.sendBuffered(
-                SendWebhookAlarmCommand.builder()
-                    .title("챌린저 기록이 추가되었습니다.")
-                    .content(
-                        memberInfo.schoolName() + " " + memberInfo.nickname() + "/" + memberInfo.name() + " 님이 gisuId"
-                            + record.getGisuId() + "에 "
-                            + (record.getTrack() == null ? record.getPart() + " 파트" : record.getTrack() + " 트랙")
-                            + " 챌린저 코드를 등록하였습니다.")
-                    .platforms(List.of(WebhookPlatform.TELEGRAM, WebhookPlatform.DISCORD))
-                    .build()
-            );
+        boolean membershipAdded = existing.isEmpty();
+        Challenger challenger = existing.orElseGet(() -> newMembership(record, memberId, learningType));
+        boolean tracksAdded = false;
+        for (var track : record.getTracks()) {
+            tracksAdded |= challenger.addTrack(track);
+        }
+        boolean roleAdded = record.isAdminRecord() && !hasRole(record, memberId);
+        if (!membershipAdded && !tracksAdded && !roleAdded) {
+            throw new ChallengerDomainException(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS,
+                "코드의 수강과 운영진 역할이 모두 이미 등록되어 있습니다.");
         }
 
+        if (membershipAdded || tracksAdded) {
+            challenger = saveChallengerPort.save(challenger);
+        }
+        if (roleAdded) {
+            manageChallengerRoleUseCase.createChallengerRole(CreateChallengerRoleCommand.builder()
+                .challengerId(challenger.getId())
+                .roleType(record.getChallengerRoleType())
+                .organizationId(record.getOrganizationId())
+                .responsiblePart(record.getPart())
+                .gisuId(record.getGisuId())
+                .build());
+        }
         record.markAsUsed(memberId);
+        evictAuthoritySnapshotCacheUseCase.evictByMemberId(memberId);
+        sendWebhookAlarmUseCase.sendBuffered(SendWebhookAlarmCommand.builder()
+            .title("챌린저 코드가 등록되었습니다.")
+            .content(memberInfo.schoolName() + " " + memberInfo.nickname() + "/" + memberInfo.name()
+                + " 님이 gisuId=" + record.getGisuId() + "의 코드를 등록했습니다."
+                + " tracks=" + record.getTracks() + ", role=" + record.getChallengerRoleType())
+            .platforms(List.of(WebhookPlatform.TELEGRAM, WebhookPlatform.DISCORD))
+            .build());
+    }
+
+    private Challenger newMembership(ChallengerRecord record, Long memberId, GisuLearningType learningType) {
+        if (learningType == GisuLearningType.TRACK) {
+            return Challenger.createWithoutEnrollment(memberId, record.getGisuId());
+        }
+        return Challenger.builder().memberId(memberId).gisuId(record.getGisuId()).part(record.getPart()).build();
+    }
+
+    private boolean hasRole(ChallengerRecord record, Long memberId) {
+        return listChallengerRoleUseCase.listByMemberIdAndGisuId(memberId, record.getGisuId()).stream()
+            .anyMatch(role -> role.roleType() == record.getChallengerRoleType()
+                && Objects.equals(role.organizationId(), record.getOrganizationId())
+                && (record.getChallengerRoleType() != ChallengerRoleType.SCHOOL_PART_LEADER
+                    || role.responsiblePart() == record.getPart()));
     }
 
     private ChallengerRecord createValidatedRecord(CreateChallengerRecordCommand command) {
         ChallengerRecord record = command.toEntity();
         record.validateLearningType(getGisuUseCase.getById(command.gisuId()).learningType());
-        validateRecord(command.gisuId(), command.schoolId(), command.chapterId());
+        validateRecord(record);
         return record;
     }
 
-    private void validateRecord(Long gisuId, Long schoolId, Long chapterId) {
+    private void validateRecord(ChallengerRecord record) {
+        if (record.getChapterId() == null) {
+            if (record.canOmitChapter()) {
+                getSchoolUseCase.getSchoolDetail(record.getSchoolId());
+                return;
+            }
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST,
+                "수강 없는 중앙 운영진만 지부를 생략할 수 있습니다.");
+        }
+        Long gisuId = record.getGisuId();
+        Long schoolId = record.getSchoolId();
+        Long chapterId = record.getChapterId();
         ChapterInfo chapterInfo = getChapterUseCase.byGisuAndSchool(gisuId, schoolId);
 
         if (!chapterInfo.id().equals(chapterId)) {

--- a/src/main/java/com/umc/product/challenger/domain/ChallengerRecord.java
+++ b/src/main/java/com/umc/product/challenger/domain/ChallengerRecord.java
@@ -1,8 +1,14 @@
 package com.umc.product.challenger.domain;
 
+import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.stream.IntStream;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
@@ -11,6 +17,7 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.common.domain.enums.GisuLearningType;
+import com.umc.product.common.domain.enums.OrganizationType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,6 +36,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "challenger_record")
 public class ChallengerRecord extends BaseEntity {
+    private static final SecureRandom CODE_RANDOM = new SecureRandom();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -45,7 +54,7 @@ public class ChallengerRecord extends BaseEntity {
     @Column(nullable = false, name = "gisu_id")
     private Long gisuId;
 
-    @Column(nullable = false, name = "chapter_id")
+    @Column(name = "chapter_id")
     private Long chapterId;
 
     @Column(nullable = false, name = "school_id")
@@ -58,6 +67,11 @@ public class ChallengerRecord extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "track")
     private ChallengerTrack track;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(nullable = false, name = "tracks", columnDefinition = "text[]")
+    private List<ChallengerTrack> tracks = new ArrayList<>();
 
     @Column(name = "challenger_role_type")
     @Enumerated(EnumType.STRING)
@@ -86,22 +100,15 @@ public class ChallengerRecord extends BaseEntity {
         Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
         ChallengerPart part, ChallengerTrack track, String memberName
     ) {
-        if (track != null && (part != null || !track.isBasic())) {
-            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST);
-        }
-        ChallengerRecord record = new ChallengerRecord();
+        return createWithTracks(createdMemberId, gisuId, chapterId, schoolId, part,
+            track == null ? List.of() : List.of(track), memberName);
+    }
 
-        record.code = generateUniqueCode();
-        record.createdMemberId = createdMemberId;
-        record.part = part;
-        record.track = track;
-        record.gisuId = gisuId;
-        record.schoolId = schoolId;
-        record.chapterId = chapterId;
-        record.memberName = memberName;
-        record.isUsed = false; // 생성 시에는 사용되지 않은 상태로 시작
-
-        return record;
+    public static ChallengerRecord createWithTracks(
+        Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
+        ChallengerPart part, List<ChallengerTrack> tracks, String memberName
+    ) {
+        return createRecord(createdMemberId, gisuId, chapterId, schoolId, part, tracks, memberName, null, null);
     }
 
     public static ChallengerRecord createAdmin(
@@ -109,36 +116,77 @@ public class ChallengerRecord extends BaseEntity {
         ChallengerPart part, String memberName,
         ChallengerRoleType challengerRoleType, Long organizationId
     ) {
-        // 이전 팩토리 메소드 재사용
-        ChallengerRecord record = create(createdMemberId, gisuId, chapterId, schoolId, part, memberName);
+        return createAdminWithTracks(createdMemberId, gisuId, chapterId, schoolId, part,
+            List.of(), memberName, challengerRoleType, organizationId);
+    }
 
+    public static ChallengerRecord createAdminWithTracks(
+        Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
+        ChallengerPart part, List<ChallengerTrack> tracks, String memberName,
+        ChallengerRoleType challengerRoleType, Long organizationId
+    ) {
+        return createRecord(createdMemberId, gisuId, chapterId, schoolId, part, tracks,
+            memberName, challengerRoleType, organizationId);
+    }
+
+    private static ChallengerRecord createRecord(
+        Long createdMemberId, Long gisuId, Long chapterId, Long schoolId,
+        ChallengerPart part, List<ChallengerTrack> tracks, String memberName,
+        ChallengerRoleType challengerRoleType, Long organizationId
+    ) {
+        List<ChallengerTrack> selectedTracks = tracks == null ? List.of() : tracks;
+        if (selectedTracks.stream().anyMatch(value -> value == null || !value.isBasic())
+            || (challengerRoleType == null && part != null && !selectedTracks.isEmpty())) {
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST);
+        }
+        ChallengerRecord record = new ChallengerRecord();
+        record.code = generateUniqueCode();
+        record.createdMemberId = createdMemberId;
+        record.gisuId = gisuId;
+        record.chapterId = chapterId;
+        record.schoolId = schoolId;
+        record.memberName = memberName;
+        record.part = part;
+        record.tracks = new ArrayList<>(new LinkedHashSet<>(selectedTracks));
+        record.track = record.tracks.size() == 1 ? record.tracks.getFirst() : null;
         record.challengerRoleType = challengerRoleType;
         record.organizationId = organizationId;
-
+        if (chapterId == null && !record.canOmitChapter()) {
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST,
+                "수강하지 않는 중앙 운영진 코드만 지부를 생략할 수 있습니다.");
+        }
         return record;
     }
 
     private static String generateUniqueCode() {
         String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-
         return IntStream.range(0, 6)
-            .map(i -> chars.charAt(random.nextInt(chars.length())))
+            .map(i -> chars.charAt(CODE_RANDOM.nextInt(chars.length())))
             .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
             .toString();
+    }
+
+    public List<ChallengerTrack> getTracks() {
+        return List.copyOf(tracks);
     }
 
     public boolean isAdminRecord() {
         return this.challengerRoleType != null;
     }
 
+    public boolean canOmitChapter() {
+        return isAdminRecord() && challengerRoleType.organizationType() == OrganizationType.CENTRAL
+            && tracks.isEmpty();
+    }
+
     public void validateLearningType(GisuLearningType learningType) {
-        if (isAdminRecord()) {
-            return;
+        if (tracks.stream().anyMatch(value -> value == null || !value.isBasic())) {
+            throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST);
         }
         boolean valid = switch (learningType) {
-            case PART -> part != null && track == null;
-            case TRACK -> part == null && track != null && track.isBasic();
+            case PART -> tracks.isEmpty() && (isAdminRecord() || part != null);
+            case TRACK -> isAdminRecord() || (part == null && !tracks.isEmpty())
+                || (part == ChallengerPart.ADMIN && tracks.isEmpty());
         };
         if (!valid) {
             throw new ChallengerDomainException(ChallengerErrorCode.INVALID_CHALLENGER_RECORD_CREATE_REQUEST,
@@ -161,7 +209,7 @@ public class ChallengerRecord extends BaseEntity {
     }
 
     public void validateMember(String memberName, Long schoolId) {
-        if (!this.memberName.equals(memberName)) {
+        if (this.memberName == null || !this.memberName.equals(memberName)) {
             throw new ChallengerDomainException(ChallengerErrorCode.INVALID_MEMBER_NAME_FOR_RECORD);
         }
 

--- a/src/main/java/com/umc/product/member/application/port/in/command/LockMemberUseCase.java
+++ b/src/main/java/com/umc/product/member/application/port/in/command/LockMemberUseCase.java
@@ -1,0 +1,9 @@
+package com.umc.product.member.application.port.in.command;
+
+/**
+ * 호출한 트랜잭션이 끝날 때까지 회원의 변경 요청을 직렬화한다.
+ */
+public interface LockMemberUseCase {
+
+    void lockById(Long memberId);
+}

--- a/src/main/java/com/umc/product/member/application/service/MemberLockService.java
+++ b/src/main/java/com/umc/product/member/application/service/MemberLockService.java
@@ -1,0 +1,26 @@
+package com.umc.product.member.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.umc.product.member.application.port.in.command.LockMemberUseCase;
+import com.umc.product.member.application.port.out.LoadMemberPort;
+import com.umc.product.member.domain.exception.MemberDomainException;
+import com.umc.product.member.domain.exception.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class MemberLockService implements LockMemberUseCase {
+
+    private final LoadMemberPort loadMemberPort;
+
+    @Override
+    public void lockById(Long memberId) {
+        loadMemberPort.findByIdForUpdate(memberId)
+            .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/umc/product/organization/adapter/in/web/dto/request/CreateGisuRequest.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/dto/request/CreateGisuRequest.java
@@ -2,7 +2,6 @@ package com.umc.product.organization.adapter.in.web.dto.request;
 
 import java.time.Instant;
 
-import com.umc.product.common.domain.enums.GisuLearningType;
 import com.umc.product.organization.application.port.in.command.dto.CreateGisuCommand;
 
 import jakarta.validation.constraints.NotNull;
@@ -13,6 +12,6 @@ public record CreateGisuRequest(
     @NotNull Instant endAt
 ) {
     public CreateGisuCommand toCommand() {
-        return new CreateGisuCommand(generation, startAt, endAt, GisuLearningType.TRACK);
+        return new CreateGisuCommand(generation, startAt, endAt);
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/in/web/dto/request/CreateGisuRequest.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/dto/request/CreateGisuRequest.java
@@ -10,14 +10,9 @@ import jakarta.validation.constraints.NotNull;
 public record CreateGisuRequest(
     @NotNull Long generation,
     @NotNull Instant startAt,
-    @NotNull Instant endAt,
-    GisuLearningType learningType
+    @NotNull Instant endAt
 ) {
-    public CreateGisuRequest(Long generation, Instant startAt, Instant endAt) {
-        this(generation, startAt, endAt, GisuLearningType.PART);
-    }
-
     public CreateGisuCommand toCommand() {
-        return new CreateGisuCommand(generation, startAt, endAt, learningType);
+        return new CreateGisuCommand(generation, startAt, endAt, GisuLearningType.TRACK);
     }
 }

--- a/src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java
+++ b/src/main/java/com/umc/product/organization/adapter/in/web/swagger/AdminGisuControllerApi.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Organization | 기수 Command", description = "")
 public interface AdminGisuControllerApi {
 
-    @Operation(operationId = "GISU-001", summary = "기수 생성", description = "새로운 기수를 생성합니다.")
+    @Operation(operationId = "GISU-001", summary = "기수 생성", description = "새로운 기수를 TRACK 학습 방식으로 생성합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "생성 성공"),
         @ApiResponse(responseCode = "409", description = "이미 존재하는 기수")

--- a/src/main/java/com/umc/product/organization/application/port/in/command/dto/CreateGisuCommand.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/command/dto/CreateGisuCommand.java
@@ -2,22 +2,12 @@ package com.umc.product.organization.application.port.in.command.dto;
 
 import java.time.Instant;
 
-import com.umc.product.common.domain.enums.GisuLearningType;
-
 import lombok.Builder;
 
 @Builder
 public record CreateGisuCommand(
     Long generation,
     Instant startAt,
-    Instant endAt,
-    GisuLearningType learningType
+    Instant endAt
 ) {
-    public CreateGisuCommand {
-        learningType = learningType == null ? GisuLearningType.PART : learningType;
-    }
-
-    public CreateGisuCommand(Long generation, Instant startAt, Instant endAt) {
-        this(generation, startAt, endAt, GisuLearningType.PART);
-    }
 }

--- a/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
+++ b/src/main/java/com/umc/product/organization/application/port/in/query/GetChapterUseCase.java
@@ -3,6 +3,7 @@ package com.umc.product.organization.application.port.in.query;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
@@ -20,6 +21,11 @@ public interface GetChapterUseCase {
      * 기수와 학교 정보로 지부 정보를 조회합니다.
      */
     ChapterInfo byGisuAndSchool(Long gisuId, Long schoolId);
+
+    /**
+     * 해당 기수에 학교가 배정된 지부가 없으면 빈 값을 반환합니다.
+     */
+    Optional<ChapterInfo> findByGisuAndSchool(Long gisuId, Long schoolId);
 
     List<ChapterInfo> getChaptersBySchool(Long schoolId);
 

--- a/src/main/java/com/umc/product/organization/application/port/service/command/GisuService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/command/GisuService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.product.common.domain.enums.GisuLearningType;
 import com.umc.product.organization.application.port.in.command.ManageGisuUseCase;
 import com.umc.product.organization.application.port.in.command.dto.CreateGisuCommand;
 import com.umc.product.organization.application.port.out.command.SaveGisuPort;
@@ -30,7 +31,7 @@ public class GisuService implements ManageGisuUseCase {
         validateGenerationNotDuplicated(command);
 
         Gisu gisu = Gisu.create(
-            command.generation(), command.startAt(), command.endAt(), false, command.learningType()
+            command.generation(), command.startAt(), command.endAt(), false, GisuLearningType.TRACK
         );
 
         return saveGisuPort.save(gisu).getId();

--- a/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
+++ b/src/main/java/com/umc/product/organization/application/port/service/query/ChapterQueryService.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -59,6 +60,12 @@ public class ChapterQueryService implements GetChapterUseCase {
 
     @Override
     public ChapterInfo byGisuAndSchool(Long gisuId, Long schoolId) {
+        return findByGisuAndSchool(gisuId, schoolId)
+            .orElseThrow(() -> new OrganizationDomainException(OrganizationErrorCode.CHAPTER_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<ChapterInfo> findByGisuAndSchool(Long gisuId, Long schoolId) {
         // 지부 정보를 보여줘야 하면 ChapterSchool을 봐야 함
         // 전체 ChapterSchool 중에서 schoolId에 따라서 필터링하고
         // ChapterSchool 중에서 gisuId가 일치하는 chapter를 반환하면 됨
@@ -67,11 +74,11 @@ public class ChapterQueryService implements GetChapterUseCase {
         for (ChapterSchool chapterSchool : chapterSchools) {
             Chapter chapter = chapterSchool.getChapter();
             if (chapter.getGisu().getId().equals(gisuId)) {
-                return ChapterInfo.from(chapter);
+                return Optional.of(ChapterInfo.from(chapter));
             }
         }
 
-        throw new OrganizationDomainException(OrganizationErrorCode.CHAPTER_NOT_FOUND);
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/resources/db/migration/V2026.09.10.03.00__seed_11th_schools_chapters.sql
+++ b/src/main/resources/db/migration/V2026.09.10.03.00__seed_11th_schools_chapters.sql
@@ -1,0 +1,92 @@
+-- 11기 운영 보드의 지부학교 목록을 등록한다. 기존 학교와 기수별 지부 배정은 보존한다.
+DO $$
+DECLARE
+    target_gisu_id BIGINT;
+    target_school_id BIGINT;
+    target_chapter_id BIGINT;
+    assigned_chapter_id BIGINT;
+    existing_count BIGINT;
+    seed RECORD;
+BEGIN
+    SELECT id INTO STRICT target_gisu_id
+    FROM public.gisu
+    WHERE generation = 11
+    FOR SHARE;
+
+    -- 학교명과 학교의 기수별 지부 배정에는 UNIQUE 제약이 없어 조회·등록 사이의 변경을 막는다.
+    LOCK TABLE public.school, public.chapter, public.chapter_school IN SHARE ROW EXCLUSIVE MODE;
+
+    FOR seed IN
+        SELECT * FROM (VALUES
+            ('캥거루', '가천대학교'),
+            ('캥거루', '서울여자대학교'),
+            ('캥거루', '한국항공대학교'),
+            ('캥거루', '한성대학교'),
+            ('쿼카', '동양미래대학교'),
+            ('쿼카', '숭실대학교'),
+            ('쿼카', '이화여자대학교'),
+            ('쿼카', '인하대학교'),
+            ('쿼카', '한양대학교 ERICA'),
+            ('수달', '성신여자대학교'),
+            ('수달', '숙명여자대학교'),
+            ('수달', '중앙대학교'),
+            ('수달', '한국외국어대학교'),
+            ('아홀로틀', '가톨릭대학교'),
+            ('아홀로틀', '덕성여자대학교'),
+            ('아홀로틀', '세종대학교'),
+            ('아홀로틀', '안양대학교'),
+            ('아홀로틀', '홍익대학교 서울캠퍼스'),
+            ('티라노', '단국대학교'),
+            ('티라노', '동국대학교'),
+            ('티라노', '동덕여자대학교'),
+            ('티라노', '서경대학교'),
+            ('티라노', '홍익대학교 세종캠퍼스'),
+            -- 중앙 운영진의 소속 학교는 학교 목록에만 등록하고 지부를 배정하지 않는다.
+            (NULL, '인천가톨릭대학교')
+        ) AS mapping(chapter_name, school_name)
+    LOOP
+        SELECT COUNT(*), MIN(id) INTO existing_count, target_school_id
+        FROM public.school
+        WHERE name = seed.school_name;
+
+        IF existing_count > 1 THEN
+            RAISE EXCEPTION '학교명이 중복되어 11기 지부를 배정할 수 없습니다: %', seed.school_name;
+        END IF;
+
+        IF target_school_id IS NULL THEN
+            INSERT INTO public.school (name, created_at, updated_at)
+            VALUES (seed.school_name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            RETURNING id INTO target_school_id;
+        END IF;
+
+        IF seed.chapter_name IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        INSERT INTO public.chapter (gisu_id, name, created_at, updated_at)
+        VALUES (target_gisu_id, seed.chapter_name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT (gisu_id, name) DO NOTHING;
+
+        SELECT id INTO STRICT target_chapter_id
+        FROM public.chapter
+        WHERE gisu_id = target_gisu_id AND name = seed.chapter_name;
+
+        SELECT COUNT(*), MIN(chapter.id) INTO existing_count, assigned_chapter_id
+        FROM public.chapter_school chapter_school
+        JOIN public.chapter chapter ON chapter.id = chapter_school.chapter_id
+        WHERE chapter_school.school_id = target_school_id AND chapter.gisu_id = target_gisu_id;
+
+        IF existing_count > 1 THEN
+            RAISE EXCEPTION '11기 학교의 지부 배정이 중복되어 있습니다: %', seed.school_name;
+        END IF;
+
+        IF assigned_chapter_id IS NOT NULL AND assigned_chapter_id <> target_chapter_id THEN
+            RAISE EXCEPTION '11기 학교가 다른 지부에 배정되어 있습니다: %', seed.school_name;
+        END IF;
+
+        IF existing_count = 0 THEN
+            INSERT INTO public.chapter_school (chapter_id, school_id, created_at, updated_at)
+            VALUES (target_chapter_id, target_school_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+        END IF;
+    END LOOP;
+END $$;

--- a/src/main/resources/db/migration/V2026.09.10.04.00__support_challenger_record_tracks.sql
+++ b/src/main/resources/db/migration/V2026.09.10.04.00__support_challenger_record_tracks.sql
@@ -1,0 +1,36 @@
+-- 기존 코드와 단일 track을 보존하고, 신규 발급은 tracks를 수강 정보의 기준으로 사용한다.
+-- 구버전 서버의 scalar-only 쓰기는 배열에 반영되지 않으므로 전환 중 코드 발급은 중단해야 한다.
+ALTER TABLE public.challenger_record
+    ADD COLUMN tracks TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+UPDATE public.challenger_record
+SET tracks = ARRAY[track]::TEXT[]
+WHERE track IS NOT NULL;
+
+ALTER TABLE public.challenger_record
+    DROP CONSTRAINT challenger_record_track_registration_check,
+    ALTER COLUMN chapter_id DROP NOT NULL,
+    ADD CONSTRAINT challenger_record_tracks_values_check
+        CHECK (tracks <@ ARRAY['PLAN', 'DESIGN', 'WEB_PRODUCT_ENGINEER', 'MOBILE_PRODUCT_ENGINEER']::TEXT[]),
+    ADD CONSTRAINT challenger_record_tracks_no_null_elements_check
+        CHECK (array_position(tracks, NULL) IS NULL),
+    ADD CONSTRAINT challenger_record_tracks_no_duplicates_check
+        CHECK (
+            cardinality(array_positions(tracks, 'PLAN')) <= 1
+            AND cardinality(array_positions(tracks, 'DESIGN')) <= 1
+            AND cardinality(array_positions(tracks, 'WEB_PRODUCT_ENGINEER')) <= 1
+            AND cardinality(array_positions(tracks, 'MOBILE_PRODUCT_ENGINEER')) <= 1
+        ),
+    ADD CONSTRAINT challenger_record_optional_chapter_check
+        CHECK (
+            chapter_id IS NOT NULL
+            OR (
+                challenger_role_type IS NOT NULL
+                AND challenger_role_type IN (
+                    'CENTRAL_PRESIDENT', 'CENTRAL_VICE_PRESIDENT',
+                    'CENTRAL_OPERATING_TEAM_MEMBER', 'CENTRAL_EDUCATION_TEAM_MEMBER'
+                )
+                AND cardinality(tracks) = 0
+                AND track IS NULL
+            )
+        );

--- a/src/test/java/com/umc/product/authorization/application/service/AuthoritySnapshotCacheSerializerTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/AuthoritySnapshotCacheSerializerTest.java
@@ -63,6 +63,33 @@ class AuthoritySnapshotCacheSerializerTest {
     }
 
     @Test
+    @DisplayName("지부 없는 비수강 중앙 운영진의 캐시를 복원해도 기수와 역할 범위를 유지한다")
+    void 지부_없는_중앙_운영진의_권한_범위를_복원한다() {
+        // given
+        AuthoritySnapshotCacheSerializer serializer = new AuthoritySnapshotCacheSerializer(productionObjectMapper());
+        AuthoritySnapshot snapshot = AuthoritySnapshot.of(
+            1L,
+            30L,
+            List.of(GisuChallengerInfo.builder().gisuId(11L).challengerId(100L).build()),
+            List.of(new RoleAttribute(
+                ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, OrganizationType.CENTRAL, null, null, 11L
+            )),
+            Set.of()
+        );
+
+        // when
+        AuthoritySnapshot restored = serializer.deserialize(serializer.serialize(snapshot));
+
+        // then
+        assertThat(restored.gisuChallengerInfos()).isEqualTo(snapshot.gisuChallengerInfos());
+        assertThat(restored.gisuChallengerInfos().getFirst().chapterId()).isNull();
+        assertThat(restored.isCentralMemberInGisu(11L)).isTrue();
+        assertThat(restored.isCentralMemberInGisu(10L)).isFalse();
+        assertThat(restored.isSchoolCoreInGisu(11L, 30L)).isFalse();
+        assertThat(restored.isChapterPresidentInGisu(11L, 90L)).isFalse();
+    }
+
+    @Test
     @DisplayName("schema version이 없거나 지원하지 않는 캐시 payload는 복원하지 않는다")
     void reject_missing_or_unsupported_schema_version() {
         AuthoritySnapshotCacheSerializer serializer = new AuthoritySnapshotCacheSerializer(

--- a/src/test/java/com/umc/product/authorization/application/service/AuthorizationServiceCacheTest.java
+++ b/src/test/java/com/umc/product/authorization/application/service/AuthorizationServiceCacheTest.java
@@ -3,14 +3,20 @@ package com.umc.product.authorization.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,6 +28,7 @@ import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase
 import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.global.cache.application.port.in.CacheUseCase;
 import com.umc.product.global.cache.domain.CacheKey;
 import com.umc.product.global.cache.domain.CacheLookup;
@@ -35,6 +42,8 @@ import com.umc.product.member.application.port.in.query.dto.MemberSystemRoleInfo
 import com.umc.product.member.domain.exception.MemberDomainException;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.exception.OrganizationDomainException;
+import com.umc.product.organization.exception.OrganizationErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AuthorizationService 캐시")
@@ -216,6 +225,103 @@ class AuthorizationServiceCacheTest {
         assertThat(result.memberId()).isEqualTo(MEMBER_ID);
         assertThat(cacheUseCase.latestEvictedKey()).isEqualTo(CacheKey.from("member:" + MEMBER_ID));
         verify(getMemberUseCase).getById(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("지부 없는 비수강 중앙 운영진은 권한 로딩과 캐시 복원 후에도 해당 기수 중앙 권한만 가진다")
+    void 지부_없는_비수강_중앙_운영진의_권한을_로드하고_캐시한다() {
+        // given
+        InMemoryCacheUseCase cacheUseCase = new InMemoryCacheUseCase();
+        AuthorizationService sut = authorizationService(cacheUseCase);
+        givenSubject(null, List.of(), ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, GISU_ID);
+        given(getChapterUseCase.findByGisuAndSchool(GISU_ID, SCHOOL_ID)).willReturn(Optional.empty());
+        given(getMemberUseCase.existsById(MEMBER_ID)).willReturn(true);
+
+        // when
+        SubjectAttributes first = sut.loadSubject(MEMBER_ID);
+        SubjectAttributes cached = sut.loadSubject(MEMBER_ID);
+
+        // then
+        assertThat(first.gisuChallengerInfos().getFirst().chapterId()).isNull();
+        assertThat(cached).isEqualTo(first);
+        assertThat(cached.toAuthoritySnapshot().isCentralMemberInGisu(GISU_ID)).isTrue();
+        assertThat(cached.toAuthoritySnapshot().isCentralMemberInGisu(GISU_ID + 1)).isFalse();
+        assertThat(cached.toAuthoritySnapshot().isSchoolCoreInGisu(GISU_ID, SCHOOL_ID)).isFalse();
+        assertThat(cached.toAuthoritySnapshot().isChapterPresidentInGisu(GISU_ID, CHAPTER_ID)).isFalse();
+        verify(getChapterUseCase).findByGisuAndSchool(GISU_ID, SCHOOL_ID);
+        verify(getChapterUseCase, never()).byGisuAndSchool(GISU_ID, SCHOOL_ID);
+    }
+
+    @Test
+    @DisplayName("비수강 중앙 운영진도 해당 기수의 학교 지부 연결이 있으면 권한 정보에 보존한다")
+    void 비수강_중앙_운영진의_기존_지부_연결을_보존한다() {
+        // given
+        AuthorizationService sut = authorizationService(new InMemoryCacheUseCase());
+        givenSubject(null, List.of(), ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, GISU_ID);
+        given(getChapterUseCase.findByGisuAndSchool(GISU_ID, SCHOOL_ID))
+            .willReturn(Optional.of(new ChapterInfo(CHAPTER_ID, "현재 지부")));
+
+        // when
+        SubjectAttributes subject = sut.loadSubject(MEMBER_ID);
+
+        // then
+        assertThat(subject.gisuChallengerInfos().getFirst().chapterId()).isEqualTo(CHAPTER_ID);
+        assertThat(subject.toAuthoritySnapshot().isCentralMemberInGisu(GISU_ID)).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("지부가_필요한_소속")
+    @DisplayName("같은 기수 비수강 중앙 운영진 이외의 소속은 지부 누락을 허용하지 않는다")
+    void 지부_누락_허용을_다른_소속으로_확대하지_않는다(
+        String description, ChallengerPart part, List<ChallengerTrack> tracks,
+        ChallengerRoleType roleType, Long roleGisuId
+    ) {
+        // given
+        InMemoryCacheUseCase cacheUseCase = new InMemoryCacheUseCase();
+        AuthorizationService sut = authorizationService(cacheUseCase);
+        givenSubject(part, tracks, roleType, roleGisuId);
+        given(getChapterUseCase.byGisuAndSchool(GISU_ID, SCHOOL_ID))
+            .willThrow(new OrganizationDomainException(OrganizationErrorCode.CHAPTER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> sut.loadSubject(MEMBER_ID))
+            .isInstanceOfSatisfying(OrganizationDomainException.class,
+                exception -> assertThat(exception.getBaseCode()).isEqualTo(OrganizationErrorCode.CHAPTER_NOT_FOUND));
+        assertThat(cacheUseCase.latestValue()).isNull();
+        verify(getChapterUseCase, never()).findByGisuAndSchool(GISU_ID, SCHOOL_ID);
+    }
+
+    private static Stream<Arguments> 지부가_필요한_소속() {
+        return Stream.of(
+            Arguments.of("운영진 역할 없음", null, List.of(), null, GISU_ID),
+            Arguments.of("비수강 학교 회장", null, List.of(), ChallengerRoleType.SCHOOL_PRESIDENT, GISU_ID),
+            Arguments.of("다른 기수 중앙 운영진", null, List.of(),
+                ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, GISU_ID + 1),
+            Arguments.of("Track 수강 중인 중앙 운영진", null, List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER),
+                ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, GISU_ID),
+            Arguments.of("레거시 ADMIN 소속 중앙 운영진", ChallengerPart.ADMIN, List.of(),
+                ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER, GISU_ID)
+        );
+    }
+
+    private void givenSubject(ChallengerPart part, List<ChallengerTrack> tracks,
+                              ChallengerRoleType roleType, Long roleGisuId) {
+        given(getMemberUseCase.getById(MEMBER_ID))
+            .willReturn(MemberInfo.builder().id(MEMBER_ID).schoolId(SCHOOL_ID).build());
+        given(getChallengerUseCase.getAllByMemberId(MEMBER_ID)).willReturn(List.of(ChallengerInfo.builder()
+            .challengerId(CHALLENGER_ID).memberId(MEMBER_ID).gisuId(GISU_ID).part(part).tracks(tracks).build()));
+        given(loadChallengerRolePort.findByMemberId(MEMBER_ID)).willReturn(roleType == null ? List.of() : List.of(
+            ChallengerRole.create(CHALLENGER_ID, roleType,
+                roleType.isAtLeastCentralMember() ? null : SCHOOL_ID, null, roleGisuId)
+        ));
+    }
+
+    private AuthorizationService authorizationService(CacheUseCase cacheUseCase) {
+        return new AuthorizationService(
+            loadChallengerRolePort, List.of(), getMemberUseCase, listMemberSystemRoleUseCase,
+            getChapterUseCase, getChallengerUseCase, operationalMetrics, cacheUseCase,
+            new AuthoritySnapshotCacheSerializer(new ObjectMapper().findAndRegisterModules())
+        );
     }
 
     private static class InMemoryCacheUseCase implements CacheUseCase {

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +45,6 @@ import com.umc.product.global.security.MemberPrincipal;
 import com.umc.product.member.application.port.out.SaveMemberPort;
 import com.umc.product.member.domain.Member;
 import com.umc.product.organization.application.port.out.command.SaveGisuPort;
-import com.umc.product.organization.application.port.out.query.LoadGisuPort;
 import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.organization.domain.School;
@@ -61,9 +61,6 @@ class ChallengerRecordControllerIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private GisuFixture gisuFixture;
-
-    @Autowired
-    private LoadGisuPort loadGisuPort;
 
     @Autowired
     private ChapterFixture chapterFixture;
@@ -253,6 +250,7 @@ class ChallengerRecordControllerIntegrationTest extends IntegrationTestSupport {
         assertThat(response.chapterId()).isEqualTo(chapter.getId());
         assertThat(response.chapterName()).isEqualTo(chapter.getName());
         assertThat(response.track()).isEqualTo(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(response.tracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
         authenticate(member.getId());
 
         // when
@@ -266,6 +264,33 @@ class ChallengerRecordControllerIntegrationTest extends IntegrationTestSupport {
         assertThat(challenger.getPart()).isNull();
         assertThat(challenger.getTracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
         assertThat(challengerRecordJpaRepository.findById(recordId).orElseThrow().isUsed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("지부 없는 비수강 중앙 운영진 코드를 조회하면 학교와 역할을 보존하고 지부는 비운다")
+    void 지부_없는_비수강_중앙_운영진_코드를_조회한다() {
+        // Given
+        Gisu gisu = saveGisuPort.save(Gisu.create(
+            9303L, Instant.parse("2026-09-01T00:00:00Z"), Instant.parse("2027-02-01T00:00:00Z"),
+            false, GisuLearningType.TRACK));
+        School school = schoolFixture.학교("지부미배정중앙학교");
+        Member member = member("중앙회원", "중앙", "central-code@test.com", school.getId());
+        Long recordId = manageChallengerRecordUseCase.create(CreateChallengerRecordCommand.builder()
+            .creatorMemberId(member.getId()).gisuId(gisu.getId()).schoolId(school.getId())
+            .tracks(List.of()).memberName(member.getName())
+            .challengerRoleType(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER).build());
+
+        // When
+        ChallengerRecordResponse response = recordResponseAssembler.from(recordId);
+
+        // Then
+        assertThat(response.chapterId()).isNull();
+        assertThat(response.chapterName()).isNull();
+        assertThat(response.schoolId()).isEqualTo(school.getId());
+        assertThat(response.schoolName()).isEqualTo(school.getName());
+        assertThat(response.tracks()).isEmpty();
+        assertThat(response.track()).isNull();
+        assertThat(response.challengerRoleType()).isEqualTo(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER);
     }
 
     @Test
@@ -321,8 +346,7 @@ class ChallengerRecordControllerIntegrationTest extends IntegrationTestSupport {
     }
 
     private RecordContext recordContext(Long generation, String prefix) {
-        Gisu gisu = loadGisuPort.findActiveGisu()
-            .orElseGet(() -> gisuFixture.활성_기수(generation));
+        Gisu gisu = gisuFixture.비활성_기수(generation);
         Chapter chapter = chapterFixture.지부(gisu, prefix + "지부");
         School school = schoolFixture.지부에_소속된_학교(prefix + "학교", chapter);
         return new RecordContext(gisu, chapter, school);

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ import com.umc.product.challenger.application.port.in.command.ManageChallengerRe
 import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
 import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.global.config.JacksonConfig;
 import com.umc.product.global.security.JwtTokenProvider;
@@ -93,21 +96,98 @@ class ChallengerRecordControllerTest {
                     {"gisuId":1,"chapterId":2,"schoolId":3,"track":"WEB_PRODUCT_ENGINEER","memberName":"홍길동"}
                     """))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.result.track").value("WEB_PRODUCT_ENGINEER"));
+            .andExpect(jsonPath("$.result.track").value("WEB_PRODUCT_ENGINEER"))
+            .andExpect(jsonPath("$.result.tracks[0]").value("WEB_PRODUCT_ENGINEER"));
 
         ArgumentCaptor<CreateChallengerRecordCommand> captor =
             ArgumentCaptor.forClass(CreateChallengerRecordCommand.class);
         then(manageChallengerRecordUseCase).should().create(captor.capture());
         assertThat(captor.getValue().part()).isNull();
         assertThat(captor.getValue().track()).isEqualTo(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(captor.getValue().tracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
         assertThat(captor.getValue().creatorMemberId()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("복수 트랙과 담당 역할을 단건 발급하고 단일 track 응답은 비운다")
+    void 복수_트랙과_담당_역할을_단건_발급한다() throws Exception {
+        // Given
+        given(manageChallengerRecordUseCase.create(any())).willReturn(10L);
+        given(assembler.from(10L)).willReturn(ChallengerRecordResponse.builder()
+            .code("ABC123").part(ChallengerPart.SPRINGBOOT)
+            .tracks(List.of(ChallengerTrack.DESIGN, ChallengerTrack.WEB_PRODUCT_ENGINEER))
+            .challengerRoleType(ChallengerRoleType.SCHOOL_PART_LEADER).build());
+
+        // When / Then
+        mockMvc.perform(post("/api/v1/challenger-record")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"gisuId":1,"chapterId":2,"schoolId":3,"part":"SPRINGBOOT",
+                     "tracks":["DESIGN","WEB_PRODUCT_ENGINEER"],"memberName":"홍길동",
+                     "challengerRoleType":"SCHOOL_PART_LEADER"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.track").isEmpty())
+            .andExpect(jsonPath("$.result.tracks[0]").value("DESIGN"))
+            .andExpect(jsonPath("$.result.tracks[1]").value("WEB_PRODUCT_ENGINEER"));
+        ArgumentCaptor<CreateChallengerRecordCommand> captor =
+            ArgumentCaptor.forClass(CreateChallengerRecordCommand.class);
+        then(manageChallengerRecordUseCase).should().create(captor.capture());
+        assertThat(captor.getValue().tracks()).containsExactly(ChallengerTrack.DESIGN, ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(captor.getValue().part()).isEqualTo(ChallengerPart.SPRINGBOOT);
+        assertThat(captor.getValue().challengerRoleType()).isEqualTo(ChallengerRoleType.SCHOOL_PART_LEADER);
+    }
+
+    @Test
+    @DisplayName("일괄 발급에서 복수 트랙과 지부 없는 비수강 중앙 운영진을 전달한다")
+    void 일괄_발급에서_복수_트랙과_지부_없는_중앙_운영진을_전달한다() throws Exception {
+        // Given
+        given(manageChallengerRecordUseCase.createBulk(any())).willReturn(List.of(10L, 11L));
+
+        // When / Then
+        mockMvc.perform(post("/api/v1/challenger-record/bulk")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    [{"gisuId":1,"chapterId":2,"schoolId":3,"tracks":["PLAN","DESIGN"],"memberName":"홍길동"},
+                     {"gisuId":1,"schoolId":3,"tracks":[],"memberName":"김철수",
+                      "challengerRoleType":"CENTRAL_OPERATING_TEAM_MEMBER"}]
+                    """))
+            .andExpect(status().isOk());
+        ArgumentCaptor<List<CreateChallengerRecordCommand>> captor = ArgumentCaptor.captor();
+        then(manageChallengerRecordUseCase).should().createBulk(captor.capture());
+        assertThat(captor.getValue().getFirst().tracks()).containsExactly(ChallengerTrack.PLAN, ChallengerTrack.DESIGN);
+        assertThat(captor.getValue().getLast().tracks()).isEmpty();
+        assertThat(captor.getValue().getLast().chapterId()).isNull();
+        assertThat(captor.getValue().getLast().toEntity().canOmitChapter()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "\"tracks\":[],",
+        "\"tracks\":[],\"challengerRoleType\":\"SCHOOL_PRESIDENT\",",
+        "\"tracks\":[\"PLAN\"],\"challengerRoleType\":\"CENTRAL_PRESIDENT\","
+    })
+    @DisplayName("비수강 중앙 운영진 외에는 지부 없는 코드 발급을 거부한다")
+    void 비수강_중앙_운영진_외에는_지부_생략을_거부한다(String selection) throws Exception {
+        // Given / When / Then
+        mockMvc.perform(post("/api/v1/challenger-record")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"gisuId":1,"schoolId":3,%s"memberName":"홍길동"}
+                    """.formatted(selection)))
+            .andExpect(status().isBadRequest());
+        then(manageChallengerRecordUseCase).should(never()).create(any());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
         "\"part\":\"WEB\",\"track\":\"WEB_PRODUCT_ENGINEER\",",
         "\"track\":\"INFRA_PLUS\",",
-        "\"track\":\"DESIGN\",\"challengerRoleType\":\"SCHOOL_PART_LEADER\",",
+        "\"tracks\":[\"INFRA_PLUS\"],\"challengerRoleType\":\"SCHOOL_PART_LEADER\",",
+        "\"part\":\"WEB\",\"tracks\":[\"WEB_PRODUCT_ENGINEER\"],",
+        "\"track\":\"DESIGN\",\"tracks\":[],",
+        "\"tracks\":[null],",
+        "\"tracks\":[],",
         ""
     })
     @DisplayName("혼합 유형과 PLUS 및 빈 학습 유형은 코드로 발급할 수 없다")

--- a/src/test/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssemblerTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/in/web/assembler/ChallengerResponseAssemblerTest.java
@@ -1,0 +1,117 @@
+package com.umc.product.challenger.adapter.in.web.assembler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.product.authorization.application.port.in.query.dto.ChallengerRoleInfo;
+import com.umc.product.challenger.adapter.in.web.dto.response.ChallengerInfoResponse;
+import com.umc.product.challenger.application.port.in.query.GetChallengerUseCase;
+import com.umc.product.challenger.application.port.in.query.dto.ChallengerInfo;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.GisuLearningType;
+import com.umc.product.common.domain.enums.OrganizationType;
+import com.umc.product.member.application.port.in.query.GetMemberUseCase;
+import com.umc.product.member.application.port.in.query.dto.MemberInfo;
+import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
+import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
+import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("챌린저 응답의 지부 정보")
+class ChallengerResponseAssemblerTest {
+
+    @Mock
+    GetChallengerUseCase getChallengerUseCase;
+    @Mock
+    GetMemberUseCase getMemberUseCase;
+    @Mock
+    GetGisuUseCase getGisuUseCase;
+    @Mock
+    GetChapterUseCase getChapterUseCase;
+    @InjectMocks
+    ChallengerResponseAssembler assembler;
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("비수강 소속의 단건과 목록 조회는 지부 연결 유무를 동일하게 반영한다")
+    void 단건과_목록에서_지부_연결을_동일하게_반영한다(boolean hasChapter) {
+        // given
+        ChallengerInfo challenger = challenger();
+        MemberInfo member = member();
+        GisuInfo gisu = gisu();
+        ChapterInfo chapter = hasChapter ? new ChapterInfo(20L, "현재 지부") : null;
+        given(getChallengerUseCase.getById(100L)).willReturn(challenger);
+        given(getChallengerUseCase.getAllByMemberId(1L)).willReturn(List.of(challenger));
+        given(getMemberUseCase.getById(1L)).willReturn(member);
+        given(getGisuUseCase.getById(6L)).willReturn(gisu);
+        given(getGisuUseCase.getByIds(Set.of(6L))).willReturn(List.of(gisu));
+        given(getChapterUseCase.findByGisuAndSchool(6L, 30L)).willReturn(Optional.ofNullable(chapter));
+        given(getChapterUseCase.getChapterMapByGisuIdsAndSchoolIds(Set.of(6L), Set.of(30L)))
+            .willReturn(hasChapter ? Map.of(6L, Map.of(30L, chapter)) : Map.of());
+
+        // when
+        ChallengerInfoResponse single = assembler.fromChallengerId(100L);
+        List<ChallengerInfoResponse> all = assembler.fromMemberId(1L);
+
+        // then
+        assertThat(all).containsExactly(single);
+        assertThat(single.challengerId()).isEqualTo(100L);
+        assertThat(single.gisuId()).isEqualTo(6L);
+        assertThat(single.schoolId()).isEqualTo(30L);
+        assertThat(single.tracks()).isEmpty();
+        assertThat(single.chapterId()).isEqualTo(hasChapter ? 20L : null);
+        assertThat(single.chapterName()).isEqualTo(hasChapter ? "현재 지부" : null);
+    }
+
+    @Test
+    @DisplayName("지부가 없어도 역할을 포함한 응답에서 중앙 운영진 역할을 보존한다")
+    void 지부_없는_응답에_중앙_역할을_보존한다() {
+        // given
+        ChallengerRoleInfo role = ChallengerRoleInfo.builder().id(200L).challengerId(100L)
+            .gisuId(6L).roleType(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)
+            .organizationType(OrganizationType.CENTRAL).build();
+
+        // when
+        ChallengerInfoResponse response = ChallengerInfoResponse.from(
+            challenger(), member(), gisu(), null, List.of(role)
+        );
+
+        // then
+        assertThat(response.chapterId()).isNull();
+        assertThat(response.chapterName()).isNull();
+        assertThat(response.roles()).singleElement().satisfies(result -> {
+            assertThat(result.challengerRoleId()).isEqualTo(200L);
+            assertThat(result.roleType()).isEqualTo(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER);
+            assertThat(result.gisuId()).isEqualTo(6L);
+        });
+    }
+
+    private ChallengerInfo challenger() {
+        return ChallengerInfo.builder().challengerId(100L).memberId(1L).gisuId(6L).tracks(List.of()).build();
+    }
+
+    private MemberInfo member() {
+        return MemberInfo.builder().id(1L).schoolId(30L).name("중앙 회원").build();
+    }
+
+    private GisuInfo gisu() {
+        return new GisuInfo(6L, 11L, Instant.parse("2026-08-31T15:00:00Z"),
+            Instant.parse("2027-02-27T15:00:00Z"), true, GisuLearningType.TRACK);
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerRecordTracksMigrationTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerRecordTracksMigrationTest.java
@@ -1,0 +1,153 @@
+package com.umc.product.challenger.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@TestPropertySource(properties = "decorator.datasource.p6spy.enable-logging=false")
+@DisplayName("챌린저 코드의 복수 트랙 Flyway 마이그레이션")
+class ChallengerRecordTracksMigrationTest {
+
+    private static final String MIGRATION_PATH =
+        "db/migration/V2026.09.10.04.00__support_challenger_record_tracks.sql";
+
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void preparePreviousSchemaWithinTestTransaction() {
+        // 실제 Flyway 스키마에서 이번 변경만 되돌려 이전 코드 데이터를 준비한다. 테스트 종료 시 함께 롤백된다.
+        jdbcTemplate.update("DELETE FROM challenger_record");
+        jdbcTemplate.execute("ALTER TABLE challenger_record DROP COLUMN tracks CASCADE");
+        jdbcTemplate.execute("""
+            ALTER TABLE challenger_record
+                ALTER COLUMN chapter_id SET NOT NULL,
+                ADD CONSTRAINT challenger_record_track_registration_check
+                    CHECK (track IS NULL OR (part IS NULL AND challenger_role_type IS NULL AND organization_id IS NULL))
+            """);
+        jdbcTemplate.update("""
+            INSERT INTO challenger_record
+                (code, member_name, created_member_id, gisu_id, chapter_id, school_id, part, track,
+                 challenger_role_type, organization_id, is_used, used_member_id, used_at, created_at, updated_at)
+            VALUES
+                ('PART01', '기존 파트', 1, 10, 2, 3, 'SPRINGBOOT', NULL, NULL, NULL, false, NULL, NULL, now(), now()),
+                ('TRACK1', '사용한 코드', 1, 11, 2, 3, NULL, 'WEB_PRODUCT_ENGINEER', NULL, NULL,
+                    true, 10, '2026-09-10T01:00:00Z', now(), now()),
+                ('STAFF1', '담당 운영진', 1, 11, 2, 3, 'DESIGN', NULL, 'SCHOOL_PART_LEADER', 3,
+                    false, NULL, NULL, now(), now())
+            """);
+    }
+
+    @Test
+    @DisplayName("기존 코드와 사용 이력은 보존하고 단일 트랙만 배열로 옮기며 담당 파트는 수강으로 바꾸지 않는다")
+    void preservesExistingCodesAndBackfillsOnlyEnrollmentTrack() throws Exception {
+        // Given
+        List<String> previous = readLegacyRows();
+
+        // When
+        executeMigration();
+
+        // Then
+        assertThat(readLegacyRows()).isEqualTo(previous);
+        assertThat(jdbcTemplate.queryForList(
+            "SELECT code || ':' || tracks::TEXT FROM challenger_record ORDER BY code", String.class))
+            .containsExactly("PART01:{}", "STAFF1:{}", "TRACK1:{WEB_PRODUCT_ENGINEER}");
+    }
+
+    @Test
+    @DisplayName("복수 트랙과 담당 역할을 함께 저장하고 비수강 중앙 운영진은 지부 없이 저장한다")
+    void storesMultipleTracksWithRoleAndUnassignedCentralStaff() throws Exception {
+        // Given
+        executeMigration();
+
+        // When
+        jdbcTemplate.update("""
+            UPDATE challenger_record SET tracks = ARRAY['DESIGN', 'WEB_PRODUCT_ENGINEER']::TEXT[]
+            WHERE code = 'STAFF1'
+            """);
+        jdbcTemplate.update("""
+            UPDATE challenger_record SET challenger_role_type = 'CENTRAL_OPERATING_TEAM_MEMBER',
+                chapter_id = NULL, organization_id = NULL WHERE code = 'PART01'
+            """);
+
+        // Then
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT tracks::TEXT FROM challenger_record WHERE code = 'STAFF1'", String.class))
+            .isEqualTo("{DESIGN,WEB_PRODUCT_ENGINEER}");
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT chapter_id FROM challenger_record WHERE code = 'PART01'", Long.class)).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "ARRAY['INFRA_PLUS']::TEXT[]", "ARRAY['PLAN', NULL]::TEXT[]", "ARRAY['DESIGN', 'DESIGN']::TEXT[]", "NULL"
+    })
+    @DisplayName("PLUS와 null 및 중복 트랙을 데이터베이스에서도 거부한다")
+    void rejectsInvalidEnrollmentTracks(String tracksSql) throws Exception {
+        // Given
+        executeMigration();
+
+        // When / Then
+        assertThatThrownBy(() -> executeSql(
+            "UPDATE challenger_record SET tracks = " + tracksSql + " WHERE code = 'STAFF1'"))
+            .isInstanceOf(DataAccessException.class);
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT tracks::TEXT FROM challenger_record WHERE code = 'STAFF1'", String.class)).isEqualTo("{}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NULL", "'SCHOOL_PRESIDENT'", "'CENTRAL_PRESIDENT'"})
+    @DisplayName("일반 코드와 학교 운영진 및 수강 중인 중앙 운영진의 지부 생략을 거부한다")
+    void rejectsMissingChapterOutsideNonLearningCentralStaff(String roleSql) throws Exception {
+        // Given
+        executeMigration();
+
+        // When / Then
+        assertThatThrownBy(() -> executeSql("""
+            UPDATE challenger_record SET chapter_id = NULL, challenger_role_type = %s WHERE code = 'TRACK1'
+            """.formatted(roleSql))).isInstanceOf(DataAccessException.class);
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT chapter_id FROM challenger_record WHERE code = 'TRACK1'", Long.class)).isEqualTo(2L);
+    }
+
+    private List<String> readLegacyRows() {
+        return jdbcTemplate.queryForList(
+            "SELECT (to_jsonb(record) - 'tracks')::TEXT FROM challenger_record record ORDER BY code", String.class);
+    }
+
+    private void executeMigration() throws Exception {
+        executeSql(new ClassPathResource(MIGRATION_PATH).getContentAsString(StandardCharsets.UTF_8));
+    }
+
+    private void executeSql(String sql) {
+        jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
+            var savepoint = connection.setSavepoint();
+            try (var statement = connection.createStatement()) {
+                statement.execute(sql);
+            } catch (SQLException | RuntimeException exception) {
+                connection.rollback(savepoint);
+                throw exception;
+            } finally {
+                connection.releaseSavepoint(savepoint);
+            }
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerRecordTracksMigrationTest.java
+++ b/src/test/java/com/umc/product/challenger/adapter/out/persistence/ChallengerRecordTracksMigrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,15 +15,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.TestPropertySource;
 
+import com.p6spy.engine.wrapper.P6Proxy;
 import com.umc.product.support.PersistenceAdapterTest;
 
 @PersistenceAdapterTest
-@TestPropertySource(properties = "decorator.datasource.p6spy.enable-logging=false")
 @DisplayName("챌린저 코드의 복수 트랙 Flyway 마이그레이션")
 class ChallengerRecordTracksMigrationTest {
 
@@ -107,7 +107,10 @@ class ChallengerRecordTracksMigrationTest {
         // When / Then
         assertThatThrownBy(() -> executeSql(
             "UPDATE challenger_record SET tracks = " + tracksSql + " WHERE code = 'STAFF1'"))
-            .isInstanceOf(DataAccessException.class);
+            .isInstanceOfSatisfying(DataIntegrityViolationException.class, exception -> {
+                SQLException sqlException = (SQLException)exception.getMostSpecificCause();
+                assertThat(sqlException.getSQLState()).isEqualTo(tracksSql.equals("NULL") ? "23502" : "23514");
+            });
         assertThat(jdbcTemplate.queryForObject(
             "SELECT tracks::TEXT FROM challenger_record WHERE code = 'STAFF1'", String.class)).isEqualTo("{}");
     }
@@ -122,7 +125,7 @@ class ChallengerRecordTracksMigrationTest {
         // When / Then
         assertThatThrownBy(() -> executeSql("""
             UPDATE challenger_record SET chapter_id = NULL, challenger_role_type = %s WHERE code = 'TRACK1'
-            """.formatted(roleSql))).isInstanceOf(DataAccessException.class);
+            """.formatted(roleSql))).isInstanceOf(DataIntegrityViolationException.class);
         assertThat(jdbcTemplate.queryForObject(
             "SELECT chapter_id FROM challenger_record WHERE code = 'TRACK1'", Long.class)).isEqualTo(2L);
     }
@@ -140,7 +143,10 @@ class ChallengerRecordTracksMigrationTest {
         jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
             var savepoint = connection.setSavepoint();
             try (var statement = connection.createStatement()) {
-                statement.execute(sql);
+                // DB 제약 검증이 전역 P6Spy 포매터의 배열 SQL 처리에 영향받지 않도록 실제 JDBC로 실행한다.
+                Statement jdbcStatement = statement instanceof P6Proxy proxy
+                    ? (Statement)proxy.unwrapP6SpyProxy() : statement;
+                jdbcStatement.execute(sql);
             } catch (SQLException | RuntimeException exception) {
                 connection.rollback(savepoint);
                 throw exception;

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordCommandServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.umc.product.authorization.application.port.in.command.EvictAuthoritySnapshotCacheUseCase;
 import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
 import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
+import com.umc.product.authorization.application.port.in.query.ListChallengerRoleUseCase;
 import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
 import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
 import com.umc.product.challenger.application.port.out.LoadChallengerPort;
@@ -39,11 +40,13 @@ import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
 import com.umc.product.common.domain.enums.ChallengerTrack;
 import com.umc.product.common.domain.enums.GisuLearningType;
+import com.umc.product.member.application.port.in.command.LockMemberUseCase;
 import com.umc.product.member.application.port.in.query.GetMemberUseCase;
 import com.umc.product.member.application.port.in.query.dto.MemberInfo;
 import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
 import com.umc.product.organization.application.port.in.query.GetChapterUseCase;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
+import com.umc.product.organization.application.port.in.query.GetSchoolUseCase;
 import com.umc.product.organization.application.port.in.query.dto.chapter.ChapterInfo;
 import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 
@@ -81,11 +84,22 @@ class ChallengerRecordCommandServiceTest {
     @Mock
     GetGisuUseCase getGisuUseCase;
 
+    @Mock
+    GetSchoolUseCase getSchoolUseCase;
+
+    @Mock
+    LockMemberUseCase lockMemberUseCase;
+
+    @Mock
+    ListChallengerRoleUseCase listChallengerRoleUseCase;
+
     @BeforeEach
     void 기본_기수는_파트_학습을_사용한다() {
         GisuInfo gisu = mock(GisuInfo.class);
         lenient().when(gisu.learningType()).thenReturn(GisuLearningType.PART);
         lenient().when(getGisuUseCase.getById(9L)).thenReturn(gisu);
+        lenient().when(getChapterUseCase.byGisuAndSchool(9L, 3L)).thenReturn(new ChapterInfo(2L, "서울"));
+        lenient().when(saveChallengerPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @InjectMocks
@@ -243,6 +257,7 @@ class ChallengerRecordCommandServiceTest {
         );
         given(loadChallengerRecordPort.getByCodeForUpdate("ABC123")).willReturn(record);
         given(loadChallengerPort.findByMemberIdAndGisuId(100L, 9L)).willReturn(Optional.empty());
+        given(getMemberUseCase.getById(100L)).willReturn(member("홍길동", 3L));
 
         assertThatThrownBy(() -> sut.consumeCode(consumeCommand()))
             .isInstanceOf(ChallengerDomainException.class)
@@ -364,15 +379,22 @@ class ChallengerRecordCommandServiceTest {
     }
 
     @Test
-    @DisplayName("운영진 코드에는 수강 트랙을 함께 발급할 수 없다")
-    void 운영진_코드에는_수강_트랙을_함께_발급할_수_없다() {
+    @DisplayName("운영진 코드에 수강 트랙을 함께 발급하고 담당 파트는 보존한다")
+    void 운영진_코드에_수강_트랙을_함께_발급하고_담당_파트는_보존한다() {
+        givenTrackGisu();
+        given(saveChallengerRecordPort.save(any())).willAnswer(invocation -> invocation.getArgument(0));
         CreateChallengerRecordCommand command = CreateChallengerRecordCommand.builder()
             .creatorMemberId(1L).gisuId(9L).chapterId(2L).schoolId(3L)
             .part(ChallengerPart.WEB).track(ChallengerTrack.WEB_PRODUCT_ENGINEER)
             .memberName("홍길동").challengerRoleType(ChallengerRoleType.SCHOOL_PART_LEADER).build();
 
-        assertThatThrownBy(() -> sut.create(command)).isInstanceOf(ChallengerDomainException.class);
-        then(saveChallengerRecordPort).should(never()).save(any());
+        sut.create(command);
+
+        ArgumentCaptor<ChallengerRecord> captor = ArgumentCaptor.forClass(ChallengerRecord.class);
+        then(saveChallengerRecordPort).should().save(captor.capture());
+        assertThat(captor.getValue().getTracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(captor.getValue().getPart()).isEqualTo(ChallengerPart.WEB);
+        assertThat(captor.getValue().getChallengerRoleType()).isEqualTo(ChallengerRoleType.SCHOOL_PART_LEADER);
     }
 
     private void givenTrackGisu() {

--- a/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordRegistrationIntegrationTest.java
+++ b/src/test/java/com/umc/product/challenger/application/service/ChallengerRecordRegistrationIntegrationTest.java
@@ -1,0 +1,363 @@
+package com.umc.product.challenger.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.umc.product.authorization.adapter.out.persistence.ChallengerRoleJpaRepository;
+import com.umc.product.authorization.application.port.in.CheckPermissionUseCase;
+import com.umc.product.authorization.application.port.in.command.ManageChallengerRoleUseCase;
+import com.umc.product.authorization.application.port.in.command.dto.CreateChallengerRoleCommand;
+import com.umc.product.challenger.adapter.out.persistence.ChallengerJpaRepository;
+import com.umc.product.challenger.adapter.out.persistence.ChallengerRecordJpaRepository;
+import com.umc.product.challenger.application.port.in.command.ManageChallengerRecordUseCase;
+import com.umc.product.challenger.application.port.in.command.dto.ConsumeChallengerRecordCommand;
+import com.umc.product.challenger.application.port.in.command.dto.CreateChallengerRecordCommand;
+import com.umc.product.challenger.application.port.out.SaveChallengerPort;
+import com.umc.product.challenger.domain.Challenger;
+import com.umc.product.challenger.domain.ChallengerRecord;
+import com.umc.product.challenger.domain.exception.ChallengerDomainException;
+import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
+import com.umc.product.common.domain.enums.ChallengerPart;
+import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerStatus;
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.common.domain.enums.GisuLearningType;
+import com.umc.product.member.application.port.out.SaveMemberPort;
+import com.umc.product.member.domain.Member;
+import com.umc.product.notification.application.port.in.SendWebhookAlarmUseCase;
+import com.umc.product.organization.application.port.out.command.SaveGisuPort;
+import com.umc.product.organization.domain.Chapter;
+import com.umc.product.organization.domain.Gisu;
+import com.umc.product.organization.domain.School;
+import com.umc.product.support.IntegrationTestSupport;
+import com.umc.product.support.concurrency.PostgreSqlTransactionRace;
+import com.umc.product.support.fixture.ChapterFixture;
+import com.umc.product.support.fixture.SchoolFixture;
+
+@DisplayName("코드 한 번으로 기수 수강과 운영진 역할 등록")
+class ChallengerRecordRegistrationIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ManageChallengerRecordUseCase records;
+    @Autowired
+    private SaveGisuPort saveGisuPort;
+    @Autowired
+    private ChapterFixture chapterFixture;
+    @Autowired
+    private SchoolFixture schoolFixture;
+    @Autowired
+    private SaveMemberPort saveMemberPort;
+    @Autowired
+    private SaveChallengerPort saveChallengerPort;
+    @Autowired
+    private ChallengerJpaRepository challengers;
+    @Autowired
+    private ChallengerRecordJpaRepository recordRepository;
+    @Autowired
+    private ChallengerRoleJpaRepository roles;
+    @Autowired
+    private ManageChallengerRoleUseCase manageRoles;
+    @Autowired
+    private CheckPermissionUseCase permissions;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @MockitoBean
+    private SendWebhookAlarmUseCase notifications;
+
+    private Gisu gisu;
+    private Chapter chapter;
+    private School school;
+    private Member member;
+
+    @BeforeEach
+    void 준비() {
+        gisu = saveGisuPort.save(Gisu.create(9310L,
+            Instant.parse("2026-09-01T00:00:00Z"), Instant.parse("2027-02-28T00:00:00Z"),
+            false, GisuLearningType.TRACK));
+        chapter = chapterFixture.지부(gisu, "통합등록지부");
+        school = schoolFixture.지부에_소속된_학교("통합등록학교", chapter);
+        member = saveMemberPort.save(Member.create("등록회원", "등록", "register@test.com", school.getId(), null));
+    }
+
+    @Test
+    @DisplayName("신규 회원이 복수 트랙과 학교 회장 역할을 한 번에 등록한다")
+    void 신규_수강과_역할_등록() {
+        ChallengerRecord record = issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER, ChallengerTrack.DESIGN),
+            ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        consume(record);
+
+        Challenger challenger = membership();
+        assertThat(challenger.getPart()).isNull();
+        assertThat(challenger.getTracks()).containsExactly(
+            ChallengerTrack.WEB_PRODUCT_ENGINEER, ChallengerTrack.DESIGN);
+        assertThat(roles.findByChallengerId(challenger.getId())).singleElement().satisfies(role -> {
+            assertThat(role.getChallengerRoleType()).isEqualTo(ChallengerRoleType.SCHOOL_PRESIDENT);
+            assertThat(role.getOrganizationId()).isEqualTo(school.getId());
+            assertThat(role.getGisuId()).isEqualTo(gisu.getId());
+        });
+        assertUsed(record);
+    }
+
+    @Test
+    @DisplayName("수강 없는 학교 운영진이 빈 트랙 소속과 역할을 한 번에 등록한다")
+    void 비수강_학교_운영진_등록() {
+        ChallengerRecord record = issue(List.of(), ChallengerRoleType.SCHOOL_VICE_PRESIDENT);
+
+        consume(record);
+
+        assertThat(membership().getTracks()).isEmpty();
+        assertThat(membership().getPart()).isNull();
+        assertThat(roles.findByChallengerId(membership().getId())).hasSize(1);
+        assertUsed(record);
+    }
+
+    @Test
+    @DisplayName("지부 없는 중앙 운영진이 가입하고 중앙 권한을 조회한다")
+    void 지부_없는_중앙_운영진_등록과_권한조회() {
+        school = schoolFixture.학교("중앙만참여학교");
+        member = saveMemberPort.save(Member.create("중앙회원", "중앙", "central@test.com", school.getId(), null));
+        Long id = records.create(command(List.of(), ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER)
+            .chapterId(null).build());
+
+        consume(recordRepository.findById(id).orElseThrow());
+
+        var snapshot = permissions.loadSubject(member.getId()).toAuthoritySnapshot();
+        assertThat(snapshot.isCentralMemberInGisu(gisu.getId())).isTrue();
+        assertThat(snapshot.isSchoolCoreInGisu(gisu.getId(), school.getId())).isFalse();
+        assertThat(snapshot.gisuChallengerInfos()).singleElement()
+            .satisfies(info -> assertThat(info.chapterId()).isNull());
+        assertThat(membership().getTracks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기존 웹 수강생은 웹과 회장 코드로 역할만 추가하고 기존 소속과 다른 역할을 보존한다")
+    void 기존_소속과_수강과_역할_보존() {
+        Challenger existing = saveChallengerPort.save(Challenger.builder().memberId(member.getId())
+            .gisuId(gisu.getId()).tracks(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER)).build());
+        Long oldRole = manageRoles.createChallengerRole(CreateChallengerRoleCommand.builder()
+            .challengerId(existing.getId()).gisuId(gisu.getId()).organizationId(chapter.getId())
+            .roleType(ChallengerRoleType.CHAPTER_PRESIDENT).build());
+        ChallengerRecord record = issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        consume(record);
+
+        assertThat(membership().getId()).isEqualTo(existing.getId());
+        assertThat(membership().getTracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(roles.findByChallengerId(existing.getId())).hasSize(2)
+            .anySatisfy(role -> assertThat(role.getId()).isEqualTo(oldRole));
+        assertUsed(record);
+    }
+
+    @Test
+    @DisplayName("겸직자는 역할별 코드를 두 번 등록해도 한 소속에 수강과 두 역할을 보존한다")
+    void 역할별_코드로_겸직_등록() {
+        ChallengerRecord central = issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER);
+        ChallengerRecord president = issue(List.of(), ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        consume(central);
+        Long challengerId = membership().getId();
+        consume(president);
+
+        assertThat(challengers.findByMemberId(member.getId())).hasSize(1);
+        assertThat(membership().getId()).isEqualTo(challengerId);
+        assertThat(membership().getTracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(roles.findByChallengerId(challengerId)).extracting(role -> role.getChallengerRoleType())
+            .containsExactlyInAnyOrder(ChallengerRoleType.CENTRAL_OPERATING_TEAM_MEMBER,
+                ChallengerRoleType.SCHOOL_PRESIDENT);
+        assertUsed(central);
+        assertUsed(president);
+    }
+
+    @Test
+    @DisplayName("같은 역할은 중복 생성하지 않고 코드에 추가된 트랙만 등록한다")
+    void 기존_역할을_보존하며_트랙_추가() {
+        consume(issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER), ChallengerRoleType.SCHOOL_PRESIDENT));
+        Long id = membership().getId();
+        ChallengerRecord record = issue(List.of(ChallengerTrack.DESIGN), ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        consume(record);
+
+        assertThat(membership().getId()).isEqualTo(id);
+        assertThat(membership().getTracks()).containsExactly(
+            ChallengerTrack.WEB_PRODUCT_ENGINEER, ChallengerTrack.DESIGN);
+        assertThat(roles.findByChallengerId(id)).hasSize(1);
+        assertUsed(record);
+    }
+
+    @Test
+    @DisplayName("코드의 수강과 역할을 이미 모두 갖고 있으면 코드를 사용하지 않는다")
+    void 완전_중복_코드_거절() {
+        consume(issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER), ChallengerRoleType.SCHOOL_PRESIDENT));
+        ChallengerRecord duplicate = issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        assertThatThrownBy(() -> consume(duplicate)).isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode").isEqualTo(ChallengerErrorCode.CHALLENGER_ALREADY_EXISTS);
+
+        assertThat(recordRepository.findById(duplicate.getId()).orElseThrow().isUsed()).isFalse();
+        assertThat(roles.findByChallengerId(membership().getId())).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("운영진 코드도 이름이나 학교가 다르면 아무 소속과 역할을 만들지 않는다")
+    void 운영진도_회원_일치_검증(boolean wrongName) {
+        ChallengerRecord record = issue(List.of(), ChallengerRoleType.SCHOOL_PRESIDENT);
+        Long otherSchool = wrongName ? school.getId() : schoolFixture.학교("다른학교").getId();
+        Member other = saveMemberPort.save(Member.create(wrongName ? "다른이름" : member.getName(), "불일치",
+            "mismatch@test.com", otherSchool, null));
+
+        assertThatThrownBy(() -> consume(record, other.getId())).isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode").isEqualTo(wrongName ? ChallengerErrorCode.INVALID_MEMBER_NAME_FOR_RECORD
+                : ChallengerErrorCode.INVALID_SCHOOL_FOR_RECORD);
+
+        assertThat(challengers.findByMemberId(other.getId())).isEmpty();
+        assertThat(recordRepository.findById(record.getId()).orElseThrow().isUsed()).isFalse();
+        assertThat(roles.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("비활성 트랙 소속은 코드로 자동 복구하지 않는다")
+    void 비활성_소속_거절() {
+        Challenger inactive = Challenger.createWithoutEnrollment(member.getId(), gisu.getId());
+        inactive.changeStatus(ChallengerStatus.WITHDRAWN, member.getId(), "중도탈퇴");
+        saveChallengerPort.save(inactive);
+        ChallengerRecord record = issue(List.of(ChallengerTrack.DESIGN), ChallengerRoleType.SCHOOL_PRESIDENT);
+
+        assertThatThrownBy(() -> consume(record)).isInstanceOf(ChallengerDomainException.class)
+            .extracting("baseCode").isEqualTo(ChallengerErrorCode.CHALLENGER_NOT_ACTIVE);
+
+        assertThat(membership().getStatus()).isEqualTo(ChallengerStatus.WITHDRAWN);
+        assertThat(roles.count()).isZero();
+        assertThat(recordRepository.findById(record.getId()).orElseThrow().isUsed()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("등록 중 실패하면 신규 소속 또는 기존 수강 변경과 역할 및 코드 사용을 모두 롤백한다")
+    void 등록_전체_롤백(boolean existingMembership) {
+        if (existingMembership) {
+            consume(issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER), null));
+        }
+        ChallengerRecord record = issue(List.of(ChallengerTrack.DESIGN), ChallengerRoleType.SCHOOL_PRESIDENT);
+        doThrow(new IllegalStateException("등록 후처리 실패")).when(notifications).sendBuffered(any());
+
+        assertThatThrownBy(() -> consume(record)).isInstanceOf(IllegalStateException.class);
+
+        if (existingMembership) {
+            assertThat(membership().getTracks()).containsExactly(ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        } else {
+            assertThat(challengers.findByMemberId(member.getId())).isEmpty();
+        }
+        assertThat(roles.count()).isZero();
+        assertThat(recordRepository.findById(record.getId()).orElseThrow().isUsed()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("같은 회원의 서로 다른 코드는 직렬화되어 하나의 소속에 두 수강을 모두 남긴다")
+    void 서로_다른_코드의_동시_등록(boolean existingMembership) throws Exception {
+        if (existingMembership) {
+            saveChallengerPort.save(Challenger.createWithoutEnrollment(member.getId(), gisu.getId()));
+        }
+        ChallengerRecord firstRecord = issue(List.of(ChallengerTrack.WEB_PRODUCT_ENGINEER),
+            ChallengerRoleType.SCHOOL_PRESIDENT);
+        ChallengerRecord secondRecord = issue(List.of(ChallengerTrack.DESIGN), ChallengerRoleType.SCHOOL_PRESIDENT);
+        CountDownLatch firstConsumed = new CountDownLatch(1);
+        CountDownLatch allowCommit = new CountDownLatch(1);
+
+        try (PostgreSqlTransactionRace race = new PostgreSqlTransactionRace(transactionManager, jdbcTemplate)) {
+            var first = race.submit(() -> {
+                consume(firstRecord);
+                firstConsumed.countDown();
+                race.await(allowCommit, "첫 등록 커밋 대기");
+                return null;
+            });
+            race.await(firstConsumed, "첫 등록 완료");
+            var second = race.submit(() -> {
+                consume(secondRecord);
+                return null;
+            });
+            try {
+                race.awaitPostgreSqlLockWait(second);
+                assertThat(second.future().isDone()).isFalse();
+            } finally {
+                allowCommit.countDown();
+            }
+            first.future().get(10, TimeUnit.SECONDS);
+            second.future().get(10, TimeUnit.SECONDS);
+        }
+
+        assertThat(challengers.findByMemberId(member.getId())).hasSize(1);
+        assertThat(membership().getTracks()).containsExactly(
+            ChallengerTrack.WEB_PRODUCT_ENGINEER, ChallengerTrack.DESIGN);
+        assertThat(roles.findByChallengerId(membership().getId())).hasSize(1);
+        assertUsed(firstRecord);
+        assertUsed(secondRecord);
+    }
+
+    @Test
+    @DisplayName("기존 ADMIN 입력은 트랙 기수의 빈 수강 소속으로 등록한다")
+    void ADMIN_입력_호환() {
+        Long id = records.create(command(List.of(), null).part(ChallengerPart.ADMIN).build());
+
+        consume(recordRepository.findById(id).orElseThrow());
+
+        assertThat(membership().getTracks()).isEmpty();
+        assertThat(membership().getPart()).isNull();
+        assertThat(roles.count()).isZero();
+    }
+
+    private CreateChallengerRecordCommand.CreateChallengerRecordCommandBuilder command(
+        List<ChallengerTrack> tracks, ChallengerRoleType role
+    ) {
+        return CreateChallengerRecordCommand.builder().creatorMemberId(member.getId())
+            .gisuId(gisu.getId()).chapterId(chapter.getId()).schoolId(school.getId())
+            .memberName(member.getName()).tracks(tracks).challengerRoleType(role);
+    }
+
+    private ChallengerRecord issue(List<ChallengerTrack> tracks, ChallengerRoleType role) {
+        return recordRepository.findById(records.create(command(tracks, role).build())).orElseThrow();
+    }
+
+    private void consume(ChallengerRecord record) {
+        consume(record, member.getId());
+    }
+
+    private void consume(ChallengerRecord record, Long memberId) {
+        records.consumeCode(ConsumeChallengerRecordCommand.builder()
+            .targetMemberId(memberId).code(record.getCode()).build());
+    }
+
+    private Challenger membership() {
+        return challengers.findByMemberIdAndGisuId(member.getId(), gisu.getId()).orElseThrow();
+    }
+
+    private void assertUsed(ChallengerRecord record) {
+        ChallengerRecord saved = recordRepository.findById(record.getId()).orElseThrow();
+        assertThat(saved.isUsed()).isTrue();
+        assertThat(saved.getUsedMemberId()).isEqualTo(member.getId());
+    }
+}

--- a/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
+++ b/src/test/java/com/umc/product/challenger/domain/ChallengerRecordTest.java
@@ -3,6 +3,8 @@ package com.umc.product.challenger.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +12,8 @@ import com.umc.product.challenger.domain.exception.ChallengerDomainException;
 import com.umc.product.challenger.domain.exception.ChallengerErrorCode;
 import com.umc.product.common.domain.enums.ChallengerPart;
 import com.umc.product.common.domain.enums.ChallengerRoleType;
+import com.umc.product.common.domain.enums.ChallengerTrack;
+import com.umc.product.common.domain.enums.GisuLearningType;
 
 @DisplayName("ChallengerRecord 도메인")
 class ChallengerRecordTest {
@@ -78,5 +82,84 @@ class ChallengerRecordTest {
             .isInstanceOf(ChallengerDomainException.class)
             .extracting("baseCode")
             .isEqualTo(ChallengerErrorCode.INVALID_SCHOOL_FOR_RECORD);
+    }
+
+    @Test
+    @DisplayName("복수 수강 트랙과 담당 파트 역할을 한 코드에 보존하고 PART 기수에서는 거부한다")
+    void 복수_트랙과_역할을_보존하고_PART_기수에서는_거부한다() {
+        // Given
+        ChallengerRecord record = ChallengerRecord.createAdminWithTracks(
+            1L, 11L, 2L, 3L, ChallengerPart.SPRINGBOOT,
+            List.of(ChallengerTrack.DESIGN, ChallengerTrack.WEB_PRODUCT_ENGINEER), "홍길동",
+            ChallengerRoleType.SCHOOL_PART_LEADER, 3L);
+
+        // When
+        record.validateLearningType(GisuLearningType.TRACK);
+
+        // Then
+        assertThat(record.getPart()).isEqualTo(ChallengerPart.SPRINGBOOT);
+        assertThat(record.getTracks()).containsExactly(ChallengerTrack.DESIGN, ChallengerTrack.WEB_PRODUCT_ENGINEER);
+        assertThat(record.getTrack()).isNull();
+        assertThatThrownBy(() -> record.validateLearningType(GisuLearningType.PART))
+            .isInstanceOf(ChallengerDomainException.class);
+    }
+
+    @Test
+    @DisplayName("기존 운영진의 담당 파트는 수강으로 변환하지 않고 비수강 중앙 운영진은 지부를 생략한다")
+    void 담당_파트는_수강이_아니며_비수강_중앙_운영진은_지부를_생략한다() {
+        // Given / When
+        ChallengerRecord record = ChallengerRecord.createAdmin(
+            1L, 11L, null, 3L, ChallengerPart.DESIGN, "홍길동",
+            ChallengerRoleType.CENTRAL_EDUCATION_TEAM_MEMBER, null);
+        record.validateLearningType(GisuLearningType.TRACK);
+        record.validateLearningType(GisuLearningType.PART);
+
+        // Then
+        assertThat(record.getTracks()).isEmpty();
+        assertThat(record.canOmitChapter()).isTrue();
+        assertThat(record.getPart()).isEqualTo(ChallengerPart.DESIGN);
+    }
+
+    @Test
+    @DisplayName("수강 중인 중앙 운영진과 학교 운영진은 지부를 생략할 수 없다")
+    void 수강_중앙_운영진과_학교_운영진은_지부를_생략할_수_없다() {
+        // Given / When / Then
+        assertThatThrownBy(() -> ChallengerRecord.createAdminWithTracks(
+            1L, 11L, null, 3L, null, List.of(ChallengerTrack.PLAN), "홍길동",
+            ChallengerRoleType.CENTRAL_PRESIDENT, null)).isInstanceOf(ChallengerDomainException.class);
+        assertThatThrownBy(() -> ChallengerRecord.createAdminWithTracks(
+            1L, 11L, null, 3L, null, List.of(), "홍길동",
+            ChallengerRoleType.SCHOOL_PRESIDENT, 3L)).isInstanceOf(ChallengerDomainException.class);
+    }
+
+    @Test
+    @DisplayName("TRACK 기수에서 기존 ADMIN 비수강 코드는 허용하고 역할 없는 빈 코드와 일반 학습 파트는 거부한다")
+    void TRACK_기수의_ADMIN은_허용하고_역할없는_빈코드와_학습_파트는_거부한다() {
+        // Given
+        ChallengerRecord staff = ChallengerRecord.createWithTracks(1L, 11L, 2L, 3L, null, List.of(), "홍길동");
+        ChallengerRecord legacyStaff = ChallengerRecord.create(1L, 11L, 2L, 3L, ChallengerPart.ADMIN, "홍길동");
+        ChallengerRecord learner = ChallengerRecord.create(1L, 11L, 2L, 3L, ChallengerPart.WEB, "홍길동");
+
+        // When
+        legacyStaff.validateLearningType(GisuLearningType.TRACK);
+
+        // Then
+        assertThat(staff.getTracks()).isEmpty();
+        assertThat(legacyStaff.getTracks()).isEmpty();
+        assertThatThrownBy(() -> staff.validateLearningType(GisuLearningType.TRACK))
+            .isInstanceOf(ChallengerDomainException.class);
+        assertThatThrownBy(() -> staff.validateLearningType(GisuLearningType.PART))
+            .isInstanceOf(ChallengerDomainException.class);
+        assertThatThrownBy(() -> learner.validateLearningType(GisuLearningType.TRACK))
+            .isInstanceOf(ChallengerDomainException.class);
+    }
+
+    @Test
+    @DisplayName("PLUS 트랙은 운영진 역할이 있어도 발급할 수 없다")
+    void PLUS_트랙은_운영진_역할이_있어도_발급할_수_없다() {
+        // Given / When / Then
+        assertThatThrownBy(() -> ChallengerRecord.createAdminWithTracks(
+            1L, 11L, 2L, 3L, null, List.of(ChallengerTrack.INFRA_PLUS), "홍길동",
+            ChallengerRoleType.SCHOOL_PRESIDENT, 3L)).isInstanceOf(ChallengerDomainException.class);
     }
 }

--- a/src/test/java/com/umc/product/integration/TrackLearningIntegrationTest.java
+++ b/src/test/java/com/umc/product/integration/TrackLearningIntegrationTest.java
@@ -47,7 +47,9 @@ import com.umc.product.organization.application.port.in.command.ManageStudyGroup
 import com.umc.product.organization.application.port.in.command.dto.CreateGisuCommand;
 import com.umc.product.organization.application.port.in.command.dto.CreateStudyGroupCommand;
 import com.umc.product.organization.application.port.in.query.GetStudyGroupUseCase;
+import com.umc.product.organization.application.port.out.command.SaveGisuPort;
 import com.umc.product.organization.application.port.out.query.LoadGisuPort;
+import com.umc.product.organization.domain.Gisu;
 import com.umc.product.support.IntegrationTestSupport;
 import com.umc.product.support.fixture.ChapterFixture;
 import com.umc.product.support.fixture.SchoolFixture;
@@ -55,6 +57,7 @@ import com.umc.product.support.fixture.SchoolFixture;
 class TrackLearningIntegrationTest extends IntegrationTestSupport {
 
     @Autowired private ManageGisuUseCase manageGisuUseCase;
+    @Autowired private SaveGisuPort saveGisuPort;
     @Autowired private LoadGisuPort loadGisuPort;
     @Autowired private ChapterFixture chapterFixture;
     @Autowired private SchoolFixture schoolFixture;
@@ -82,8 +85,12 @@ class TrackLearningIntegrationTest extends IntegrationTestSupport {
     void registerAndStudy(GisuLearningType learningType) {
         // Given
         Instant now = Instant.now();
-        Long gisuId = manageGisuUseCase.create(new CreateGisuCommand(
-            99L, now.minus(1, ChronoUnit.DAYS), now.plus(90, ChronoUnit.DAYS), learningType));
+        Long gisuId = learningType == GisuLearningType.TRACK
+            ? manageGisuUseCase.create(new CreateGisuCommand(
+                99L, now.minus(1, ChronoUnit.DAYS), now.plus(90, ChronoUnit.DAYS)))
+            : saveGisuPort.save(Gisu.create(
+                99L, now.minus(1, ChronoUnit.DAYS), now.plus(90, ChronoUnit.DAYS), false,
+                GisuLearningType.PART)).getId();
         var chapter = chapterFixture.지부(loadGisuPort.getById(gisuId), "신규 지부");
         var school = schoolFixture.지부에_소속된_학교("학습 학교", chapter);
         var member = saveMemberPort.save(Member.create(

--- a/src/test/java/com/umc/product/organization/adapter/in/web/GisuCommandControllerTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/in/web/GisuCommandControllerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.umc.product.common.domain.enums.GisuLearningType;
 import com.umc.product.organization.adapter.in.web.dto.request.CreateGisuRequest;
 import com.umc.product.organization.application.port.in.command.dto.CreateGisuCommand;
 import com.umc.product.support.ControllerTestSupport;
@@ -38,7 +37,7 @@ class GisuCommandControllerTest extends ControllerTestSupport {
             .andExpect(status().isOk());
 
         // then
-        then(manageGisuUseCase).should().create(new CreateGisuCommand(11L, START_AT, END_AT, GisuLearningType.TRACK));
+        then(manageGisuUseCase).should().create(new CreateGisuCommand(11L, START_AT, END_AT));
     }
 
     @Test
@@ -56,7 +55,7 @@ class GisuCommandControllerTest extends ControllerTestSupport {
             .andExpect(status().isOk());
 
         // then
-        then(manageGisuUseCase).should().create(new CreateGisuCommand(12L, START_AT, END_AT, GisuLearningType.TRACK));
+        then(manageGisuUseCase).should().create(new CreateGisuCommand(12L, START_AT, END_AT));
     }
 
     @Test

--- a/src/test/java/com/umc/product/organization/adapter/in/web/GisuCommandControllerTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/in/web/GisuCommandControllerTest.java
@@ -25,36 +25,38 @@ class GisuCommandControllerTest extends ControllerTestSupport {
     private static final Instant END_AT = Instant.parse("2025-08-31T23:59:59Z");
 
     @Test
-    void 트랙_학습방식으로_새기수를_추가한다() throws Exception {
+    void 학습방식_입력없이_트랙기수를_생성한다() throws Exception {
         // given
-        CreateGisuRequest request = new CreateGisuRequest(11L, START_AT, END_AT, GisuLearningType.TRACK);
         given(manageGisuUseCase.create(any())).willReturn(11L);
 
         // when
         mockMvc.perform(post("/api/v1/gisu")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
-
-        // then
-        then(manageGisuUseCase).should().create(request.toCommand());
-    }
-
-    @Test
-    void 학습방식이_누락된_기존요청은_파트기수로_처리한다() throws Exception {
-        // given
-        given(manageGisuUseCase.create(any())).willReturn(9L);
-
-        // when
-        mockMvc.perform(post("/api/v1/gisu")
                 .content("""
-                    {"generation":9,"startAt":"2025-03-01T00:00:00Z","endAt":"2025-08-31T23:59:59Z"}
+                    {"generation":11,"startAt":"2025-03-01T00:00:00Z","endAt":"2025-08-31T23:59:59Z"}
                     """)
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
         // then
-        then(manageGisuUseCase).should().create(new CreateGisuCommand(9L, START_AT, END_AT, GisuLearningType.PART));
+        then(manageGisuUseCase).should().create(new CreateGisuCommand(11L, START_AT, END_AT, GisuLearningType.TRACK));
+    }
+
+    @Test
+    void 기존_학습방식_필드를_전달해도_트랙기수로_생성한다() throws Exception {
+        // given
+        given(manageGisuUseCase.create(any())).willReturn(12L);
+
+        // when
+        mockMvc.perform(post("/api/v1/gisu")
+                .content("""
+                    {"generation":12,"startAt":"2025-03-01T00:00:00Z","endAt":"2025-08-31T23:59:59Z",
+                     "learningType":"PART"}
+                    """)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        // then
+        then(manageGisuUseCase).should().create(new CreateGisuCommand(12L, START_AT, END_AT, GisuLearningType.TRACK));
     }
 
     @Test

--- a/src/test/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterOrganizationSeedMigrationTest.java
+++ b/src/test/java/com/umc/product/organization/adapter/out/persistence/chapter/ChapterOrganizationSeedMigrationTest.java
@@ -1,0 +1,260 @@
+package com.umc.product.organization.adapter.out.persistence.chapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.umc.product.support.PersistenceAdapterTest;
+
+@PersistenceAdapterTest
+@DisplayName("11기 학교·지부 배정 Flyway 마이그레이션")
+class ChapterOrganizationSeedMigrationTest {
+
+    private static final String MIGRATION_PATH =
+        "db/migration/V2026.09.10.03.00__seed_11th_schools_chapters.sql";
+    private static final Map<String, List<String>> EXPECTED_SCHOOLS = Map.of(
+        "캥거루", List.of("가천대학교", "서울여자대학교", "한국항공대학교", "한성대학교"),
+        "쿼카", List.of("동양미래대학교", "숭실대학교", "이화여자대학교", "인하대학교", "한양대학교 ERICA"),
+        "수달", List.of("성신여자대학교", "숙명여자대학교", "중앙대학교", "한국외국어대학교"),
+        "아홀로틀", List.of("가톨릭대학교", "덕성여자대학교", "세종대학교", "안양대학교", "홍익대학교 서울캠퍼스"),
+        "티라노", List.of("단국대학교", "동국대학교", "동덕여자대학교", "서경대학교", "홍익대학교 세종캠퍼스"));
+
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private Long gisuId;
+
+    @BeforeEach
+    void prepareEleventhGisuWithGeneratedId() {
+        // 기본 데이터는 다른 기수로 보존하고, 고정 ID를 사용할 수 없는 새 11기를 준비한다.
+        jdbcTemplate.update("UPDATE gisu SET generation = 111 WHERE generation = 11");
+        gisuId = insertGisu(11);
+    }
+
+    @Test
+    @DisplayName("세종대와 인천가톨릭대를 추가하고 11기 23개 지부 배정과 중앙 운영진 학교의 미배정을 확인한다")
+    void createsMissingSchoolAndAllEleventhAssignments() throws Exception {
+        // Given
+        prepareMissingSejongSchool();
+        jdbcTemplate.update("UPDATE school SET name = '기존 인천가톨릭대 명칭' WHERE name = '인천가톨릭대학교'");
+        for (Assignment assignment : expectedAssignments()) {
+            if (!assignment.schoolName().equals("세종대학교")) {
+                ensureSchool(assignment.schoolName());
+            }
+        }
+        OrganizationSnapshot previous = snapshot();
+
+        // When
+        executeMigration();
+
+        // Then
+        assertThat(readAssignments(gisuId)).containsExactlyInAnyOrderElementsOf(expectedAssignments());
+        OrganizationSnapshot migrated = snapshot();
+        assertThat(migrated.schools()).containsAll(previous.schools());
+        assertThat(migrated.chapters()).hasSize(previous.chapters().size() + 5).containsAll(previous.chapters());
+        assertThat(migrated.links()).hasSize(previous.links().size() + 23).containsAll(previous.links());
+        assertThat(migrated.gisus()).isEqualTo(previous.gisus());
+        assertThat(jdbcTemplate.queryForList("SELECT id FROM school WHERE name = '세종대학교'", Long.class)).hasSize(1);
+        var headquartersSchoolIds = jdbcTemplate.queryForList(
+            "SELECT id FROM school WHERE name = '인천가톨릭대학교'", Long.class);
+        assertThat(headquartersSchoolIds).hasSize(1);
+        assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM chapter_school WHERE school_id = ?",
+            Long.class, headquartersSchoolIds.getFirst())).isZero();
+    }
+
+    @Test
+    @DisplayName("기존 다섯 지부와 22개 배정 및 학교 정보를 보존하고 ERICA 배정만 추가하며 재실행해도 같다")
+    void preservesExistingOrganizationAndOtherGisuOnRerun() throws Exception {
+        // Given
+        for (Map.Entry<String, List<String>> entry : EXPECTED_SCHOOLS.entrySet()) {
+            Long chapterId = insertChapter(gisuId, entry.getKey());
+            for (String schoolName : entry.getValue()) {
+                Long schoolId = ensureSchool(schoolName);
+                if (!schoolName.equals("한양대학교 ERICA")) {
+                    insertLink(chapterId, schoolId);
+                }
+            }
+        }
+        Long existingSchoolId = ensureSchool("가천대학교");
+        jdbcTemplate.update("""
+            UPDATE school SET short_name = '학교 약칭', logo_image_id = '기존 로고', remark = '직접 등록한 메모'
+            WHERE id = ?
+            """, existingSchoolId);
+        ensureSchool("남서울대학교");
+        Long otherGisuId = insertGisu(77);
+        insertLink(insertChapter(otherGisuId, "기존 기수 지부"), existingSchoolId);
+        var otherAssignments = readAssignments(otherGisuId);
+        OrganizationSnapshot previous = snapshot();
+
+        // When
+        executeMigration();
+
+        // Then
+        assertThat(readAssignments(gisuId)).containsExactlyInAnyOrderElementsOf(expectedAssignments());
+        OrganizationSnapshot migrated = snapshot();
+        assertThat(migrated.schools()).containsAll(previous.schools());
+        assertThat(migrated.chapters()).isEqualTo(previous.chapters());
+        assertThat(migrated.links()).hasSize(previous.links().size() + 1).containsAll(previous.links());
+        assertThat(migrated.gisus()).isEqualTo(previous.gisus());
+        assertThat(readAssignments(otherGisuId)).isEqualTo(otherAssignments);
+
+        // When
+        executeMigration();
+
+        // Then
+        assertThat(snapshot()).isEqualTo(migrated);
+    }
+
+    @ParameterizedTest(name = "{0} 충돌은 앞서 등록한 학교와 지부까지 롤백한다")
+    @ValueSource(strings = {"학교명 중복", "다른 지부 배정", "동일 배정 중복"})
+    @DisplayName("뒤쪽 학교에서 중복이나 배정 충돌이 발생하면 모든 조직 데이터를 변경하지 않는다")
+    void rejectsLateConflictWithoutPartialCreation(String conflict) {
+        // Given
+        prepareMissingSejongSchool();
+        Long schoolId = ensureSchool("홍익대학교 세종캠퍼스");
+        String expectedMessage = switch (conflict) {
+            case "학교명 중복" -> {
+                insertSchool("홍익대학교 세종캠퍼스");
+                yield "학교명이 중복되어 11기 지부를 배정할 수 없습니다";
+            }
+            case "다른 지부 배정" -> {
+                insertLink(insertChapter(gisuId, "캥거루"), schoolId);
+                yield "11기 학교가 다른 지부에 배정되어 있습니다";
+            }
+            case "동일 배정 중복" -> {
+                Long chapterId = insertChapter(gisuId, "티라노");
+                insertLink(chapterId, schoolId);
+                insertLink(chapterId, schoolId);
+                yield "11기 학교의 지부 배정이 중복되어 있습니다";
+            }
+            default -> throw new IllegalArgumentException(conflict);
+        };
+        OrganizationSnapshot previous = snapshot();
+
+        // When / Then
+        assertThatThrownBy(this::executeMigration).isInstanceOf(DataAccessException.class)
+            .hasMessageContaining(expectedMessage);
+        assertThat(snapshot()).isEqualTo(previous);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @DisplayName("11기 기수가 없거나 중복이면 학교와 지부를 생성하지 않는다")
+    void rejectsMissingOrDuplicateEleventhGisu(boolean duplicate) {
+        // Given
+        if (duplicate) {
+            insertGisu(11);
+        } else {
+            jdbcTemplate.update("UPDATE gisu SET generation = 112 WHERE id = ?", gisuId);
+        }
+        OrganizationSnapshot previous = snapshot();
+
+        // When / Then
+        assertThatThrownBy(this::executeMigration).isInstanceOf(DataAccessException.class);
+        assertThat(snapshot()).isEqualTo(previous);
+    }
+
+    private void prepareMissingSejongSchool() {
+        jdbcTemplate.update("UPDATE school SET name = '기존 세종대 명칭' WHERE name = '세종대학교'");
+    }
+
+    private Long insertGisu(long generation) {
+        return jdbcTemplate.queryForObject("""
+            INSERT INTO gisu (generation, is_active, learning_type, start_at, end_at, created_at, updated_at)
+            VALUES (?, false, 'TRACK', '2026-09-01T00:00:00+09:00',
+                '2027-02-27T23:59:59.999999+09:00', now(), now()) RETURNING id
+            """, Long.class, generation);
+    }
+
+    private Long ensureSchool(String name) {
+        List<Long> schoolIds = jdbcTemplate.queryForList("SELECT id FROM school WHERE name = ?", Long.class, name);
+        if (schoolIds.isEmpty()) {
+            return insertSchool(name);
+        }
+        assertThat(schoolIds).hasSize(1);
+        return schoolIds.getFirst();
+    }
+
+    private Long insertSchool(String name) {
+        return jdbcTemplate.queryForObject("""
+            INSERT INTO school (name, created_at, updated_at) VALUES (?, now(), now()) RETURNING id
+            """, Long.class, name);
+    }
+
+    private Long insertChapter(Long targetGisuId, String name) {
+        return jdbcTemplate.queryForObject("""
+            INSERT INTO chapter (gisu_id, name, created_at, updated_at) VALUES (?, ?, now(), now()) RETURNING id
+            """, Long.class, targetGisuId, name);
+    }
+
+    private void insertLink(Long chapterId, Long schoolId) {
+        jdbcTemplate.update("""
+            INSERT INTO chapter_school (chapter_id, school_id, created_at, updated_at) VALUES (?, ?, now(), now())
+            """, chapterId, schoolId);
+    }
+
+    private void executeMigration() throws Exception {
+        String sql = new ClassPathResource(MIGRATION_PATH).getContentAsString(StandardCharsets.UTF_8);
+        jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
+            var savepoint = connection.setSavepoint();
+            try (var statement = connection.createStatement()) {
+                statement.execute(sql);
+            } catch (SQLException exception) {
+                connection.rollback(savepoint);
+                throw exception;
+            } finally {
+                connection.releaseSavepoint(savepoint);
+            }
+            return null;
+        });
+    }
+
+    private List<Assignment> readAssignments(Long targetGisuId) {
+        return jdbcTemplate.query("""
+            SELECT chapter.name AS chapter_name, school.name AS school_name
+            FROM chapter_school
+            JOIN chapter ON chapter.id = chapter_school.chapter_id
+            JOIN school ON school.id = chapter_school.school_id
+            WHERE chapter.gisu_id = ?
+            ORDER BY chapter.name, school.name
+            """, (row, rowNum) -> new Assignment(row.getString("chapter_name"), row.getString("school_name")),
+            targetGisuId);
+    }
+
+    private List<Assignment> expectedAssignments() {
+        return EXPECTED_SCHOOLS.entrySet().stream()
+            .flatMap(entry -> entry.getValue().stream().map(school -> new Assignment(entry.getKey(), school)))
+            .toList();
+    }
+
+    private OrganizationSnapshot snapshot() {
+        return new OrganizationSnapshot(
+            jdbcTemplate.queryForList("SELECT * FROM gisu ORDER BY id"),
+            jdbcTemplate.queryForList("SELECT * FROM school ORDER BY id"),
+            jdbcTemplate.queryForList("SELECT * FROM chapter ORDER BY id"),
+            jdbcTemplate.queryForList("SELECT * FROM chapter_school ORDER BY id"));
+    }
+
+    private record Assignment(String chapterName, String schoolName) {
+    }
+
+    private record OrganizationSnapshot(
+        List<Map<String, Object>> gisus, List<Map<String, Object>> schools,
+        List<Map<String, Object>> chapters, List<Map<String, Object>> links
+    ) {
+    }
+}

--- a/src/test/java/com/umc/product/organization/application/port/in/command/ManageGisuUseCaseTest.java
+++ b/src/test/java/com/umc/product/organization/application/port/in/command/ManageGisuUseCaseTest.java
@@ -3,6 +3,12 @@ package com.umc.product.organization.application.port.in.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.umc.product.common.domain.enums.GisuLearningType;
 import com.umc.product.global.exception.BusinessException;
 import com.umc.product.organization.application.port.in.command.dto.CreateGisuCommand;
 import com.umc.product.organization.application.port.in.query.GetGisuUseCase;
@@ -10,9 +16,6 @@ import com.umc.product.organization.application.port.in.query.dto.gisu.GisuInfo;
 import com.umc.product.organization.exception.OrganizationErrorCode;
 import com.umc.product.support.UseCaseTestSupport;
 import com.umc.product.support.fixture.GisuFixture;
-import java.time.Instant;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 class ManageGisuUseCaseTest extends UseCaseTestSupport {
 
@@ -26,7 +29,7 @@ class ManageGisuUseCaseTest extends UseCaseTestSupport {
     private GisuFixture gisuFixture;
 
     @Test
-    void 신규_기수를_생성한다() {
+    void 신규_기수를_트랙방식으로_생성한다() {
         // given
         CreateGisuCommand command = new CreateGisuCommand(
             10L,
@@ -42,6 +45,7 @@ class ManageGisuUseCaseTest extends UseCaseTestSupport {
         GisuInfo savedGisu = getGisuUseCase.getById(gisuId);
         assertThat(savedGisu.generation()).isEqualTo(10L);
         assertThat(savedGisu.isActive()).isFalse();
+        assertThat(savedGisu.learningType()).isEqualTo(GisuLearningType.TRACK);
     }
 
     @Test
@@ -92,7 +96,9 @@ class ManageGisuUseCaseTest extends UseCaseTestSupport {
     @Test
     void 활성_기수를_변경한다() {
         // given
-        GisuInfo oldActiveGisu = getGisuUseCase.getById(gisuFixture.활성_기수(8L).getId());
+        Long oldActiveGisuId = gisuFixture.비활성_기수(8L).getId();
+        manageGisuUseCase.updateActiveGisu(oldActiveGisuId);
+        GisuInfo oldActiveGisu = getGisuUseCase.getById(oldActiveGisuId);
         Long newGisuId = gisuFixture.비활성_기수(9L).getId();
 
         // when

--- a/src/test/java/com/umc/product/organization/application/port/service/query/ChapterQueryServiceTest.java
+++ b/src/test/java/com/umc/product/organization/application/port/service/query/ChapterQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.umc.product.organization.application.port.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -25,6 +26,8 @@ import com.umc.product.organization.domain.Chapter;
 import com.umc.product.organization.domain.ChapterSchool;
 import com.umc.product.organization.domain.Gisu;
 import com.umc.product.organization.domain.School;
+import com.umc.product.organization.exception.OrganizationDomainException;
+import com.umc.product.organization.exception.OrganizationErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChapterQueryService")
@@ -38,6 +41,41 @@ class ChapterQueryServiceTest {
 
     @InjectMocks
     ChapterQueryService chapterQueryService;
+
+    @Test
+    @DisplayName("학교가 여러 기수에 참여했어도 요청한 기수의 지부를 조회한다")
+    void 요청한_기수의_학교_지부를_조회한다() {
+        // given
+        School school = school(100L, "A 대학교");
+        Chapter previousChapter = chapter(10L, gisu(1L, 10L), "이전 지부");
+        Chapter currentChapter = chapter(20L, gisu(2L, 11L), "현재 지부");
+        given(loadChapterSchoolPort.findBySchoolId(100L)).willReturn(List.of(
+            ChapterSchool.create(previousChapter, school),
+            ChapterSchool.create(currentChapter, school)
+        ));
+
+        // when & then
+        assertThat(chapterQueryService.findByGisuAndSchool(2L, 100L))
+            .contains(new ChapterInfo(20L, "현재 지부"));
+        assertThat(chapterQueryService.byGisuAndSchool(2L, 100L))
+            .isEqualTo(new ChapterInfo(20L, "현재 지부"));
+    }
+
+    @Test
+    @DisplayName("해당 기수 지부가 없으면 선택 조회는 빈 값을 반환하고 필수 조회는 거부한다")
+    void 지부가_없는_학교의_선택_조회와_필수_조회를_구분한다() {
+        // given
+        School school = school(100L, "A 대학교");
+        Chapter previousChapter = chapter(10L, gisu(1L, 10L), "이전 지부");
+        given(loadChapterSchoolPort.findBySchoolId(100L))
+            .willReturn(List.of(ChapterSchool.create(previousChapter, school)));
+
+        // when & then
+        assertThat(chapterQueryService.findByGisuAndSchool(2L, 100L)).isEmpty();
+        assertThatThrownBy(() -> chapterQueryService.byGisuAndSchool(2L, 100L))
+            .isInstanceOfSatisfying(OrganizationDomainException.class,
+                exception -> assertThat(exception.getBaseCode()).isEqualTo(OrganizationErrorCode.CHAPTER_NOT_FOUND));
+    }
 
     @Test
     @DisplayName("listByGisuIds는 기수별 지부 목록을 그룹화한다")


### PR DESCRIPTION
11기 학교·지부 기준 데이터와 챌린저 코드 등록 흐름을 함께 준비합니다. 기존에는 운영진 코드를 사용하려면 해당 기수의 Challenger가 먼저 있어야 했고, 수강 Track과 운영진 역할을 하나의 코드에 담을 수 없었습니다. 이제 Track 기수의 회원은 코드 한 번으로 기수 소속·복수 수강·운영진 역할을 등록할 수 있습니다. 예를 들어 기존 웹 수강생이 웹+학교 회장 코드를 사용하면 기존 Challenger ID와 수강을 보존하면서 회장 역할만 추가합니다.

## 변경 내용

- 운영 보드에 맞춰 11기 5개 지부·23개 학교 연결을 Flyway로 등록합니다. 누락 학교만 만들고 기존 환경의 ID·배정·메타데이터를 보존합니다. 중앙 운영진의 학교인 인천가톨릭대학교는 학교 목록에만 등록합니다.
- `challenger_record.tracks`를 추가하고 기존 단일 `track`을 배열로 이전합니다. 기존 코드·사용 이력과 운영진의 담당 `part`는 유지합니다. 기본 4개 Track만 허용합니다.
- 발급과 사용에 기수 학습 유형·학교/지부 관계를 검증하고, 모든 코드 사용에 이름·학교 일치 검증을 적용합니다. 비수강 중앙 운영진만 지부를 생략할 수 있습니다.
- 같은 회원의 서로 다른 코드 사용을 회원 행 잠금으로 직렬화합니다. 빠진 Track·역할만 추가하며, 모두 이미 보유한 경우 409로 거절하고 코드를 미사용 상태로 유지합니다. 실패하면 소속·수강·역할·코드 사용을 함께 롤백합니다.
- 비활성 Track 소속은 자동 복구하지 않습니다. 기존 Part 기수의 일반 가입·기존 소속에 대한 운영진 등록은 유지하고, Track 기수의 기존 `part=ADMIN` 입력은 수강 없는 소속으로 처리합니다.
- 지부 없는 비수강 중앙 운영진의 권한 로딩과 챌린저 단건·목록 응답을 보완합니다. 중앙 역할을 통해 학교·지부 권한이 추가되지 않도록 기존 권한 범위를 유지합니다.
- 환경별 발급 요청·결과를 로컬 비공개 파일로 관리하는 스크립트를 제공합니다. 응답 유실 시 자동 재발급을 차단합니다. 실제 명단과 개인별 코드는 저장소에 포함하지 않습니다.

## 검증

- 등록·마이그레이션·회원 응답·권한·조직 조회의 영향 범위 101개를 실행해 모두 통과했습니다. 겸직자가 역할별 코드 두 개로 같은 소속에 등록되는 회귀도 포함합니다.
- 전체 CI에서 전역 P6Spy 포매터가 배열 SQL의 DB 예외를 가리던 문제를 해결했습니다. 마이그레이션 테스트는 실제 JDBC로 SQL을 실행하고 CHECK·NOT NULL 제약의 SQLSTATE까지 검증합니다.
- 전역 P6Spy 로깅을 강제로 활성화한 상태에서 마이그레이션 테스트와 로그 설정에 영향을 주는 통합 테스트를 함께 실행해 19개 모두 통과했습니다.
- Spotless·Checkstyle·Java/테스트 컴파일·bootJar 검증을 완료했습니다. 배포 JAR에 학교·지부 및 코드 Track 배열 마이그레이션이 현재 파일과 동일하게 포함된 것을 확인했습니다.
- 발급 스크립트의 성공·응답 유실·잘못된 응답·중단 후 재실행 처리를 모의 검증했으며 외부 발급 요청은 보내지 않았습니다.

- 기수 생성 API·기수 관리·PART/TRACK 학습 흐름 테스트 12개를 실행해 모두 통과했습니다. 신규 기수의 TRACK 저장과 기존 PART 기수의 등록·스터디·워크북 흐름을 확인했습니다. 기수 준비 스크립트의 요청 미리보기에서도 생성 요청 필드 세 개만 전송하는 것을 확인했습니다.
