### PR TITLE
[Fix] 이메일 인증 재전송 간격 30초 및 Retry-After 응답

### DIFF
--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -137,10 +137,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         // 메일 폭주 위험이 없으므로 throttle 대상이 아니다.
         if (shouldSendEmail) {
             loadEmailVerificationPort.findLatestSentByEmail(email)
-                .filter(EmailVerification::isSendThrottled)
-                .ifPresent(latest -> {
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-                });
+                .ifPresent(EmailVerification::validateSendInterval);
         }
 
         String code = generateRandomCode();
@@ -168,9 +165,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     public void resendEmailVerification(Long sessionId) {
         EmailVerification emailVerification = loadEmailVerificationPort.getById(sessionId);
 
-        if (emailVerification.isSendThrottled()) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-        }
+        emailVerification.validateSendInterval();
 
         String newCode = generateRandomCode();
         String newToken = UUID.randomUUID().toString();

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -1,9 +1,11 @@
 package com.umc.product.authentication.domain;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.common.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -38,7 +40,7 @@ public class EmailVerification extends BaseEntity {
     /**
      * 같은 이메일 / 같은 세션에 대한 연속 발송 간 최소 간격(초). 메일 폭주 방어.
      */
-    public static final long MIN_SEND_INTERVAL_SECONDS = 60;
+    public static final long MIN_SEND_INTERVAL_SECONDS = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -87,7 +89,7 @@ public class EmailVerification extends BaseEntity {
     private int attemptCount;
 
     /**
-     * 마지막으로 메일을 실제로 발송한 시각. throttle 검사에 사용한다.
+     * 마지막 메일 발송 요청을 접수한 시각. 실제 발송 성공 여부와 관계없이 throttle 검사에 사용한다.
      * silent skip (예: PASSWORD_RESET 미가입) 인 경우에는 갱신하지 않는다.
      */
     @Column(name = "last_sent_at")
@@ -110,18 +112,35 @@ public class EmailVerification extends BaseEntity {
     }
 
     /**
-     * 마지막 실제 발송 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
-     * lastSentAt 이 null 이면 (아직 실제로 발송된 적이 없음) 즉시 발송 가능하다.
+     * 마지막 발송 요청 접수 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
+     * lastSentAt 이 null 이면 즉시 발송 요청을 접수할 수 있다.
      */
     public boolean isSendThrottled() {
-        if (this.lastSentAt == null) {
-            return false;
+        return remainingSendIntervalSeconds() > 0;
+    }
+
+    public void validateSendInterval() {
+        long remainingSeconds = remainingSendIntervalSeconds();
+        if (remainingSeconds > 0) {
+            throw new EmailVerificationThrottledException(remainingSeconds);
         }
-        return Instant.now().isBefore(this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+    }
+
+    private long remainingSendIntervalSeconds() {
+        if (this.lastSentAt == null) {
+            return 0;
+        }
+        Duration remaining = Duration.between(
+            Instant.now(), this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+        if (remaining.isNegative() || remaining.isZero()) {
+            return 0;
+        }
+        // 초 단위 응답을 내림하면 제한이 풀리기 전에 다시 요청하게 되므로 올림한다.
+        return remaining.getSeconds() + (remaining.getNano() > 0 ? 1 : 0);
     }
 
     /**
-     * 실제 메일 발송이 트리거된 시점을 기록한다. AFTER_COMMIT 이벤트 발행 직전에 호출된다.
+     * 발송 요청 접수 시점을 기록한다. 거절된 요청과 비동기 발송 결과는 이 시각을 변경하지 않는다.
      */
     public void markSent() {
         this.lastSentAt = Instant.now();

--- a/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
@@ -1,0 +1,14 @@
+package com.umc.product.authentication.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationThrottledException extends AuthenticationDomainException {
+
+    private final long retryAfterSeconds;
+
+    public EmailVerificationThrottledException(long retryAfterSeconds) {
+        super(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -193,8 +193,8 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
-        // Trace ID 헤더를 클라이언트에서 읽을 수 있도록 노출
-        configuration.setExposedHeaders(List.of("X-Trace-Id"));
+        // Trace ID와 재요청 대기 시간을 클라이언트에서 읽을 수 있도록 노출
+        configuration.setExposedHeaders(List.of("X-Trace-Id", "Retry-After"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.form.domain.FormResponse;
 import com.umc.product.form.domain.exception.DraftSchemaMismatchException;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -240,10 +241,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             e.getMessage(), e);
 
         ApiResponse<Object> body = BusinessExceptionResponseResolver.toApiResponse(e);
+        HttpHeaders headers = HttpHeaders.EMPTY;
+        if (e instanceof EmailVerificationThrottledException throttled) {
+            headers = new HttpHeaders();
+            headers.set(HttpHeaders.RETRY_AFTER, Long.toString(throttled.getRetryAfterSeconds()));
+        }
         return super.handleExceptionInternal(
             e,
             body,
-            HttpHeaders.EMPTY,
+            headers,
             e.getBaseCode().getHttpStatus(),
             request
         );


### PR DESCRIPTION
이 변경은 [PR #1327](https://github.com/UMC-PRODUCT/umc-product-server/pull/1327)에 통합했습니다. 리뷰는 #1327에서 진행합니다.

## 🚀 작업 내용

이메일 인증 요청 후 재전송까지 기다려야 하는 시간을 60초에서 30초로 줄입니다. 신규 인증 요청과 기존 세션 재전송에 같은 정책을 적용합니다.

제한 중인 요청은 기존 `429 / AUTHENTICATION-0027` 응답을 유지하면서 `Retry-After` 헤더로 남은 대기 시간을 반환합니다. 브라우저에서도 읽을 수 있도록 CORS 노출 헤더에 추가했습니다.

## 💬 리뷰 중점사항

- 대기 시간은 마지막 발송 요청 접수 시점부터 계산합니다. 비동기 발송 실패에도 같은 기준을 유지하고, 거절된 요청은 시간을 갱신하지 않습니다. 허용된 재전송이 접수되면 다시 30초를 계산합니다.
- 남은 소수 초는 올림해 너무 이른 재요청을 방지하며, 정확히 30초가 지나면 허용합니다. 실제 메일 발송 실패에 대한 outbox 자동 재시도는 추가하지 않습니다.
- 기존 인증 도메인·서비스, 공통 예외·응답, SecurityConfig 관련 테스트 44개 통과. 저장소 밖 임시 검증 9개로 정확한 경계, 거절 요청의 상태 보존, 접수 시각 갱신, 실제 컨트롤러 429 응답 및 CORS 헤더를 확인했습니다.
- `spotlessCheck`, `checkstyleMain`, `checkstyleTest`, `compileJava`, `compileTestJava`, `bootJar` 통과. PR에는 백엔드 실행 코드 5개 파일만 포함합니다.
