### PR TITLE
[Feat] Gmail SMTP 이메일 발송 및 SES 전환 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,14 +262,22 @@ LLM_GEMINI_API_KEY=
 LLM_GOOGLE_GENAI_VERTEX_AI=false
 
 # ------------------------------------------------------------------
-# Email (SES v2)
-# access-key/secret 을 비워두면 DefaultCredentialsProvider 체인으로 폴백한다.
+# Email (ses 또는 smtp; 기본값 ses)
+# 선택한 제공자의 자격증명만 필수. 실제 값은 배포 Secret 또는 Git에서 제외된 로컬 env로 관리한다.
 # ------------------------------------------------------------------
+EMAIL_PROVIDER=ses
 SES_REGION=ap-northeast-2
 SES_ACCESS_KEY_ID=
 SES_SECRET_ACCESS_KEY=
 # 바운스/컴플레인트 트래킹이 필요할 때만 주입한다.
 SES_CONFIGURATION_SET=
+# 개인 Gmail 임시 사용 시 EMAIL_PROVIDER=smtp 및 아래 값을 설정한다.
+# SMTP_PASSWORD에는 일반 로그인 비밀번호가 아니라 Google 앱 비밀번호를 넣는다.
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+# Gmail 사용 시 SMTP_USERNAME과 같은 주소. SES 복귀 시 검증된 도메인 발신 주소로 함께 변경한다.
 EMAIL_NO_REPLY_ADDRESS=
 EMAIL_NO_REPLY_DISPLAY_NAME=University MakeUs Challenge
 

--- a/docs/onboarding/domain/notification.md
+++ b/docs/onboarding/domain/notification.md
@@ -15,6 +15,29 @@
 
 notification은 메시지를 전달할 뿐, 메시지를 보내야 하는 업무 판단은 호출한 도메인이 한다. 외부 제공자 장애나 설정 누락은 사용자에게 복구 행동을 중심으로 안내한다.
 
+## 이메일 제공자 전환
+
+이메일 템플릿과 인증 API는 그대로 두고 `EMAIL_PROVIDER`로 `SendEmailPort` 구현체를 선택한다.
+기본값은 `ses`이며, 설정 변경 후 애플리케이션을 재시작해야 한다. 실패 시 다른 제공자로 자동 재발송하지 않는다.
+
+- SES: `EMAIL_PROVIDER=ses`, `SES_REGION`, `SES_ACCESS_KEY_ID`, `SES_SECRET_ACCESS_KEY`와 검증된
+  `EMAIL_NO_REPLY_ADDRESS`를 설정한다. `SES_CONFIGURATION_SET`은 선택 항목이다.
+- 개인 Gmail SMTP: `EMAIL_PROVIDER=smtp`, `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`,
+  `SMTP_USERNAME`과 `SMTP_PASSWORD`를 설정한다. `SMTP_PASSWORD`에는 Google 2단계 인증 후 발급한 앱 비밀번호를
+  사용하며, 일반 로그인 비밀번호를 넣지 않는다. `EMAIL_NO_REPLY_ADDRESS`는 해당 Gmail 주소와 맞춘다.
+- 선택하지 않은 제공자의 자격증명은 필요하지 않다. SMTP는 인증과 STARTTLS를 필수로 사용하고,
+  서버 인증서의 호스트 이름을 검사하며 연결·읽기·쓰기 대기에 각각 5초 제한을 둔다.
+
+실제 자격증명은 배포 Secret 또는 Git에서 제외된 로컬 env에만 보관한다. SMTP 프로토콜 디버그를 켜거나
+인증코드·수신 주소·메일 본문·비밀번호를 로그에 기록하지 않는다.
+SMTP 예외 원문은 수신 주소를 포함할 수 있어 예외 종류만 기록하고 기존 `EMAIL_SEND_FAILED`로 변환한다.
+SMTP health check는 상태 조회마다 외부 인증을 반복하지 않도록 끄고, 발송 성공·실패 로그와 지표를 확인한다.
+
+SES로 복귀할 때는 프로덕션 액세스 승인 여부를 먼저 확인한 뒤 `EMAIL_PROVIDER=ses`와
+`EMAIL_NO_REPLY_ADDRESS`를 기존 검증된 SES 발신 주소로 함께 되돌린다. 배포 후 허가된 테스트 주소에서
+실제 수신을 확인하고, 더 이상 쓰지 않는 Gmail 앱 비밀번호를 폐기한다.
+개인 Gmail 발송 제한은 별도로 적용되므로 SMTP 전환만으로 대량 발송이 보장되지는 않는다.
+
 ## FCM installation 등록
 
 FCM 등록은 물리적 기기가 아니라 앱 설치 인스턴스인 `installationId`를 기준으로 관리한다. 모바일 앱은 Firebase Installation ID처럼 재설치 시 교체 가능한 opaque identifier를 사용하며, 하드웨어 식별자를 보내지 않는다.

