### PR TITLE
[Fix] 이메일 인증 재전송 대기 시간과 SMTP 오류 진단 개선

### DIFF
--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -137,10 +137,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         // 메일 폭주 위험이 없으므로 throttle 대상이 아니다.
         if (shouldSendEmail) {
             loadEmailVerificationPort.findLatestSentByEmail(email)
-                .filter(EmailVerification::isSendThrottled)
-                .ifPresent(latest -> {
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-                });
+                .ifPresent(EmailVerification::validateSendInterval);
         }
 
         String code = generateRandomCode();
@@ -168,9 +165,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     public void resendEmailVerification(Long sessionId) {
         EmailVerification emailVerification = loadEmailVerificationPort.getById(sessionId);
 
-        if (emailVerification.isSendThrottled()) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-        }
+        emailVerification.validateSendInterval();
 
         String newCode = generateRandomCode();
         String newToken = UUID.randomUUID().toString();

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -1,9 +1,11 @@
 package com.umc.product.authentication.domain;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.common.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -38,7 +40,7 @@ public class EmailVerification extends BaseEntity {
     /**
      * 같은 이메일 / 같은 세션에 대한 연속 발송 간 최소 간격(초). 메일 폭주 방어.
      */
-    public static final long MIN_SEND_INTERVAL_SECONDS = 60;
+    public static final long MIN_SEND_INTERVAL_SECONDS = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -87,7 +89,7 @@ public class EmailVerification extends BaseEntity {
     private int attemptCount;
 
     /**
-     * 마지막으로 메일을 실제로 발송한 시각. throttle 검사에 사용한다.
+     * 마지막 메일 발송 요청을 접수한 시각. 실제 발송 성공 여부와 관계없이 throttle 검사에 사용한다.
      * silent skip (예: PASSWORD_RESET 미가입) 인 경우에는 갱신하지 않는다.
      */
     @Column(name = "last_sent_at")
@@ -110,18 +112,35 @@ public class EmailVerification extends BaseEntity {
     }
 
     /**
-     * 마지막 실제 발송 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
-     * lastSentAt 이 null 이면 (아직 실제로 발송된 적이 없음) 즉시 발송 가능하다.
+     * 마지막 발송 요청 접수 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
+     * lastSentAt 이 null 이면 즉시 발송 요청을 접수할 수 있다.
      */
     public boolean isSendThrottled() {
-        if (this.lastSentAt == null) {
-            return false;
+        return remainingSendIntervalSeconds() > 0;
+    }
+
+    public void validateSendInterval() {
+        long remainingSeconds = remainingSendIntervalSeconds();
+        if (remainingSeconds > 0) {
+            throw new EmailVerificationThrottledException(remainingSeconds);
         }
-        return Instant.now().isBefore(this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+    }
+
+    private long remainingSendIntervalSeconds() {
+        if (this.lastSentAt == null) {
+            return 0;
+        }
+        Duration remaining = Duration.between(
+            Instant.now(), this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+        if (remaining.isNegative() || remaining.isZero()) {
+            return 0;
+        }
+        // 초 단위 응답을 내림하면 제한이 풀리기 전에 다시 요청하게 되므로 올림한다.
+        return remaining.getSeconds() + (remaining.getNano() > 0 ? 1 : 0);
     }
 
     /**
-     * 실제 메일 발송이 트리거된 시점을 기록한다. AFTER_COMMIT 이벤트 발행 직전에 호출된다.
+     * 발송 요청 접수 시점을 기록한다. 거절된 요청과 비동기 발송 결과는 이 시각을 변경하지 않는다.
      */
     public void markSent() {
         this.lastSentAt = Instant.now();

--- a/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
@@ -1,0 +1,14 @@
+package com.umc.product.authentication.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationThrottledException extends AuthenticationDomainException {
+
+    private final long retryAfterSeconds;
+
+    public EmailVerificationThrottledException(long retryAfterSeconds) {
+        super(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -193,8 +193,8 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
-        // Trace ID 헤더를 클라이언트에서 읽을 수 있도록 노출
-        configuration.setExposedHeaders(List.of("X-Trace-Id"));
+        // Trace ID와 재요청 대기 시간을 클라이언트에서 읽을 수 있도록 노출
+        configuration.setExposedHeaders(List.of("X-Trace-Id", "Retry-After"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.form.domain.FormResponse;
 import com.umc.product.form.domain.exception.DraftSchemaMismatchException;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -240,10 +241,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             e.getMessage(), e);
 
         ApiResponse<Object> body = BusinessExceptionResponseResolver.toApiResponse(e);
+        HttpHeaders headers = HttpHeaders.EMPTY;
+        if (e instanceof EmailVerificationThrottledException throttled) {
+            headers = new HttpHeaders();
+            headers.set(HttpHeaders.RETRY_AFTER, Long.toString(throttled.getRetryAfterSeconds()));
+        }
         return super.handleExceptionInternal(
             e,
             body,
-            HttpHeaders.EMPTY,
+            headers,
             e.getBaseCode().getHttpStatus(),
             request
         );

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
@@ -1,8 +1,12 @@
 package com.umc.product.notification.adapter.out.external.smtp;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -14,21 +18,34 @@ import com.umc.product.notification.application.port.out.dto.EmailMessage;
 import com.umc.product.notification.domain.exception.EmailDomainException;
 import com.umc.product.notification.domain.exception.EmailErrorCode;
 
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "smtp")
-@RequiredArgsConstructor
 public class SmtpEmailAdapter implements SendEmailPort {
 
     private final JavaMailSender mailSender;
+    private final Tracer tracer;
+
+    @Autowired
+    public SmtpEmailAdapter(JavaMailSender mailSender, ObjectProvider<Tracer> tracerProvider) {
+        this.mailSender = mailSender;
+        this.tracer = tracerProvider.getIfAvailable(() -> Tracer.NOOP);
+    }
+
+    public SmtpEmailAdapter(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+        this.tracer = Tracer.NOOP;
+    }
 
     @Override
     public void send(EmailMessage message) {
+        long startNanos = System.nanoTime();
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
@@ -38,9 +55,33 @@ public class SmtpEmailAdapter implements SendEmailPort {
             helper.setText(message.htmlBody(), true);
             ExternalApiCallLogger.measure("SMTP", "SEND_EMAIL", () -> mailSender.send(mimeMessage));
         } catch (MessagingException | UnsupportedEncodingException | RuntimeException e) {
-            // SMTP 예외에는 수신 주소와 서버 응답이 포함될 수 있어 원문이나 cause를 상위 로그로 전달하지 않는다.
-            log.warn("SMTP 이메일 발송 실패: errorClass={}", e.getClass().getSimpleName());
+            recordFailure(e, (System.nanoTime() - startNanos) / 1_000_000L);
+            // 수신 주소·인증코드를 포함할 수 있는 원문과 cause는 외부 응답이나 상위 예외에 전달하지 않는다.
             throw new EmailDomainException(EmailErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private void recordFailure(Exception error, long durationMs) {
+        SmtpFailureDetails details = SmtpFailureDetails.from(error);
+        log.warn("SMTP 이메일 발송 실패: {} {} {} {} {} {} {} {} {} {} {}",
+            kv("event", "email_send_failed"), kv("provider", "SMTP"), kv("operation", "SEND_EMAIL"),
+            kv("result", "FAILURE"), kv("errorClass", error.getClass().getSimpleName()),
+            kv("errorReason", details.errorReason()), kv("causeErrorClass", details.causeErrorClass()),
+            kv("failureStage", details.failureStage()), kv("smtpResponseCode", details.smtpResponseCode()),
+            kv("smtpEnhancedStatusCode", details.smtpEnhancedStatusCode()), kv("durationMs", durationMs));
+
+        Span span = tracer.currentSpan();
+        if (span != null) {
+            span.tag("email.provider", "SMTP");
+            span.tag("email.error.reason", details.errorReason());
+            span.tag("email.error.cause_class", details.causeErrorClass());
+            span.tag("email.error.stage", details.failureStage());
+            if (details.smtpResponseCode() != null) {
+                span.tag("email.smtp.response_code", details.smtpResponseCode().toString());
+            }
+            if (details.smtpEnhancedStatusCode() != null) {
+                span.tag("email.smtp.enhanced_status_code", details.smtpEnhancedStatusCode());
+            }
         }
     }
 }

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpFailureDetails.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpFailureDetails.java
@@ -1,0 +1,177 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+
+import org.eclipse.angus.mail.smtp.SMTPAddressFailedException;
+import org.eclipse.angus.mail.smtp.SMTPSendFailedException;
+import org.eclipse.angus.mail.util.MailConnectException;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
+
+import jakarta.mail.AuthenticationFailedException;
+import jakarta.mail.MessagingException;
+
+/** SMTP 예외에서 원문과 주소를 보존하지 않고 진단에 필요한 분류와 숫자 코드만 추출한다. */
+record SmtpFailureDetails(
+    String errorReason,
+    String causeErrorClass,
+    String failureStage,
+    Integer smtpResponseCode,
+    String smtpEnhancedStatusCode
+) {
+
+    private static final int MAX_CAUSES = 32;
+    private static final Pattern SMTP_REPLY = Pattern.compile(
+        "\\A([45][0-9]{2})(?:[ -]([245]\\.[0-9]{1,3}\\.[0-9]{1,3})(?=\\s|$))?(?=\\s|-|$)"
+    );
+
+    static SmtpFailureDetails from(Exception exception) {
+        List<Cause> causes = causes(exception);
+        Cause selected = causes.getFirst();
+        String reason = "UNKNOWN";
+        for (Cause cause : causes) {
+            String candidateReason = reason(cause.exception());
+            if (priority(candidateReason) >= priority(reason)) {
+                selected = cause;
+                reason = candidateReason;
+            }
+        }
+
+        String failureStage = "UNKNOWN";
+        Integer responseCode = null;
+        String enhancedStatusCode = null;
+        boolean typedResponseCode = false;
+        // 다른 메일의 실패나 연결 종료 예외를 선택한 원인의 단계/응답 코드와 섞지 않는다.
+        for (Cause path = selected; path != null; path = path.parent()) {
+            Throwable cause = path.exception();
+            if ("UNKNOWN".equals(failureStage)) {
+                failureStage = stage(cause);
+            }
+
+            Integer typedCode = responseCode(cause);
+            if (typedCode != null && !typedResponseCode) {
+                responseCode = typedCode;
+                enhancedStatusCode = null;
+                typedResponseCode = true;
+            }
+            Matcher reply = reply(cause);
+            if (reply != null) {
+                int parsedCode = Integer.parseInt(reply.group(1));
+                if (responseCode == null) {
+                    responseCode = parsedCode;
+                    enhancedStatusCode = reply.group(2);
+                } else if (responseCode == parsedCode && enhancedStatusCode == null) {
+                    enhancedStatusCode = reply.group(2);
+                }
+            }
+        }
+
+        return new SmtpFailureDetails(reason, selected.exception().getClass().getSimpleName(),
+            failureStage, responseCode, enhancedStatusCode);
+    }
+
+    private static List<Cause> causes(Throwable exception) {
+        List<Cause> causes = new ArrayList<>();
+        Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        addCause(exception, null, causes, visited);
+        for (int index = 0; index < causes.size(); index++) {
+            Cause parent = causes.get(index);
+            Throwable cause = parent.exception();
+            addCause(cause.getCause(), parent, causes, visited);
+            if (cause instanceof MessagingException messagingException) {
+                addCause(messagingException.getNextException(), parent, causes, visited);
+            }
+            if (cause instanceof MailSendException mailSendException) {
+                for (Exception messageException : mailSendException.getMessageExceptions()) {
+                    addCause(messageException, parent, causes, visited);
+                    if (causes.size() == MAX_CAUSES) {
+                        break;
+                    }
+                }
+            }
+        }
+        return causes;
+    }
+
+    private static void addCause(Throwable cause, Cause parent, List<Cause> causes, Set<Throwable> visited) {
+        if (cause != null && causes.size() < MAX_CAUSES && visited.add(cause)) {
+            causes.add(new Cause(cause, parent));
+        }
+    }
+
+    private static String reason(Throwable cause) {
+        if (cause instanceof SSLException) {
+            return "TLS_FAILED";
+        }
+        if (cause instanceof UnknownHostException) {
+            return "DNS_FAILED";
+        }
+        if (cause instanceof SocketTimeoutException) {
+            return "TIMEOUT";
+        }
+        if (cause instanceof ConnectException || cause instanceof MailConnectException) {
+            return "CONNECTION_FAILED";
+        }
+        if (cause instanceof MailAuthenticationException || cause instanceof AuthenticationFailedException) {
+            return "AUTHENTICATION_FAILED";
+        }
+        return responseCode(cause) != null || reply(cause) != null ? "SMTP_REJECTED" : "UNKNOWN";
+    }
+
+    private static int priority(String reason) {
+        return switch (reason) {
+            case "TLS_FAILED", "DNS_FAILED", "TIMEOUT" -> 3;
+            case "CONNECTION_FAILED", "AUTHENTICATION_FAILED" -> 2;
+            case "SMTP_REJECTED" -> 1;
+            default -> 0;
+        };
+    }
+
+    private static String stage(Throwable cause) {
+        if (cause instanceof SSLHandshakeException) {
+            return "TLS_HANDSHAKE";
+        }
+        if (cause instanceof ConnectException || cause instanceof MailConnectException) {
+            return "CONNECT";
+        }
+        if (cause instanceof MailAuthenticationException || cause instanceof AuthenticationFailedException) {
+            return "AUTHENTICATE";
+        }
+        return responseCode(cause) != null ? "SMTP_COMMAND" : "UNKNOWN";
+    }
+
+    private static Integer responseCode(Throwable cause) {
+        int code = switch (cause) {
+            case SMTPSendFailedException smtp -> smtp.getReturnCode();
+            case SMTPAddressFailedException smtp -> smtp.getReturnCode();
+            default -> -1;
+        };
+        return code >= 400 && code <= 599 ? code : null;
+    }
+
+    private static Matcher reply(Throwable cause) {
+        if (cause instanceof MessagingException || cause instanceof MailAuthenticationException) {
+            String message = cause.getMessage();
+            if (message != null) {
+                Matcher reply = SMTP_REPLY.matcher(message);
+                return reply.find() ? reply : null;
+            }
+        }
+        return null;
+    }
+
+    private record Cause(Throwable exception, Cause parent) {
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

이메일 인증 재전송을 60초 동안 기다려야 하고, SMTP 발송 실패 원인이 `MailSendException`으로만 기록돼 원인을 구별하기 어려웠습니다. 재전송 대기 시간을 30초로 줄이고 남은 시간 응답과 SMTP 오류 진단을 함께 개선합니다.

신규 인증 요청과 재전송 모두 마지막 발송 요청 접수 시점부터 30초를 적용합니다. 제한 중에는 기존 `429 / AUTHENTICATION-0027` 응답에 `Retry-After` 헤더로 남은 초를 제공하고, 브라우저가 읽을 수 있도록 CORS에 노출합니다. 실제 발송 실패에도 접수 시각을 기준으로 대기하며 사용자가 재전송합니다.

기존 SMTP 실패 로그에는 `email_send_failed` 이벤트, 원인 분류, 내부 예외 종류, 확인 가능한 실패 단계와 SMTP 숫자 응답 코드를 추가합니다. 같은 정보를 기존 adapter span에도 남겨 Loki·Tempo에서 연결해 확인할 수 있습니다. 예를 들어 내부 `SocketTimeoutException`이 확인되면 `errorReason=TIMEOUT`, `email.error.reason=TIMEOUT`으로 조회할 수 있습니다.

## 💬 리뷰 중점사항

- 거절된 요청은 대기 시간을 갱신하지 않습니다. 허용된 재전송이 접수되면 다시 30초를 계산합니다. 남은 소수 초는 올림하고, 정확히 30초가 지나면 허용합니다.
- SMTP 원인은 실제 예외에서 추출합니다. 소요 시간만으로 타임아웃을 추측하지 않으며, 확인할 수 없는 단계는 `UNKNOWN`입니다. `cause`, 메일별 예외, `nextException`을 제한적으로 탐색하고 선택한 원인의 경로에서만 단계와 응답 코드를 가져옵니다.
- 수신 주소·인증코드·비밀번호·본문·예외 원문을 새 진단 필드에 기록하지 않습니다. Tracer 빈이 없어도 발송할 수 있습니다. 실제 메일 발송 실패의 outbox 자동 재시도는 추가하지 않습니다.
- 백엔드 실행 코드 7개 파일을 변경합니다.

검증: 통합 상태에서 기존 관련 테스트 46개와 저장소 밖 임시 경계·응답·CORS 검증 9개, 총 55개 통과. `spotlessCheck`, `checkstyleMain`, `checkstyleTest`, `compileJava`, `compileTestJava`, `bootJar`도 통과했습니다.
