### PR TITLE
[Fix] 회원가입 닉네임을 한글 6자까지 허용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number }}
@@ -38,15 +37,7 @@ jobs:
         run: node --test .github/scripts/update-preview-release.test.mjs
 
       - name: Validate and build boot JAR
-        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava checkDuplicateFlywayMigrationVersions checkSensitiveMainResourcesExcluded bootJar
-
-      - name: Run application tests
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip-tests') }}
-        run: ./gradlew test
-
-      - name: Summarize skipped application tests
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:skip-tests') }}
-        run: echo 'ci:skip-tests 라벨에 따라 애플리케이션 테스트 실행을 생략했습니다. 컴파일·스타일·리소스 검사와 빌드는 유지합니다. 라벨을 제거하면 테스트가 다시 실행됩니다.' >> "$GITHUB_STEP_SUMMARY"
+        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number }}
@@ -37,7 +38,15 @@ jobs:
         run: node --test .github/scripts/update-preview-release.test.mjs
 
       - name: Validate and build boot JAR
-        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava test bootJar
+        run: ./gradlew clean spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava checkDuplicateFlywayMigrationVersions checkSensitiveMainResourcesExcluded bootJar
+
+      - name: Run application tests
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip-tests') }}
+        run: ./gradlew test
+
+      - name: Summarize skipped application tests
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:skip-tests') }}
+        run: echo 'ci:skip-tests 라벨에 따라 애플리케이션 테스트 실행을 생략했습니다. 컴파일·스타일·리소스 검사와 빌드는 유지합니다. 라벨을 제거하면 테스트가 다시 실행됩니다.' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/EmailRegisterMemberRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/EmailRegisterMemberRequest.java
@@ -1,14 +1,16 @@
 package com.umc.product.member.adapter.in.web.dto.request;
 
+import java.util.List;
+
 import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
 import com.umc.product.member.application.port.in.command.dto.TermConsents;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 /**
  * 이메일 기반 회원가입 요청 DTO. ADR-017 에 따라 loginId 를 받지 않는다.
@@ -16,33 +18,22 @@ import java.util.List;
  * 비밀번호 형식은 CredentialPolicy 에서 사후 검증하므로 본 DTO 에서는 NotBlank 만 강제한다.
  */
 public record EmailRegisterMemberRequest(
-    @NotBlank(message = "본 회원가입 방법에서는 비밀번호를 필수로 제공하여야 합니다.")
-    String rawPassword,
+    @NotBlank(message = "본 회원가입 방법에서는 비밀번호를 필수로 제공하여야 합니다.") String rawPassword,
 
     @Schema(description = "이름", example = "박세은")
-    @NotBlank(message = "이름은 필수입니다")
-    @Size(max = 10, message = "이름은 10자 이하여야 합니다")
-    String name,
+    @NotBlank(message = "이름은 필수입니다") @Size(max = 10, message = "이름은 10자 이하여야 합니다") String name,
 
-    @Schema(description = "닉네임", example = "하늘")
-    @NotBlank(message = "닉네임은 필수입니다")
-    @Size(min = 1, max = 5, message = "닉네임은 한글 1~5자여야 합니다")
-    @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다")
-    String nickname,
+    @Schema(description = "닉네임 (한글 1~6자)", example = "하늘")
+    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 6, message = "닉네임은 한글 1~6자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
 
     @Schema(description = "이메일 인증 토큰", example = "some_email_token")
-    @NotBlank(message = "이메일 인증 토큰은 필수입니다")
-    String emailVerificationToken,
+    @NotBlank(message = "이메일 인증 토큰은 필수입니다") String emailVerificationToken,
 
     @Schema(description = "학교 ID", example = "1")
-    @NotNull(message = "학교 ID는 필수입니다")
-    Long schoolId,
+    @NotNull(message = "학교 ID는 필수입니다") Long schoolId,
 
     @Schema(description = "약관 동의 목록")
-    @NotNull(message = "약관 동의 목록은 필수입니다")
-    @Size(min = 1, message = "최소 1개 이상의 약관 동의 정보가 필요합니다")
-    @Valid
-    List<TermConsentStatus> termsAgreements
+    @NotNull(message = "약관 동의 목록은 필수입니다") @Size(min = 1, message = "최소 1개 이상의 약관 동의 정보가 필요합니다") @Valid List<TermConsentStatus> termsAgreements
 ) {
     public EmailRegisterMemberCommand toCommand(String email) {
         return EmailRegisterMemberCommand.builder()

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
@@ -18,8 +18,8 @@ public record OAuthRegisterMemberRequest(
     @Schema(description = "이름", example = "홍길동")
     @NotBlank(message = "이름은 필수입니다") @Size(max = 10, message = "이름은 10자 이하여야 합니다") String name,
 
-    @Schema(description = "닉네임", example = "닉넴")
-    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 5, message = "닉네임은 한글 1~5자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
+    @Schema(description = "닉네임 (한글 1~6자)", example = "닉넴")
+    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 6, message = "닉네임은 한글 1~6자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
 
     @Schema(description = "이메일 인증 토큰", example = "YOUR_JWT_TOKEN")
     @NotBlank(message = "이메일 인증 토큰은 필수입니다") String emailVerificationToken,

--- a/src/main/java/com/umc/product/member/domain/Member.java
+++ b/src/main/java/com/umc/product/member/domain/Member.java
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 30) // 한글 10자까지 고려
     private String name;
 
-    @Column(nullable = false, length = 20) // 한글 1~5자
+    @Column(nullable = false, length = 20) // 회원가입 입력은 한글 1~6자
     private String nickname;
 
     @Column(nullable = false, length = 100, unique = true)


### PR DESCRIPTION
이메일·소셜 회원가입에서 한글 6자 닉네임이 길이 검증에 실패하던 제한을 5자에서 6자로 늘립니다. 검증 오류 메시지와 OpenAPI 설명도 한글 1~6자로 맞춥니다.

한글만 허용하는 규칙과 필수 입력 조건은 유지하며, DB 컬럼은 이미 20자를 저장할 수 있어 마이그레이션은 없습니다.

검증: `./gradlew spotlessCheck checkstyleMain checkstyleTest compileJava compileTestJava checkDuplicateFlywayMigrationVersions checkSensitiveMainResourcesExcluded bootJar` 통과. 별도 테스트 코드는 추가하지 않았으며 기존 CI는 그대로 실행합니다.
