### PR TITLE
[Fix] 신뢰된 Preview 이미지 발행과 성공 버전 GitOps 전달

### DIFF
--- a/.github/scripts/update-preview-release.mjs
+++ b/.github/scripts/update-preview-release.mjs
@@ -1,0 +1,97 @@
+import { execFileSync } from "node:child_process";
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function hasExactKeys(value, keys) {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+        && Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+}
+
+export function validatePreviewRelease(document) {
+    if (!hasExactKeys(document, ["release"])
+        || !hasExactKeys(document.release, ["prNumber", "headSha", "imageTag", "imageDigest"])) {
+        throw new Error("Preview release schema has missing or unexpected fields");
+    }
+    const { prNumber, headSha, imageTag, imageDigest } = document.release;
+    if (typeof prNumber !== "string" || !/^[1-9][0-9]*$/.test(prNumber)
+        || !Number.isSafeInteger(Number(prNumber)) || prNumber !== String(Number(prNumber))) {
+        throw new Error("PR number must be a positive canonical integer string");
+    }
+    if (typeof headSha !== "string" || headSha.length !== 40 || !/^[a-f0-9]{40}$/.test(headSha)) {
+        throw new Error("PR head must be a full lowercase commit SHA");
+    }
+    if (typeof imageTag !== "string" || imageTag !== headSha.slice(0, 12)) {
+        throw new Error("Image tag must match the first 12 characters of the PR head");
+    }
+    if (typeof imageDigest !== "string" || imageDigest.length !== 71 || !/^sha256:[a-f0-9]{64}$/.test(imageDigest)) {
+        throw new Error("Image digest must be a lowercase sha256 digest");
+    }
+    return `argocd/preview-releases/pr-${prNumber}.json`;
+}
+
+function inspectPath(path, directory) {
+    const stat = lstatSync(path, { throwIfNoEntry: false });
+    if (stat && (stat.isSymbolicLink() || !(directory ? stat.isDirectory() : stat.isFile()))) {
+        throw new Error("Preview release paths must be regular directories and files, not symlinks");
+    }
+    return stat;
+}
+
+export function assertOnlyPreviewReleaseChanged(repository, markerPath) {
+    // untracked 파일도 포함한다. rename/copy/delete 및 대상 외 변경은 commit 전에 거부한다.
+    const status = execFileSync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+        cwd: repository,
+        encoding: "utf8",
+    });
+    for (const entry of status.split("\0").filter(Boolean)) {
+        if (!["??", " M", "M ", "A "].includes(entry.slice(0, 2)) || entry.slice(3) !== markerPath) {
+            throw new Error("Infrastructure has changes outside the selected Preview release");
+        }
+    }
+}
+
+export function updatePreviewRelease(repository, document) {
+    const markerPath = validatePreviewRelease(document);
+    const root = resolve(repository);
+    if (!inspectPath(root, true) || !inspectPath(resolve(root, "argocd"), true)) {
+        throw new Error("Expected an infrastructure checkout containing argocd");
+    }
+    const directory = resolve(root, "argocd/preview-releases");
+    inspectPath(directory, true);
+    const target = resolve(root, markerPath);
+    const exists = inspectPath(target, false);
+    assertOnlyPreviewReleaseChanged(root, markerPath);
+
+    let previous = null;
+    if (exists) {
+        previous = readFileSync(target, "utf8");
+        const previousPath = validatePreviewRelease(JSON.parse(previous));
+        if (previousPath !== markerPath) {
+            throw new Error("Existing release PR number does not match its filename");
+        }
+    }
+    const updated = `${JSON.stringify(document, null, 2)}\n`;
+    if (previous === updated) {
+        return { markerPath, changed: false };
+    }
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(target, updated, "utf8");
+    assertOnlyPreviewReleaseChanged(root, markerPath);
+    return { markerPath, changed: true };
+}
+
+function main() {
+    const [repository, prNumber, headSha, imageTag, imageDigest, ...extra] = process.argv.slice(2);
+    if (!repository || extra.length) {
+        throw new Error("usage: update-preview-release.mjs <infra-checkout> <pr-number> <head-sha> <tag> <digest>");
+    }
+    const result = updatePreviewRelease(repository, {
+        release: { prNumber, headSha, imageTag, imageDigest },
+    });
+    console.log(`${result.markerPath}: ${result.changed ? "updated" : "unchanged"}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/.github/scripts/update-preview-release.test.mjs
+++ b/.github/scripts/update-preview-release.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { assertOnlyPreviewReleaseChanged, updatePreviewRelease, validatePreviewRelease } from "./update-preview-release.mjs";
+
+const headSha = `123456789012${"a".repeat(28)}`;
+const release = () => ({
+    release: { prNumber: "42", headSha, imageTag: headSha.slice(0, 12), imageDigest: `sha256:${"a".repeat(64)}` },
+});
+
+function repository(t) {
+    const root = mkdtempSync(join(tmpdir(), "umc-preview-release-test-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    mkdirSync(join(root, "argocd"));
+    writeFileSync(join(root, "argocd/.gitkeep"), "");
+    execFileSync("git", ["init", "--quiet"], { cwd: root });
+    execFileSync("git", ["add", "argocd/.gitkeep"], { cwd: root });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "initial"], { cwd: root });
+    return root;
+}
+
+test("성공 이미지 marker만 생성하고 같은 입력을 재실행하면 변경하지 않는다", (t) => {
+    const root = repository(t);
+    const document = release();
+    const first = updatePreviewRelease(root, document);
+    assert.deepEqual(first, { markerPath: "argocd/preview-releases/pr-42.json", changed: true });
+    assert.deepEqual(JSON.parse(readFileSync(join(root, first.markerPath), "utf8")), document);
+    assert.equal(typeof document.release.imageTag, "string");
+    assert.deepEqual(updatePreviewRelease(root, document), { ...first, changed: false });
+});
+
+test("후속 성공 이미지의 SHA와 digest를 같은 PR marker에만 갱신한다", (t) => {
+    const root = repository(t);
+    const first = updatePreviewRelease(root, release());
+    execFileSync("git", ["add", first.markerPath], { cwd: root });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "release"], { cwd: root });
+    const next = release();
+    next.release.headSha = "b".repeat(40);
+    next.release.imageTag = "b".repeat(12);
+    next.release.imageDigest = `sha256:${"c".repeat(64)}`;
+    assert.equal(updatePreviewRelease(root, next).changed, true);
+    assert.deepEqual(JSON.parse(readFileSync(join(root, first.markerPath), "utf8")), next);
+    assertOnlyPreviewReleaseChanged(root, first.markerPath);
+});
+
+test("변형된 PR 번호·SHA·tag·digest와 추가 필드는 거부한다", () => {
+    for (const prNumber of [42, "0", "-1", "042", "../prod", "42\n", "9007199254740992"]) {
+        assert.throws(() => validatePreviewRelease({ release: { ...release().release, prNumber } }));
+    }
+    for (const patch of [
+        { headSha: "a".repeat(39) }, { headSha: "A".repeat(40) },
+        { headSha: `${headSha}\n` },
+        { imageTag: 123456789012 }, { imageTag: "b".repeat(12) },
+        { imageDigest: "sha256:bad" }, { imageDigest: `sha256:${"A".repeat(64)}` },
+        { imageDigest: `sha256:${"a".repeat(64)}\n` },
+        { file: "values-prod.yaml" },
+    ]) {
+        assert.throws(() => validatePreviewRelease({ release: { ...release().release, ...patch } }));
+    }
+    assert.throws(() => validatePreviewRelease({ ...release(), extra: true }));
+    assert.throws(() => validatePreviewRelease({ release: null }));
+    assert.throws(() => validatePreviewRelease({ release: [] }));
+    const missing = release();
+    delete missing.release.imageDigest;
+    assert.throws(() => validatePreviewRelease(missing));
+});
+
+test("다른 파일이 변경되어 있으면 marker를 쓰기 전에 중단한다", (t) => {
+    const root = repository(t);
+    writeFileSync(join(root, "unexpected.txt"), "do not commit");
+    assert.throws(() => updatePreviewRelease(root, release()), /outside the selected Preview release/);
+    assert.throws(() => readFileSync(join(root, "argocd/preview-releases/pr-42.json")), { code: "ENOENT" });
+});
+
+test("기존 marker의 PR 번호가 파일명과 다르거나 추가 필드가 있으면 덮어쓰지 않는다", (t) => {
+    const root = repository(t);
+    const { markerPath } = updatePreviewRelease(root, release());
+    for (const document of [
+        { release: { ...release().release, prNumber: "43" } },
+        { ...release(), unexpected: "field" },
+    ]) {
+        const content = JSON.stringify(document);
+        writeFileSync(join(root, markerPath), content);
+        assert.throws(() => updatePreviewRelease(root, release()));
+        assert.equal(readFileSync(join(root, markerPath), "utf8"), content);
+    }
+});
+
+test("marker 파일이나 상위 디렉터리가 symlink이면 따라가지 않는다", (t) => {
+    for (const directoryLink of [false, true]) {
+        const root = repository(t);
+        const outside = mkdtempSync(join(tmpdir(), "umc-preview-outside-test-"));
+        t.after(() => rmSync(outside, { recursive: true, force: true }));
+        const parent = join(root, "argocd/preview-releases");
+        if (directoryLink) {
+            symlinkSync(outside, parent);
+        } else {
+            mkdirSync(parent);
+            const externalFile = join(outside, "target.json");
+            writeFileSync(externalFile, JSON.stringify(release()));
+            symlinkSync(externalFile, join(parent, "pr-42.json"));
+        }
+        assert.throws(() => updatePreviewRelease(root, release()), /not symlinks/);
+    }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: corretto
           cache: gradle
 
+      - name: Validate Preview release updater
+        run: node --test .github/scripts/update-preview-release.test.mjs
+
       - name: Validate and build boot JAR
         run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
 

--- a/.github/workflows/publish-gitops.yml
+++ b/.github/workflows/publish-gitops.yml
@@ -37,6 +37,7 @@ jobs:
     concurrency:
       group: ghcr-image-${{ github.sha }}
       cancel-in-progress: false
+      queue: max
     outputs:
       deploy_environment: ${{ steps.metadata.outputs.deploy_environment }}
       values_file: ${{ steps.metadata.outputs.values_file }}
@@ -189,10 +190,11 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # dev/prod publish가 동시에 infra main을 갱신해 push 경합을 만들지 않게 직렬화한다.
+    # dev/prod/Preview의 infra 갱신을 직렬화하고 대기 중인 다른 배포를 취소하지 않는다.
     concurrency:
       group: umc-product-infra-main-update
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
 

--- a/.github/workflows/publish-gitops.yml
+++ b/.github/workflows/publish-gitops.yml
@@ -2,7 +2,7 @@
 # - UMC_INFRA_GITOPS_TOKEN: UMC-PRODUCT/umc-product-infra만 대상으로 하고
 #   Contents 읽기/쓰기 권한만 부여한 fine-grained PAT
 # 최초 GHCR package는 조직 관리자가 Public으로 전환해야 한다.
-# Preview는 PR 코드에 쓰기 token을 노출하지 않도록 빌드와 발행 단계를 분리하기 전까지 비활성화한다.
+# Preview는 publish-preview.yml에서 읽기 권한의 PR 빌드와 쓰기 권한의 이미지 발행을 분리한다.
 
 name: Publish GitOps Image
 
@@ -33,6 +33,10 @@ jobs:
     name: Build and publish immutable image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Preview 발행과 같은 SHA tag를 동시에 쓰지 않는다. 환경별 배포 순서는 상위에서 유지한다.
+    concurrency:
+      group: ghcr-image-${{ github.sha }}
+      cancel-in-progress: false
     outputs:
       deploy_environment: ${{ steps.metadata.outputs.deploy_environment }}
       values_file: ${{ steps.metadata.outputs.values_file }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,6 +1,7 @@
 # 기본 브랜치의 workflow만 신뢰한다. PR 코드는 읽기 권한의 별도 runner에서 빌드하고,
 # packages:write runner는 완성된 Docker archive를 읽어 발행만 한다.
-# GHCR package는 Public이어야 하며 별도 저장소 Secret이나 infra PAT는 사용하지 않는다.
+# GHCR package는 Public이어야 한다. infra PAT는 마지막 GitOps 갱신 job에만 전달하고,
+# 이미지 발행과 익명 pull 검증에 성공한 SHA·digest만 Argo에 전달한다.
 name: Publish Preview Image
 
 on:
@@ -96,9 +97,15 @@ jobs:
     concurrency:
       group: ghcr-image-${{ github.event.pull_request.head.sha }}
       cancel-in-progress: false
+      queue: max
     permissions:
       packages: write
       pull-requests: read
+    outputs:
+      eligible: ${{ steps.ready.outputs.eligible }}
+      head_sha: ${{ steps.ready.outputs.head_sha }}
+      image_tag: ${{ steps.ready.outputs.image_tag }}
+      image_digest: ${{ steps.ready.outputs.image_digest }}
 
     steps:
       # PR checkout·로컬 action·Gradle·Docker build/run을 이 job에 추가하지 않는다.
@@ -189,6 +196,7 @@ jobs:
           echo "IMAGE_DIGEST=$registry_digest" >> "$GITHUB_ENV"
 
       - name: Verify public anonymous image pull
+        id: ready
         if: steps.current.outputs.eligible == 'true'
         run: |
           set -euo pipefail
@@ -202,3 +210,109 @@ jobs:
             exit 1
           fi
           echo "Preview image ready: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
+  update-infra:
+    name: Promote ready Preview image in infrastructure
+    needs: publish
+    if: needs.publish.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # dev/prod의 infra main 갱신과 같은 lock을 사용한다. force push는 하지 않는다.
+    concurrency:
+      group: umc-product-infra-main-update
+      cancel-in-progress: false
+      queue: max
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      # PR head의 script/action은 절대 실행하지 않는다. 이 실행을 정의한 기본 브랜치
+      # workflow의 정확한 commit에서 updater만 읽는다. PR artifact도 이 job에 전달하지 않는다.
+      - name: Checkout trusted default-branch automation
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-server
+          ref: ${{ github.workflow_sha }}
+          path: backend
+          persist-credentials: false
+
+      - name: Checkout infrastructure main
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-infra
+          ref: main
+          token: ${{ secrets.UMC_INFRA_GITOPS_TOKEN }}
+          path: infra
+
+      - name: Record the successfully published immutable release
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_HEAD_SHA: ${{ needs.publish.outputs.head_sha }}
+          READY_IMAGE_TAG: ${{ needs.publish.outputs.image_tag }}
+          READY_IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          git -C infra pull --ff-only origin main
+          node backend/.github/scripts/update-preview-release.mjs \
+            infra "$PR_NUMBER" "$READY_HEAD_SHA" "$READY_IMAGE_TAG" "$READY_IMAGE_DIGEST"
+
+      - name: Commit only the selected Preview release
+        id: commit
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_IMAGE_TAG: ${{ needs.publish.outputs.image_tag }}
+        working-directory: infra
+        run: |
+          set -euo pipefail
+          marker="argocd/preview-releases/pr-${PR_NUMBER}.json"
+          git add -- "$marker"
+          changed_files="$(git diff --cached --name-only)"
+          if [[ -z "$changed_files" ]]; then
+            echo "Preview already references this successfully published image."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$changed_files" != "$marker" ]]; then
+            echo "::error::Automation staged a file outside the selected Preview release."
+            exit 1
+          fi
+          git diff --cached --check
+          git config user.name "umc-product-deploy-bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(preview): deploy PR ${PR_NUMBER} ${READY_IMAGE_TAG}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Recheck current PR immediately before infrastructure push
+        if: steps.commit.outputs.changed == 'true'
+        id: current
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          READY_HEAD_SHA: ${{ needs.publish.outputs.head_sha }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'UMC-PRODUCT',
+              repo: 'umc-product-server',
+              pull_number: context.payload.pull_request.number,
+            });
+            const eligible =
+              pr.state === 'open' &&
+              pr.base.repo.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              pr.base.ref === 'develop' &&
+              pr.head.repo?.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.author_association) &&
+              pr.labels.some(label => label.name === 'preview') &&
+              pr.head.sha === process.env.READY_HEAD_SHA &&
+              pr.head.sha === context.payload.pull_request.head.sha;
+            core.setOutput('eligible', String(eligible));
+            if (!eligible) core.notice('PR closed, label removed, or head changed; infrastructure push skipped.');
+
+      - name: Push ready release without overwriting concurrent changes
+        if: steps.commit.outputs.changed == 'true' && steps.current.outputs.eligible == 'true'
+        working-directory: infra
+        run: git push origin HEAD:main

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,204 @@
+# 기본 브랜치의 workflow만 신뢰한다. PR 코드는 읽기 권한의 별도 runner에서 빌드하고,
+# packages:write runner는 완성된 Docker archive를 읽어 발행만 한다.
+# GHCR package는 Public이어야 하며 별도 저장소 Secret이나 infra PAT는 사용하지 않는다.
+name: Publish Preview Image
+
+on:
+  pull_request_target:
+    branches:
+      - develop
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited, closed]
+
+# PR 종료·preview 제거도 같은 group을 취소한다. 다른 라벨 변경 때 preview가 남아 있으면
+# 새 빌드를 실행해 이전 실행만 취소되고 발행이 누락되는 일을 막는다.
+concurrency:
+  group: publish-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+# 명시적인 캐시 설정뿐 아니라 runtime token의 암묵적 캐시 읽기·쓰기도 차단한다.
+cache-mode: none
+
+env:
+  IMAGE: ghcr.io/umc-product/umc-product-server
+  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  build:
+    name: Validate and export trusted PR image
+    if: >-
+      github.repository == 'UMC-PRODUCT/umc-product-server' &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout exact trusted PR head
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-server
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK 21 without shared cache
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: corretto
+
+      - name: Validate and build boot JAR
+        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
+
+      - name: Export container without publishing
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: .
+          file: docker/app/dockerfile
+          push: false
+          platforms: linux/amd64
+          tags: local/umc-product-server:preview-${{ github.event.pull_request.head.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/UMC-PRODUCT/umc-product-server
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          outputs: type=docker,dest=${{ runner.temp }}/preview-image.tar
+
+      - name: Upload image archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-image-${{ github.run_id }}
+          path: ${{ runner.temp }}/preview-image.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  publish:
+    name: Publish immutable preview image
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # PR끼리뿐 아니라 main/develop 발행과도 같은 SHA 이미지 쓰기를 직렬화한다.
+    concurrency:
+      group: ghcr-image-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: false
+    permissions:
+      packages: write
+      pull-requests: read
+
+    steps:
+      # PR checkout·로컬 action·Gradle·Docker build/run을 이 job에 추가하지 않는다.
+      # tag와 archive 이름은 build의 output이나 archive metadata에서 받아오지 않는다.
+      - name: Resolve tag from trusted event
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "::error::Invalid PR head SHA."
+            exit 1
+          fi
+          echo "IMAGE_TAG=${HEAD_SHA:0:12}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
+
+      - name: Download this run's image archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: preview-image-${{ github.run_id }}
+          path: ${{ runner.temp }}/preview-image
+
+      - name: Load and inspect image without executing it
+        run: |
+          set -euo pipefail
+          docker load --input "${RUNNER_TEMP}/preview-image/preview-image.tar"
+          local_image="local/umc-product-server:preview-${HEAD_SHA}"
+          revision="$(docker image inspect "$local_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+          platform="$(docker image inspect "$local_image" --format '{{.Os}}/{{.Architecture}}')"
+          if [[ "$revision" != "$HEAD_SHA" || "$platform" != "linux/amd64" ]]; then
+            echo "::error::Archive does not match the expected PR head and platform."
+            exit 1
+          fi
+          docker tag "$local_image" "${IMAGE}:${IMAGE_TAG}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Recheck current PR before publishing
+        id: current
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'UMC-PRODUCT',
+              repo: 'umc-product-server',
+              pull_number: context.payload.pull_request.number,
+            });
+            const eligible =
+              pr.state === 'open' &&
+              pr.base.repo.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              pr.base.ref === 'develop' &&
+              pr.head.repo?.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.author_association) &&
+              pr.labels.some(label => label.name === 'preview') &&
+              pr.head.sha === context.payload.pull_request.head.sha;
+            core.setOutput('eligible', String(eligible));
+            if (!eligible) core.notice('PR is no longer eligible or its head changed; publishing skipped.');
+
+      - name: Publish only a missing immutable tag
+        if: steps.current.outputs.eligible == 'true'
+        run: |
+          set -euo pipefail
+          lookup_error="${RUNNER_TEMP}/preview-image-lookup.err"
+          if manifest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' 2>"$lookup_error")"; then
+            # 재실행은 이미 발행한 tag를 덮어쓰지 않는다.
+            registry_digest="$(jq -er '.digest' <<< "$manifest")"
+          else
+            # 인증·네트워크 오류를 tag 부재로 오인해 기존 이미지를 덮어쓰지 않는다.
+            lookup_message="$(<"$lookup_error")"
+            if [[ "$lookup_message" != *"${IMAGE}:${IMAGE_TAG}: not found"* ]]; then
+              echo "::error::Cannot establish whether the immutable tag exists."
+              exit 1
+            fi
+            docker push "${IMAGE}:${IMAGE_TAG}"
+            registry_digest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' | jq -er '.digest')"
+          fi
+          if [[ ! "$registry_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Registry returned an invalid image digest."
+            exit 1
+          fi
+          echo "IMAGE_DIGEST=$registry_digest" >> "$GITHUB_ENV"
+
+      - name: Verify public anonymous image pull
+        if: steps.current.outputs.eligible == 'true'
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          if ! anonymous_digest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest')"; then
+            echo "::error::GHCR package is not publicly pullable. Make the package Public, then rerun all jobs."
+            exit 1
+          fi
+          if [[ "$anonymous_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "::error::Anonymous GHCR lookup returned a different digest."
+            exit 1
+          fi
+          echo "Preview image ready: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"


### PR DESCRIPTION
## 변경 내용

- 신뢰된 same-repository `develop` 대상 PR에 `preview` 라벨이 있을 때 head 이미지를 빌드·발행합니다.
- PR 코드는 read-only 권한·cache-mode none의 별도 runner에서만 실행합니다. packages:write runner는 PR checkout/코드 실행 없이 Docker archive만 발행합니다.
- 이미지 발행과 익명 GHCR digest 조회 성공 이후에만 infra `main`의 `argocd/preview-releases/pr-<번호>.json`을 갱신합니다. 실패한 빌드는 성공 기록을 바꾸지 않습니다.
- infra PAT는 마지막 별도 job의 checkout에만 전달합니다. updater는 PR head가 아니라 이 실행을 정의한 `github.workflow_sha`에서 읽고, PR artifact를 받지 않습니다.
- marker의 PR/SHA/tag/digest exact schema, 대상 외 변경·symlink 차단, 선택 marker만 commit, 비강제 push를 적용합니다.
- 발행 직전과 infra push 직전에 PR open/base/head repository/작성자 관계/라벨/최신 SHA를 다시 확인하고, stale 실행은 push하지 않습니다.
- dev/prod/Preview infra writer와 같은 lock을 사용하고 `queue: max`로 대기 중 다른 배포가 취소되는 것을 방지합니다. 기존 dev/prod 이미지 발행 lock에도 동일한 대기열 보존 설정을 적용합니다.
- updater 단위 테스트 6개와 CI 실행 단계를 추가합니다. 애플리케이션 코드·환경 변수·DB migration 변경은 없습니다.

## 적용 순서와 주의

이 PR은 `develop` 대상입니다. `pull_request_target`은 기본 브랜치 `main`의 workflow를 사용하므로 **develop 병합만으로 Preview 발행이 시작되지 않습니다.** workflow와 `.github/scripts/update-preview-release.mjs`를 함께 main에도 정규 PR/승인 절차로 반영해야 합니다.

- `UMC_INFRA_GITOPS_TOKEN`은 infra main에 Contents write/push 가능한 기존 automation 자격증명이어야 합니다. GitHub 기본 token의 읽기 권한이나 Argo PR 읽기 token만으로는 부족합니다.
- 인프라 연동/고정 문서 인증: https://github.com/UMC-PRODUCT/umc-product-infra/pull/6 . AWS Preview docs Secret 및 IAM 준비가 선행되어야 합니다.
- 기존 main/develop push 배포는 유지되므로 각 브랜치 병합 시 dev/prod 이미지 발행과 GitOps 갱신이 실행될 수 있습니다.
- fork/외부 PR에는 preview 라벨을 붙이지 않습니다. 라벨 유지 후 새 commit도 자동 신뢰하므로 maintainer 검토가 필요합니다.
- 성공 기록 갱신 후 앱 기동/Flyway 실패는 이 workflow의 빌드 성공 보장과 별개이며, 인프라 Recreate 교체 중 무중단이나 DB rollback은 보장하지 않습니다.

## 검증

- `node --test .github/scripts/update-preview-release.test.mjs`: 6개 통과.
- 두 신규 JS 파일 `node --check`, YAML 3개 parse, workflow Bash run 18개 syntax, `git diff --check` 통과.
- 독립 읽기 전용 검토에서 새 P1/P2 문제 없음. 실제 Actions 실행·GHCR 발행·infra push 경로는 merge 후 smoke test 필요.
- 이 변경에서는 애플리케이션 코드가 없어 Gradle 전체 빌드는 로컬 재실행하지 않았습니다. PR CI에서 수행합니다.
- 현재 로컬 actionlint가 없어 재실행하지 않았습니다. 이전 v1.7.12 검사에서는 신규 공식 `cache-mode`를 인식하지 못했습니다. `cache-mode: none`과 `queue: max`는 현재 GitHub 공식 문서에 맞춘 설정입니다.
