### PR TITLE
[Release] v2.4.22

### DIFF
--- a/.github/scripts/update-preview-release.mjs
+++ b/.github/scripts/update-preview-release.mjs
@@ -1,0 +1,97 @@
+import { execFileSync } from "node:child_process";
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function hasExactKeys(value, keys) {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+        && Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+}
+
+export function validatePreviewRelease(document) {
+    if (!hasExactKeys(document, ["release"])
+        || !hasExactKeys(document.release, ["prNumber", "headSha", "imageTag", "imageDigest"])) {
+        throw new Error("Preview release schema has missing or unexpected fields");
+    }
+    const { prNumber, headSha, imageTag, imageDigest } = document.release;
+    if (typeof prNumber !== "string" || !/^[1-9][0-9]*$/.test(prNumber)
+        || !Number.isSafeInteger(Number(prNumber)) || prNumber !== String(Number(prNumber))) {
+        throw new Error("PR number must be a positive canonical integer string");
+    }
+    if (typeof headSha !== "string" || headSha.length !== 40 || !/^[a-f0-9]{40}$/.test(headSha)) {
+        throw new Error("PR head must be a full lowercase commit SHA");
+    }
+    if (typeof imageTag !== "string" || imageTag !== headSha.slice(0, 12)) {
+        throw new Error("Image tag must match the first 12 characters of the PR head");
+    }
+    if (typeof imageDigest !== "string" || imageDigest.length !== 71 || !/^sha256:[a-f0-9]{64}$/.test(imageDigest)) {
+        throw new Error("Image digest must be a lowercase sha256 digest");
+    }
+    return `argocd/preview-releases/pr-${prNumber}.json`;
+}
+
+function inspectPath(path, directory) {
+    const stat = lstatSync(path, { throwIfNoEntry: false });
+    if (stat && (stat.isSymbolicLink() || !(directory ? stat.isDirectory() : stat.isFile()))) {
+        throw new Error("Preview release paths must be regular directories and files, not symlinks");
+    }
+    return stat;
+}
+
+export function assertOnlyPreviewReleaseChanged(repository, markerPath) {
+    // untracked 파일도 포함한다. rename/copy/delete 및 대상 외 변경은 commit 전에 거부한다.
+    const status = execFileSync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+        cwd: repository,
+        encoding: "utf8",
+    });
+    for (const entry of status.split("\0").filter(Boolean)) {
+        if (!["??", " M", "M ", "A "].includes(entry.slice(0, 2)) || entry.slice(3) !== markerPath) {
+            throw new Error("Infrastructure has changes outside the selected Preview release");
+        }
+    }
+}
+
+export function updatePreviewRelease(repository, document) {
+    const markerPath = validatePreviewRelease(document);
+    const root = resolve(repository);
+    if (!inspectPath(root, true) || !inspectPath(resolve(root, "argocd"), true)) {
+        throw new Error("Expected an infrastructure checkout containing argocd");
+    }
+    const directory = resolve(root, "argocd/preview-releases");
+    inspectPath(directory, true);
+    const target = resolve(root, markerPath);
+    const exists = inspectPath(target, false);
+    assertOnlyPreviewReleaseChanged(root, markerPath);
+
+    let previous = null;
+    if (exists) {
+        previous = readFileSync(target, "utf8");
+        const previousPath = validatePreviewRelease(JSON.parse(previous));
+        if (previousPath !== markerPath) {
+            throw new Error("Existing release PR number does not match its filename");
+        }
+    }
+    const updated = `${JSON.stringify(document, null, 2)}\n`;
+    if (previous === updated) {
+        return { markerPath, changed: false };
+    }
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(target, updated, "utf8");
+    assertOnlyPreviewReleaseChanged(root, markerPath);
+    return { markerPath, changed: true };
+}
+
+function main() {
+    const [repository, prNumber, headSha, imageTag, imageDigest, ...extra] = process.argv.slice(2);
+    if (!repository || extra.length) {
+        throw new Error("usage: update-preview-release.mjs <infra-checkout> <pr-number> <head-sha> <tag> <digest>");
+    }
+    const result = updatePreviewRelease(repository, {
+        release: { prNumber, headSha, imageTag, imageDigest },
+    });
+    console.log(`${result.markerPath}: ${result.changed ? "updated" : "unchanged"}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/.github/scripts/update-preview-release.test.mjs
+++ b/.github/scripts/update-preview-release.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { assertOnlyPreviewReleaseChanged, updatePreviewRelease, validatePreviewRelease } from "./update-preview-release.mjs";
+
+const headSha = `123456789012${"a".repeat(28)}`;
+const release = () => ({
+    release: { prNumber: "42", headSha, imageTag: headSha.slice(0, 12), imageDigest: `sha256:${"a".repeat(64)}` },
+});
+
+function repository(t) {
+    const root = mkdtempSync(join(tmpdir(), "umc-preview-release-test-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    mkdirSync(join(root, "argocd"));
+    writeFileSync(join(root, "argocd/.gitkeep"), "");
+    execFileSync("git", ["init", "--quiet"], { cwd: root });
+    execFileSync("git", ["add", "argocd/.gitkeep"], { cwd: root });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "initial"], { cwd: root });
+    return root;
+}
+
+test("성공 이미지 marker만 생성하고 같은 입력을 재실행하면 변경하지 않는다", (t) => {
+    const root = repository(t);
+    const document = release();
+    const first = updatePreviewRelease(root, document);
+    assert.deepEqual(first, { markerPath: "argocd/preview-releases/pr-42.json", changed: true });
+    assert.deepEqual(JSON.parse(readFileSync(join(root, first.markerPath), "utf8")), document);
+    assert.equal(typeof document.release.imageTag, "string");
+    assert.deepEqual(updatePreviewRelease(root, document), { ...first, changed: false });
+});
+
+test("후속 성공 이미지의 SHA와 digest를 같은 PR marker에만 갱신한다", (t) => {
+    const root = repository(t);
+    const first = updatePreviewRelease(root, release());
+    execFileSync("git", ["add", first.markerPath], { cwd: root });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "release"], { cwd: root });
+    const next = release();
+    next.release.headSha = "b".repeat(40);
+    next.release.imageTag = "b".repeat(12);
+    next.release.imageDigest = `sha256:${"c".repeat(64)}`;
+    assert.equal(updatePreviewRelease(root, next).changed, true);
+    assert.deepEqual(JSON.parse(readFileSync(join(root, first.markerPath), "utf8")), next);
+    assertOnlyPreviewReleaseChanged(root, first.markerPath);
+});
+
+test("변형된 PR 번호·SHA·tag·digest와 추가 필드는 거부한다", () => {
+    for (const prNumber of [42, "0", "-1", "042", "../prod", "42\n", "9007199254740992"]) {
+        assert.throws(() => validatePreviewRelease({ release: { ...release().release, prNumber } }));
+    }
+    for (const patch of [
+        { headSha: "a".repeat(39) }, { headSha: "A".repeat(40) },
+        { headSha: `${headSha}\n` },
+        { imageTag: 123456789012 }, { imageTag: "b".repeat(12) },
+        { imageDigest: "sha256:bad" }, { imageDigest: `sha256:${"A".repeat(64)}` },
+        { imageDigest: `sha256:${"a".repeat(64)}\n` },
+        { file: "values-prod.yaml" },
+    ]) {
+        assert.throws(() => validatePreviewRelease({ release: { ...release().release, ...patch } }));
+    }
+    assert.throws(() => validatePreviewRelease({ ...release(), extra: true }));
+    assert.throws(() => validatePreviewRelease({ release: null }));
+    assert.throws(() => validatePreviewRelease({ release: [] }));
+    const missing = release();
+    delete missing.release.imageDigest;
+    assert.throws(() => validatePreviewRelease(missing));
+});
+
+test("다른 파일이 변경되어 있으면 marker를 쓰기 전에 중단한다", (t) => {
+    const root = repository(t);
+    writeFileSync(join(root, "unexpected.txt"), "do not commit");
+    assert.throws(() => updatePreviewRelease(root, release()), /outside the selected Preview release/);
+    assert.throws(() => readFileSync(join(root, "argocd/preview-releases/pr-42.json")), { code: "ENOENT" });
+});
+
+test("기존 marker의 PR 번호가 파일명과 다르거나 추가 필드가 있으면 덮어쓰지 않는다", (t) => {
+    const root = repository(t);
+    const { markerPath } = updatePreviewRelease(root, release());
+    for (const document of [
+        { release: { ...release().release, prNumber: "43" } },
+        { ...release(), unexpected: "field" },
+    ]) {
+        const content = JSON.stringify(document);
+        writeFileSync(join(root, markerPath), content);
+        assert.throws(() => updatePreviewRelease(root, release()));
+        assert.equal(readFileSync(join(root, markerPath), "utf8"), content);
+    }
+});
+
+test("marker 파일이나 상위 디렉터리가 symlink이면 따라가지 않는다", (t) => {
+    for (const directoryLink of [false, true]) {
+        const root = repository(t);
+        const outside = mkdtempSync(join(tmpdir(), "umc-preview-outside-test-"));
+        t.after(() => rmSync(outside, { recursive: true, force: true }));
+        const parent = join(root, "argocd/preview-releases");
+        if (directoryLink) {
+            symlinkSync(outside, parent);
+        } else {
+            mkdirSync(parent);
+            const externalFile = join(outside, "target.json");
+            writeFileSync(externalFile, JSON.stringify(release()));
+            symlinkSync(externalFile, join(parent, "pr-42.json"));
+        }
+        assert.throws(() => updatePreviewRelease(root, release()), /not symlinks/);
+    }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: corretto
           cache: gradle
 
+      - name: Validate Preview release updater
+        run: node --test .github/scripts/update-preview-release.test.mjs
+
       - name: Validate and build boot JAR
         run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
 

--- a/.github/workflows/publish-gitops.yml
+++ b/.github/workflows/publish-gitops.yml
@@ -2,7 +2,7 @@
 # - UMC_INFRA_GITOPS_TOKEN: UMC-PRODUCT/umc-product-infra만 대상으로 하고
 #   Contents 읽기/쓰기 권한만 부여한 fine-grained PAT
 # 최초 GHCR package는 조직 관리자가 Public으로 전환해야 한다.
-# Preview는 PR 코드에 쓰기 token을 노출하지 않도록 빌드와 발행 단계를 분리하기 전까지 비활성화한다.
+# Preview는 publish-preview.yml에서 읽기 권한의 PR 빌드와 쓰기 권한의 이미지 발행을 분리한다.
 
 name: Publish GitOps Image
 
@@ -33,6 +33,11 @@ jobs:
     name: Build and publish immutable image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Preview 발행과 같은 SHA tag를 동시에 쓰지 않는다. 환경별 배포 순서는 상위에서 유지한다.
+    concurrency:
+      group: ghcr-image-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     outputs:
       deploy_environment: ${{ steps.metadata.outputs.deploy_environment }}
       values_file: ${{ steps.metadata.outputs.values_file }}
@@ -185,10 +190,11 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # dev/prod publish가 동시에 infra main을 갱신해 push 경합을 만들지 않게 직렬화한다.
+    # dev/prod/Preview의 infra 갱신을 직렬화하고 대기 중인 다른 배포를 취소하지 않는다.
     concurrency:
       group: umc-product-infra-main-update
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,318 @@
+# 기본 브랜치의 workflow만 신뢰한다. PR 코드는 읽기 권한의 별도 runner에서 빌드하고,
+# packages:write runner는 완성된 Docker archive를 읽어 발행만 한다.
+# GHCR package는 Public이어야 한다. infra PAT는 마지막 GitOps 갱신 job에만 전달하고,
+# 이미지 발행과 익명 pull 검증에 성공한 SHA·digest만 Argo에 전달한다.
+name: Publish Preview Image
+
+on:
+  pull_request_target:
+    branches:
+      - develop
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited, closed]
+
+# PR 종료·preview 제거도 같은 group을 취소한다. 다른 라벨 변경 때 preview가 남아 있으면
+# 새 빌드를 실행해 이전 실행만 취소되고 발행이 누락되는 일을 막는다.
+concurrency:
+  group: publish-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+# 명시적인 캐시 설정뿐 아니라 runtime token의 암묵적 캐시 읽기·쓰기도 차단한다.
+cache-mode: none
+
+env:
+  IMAGE: ghcr.io/umc-product/umc-product-server
+  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  build:
+    name: Validate and export trusted PR image
+    if: >-
+      github.repository == 'UMC-PRODUCT/umc-product-server' &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout exact trusted PR head
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-server
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK 21 without shared cache
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: corretto
+
+      - name: Validate and build boot JAR
+        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
+
+      - name: Export container without publishing
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: .
+          file: docker/app/dockerfile
+          push: false
+          platforms: linux/amd64
+          tags: local/umc-product-server:preview-${{ github.event.pull_request.head.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/UMC-PRODUCT/umc-product-server
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          outputs: type=docker,dest=${{ runner.temp }}/preview-image.tar
+
+      - name: Upload image archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-image-${{ github.run_id }}
+          path: ${{ runner.temp }}/preview-image.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  publish:
+    name: Publish immutable preview image
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # PR끼리뿐 아니라 main/develop 발행과도 같은 SHA 이미지 쓰기를 직렬화한다.
+    concurrency:
+      group: ghcr-image-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: false
+      queue: max
+    permissions:
+      packages: write
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.ready.outputs.eligible }}
+      head_sha: ${{ steps.ready.outputs.head_sha }}
+      image_tag: ${{ steps.ready.outputs.image_tag }}
+      image_digest: ${{ steps.ready.outputs.image_digest }}
+
+    steps:
+      # PR checkout·로컬 action·Gradle·Docker build/run을 이 job에 추가하지 않는다.
+      # tag와 archive 이름은 build의 output이나 archive metadata에서 받아오지 않는다.
+      - name: Resolve tag from trusted event
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "::error::Invalid PR head SHA."
+            exit 1
+          fi
+          echo "IMAGE_TAG=${HEAD_SHA:0:12}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
+
+      - name: Download this run's image archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: preview-image-${{ github.run_id }}
+          path: ${{ runner.temp }}/preview-image
+
+      - name: Load and inspect image without executing it
+        run: |
+          set -euo pipefail
+          docker load --input "${RUNNER_TEMP}/preview-image/preview-image.tar"
+          local_image="local/umc-product-server:preview-${HEAD_SHA}"
+          revision="$(docker image inspect "$local_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+          platform="$(docker image inspect "$local_image" --format '{{.Os}}/{{.Architecture}}')"
+          if [[ "$revision" != "$HEAD_SHA" || "$platform" != "linux/amd64" ]]; then
+            echo "::error::Archive does not match the expected PR head and platform."
+            exit 1
+          fi
+          docker tag "$local_image" "${IMAGE}:${IMAGE_TAG}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Recheck current PR before publishing
+        id: current
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'UMC-PRODUCT',
+              repo: 'umc-product-server',
+              pull_number: context.payload.pull_request.number,
+            });
+            const eligible =
+              pr.state === 'open' &&
+              pr.base.repo.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              pr.base.ref === 'develop' &&
+              pr.head.repo?.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.author_association) &&
+              pr.labels.some(label => label.name === 'preview') &&
+              pr.head.sha === context.payload.pull_request.head.sha;
+            core.setOutput('eligible', String(eligible));
+            if (!eligible) core.notice('PR is no longer eligible or its head changed; publishing skipped.');
+
+      - name: Publish only a missing immutable tag
+        if: steps.current.outputs.eligible == 'true'
+        run: |
+          set -euo pipefail
+          lookup_error="${RUNNER_TEMP}/preview-image-lookup.err"
+          if manifest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' 2>"$lookup_error")"; then
+            # 재실행은 이미 발행한 tag를 덮어쓰지 않는다.
+            registry_digest="$(jq -er '.digest' <<< "$manifest")"
+          else
+            # 인증·네트워크 오류를 tag 부재로 오인해 기존 이미지를 덮어쓰지 않는다.
+            lookup_message="$(<"$lookup_error")"
+            if [[ "$lookup_message" != *"${IMAGE}:${IMAGE_TAG}: not found"* ]]; then
+              echo "::error::Cannot establish whether the immutable tag exists."
+              exit 1
+            fi
+            docker push "${IMAGE}:${IMAGE_TAG}"
+            registry_digest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' | jq -er '.digest')"
+          fi
+          if [[ ! "$registry_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Registry returned an invalid image digest."
+            exit 1
+          fi
+          echo "IMAGE_DIGEST=$registry_digest" >> "$GITHUB_ENV"
+
+      - name: Verify public anonymous image pull
+        id: ready
+        if: steps.current.outputs.eligible == 'true'
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          if ! anonymous_digest="$(docker buildx imagetools inspect "${IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest}}' 2>/dev/null | jq -er '.digest')"; then
+            echo "::error::GHCR package is not publicly pullable. Make the package Public, then rerun all jobs."
+            exit 1
+          fi
+          if [[ "$anonymous_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "::error::Anonymous GHCR lookup returned a different digest."
+            exit 1
+          fi
+          echo "Preview image ready: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
+  update-infra:
+    name: Promote ready Preview image in infrastructure
+    needs: publish
+    if: needs.publish.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # dev/prod의 infra main 갱신과 같은 lock을 사용한다. force push는 하지 않는다.
+    concurrency:
+      group: umc-product-infra-main-update
+      cancel-in-progress: false
+      queue: max
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      # PR head의 script/action은 절대 실행하지 않는다. 이 실행을 정의한 기본 브랜치
+      # workflow의 정확한 commit에서 updater만 읽는다. PR artifact도 이 job에 전달하지 않는다.
+      - name: Checkout trusted default-branch automation
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-server
+          ref: ${{ github.workflow_sha }}
+          path: backend
+          persist-credentials: false
+
+      - name: Checkout infrastructure main
+        uses: actions/checkout@v4
+        with:
+          repository: UMC-PRODUCT/umc-product-infra
+          ref: main
+          token: ${{ secrets.UMC_INFRA_GITOPS_TOKEN }}
+          path: infra
+
+      - name: Record the successfully published immutable release
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_HEAD_SHA: ${{ needs.publish.outputs.head_sha }}
+          READY_IMAGE_TAG: ${{ needs.publish.outputs.image_tag }}
+          READY_IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          git -C infra pull --ff-only origin main
+          node backend/.github/scripts/update-preview-release.mjs \
+            infra "$PR_NUMBER" "$READY_HEAD_SHA" "$READY_IMAGE_TAG" "$READY_IMAGE_DIGEST"
+
+      - name: Commit only the selected Preview release
+        id: commit
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_IMAGE_TAG: ${{ needs.publish.outputs.image_tag }}
+        working-directory: infra
+        run: |
+          set -euo pipefail
+          marker="argocd/preview-releases/pr-${PR_NUMBER}.json"
+          git add -- "$marker"
+          changed_files="$(git diff --cached --name-only)"
+          if [[ -z "$changed_files" ]]; then
+            echo "Preview already references this successfully published image."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$changed_files" != "$marker" ]]; then
+            echo "::error::Automation staged a file outside the selected Preview release."
+            exit 1
+          fi
+          git diff --cached --check
+          git config user.name "umc-product-deploy-bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(preview): deploy PR ${PR_NUMBER} ${READY_IMAGE_TAG}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Recheck current PR immediately before infrastructure push
+        if: steps.commit.outputs.changed == 'true'
+        id: current
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          READY_HEAD_SHA: ${{ needs.publish.outputs.head_sha }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'UMC-PRODUCT',
+              repo: 'umc-product-server',
+              pull_number: context.payload.pull_request.number,
+            });
+            const eligible =
+              pr.state === 'open' &&
+              pr.base.repo.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              pr.base.ref === 'develop' &&
+              pr.head.repo?.full_name === 'UMC-PRODUCT/umc-product-server' &&
+              ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.author_association) &&
+              pr.labels.some(label => label.name === 'preview') &&
+              pr.head.sha === process.env.READY_HEAD_SHA &&
+              pr.head.sha === context.payload.pull_request.head.sha;
+            core.setOutput('eligible', String(eligible));
+            if (!eligible) core.notice('PR closed, label removed, or head changed; infrastructure push skipped.');
+
+      - name: Push ready release without overwriting concurrent changes
+        if: steps.commit.outputs.changed == 'true' && steps.current.outputs.eligible == 'true'
+        working-directory: infra
+        run: git push origin HEAD:main

--- a/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
+++ b/src/main/java/com/umc/product/authentication/application/service/AuthenticationService.java
@@ -137,10 +137,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
         // 메일 폭주 위험이 없으므로 throttle 대상이 아니다.
         if (shouldSendEmail) {
             loadEmailVerificationPort.findLatestSentByEmail(email)
-                .filter(EmailVerification::isSendThrottled)
-                .ifPresent(latest -> {
-                    throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-                });
+                .ifPresent(EmailVerification::validateSendInterval);
         }
 
         String code = generateRandomCode();
@@ -168,9 +165,7 @@ public class AuthenticationService implements ManageAuthenticationUseCase {
     public void resendEmailVerification(Long sessionId) {
         EmailVerification emailVerification = loadEmailVerificationPort.getById(sessionId);
 
-        if (emailVerification.isSendThrottled()) {
-            throw new AuthenticationDomainException(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
-        }
+        emailVerification.validateSendInterval();
 
         String newCode = generateRandomCode();
         String newToken = UUID.randomUUID().toString();

--- a/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
+++ b/src/main/java/com/umc/product/authentication/domain/EmailVerification.java
@@ -1,9 +1,11 @@
 package com.umc.product.authentication.domain;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import com.umc.product.authentication.domain.exception.AuthenticationDomainException;
 import com.umc.product.authentication.domain.exception.AuthenticationErrorCode;
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.common.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -38,7 +40,7 @@ public class EmailVerification extends BaseEntity {
     /**
      * 같은 이메일 / 같은 세션에 대한 연속 발송 간 최소 간격(초). 메일 폭주 방어.
      */
-    public static final long MIN_SEND_INTERVAL_SECONDS = 60;
+    public static final long MIN_SEND_INTERVAL_SECONDS = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -87,7 +89,7 @@ public class EmailVerification extends BaseEntity {
     private int attemptCount;
 
     /**
-     * 마지막으로 메일을 실제로 발송한 시각. throttle 검사에 사용한다.
+     * 마지막 메일 발송 요청을 접수한 시각. 실제 발송 성공 여부와 관계없이 throttle 검사에 사용한다.
      * silent skip (예: PASSWORD_RESET 미가입) 인 경우에는 갱신하지 않는다.
      */
     @Column(name = "last_sent_at")
@@ -110,18 +112,35 @@ public class EmailVerification extends BaseEntity {
     }
 
     /**
-     * 마지막 실제 발송 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
-     * lastSentAt 이 null 이면 (아직 실제로 발송된 적이 없음) 즉시 발송 가능하다.
+     * 마지막 발송 요청 접수 시각으로부터 MIN_SEND_INTERVAL_SECONDS 가 지나지 않았다면 throttle 위반.
+     * lastSentAt 이 null 이면 즉시 발송 요청을 접수할 수 있다.
      */
     public boolean isSendThrottled() {
-        if (this.lastSentAt == null) {
-            return false;
+        return remainingSendIntervalSeconds() > 0;
+    }
+
+    public void validateSendInterval() {
+        long remainingSeconds = remainingSendIntervalSeconds();
+        if (remainingSeconds > 0) {
+            throw new EmailVerificationThrottledException(remainingSeconds);
         }
-        return Instant.now().isBefore(this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+    }
+
+    private long remainingSendIntervalSeconds() {
+        if (this.lastSentAt == null) {
+            return 0;
+        }
+        Duration remaining = Duration.between(
+            Instant.now(), this.lastSentAt.plusSeconds(MIN_SEND_INTERVAL_SECONDS));
+        if (remaining.isNegative() || remaining.isZero()) {
+            return 0;
+        }
+        // 초 단위 응답을 내림하면 제한이 풀리기 전에 다시 요청하게 되므로 올림한다.
+        return remaining.getSeconds() + (remaining.getNano() > 0 ? 1 : 0);
     }
 
     /**
-     * 실제 메일 발송이 트리거된 시점을 기록한다. AFTER_COMMIT 이벤트 발행 직전에 호출된다.
+     * 발송 요청 접수 시점을 기록한다. 거절된 요청과 비동기 발송 결과는 이 시각을 변경하지 않는다.
      */
     public void markSent() {
         this.lastSentAt = Instant.now();

--- a/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
+++ b/src/main/java/com/umc/product/authentication/domain/exception/EmailVerificationThrottledException.java
@@ -1,0 +1,14 @@
+package com.umc.product.authentication.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationThrottledException extends AuthenticationDomainException {
+
+    private final long retryAfterSeconds;
+
+    public EmailVerificationThrottledException(long retryAfterSeconds) {
+        super(AuthenticationErrorCode.EMAIL_VERIFICATION_THROTTLED);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/umc/product/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/product/global/config/SecurityConfig.java
@@ -193,8 +193,8 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
-        // Trace ID 헤더를 클라이언트에서 읽을 수 있도록 노출
-        configuration.setExposedHeaders(List.of("X-Trace-Id"));
+        // Trace ID와 재요청 대기 시간을 클라이언트에서 읽을 수 있도록 노출
+        configuration.setExposedHeaders(List.of("X-Trace-Id", "Retry-After"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/product/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.umc.product.authentication.domain.exception.EmailVerificationThrottledException;
 import com.umc.product.form.domain.FormResponse;
 import com.umc.product.form.domain.exception.DraftSchemaMismatchException;
 import com.umc.product.form.domain.exception.FormErrorCode;
@@ -240,10 +241,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             e.getMessage(), e);
 
         ApiResponse<Object> body = BusinessExceptionResponseResolver.toApiResponse(e);
+        HttpHeaders headers = HttpHeaders.EMPTY;
+        if (e instanceof EmailVerificationThrottledException throttled) {
+            headers = new HttpHeaders();
+            headers.set(HttpHeaders.RETRY_AFTER, Long.toString(throttled.getRetryAfterSeconds()));
+        }
         return super.handleExceptionInternal(
             e,
             body,
-            HttpHeaders.EMPTY,
+            headers,
             e.getBaseCode().getHttpStatus(),
             request
         );

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpEmailAdapter.java
@@ -1,8 +1,12 @@
 package com.umc.product.notification.adapter.out.external.smtp;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -14,21 +18,34 @@ import com.umc.product.notification.application.port.out.dto.EmailMessage;
 import com.umc.product.notification.domain.exception.EmailDomainException;
 import com.umc.product.notification.domain.exception.EmailErrorCode;
 
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @ConditionalOnProperty(prefix = "app.notification.email", name = "provider", havingValue = "smtp")
-@RequiredArgsConstructor
 public class SmtpEmailAdapter implements SendEmailPort {
 
     private final JavaMailSender mailSender;
+    private final Tracer tracer;
+
+    @Autowired
+    public SmtpEmailAdapter(JavaMailSender mailSender, ObjectProvider<Tracer> tracerProvider) {
+        this.mailSender = mailSender;
+        this.tracer = tracerProvider.getIfAvailable(() -> Tracer.NOOP);
+    }
+
+    public SmtpEmailAdapter(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+        this.tracer = Tracer.NOOP;
+    }
 
     @Override
     public void send(EmailMessage message) {
+        long startNanos = System.nanoTime();
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
@@ -38,9 +55,33 @@ public class SmtpEmailAdapter implements SendEmailPort {
             helper.setText(message.htmlBody(), true);
             ExternalApiCallLogger.measure("SMTP", "SEND_EMAIL", () -> mailSender.send(mimeMessage));
         } catch (MessagingException | UnsupportedEncodingException | RuntimeException e) {
-            // SMTP 예외에는 수신 주소와 서버 응답이 포함될 수 있어 원문이나 cause를 상위 로그로 전달하지 않는다.
-            log.warn("SMTP 이메일 발송 실패: errorClass={}", e.getClass().getSimpleName());
+            recordFailure(e, (System.nanoTime() - startNanos) / 1_000_000L);
+            // 수신 주소·인증코드를 포함할 수 있는 원문과 cause는 외부 응답이나 상위 예외에 전달하지 않는다.
             throw new EmailDomainException(EmailErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private void recordFailure(Exception error, long durationMs) {
+        SmtpFailureDetails details = SmtpFailureDetails.from(error);
+        log.warn("SMTP 이메일 발송 실패: {} {} {} {} {} {} {} {} {} {} {}",
+            kv("event", "email_send_failed"), kv("provider", "SMTP"), kv("operation", "SEND_EMAIL"),
+            kv("result", "FAILURE"), kv("errorClass", error.getClass().getSimpleName()),
+            kv("errorReason", details.errorReason()), kv("causeErrorClass", details.causeErrorClass()),
+            kv("failureStage", details.failureStage()), kv("smtpResponseCode", details.smtpResponseCode()),
+            kv("smtpEnhancedStatusCode", details.smtpEnhancedStatusCode()), kv("durationMs", durationMs));
+
+        Span span = tracer.currentSpan();
+        if (span != null) {
+            span.tag("email.provider", "SMTP");
+            span.tag("email.error.reason", details.errorReason());
+            span.tag("email.error.cause_class", details.causeErrorClass());
+            span.tag("email.error.stage", details.failureStage());
+            if (details.smtpResponseCode() != null) {
+                span.tag("email.smtp.response_code", details.smtpResponseCode().toString());
+            }
+            if (details.smtpEnhancedStatusCode() != null) {
+                span.tag("email.smtp.enhanced_status_code", details.smtpEnhancedStatusCode());
+            }
         }
     }
 }

--- a/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpFailureDetails.java
+++ b/src/main/java/com/umc/product/notification/adapter/out/external/smtp/SmtpFailureDetails.java
@@ -1,0 +1,177 @@
+package com.umc.product.notification.adapter.out.external.smtp;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+
+import org.eclipse.angus.mail.smtp.SMTPAddressFailedException;
+import org.eclipse.angus.mail.smtp.SMTPSendFailedException;
+import org.eclipse.angus.mail.util.MailConnectException;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
+
+import jakarta.mail.AuthenticationFailedException;
+import jakarta.mail.MessagingException;
+
+/** SMTP 예외에서 원문과 주소를 보존하지 않고 진단에 필요한 분류와 숫자 코드만 추출한다. */
+record SmtpFailureDetails(
+    String errorReason,
+    String causeErrorClass,
+    String failureStage,
+    Integer smtpResponseCode,
+    String smtpEnhancedStatusCode
+) {
+
+    private static final int MAX_CAUSES = 32;
+    private static final Pattern SMTP_REPLY = Pattern.compile(
+        "\\A([45][0-9]{2})(?:[ -]([245]\\.[0-9]{1,3}\\.[0-9]{1,3})(?=\\s|$))?(?=\\s|-|$)"
+    );
+
+    static SmtpFailureDetails from(Exception exception) {
+        List<Cause> causes = causes(exception);
+        Cause selected = causes.getFirst();
+        String reason = "UNKNOWN";
+        for (Cause cause : causes) {
+            String candidateReason = reason(cause.exception());
+            if (priority(candidateReason) >= priority(reason)) {
+                selected = cause;
+                reason = candidateReason;
+            }
+        }
+
+        String failureStage = "UNKNOWN";
+        Integer responseCode = null;
+        String enhancedStatusCode = null;
+        boolean typedResponseCode = false;
+        // 다른 메일의 실패나 연결 종료 예외를 선택한 원인의 단계/응답 코드와 섞지 않는다.
+        for (Cause path = selected; path != null; path = path.parent()) {
+            Throwable cause = path.exception();
+            if ("UNKNOWN".equals(failureStage)) {
+                failureStage = stage(cause);
+            }
+
+            Integer typedCode = responseCode(cause);
+            if (typedCode != null && !typedResponseCode) {
+                responseCode = typedCode;
+                enhancedStatusCode = null;
+                typedResponseCode = true;
+            }
+            Matcher reply = reply(cause);
+            if (reply != null) {
+                int parsedCode = Integer.parseInt(reply.group(1));
+                if (responseCode == null) {
+                    responseCode = parsedCode;
+                    enhancedStatusCode = reply.group(2);
+                } else if (responseCode == parsedCode && enhancedStatusCode == null) {
+                    enhancedStatusCode = reply.group(2);
+                }
+            }
+        }
+
+        return new SmtpFailureDetails(reason, selected.exception().getClass().getSimpleName(),
+            failureStage, responseCode, enhancedStatusCode);
+    }
+
+    private static List<Cause> causes(Throwable exception) {
+        List<Cause> causes = new ArrayList<>();
+        Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        addCause(exception, null, causes, visited);
+        for (int index = 0; index < causes.size(); index++) {
+            Cause parent = causes.get(index);
+            Throwable cause = parent.exception();
+            addCause(cause.getCause(), parent, causes, visited);
+            if (cause instanceof MessagingException messagingException) {
+                addCause(messagingException.getNextException(), parent, causes, visited);
+            }
+            if (cause instanceof MailSendException mailSendException) {
+                for (Exception messageException : mailSendException.getMessageExceptions()) {
+                    addCause(messageException, parent, causes, visited);
+                    if (causes.size() == MAX_CAUSES) {
+                        break;
+                    }
+                }
+            }
+        }
+        return causes;
+    }
+
+    private static void addCause(Throwable cause, Cause parent, List<Cause> causes, Set<Throwable> visited) {
+        if (cause != null && causes.size() < MAX_CAUSES && visited.add(cause)) {
+            causes.add(new Cause(cause, parent));
+        }
+    }
+
+    private static String reason(Throwable cause) {
+        if (cause instanceof SSLException) {
+            return "TLS_FAILED";
+        }
+        if (cause instanceof UnknownHostException) {
+            return "DNS_FAILED";
+        }
+        if (cause instanceof SocketTimeoutException) {
+            return "TIMEOUT";
+        }
+        if (cause instanceof ConnectException || cause instanceof MailConnectException) {
+            return "CONNECTION_FAILED";
+        }
+        if (cause instanceof MailAuthenticationException || cause instanceof AuthenticationFailedException) {
+            return "AUTHENTICATION_FAILED";
+        }
+        return responseCode(cause) != null || reply(cause) != null ? "SMTP_REJECTED" : "UNKNOWN";
+    }
+
+    private static int priority(String reason) {
+        return switch (reason) {
+            case "TLS_FAILED", "DNS_FAILED", "TIMEOUT" -> 3;
+            case "CONNECTION_FAILED", "AUTHENTICATION_FAILED" -> 2;
+            case "SMTP_REJECTED" -> 1;
+            default -> 0;
+        };
+    }
+
+    private static String stage(Throwable cause) {
+        if (cause instanceof SSLHandshakeException) {
+            return "TLS_HANDSHAKE";
+        }
+        if (cause instanceof ConnectException || cause instanceof MailConnectException) {
+            return "CONNECT";
+        }
+        if (cause instanceof MailAuthenticationException || cause instanceof AuthenticationFailedException) {
+            return "AUTHENTICATE";
+        }
+        return responseCode(cause) != null ? "SMTP_COMMAND" : "UNKNOWN";
+    }
+
+    private static Integer responseCode(Throwable cause) {
+        int code = switch (cause) {
+            case SMTPSendFailedException smtp -> smtp.getReturnCode();
+            case SMTPAddressFailedException smtp -> smtp.getReturnCode();
+            default -> -1;
+        };
+        return code >= 400 && code <= 599 ? code : null;
+    }
+
+    private static Matcher reply(Throwable cause) {
+        if (cause instanceof MessagingException || cause instanceof MailAuthenticationException) {
+            String message = cause.getMessage();
+            if (message != null) {
+                Matcher reply = SMTP_REPLY.matcher(message);
+                return reply.find() ? reply : null;
+            }
+        }
+        return null;
+    }
+
+    private record Cause(Throwable exception, Cause parent) {
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용

`develop` → `main` 릴리스 PR입니다. 버전은 **v2.4.22**입니다.

### 이메일 인증·SMTP 진단 개선 — #1327

- 이메일 인증 발송·재전송 대기 시간을 60초에서 30초로 조정합니다.
- 제한된 요청은 기존 `429 / AUTHENTICATION-0027` 응답과 함께 `Retry-After` 헤더로 남은 대기 시간을 전달하고, 브라우저에서도 읽을 수 있도록 CORS에 노출합니다.
- 대기 시간은 발송 요청 접수 시점을 기준으로 하며, 거절된 재요청은 대기 시간을 연장하지 않습니다. SMTP 실패 시에도 재요청 제한은 유지합니다.
- SMTP 실패 원인을 `email_send_failed` 로그와 trace span에서 분류·확인할 수 있도록 개선합니다. 새 진단 필드에는 수신 주소·인증 코드·비밀번호·메일 본문·예외 원문을 기록하지 않습니다.
- 메일 공급자를 바꾸거나 실제 수신 지연을 해결하는 변경은 아닙니다.

### 신뢰된 PR Preview 이미지 발행 — #1329

- 검토된 내부 `develop` 대상 PR에 `preview` 라벨이 있을 때 이미지를 빌드·발행합니다.
- PR 코드 빌드, 이미지 발행, infra 갱신을 권한이 분리된 job에서 처리합니다.
- 이미지 발행·익명 GHCR digest 조회에 성공한 버전만 infra의 PR별 성공 기록에 반영합니다. 빌드·발행 실패와 오래된 실행은 기존 성공 기록을 바꾸지 않습니다.
- dev/prod/Preview 이미지 및 infra 갱신의 공통 잠금·대기열을 적용합니다.
- 성공 기록 갱신 스크립트의 단위 테스트와 CI 단계를 추가합니다.

## 💬 리뷰 중점사항

- 이번 main 병합으로 `pull_request_target` Preview workflow가 기본 브랜치에 반영됩니다. infra 연동은 [인프라 PR #6](https://github.com/UMC-PRODUCT/umc-product-infra/pull/6), `UMC_INFRA_GITOPS_TOKEN` 쓰기 권한, Preview 문서용 AWS Secret/IAM 준비가 별도로 필요합니다.
- Preview의 빌드·발행 실패 시 기존 이미지 유지와 앱 기동/Flyway 실패 시 무중단·DB 복구는 별개입니다. 후자는 이번 릴리스에서 해결됐다고 간주하지 않습니다.
- 기존 main push 배포가 실행되므로 병합 후 prod 이미지 발행, infra 갱신, Argo 상태와 실제 API 동작을 확인해야 합니다.
- 비교 시점 기준 develop의 미반영 커밋 2개, 변경 파일 12개이며 DB migration 파일 변경은 없습니다.
- 이 PR 생성 작업에서는 애플리케이션 버전 파일, Git tag, GitHub Release를 별도로 변경·생성하지 않았습니다.

## ✅ 검증 및 배포 확인

- #1327 CI 통과: [Product Team Server CI](https://github.com/UMC-PRODUCT/umc-product-server/actions/runs/34683860018)
- #1329 CI 통과: [Product Team Server CI](https://github.com/UMC-PRODUCT/umc-product-server/actions/runs/34686887303)
- 릴리스 PR 자체의 CI·merge 가능 여부는 이 PR에서 별도로 확인합니다. 이번 PR 작성 과정에서 로컬 전체 테스트를 재실행하지 않았습니다.
- [ ] 이메일 인증 요청 및 30초 이내 재요청의 `429`·`Retry-After` 확인
- [ ] 정상 메일 발송과 SMTP 실패 진단 필드 확인
- [ ] 병합 후 prod 이미지·infra main·Argo 동기화 및 readiness 확인
- [ ] Preview 선행 조건 준비 후 내부 테스트 PR의 성공 기록·생성·삭제 확인
