### PR TITLE
[Release] v2.4.23

### DIFF
--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/EmailRegisterMemberRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/EmailRegisterMemberRequest.java
@@ -1,14 +1,16 @@
 package com.umc.product.member.adapter.in.web.dto.request;
 
+import java.util.List;
+
 import com.umc.product.member.application.port.in.command.dto.EmailRegisterMemberCommand;
 import com.umc.product.member.application.port.in.command.dto.TermConsents;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 /**
  * 이메일 기반 회원가입 요청 DTO. ADR-017 에 따라 loginId 를 받지 않는다.
@@ -16,33 +18,22 @@ import java.util.List;
  * 비밀번호 형식은 CredentialPolicy 에서 사후 검증하므로 본 DTO 에서는 NotBlank 만 강제한다.
  */
 public record EmailRegisterMemberRequest(
-    @NotBlank(message = "본 회원가입 방법에서는 비밀번호를 필수로 제공하여야 합니다.")
-    String rawPassword,
+    @NotBlank(message = "본 회원가입 방법에서는 비밀번호를 필수로 제공하여야 합니다.") String rawPassword,
 
     @Schema(description = "이름", example = "박세은")
-    @NotBlank(message = "이름은 필수입니다")
-    @Size(max = 10, message = "이름은 10자 이하여야 합니다")
-    String name,
+    @NotBlank(message = "이름은 필수입니다") @Size(max = 10, message = "이름은 10자 이하여야 합니다") String name,
 
-    @Schema(description = "닉네임", example = "하늘")
-    @NotBlank(message = "닉네임은 필수입니다")
-    @Size(min = 1, max = 5, message = "닉네임은 한글 1~5자여야 합니다")
-    @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다")
-    String nickname,
+    @Schema(description = "닉네임 (한글 1~6자)", example = "하늘")
+    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 6, message = "닉네임은 한글 1~6자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
 
     @Schema(description = "이메일 인증 토큰", example = "some_email_token")
-    @NotBlank(message = "이메일 인증 토큰은 필수입니다")
-    String emailVerificationToken,
+    @NotBlank(message = "이메일 인증 토큰은 필수입니다") String emailVerificationToken,
 
     @Schema(description = "학교 ID", example = "1")
-    @NotNull(message = "학교 ID는 필수입니다")
-    Long schoolId,
+    @NotNull(message = "학교 ID는 필수입니다") Long schoolId,
 
     @Schema(description = "약관 동의 목록")
-    @NotNull(message = "약관 동의 목록은 필수입니다")
-    @Size(min = 1, message = "최소 1개 이상의 약관 동의 정보가 필요합니다")
-    @Valid
-    List<TermConsentStatus> termsAgreements
+    @NotNull(message = "약관 동의 목록은 필수입니다") @Size(min = 1, message = "최소 1개 이상의 약관 동의 정보가 필요합니다") @Valid List<TermConsentStatus> termsAgreements
 ) {
     public EmailRegisterMemberCommand toCommand(String email) {
         return EmailRegisterMemberCommand.builder()

--- a/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
+++ b/src/main/java/com/umc/product/member/adapter/in/web/dto/request/OAuthRegisterMemberRequest.java
@@ -18,8 +18,8 @@ public record OAuthRegisterMemberRequest(
     @Schema(description = "이름", example = "홍길동")
     @NotBlank(message = "이름은 필수입니다") @Size(max = 10, message = "이름은 10자 이하여야 합니다") String name,
 
-    @Schema(description = "닉네임", example = "닉넴")
-    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 5, message = "닉네임은 한글 1~5자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
+    @Schema(description = "닉네임 (한글 1~6자)", example = "닉넴")
+    @NotBlank(message = "닉네임은 필수입니다") @Size(min = 1, max = 6, message = "닉네임은 한글 1~6자여야 합니다") @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다") String nickname,
 
     @Schema(description = "이메일 인증 토큰", example = "YOUR_JWT_TOKEN")
     @NotBlank(message = "이메일 인증 토큰은 필수입니다") String emailVerificationToken,

--- a/src/main/java/com/umc/product/member/domain/Member.java
+++ b/src/main/java/com/umc/product/member/domain/Member.java
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 30) // 한글 10자까지 고려
     private String name;
 
-    @Column(nullable = false, length = 20) // 한글 1~5자
+    @Column(nullable = false, length = 20) // 회원가입 입력은 한글 1~6자
     private String nickname;
 
     @Column(nullable = false, length = 100, unique = true)


### PR DESCRIPTION
이메일·소셜 회원가입의 닉네임 제한을 한글 5자에서 6자로 확장한 변경을 운영 환경에 배포합니다. 오류 메시지와 OpenAPI 설명도 함께 반영됩니다.

- 개발 반영: #1333
- 기존 한글 입력 규칙 유지, DB 마이그레이션 없음
- 로컬 스타일 검사·소스와 테스트 컴파일·Flyway 중복 및 민감 리소스 검사·boot JAR 빌드 통과
- #1333의 기존 전체 CI 통과: https://github.com/UMC-PRODUCT/umc-product-server/actions/runs/34703896047

이 릴리스 PR의 CI와 개발 배포 결과를 확인한 후 main으로 병합합니다. main 병합 커밋에 v2.4.23 태그를 생성하고, 운영 이미지 발행 및 GitOps 반영을 확인합니다. CI 생략 옵션이나 프리뷰 인프라 변경은 포함하지 않습니다.