--- a/gradle/dependencies.gradle.kts
+++ b/gradle/dependencies.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     add("implementation", "software.amazon.awssdk:sesv2")
 
     // --- Email ---
+    add("implementation", "org.springframework.boot:spring-boot-starter-mail")
     add("implementation", "org.springframework.boot:spring-boot-starter-thymeleaf")
 
     // --- PDF / QR ---

--- a/src/main/java/com/umc/product/notification/adapter/out/external/EmailProviderProperties.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/EmailProviderProperties.java
@@ -1,0 +1,17 @@
+package com.umc.product.notification.adapter.out.external;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+
+@Validated
+@ConfigurationProperties(prefix = "app.notification.email")
+public record EmailProviderProperties(@DefaultValue("ses") @NotNull Provider provider) {
+
+    public enum Provider {
+        SES,
+        SMTP
+    }
+}

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailAdapter.java
@@ -1,5 +1,6 @@
 package com.umc.product.notification.adapter.out.external.ses;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.umc.product.global.logging.ExternalApiCallLogger;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
  */
 @Slf4j
 @Component
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "ses", matchIfMissing = true)
 @RequiredArgsConstructor
 public class SesEmailAdapter implements SendEmailPort {
 

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailConfig.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesEmailConfig.java
@@ -1,9 +1,11 @@
 package com.umc.product.notification.adapter.out.external.ses;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -18,6 +20,7 @@ import software.amazon.awssdk.services.sesv2.SesV2Client;
  */
 @Validated
 @Configuration
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "ses", matchIfMissing = true)
 @EnableConfigurationProperties(SesProperties.class)
 public class SesEmailConfig {
 

--- a/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesProperties.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/ses/SesProperties.java
@@ -1,8 +1,10 @@
 package com.umc.product.notification.adapter.out.external.ses;
 
-import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * AWS SES v2 인프라 설정.
@@ -18,6 +20,7 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @ConfigurationProperties(prefix = "app.notification.email.ses")
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "ses", matchIfMissing = true)
 public record SesProperties(
     @NotBlank String region,
     @NotBlank String accessKeyId,

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
@@ -1,0 +1,46 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import com.umc.product.global.logging.ExternalApiCallLogger;
+import com.umc.product.notification.application.port.out.SendEmailPort;
+import com.umc.product.notification.application.port.out.dto.EmailMessage;
+import com.umc.product.notification.domain.exception.EmailDomainException;
+import com.umc.product.notification.domain.exception.EmailErrorCode;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "smtp")
+@RequiredArgsConstructor
+public class SmtpEmailAdapter implements SendEmailPort {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void send(EmailMessage message) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
+            helper.setFrom(message.fromAddress(), message.fromDisplayName());
+            helper.setTo(message.to());
+            helper.setSubject(message.subject());
+            helper.setText(message.htmlBody(), true);
+            ExternalApiCallLogger.measure("SMTP", "SEND_EMAIL", () -> mailSender.send(mimeMessage));
+        } catch (MessagingException | UnsupportedEncodingException | RuntimeException e) {
+            // SMTP 예외에는 수신 주소와 서버 응답이 포함될 수 있어 원문이나 cause를 상위 로그로 전달하지 않는다.
+            log.warn("SMTP 이메일 발송 실패: errorClass={}", e.getClass().getSimpleName());
+            throw new EmailDomainException(EmailErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailConfig.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailConfig.java
@@ -1,0 +1,39 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "smtp")
+@EnableConfigurationProperties(SmtpProperties.class)
+public class SmtpEmailConfig {
+
+    @Bean
+    public JavaMailSenderImpl smtpMailSender(SmtpProperties properties) {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(properties.host());
+        sender.setPort(properties.port());
+        sender.setUsername(properties.username());
+        sender.setPassword(properties.password());
+        sender.setDefaultEncoding(StandardCharsets.UTF_8.name());
+
+        // 평문 인증과 인증서 검증 우회를 허용하지 않는다. 응답 없는 SMTP 서버가 작업 스레드를 점유하지 않게 한다.
+        Properties mailProperties = sender.getJavaMailProperties();
+        mailProperties.setProperty("mail.smtp.auth", "true");
+        mailProperties.setProperty("mail.smtp.starttls.enable", "true");
+        mailProperties.setProperty("mail.smtp.starttls.required", "true");
+        mailProperties.setProperty("mail.smtp.ssl.checkserveridentity", "true");
+        mailProperties.setProperty("mail.smtp.connectiontimeout", "5000");
+        mailProperties.setProperty("mail.smtp.timeout", "5000");
+        mailProperties.setProperty("mail.smtp.writetimeout", "5000");
+        mailProperties.setProperty("mail.debug", "false");
+        sender.getSession().setDebug(false);
+        return sender;
+    }
+}

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpProperties.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpProperties.java
@@ -1,0 +1,26 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Validated
+@ConfigurationProperties(prefix = "app.notification.email.smtp")
+@ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "smtp")
+public record SmtpProperties(
+    @DefaultValue("smtp.gmail.com") @NotBlank String host,
+    @DefaultValue("587") @Min(1) @Max(65535) int port,
+    @NotBlank String username,
+    @NotBlank String password
+) {
+
+    @Override
+    public String toString() {
+        return "SmtpProperties[credentials=REDACTED]";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -243,6 +243,11 @@ management:
   server:
     port: ${MANAGEMENT_PORT:9090}
 
+  health:
+    # 상태 조회마다 SMTP 인증을 반복하지 않는다. 메일 장애는 발송 실패 로그와 지표로 확인한다.
+    mail:
+      enabled: false
+
   endpoint:
     health:
       show-details: always
@@ -546,16 +551,20 @@ app:
       burst: ${LLM_RATE_LIMIT_BURST:5}
 
   notification:
-    # 인증 이메일 등 SES v2 발송 설정.
-    # access-key/secret을 비워두면 DefaultCredentialsProvider 체인(IAM Role / IRSA / 환경변수 등)으로 폴백한다.
-    # configuration-set 은 바운스/컴플레인트 트래킹이 필요할 때만 주입한다 (미설정 시 SendEmail 요청에 미포함).
-    # sender.* 는 발송 case 별 발신자 식별자. SES 콘솔에서 verified 처리된 identity 여야 한다.
+    # provider는 ses(기본) 또는 smtp. 선택한 제공자의 자격증명만 필수다.
+    # SMTP는 STARTTLS 인증 연결을 사용하며, Gmail에서는 sender 주소를 SMTP 계정 주소와 맞춘다.
     email:
+      provider: ${EMAIL_PROVIDER:ses}
       ses:
         region: ${SES_REGION:ap-northeast-2}
         access-key-id: ${SES_ACCESS_KEY_ID:}
         secret-access-key: ${SES_SECRET_ACCESS_KEY:}
         configuration-set: ${SES_CONFIGURATION_SET:}
+      smtp:
+        host: ${SMTP_HOST:smtp.gmail.com}
+        port: ${SMTP_PORT:587}
+        username: ${SMTP_USERNAME:}
+        password: ${SMTP_PASSWORD:}
       sender:
         no-reply-address: ${EMAIL_NO_REPLY_ADDRESS}
         no-reply-display-name: ${EMAIL_NO_REPLY_DISPLAY_NAME:University MakeUs Challenge}

--- a/src/test/java/com/umc/product/notification/adapter/out/external/EmailProviderConfigurationTest.java
+++ b/src/test/java/com/umc/product/notification/adapter/out/external/EmailProviderConfigurationTest.java
@@ -1,0 +1,128 @@
+package com.umc.product.notification.adapter.out.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import com.umc.product.notification.adapter.out.external.ses.SesEmailAdapter;
+import com.umc.product.notification.adapter.out.external.ses.SesEmailConfig;
+import com.umc.product.notification.adapter.out.external.ses.SesProperties;
+import com.umc.product.notification.adapter.out.external.smtp.SmtpEmailAdapter;
+import com.umc.product.notification.adapter.out.external.smtp.SmtpEmailConfig;
+import com.umc.product.notification.adapter.out.external.smtp.SmtpProperties;
+import com.umc.product.notification.application.port.out.SendEmailPort;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+
+class EmailProviderConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(EmailConfiguration.class);
+
+    @Test
+    @DisplayName("기본 제공자는 SES이고 SMTP 자격증명 없이 부팅한다")
+    void default_provider_uses_ses_without_smtp_credentials() {
+        // given / when
+        contextRunner.withPropertyValues(
+            "app.notification.email.ses.region=ap-northeast-2",
+            "app.notification.email.ses.access-key-id=test-access-key",
+            "app.notification.email.ses.secret-access-key=test-secret-key"
+        ).run(context -> {
+            // then
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(SendEmailPort.class);
+            assertThat(context).hasSingleBean(SesEmailAdapter.class);
+            assertThat(context).hasSingleBean(SesV2Client.class);
+            assertThat(context).doesNotHaveBean(SmtpProperties.class);
+            assertThat(context).doesNotHaveBean(JavaMailSender.class);
+            assertThat(context.getBean(EmailProviderProperties.class).provider())
+                .isEqualTo(EmailProviderProperties.Provider.SES);
+        });
+    }
+
+    @Test
+    @DisplayName("SMTP 제공자는 SES 자격증명 없이 부팅하고 TLS 및 timeout을 강제한다")
+    void smtp_provider_boots_without_ses_credentials() {
+        // given / when
+        contextRunner.withPropertyValues(
+            "app.notification.email.provider=smtp",
+            "app.notification.email.smtp.username=sender@example.org",
+            "app.notification.email.smtp.password=test-app-password"
+        ).run(context -> {
+            // then
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(SendEmailPort.class);
+            assertThat(context).hasSingleBean(SmtpEmailAdapter.class);
+            assertThat(context).doesNotHaveBean(SesProperties.class);
+            assertThat(context).doesNotHaveBean(SesV2Client.class);
+            assertThat(context).doesNotHaveBean(SesEmailAdapter.class);
+            JavaMailSenderImpl sender = context.getBean(JavaMailSenderImpl.class);
+            assertThat(sender.getHost()).isEqualTo("smtp.gmail.com");
+            assertThat(sender.getPort()).isEqualTo(587);
+            assertThat(sender.getJavaMailProperties())
+                .containsEntry("mail.smtp.auth", "true")
+                .containsEntry("mail.smtp.starttls.enable", "true")
+                .containsEntry("mail.smtp.starttls.required", "true")
+                .containsEntry("mail.smtp.ssl.checkserveridentity", "true")
+                .containsEntry("mail.smtp.connectiontimeout", "5000")
+                .containsEntry("mail.smtp.timeout", "5000")
+                .containsEntry("mail.smtp.writetimeout", "5000")
+                .doesNotContainKey("mail.smtp.ssl.trust");
+            assertThat(sender.getSession().getDebug()).isFalse();
+            assertThat(context.getBean(SmtpProperties.class).toString())
+                .doesNotContain("sender@example.org", "test-app-password");
+        });
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일 제공자는 설정 바인딩 오류로 부팅을 막는다")
+    void unsupported_provider_fails_at_startup() {
+        // given / when
+        contextRunner.withPropertyValues("app.notification.email.provider=unsupported").run(context -> {
+            // then
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasStackTraceContaining("app.notification.email.provider");
+        });
+    }
+
+    @Test
+    @DisplayName("SMTP를 선택하고 비밀번호를 누락하면 부팅을 막는다")
+    void smtp_requires_password() {
+        // given / when
+        contextRunner.withPropertyValues(
+            "app.notification.email.provider=smtp",
+            "app.notification.email.smtp.username=sender@example.org"
+        ).run(context -> {
+            // then
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasStackTraceContaining("password");
+        });
+    }
+
+    @Test
+    @DisplayName("SES 선택 시 기존 자격증명 필수 검증을 유지한다")
+    void ses_still_requires_credentials() {
+        // given / when
+        contextRunner.withPropertyValues(
+            "app.notification.email.provider=ses",
+            "app.notification.email.ses.region=ap-northeast-2"
+        ).run(context -> {
+            // then
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure()).hasStackTraceContaining("accessKeyId");
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConfigurationPropertiesScan(basePackageClasses = EmailProviderProperties.class)
+    @Import({SesEmailConfig.class, SesEmailAdapter.class, SmtpEmailConfig.class, SmtpEmailAdapter.class})
+    static class EmailConfiguration {
+    }
+}

--- a/src/test/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapterTest.java
+++ b/src/test/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapterTest.java
@@ -1,0 +1,105 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import com.umc.product.notification.application.port.out.dto.EmailMessage;
+import com.umc.product.notification.domain.exception.EmailDomainException;
+import com.umc.product.notification.domain.exception.EmailErrorCode;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+@ExtendWith(MockitoExtension.class)
+class SmtpEmailAdapterTest {
+
+    @Mock
+    JavaMailSender mailSender;
+
+    SmtpEmailAdapter sut;
+    MimeMessage mimeMessage;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SmtpEmailAdapter(mailSender);
+        mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        given(mailSender.createMimeMessage()).willReturn(mimeMessage);
+    }
+
+    @Test
+    @DisplayName("SMTP는 발신자 표시명과 한국어 제목 및 HTML 본문을 유지한다")
+    void sends_utf8_html_with_sender_identity() throws Exception {
+        // given
+        EmailMessage message = createMessage();
+
+        // when
+        sut.send(message);
+        mimeMessage.saveChanges();
+
+        // then
+        then(mailSender).should().send(mimeMessage);
+        InternetAddress from = (InternetAddress)mimeMessage.getFrom()[0];
+        assertThat(from.getAddress()).isEqualTo(message.fromAddress());
+        assertThat(from.getPersonal()).isEqualTo(message.fromDisplayName());
+        assertThat(mimeMessage.getAllRecipients()).extracting(Object::toString).containsExactly(message.to());
+        assertThat(mimeMessage.getSubject()).isEqualTo(message.subject());
+        assertThat(mimeMessage.getContentType()).containsIgnoringCase("text/html").containsIgnoringCase("UTF-8");
+        assertThat(mimeMessage.getContent()).isEqualTo(message.htmlBody());
+    }
+
+    @Test
+    @DisplayName("SMTP 실패는 도메인 오류로 변환하고 원문이나 민감정보를 로그와 cause에 남기지 않는다")
+    void sanitizes_smtp_failure() {
+        // given
+        String sensitiveError = "recipient@example.org 인증코드 123456 app-password-secret";
+        doThrow(new MailSendException(sensitiveError)).when(mailSender).send(any(MimeMessage.class));
+        Logger logger = (Logger)LoggerFactory.getLogger(SmtpEmailAdapter.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            // when / then
+            assertThatThrownBy(() -> sut.send(createMessage()))
+                .isInstanceOfSatisfying(EmailDomainException.class,
+                    error -> assertThat(error.getBaseCode()).isEqualTo(EmailErrorCode.EMAIL_SEND_FAILED))
+                .hasCause(null)
+                .hasStackTraceContaining("EmailDomainException")
+                .hasStackTraceContaining("SmtpEmailAdapter");
+            assertThat(appender.list).isNotEmpty().allSatisfy(event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain(
+                    "recipient@example.org", "123456", "app-password-secret", "<html>");
+                assertThat(event.getThrowableProxy()).isNull();
+            });
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    private EmailMessage createMessage() {
+        return new EmailMessage(
+            "sender@example.org", "윰씨", "recipient@example.org", "이메일 인증 코드", "<html>인증 안내</html>"
+        );
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

- 기존 이메일 UseCase와 HTML 템플릿을 유지하면서 Gmail SMTP 발송 어댑터를 추가했습니다.
- `EMAIL_PROVIDER=ses|smtp`로 제공자를 선택합니다. 기본값은 `ses`로 유지하여 이 PR을 합치는 것만으로 운영 발송 방식이 바뀌지 않습니다.
- 선택한 제공자의 자격증명만 필수 검증하고, SMTP는 STARTTLS·인증서 검증·5초 timeout을 적용합니다.
- 메일 상태 조회로 SMTP 인증이 반복되지 않도록 mail health check를 비활성화하고, 실패 로그에는 자격증명·수신자·SMTP 응답 원문을 남기지 않습니다.
- `.env.example`과 이메일 운영 문서에 설정 및 SES 복귀 방법을 추가했습니다. 실제 앱 비밀번호는 포함하지 않았습니다.
- SQL 마이그레이션, 기존 API 계약, FCM 동작은 변경하지 않습니다.

## 💬 리뷰 중점사항

### 반영 순서

1. 이 PR을 **develop에 먼저 merge**합니다.
2. 기존 GitOps CI가 SMTP 지원 dev 이미지를 발행·반영하는지 확인합니다.
3. 별도 infra 변경에서 검증된 SMTP Secret·외부 TCP 587 egress·dev `EMAIL_PROVIDER=smtp`를 적용합니다.
4. dev의 실제 인증 메일 발송·수신을 확인한 뒤 develop → main 릴리스와 prod 설정 전환을 진행합니다.

이 PR 자체는 main에 merge하지 않으며, 실제 SMTP 발송 검증은 아직 수행하지 않았습니다. 코드 배포와 환경 설정 전환은 별도 단계입니다.

### 검증

- [x] `compileJava`, `compileTestJava`
- [x] `spotlessCheck`, `checkstyleMain`, `checkstyleTest` (`-PlintBase=origin/develop`)
- [x] 이메일 테스트 8개 통과: 제공자 설정 5개, SMTP 어댑터 2개, 기존 이메일 서비스 1개
- [x] diff에 실제 SMTP 비밀번호가 없는지 확인
- [x] SQL 마이그레이션 변경 없음
- [x] PR CI 전체 검사
- [ ] dev 환경의 실제 메일 수신 확인

개인 Gmail의 발송 한도는 dev/prod에서 같은 계정을 사용하면 함께 소비되며, SES 전환 시 `EMAIL_PROVIDER=ses`와 SES 발신자 주소를 복구해야 합니다.
