### PR TITLE
[Fix] 개발 테스트 API의 Scalar 인증 방식 수정

### DIFF
--- a/src/main/java/com/umc/product/global/config/OpenApiConfig.java
+++ b/src/main/java/com/umc/product/global/config/OpenApiConfig.java
@@ -3,7 +3,9 @@ package com.umc.product.global.config;
 import java.util.List;
 import java.util.Optional;
 
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class OpenApiConfig {
 
     private static final String DEFAULT_API_VERSION = "local";
+    private static final String TEST_API_BASIC_AUTH = "Test API Basic Auth";
 
     private final String accessToken = "Access Token";
     private final ObjectProvider<BuildProperties> buildPropertiesProvider;
@@ -36,6 +39,33 @@ public class OpenApiConfig {
             .servers(List.of(new Server().url("/").description("현재 접속 서버")))
             .components(securityComponents())
             .addSecurityItem(securityRequirement());
+    }
+
+    @Bean
+    public OpenApiCustomizer testApiSecurityCustomizer(@Value("${app.environment:local}") String environment) {
+        return openApi -> {
+            boolean requiresBasicAuth = "dev".equals(environment);
+            if (requiresBasicAuth) {
+                openApi.getComponents().addSecuritySchemes(TEST_API_BASIC_AUTH,
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("basic")
+                        .description("API 문서 접속 시 사용한 아이디와 비밀번호를 입력하세요.")
+                );
+            }
+
+            openApi.getPaths().forEach((path, pathItem) -> {
+                // 회원 JWT 검증용 API는 기존 Bearer 인증을 유지한다.
+                if (!path.startsWith("/test/") || path.equals("/test/check-authenticated")) {
+                    return;
+                }
+                pathItem.readOperations().forEach(operation -> operation.setSecurity(
+                    requiresBasicAuth
+                        ? List.of(new SecurityRequirement().addList(TEST_API_BASIC_AUTH))
+                        : List.of()
+                ));
+            });
+        };
     }
 
     private Info apiInfo() {

--- a/src/test/java/com/umc/product/test/adapter/in/web/DevTestApiOpenApiIntegrationTest.java
+++ b/src/test/java/com/umc/product/test/adapter/in/web/DevTestApiOpenApiIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.umc.product.test.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.umc.product.support.IntegrationTestSupport;
+
+@TestPropertySource(properties = {
+    "springdoc.api-docs.enabled=true",
+    "app.seed.enabled=true",
+    "app.test-api.enabled=true",
+    "app.environment=dev"
+})
+@DisplayName("개발 환경 테스트 API의 OpenAPI 인증 계약")
+class DevTestApiOpenApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("공개 테스트 API는 개발 서버의 Basic 인증만 요구한다")
+    void 공개_테스트_API는_Basic_인증을_명시한다() throws Exception {
+        // given
+        JsonNode openApi = readOpenApi();
+        JsonNode expectedSecurity = objectMapper.readTree("[{\"Test API Basic Auth\":[]}]");
+
+        // when
+        JsonNode paths = openApi.path("paths");
+        JsonNode basicAuth = openApi.path("components").path("securitySchemes").path("Test API Basic Auth");
+
+        // then
+        assertThat(paths.path("/test/seed/members").path("post").path("security")).isEqualTo(expectedSecurity);
+        assertThat(paths.path("/test/token/access").path("get").path("security")).isEqualTo(expectedSecurity);
+        assertThat(paths.path("/test/health-check").path("get").path("security")).isEqualTo(expectedSecurity);
+        assertThat(basicAuth.path("type").asText()).isEqualTo("http");
+        assertThat(basicAuth.path("scheme").asText()).isEqualTo("basic");
+    }
+
+    @Test
+    @DisplayName("회원 조회와 인증 확인 테스트 API는 기존 Access Token 인증을 유지한다")
+    void 회원_API와_인증_확인_API는_JWT_인증을_유지한다() throws Exception {
+        // given
+        JsonNode openApi = readOpenApi();
+        JsonNode expectedSecurity = objectMapper.readTree("[{\"Access Token\":[]}]");
+
+        // when
+        JsonNode globalSecurity = openApi.path("security");
+
+        // then
+        assertThat(globalSecurity).isEqualTo(expectedSecurity);
+        for (String path : List.of("/api/v1/member/me", "/test/check-authenticated")) {
+            JsonNode operation = openApi.path("paths").path(path).path("get");
+            assertThat(operation.isMissingNode()).as(path).isFalse();
+            JsonNode effectiveSecurity = operation.has("security") ? operation.path("security") : globalSecurity;
+            assertThat(effectiveSecurity).as(path).isEqualTo(expectedSecurity);
+        }
+    }
+
+    @Test
+    @DisplayName("JWT 없는 시딩 요청은 인증 오류 대신 입력값 검증까지 도달한다")
+    void 익명_시딩_요청은_잘못된_건수에_검증_오류를_반환한다() throws Exception {
+        // given
+        String invalidRequest = """
+            {"count": -1, "force": false}
+            """;
+
+        // when & then
+        mockMvc.perform(post("/test/seed/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidRequest))
+            .andExpect(status().isBadRequest())
+            .andExpect(result -> assertThat(result.getResolvedException())
+                .isInstanceOf(MethodArgumentNotValidException.class));
+    }
+
+    private JsonNode readOpenApi() throws Exception {
+        String openApiJson = mockMvc.perform(get("/docs-json"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        return objectMapper.readTree(openApiJson);
+    }
+}

--- a/src/test/java/com/umc/product/test/adapter/in/web/LocalTestApiOpenApiIntegrationTest.java
+++ b/src/test/java/com/umc/product/test/adapter/in/web/LocalTestApiOpenApiIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.umc.product.test.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.umc.product.support.IntegrationTestSupport;
+
+@TestPropertySource(properties = {
+    "springdoc.api-docs.enabled=true",
+    "app.seed.enabled=true",
+    "app.test-api.enabled=true",
+    "app.environment=local"
+})
+@DisplayName("로컬 환경 테스트 API의 OpenAPI 인증 계약")
+class LocalTestApiOpenApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("공개 테스트 API는 인증을 요구하지 않고 회원 인증 API는 JWT를 유지한다")
+    void 공개_테스트_API의_인증만_해제한다() throws Exception {
+        // given
+        String openApiJson = mockMvc.perform(get("/docs-json"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        JsonNode openApi = objectMapper.readTree(openApiJson);
+        JsonNode expectedPublicSecurity = objectMapper.createArrayNode();
+        JsonNode expectedJwtSecurity = objectMapper.readTree("[{\"Access Token\":[]}]");
+
+        // when
+        JsonNode paths = openApi.path("paths");
+        JsonNode globalSecurity = openApi.path("security");
+
+        // then
+        assertThat(paths.path("/test/seed/members").path("post").path("security"))
+            .isEqualTo(expectedPublicSecurity);
+        assertThat(paths.path("/test/token/access").path("get").path("security"))
+            .isEqualTo(expectedPublicSecurity);
+        assertThat(paths.path("/test/health-check").path("get").path("security"))
+            .isEqualTo(expectedPublicSecurity);
+        assertThat(globalSecurity).isEqualTo(expectedJwtSecurity);
+        for (String path : List.of("/api/v1/member/me", "/test/check-authenticated")) {
+            JsonNode operation = paths.path(path).path("get");
+            assertThat(operation.isMissingNode()).as(path).isFalse();
+            JsonNode effectiveSecurity = operation.has("security") ? operation.path("security") : globalSecurity;
+            assertThat(effectiveSecurity).as(path).isEqualTo(expectedJwtSecurity);
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

개발 서버 Scalar에서 `/test/seed/members`를 호출하면 전역 OpenAPI 설정을 상속해 `Authorization: Bearer`를 보내지만, `/test` Ingress는 Basic Auth를 요구해 401로 차단됩니다. 시딩·토큰 발급 API는 `@Public`이며 회원 JWT가 필요하지 않습니다.

개발 환경의 일반 테스트 API에는 문서 접속 계정을 사용하는 HTTP Basic 인증을 명시하고, 로컬 환경에서는 문서상 인증 요구를 제거했습니다. 일반 회원 API와 JWT 검증용 `/test/check-authenticated`의 Bearer 문서는 유지합니다.

## 💬 리뷰 중점사항

- OpenAPI의 작업별 `security`로 전역 Bearer 상속을 대체합니다. Spring Security와 Traefik 인증 정책은 변경하지 않습니다.
- `/test/check-authenticated`는 기존 예외 경로입니다. dev의 Basic Auth Ingress에서 Bearer 인증까지 동시에 검증하지 못하는 기존 제약은 이번 수정 범위에 포함하지 않습니다.
- 검증: 실제 `/docs-json` 계약과 JWT 없는 시딩 입력값 검증을 포함한 통합 테스트 4개 통과. `compileJava`, `compileTestJava`, `spotlessCheck`, `checkstyleMain`, `checkstyleTest` 통과.
